### PR TITLE
feat(spec): add landing page and loading sequence specs for onboarding flow

### DIFF
--- a/openspec/changes/frontend-landing-page/.openspec.yaml
+++ b/openspec/changes/frontend-landing-page/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-02-15

--- a/openspec/changes/frontend-landing-page/design.md
+++ b/openspec/changes/frontend-landing-page/design.md
@@ -1,0 +1,56 @@
+## Context
+
+The current frontend (`welcome-page`) is a placeholder with no product messaging or auth integration. The `auth-service` and `auth-callback` route already exist and handle the Zitadel OIDC flow with Passkey authentication (Passkeys-only policy configured in Zitadel), but there is no dedicated landing page that funnels first-time users into sign-up.
+
+The Artist Discovery step (`frontend-artist-discovery-ui`) is being implemented in a separate worktree and is near completion. The landing page is the immediate predecessor in the onboarding flow.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Create a visually compelling, mobile-first landing page with hero copy and Sign Up / Sign In CTA (Passkey auth via Zitadel).
+- Route authenticated users to the correct next step (Artist Discovery for new users, Dashboard for returning users).
+- Maintain sub-second load time for the landing page (no heavy assets).
+
+**Non-Goals:**
+- Multi-provider OAuth (Google, Spotify, Apple Music, YouTube) — out of MVP scope; Passkey-only.
+- Email/password sign-up — Passkey-only via Zitadel.
+- A/B testing of hero copy — future concern.
+- SEO optimization beyond basic meta tags — PWA focus.
+
+## Decisions
+
+### 1. Replace WelcomePage In-Place
+**Decision**: Replace the existing `WelcomePage` component content rather than creating a new route.
+**Rationale**: The root route (`/`) should serve as the landing page. No need for an additional route. The existing routing structure already handles `/` → `WelcomePage`.
+
+### 2. Auth State-Based Routing
+**Decision**: Use the existing `auth-service` to check authentication status on the landing page. If already authenticated, redirect immediately.
+**Rationale**: Prevents authenticated users from seeing the sign-up page. The `auth-service` already provides `isAuthenticated` state.
+
+**Post-auth redirect flow:**
+```
+Landing Page (/)
+  → [Click "Sign Up" / "Sign In"]
+  → Zitadel OIDC flow (Passkey authentication)
+  → /auth/callback
+  → Check onboarding status
+  → /onboarding/discover (new user)
+  → /dashboard (returning user)
+```
+
+### 3. Onboarding Completion Check
+**Decision**: Use the `ListFollowedArtists` RPC to determine onboarding completion. If the user has ≥1 followed artist, they are considered onboarded and routed to the Dashboard.
+**Rationale**: Simple heuristic that avoids adding a separate "onboarding_completed" flag. A user who has followed at least one artist has completed the discovery step.
+
+### 4. Styling Approach
+**Decision**: Use Tailwind CSS utility classes, consistent with the existing frontend setup.
+**Rationale**: The project already uses Tailwind. The landing page is primarily typography and a button — no complex component library needed.
+
+## Risks / Trade-offs
+
+- **[Risk] Auth redirect loop** → If auth state is stale, the user could be redirected back to landing.
+  - **Mitigation**: Check token validity on landing page load; clear stale tokens before rendering.
+- **[Trade-off] No server-side rendering** → First paint depends on JS bundle load.
+  - **Mitigation**: Keep the landing page component minimal (no heavy imports). Consider inlining critical CSS.
+- **[Risk] Onboarding heuristic false positive** → A user who unfollowed all artists would be treated as "not onboarded."
+  - **Mitigation**: Acceptable for MVP. Can add explicit onboarding status later if needed.

