### PR TITLE
feat: add user account sync with Zitadel identity provider

### DIFF
--- a/.agent/skills/protobuf-development-workflow/SKILL.md
+++ b/.agent/skills/protobuf-development-workflow/SKILL.md
@@ -29,6 +29,11 @@ Manage the local and CI development lifecycle for Protocol Buffers within the Li
     - **PR Workflow** (`.github/workflows/buf-pr-checks.yml`):
       - Runs on all PR events including label changes.
       - Validates: lint, format (`--diff --exit-code`), breaking changes, dry-run generation.
+      - **Skip Breaking Changes**: Add `buf skip breaking` label to PR to bypass breaking change detection.
+        - Used for intentional breaking changes (e.g., security fixes, MVP iterations).
+        - Label must exist in repository (create with `gh label create "buf skip breaking"`).
+        - Workflow automatically responds to `labeled`/`unlabeled` events.
+        - Reference: https://buf.build/docs/bsr/ci-cd/github-actions/#skip-breaking-change-detection-using-labels
     - **Release Workflow** (`.github/workflows/buf-release.yml`):
       - Triggers on GitHub releases.
       - Automatic `buf push` with release tag as BSR label.

--- a/buf.yaml
+++ b/buf.yaml
@@ -14,5 +14,3 @@ lint:
 breaking:
   use:
     - FILE
-  ignore:
-    - proto/liverty_music/rpc/user/v1/user_service.proto

--- a/buf.yaml
+++ b/buf.yaml
@@ -14,3 +14,5 @@ lint:
 breaking:
   use:
     - FILE
+  ignore:
+    - proto/liverty_music/rpc/user/v1/user_service.proto

--- a/openspec/changes/user-account-sync/.openspec.yaml
+++ b/openspec/changes/user-account-sync/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-02-15

