### PR TITLE
docs(openspec): sync refine-ui-design specs to main

### DIFF
--- a/openspec/specs/app-shell-layout/spec.md
+++ b/openspec/specs/app-shell-layout/spec.md
@@ -12,7 +12,7 @@ The system SHALL display proper brand identity elements across the application.
 #### Scenario: Page title displays service name
 - **WHEN** any page is loaded
 - **THEN** the HTML `<title>` SHALL include "Liverty Music" (e.g., "Liverty Music" or "Liverty Music - [Page Name]")
-- **AND** the system SHALL NOT display scaffold names like "Aurelia"
+- **AND** the system SHALL NOT display default scaffold or template names (e.g., "Aurelia", "Vite", "React App")
 
 #### Scenario: Favicon and PWA icons
 - **WHEN** the application is loaded

--- a/openspec/specs/app-shell-layout/spec.md
+++ b/openspec/specs/app-shell-layout/spec.md
@@ -18,6 +18,7 @@ The system SHALL display proper brand identity elements across the application.
 - **WHEN** the application is loaded
 - **THEN** the system SHALL display a brand favicon in the browser tab
 - **AND** the system SHALL provide apple-touch-icon for iOS home screen
+- **AND** the system SHALL provide a web app manifest with themed icons (including maskable versions) for Android and other PWA-compliant platforms
 
 ---
 

--- a/openspec/specs/app-shell-layout/spec.md
+++ b/openspec/specs/app-shell-layout/spec.md
@@ -1,0 +1,66 @@
+# App Shell Layout
+
+## Purpose
+
+Defines the application shell structure including brand identity, conditional navigation display, page transition animations, and authentication status UI. The app shell provides the consistent outer frame for all routes in the Liverty Music application.
+
+## Requirements
+
+### Requirement: Brand Identity Elements
+The system SHALL display proper brand identity elements across the application.
+
+#### Scenario: Page title displays service name
+- **WHEN** any page is loaded
+- **THEN** the HTML `<title>` SHALL include "Liverty Music" (e.g., "Liverty Music" or "Liverty Music - [Page Name]")
+- **AND** the system SHALL NOT display scaffold names like "Aurelia"
+
+#### Scenario: Favicon and PWA icons
+- **WHEN** the application is loaded
+- **THEN** the system SHALL display a brand favicon in the browser tab
+- **AND** the system SHALL provide apple-touch-icon for iOS home screen
+
+---
+
+### Requirement: Conditional Navigation Display
+The system SHALL conditionally show or hide the navigation bar based on the current route context.
+
+#### Scenario: Navigation hidden during onboarding
+- **WHEN** the user is on the Landing Page, Artist Discovery, or Loading Sequence routes
+- **THEN** the system SHALL NOT display the top navigation bar
+- **AND** the full viewport SHALL be available for the onboarding content
+
+#### Scenario: Navigation shown on dashboard
+- **WHEN** the user is on the Dashboard or post-onboarding routes
+- **THEN** the system SHALL display a minimal, dark-themed navigation bar
+- **AND** the navigation bar SHALL include the service logo and user account controls
+
+---
+
+### Requirement: Page Transition Animations
+The system SHALL animate transitions between routes to provide visual continuity.
+
+#### Scenario: Forward navigation transition
+- **WHEN** the user navigates from one route to another
+- **THEN** the outgoing page SHALL fade out (opacity 1->0)
+- **AND** the incoming page SHALL fade in with a subtle upward slide (opacity 0->1, translateY 20px->0)
+- **AND** the total transition duration SHALL be 250-350ms with ease-out timing
+
+#### Scenario: Reduced motion preference
+- **WHEN** the user has `prefers-reduced-motion: reduce` enabled in their OS/browser settings
+- **THEN** the system SHALL skip all page transition animations
+- **AND** route changes SHALL occur instantly
+
+---
+
+### Requirement: Auth Status UI Redesign
+The system SHALL display authentication status with a cohesive, dark-themed design.
+
+#### Scenario: Authenticated user display
+- **WHEN** a user is authenticated
+- **THEN** the system SHALL display the user's name in a compact format
+- **AND** the sign-out control SHALL use a subtle, secondary-styled button (not a red button)
+- **AND** the overall auth UI SHALL use the design system's color tokens
+
+#### Scenario: Unauthenticated user display
+- **WHEN** no user is authenticated and the navigation bar is visible
+- **THEN** the system SHALL display a single "Sign In" button using the brand accent color

