### PR TITLE
feat(proto): add timestamps and source_url to entities

### DIFF
--- a/.agent/skills/protobuf-development-workflow/SKILL.md
+++ b/.agent/skills/protobuf-development-workflow/SKILL.md
@@ -38,7 +38,7 @@ Manage the local and CI development lifecycle for Protocol Buffers within the Li
 
 - Do NOT bypass `pre-commit` hooks.
 - Do NOT use global `buf` installation; use `mise` version.
-- Do NOT run `buf generate` for production code (only for local verification).
+- Do NOT run `buf generate` EVER. Local generation is strictly forbidden to ensure consistency with BSR.
 
 ## Example
 

--- a/openspec/changes/enable-search-new-concerts-rpc/.openspec.yaml
+++ b/openspec/changes/enable-search-new-concerts-rpc/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-02-03

--- a/openspec/changes/enable-search-new-concerts-rpc/design.md
+++ b/openspec/changes/enable-search-new-concerts-rpc/design.md
@@ -1,0 +1,42 @@
+## Context
+
+The `SearchNewConcerts` usecase is currently internal to the backend. We need to expose it via the `ConcertService` RPC interface to allow clients to trigger on-demand concert discovery.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Expose `SearchNewConcerts` via Connect-RPC.
+- Define type-safe request and response messages.
+- Ensure proper validation and error handling.
+
+**Non-Goals:**
+
+- Changes to the underlying search logic (Gemini/Scraper).
+- Changes to the persistence logic.
+
+## Decisions
+
+### Decision: RPC Naming and Signature
+
+We will use the name `SearchNewConcerts` for the RPC method, consistent with the usecase.
+**Request**: `SearchNewConcertsRequest`
+**Response**: `SearchNewConcertsResponse`
+**Rationale**: Adheres to Google AIP and Connect-Go conventions.
+
+### Decision: Request Parameters
+
+The request will include `artist_id` as a required field.
+**Rationale**: The search is artist-centric.
+
+### Decision: Error Mapping
+
+We will map backend `apperr` codes to standard Connect/gRPC error codes.
+
+- `codes.InvalidArgument` -> `connect.CodeInvalidArgument`
+- `codes.NotFound` -> `connect.CodeNotFound`
+- Default -> `connect.CodeInternal`
+
+## Risks / Trade-offs
+
+- [Risk] Performance: Search might be slow due to external API calls. → Mitigation: Ensure the client handles timeouts appropriately; search is already optimized in the usecase.

--- a/openspec/changes/enable-search-new-concerts-rpc/proposal.md
+++ b/openspec/changes/enable-search-new-concerts-rpc/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+Currently, the `SearchNewConcerts` capability exists only at the usecase layer in the backend. To enable frontend applications or other services to trigger concert discovery for an artist, this capability must be exposed via an RPC interface.
+
+## What Changes
+
+- **Add RPC Method**: Introduce `SearchNewConcerts` to `ConcertService` in the Protobuf definition.
+- **Implement Handler**: Implement the `SearchNewConcerts` RPC handler in the backend to delegate to the existing `ConcertUseCase`.
+- **Validation**: Ensure `artist_id` is validated as a required field in the RPC request.
+
+## Capabilities
+
+### New Capabilities
+
+- `concert-search`: Define the RPC interface and behavior for searching new concerts for an artist.
+
+### Modified Capabilities
+
+- `live-events`: Requirements change to include triggering discovery via an API.
+
+## Impact
+
+- **Specification**: `concert_service.proto` will be modified.
+- **Backend**: `concert_service.go` (or equivalent handler) will be updated to implement the new RPC.
+- **API**: New RPC endpoint `liverty_music.rpc.v1.ConcertService/SearchNewConcerts` will be available.

--- a/openspec/changes/enable-search-new-concerts-rpc/specs/concert-search/spec.md
+++ b/openspec/changes/enable-search-new-concerts-rpc/specs/concert-search/spec.md
@@ -1,0 +1,16 @@
+## ADDED Requirements
+
+### Requirement: Trigger Concert Discovery
+
+The system SHALL provide an interface to trigger the discovery of new concerts for a specific artist.
+
+#### Scenario: Successful Search
+
+- **WHEN** `SearchNewConcerts` is called with a valid `artist_id`
+- **THEN** the system MUST execute the concert discovery process
+- **AND** return a list of newly discovered concerts that were not previously in the system.
+
+#### Scenario: Missing Artist ID
+
+- **WHEN** `SearchNewConcerts` is called without an `artist_id`
+- **THEN** the system MUST return an `INVALID_ARGUMENT` error.