--- a/openspec/changes/frontend-landing-page/proposal.md
+++ b/openspec/changes/frontend-landing-page/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+The current frontend has a generic welcome page placeholder with no value proposition or authentication integration. New users need a landing page that communicates the core service promise ("Never miss your favorite artist's live show again") and provides frictionless Passkey authentication via Zitadel, serving as the entry point to the onboarding flow.
+
+## What Changes
+
+- Replace the existing `WelcomePage` with a purpose-built Landing Page component that presents the hero copy and a Sign Up / Sign In CTA.
+- Integrate the existing `auth-service` to trigger the Zitadel OIDC flow (Passkey authentication) from the CTA button.
+- Implement post-authentication routing: redirect authenticated users to the Artist Discovery step (or Dashboard if onboarding is already complete).
+- Add mobile-first responsive styling optimized for smartphone portrait mode.
+
+## Capabilities
+
+### New Capabilities
+- `landing-page`: The first-view landing page UI component, hero messaging, and CTA-to-auth integration.
+
+### Modified Capabilities
+- `user-auth`: Add routing logic for post-authentication redirect to onboarding flow (Artist Discovery) vs. returning user redirect to Dashboard.
+- `frontend-onboarding-flow`: Update the overall flow to formally define the Landing Page as Step 1 entry point.
+
+## Impact
+
+- **Frontend**: New landing page component replaces `WelcomePage`. Route configuration updates for onboarding flow entry.
+- **Auth**: Post-login redirect logic changes (callback route needs to check onboarding completion status).
+- **No backend changes**: All authentication infrastructure (Zitadel, JWT validation) already exists.

--- a/openspec/changes/frontend-landing-page/specs/frontend-onboarding-flow/spec.md
+++ b/openspec/changes/frontend-landing-page/specs/frontend-onboarding-flow/spec.md
@@ -1,0 +1,19 @@
+## MODIFIED Requirements
+
+### Requirement: Landing Page with Authentication
+The system SHALL provide a landing page that communicates the service value proposition and enables user authentication via Zitadel (Passkey authentication), with post-authentication routing based on onboarding completion status.
+
+#### Scenario: First-time user visits landing page
+- **WHEN** a user accesses the application for the first time
+- **THEN** the system SHALL display a hero message communicating the core value ("大好きなあのバンドのライブ、もう二度と見逃さない。")
+- **AND** the system SHALL display a sub-message ("あなたの推しアーティストを登録するだけで、全国のライブ日程を自動収集。")
+- **AND** the system SHALL provide "Sign Up" and "Sign In" buttons for Passkey authentication
+- **AND** the system SHALL NOT provide Google, Spotify, Apple Music, or YouTube OAuth (out of MVP scope)
+
+#### Scenario: User initiates Passkey authentication via Zitadel
+- **WHEN** a user clicks the "Sign Up" or "Sign In" button
+- **THEN** the system SHALL redirect the user to Zitadel OIDC flow for Passkey authentication
+- **AND** upon successful authentication, Zitadel SHALL create or retrieve the user account
+- **AND** the system SHALL check onboarding completion status
+- **AND** if incomplete, the system SHALL redirect to the Artist Discovery step
+- **AND** if complete, the system SHALL redirect to the Dashboard