--- a/openspec/specs/app-shell-layout/spec.md
+++ b/openspec/specs/app-shell-layout/spec.md
@@ -46,6 +46,12 @@ The system SHALL animate transitions between routes to provide visual continuity
 - **AND** the incoming page SHALL fade in with a subtle upward slide (opacity 0->1, translateY 20px->0)
 - **AND** the total transition duration SHALL be 250-350ms with ease-out timing
 
+#### Scenario: Backward navigation transition
+- **WHEN** the user navigates back (browser back or in-app back action)
+- **THEN** the outgoing page SHALL fade out with a subtle downward slide (opacity 1->0, translateY 0->20px)
+- **AND** the incoming page SHALL fade in (opacity 0->1)
+- **AND** the total transition duration SHALL match the forward transition (250-350ms with ease-out timing)
+
 #### Scenario: Reduced motion preference
 - **WHEN** the user has `prefers-reduced-motion: reduce` enabled in their OS/browser settings
 - **THEN** the system SHALL skip all page transition animations

--- a/openspec/specs/artist-discovery-dna-orb-ui/spec.md
+++ b/openspec/specs/artist-discovery-dna-orb-ui/spec.md
@@ -15,13 +15,33 @@ This capability defines the Artist Discovery UI for the Liverty Music MVP onboar
 ## Requirements
 
 ### Requirement: DNA Extraction UI Concept
-The system SHALL provide a gamified artist discovery interface using a "DNA Extraction" metaphor with an interactive orb (glass sphere) UI that collects user preferences.
+The system SHALL provide a gamified artist discovery interface using a "DNA Extraction" metaphor with an interactive orb (glass sphere) UI that collects user preferences, with visual differentiation per artist and onboarding guidance.
 
 #### Scenario: Initial bubble display with DNA Orb
 - **WHEN** a user reaches the Artist Discovery step after authentication
 - **THEN** the system SHALL display approximately 30 artist bubbles in the center area using physics-based animation
 - **AND** the system SHALL display a "Music DNA Orb" (glass sphere UI) at the bottom of the screen
 - **AND** the orb SHALL serve as a visual inventory for collected artists
+
+#### Scenario: Per-artist bubble color differentiation
+- **WHEN** artist bubbles are rendered
+- **THEN** each bubble SHALL have a unique gradient color derived from the artist's name using a deterministic HSL-based algorithm
+- **AND** the colors SHALL provide visual variety across the bubble field (not uniform purple)
+
+#### Scenario: Onboarding guidance overlay
+- **WHEN** the Artist Discovery screen is displayed for the first time
+- **THEN** the system SHALL display a brief instructional overlay or tooltip explaining the interaction: "Tap bubbles to follow artists"
+- **AND** the overlay SHALL dismiss after the user taps their first bubble or after 5 seconds
+
+#### Scenario: Orb label text
+- **WHEN** the DNA Orb is displayed
+- **THEN** the system SHALL display a label near the orb indicating its purpose (e.g., "Music DNA" or the current follow count)
+- **AND** the label SHALL update dynamically as artists are followed
+
+#### Scenario: Background visual depth
+- **WHEN** the Artist Discovery screen is displayed
+- **THEN** the background SHALL include subtle visual elements (e.g., particle field, starfield, or animated gradient) to create depth
+- **AND** these elements SHALL NOT compete with the foreground bubbles and orb for attention
 
 ---
 

--- a/openspec/specs/design-system/spec.md
+++ b/openspec/specs/design-system/spec.md
@@ -30,7 +30,7 @@ The system SHALL define a centralized set of design tokens using Tailwind CSS v4
   - `--font-body`: body text font (system-ui, sans-serif) for paragraphs, labels, metadata
 - **AND** the system SHALL define a type scale with sizes for mega (4xl or larger), heading (2xl-3xl), body (base-lg), caption (xs-sm)
 