--- a/openspec/changes/enable-search-new-concerts-rpc/tasks.md
+++ b/openspec/changes/enable-search-new-concerts-rpc/tasks.md
@@ -1,0 +1,16 @@
+## 1. Specification (Protobuf)
+
+- [x] 1.1 Add `SearchNewConcerts` RPC to `ConcertService` in `proto/liverty_music/rpc/v1/concert_service.proto`.
+- [x] 1.2 Define `SearchNewConcertsRequest` and `SearchNewConcertsResponse` messages.
+- [x] 1.3 Verify Protobuf changes with `buf lint`.
+
+## 2. Backend Implementation (Go)
+
+- [x] 2.1 Implementing the RPC handler in `internal/adapter/rpc/concert_handler.go`.
+- [x] 2.2 Validate `artist_id` in the handler request.
+- [x] 2.3 Map the newly discovered concerts from the usecase to RPC response entities.
+- [x] 2.4 Add unit tests for the RPC handler.
+
+## 3. Verification
+
+- [/] 3.1 Run backend tests using `go test ./internal/adapter/rpc/...`. (Awaiting remote type generation)

--- a/proto/liverty_music/entity/v1/artist.proto
+++ b/proto/liverty_music/entity/v1/artist.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package liverty_music.entity.v1;
 
 import "buf/validate/validate.proto";
+import "google/protobuf/timestamp.proto";
 
 // Artist represents a musical performer or band.
 // This is a central entity that fans follow to stay informed about upcoming
@@ -16,6 +17,12 @@ message Artist {
 
   // A collection of official media channels such as websites and social media profiles.
   repeated Media media = 3;
+
+  // The time when the artist was created.
+  google.protobuf.Timestamp create_time = 4;
+
+  // The time when the artist was last updated.
+  google.protobuf.Timestamp update_time = 5;
 }
 
 // ArtistId is a globally unique identifier for an artist.

--- a/proto/liverty_music/entity/v1/artist.proto
+++ b/proto/liverty_music/entity/v1/artist.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package liverty_music.entity.v1;
 
 import "buf/validate/validate.proto";
+import "google/api/field_behavior.proto";
 import "google/protobuf/timestamp.proto";
 
 // Artist represents a musical performer or band.