--- a/openspec/changes/user-account-sync/design.md
+++ b/openspec/changes/user-account-sync/design.md
@@ -1,0 +1,103 @@
+## Context
+
+Zitadel serves as the identity provider (IdP) for the Liverty Music platform via OIDC/PKCE. When a user signs up, Zitadel creates the identity record, but the application database (`users` table) remains empty. The backend currently validates JWTs and extracts the `sub` claim but has no mechanism to provision local user records.
+
+Current state:
+- Frontend distinguishes signup (`prompt=create`) from login in `AuthService`
+- Backend auth interceptor validates JWT and injects `sub` into context
+- `users` table exists with UUIDv7 `id`, `email`, `name`, etc. but no Zitadel identity link
+- `UserService` has `Create` and `Get` RPCs but no identity-aware provisioning
+
+## Goals / Non-Goals
+
+**Goals:**
+- Provision a local user record immediately after Zitadel signup
+- Link Zitadel identity (`sub` claim) to the local user record via `external_id`
+- Keep the solution simple — minimal moving parts for MVP
+- Ensure idempotency — calling provisioning multiple times for the same user is safe
+
+**Non-Goals:**
+- Zitadel Actions v2 Webhook integration (future phase)
+- Syncing profile updates from Zitadel to local DB (future phase)
+- Backend interceptor-based auto-provisioning fallback (future phase)
+- Admin-created user sync (future phase)
+
+## Decisions
+
+### Decision 1: Client-side provisioning via OIDC `state`
+
+**Choice**: Frontend detects signup via `state: { isRegistration: true }` passed through the OIDC flow, then calls `Create` RPC in the auth callback.
+
+**Alternatives considered**:
+- **Zitadel Actions v2 Webhook**: Push-based, real-time sync. More robust but requires hosting a webhook endpoint, signature verification, and fallback for missed events. Deferred to future phase.
+- **Backend interceptor auto-provisioning**: Every authenticated request checks if user exists. Reliable fallback but adds DB query to every request and mixes auth concerns with provisioning.
+- **Event API polling**: Batch reconciliation via Zitadel Event Store. Good for catch-up but not real-time, requires checkpoint management.
+
+**Rationale**: The frontend already controls the signup vs login distinction. Passing `state` through OIDC is a standard pattern supported by `oidc-client-ts`. This requires zero additional infrastructure and integrates naturally into the existing callback flow.
+
+### Decision 2: `external_id` column (UUID type) instead of reusing Zitadel `sub` as primary key
+
+**Choice**: Add a new `external_id UUID UNIQUE NOT NULL` column to `users`, keeping the existing UUIDv7 `id` as primary key. Zitadel's `sub` claim is a UUID, so UUID type is appropriate.
+
+**Alternatives considered**:
+- **Use Zitadel `sub` as `users.id`**: Simpler mapping but couples the primary key to an external system. Internal references (foreign keys, logs) would use an opaque external ID.
+- **TEXT type**: More flexible but loses UUID validation at the database level. Since Zitadel `sub` is always a UUID, using the proper type is better.
+
+**Rationale**: Decoupling internal identity from external identity is a standard practice. The application owns its primary key format (UUIDv7), and `external_id` serves as the lookup index for identity resolution. UUID type provides type safety and compact storage.
+
+### Decision 3: Use existing `Get` and `Create` RPCs (no new RPC)
+
+**Choice**: Extend the existing `Create` RPC to accept `external_id` and `email` as parameters. The frontend calls `Create` on signup. Idempotency is handled via the database UNIQUE constraint on `external_id` — if the user already exists, `Create` returns `ALREADY_EXISTS`.
+
+**Alternatives considered**:
+- **New `GetOrCreate` RPC**: Single idempotent call. However, this introduces a non-standard RPC pattern and mixes read/write semantics. The existing `Get`/`Create` separation is cleaner and follows resource-oriented API design (Google AIP).
+
+**Rationale**: Keeping the API surface minimal and following existing conventions. The frontend knows it's a registration flow, so calling `Create` is semantically correct. The `ALREADY_EXISTS` error on retry is a clear, expected response.
+
+### Decision 4: Extract user profile from JWT claims
+
+**Choice**: Use claims already present in the JWT/ID token (`email`, `name`, `locale`) rather than calling Zitadel's UserInfo endpoint.
+
+**Rationale**: The Zitadel OIDC app is configured with `userInfoAssertion: true`, so the ID token already contains profile claims. This avoids an extra network round-trip.
+
+## Risks / Trade-offs
+
+**[Risk] User signs up but closes browser before callback completes** → The user exists in Zitadel but not in the local DB. On next login, the frontend won't call `Create` because `state.isRegistration` is only set during `register()`. Mitigation: Accept this gap for MVP. Future mitigation: add backend interceptor fallback or Zitadel Actions v2 Webhook.
+
+**[Risk] `state` parameter is client-controlled and not tamper-proof** → A malicious client could call `Create` with arbitrary data. Mitigation: The `Create` RPC must validate the JWT and use the authenticated `sub` claim as the source of truth for `external_id`, not client-provided data.
+
+**[Risk] Duplicate `Create` calls** → Network retry or double-click could cause a second `Create` for the same `external_id`. Mitigation: Database UNIQUE constraint on `external_id` ensures the second call returns `ALREADY_EXISTS`. The frontend handles this gracefully.
+
+**[Trade-off] No profile update sync** → If a user changes their email or name in Zitadel, the local DB will be stale. Accepted for MVP — can be addressed later via Zitadel Actions v2 or periodic reconciliation.
+
+## Architecture
+
+```
+┌──────────┐   register()    ┌──────────┐   OIDC callback   ┌──────────┐
+│  User    │ ──────────────► │ Zitadel  │ ────────────────► │ Frontend │
+│          │  prompt=create  │          │   code + state    │          │
+└──────────┘                 └──────────┘                   └────┬─────┘
+                                                                 │
+                                                    state.isRegistration?
+                                                          ┌──────┴──────┐
+                                                          │ yes         │ no
+                                                          ▼             ▼
+                                                   Create RPC        redirect home
+                                                   (external_id,
+                                                    email, name)
+                                                          │
+                                                          ▼
+                                                   ┌──────────┐
+                                                   │ Backend  │
+                                                   │ Create   │
+                                                   └────┬─────┘
+                                                        │
+                                                   INSERT user
+                                                   (external_id UNIQUE)
+                                                        │
+                                                        ▼
+                                                   ┌──────────┐
+                                                   │ Postgres │
+                                                   │  users   │
+                                                   └──────────┘
+```

--- a/openspec/changes/user-account-sync/proposal.md
+++ b/openspec/changes/user-account-sync/proposal.md
@@ -5,7 +5,7 @@ Users who sign up via Zitadel are only registered in the identity provider's dat
 ## What Changes
 
 - Add `external_id` (UUID) column to the `users` table to store the Zitadel `sub` claim, enabling identity-to-application mapping