-#### Scenario: Spacing and shape tokens defined
+#### Scenario: Shape tokens defined
 - **WHEN** the design system is initialized
 - **THEN** the system SHALL define radius tokens: `--radius-card` (1rem), `--radius-button` (0.75rem), `--radius-sheet` (1.5rem)
 - **AND** the system SHALL define shadow tokens: `--shadow-card-glow`, `--shadow-sheet`, `--shadow-button`

--- a/openspec/specs/design-system/spec.md
+++ b/openspec/specs/design-system/spec.md
@@ -28,7 +28,7 @@ The system SHALL define a centralized set of design tokens using Tailwind CSS v4
 - **THEN** the system SHALL define font family tokens:
   - `--font-display`: display/heading font (e.g., Outfit) for hero copy, card headlines, section titles
   - `--font-body`: body text font (system-ui, sans-serif) for paragraphs, labels, metadata
-- **AND** the system SHALL define a type scale with sizes for mega (4xl+), heading (2xl-3xl), body (base-lg), caption (xs-sm)
+- **AND** the system SHALL define a type scale with sizes for mega (4xl or larger), heading (2xl-3xl), body (base-lg), caption (xs-sm)
 
 #### Scenario: Spacing and shape tokens defined
 - **WHEN** the design system is initialized
@@ -59,5 +59,5 @@ The system SHALL load and apply a display font for headings with appropriate fal
 - **WHEN** the application loads
 - **THEN** the system SHALL preconnect to the font provider domains (fonts.googleapis.com and fonts.gstatic.com) in the HTML head
 - **AND** the preconnect to `fonts.gstatic.com` SHALL include the `crossorigin` attribute
-- **AND** the system SHALL load the display font with `font-display: swap` to prevent invisible text during load
+- **AND** the system SHALL load the display font with `font-display: swap` and include necessary weights (e.g., Bold 700, Extra-Bold 800) to prevent layout shifts or faux-bolding during load
 - **AND** the system SHALL use `system-ui` as the immediate fallback until the display font is ready

--- a/openspec/specs/design-system/spec.md
+++ b/openspec/specs/design-system/spec.md
@@ -52,5 +52,6 @@ The system SHALL load and apply a display font for headings with appropriate fal
 #### Scenario: Font preloading
 - **WHEN** the application loads
 - **THEN** the system SHALL preconnect to the font provider domains (fonts.googleapis.com and fonts.gstatic.com) in the HTML head
+- **AND** the preconnect to `fonts.gstatic.com` SHALL include the `crossorigin` attribute
 - **AND** the system SHALL load the display font with `font-display: swap` to prevent invisible text during load
 - **AND** the system SHALL use `system-ui` as the immediate fallback until the display font is ready

--- a/openspec/specs/design-system/spec.md
+++ b/openspec/specs/design-system/spec.md
@@ -51,6 +51,6 @@ The system SHALL load and apply a display font for headings with appropriate fal
 
 #### Scenario: Font preloading
 - **WHEN** the application loads
-- **THEN** the system SHALL preconnect to the font provider (Google Fonts) in the HTML head
+- **THEN** the system SHALL preconnect to the font provider domains (fonts.googleapis.com and fonts.gstatic.com) in the HTML head
 - **AND** the system SHALL load the display font with `font-display: swap` to prevent invisible text during load
 - **AND** the system SHALL use `system-ui` as the immediate fallback until the display font is ready

--- a/openspec/specs/design-system/spec.md
+++ b/openspec/specs/design-system/spec.md
@@ -12,9 +12,15 @@ The system SHALL define a centralized set of design tokens using Tailwind CSS v4
 #### Scenario: Color tokens defined
 - **WHEN** the design system is initialized
 - **THEN** the system SHALL define the following color token groups via CSS custom properties:
-  - `--color-brand-*`: primary (indigo-500), secondary (violet-500), accent (cyan-400)
-  - `--color-surface-*`: background layers (gray-950, gray-900, gray-800)
-  - `--color-text-*`: primary (white), secondary (gray-300), muted (gray-500)
+  - `--color-brand-primary`: indigo-500
+  - `--color-brand-secondary`: violet-500
+  - `--color-brand-accent`: cyan-400
+  - `--color-surface-background`: gray-950
+  - `--color-surface-layer-1`: gray-900
+  - `--color-surface-layer-2`: gray-800
+  - `--color-text-primary`: white
+  - `--color-text-secondary`: gray-300
+  - `--color-text-muted`: gray-500
 - **AND** all components SHALL reference these tokens instead of hardcoded color values
 
 #### Scenario: Typography tokens defined

--- a/openspec/specs/design-system/spec.md
+++ b/openspec/specs/design-system/spec.md
@@ -1,0 +1,56 @@
+# Design System
+
+## Purpose
+
+Defines the centralized design token system and visual foundation for the Liverty Music application, ensuring consistency across all screens through Tailwind CSS v4 design tokens, a dark-first theme, and optimized display font loading.
+
+## Requirements
+
+### Requirement: Design Token Definition
+The system SHALL define a centralized set of design tokens using Tailwind CSS v4's `@theme` directive to ensure visual consistency across all screens.
+
+#### Scenario: Color tokens defined
+- **WHEN** the design system is initialized
+- **THEN** the system SHALL define the following color token groups via CSS custom properties:
+  - `--color-brand-*`: primary (indigo-500), secondary (violet-500), accent (cyan-400)
+  - `--color-surface-*`: background layers (gray-950, gray-900, gray-800)
+  - `--color-text-*`: primary (white), secondary (gray-300), muted (gray-500)
+- **AND** all components SHALL reference these tokens instead of hardcoded color values
+
+#### Scenario: Typography tokens defined
+- **WHEN** the design system is initialized
+- **THEN** the system SHALL define font family tokens:
+  - `--font-display`: display/heading font (e.g., Outfit) for hero copy, card headlines, section titles
+  - `--font-body`: body text font (system-ui, sans-serif) for paragraphs, labels, metadata
+- **AND** the system SHALL define a type scale with sizes for mega (4xl+), heading (2xl-3xl), body (base-lg), caption (xs-sm)
+
+#### Scenario: Spacing and shape tokens defined
+- **WHEN** the design system is initialized
+- **THEN** the system SHALL define radius tokens: `--radius-card` (1rem), `--radius-button` (0.75rem), `--radius-sheet` (1.5rem)
+- **AND** the system SHALL define shadow tokens: `--shadow-card-glow`, `--shadow-sheet`, `--shadow-button`
+
+---
+
+### Requirement: Dark Theme as Default
+The system SHALL apply a dark-first visual theme consistently across all screens and components.
+
+#### Scenario: Dark background applied globally
+- **WHEN** any screen is rendered
+- **THEN** the body background SHALL use a dark gradient or solid dark color from the surface token palette
+- **AND** primary text SHALL be white or light gray (meeting WCAG AA contrast ratio against the dark background)
+
+#### Scenario: Dark theme consistency across onboarding
+- **WHEN** the user navigates from Landing Page -> Artist Discovery -> Loading -> Dashboard
+- **THEN** all screens SHALL use the same dark surface palette
+- **AND** there SHALL be no jarring light-to-dark or dark-to-light transitions between screens
+
+---
+
+### Requirement: Display Font Loading
+The system SHALL load and apply a display font for headings with appropriate fallback and performance optimization.
+
+#### Scenario: Font preloading
+- **WHEN** the application loads
+- **THEN** the system SHALL preconnect to the font provider (Google Fonts) in the HTML head
+- **AND** the system SHALL load the display font with `font-display: swap` to prevent invisible text during load
+- **AND** the system SHALL use `system-ui` as the immediate fallback until the display font is ready

--- a/openspec/specs/frontend-onboarding-flow/spec.md
+++ b/openspec/specs/frontend-onboarding-flow/spec.md
@@ -33,11 +33,12 @@ The system SHALL collect the user's primary residential area using a Just-in-Tim
 - **THEN** the system SHALL display the Dashboard with a blurred background
 - **AND** the system SHALL present a bottom sheet overlay with the message "To find live events near you, tell us your main area"
 - **AND** the system SHALL provide a prefecture dropdown selector or quick-select buttons for major cities