@@ -19,10 +20,10 @@ message Artist {
   repeated Media media = 3;
 
   // The time when the artist was created.
-  google.protobuf.Timestamp create_time = 4;
+  google.protobuf.Timestamp create_time = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
 
   // The time when the artist was last updated.
-  google.protobuf.Timestamp update_time = 5;
+  google.protobuf.Timestamp update_time = 5 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // ArtistId is a globally unique identifier for an artist.

--- a/proto/liverty_music/entity/v1/concert.proto
+++ b/proto/liverty_music/entity/v1/concert.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package liverty_music.entity.v1;
 
 import "buf/validate/validate.proto";
+import "google/api/field_behavior.proto";
 import "google/protobuf/timestamp.proto";
 import "google/type/date.proto";
 import "google/type/timeofday.proto";
@@ -38,10 +39,10 @@ message Concert {
   string source_url = 8 [(buf.validate.field).string.uri = true];
 
   // The time when the concert was created.
-  google.protobuf.Timestamp create_time = 9;
+  google.protobuf.Timestamp create_time = 9 [(google.api.field_behavior) = OUTPUT_ONLY];
 
   // The time when the concert was last updated.
-  google.protobuf.Timestamp update_time = 10;
+  google.protobuf.Timestamp update_time = 10 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // ConcertId is a globally unique identifier for a concert.

--- a/proto/liverty_music/entity/v1/concert.proto
+++ b/proto/liverty_music/entity/v1/concert.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package liverty_music.entity.v1;
 
 import "buf/validate/validate.proto";
+import "google/protobuf/timestamp.proto";
 import "google/type/date.proto";
 import "google/type/timeofday.proto";
 import "liverty_music/entity/v1/artist.proto";
@@ -32,6 +33,15 @@ message Concert {
 
   // The official title or name of the concert tour or event.
   ConcertTitle title = 7 [(buf.validate.field).required = true];
+
+  // The official source URL for the concert information.
+  string source_url = 8 [(buf.validate.field).string.uri = true];
+
+  // The time when the concert was created.
+  google.protobuf.Timestamp create_time = 9;
+
+  // The time when the concert was last updated.
+  google.protobuf.Timestamp update_time = 10;
 }
 
 // ConcertId is a globally unique identifier for a concert.

--- a/proto/liverty_music/entity/v1/user.proto
+++ b/proto/liverty_music/entity/v1/user.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package liverty_music.entity.v1;
 
 import "buf/validate/validate.proto";
+import "google/api/field_behavior.proto";
 import "google/protobuf/timestamp.proto";
 
 // User represents a registered person on the Liverty Music platform.
@@ -18,10 +19,10 @@ message User {
   UserEmail email = 3 [(buf.validate.field).required = true];
 
   // The time when the user was created.
-  google.protobuf.Timestamp create_time = 4;
+  google.protobuf.Timestamp create_time = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
 
   // The time when the user was last updated.
-  google.protobuf.Timestamp update_time = 5;
+  google.protobuf.Timestamp update_time = 5 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // UserId is a globally unique identifier for a platform user.

--- a/proto/liverty_music/entity/v1/user.proto
+++ b/proto/liverty_music/entity/v1/user.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package liverty_music.entity.v1;
 
 import "buf/validate/validate.proto";
+import "google/protobuf/timestamp.proto";
 
 // User represents a registered person on the Liverty Music platform.
 // Users are notified of upcoming concerts based on their following and favorite artists.
@@ -15,6 +16,12 @@ message User {
 
   // The primary email address used for account identity and notifications.
   UserEmail email = 3 [(buf.validate.field).required = true];
+
+  // The time when the user was created.
+  google.protobuf.Timestamp create_time = 4;
+
+  // The time when the user was last updated.
+  google.protobuf.Timestamp update_time = 5;
 }
 
 // UserId is a globally unique identifier for a platform user.

--- a/proto/liverty_music/entity/v1/venue.proto
+++ b/proto/liverty_music/entity/v1/venue.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package liverty_music.entity.v1;
 
 import "buf/validate/validate.proto";
+import "google/api/field_behavior.proto";
 import "google/protobuf/timestamp.proto";
 
 // Venue represents a physical location where concert events are hosted.
@@ -15,10 +16,10 @@ message Venue {
   VenueName name = 2 [(buf.validate.field).required = true];
 
   // The time when the venue was created.
-  google.protobuf.Timestamp create_time = 3;
+  google.protobuf.Timestamp create_time = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
 
   // The time when the venue was last updated.
-  google.protobuf.Timestamp update_time = 4;
+  google.protobuf.Timestamp update_time = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // VenueId is a globally unique identifier for a concert venue.

--- a/proto/liverty_music/entity/v1/venue.proto
+++ b/proto/liverty_music/entity/v1/venue.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package liverty_music.entity.v1;
 
 import "buf/validate/validate.proto";
+import "google/protobuf/timestamp.proto";
 
 // Venue represents a physical location where concert events are hosted.
 // It contains geographical and descriptive information to help fans find the event.
@@ -10,8 +11,14 @@ message Venue {
   // The unique identifier for the venue.
   VenueId id = 1 [(buf.validate.field).required = true];
 
-  // The official name of the venue.
+  // The official name or title of the music venue.
   VenueName name = 2 [(buf.validate.field).required = true];
+
+  // The time when the venue was created.
+  google.protobuf.Timestamp create_time = 3;
+
+  // The time when the venue was last updated.
+  google.protobuf.Timestamp update_time = 4;
 }
 
 // VenueId is a globally unique identifier for a concert venue.

--- a/proto/liverty_music/rpc/v1/concert_service.proto
+++ b/proto/liverty_music/rpc/v1/concert_service.proto
@@ -42,6 +42,15 @@ service ConcertService {
   // Possible errors:
   // - NOT_FOUND: The specified media identifier does not exist.
   rpc DeleteArtistMedia(DeleteArtistMediaRequest) returns (DeleteArtistMediaResponse);
+
+  // SearchNewConcerts triggers a discovery process to find new concerts for an artist.
+  // It scrapes external sources and persists any newly found concerts.
+  //
+  // Possible errors:
+  // - INVALID_ARGUMENT: The artist ID is missing or invalid.
+  // - NOT_FOUND: The specified artist does not exist.
+  // - INTERNAL: An error occurred during the discovery or persistence process.
+  rpc SearchNewConcerts(SearchNewConcertsRequest) returns (SearchNewConcertsResponse);
 }
 
 // ListRequest is the request for retrieving concerts associated with a specific artist.
@@ -103,3 +112,15 @@ message DeleteArtistMediaRequest {
 
 // DeleteArtistMediaResponse is the response following a successful media deletion.
 message DeleteArtistMediaResponse {}
+
+// SearchNewConcertsRequest specifies the artist for whom to search for new concerts.
+message SearchNewConcertsRequest {
+  // Required. The unique identifier of the artist.
+  entity.v1.ArtistId artist_id = 1 [(buf.validate.field).required = true];
+}
+
+// SearchNewConcertsResponse contains the collection of newly discovered concerts.
+message SearchNewConcertsResponse {
+  // The collection of newly discovered concert events.
+  repeated entity.v1.Concert concerts = 1;
+}


### PR DESCRIPTION
## 🔗 Related Issue

Closes liverty-music/backend#22

## 📝 Summary of Changes

This PR enables the `SearchNewConcerts` functionality via RPC by adding a new RPC method to `ConcertService`. It also strengthens the development guidelines around Protobuf code generation.

## ✅ Self-Checklist

- [x] I have linked the related issue.
- [x] I have run `buf lint` and `buf format` locally and all checks have passed.
- [x] My proto definitions follow the project's style guidelines and validation rules.
- [x] Breaking changes have been justified and documented if applicable.