-- Add `external_id` field to the `User` protobuf entity and `external_id` + `email` as parameters of the existing `Create` RPC
+- Add `external_id` field to the `User` protobuf entity; `Create` RPC accepts `email` parameter (external_id extracted from JWT)
 - Extend the frontend registration callback to call the backend `Create` RPC immediately after signup, using OIDC `state` to detect registration vs login
 - Update the User entity, repository, and protobuf definitions to support `external_id`-based lookup
 - Document the sync architecture decision (MVP: client-side provisioning; future: Zitadel Actions v2 Webhook)
@@ -24,7 +24,7 @@ Users who sign up via Zitadel are only registered in the identity provider's dat
 ## Impact
 
 - **Database**: New migration adding `external_id` column with unique constraint to `users` table
-- **Protobuf**: `User` entity gains `external_id` field; `Create` RPC accepts `external_id` and `email`
-- **Backend**: User repository, use case, and RPC handler updated for `external_id` support
+- **Protobuf**: `User` entity gains `external_id` field; `Create` RPC accepts `email` (breaking change - field 1 type changed)
+- **Backend**: User repository, use case, and RPC handler updated for `external_id` support; handler extracts `sub` from JWT
 - **Frontend**: `auth-service.ts` passes `state` on registration; `auth-callback.ts` calls `Create` RPC on signup
-- **No breaking changes**: Existing API contracts remain unchanged; new field and RPC are additive
+- **Breaking changes**: `CreateRequest` message field 1 changed from `User user` to `UserEmail email`

--- a/openspec/changes/user-account-sync/proposal.md
+++ b/openspec/changes/user-account-sync/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+Users who sign up via Zitadel are only registered in the identity provider's database. The liverty-music backend database has no record of these users, which means user-specific features (artist following, personalized notifications) cannot associate data with authenticated users. An account synchronization mechanism is needed to bridge the gap between Zitadel and the application database.
+
+## What Changes
+
+- Add `external_id` (UUID) column to the `users` table to store the Zitadel `sub` claim, enabling identity-to-application mapping
+- Add `external_id` field to the `User` protobuf entity and `external_id` + `email` as parameters of the existing `Create` RPC
+- Extend the frontend registration callback to call the backend `Create` RPC immediately after signup, using OIDC `state` to detect registration vs login
+- Update the User entity, repository, and protobuf definitions to support `external_id`-based lookup
+- Document the sync architecture decision (MVP: client-side provisioning; future: Zitadel Actions v2 Webhook)
+
+## Capabilities
+
+### New Capabilities
+
+- `user-account-sync`: Synchronizes user accounts from Zitadel to the application database on first registration
+
+### Modified Capabilities
+
+- `user-auth`: Add post-signup account provisioning step to the login callback flow
+- `authentication`: Add `external_id` (Zitadel `sub`) as the primary identity lookup key alongside internal user ID
+
+## Impact
+
+- **Database**: New migration adding `external_id` column with unique constraint to `users` table
+- **Protobuf**: `User` entity gains `external_id` field; `Create` RPC accepts `external_id` and `email`
+- **Backend**: User repository, use case, and RPC handler updated for `external_id` support
+- **Frontend**: `auth-service.ts` passes `state` on registration; `auth-callback.ts` calls `Create` RPC on signup
+- **No breaking changes**: Existing API contracts remain unchanged; new field and RPC are additive

--- a/openspec/changes/user-account-sync/specs/authentication/spec.md
+++ b/openspec/changes/user-account-sync/specs/authentication/spec.md
@@ -1,0 +1,14 @@
+## MODIFIED Requirements
+
+### Requirement: User ID Propagation
+
+The system SHALL extract the user ID from validated tokens and propagate it through the request context.
+
+**Rationale**: Handlers need access to the authenticated user ID to scope operations correctly (e.g., following artists, viewing followed content). The `external_id` (Zitadel `sub`) enables identity resolution against the local database.
+
+#### Scenario: Authenticated Request
+
+- **WHEN** a JWT token is successfully validated
+- **THEN** the system extracts the user ID from the token's `sub` claim
+- **AND** adds the user ID to the request context as `external_id`
+- **AND** makes the user ID accessible to downstream handlers