+- **AND** the bottom sheet SHALL use the design system's dark surface palette and sheet radius token
 
 #### Scenario: Magic moment after region selection
 - **WHEN** the user selects their region in the bottom sheet
 - **THEN** the system SHALL immediately close the bottom sheet
-- **AND** the system SHALL unblur the Dashboard background
+- **AND** the system SHALL unblur the Dashboard background with a smooth transition animation
 - **AND** the system SHALL dynamically populate the Live Highway UI with region-relevant events
 - **AND** this SHALL create a "magic moment" where personalized content appears instantly
 
@@ -83,6 +84,7 @@ The system SHALL provide an engaging loading experience during data aggregation 
 - **AND** the system SHALL enforce a minimum 3-second display duration even if data loading completes earlier
 - **AND** the system SHALL call `SearchNewConcerts` for each followed artist in parallel
 - **AND** the system SHALL use a 10-second global timeout via `AbortController`
+- **AND** the system SHALL display a visual progress indicator advancing through the phases
 
 #### Scenario: Loading timeout handling
 - **WHEN** data loading exceeds 10 seconds

--- a/openspec/specs/landing-page/spec.md
+++ b/openspec/specs/landing-page/spec.md
@@ -7,16 +7,25 @@ The landing page serves as the entry point to the Liverty Music application, com
 ## Requirements
 
 ### Requirement: Landing Page Hero Display
-The system SHALL display a landing page with a compelling value proposition when an unauthenticated user visits the root URL.
+The system SHALL display a landing page with a compelling value proposition and immersive dark-themed design when an unauthenticated user visits the root URL.
 
 #### Scenario: First-time visitor sees hero content
 - **WHEN** an unauthenticated user navigates to `/`
 - **THEN** the system SHALL display a hero heading with the text "大好きなあのバンドのライブ、もう二度と見逃さない。"
 - **AND** the system SHALL display a sub-heading with the text "あなたの推しアーティストを登録するだけで、全国のライブ日程を自動収集。"
 - **AND** the page SHALL be optimized for mobile portrait orientation
+- **AND** the page SHALL use a dark gradient background consistent with the design system's surface palette
+- **AND** the hero heading SHALL use the display font at mega size (text-4xl or larger)
+- **AND** the service logo or wordmark SHALL be displayed above the hero copy
+
+#### Scenario: Hero entrance animation
+- **WHEN** the landing page is first rendered
+- **THEN** the hero heading SHALL fade in with a subtle upward slide animation (300-500ms delay)
+- **AND** the sub-heading SHALL fade in after the heading (staggered by 200ms)
+- **AND** the CTA button SHALL fade in after the sub-heading (staggered by 200ms)
 
 ### Requirement: Passkey Authentication CTA
-The system SHALL provide "Sign Up" and "Sign In" buttons that trigger Passkey authentication via Zitadel.
+The system SHALL provide "Sign Up" and "Sign In" buttons with visually prominent, branded styling that triggers Passkey authentication via Zitadel.
 
 #### Scenario: New user initiates sign-up
 - **WHEN** an unauthenticated user clicks the "Sign Up" button
@@ -26,6 +35,12 @@ The system SHALL provide "Sign Up" and "Sign In" buttons that trigger Passkey au
 #### Scenario: Returning user initiates sign-in
 - **WHEN** an unauthenticated user clicks the "Sign In" button
 - **THEN** the system SHALL initiate the Zitadel OIDC flow for Passkey authentication
+
+#### Scenario: CTA button visual styling
+- **WHEN** the landing page is displayed
+- **THEN** the primary CTA (Sign Up) SHALL use the brand accent color with a glow/shadow effect
+- **AND** the secondary CTA (Sign In) SHALL use a ghost/outline style with the brand color
+- **AND** both buttons SHALL have rounded corners using the design system's button radius token
 
 #### Scenario: No alternative auth methods displayed
 - **WHEN** the landing page is displayed

--- a/openspec/specs/loading-sequence/spec.md
+++ b/openspec/specs/loading-sequence/spec.md
@@ -5,7 +5,7 @@ This capability defines the loading sequence experience displayed during data ag
 ## Requirements
 
 ### Requirement: Progressive Loading Animation
