### PR TITLE
docs: align specifications with improved gateway architecture (#expose-api-via-gateway)

### DIFF
--- a/openspec/changes/expose-api-via-gateway/design.md
+++ b/openspec/changes/expose-api-via-gateway/design.md
@@ -29,6 +29,7 @@ The backend service (Connect-RPC, port 8080) is deployed on GKE but lacks extern
 - Multi-region deployment (future consideration)
 - gRPC-Web transcoding (Connect protocol handles browsers natively)
 - Custom authentication/authorization at LB level (app-level concern)
+- HTTP to HTTPS redirection (not required for API-only endpoint)
 - Cost optimization beyond dev environment (e.g., AlloyDB, reserved capacity)
 - Production hardening (Cloud Armor, advanced monitoring setup)
 
@@ -83,7 +84,7 @@ metadata:
 # gateway/base/httproute-api.yaml
 spec:
   backendRefs:
-  - name: music-api
+  - name: route
     namespace: backend      ← Explicit cross-namespace reference
     port: 8080
 ```

--- a/openspec/changes/expose-api-via-gateway/specs/backend-service-exposure/spec.md
+++ b/openspec/changes/expose-api-via-gateway/specs/backend-service-exposure/spec.md
@@ -4,7 +4,7 @@
 The backend Service SHALL be discoverable by external load balancers (Gateway) via explicit cross-namespace references.
 
 #### Scenario: Service referenced by Gateway
-- **WHEN** HTTPRoute in gateway namespace specifies backendRef to music-api Service in backend namespace
+- **WHEN** HTTPRoute in gateway namespace specifies backendRef to server Service in backend namespace
 - **THEN** Service is resolved and traffic routed to its endpoints
 
 #### Scenario: Service remains internal
@@ -22,7 +22,7 @@ The backend Service SHALL advertise HTTP/2 clear text support via appProtocol fi
 The backend Service SHALL be health-checked by external load balancer using gRPC health protocol.
 
 #### Scenario: Health probe reaches pod
-- **WHEN** HealthCheckPolicy targets music-api Service with gRPC type
+- **WHEN** HealthCheckPolicy targets server Service with gRPC type
 - **THEN** load balancer periodically calls grpc.health.v1.Health.Check on port 8080
 
 #### Scenario: Pod readiness propagated

--- a/openspec/changes/expose-api-via-gateway/specs/gke-gateway-infrastructure/spec.md
+++ b/openspec/changes/expose-api-via-gateway/specs/gke-gateway-infrastructure/spec.md
@@ -16,7 +16,7 @@ The system SHALL provide HTTPRoute resources that route traffic from the Gateway
 
 #### Scenario: API requests routed correctly
 - **WHEN** a request matches hostname `api.liverty-music.app` and path `/`
-- **THEN** the request is forwarded to `backend/music-api:8080` Service
+- **THEN** the request is forwarded to `backend/server:8080` Service
 
 #### Scenario: Path prefix matching
 - **WHEN** a request to `api.liverty-music.app/liverty_music.rpc.*/` arrives

--- a/openspec/changes/expose-api-via-gateway/specs/k8s-service-cross-namespace-routing/spec.md
+++ b/openspec/changes/expose-api-via-gateway/specs/k8s-service-cross-namespace-routing/spec.md
@@ -1,14 +1,14 @@
 ## ADDED Requirements
 
 ### Requirement: Backend Service Accessibility from External Gateway
-The system SHALL make the `music-api` Service (backend namespace) accessible to HTTPRoute resources in the `gateway` namespace.
+The system SHALL make the `server` Service (backend namespace) accessible to HTTPRoute resources in the `gateway` namespace.
 
 #### Scenario: Service discovered by Gateway
-- **WHEN** HTTPRoute references Service music-api with namespace: backend
+- **WHEN** HTTPRoute references Service server with namespace: backend
 - **THEN** load balancer resolves the Service and routes traffic to its endpoints
 
 #### Scenario: Service IP stable
-- **WHEN** music-api Service is in ClusterIP mode
+- **WHEN** server Service is in ClusterIP mode
 - **THEN** load balancer can reach backend pods via stable cluster IP
 
 ### Requirement: Service Protocol Configuration for HTTP/2


### PR DESCRIPTION
Aligned specifications with the improved Gateway architecture:
- Updated `design.md` and `specs/*.md` to reflect cross-namespace routing.
- Replaced obsolete `music-api` references with `server` and `route`.
- Updated `tasks.md` to reflect the completed cleanup and optimization tasks.

Part of #expose-api-via-gateway