--- a/openspec/changes/frontend-landing-page/specs/landing-page/spec.md
+++ b/openspec/changes/frontend-landing-page/specs/landing-page/spec.md
@@ -1,0 +1,45 @@
+## ADDED Requirements
+
+### Requirement: Landing Page Hero Display
+The system SHALL display a landing page with a compelling value proposition when an unauthenticated user visits the root URL.
+
+#### Scenario: First-time visitor sees hero content
+- **WHEN** an unauthenticated user navigates to `/`
+- **THEN** the system SHALL display a hero heading with the text "大好きなあのバンドのライブ、もう二度と見逃さない。"
+- **AND** the system SHALL display a sub-heading with the text "あなたの推しアーティストを登録するだけで、全国のライブ日程を自動収集。"
+- **AND** the page SHALL be optimized for mobile portrait orientation
+
+### Requirement: Passkey Authentication CTA
+The system SHALL provide "Sign Up" and "Sign In" buttons that trigger Passkey authentication via Zitadel.
+
+#### Scenario: New user initiates sign-up
+- **WHEN** an unauthenticated user clicks the "Sign Up" button
+- **THEN** the system SHALL initiate the Zitadel OIDC flow with `prompt=create` to default to the registration form
+- **AND** Zitadel SHALL handle Passkey registration via its hosted UI
+
+#### Scenario: Returning user initiates sign-in
+- **WHEN** an unauthenticated user clicks the "Sign In" button
+- **THEN** the system SHALL initiate the Zitadel OIDC flow for Passkey authentication
+
+#### Scenario: No alternative auth methods displayed
+- **WHEN** the landing page is displayed
+- **THEN** the system SHALL NOT display email/password fields or social login buttons (Google, Spotify, etc.)
+- **AND** Passkey SHALL be the sole authentication method
+
+### Requirement: Authenticated User Redirect
+The system SHALL redirect already-authenticated users away from the landing page.
+
+#### Scenario: Authenticated user visits landing page
+- **WHEN** an authenticated user navigates to `/`
+- **THEN** the system SHALL check whether the user has completed onboarding (has ≥1 followed artist)
+- **AND** if onboarding is incomplete, the system SHALL redirect to the Artist Discovery page
+- **AND** if onboarding is complete, the system SHALL redirect to the Dashboard
+
+### Requirement: Mobile-First Layout
+The system SHALL render the landing page with a mobile-first responsive design.
+
+#### Scenario: Mobile viewport rendering
+- **WHEN** the landing page is accessed on a smartphone (viewport width < 768px)
+- **THEN** the system SHALL center the hero content vertically and horizontally
+- **AND** the CTA button SHALL be full-width with adequate touch target size (minimum 48px height)
+- **AND** the system SHALL NOT produce horizontal scrolling

--- a/openspec/changes/frontend-landing-page/specs/user-auth/spec.md
+++ b/openspec/changes/frontend-landing-page/specs/user-auth/spec.md
@@ -1,0 +1,20 @@
+## MODIFIED Requirements
+
+### Requirement: Sign Up / Sign In
+
+The system SHALL provide a mechanism for users to authenticate via the Zitadel Hosted UI using OIDC.
+
+#### Scenario: Initiate Login
+
+- **WHEN** user clicks the "Sign Up" or "Sign In" button on the landing page
+- **THEN** the system redirects the user to the configured Zitadel Issuer URL
+- **AND** the request includes the correct Client ID and PKCE challenge
+
+#### Scenario: Handle Login Callback with Onboarding Routing
+
+- **WHEN** the user is redirected back to `/auth/callback` after successful authentication
+- **THEN** the system exchanges the authorization code for ID/Access tokens
+- **AND** updates the application state to "Authenticated"
+- **AND** the system SHALL check if the user has ≥1 followed artist via `ListFollowedArtists` RPC
+- **AND** if the user has no followed artists, the system SHALL redirect to the Artist Discovery page (`/onboarding/discover`)
+- **AND** if the user has ≥1 followed artist, the system SHALL redirect to the Dashboard (`/dashboard`)

--- a/openspec/changes/frontend-landing-page/tasks.md
+++ b/openspec/changes/frontend-landing-page/tasks.md
@@ -1,0 +1,17 @@
+## 1. Landing Page Component
+
+- [ ] 1.1 Replace `WelcomePage` component with `LandingPage` (hero heading, sub-heading, layout structure)
+- [ ] 1.2 Add "Sign Up" (calls `auth-service.register()`) and "Sign In" (calls `auth-service.signIn()`) CTA buttons for Passkey authentication
+- [ ] 1.3 Implement mobile-first responsive styling (centered hero, full-width CTA, no horizontal scroll)
+
+## 2. Post-Authentication Routing
+
+- [ ] 2.1 Update `auth-callback` route to check onboarding status via `ListFollowedArtists` RPC after token exchange
+- [ ] 2.2 Implement conditional redirect: `/onboarding/discover` (no followed artists) vs `/dashboard` (≥1 followed artist)
+- [ ] 2.3 Add authenticated-user redirect on landing page (skip landing if already authenticated)
+
+## 3. Route Configuration
+
+- [ ] 3.1 Register `/onboarding/discover` route placeholder for Artist Discovery handoff
+- [ ] 3.2 Register `/dashboard` route placeholder for Dashboard handoff
+- [ ] 3.3 Update root route `/` to use `LandingPage` component