-The system SHALL display a multi-phase animated loading sequence during data aggregation, replacing a simple spinner.
+The system SHALL display a multi-phase animated loading sequence with visual richness during data aggregation, replacing a simple spinner.
 
 #### Scenario: Phase 1 display (0-2 seconds)
 - **WHEN** the loading sequence begins
@@ -20,6 +20,22 @@ The system SHALL display a multi-phase animated loading sequence during data agg
 #### Scenario: Phase 3 display (5+ seconds)
 - **WHEN** 5 seconds have elapsed since the loading sequence began
 - **THEN** the system SHALL transition to display the message "AIが最新のツアー情報を検索中... 🤖"
+
+#### Scenario: Visual progress indicator
+- **WHEN** the loading sequence is active
+- **THEN** the system SHALL display a visual progress indicator (e.g., progress bar, step dots, or animated ring)
+- **AND** the indicator SHALL advance through the phases to communicate progress
+- **AND** the indicator SHALL be styled using the design system's brand accent color
+
+#### Scenario: Step indicator display
+- **WHEN** the loading sequence transitions between phases
+- **THEN** the system SHALL display a step indicator showing the current phase number (e.g., "1/3", "2/3", "3/3") or equivalent visual dots
+- **AND** completed phases SHALL be visually distinguished from pending phases
+
+#### Scenario: Visual effects beyond text
+- **WHEN** the loading sequence is displayed
+- **THEN** the system SHALL include at least one animated visual element beyond text (e.g., pulsing orb, particle animation, or animated gradient)
+- **AND** the visual element SHALL enhance the feeling of "something being built" to match the messages
 
 ---
 
@@ -84,3 +100,13 @@ The system SHALL prevent direct access to the loading sequence route.
 #### Scenario: Direct URL access while authenticated without followed artists
 - **WHEN** an authenticated user with no followed artists navigates directly to `/onboarding/loading`
 - **THEN** the system SHALL redirect to the Artist Discovery page (`/onboarding/discover`)
+
+---
+
+### Requirement: Visual Continuity from Discovery
+The loading sequence SHALL maintain visual continuity with the preceding Artist Discovery screen.
+
+#### Scenario: Consistent visual theme
+- **WHEN** the user transitions from Artist Discovery to the Loading Sequence
+- **THEN** the background gradient SHALL match the Artist Discovery screen's dark gradient
+- **AND** the transition SHALL not introduce a jarring visual break

--- a/openspec/specs/typography-focused-dashboard/spec.md
+++ b/openspec/specs/typography-focused-dashboard/spec.md
@@ -66,7 +66,7 @@ The system SHALL prioritize typography and dynamic colors over images in all eve
 #### Scenario: Card entrance animation
 - **WHEN** event cards scroll into the viewport
 - **THEN** the system SHALL apply a subtle entrance animation (fade-in or slide-up) as cards become visible
-- **AND** cards in the same date group SHALL stagger their entrance slightly for visual rhythm
+- **AND** cards in the same date group SHALL stagger their entrance (e.g., 50-100ms delay per card) for visual rhythm
 
 ---
 

--- a/openspec/specs/typography-focused-dashboard/spec.md
+++ b/openspec/specs/typography-focused-dashboard/spec.md
@@ -2,36 +2,39 @@
 
 ## Purpose
 
-Defines the Live Dashboard UI for Liverty Music, featuring a typography-first, image-free design with a three-lane "Live Highway" layout organized by geographical proximity and date.
+Defines the Live Dashboard UI for Liverty Music, featuring a typography-first, image-free design with a three-lane "Live Highway" layout organized by geographical proximity and date, with a dark-themed aesthetic.
 
 ## Requirements
 
 ### Requirement: Image-Free Typography-Focused Design
-The system SHALL implement a typography-focused dashboard design that avoids artist images to eliminate copyright concerns and operational costs.
+The system SHALL implement a typography-focused dashboard design with enhanced visual polish, avoiding artist images to eliminate copyright concerns and operational costs.
 
 #### Scenario: Dynamic color generation from artist names
 - **WHEN** displaying live event cards
 - **THEN** the system SHALL generate a unique theme color for each artist based on their name string
 - **AND** the color SHALL be derived using a deterministic algorithm mapped to the HSL color space
