### PR TITLE
chore: merge Last.fm API endpoint URLs into interactive-artist-onboarding

### DIFF
--- a/openspec/changes/interactive-artist-onboarding/design.md
+++ b/openspec/changes/interactive-artist-onboarding/design.md
@@ -35,10 +35,13 @@ To provide a chain-like discovery experience utilizing the Last.fm API, we will 
 **Endpoints Used**:
 - **Search (Incremental Search)**:
   - Method: `artist.search`
+  - URL: `http://ws.audioscrobbler.com/2.0/?method=artist.search&artist={artist_name}&api_key={api_key}&format=json`
 - **Similar Artists (Chain-like Follow Feature)**:
   - Method: `artist.getSimilar`
+  - URL: `http://ws.audioscrobbler.com/2.0/?method=artist.getsimilar&artist={artist_name}&api_key={api_key}&format=json`
 - **Top Artists (Initial Display - Popular Artists in Japan)**:
   - Method: `geo.getTopArtists`
+  - URL: `http://ws.audioscrobbler.com/2.0/?method=geo.gettopartists&country=japan&api_key={api_key}&format=json`
 
 ### 4. UI Transition Management
 **Decision**:


### PR DESCRIPTION
## Summary

Merges the Last.fm API endpoint URLs from backend's `interactive-artist-onboarding` change into specification's version.

This is part of the openspec consolidation effort - extracting valuable technical details from the backend repository before removing duplicate openspec directories.

## Changes

- Added full Last.fm API endpoint URLs to `openspec/changes/interactive-artist-onboarding/design.md`:
  - `artist.search` endpoint
  - `artist.getSimilar` endpoint
  - `geo.getTopArtists` endpoint

## Context

Backend had a Japanese version with detailed API URLs that were missing from specification's English version. This PR preserves that technical detail before cleaning up the duplicate directories.

Part of: openspec consolidation (backend, cloud-provisioning, frontend → specification)