### PR TITLE
docs: update Purpose sections in OpenSpec files

### DIFF
--- a/openspec/specs/database/spec.md
+++ b/openspec/specs/database/spec.md
@@ -1,8 +1,11 @@
 # database Specification
 
 ## Purpose
-TBD - created by archiving change provision-cloud-sql. Update Purpose after archive.
+
+The `database` capability defines the requirements for reliable, scalable, and secure relational storage. It ensures that critical domain data for users, artists, and concerts is persisted in highly available Cloud SQL instances with appropriate encryption and data integrity guarantees.
+
 ## Requirements
+
 ### Requirement: The system MUST provide persistent relational storage
 
 The system SHALL provide a durable, consistent store for relational data.
@@ -13,4 +16,3 @@ Given the backend service is deployed to production
 When it attempts to persist user data
 Then the data SHALL be stored in a highly available Cloud SQL instance
 And the data SHALL be encrypted at rest
-

--- a/openspec/specs/intel/spec.md
+++ b/openspec/specs/intel/spec.md
@@ -1,14 +1,18 @@
 # intel Specification
 
 ## Purpose
-TBD - created by archiving change prototype-live-info-collection. Update Purpose after archive.
+
+The `intel` capability provides automated gathering and processing of live performance information (concerts, tickets) from artist websites. It utilizes AI-driven crawling via Vertex AI Search and structured data extraction with Gemini to maintain a comprehensive and up-to-date database of music events without manual scraping.
+
 ## Requirements
+
 ### Requirement: Live Information Crawling
+
 The system SHALL crawl live information from artist websites using Vertex AI Search.
 
 #### Scenario: Crawl UVERworld schedule
+
 Given the target artist is "UVERworld"
 When the intel CLI is run
 Then it should query Vertex AI Search for "UVERworld live schedule"
 And parse the results to JSON.
-

--- a/openspec/specs/live-events/spec.md
+++ b/openspec/specs/live-events/spec.md
@@ -1,8 +1,11 @@
 # live-events Specification
 
 ## Purpose
-TBD - created by archiving change define-live-catalog-api. Update Purpose after archive.
+
+The `live-events` capability defines the core domain entities—Artists, Venues, and Concerts—and the standard interfaces for managing them. It establishes the single source of truth for concert metadata, enabling consistent data representation and access across the platform's crawler, backend services, and frontend applications.
+
 ## Requirements
+
 ### Requirement: Concert Schedue Data Model
 
 The system MUST define standard data structures for core concert entities to ensure consistency across services.
@@ -55,4 +58,3 @@ The system MUST provide access to the collected schedule of concerts.
 
 - **WHEN** `ListConcerts` is called for a valid artist ID
 - **THEN** the system MUST return a chronologically sorted list of future concerts for that artist.
-


### PR DESCRIPTION
## Summary
Updates the Purpose sections in , , and  to replace "TBD" placeholders with actual descriptions derived from the archived proposals.

## Changes
- **intel**: Describes AI-driven crawling and extraction.
- **live-events**: Describes domain entity definitions (Artist, Venue, Concert).
- **database**: Describes Cloud SQL persistence requirements.

## Validation
- Ran ✓ spec/database
✓ spec/intel
✓ spec/live-events
Totals: 3 passed, 0 failed (3 items) -> Passed.