+- **AND** the lightness SHALL be adjusted for adequate contrast against the dark-themed dashboard background (55-65% lightness range)
 - **AND** the color SHALL be used as the card background or accent color
 - **AND** this SHALL provide visual variety without requiring image assets
 
 ---
 
 ### Requirement: Three-Lane Live Highway Layout
-The system SHALL display live events in a three-column timeline layout organized by geographical proximity and date.
+The system SHALL display live events in a three-column timeline layout organized by geographical proximity and date, with a dark-themed aesthetic.
 
 #### Scenario: Dashboard layout structure
 - **WHEN** the dashboard is displayed
 - **THEN** the system SHALL implement a vertical-scrolling three-lane layout
 - **AND** the Y-axis SHALL represent time (date/month) displayed on the left edge or lane dividers
 - **AND** the X-axis SHALL represent distance from the user's registered region
+- **AND** the overall dashboard SHALL use the dark surface palette from the design system
 
 #### Scenario: Lane 1 - My City (Main Lane)
 - **WHEN** displaying Lane 1 (50% screen width)
 - **THEN** the system SHALL show events in the user's registered prefecture
-- **AND** the system SHALL use mega-typography style cards
-- **AND** cards SHALL feature the artist name in extra-bold, large font as the primary element
+- **AND** the system SHALL use mega-typography style cards with the display font at 4xl size or larger
+- **AND** cards SHALL feature the artist name in extra-bold font as the dominant visual element
+- **AND** cards SHALL apply a subtle gradient or shadow to create visual depth
 - **AND** cards SHALL NOT display images, dates, or venue names on the surface
 
 #### Scenario: Lane 2 - My Region (Adjacent Lane)
@@ -50,8 +53,25 @@ The system SHALL display live events in a three-column timeline layout organized
 
 ---
 
+### Requirement: Typography-First Card Design
+The system SHALL prioritize typography and dynamic colors over images in all event cards, with enhanced visual treatments.
+
+#### Scenario: Card visual design
+- **WHEN** rendering event cards
+- **THEN** the system SHALL use artist names as the primary visual element
+- **AND** the system SHALL apply dynamic colors derived from artist names
+- **AND** the system SHALL use bold, readable typography optimized for mobile screens using the display font
+- **AND** the system SHALL ensure sufficient contrast between text and background colors (WCAG AA minimum)
+
+#### Scenario: Card entrance animation
+- **WHEN** event cards scroll into the viewport
+- **THEN** the system SHALL apply a subtle entrance animation (fade-in or slide-up) as cards become visible
+- **AND** cards in the same date group SHALL stagger their entrance slightly for visual rhythm
+
+---
+
 ### Requirement: Bottom Sheet Detail Modal
-The system SHALL display detailed event information in a bottom sheet modal when users tap any event card.
+The system SHALL display detailed event information in a bottom sheet modal when users tap any event card, with enhanced interaction design.
 
 #### Scenario: Opening event details
 - **WHEN** a user taps any event card in any lane
@@ -60,23 +80,29 @@ The system SHALL display detailed event information in a bottom sheet modal when
 
 #### Scenario: Detail modal content
 - **WHEN** the bottom sheet detail modal is displayed
-- **THEN** the modal SHALL show the artist name prominently
+- **THEN** the modal SHALL show the artist name prominently using the display font
 - **AND** the modal SHALL display the event date and start time
 - **AND** the modal SHALL display the venue name with a link to Google Maps
-- **AND** the modal SHALL provide a "[🔗 View Official Info]" button linking to the source
-- **AND** the modal SHALL provide a "[📅 Add to Calendar]" button for native calendar export
+- **AND** the modal SHALL provide a "View Official Info" button linking to the source with an SVG link icon
+- **AND** the modal SHALL provide an "Add to Calendar" button for native calendar export with an SVG calendar icon
+- **AND** all icons SHALL use inline SVG (not Unicode emoji) for cross-platform visual consistency
+
+#### Scenario: Swipe-to-dismiss gesture
+- **WHEN** the bottom sheet is open
+- **AND** the user swipes downward on the sheet
+- **THEN** the system SHALL close the bottom sheet with a smooth slide-down animation
+- **AND** the backdrop SHALL fade out simultaneously
 
 ---
 