--- a/openspec/changes/frontend-loading-sequence/.openspec.yaml
+++ b/openspec/changes/frontend-loading-sequence/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-02-15

--- a/openspec/changes/frontend-loading-sequence/design.md
+++ b/openspec/changes/frontend-loading-sequence/design.md
@@ -1,0 +1,77 @@
+## Context
+
+The onboarding flow has 4 steps: Landing Page → Artist Discovery → **Loading Sequence** → Dashboard. After the user follows artists in the Discovery step, the system must aggregate live event data before it can render the Dashboard. The backend already provides `SearchNewConcerts` (per-artist Gemini-powered search) and `ListFollowedArtists` RPCs. The Loading Sequence is a frontend-only concern that orchestrates these calls and provides an engaging waiting experience.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Display a phased animated loading screen with progressive messaging during data aggregation.
+- Orchestrate parallel `SearchNewConcerts` calls for followed artists.
+- Enforce a 10-second global timeout with graceful degradation.
+- Ensure a minimum 3-second display time for the loading animation.
+- Transition to Dashboard upon completion.
+
+**Non-Goals:**
+- Modifying the `SearchNewConcerts` backend implementation.
+- Caching or persisting aggregation results on the frontend (backend handles persistence).
+- Retry logic for failed searches (proceed with partial results).
+
+## Decisions
+
+### 1. Data Aggregation Strategy
+**Decision**: Use `Promise.allSettled()` to fire `SearchNewConcerts` for all followed artists in parallel, wrapped in a global `AbortController` with 10-second timeout.
+**Rationale**: `allSettled` ensures partial failures don't block the entire flow. Artists whose searches fail or timeout are simply excluded from the initial Dashboard render — the data can be fetched later.
+
+```
+┌──────────────────────────────────────────────────────┐
+│                Loading Sequence                       │
+│                                                       │
+│  ListFollowedArtists()                               │
+│       │                                               │
+│       ▼                                               │
+│  ┌────────────────────────────────────────┐           │
+│  │  Promise.allSettled([                  │           │
+│  │    SearchNewConcerts(artist_1),        │           │
+│  │    SearchNewConcerts(artist_2),        │           │
+│  │    ...                                │           │
+│  │    SearchNewConcerts(artist_n),        │           │
+│  │  ])                                   │           │
+│  └────────────────────────────────────────┘           │
+│       │                          │                    │
+│       ▼                          ▼                    │
+│   All settled              10s timeout fires          │
+│       │                          │                    │
+│       └──────────┬───────────────┘                    │
+│                  ▼                                    │
+│         min(3s) elapsed?                             │
+│           yes → navigate(/dashboard)                 │
+│           no  → wait remaining, then navigate        │
+└──────────────────────────────────────────────────────┘
+```
+
+### 2. Animation Phases
+**Decision**: Three sequential text phases with CSS transitions, independent of actual data loading progress.
+**Rationale**: The phases are purely decorative ("benevolent deception"). Tying them to real progress would create unpredictable transitions. Fixed timing provides a polished experience.
+
+| Phase | Timing | Message |
+|-------|--------|---------|
+| 1 | 0–2s | 「あなたのMusic DNAを構築中...」 |
+| 2 | 2–5s | 「全国のライブスケジュールと照合中...」 |
+| 3 | 5s+ | 「AIが最新のツアー情報を検索中... 🤖」 |
+
+### 3. Navigation Guard
+**Decision**: The loading sequence route SHALL only be accessible from the Artist Discovery step. Direct URL access SHALL redirect to the appropriate step based on auth/onboarding state.
+**Rationale**: Prevents users from accidentally triggering redundant data aggregation by bookmarking or refreshing the loading URL.
+
+### 4. Minimum Display Duration
+**Decision**: Use `Promise.all([dataAggregation, minimumDelay(3000)])` to ensure both data loading and the minimum delay complete before navigating.
+**Rationale**: Simple and race-condition-free. The 3-second minimum ensures users always see the animation, even on fast connections.
+
+## Risks / Trade-offs
+
+- **[Risk] Large number of followed artists causes timeout** → If a user follows 30+ artists, parallel searches may overwhelm the backend.
+  - **Mitigation**: Batch searches in groups of 5 with sequential batches. The 10-second global timeout ensures the UI never blocks indefinitely.
+- **[Trade-off] No real progress indication** → Users don't see which artists have been processed.
+  - **Mitigation**: The phased messaging creates a sense of progress. Real progress bars are complex and may regress if searches fail.
+- **[Risk] Route refresh triggers re-aggregation** → Refreshing the loading page could re-trigger all searches.
+  - **Mitigation**: Navigation guard redirects direct access away from the loading route. On refresh, redirect to Dashboard (data was already persisted by backend).