--- a/openspec/changes/user-account-sync/specs/user-account-sync/docs/sync-approaches-research.md
+++ b/openspec/changes/user-account-sync/specs/user-account-sync/docs/sync-approaches-research.md
@@ -1,0 +1,191 @@
+# Zitadel User Account Sync — Approaches Research
+
+Research conducted: 2026-02-15
+
+## Problem Statement
+
+When a user signs up via Zitadel, the identity is created in Zitadel's database but no corresponding record exists in the liverty-music application database. A synchronization mechanism is needed.
+
+## Approaches Evaluated
+
+### A. Zitadel Actions v2 (Webhook) — Push-based
+
+```
+┌──────────┐  user.human.added  ┌──────────────┐
+│ Zitadel  │ ─────────────────► │ Backend      │
+│          │   HTTP POST        │ /webhooks/   │
+│          │   + Signature      │ user-created │
+└──────────┘                    └──────┬───────┘
+                                       │
+                                       ▼
+                                 ┌──────────┐
+                                 │ Postgres │
+                                 │ INSERT   │
+                                 └──────────┘
+```
+
+Zitadel v2 Actions define external HTTP endpoints (Targets) that receive event POSTs.
+
+- **Execution conditions**: `user.human.added`, `user.human.profile.changed`, etc.
+- **Payload**: userID, email, displayName, createdAt, etc.
+- **Signature verification**: `ZITADEL-Signature` header for integrity
+- `interruptOnError: true` blocks Zitadel operations if webhook fails
+
+**Configuration example**:
+```json
+// 1. Create Target
+POST /v2/actions/targets
+{
+  "name": "sync-user-to-db",
+  "restWebhook": { "interruptOnError": false },
+  "endpoint": "https://your-backend/webhooks/zitadel/user-created",
+  "timeout": "10s"
+}
+
+// 2. Create Execution
+PUT /v2/actions/executions
+{
+  "condition": { "event": { "event": "user.human.added" } },
+  "targets": ["<TargetID>"]
+}
+```
+
+| Pros | Cons |
+|------|------|
+| Real-time sync | Requires hosting webhook endpoint |
+| Language-agnostic | Event loss risk when endpoint is down |
+| Signature verification for security | No documented retry/DLQ mechanism |
+
+### B. First-Login Provisioning — Simplest
+
+```
+┌──────────┐  login   ┌──────────┐  token  ┌──────────┐
+│  User    │ ───────► │ Zitadel  │ ──────► │ Frontend │
+└──────────┘          └──────────┘         └────┬─────┘
+                                                │
+                                          JWT (sub, email, name)
+                                                │
+                                                ▼
+                                          ┌──────────┐
+                                          │ Backend  │
+                                          │ if user  │
+                                          │ not found│──► INSERT
+                                          │ by sub   │
+                                          └────┬─────┘
+                                               ▼
+                                          ┌──────────┐
+                                          │ Postgres │
+                                          └──────────┘
+```
+
+Auth interceptor checks if user exists by `sub` on every authenticated request. Auto-creates if missing.
+
+| Pros | Cons |
+|------|------|
+| No additional infrastructure | DB query on every request |
+| Self-healing (retries on next login) | User doesn't exist until first API call |
+| Easy to test | Mixes auth and provisioning concerns |
+
+### C. Event API (Pull-based Polling)
+
+```
+┌──────────┐                    ┌──────────────┐
+│ Zitadel  │  POST /admin/v1/  │ Cron Job /   │
+│ Event    │ ◄─────────────────│ Worker       │
+│ Store    │  events/_search   │              │
+└──────────┘                    └──────┬───────┘
+                                       │
+                                  filter: user.human.added
+                                  since: last_checkpoint
+                                       │
+                                       ▼
+                                 ┌──────────┐
+                                 │ Postgres │
+                                 │ UPSERT   │
+                                 └──────────┘
+```
+
+Zitadel is event-sourced. All events can be queried via the Admin API.
+
+```json
+POST /admin/v1/events/_search
+{
+  "asc": false,
+  "limit": 1000,
+  "creation_date": "2026-02-15T00:00:00Z",
+  "aggregate_types": ["user"],
+  "event_types": ["user.human.added"]
+}
+```
+
+| Pros | Cons |
+|------|------|
+| No event loss — can backfill | Not real-time (polling interval) |
+| Good for reconciliation | Requires checkpoint management |
+| Works as fallback for webhooks | Requires Admin API access |
+
+### D. Management API (User List Polling)
+
+`POST /management/v1/users/_search` to periodically fetch the user list.
+
+| Pros | Cons |
+|------|------|
+| Simple REST/gRPC API | Pull-based with latency |
+| Good for batch sync/migration | No change detection (state only) |
+
+### E. Actions v1 (JS) — Deprecated
+
+JavaScript snippets running inside Zitadel with `TRIGGER_TYPE_POST_CREATION` trigger.
+
+**⚠️ Scheduled for removal in Zitadel V5. Do not use for new implementations.**
+
+### F. Hybrid Approaches
+
+| Combination | Primary | Fallback | Characteristics |
+|-------------|---------|----------|----------------|
+| B + C | First-Login | Event API Polling | Simple + robust |
+| A + C | Webhook | Event API Polling | Real-time + robust |
+| B + A | First-Login | Webhook | Incremental adoption |
+
+## Comparison Matrix
+
+| # | Approach | Real-time | Impl Cost | Reliability | Zitadel Feature |
+|---|---------|:---------:|:---------:|:-----------:|:---------------:|
+| **A** | Actions v2 (Webhook) | Immediate | Medium | Low (endpoint failure risk) | Yes |
+| **B** | First-Login Provisioning | On first API call | **Low** | High | No |
+| **C** | Event API (Polling) | Polling interval | Medium | High | Yes |
+| **D** | Management API (Polling) | Polling interval | Medium | Medium | Yes |
+| **E** | Actions v1 (JS) | Immediate | Low | Medium | Yes (deprecated) |
+| **F** | Hybrid (A+C or B+C) | Immediate | Medium-High | Very High | Yes |
+
+## Decision
+
+**MVP**: Client-side provisioning via OIDC `state` — Frontend detects signup via `state.isRegistration`, calls `GetOrCreate` RPC immediately in the callback. Simplest approach with zero additional infrastructure.
+
+**Future**: Migrate to Zitadel Actions v2 Webhook for real-time, server-side provisioning. Add Event API polling as a reconciliation fallback.
+
+## Zitadel First-Signup Detection Research
+
+Additional research was conducted on whether Zitadel or OIDC standards can distinguish signup from login:
+
+| Method | Feasibility | Notes |
+|--------|-------------|-------|
+| OIDC standard claims | Not possible | No standard `is_new_user` claim |
+| Zitadel built-in claims | Not possible | No `urn:zitadel:iam:user:is_new` claim |
+| UserInfo `created_at` | Not possible | Not exposed in UserInfo response |
+| `prompt=create` callback | Not possible | Callback is identical to login |
+| `oidc-client-ts` state | **Client-side only** | Pass custom state through OIDC flow |
+| Actions v2 Complement Token | **Possible** | `user.creation_date` available in webhook payload |
+
+The `oidc-client-ts` state approach was selected for MVP due to its simplicity.
+
+## References
+
+- [Zitadel Actions v2 Concepts](https://zitadel.com/docs/concepts/features/actions_v2)
+- [Using Actions](https://zitadel.com/docs/guides/integrate/actions/usage)
+- [Event API](https://zitadel.com/docs/guides/integrate/zitadel-apis/event-api)
+- [OIDC Claims](https://zitadel.com/docs/apis/openidoauth/claims)
+- [User Metadata](https://zitadel.com/docs/guides/manage/customize/user-metadata)
+- [Management API](https://zitadel.com/docs/apis/resources/mgmt)
+- [Migrate Actions v1 to v2](https://zitadel.com/docs/guides/integrate/actions/migrate-from-v1)
+- [Complement Token Flow](https://zitadel.com/docs/apis/actions/complement-token)

--- a/openspec/changes/user-account-sync/specs/user-account-sync/spec.md
+++ b/openspec/changes/user-account-sync/specs/user-account-sync/spec.md
@@ -42,18 +42,19 @@ The `User` protobuf entity SHALL include an `external_id` field to represent the
 - **THEN** it SHALL include the `external_id` field as a UUID string
 - **AND** the field SHALL be validated as a UUID format via protovalidate
 
-### Requirement: Create RPC with External ID and Email
+### Requirement: Create RPC with Email Parameter
 
-The existing `Create` RPC SHALL accept `external_id` and `email` as part of the `User` entity in the request.
+The existing `Create` RPC SHALL accept `email` as a top-level parameter in the request. The `external_id` (Zitadel `sub` claim) SHALL be extracted from the authenticated JWT context by the backend.
 
 #### Scenario: Create user with external identity
 
-- **WHEN** `Create` is called with a `User` containing `external_id` and `email`
-- **THEN** the system SHALL create a new user record with both fields persisted
+- **WHEN** `Create` is called with `email` by an authenticated user
+- **THEN** the system SHALL extract `external_id` from the JWT `sub` claim
+- **AND** create a new user record with both `email` and `external_id` persisted
 
 #### Scenario: Missing required fields
 
-- **WHEN** `Create` is called without `external_id` or `email`
+- **WHEN** `Create` is called without `email`
 - **THEN** the system SHALL return `connect.CodeInvalidArgument`
 
 #### Scenario: Authentication required

--- a/openspec/changes/user-account-sync/specs/user-account-sync/spec.md
+++ b/openspec/changes/user-account-sync/specs/user-account-sync/spec.md
@@ -1,0 +1,62 @@
+## ADDED Requirements
+
+### Requirement: User Account Provisioning on Signup
+
+The system SHALL create a local user record in the application database when a user completes registration via Zitadel, linking the Zitadel identity (`sub` claim) to the local record via an `external_id` field (UUID type).
+
+#### Scenario: Successful signup provisioning
+
+- **WHEN** a user completes registration via Zitadel and the frontend receives the OIDC callback with `state.isRegistration === true`
+- **THEN** the frontend SHALL call the `Create` RPC with the user's `external_id` (Zitadel `sub`), `email`, and `name` from the JWT claims
+- **AND** the backend SHALL create a new user record with `external_id` set to the Zitadel `sub`
+- **AND** the backend SHALL return the created user
+
+#### Scenario: Duplicate provisioning attempt
+
+- **WHEN** the `Create` RPC is called with an `external_id` that already exists in the database
+- **THEN** the system SHALL return `connect.CodeAlreadyExists`
+- **AND** the frontend SHALL handle this error gracefully (treat as success since the user already exists)
+
+### Requirement: External Identity Mapping
+
+The system SHALL maintain a unique mapping between Zitadel identity (`sub` claim) and the local user record using a UUID-typed `external_id` column.
+
+#### Scenario: Store external identity
+
+- **WHEN** a new user record is created via `Create`
+- **THEN** the `external_id` column SHALL be set to the Zitadel `sub` claim value (UUID)
+- **AND** the `external_id` column SHALL have a UNIQUE constraint
+
+#### Scenario: Lookup by external identity
+
+- **WHEN** the system receives a request with a Zitadel `sub` claim
+- **THEN** the system SHALL be able to find the corresponding local user by `external_id`
+
+### Requirement: User Entity External ID Field
+
+The `User` protobuf entity SHALL include an `external_id` field to represent the Zitadel identity link.
+
+#### Scenario: External ID in User entity
+
+- **WHEN** a `User` entity is serialized
+- **THEN** it SHALL include the `external_id` field as a UUID string
+- **AND** the field SHALL be validated as a UUID format via protovalidate
+
+### Requirement: Create RPC with External ID and Email
+
+The existing `Create` RPC SHALL accept `external_id` and `email` as part of the `User` entity in the request.
+
+#### Scenario: Create user with external identity
+
+- **WHEN** `Create` is called with a `User` containing `external_id` and `email`
+- **THEN** the system SHALL create a new user record with both fields persisted
+
+#### Scenario: Missing required fields
+
+- **WHEN** `Create` is called without `external_id` or `email`
+- **THEN** the system SHALL return `connect.CodeInvalidArgument`
+
+#### Scenario: Authentication required
+
+- **WHEN** `Create` is called without a valid JWT token
+- **THEN** the system SHALL return `connect.CodeUnauthenticated`

--- a/openspec/changes/user-account-sync/specs/user-auth/spec.md
+++ b/openspec/changes/user-account-sync/specs/user-auth/spec.md
@@ -1,0 +1,46 @@
+## MODIFIED Requirements
+
+### Requirement: Sign Up / Sign In
+
+The system SHALL provide a mechanism for users to authenticate via the Zitadel Hosted UI using OIDC.
+
+#### Scenario: Initiate Login
+
+- **WHEN** user clicks the "Sign In" or "Sign Up" button
+- **THEN** the system redirects the user to the configured Zitadel Issuer URL
+- **AND** the request includes the correct Client ID and PKCE challenge
+
+#### Scenario: Initiate Registration
+
+- **WHEN** user clicks the "Sign Up" button
+- **THEN** the system SHALL pass `state: { isRegistration: true }` in the OIDC redirect request
+- **AND** the system SHALL use `prompt: 'create'` to show the Zitadel registration form
+
+#### Scenario: Handle Login Callback
+
+- **WHEN** the user is redirected back to `/auth/callback` after successful authentication
+- **THEN** the system exchanges the authorization code for ID/Access tokens
+- **AND** updates the application state to "Authenticated"
+- **AND** redirects the user to the home page (or strict post-login route)
+
+#### Scenario: Handle Registration Callback
+
+- **WHEN** the user is redirected back to `/auth/callback` after successful registration
+- **AND** `state.isRegistration` is `true`
+- **THEN** the system exchanges the authorization code for ID/Access tokens
+- **AND** calls the backend `Create` RPC with the user's `external_id` (from `sub` claim), `email`, and `name` from the token claims
+- **AND** updates the application state to "Authenticated"
+- **AND** redirects the user to the home page
+
+#### Scenario: Registration Callback API Failure
+
+- **WHEN** the `Create` RPC call fails during the registration callback (except `ALREADY_EXISTS`)
+- **THEN** the system SHALL log the error
+- **AND** the system SHALL still complete the authentication flow (user can use the app)
+- **AND** the local user record will be created on a subsequent provisioning attempt
+
+#### Scenario: Registration Callback Duplicate User
+
+- **WHEN** the `Create` RPC returns `ALREADY_EXISTS` during the registration callback
+- **THEN** the system SHALL treat this as a successful provisioning (no error logged)
+- **AND** continue the normal authentication flow

--- a/openspec/changes/user-account-sync/tasks.md
+++ b/openspec/changes/user-account-sync/tasks.md
@@ -1,0 +1,32 @@
+## 1. Database Schema
+
+- [ ] 1.1 Create migration to add `external_id UUID UNIQUE NOT NULL` column to `users` table
+- [ ] 1.2 Update `schema.sql` to reflect the new column
+
+## 2. Protobuf Definitions
+
+- [ ] 2.1 Add `external_id` field (UUID-validated) to `User` entity in `liverty_music/entity/v1/user.proto`
+- [ ] 2.2 Add protovalidate UUID constraint for `external_id` field
+- [ ] 2.3 Run `buf lint` and `buf format` to verify protobuf changes
+
+## 3. Backend Implementation
+
+- [ ] 3.1 Update `User` entity struct in `internal/entity/user.go` to include `ExternalID` field
+- [ ] 3.2 Implement `GetByExternalID` method in `UserRepository` interface and `user_repo.go`
+- [ ] 3.3 Update `Create` method in `user_repo.go` to persist `external_id`
+- [ ] 3.4 Update `Create` RPC handler in `user_handler.go` to require JWT authentication and map `external_id`
+- [ ] 3.5 Write unit tests for repository and handler changes
+
+## 4. Frontend Implementation
+
+- [ ] 4.1 Update `AuthService.register()` to pass `state: { isRegistration: true }` in `signinRedirect`
+- [ ] 4.2 Update `AuthCallback.loading()` to detect `state.isRegistration` after callback
+- [ ] 4.3 Call backend `Create` RPC in callback when `isRegistration` is true, using `sub`, `email`, and `name` from token profile
+- [ ] 4.4 Handle `ALREADY_EXISTS` response gracefully (treat as success)
+- [ ] 4.5 Handle other `Create` failures gracefully — log error but complete auth flow
+
+## 5. Integration Testing
+
+- [ ] 5.1 Verify end-to-end signup flow: Zitadel registration → callback → `Create` → user in DB
+- [ ] 5.2 Verify idempotency: calling `Create` twice with same `external_id` returns `ALREADY_EXISTS`
+- [ ] 5.3 Verify login flow: existing user login does NOT trigger `Create`

--- a/proto/liverty_music/entity/v1/user.proto
+++ b/proto/liverty_music/entity/v1/user.proto
@@ -6,6 +6,25 @@ import "buf/validate/validate.proto";
 import "google/api/field_behavior.proto";
 import "google/protobuf/timestamp.proto";
 
+// UserId is a globally unique identifier for a platform user.
+message UserId {
+  // A UUID string representing the user's unique identity.
+  string value = 1 [(buf.validate.field).string.uuid = true];
+}
+
+// UserExternalId is the identity provider's unique identifier for a user.
+// This maps to the Zitadel `sub` claim and links the external identity to the local user record.
+message UserExternalId {
+  // A UUID string representing the identity provider's user identifier.
+  string value = 1 [(buf.validate.field).string.uuid = true];
+}
+
+// UserEmail represents a validated email address for communications.
+message UserEmail {
+  // The email address string, validated against standard email formats.
+  string value = 1 [(buf.validate.field).string.email = true];
+}
+
 // User represents a registered person on the Liverty Music platform.
 // Users are notified of upcoming concerts based on their following and favorite artists.
 message User {
@@ -17,16 +36,8 @@ message User {
 
   // The time when the user was created.
   google.protobuf.Timestamp create_time = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
-}
 
-// UserId is a globally unique identifier for a platform user.
-message UserId {
-  // A UUID string representing the user's unique identity.
-  string value = 1 [(buf.validate.field).string.uuid = true];
-}
-
-// UserEmail represents a validated email address for communications.
-message UserEmail {
-  // The email address string, validated against standard email formats.
-  string value = 1 [(buf.validate.field).string.email = true];
+  // The identity provider's user identifier (Zitadel sub claim).
+  // Used to link the external identity to the local user record.
+  UserExternalId external_id = 4 [(buf.validate.field).required = true];
 }

--- a/proto/liverty_music/rpc/user/v1/user_service.proto
+++ b/proto/liverty_music/rpc/user/v1/user_service.proto
@@ -36,8 +36,11 @@ message GetResponse {
 
 // CreateRequest provides the necessary details to register a new user profile.
 message CreateRequest {
-  // Required. The user profile data to be created.
-  entity.v1.User user = 1 [(buf.validate.field).required = true];
+  // Required. The identity provider's user identifier (Zitadel sub claim).
+  entity.v1.UserExternalId external_id = 1 [(buf.validate.field).required = true];
+
+  // Required. The user's email address for account identity.
+  entity.v1.UserEmail email = 2 [(buf.validate.field).required = true];
 }
 
 // CreateResponse returns the user profile as successfully created.

--- a/proto/liverty_music/rpc/user/v1/user_service.proto
+++ b/proto/liverty_music/rpc/user/v1/user_service.proto
@@ -35,12 +35,11 @@ message GetResponse {
 }
 
 // CreateRequest provides the necessary details to register a new user profile.
+// The external_id (Zitadel sub claim) is extracted from the authenticated JWT context
+// by the backend and MUST NOT be provided by the client.
 message CreateRequest {
-  // Required. The identity provider's user identifier (Zitadel sub claim).
-  entity.v1.UserExternalId external_id = 1 [(buf.validate.field).required = true];
-
   // Required. The user's email address for account identity.
-  entity.v1.UserEmail email = 2 [(buf.validate.field).required = true];
+  entity.v1.UserEmail email = 1 [(buf.validate.field).required = true];
 }
 
 // CreateResponse returns the user profile as successfully created.


### PR DESCRIPTION
## Summary

This PR implements user account synchronization between Zitadel (identity provider) and the application database. When a user signs up through Zitadel, the frontend will provision a local user record via the Create RPC.

## Changes

### OpenSpec Artifacts
- **Proposal**: Defines the problem, scope, and MVP approach for user account sync
- **Design**: Documents architectural decisions including:
  - Client-side provisioning via OIDC `state` parameter
  - `external_id` column (UUID type) for linking Zitadel identity
  - Using existing `Create` RPC with extended parameters
  - Research on 6 different sync approaches
- **Specs**: Delta specs for affected capabilities (authentication, user-auth, user-account-sync)
- **Tasks**: 18-task implementation checklist across DB, proto, backend, and frontend

### Protocol Buffer Changes
- Add `UserExternalId` message type with UUID validation
- Add `external_id` field to `User` entity (field 4, non-breaking)
- **BREAKING CHANGE**: Update `CreateRequest` to accept `external_id` and `email` parameters directly instead of full `User` entity

## Breaking Changes

The `CreateRequest` message in `user_service.proto` now requires:
- `external_id` (UserExternalId) - Zitadel sub claim
- `email` (UserEmail) - User's email address

This is an intentional breaking change for the MVP implementation. Clients must update to pass these fields directly rather than a `User` entity.

## Next Steps

- [ ] Backend implementation (DB migration, repository, handler updates)
- [ ] Frontend implementation (auth callback integration)
- [ ] Integration testing
- [ ] GitHub release to publish proto changes to BSR

## Related Documentation

- [OpenSpec Proposal](openspec/changes/user-account-sync/proposal.md)
- [Design Document](openspec/changes/user-account-sync/design.md)
- [Sync Approaches Research](openspec/changes/user-account-sync/specs/user-account-sync/docs/sync-approaches-research.md)