### PR TITLE
docs: add name field and update documentation for JWT extraction

### DIFF
--- a/openspec/changes/user-account-sync/design.md
+++ b/openspec/changes/user-account-sync/design.md
@@ -47,7 +47,7 @@ Current state:
 
 ### Decision 3: Use existing `Get` and `Create` RPCs (no new RPC)
 
-**Choice**: Extend the existing `Create` RPC to accept `email` as a parameter. The `external_id` (Zitadel `sub` claim) is extracted from the authenticated JWT context by the backend, not provided by the client. The frontend calls `Create` on signup. Idempotency is handled via the database UNIQUE constraint on `external_id` — if the user already exists, `Create` returns `ALREADY_EXISTS`.
+**Choice**: Extend the existing `Create` RPC to accept `email` as a parameter. The `external_id` (Zitadel `sub` claim) and `name` are extracted from the authenticated JWT context by the backend, not provided by the client. The frontend calls `Create` on signup with email only. Idempotency is handled via the database UNIQUE constraint on `external_id` — if the user already exists, `Create` returns `ALREADY_EXISTS`.
 
 **Alternatives considered**:
 - **New `GetOrCreate` RPC**: Single idempotent call. However, this introduces a non-standard RPC pattern and mixes read/write semantics. The existing `Get`/`Create` separation is cleaner and follows resource-oriented API design (Google AIP).
@@ -64,7 +64,7 @@ Current state:
 
 **[Risk] User signs up but closes browser before callback completes** → The user exists in Zitadel but not in the local DB. On next login, the frontend won't call `Create` because `state.isRegistration` is only set during `register()`. Mitigation: Accept this gap for MVP. Future mitigation: add backend interceptor fallback or Zitadel Actions v2 Webhook.
 
-**[Risk] `state` parameter is client-controlled and not tamper-proof** → A malicious client could call `Create` with arbitrary `email` data. Mitigation: The `Create` RPC extracts `external_id` from the authenticated JWT `sub` claim (not from client request), preventing identity tampering. Email validation is performed by protovalidate.
+**[Risk] `state` parameter is client-controlled and not tamper-proof** → A malicious client could call `Create` with arbitrary `email` data. Mitigation: The `Create` RPC extracts `external_id` and `name` from the authenticated JWT claims (not from client request), preventing identity tampering. Email validation is performed by protovalidate.
 
 **[Risk] Duplicate `Create` calls** → Network retry or double-click could cause a second `Create` for the same `external_id`. Mitigation: Database UNIQUE constraint on `external_id` ensures the second call returns `ALREADY_EXISTS`. The frontend handles this gracefully.
 
@@ -83,8 +83,10 @@ Current state:
                                                           │ yes         │ no
                                                           ▼             ▼
                                                    Create RPC        redirect home
-                                                   (external_id,
-                                                    email, name)
+                                                   (email only;
+                                                    backend extracts
+                                                    external_id, name
+                                                    from JWT)
                                                           │
                                                           ▼
                                                    ┌──────────┐

--- a/openspec/changes/user-account-sync/proposal.md
+++ b/openspec/changes/user-account-sync/proposal.md
@@ -5,7 +5,7 @@ Users who sign up via Zitadel are only registered in the identity provider's dat
 ## What Changes
 
 - Add `external_id` (UUID) column to the `users` table to store the Zitadel `sub` claim, enabling identity-to-application mapping
-- Add `external_id` field to the `User` protobuf entity; `Create` RPC accepts `email` parameter (external_id extracted from JWT)
+- Add `external_id` and `name` fields to the `User` protobuf entity; `Create` RPC accepts `email` parameter (external_id and name extracted from JWT)
 - Extend the frontend registration callback to call the backend `Create` RPC immediately after signup, using OIDC `state` to detect registration vs login
 - Update the User entity, repository, and protobuf definitions to support `external_id`-based lookup
 - Document the sync architecture decision (MVP: client-side provisioning; future: Zitadel Actions v2 Webhook)
@@ -24,7 +24,7 @@ Users who sign up via Zitadel are only registered in the identity provider's dat
 ## Impact
 
 - **Database**: New migration adding `external_id` column with unique constraint to `users` table
-- **Protobuf**: `User` entity gains `external_id` field; `Create` RPC accepts `email` (breaking change - field 1 type changed)
-- **Backend**: User repository, use case, and RPC handler updated for `external_id` support; handler extracts `sub` from JWT
-- **Frontend**: `auth-service.ts` passes `state` on registration; `auth-callback.ts` calls `Create` RPC on signup
+- **Protobuf**: `User` entity gains `external_id` and `name` fields; `Create` RPC accepts `email` (breaking change - field 1 type changed)
+- **Backend**: User repository, use case, and RPC handler updated for `external_id` and `name` support; handler extracts `sub` and `name` from JWT
+- **Frontend**: `auth-service.ts` passes `state` on registration; `auth-callback.ts` calls `Create` RPC with email only
 - **Breaking changes**: `CreateRequest` message field 1 changed from `User user` to `UserEmail email`

--- a/openspec/changes/user-account-sync/specs/user-account-sync/spec.md
+++ b/openspec/changes/user-account-sync/specs/user-account-sync/spec.md
@@ -7,8 +7,9 @@ The system SHALL create a local user record in the application database when a u
 #### Scenario: Successful signup provisioning
 
 - **WHEN** a user completes registration via Zitadel and the frontend receives the OIDC callback with `state.isRegistration === true`