--- a/openspec/changes/frontend-loading-sequence/design.md
+++ b/openspec/changes/frontend-loading-sequence/design.md
@@ -19,8 +19,8 @@ The onboarding flow has 4 steps: Landing Page → Artist Discovery → **Loading
 ## Decisions
 
 ### 1. Data Aggregation Strategy
-**Decision**: Use `Promise.allSettled()` to fire `SearchNewConcerts` for all followed artists in parallel, wrapped in a global `AbortController` with 10-second timeout.
-**Rationale**: `allSettled` ensures partial failures don't block the entire flow. Artists whose searches fail or timeout are simply excluded from the initial Dashboard render — the data can be fetched later.
+**Decision**: Use `Promise.allSettled()` to fire `SearchNewConcerts` for all followed artists in parallel, wrapped in a global `AbortController` with 10-second timeout. If the initial `ListFollowedArtists` call fails, the system SHALL attempt a single retry before gracefully navigating to the Dashboard.
+**Rationale**: `allSettled` ensures partial failures don't block the entire flow. Artists whose searches fail or timeout are simply excluded from the initial Dashboard render — the data can be fetched later. The retry logic for `ListFollowedArtists` prevents the loading screen from becoming stuck if the initial artist list retrieval fails.
 
 ```
 ┌──────────────────────────────────────────────────────┐

--- a/openspec/changes/frontend-loading-sequence/proposal.md
+++ b/openspec/changes/frontend-loading-sequence/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+After the Artist Discovery step, the system needs to aggregate live event data for all followed artists before rendering the Dashboard. This involves querying the internal database and potentially invoking Gemini API for artists without existing event data — a process that takes 3-10 seconds. Without a purposeful loading experience, users face a blank screen or simple spinner, creating anxiety and drop-off risk at the most critical moment of the onboarding flow.
+
+## What Changes
+
+- **New Loading Sequence component**: A multi-phase animated loading screen with progressive messaging ("Building your Music DNA..." → "Cross-referencing live schedules..." → "AI searching for latest tour info...").
+- **Backend data aggregation trigger**: Frontend calls `SearchNewConcerts` for each followed artist that lacks concert data, with a 10-second global timeout.
+- **Minimum display duration**: Enforce a 3-second minimum display time even if data loads faster, ensuring the "benevolent deception" effect.
+- **Graceful degradation**: If the timeout fires, proceed to Dashboard with whatever data was successfully retrieved.
+
+## Capabilities
+
+### New Capabilities
+- `loading-sequence`: The animated loading screen UI, data aggregation orchestration, timeout handling, and transition to Dashboard.
+
+### Modified Capabilities
+- `frontend-onboarding-flow`: Update flow to include Loading Sequence as the transition between Artist Discovery and Dashboard.
+
+## Impact
+
+- **Frontend**: New Aurelia 2 component for the loading sequence. Route addition at `/onboarding/loading`.
+- **Backend**: No new endpoints — uses existing `SearchNewConcerts` and `ListFollowedArtists` RPCs.
+- **UX**: Critical flow step that bridges Artist Discovery → Dashboard with engagement rather than dead time.

--- a/openspec/changes/frontend-loading-sequence/specs/frontend-onboarding-flow/spec.md
+++ b/openspec/changes/frontend-loading-sequence/specs/frontend-onboarding-flow/spec.md
@@ -1,0 +1,26 @@
+## MODIFIED Requirements
+
+### Requirement: Loading Sequence with Benevolent Deception
+The system SHALL provide an engaging loading experience during data aggregation to maintain user engagement during processing time (3-10 seconds).
+
+#### Scenario: Data loading with progressive messaging
+- **WHEN** the system begins aggregating live event data for followed artists
+- **THEN** the system SHALL display a multi-step animated loading sequence (NOT a simple spinner)
+- **AND** Phase 1 (0-2s) SHALL display: "あなたのMusic DNAを構築中..."
+- **AND** Phase 2 (2-5s) SHALL display: "全国のライブスケジュールと照合中..."
+- **AND** Phase 3 (5s+) SHALL display: "AIが最新のツアー情報を検索中... 🤖"
+- **AND** the system SHALL enforce a minimum 3-second display duration even if data loading completes earlier
+- **AND** the system SHALL call `SearchNewConcerts` for each followed artist in parallel
+- **AND** the system SHALL use a 10-second global timeout via `AbortController`
+
+#### Scenario: Loading timeout handling
+- **WHEN** data loading exceeds 10 seconds
+- **THEN** the system SHALL terminate all remaining search requests
+- **AND** the system SHALL proceed to the Dashboard with only the successfully retrieved artist data
+- **AND** the system SHALL NOT display an infinite loading state
+
+#### Scenario: Transition from Artist Discovery
+- **WHEN** the user completes the Artist Discovery step
+- **THEN** the system SHALL navigate to `/onboarding/loading`
+- **AND** the loading sequence SHALL automatically begin data aggregation
+- **AND** upon completion, the system SHALL navigate to the Dashboard

--- a/openspec/changes/frontend-loading-sequence/specs/loading-sequence/spec.md
+++ b/openspec/changes/frontend-loading-sequence/specs/loading-sequence/spec.md
@@ -43,6 +43,12 @@ The system SHALL trigger `SearchNewConcerts` for each followed artist in paralle
 - **THEN** the system SHALL proceed with successfully retrieved data
 - **AND** the system SHALL NOT block navigation due to individual artist failures
 
+#### Scenario: Initial artist list retrieval failure
+- **WHEN** the loading sequence starts
+- **AND** the `ListFollowedArtists` RPC fails after retries
+- **THEN** the system SHALL navigate to the Dashboard
+- **AND** the system SHALL NOT display an infinite loading state
+
 ### Requirement: Global Timeout
 The system SHALL enforce a 10-second global timeout on data aggregation to prevent infinite loading states.
 

--- a/openspec/changes/frontend-loading-sequence/specs/loading-sequence/spec.md
+++ b/openspec/changes/frontend-loading-sequence/specs/loading-sequence/spec.md
@@ -1,0 +1,68 @@
+## ADDED Requirements
+
+### Requirement: Progressive Loading Animation
+The system SHALL display a multi-phase animated loading sequence during data aggregation, replacing a simple spinner.
+
+#### Scenario: Phase 1 display (0-2 seconds)
+- **WHEN** the loading sequence begins
+- **THEN** the system SHALL display the message "あなたのMusic DNAを構築中..."
+- **AND** the message SHALL appear with a fade-in animation
+
+#### Scenario: Phase 2 display (2-5 seconds)
+- **WHEN** 2 seconds have elapsed since the loading sequence began
+- **THEN** the system SHALL transition to display the message "全国のライブスケジュールと照合中..."
+- **AND** the transition SHALL use a smooth crossfade animation
+
+#### Scenario: Phase 3 display (5+ seconds)
+- **WHEN** 5 seconds have elapsed since the loading sequence began
+- **THEN** the system SHALL transition to display the message "AIが最新のツアー情報を検索中... 🤖"
+
+### Requirement: Minimum Display Duration
+The system SHALL enforce a minimum 3-second display time for the loading sequence regardless of data loading speed.
+
+#### Scenario: Fast data load
+- **WHEN** all data aggregation completes in under 3 seconds
+- **THEN** the system SHALL continue displaying the loading animation until 3 seconds have elapsed
+- **AND** the system SHALL then navigate to the Dashboard
+
+#### Scenario: Normal data load
+- **WHEN** data aggregation completes after 3 or more seconds
+- **THEN** the system SHALL navigate to the Dashboard immediately upon completion
+
+### Requirement: Data Aggregation Orchestration
+The system SHALL trigger `SearchNewConcerts` for each followed artist in parallel during the loading sequence.
+
+#### Scenario: Successful aggregation for all artists
+- **WHEN** the loading sequence starts
+- **THEN** the system SHALL call `ListFollowedArtists` to retrieve the user's followed artists
+- **AND** the system SHALL call `SearchNewConcerts` for each followed artist in parallel
+- **AND** upon all searches completing, the system SHALL navigate to the Dashboard
+
+#### Scenario: Partial failure
+- **WHEN** `SearchNewConcerts` fails for one or more artists
+- **THEN** the system SHALL proceed with successfully retrieved data
+- **AND** the system SHALL NOT block navigation due to individual artist failures
+
+### Requirement: Global Timeout
+The system SHALL enforce a 10-second global timeout on data aggregation to prevent infinite loading states.
+
+#### Scenario: Timeout fires
+- **WHEN** 10 seconds have elapsed and data aggregation has not completed
+- **THEN** the system SHALL abort all remaining search requests
+- **AND** the system SHALL navigate to the Dashboard with only the successfully retrieved data
+- **AND** the system SHALL NOT display an error message
+
+### Requirement: Navigation Guard
+The system SHALL prevent direct access to the loading sequence route.
+
+#### Scenario: Direct URL access while unauthenticated
+- **WHEN** an unauthenticated user navigates directly to `/onboarding/loading`
+- **THEN** the system SHALL redirect to the Landing Page (`/`)
+
+#### Scenario: Direct URL access while authenticated with completed onboarding
+- **WHEN** an authenticated user with ≥1 followed artist navigates directly to `/onboarding/loading`
+- **THEN** the system SHALL redirect to the Dashboard (`/dashboard`)
+
+#### Scenario: Direct URL access while authenticated without followed artists
+- **WHEN** an authenticated user with no followed artists navigates directly to `/onboarding/loading`
+- **THEN** the system SHALL redirect to the Artist Discovery page (`/onboarding/discover`)

--- a/openspec/changes/frontend-loading-sequence/tasks.md
+++ b/openspec/changes/frontend-loading-sequence/tasks.md
@@ -1,0 +1,18 @@
+## 1. Loading Sequence Component
+
+- [ ] 1.1 Create `LoadingSequence` Aurelia 2 component with phased text animation (3 phases with crossfade transitions)
+- [ ] 1.2 Implement phase timing logic: Phase 1 (0-2s), Phase 2 (2-5s), Phase 3 (5s+)
+- [ ] 1.3 Add mobile-first responsive styling (centered content, full-screen layout)
+
+## 2. Data Aggregation Orchestration
+
+- [ ] 2.1 Call `ListFollowedArtists` on component activation to retrieve followed artist list
+- [ ] 2.2 Implement parallel `SearchNewConcerts` calls using `Promise.allSettled()` with batching (groups of 5)
+- [ ] 2.3 Add `AbortController` with 10-second global timeout
+- [ ] 2.4 Implement minimum 3-second display duration using `Promise.all([aggregation, delay(3000)])`
+
+## 3. Navigation & Route Guards
+
+- [ ] 3.1 Register `/onboarding/loading` route with `LoadingSequence` component
+- [ ] 3.2 Implement navigation guard: redirect unauthenticated users to `/`, authenticated-with-artists to `/dashboard`, authenticated-without-artists to `/onboarding/discover`
+- [ ] 3.3 Navigate to `/dashboard` on aggregation completion or timeout

--- a/openspec/changes/frontend-loading-sequence/tasks.md
+++ b/openspec/changes/frontend-loading-sequence/tasks.md
@@ -7,8 +7,8 @@
 ## 2. Data Aggregation Orchestration
 
 - [ ] 2.1 Call `ListFollowedArtists` on component activation to retrieve followed artist list
-- [ ] 2.2 Implement parallel `SearchNewConcerts` calls using `Promise.allSettled()` with batching (groups of 5)
-- [ ] 2.3 Add `AbortController` with 10-second global timeout
+- [ ] 2.2 Implement parallel `SearchNewConcerts` calls using `Promise.allSettled()` with sequential batching (groups of 5 processed sequentially to prevent backend overload)
+- [ ] 2.3 Add `AbortController` with 10-second global timeout and retry logic for `ListFollowedArtists` (single retry, then fallback to Dashboard)
 - [ ] 2.4 Implement minimum 3-second display duration using `Promise.all([aggregation, delay(3000)])`
 
 ## 3. Navigation & Route Guards


### PR DESCRIPTION
## Summary

Creates OpenSpec changes for **Step 1 (Landing Page)** and **Step 3 (Loading Sequence)** of the onboarding flow, complementing the existing Artist Discovery implementation.

## Changes

### `frontend-landing-page` (Step 1)
- **Proposal**: Replace `WelcomePage` with hero copy and Passkey authentication CTA
- **Design**: Auth state-based routing, `ListFollowedArtists` heuristic for onboarding completion
- **Specs**: 
  - `landing-page` (new capability)
  - `user-auth` (modified - post-auth onboarding routing)
  - `frontend-onboarding-flow` (modified - Step 1 entry point)
- **Tasks**: 9 tasks (component replacement, auth integration, route configuration)

### `frontend-loading-sequence` (Step 3)
- **Proposal**: Multi-phase animated loading with data aggregation during Artist Discovery → Dashboard transition
- **Design**: `Promise.allSettled` orchestration, `AbortController` with 10s timeout, 3s minimum display
- **Specs**:
  - `loading-sequence` (new capability)
  - `frontend-onboarding-flow` (modified - Step 3 transition)
- **Tasks**: 10 tasks (UI component, parallel RPC calls, navigation guards)

## Architecture

**Onboarding Flow**: Landing → Artist Discovery → Loading → Dashboard

**Authentication**: Passkey-only via Zitadel (no Google OAuth per MVP scope)

**Onboarding Completion Heuristic**: User with ≥1 followed artist = onboarded → Dashboard; otherwise → Artist Discovery

## Implementation Status

- ✅ Step 1 (Landing Page): Spec complete, ready for implementation
- ⚙️ Step 2 (Artist Discovery): Implementation in progress in separate worktree
- ✅ Step 3 (Loading Sequence): Spec complete, ready for implementation
- 📋 Step 4 (Dashboard): Spec exists, tasks not yet created