-### Requirement: Typography-First Card Design
-The system SHALL prioritize typography and dynamic colors over images in all event cards.
+### Requirement: Date Separator Styling
+The system SHALL display date separators with enhanced visual treatment that matches the dark theme.
 
-#### Scenario: Card visual design
-- **WHEN** rendering event cards
-- **THEN** the system SHALL use artist names as the primary visual element
-- **AND** the system SHALL apply dynamic colors derived from artist names
-- **AND** the system SHALL use bold, readable typography optimized for mobile screens
-- **AND** the system SHALL ensure sufficient contrast between text and background colors
+#### Scenario: Date separator rendering
+- **WHEN** the dashboard renders date group headers
+- **THEN** the date text SHALL use a contrasting accent color or semi-transparent surface color
+- **AND** the separator SHALL visually anchor the timeline with adequate padding and typography weight
+- **AND** the separator SHALL be sticky at the top during scroll
 
 ---
 
@@ -100,3 +126,25 @@ The system SHALL display date markers along the timeline to provide temporal con
 - **THEN** the system SHALL display month and day markers on the left edge or lane dividers
 - **AND** date markers SHALL be fixed or scroll-following for easy reference
 - **AND** events SHALL be chronologically organized from top (near future) to bottom (distant future)
+
+---
+
+### Requirement: Dashboard Header Branding
+The system SHALL display a branded header on the Dashboard page.
+
+#### Scenario: Header display
+- **WHEN** the Dashboard page is rendered
+- **THEN** the header SHALL display "Live Highway" using the display font with brand styling
+- **AND** the header SHALL use the dark surface palette
+- **AND** lane labels (My City, Region, Others) SHALL be clearly visible with appropriate contrast
+
+---
+
+### Requirement: Toast Notification Design Enhancement
+The system SHALL display toast notifications with vibrant, attention-grabbing styling.
+
+#### Scenario: Toast visual design
+- **WHEN** a toast notification is displayed (e.g., live event found during Artist Discovery)
+- **THEN** the toast SHALL use a vibrant background color (brand accent or gradient) instead of neutral gray
+- **AND** the toast SHALL enter with a spring/bounce animation (not just opacity fade)
+- **AND** the toast text SHALL use the design system's typography tokens


### PR DESCRIPTION
## Summary

Syncs delta specs from the `refine-ui-design` OpenSpec change to the main specification after successful implementation and merge of [frontend PR #21](https://github.com/liverty-music/frontend/pull/21).

This PR updates the canonical specs to reflect the implemented design system refinements, dark theme, and UI polish that are now deployed in the frontend application.

## Changes

### New Capabilities (2)
- **design-system** — Design token system (Tailwind CSS v4 `@theme`), dark-first theme palette, display font loading
- **app-shell-layout** — Brand identity elements, conditional navigation, page transition animations, authentication status UI

### Updated Capabilities (5)
- **landing-page** — Dark theme palette, display font integration, hero entrance animations, CTA visual styling
- **artist-discovery-dna-orb-ui** — Per-artist color differentiation, onboarding guidance overlay, orb label text, background depth
- **loading-sequence** — Visual progress indicators, step dots indicator, visual effects beyond text, visual continuity requirement
- **typography-focused-dashboard** — Dark theme integration, mega-typography cards, card entrance animations, swipe-to-dismiss gestures, header branding, toast design enhancement
- **frontend-onboarding-flow** — Region setup JIT design system integration, loading sequence progress indicators

## Context

All specifications now align with the production frontend implementation that merged in [PR #21](https://github.com/liverty-music/frontend/pull/21). The `refine-ui-design` change has been archived to `openspec/changes/archive/2026-02-17-refine-ui-design/`.

## Files Changed

- 7 spec files modified (+255 additions, -22 deletions)
- 2 new capability specs created
- 5 existing capability specs enhanced