-- **THEN** the frontend SHALL call the `Create` RPC with the user's `external_id` (Zitadel `sub`), `email`, and `name` from the JWT claims
-- **AND** the backend SHALL create a new user record with `external_id` set to the Zitadel `sub`
+- **THEN** the frontend SHALL call the `Create` RPC with the user's `email` parameter only
+- **AND** the backend SHALL extract `external_id` (from JWT `sub` claim) and `name` (from JWT `name` claim)
+- **AND** the backend SHALL create a new user record with `external_id`, `email`, and `name` persisted
 - **AND** the backend SHALL return the created user
 
 #### Scenario: Duplicate provisioning attempt
@@ -49,8 +50,8 @@ The existing `Create` RPC SHALL accept `email` as a top-level parameter in the r
 #### Scenario: Create user with external identity
 
 - **WHEN** `Create` is called with `email` by an authenticated user
-- **THEN** the system SHALL extract `external_id` from the JWT `sub` claim
-- **AND** create a new user record with both `email` and `external_id` persisted
+- **THEN** the system SHALL extract `external_id` from the JWT `sub` claim and `name` from the JWT `name` claim
+- **AND** create a new user record with `email`, `external_id`, and `name` persisted
 
 #### Scenario: Missing required fields
 

--- a/openspec/changes/user-account-sync/specs/user-auth/spec.md
+++ b/openspec/changes/user-account-sync/specs/user-auth/spec.md
@@ -28,7 +28,7 @@ The system SHALL provide a mechanism for users to authenticate via the Zitadel H
 - **WHEN** the user is redirected back to `/auth/callback` after successful registration
 - **AND** `state.isRegistration` is `true`
 - **THEN** the system exchanges the authorization code for ID/Access tokens
-- **AND** calls the backend `Create` RPC with the user's `external_id` (from `sub` claim), `email`, and `name` from the token claims
+- **AND** calls the backend `Create` RPC with the user's `email` parameter (backend extracts `external_id` and `name` from JWT)
 - **AND** updates the application state to "Authenticated"
 - **AND** redirects the user to the home page
 

--- a/openspec/changes/user-account-sync/tasks.md
+++ b/openspec/changes/user-account-sync/tasks.md
@@ -21,7 +21,7 @@
 
 - [ ] 4.1 Update `AuthService.register()` to pass `state: { isRegistration: true }` in `signinRedirect`
 - [ ] 4.2 Update `AuthCallback.loading()` to detect `state.isRegistration` after callback
-- [ ] 4.3 Call backend `Create` RPC in callback when `isRegistration` is true, using `sub`, `email`, and `name` from token profile
+- [ ] 4.3 Call backend `Create` RPC in callback when `isRegistration` is true, passing `email` only (backend extracts `external_id` from JWT `sub` claim and `name` from JWT `name` claim)
 - [ ] 4.4 Handle `ALREADY_EXISTS` response gracefully (treat as success)
 - [ ] 4.5 Handle other `Create` failures gracefully — log error but complete auth flow
 

--- a/proto/liverty_music/entity/v1/user.proto
+++ b/proto/liverty_music/entity/v1/user.proto
@@ -40,4 +40,7 @@ message User {
   // The identity provider's user identifier (Zitadel sub claim).
   // Used to link the external identity to the local user record.
   UserExternalId external_id = 4 [(buf.validate.field).required = true];
+
+  // The user's display name, synced from the identity provider.
+  string name = 5;
 }

--- a/proto/liverty_music/rpc/user/v1/user_service.proto
+++ b/proto/liverty_music/rpc/user/v1/user_service.proto
@@ -35,7 +35,7 @@ message GetResponse {
 }
 
 // CreateRequest provides the necessary details to register a new user profile.
-// The external_id (Zitadel sub claim) is extracted from the authenticated JWT context
+// The external_id (Zitadel sub claim) and name are extracted from the authenticated JWT context
 // by the backend and MUST NOT be provided by the client.
 message CreateRequest {
   // Required. The user's email address for account identity.


### PR DESCRIPTION
## Summary

This PR adds the `name` field to the User entity and updates all documentation to reflect that both `external_id` and `name` are extracted from JWT by the backend (not passed by the client).

## Changes

### Proto Changes
- Add `name` field (field 5) to `User` entity in `user.proto`
- Update `CreateRequest` comment to clarify both `external_id` and `name` are extracted from JWT

### Documentation Updates
- **proposal.md**: Updated to mention `name` field addition and JWT extraction
- **design.md**: Updated Decision 3 to clarify both fields are extracted from JWT; fixed architecture diagram
- **specs/user-account-sync/spec.md**: Updated requirements to reflect backend extraction
- **specs/user-auth/spec.md**: Updated registration callback to show only email is passed
- **tasks.md**: Updated task 4.3 to clarify backend extracts identity from JWT

## Context

This follows the security improvement from PR #30 where `external_id` was removed from `CreateRequest` to prevent client-side tampering. The backend now extracts both `external_id` (from JWT `sub` claim) and `name` (from JWT `name` claim) server-side.

## Related

- Closes review feedback from PR #30
- Implements approved plan from previous session