### PR TITLE
feat(openspec): archive frontend-unit-testing change and sync main specs

### DIFF
--- a/openspec/changes/archive/2026-02-19-frontend-unit-testing/.openspec.yaml
+++ b/openspec/changes/archive/2026-02-19-frontend-unit-testing/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-02-16

--- a/openspec/changes/archive/2026-02-19-frontend-unit-testing/design.md
+++ b/openspec/changes/archive/2026-02-19-frontend-unit-testing/design.md
@@ -1,0 +1,117 @@
+## Context
+
+The Aurelia 2 frontend application (`liverty-music/frontend`) has minimal test coverage: 2 test files with 8 test cases. The existing `test/setup.ts` bootstraps the Aurelia `BrowserPlatform` for jsdom, and `@aurelia/testing` is already installed. Vitest is configured with jsdom environment. No shared test utilities or mock factories exist, causing each test file to duplicate mock setup.
+
+All services follow the same DI pattern: `resolve(IInterface)` in field initializers, with `DI.createInterface` providing mockable tokens. Components use `@bindable` properties and `createFixture` for integration testing.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Establish reusable test infrastructure (mock factories, DI helpers)
+- Achieve comprehensive test coverage for all services with business logic
+- Add component integration tests for interactive components
+- Configure coverage reporting for visibility
+- Fix the known bug in `artist-discovery-service.ts`
+
+**Non-Goals:**
+- E2E tests (Playwright) - deferred to a separate change
+- Testing thin RPC client wrappers with no business logic (`user-service.ts`, `artist-service-client.ts`)
+- Visual/snapshot testing for canvas components (`dna-orb/`)
+- Testing generated protobuf code
+
+## Decisions
+
+### 1. Test file organization: `test/` directory with subdirectories
+
+**Decision**: Keep tests in `test/` root (matching existing convention and Aurelia monorepo pattern) with `services/`, `components/`, and `helpers/` subdirectories.
+
+**Rationale**: The project already has `test/setup.ts` and two test files in `test/`. Aurelia's own monorepo uses a centralized `__tests__` package. Subdirectories add organization without restructuring.
+
+**Alternative considered**: Co-located tests (`src/services/__tests__/`). Rejected because it contradicts the existing pattern and Aurelia convention.
+
+### 2. Shared mock factories over inline mocks
+
+**Decision**: Create reusable mock factories in `test/helpers/` for commonly mocked dependencies: `ILogger`, `IAuthService`, `IRouter`, and RPC service clients.
+
+**Rationale**: Every service resolves `ILogger` and most resolve `IAuthService`. The existing `auth-service.spec.ts` already duplicates mock setup that could be shared. Factories reduce boilerplate and ensure consistent mock behavior.
+
+**Structure**:
+```
+test/helpers/
+  mock-logger.ts        # createMockLogger() -> ILogger mock
+  mock-auth.ts          # createMockAuth() -> IAuthService mock
+  mock-rpc-clients.ts   # createMockConcertService(), etc.
+  create-container.ts   # createTestContainer(...registrations)
+```
+
+### 3. Service tests via DI container (not module mocking)
+
+**Decision**: Test services by creating a real `DI.createContainer()` with mocked dependencies registered via `Registration.instance()`, rather than using `vi.mock()` for module-level mocking.
+
+**Rationale**: DI container approach is idiomatic Aurelia, matches how services are actually resolved at runtime, and avoids the fragility of module mocking. The existing `auth-service.spec.ts` already demonstrates this pattern successfully.
+
+**Exception**: `auth-service.spec.ts` will continue using `vi.mock('oidc-client-ts')` because `UserManager` is instantiated directly (not via DI).
+
+### 4. Fake timers for time-dependent tests
+
+**Decision**: Use `vi.useFakeTimers()` for tests involving `setTimeout`, `requestAnimationFrame`, and `Date.now()`.
+
+**Applicable to**: `toast-notification.ts` (show/dismiss timing), `loading-sequence-service.ts` (timeout, minimum display, retry delays).
+
+**Rationale**: Real timers make tests slow and flaky. Vitest's fake timer API provides deterministic control.
+
+### 5. Component tests via DI container (simplified unit testing)
+
+**Decision**: Use DI container instantiation (`container.get(Component)`) for component unit tests, reserving `createFixture` for complex integration tests.
+
+**Rationale**: During implementation, we found that `createFixture` adds unnecessary overhead for simple component unit tests. The DI container approach is:
+- **Simpler**: Direct instantiation without fixture boilerplate
+- **Faster**: No template compilation or DOM rendering for unit tests
+- **More focused**: Tests view-model logic and delegation directly
+- **Idiomatic**: Matches the service testing pattern (DI container with mocks)
+
+**When to use each approach**:
+- **DI container** (`container.get(Component)`): Unit tests for delegation, computed properties, simple logic
+- **createFixture**: Integration tests requiring full template binding, lifecycle hooks, or DOM interaction
+
+**Implementation pattern**:
+```typescript
+beforeEach(() => {
+  const container = createTestContainer(
+    Registration.instance(IDependency, mockDependency),
+  )
+  container.register(MyComponent)
+  component = container.get(MyComponent)
+})
+```
+
+**Deviation from original design**: Originally planned to use `createFixture` for all component tests. Implementation revealed that DI container approach is more appropriate for unit testing, with `createFixture` reserved for true integration tests.
+
+### 6. Coverage configuration
+
+**Decision**: Add `@vitest/coverage-v8` with statement/branch/function thresholds reported but not enforced.
+
+**Rationale**: V8 coverage is fast and works with jsdom. Starting without enforcement avoids blocking CI while building coverage incrementally.
+
+**Implementation results**:
+- Initial coverage: 22.15% (50 tests, 9 test files)
+- Service coverage: 90%+ on tested services (DashboardService 97.39%, OnboardingService 92.1%)
+- Component coverage: 100% on tested components
+
+**Future improvements**: Once remaining complex service tests are implemented ([Issue #24](https://github.com/liverty-music/frontend/issues/24)), consider adding coverage thresholds:
+- Target: 40%+ overall coverage
+- Enforcement: Optional, could be added to CI workflow to prevent regressions
+
+## Risks / Trade-offs
+
+**[Locale-dependent formatting]** `dashboard-service.ts` and `event-card.ts` use `toLocaleDateString('ja-JP', ...)`. Test output depends on the system locale and ICU data availability.
+-> Mitigation: Assert on structural patterns (e.g., contains year, month, day) rather than exact strings, or use regex matching.
+
+**[Shadow DOM in component tests]** The Vite plugin sets `defaultShadowOptions: 'open'`. Component tests may need to traverse `shadowRoot` to query elements.
+-> Mitigation: Use `appHost.querySelector('component-name')?.shadowRoot?.querySelector(...)` pattern, as demonstrated in existing `my-app.spec.ts`.
+
+**[Non-deterministic `Math.random()`]** `artist-discovery-service.ts` uses `Math.random()` in `toBubble()` for radius.
+-> Mitigation: Mock `Math.random` with `vi.spyOn(Math, 'random').mockReturnValue(0.5)` in relevant tests.
+
+**[Constructor side effects in RPC services]** Services create gRPC clients in constructors. Direct instantiation triggers real transport creation.
+-> Mitigation: For services with business logic (dashboard, loading-sequence, onboarding), mock the entire DI interface rather than testing the class directly. For `artist-discovery-service`, mock the protobuf client module.

--- a/openspec/changes/archive/2026-02-19-frontend-unit-testing/proposal.md
+++ b/openspec/changes/archive/2026-02-19-frontend-unit-testing/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+The Aurelia 2 frontend application has only 2 test files covering 8 test cases (7 active, 1 skipped), leaving 7 services, ~12 components, and 5 route components entirely untested. Business-critical logic such as dashboard data orchestration, onboarding flow routing, loading sequence retry/batching, and artist discovery state management has zero automated verification. Adding comprehensive unit and integration tests will catch regressions early and enable confident refactoring.
+
+## What Changes
+
+- Add shared test utilities (mock factories for ILogger, IAuthService, RPC clients, DI container helper)
+- Add unit tests for all pure functions (color-generator, showNav logic)
+- Add service-level tests for all services with business logic (dashboard-service, loading-sequence-service, onboarding-service, toast-notification, artist-discovery-service)
+- Add component integration tests using `@aurelia/testing` createFixture API (auth-status, event-card, live-highway)
+- Configure Vitest coverage reporting
+- Fix known bug: missing `this.` in artist-discovery-service.ts `listFollowedFromBackend`
+
+## Capabilities
+
+### New Capabilities
+- `frontend-testing`: Comprehensive unit and integration test suite for the Aurelia 2 frontend application, covering services, components, and pure utility functions.
+
+### Modified Capabilities
+- `artist-discovery`: Bug fix for `listFollowedFromBackend` missing `this.artistClient` reference.
+
+## Impact
+
+- **Code**: New test files under `test/` directory (services/, components/, helpers/ subdirectories)
+- **Config**: Vitest coverage configuration added to `vitest.config.ts`
+- **Dependencies**: No new dependencies (all test tooling already installed)
+- **Bug fix**: `src/services/artist-discovery-service.ts` - `this.` prefix fix
+- **CI**: Tests run via existing `npm test` script (pretest lint + vitest)

--- a/openspec/changes/archive/2026-02-19-frontend-unit-testing/research/aurelia-testing-api.md
+++ b/openspec/changes/archive/2026-02-19-frontend-unit-testing/research/aurelia-testing-api.md
@@ -1,0 +1,100 @@
+# Aurelia 2 Testing API Reference
+
+Source: https://docs.aurelia.io/developer-guides/overview/testing-components
+
+## createFixture API
+
+```typescript
+createFixture(
+  template: string,           // HTML template with component usage
+  appClass: any,             // App component class with test data
+  components: any[],         // Components to register
+  registrations?: any[]      // Optional DI registrations
+)
+```
+
+### Return Object
+- `appHost` - DOM container for rendered component
+- `startPromise` - Promise resolving when component renders
+- `started` - Awaitable shorthand (returns the fixture)
+- `stop(true)` - Cleanup function
+- `component` - Direct access to component instance
+- `getBy(selector)` - Query single element
+- `getAllBy(selector)` - Query multiple elements
+- `queryBy(selector)` - Query or null
+- `trigger` - Fire events (`.click()`, `.keydown()`)
+- `type(selector, text)` - Text input simulation
+- `assertText()` / `assertClass()` / `assertValue()` - Assertion helpers
+- `printHtml()` - Debug output
+
+## Testing Patterns
+
+### Simple Component Render Test
+```typescript
+it('renders content', async () => {
+  const { appHost, startPromise, stop } = createFixture(
+    '<my-component name.bind="testName"></my-component>',
+    class App { testName = 'Alice'; },
+    [MyComponent]
+  );
+  await startPromise;
+  expect(appHost.textContent).toContain('Alice');
+  await stop(true);
+});
+```
+
+### Mocking Dependencies via DI
+```typescript
+import { Registration } from 'aurelia';
+
+const mockService = { format: vi.fn().mockReturnValue('Formatted') };
+const { appHost } = await createFixture(
+  '<person-detail></person-detail>',
+  class App {},
+  [PersonDetail],
+  [Registration.instance(PersonFormatter, mockService)]  // 4th param
+).started;
+```
+
+### Testing Bindings
+```typescript
+const { component } = await createFixture(
+  '<my-comp items.bind="itemList"></my-comp>',
+  class App { itemList: any[] = []; },
+  [MyComp]
+).started;
+
+component.itemList = [1, 2, 3];
+await tasksSettled();
+// Assert DOM updated
+```
+
+### Testing Lifecycle Hooks
+```typescript
+const spy = vi.spyOn(MyComp.prototype, 'attached');
+const { startPromise, stop } = createFixture(
+  '<my-comp></my-comp>', class App {}, [MyComp]
+);
+await startPromise;
+expect(spy).toHaveBeenCalled();
+await stop(true);
+```
+
+### Event Triggering
+```typescript
+fixture.trigger.click('button');
+fixture.trigger.keydown('input', { key: 'Enter' });
+```
+
+## Key Utilities
+- `tasksSettled()` - Wait for async queue to flush (import from `@aurelia/testing`)
+- `Registration.instance(Token, mock)` - Register mock in DI container
+- `setPlatform()` / `BrowserPlatform` - Bootstrap test environment
+
+## Best Practices
+1. Always `await startPromise` or use `.started` before assertions
+2. Always `await stop(true)` for cleanup (prevents memory leaks)
+3. Use `tasksSettled()` after state changes that trigger async updates
+4. Mock only what's necessary
+5. Group related tests with `describe` blocks
+6. One assertion focus per test

--- a/openspec/changes/archive/2026-02-19-frontend-unit-testing/research/current-test-state.md
+++ b/openspec/changes/archive/2026-02-19-frontend-unit-testing/research/current-test-state.md
@@ -1,0 +1,86 @@
+# Current Test State Analysis
+
+## Summary
+
+| Dimension | Status |
+|-----------|--------|
+| Test framework | Vitest (unit) + Playwright (E2E) configured |
+| Total test files | 2 |
+| Total test cases | 8 (7 active, 1 skipped) |
+| E2E tests | None (config exists, no files) |
+| Storybook | 1 story (welcome-page) |
+| Test utilities | Basic Aurelia setup file only |
+| Coverage reporting | Not configured |
+
+## Test Framework Configuration
+
+### Vitest (`vitest.config.ts`)
+- Environment: `jsdom`
+- Watch mode disabled by default
+- Excludes `e2e/*` directory
+- Setup file: `./test/setup.ts`
+- Merges with main Vite config (inherits Aurelia plugin)
+
+### Playwright (`playwright.config.mjs`)
+- Test directory: `./e2e` (does not exist)
+- Only Chromium active
+- Web server: `npm start` on port 9000
+
+### Test Dependencies
+- `@aurelia/testing` (latest) - `createFixture` utility
+- `jsdom` (^25.0.1) - DOM environment
+- `@playwright/test` (^1.49.1) - E2E framework
+
+## Existing Test Files
+
+### `test/auth-service.spec.ts` (6 tests)
+- Mocks `oidc-client-ts` module entirely via `vi.mock`
+- Creates DI container with mocked `ILogger`
+- Tests: UserManager init, isAuthenticated state, signIn, register, signOut, handleCallback
+- Uses `@ts-expect-error` for private member access
+
+### `test/my-app.spec.ts` (2 tests, 1 skipped)
+- 1 skipped test (complex dependency mocking needed)
+- 1 active test verifying `<nav>` and `<au-viewport>` presence via `createFixture`
+
+### `test/setup.ts`
+- JSDOM instance with global DOM objects
+- Aurelia `BrowserPlatform` bootstrap via `setPlatform()`
+- Auto-cleanup: tracks fixtures via `onFixtureCreated`, stops in `afterEach`
+
+## Untested Code
+
+### Services (7 untested)
+- `grpc-transport.ts` - Transport factory with auth interceptor
+- `artist-service-client.ts` - Artist RPC client wrapper
+- `artist-discovery-service.ts` - Artist discovery state management
+- `concert-service.ts` - Concert RPC client
+- `dashboard-service.ts` - Dashboard data orchestration
+- `loading-sequence-service.ts` - Loading flow with retry/batching
+- `onboarding-service.ts` - Onboarding status & routing
+- `user-service.ts` - User RPC client wrapper
+
+### Components (~12 untested)
+- `auth-status` - Sign in/out UI
+- `dna-orb/` - Canvas animation (3 files)
+- `icons/` - SVG icon components (4 files)
+- `live-highway/` - Live events feature (5 files)
+- `region-setup-sheet/` - Region config
+- `toast-notification/` - Toast notification
+
+### Route Components (5 untested)
+- `auth-callback` - OIDC callback
+- `dashboard` - User dashboard
+- `artist-discovery-page` - Onboarding discovery
+- `loading-sequence` - Onboarding loading animation
+- `welcome-page` / `about-page` - Static pages
+
+## Known Bug
+
+`artist-discovery-service.ts` line ~112: `artistClient` missing `this.` prefix.
+```ts
+// Bug:
+const resp = await artistClient.listFollowed({}, { signal })
+// Should be:
+const resp = await this.artistClient.listFollowed({}, { signal })
+```

--- a/openspec/changes/archive/2026-02-19-frontend-unit-testing/research/testability-analysis.md
+++ b/openspec/changes/archive/2026-02-19-frontend-unit-testing/research/testability-analysis.md
@@ -1,0 +1,77 @@
+# Testability Analysis by Component
+
+## Test Priority Matrix (Value / Effort)
+
+| Priority | File | Type | Logic | Effort |
+|----------|------|------|-------|--------|
+| 1 | `color-generator.ts` | Pure function | Hash-to-color mapping | Trivial |
+| 2 | `dashboard-service.ts` | Service | Date grouping, concert mapping, parallel fetch | Medium |
+| 3 | `loading-sequence-service.ts` | Service | Retry, batching, timeout, abort | Medium |
+| 4 | `toast-notification.ts` | Service | Timer-based show/dismiss | Easy |
+| 5 | `onboarding-service.ts` | Service | Auth check, redirect branching | Easy |
+| 6 | `live-highway.ts` | Component | isEmpty getter, event delegation | Trivial |
+| 7 | `event-card.ts` | Component | Color, date format, click event | Easy |
+| 8 | `artist-discovery-service.ts` | Service | Follow state, dedup, orbIntensity | Medium |
+| 9 | `my-app.ts` | Component | showNav route logic | Easy |
+| 10 | `auth-status.ts` | Component | Pure delegation to IAuthService | Trivial |
+
+## Common DI Pattern
+
+All services use Aurelia `resolve()` in field initializers:
+```typescript
+export class SomeService {
+  private readonly logger = resolve(ILogger).scopeTo('SomeService')
+  private readonly dep = resolve(ISomeDep)
+}
+```
+
+Testing approach: Use `DI.createContainer()` + `Registration.instance()` to provide mocks.
+
+## Service-Specific Notes
+
+### dashboard-service.ts
+- Rich business logic: `concertToLiveEvent` (date/time formatting), `groupByDate` (sort/group)
+- `toLocaleDateString('ja-JP', ...)` - locale-dependent output
+- `Promise.allSettled` for parallel fetching
+- Dependencies: `IConcertService`, `IArtistServiceClient`, `ILogger`
+
+### loading-sequence-service.ts
+- Retry with 1 attempt, batching (BATCH_SIZE=5), timeout (10s), minimum display (3s)
+- `Date.now()` and `setTimeout` - needs `vi.useFakeTimers()`
+- `AbortController` patterns
+- Dependencies: `IArtistDiscoveryService`, `IConcertService`, `ILogger`
+
+### onboarding-service.ts
+- Two public methods with clear branching
+- `hasCompletedOnboarding` checks followed artists count
+- `redirectBasedOnStatus` gates on auth.ready, checks auth, routes
+- Dependencies: `IAuthService`, `IArtistServiceClient`, `IRouter`, `ILogger`
+
+### toast-notification.ts
+- No DI dependencies (just `DI` for interface registration)
+- Uses `requestAnimationFrame` + nested `setTimeout`
+- Simple state management: `toasts` array, auto-increment ID
+
+### artist-discovery-service.ts
+- Mutable public state: `availableBubbles`, `followedArtists`, `orbIntensity`
+- `seenArtistNames` Set for deduplication
+- `Math.random()` in `toBubble` (non-deterministic radius)
+- Constructor creates RPC client (side effect)
+- **Bug**: missing `this.` on `artistClient` in `listFollowedFromBackend`
+
+### event-card.ts
+- `resolve(INode)` for DOM element access
+- `artistColor` is pure function delegation
+- `formattedDate` uses `toLocaleDateString('ja-JP')`
+- Dispatches `CustomEvent` on host element
+
+### my-app.ts
+- `showNav` computed from `router.activeNavigation?.path`
+- `fullscreenRoutes` array matching
+
+## Cross-Cutting Concerns
+
+1. **`import.meta.env`**: Services read env vars at module level. Vitest handles this via Vite config.
+2. **Constructor side effects**: Most service constructors create gRPC clients. Module mocking needed.
+3. **Locale formatting**: `ja-JP` locale in date formatting. Tests should use snapshot or explicit assertions.
+4. **Shadow DOM**: Vite plugin sets `defaultShadowOptions: 'open'`. Component tests may need shadowRoot traversal.

--- a/openspec/changes/archive/2026-02-19-frontend-unit-testing/specs/artist-discovery/spec.md
+++ b/openspec/changes/archive/2026-02-19-frontend-unit-testing/specs/artist-discovery/spec.md
@@ -1,0 +1,12 @@
+## MODIFIED Requirements
+
+### Requirement: List followed artists from backend
+The `ArtistDiscoveryService.listFollowedFromBackend` method SHALL use the instance's `artistClient` to fetch followed artists from the backend.
+
+#### Scenario: Fetching followed artists
+- **WHEN** `listFollowedFromBackend` is called
+- **THEN** it SHALL call `this.artistClient.listFollowed()` (not the unscoped `artistClient` variable)
+
+#### Scenario: Bug fix verification
+- **WHEN** a test calls `listFollowedFromBackend`
+- **THEN** it SHALL NOT throw a `ReferenceError` for undefined `artistClient`

--- a/openspec/changes/archive/2026-02-19-frontend-unit-testing/specs/frontend-testing/spec.md
+++ b/openspec/changes/archive/2026-02-19-frontend-unit-testing/specs/frontend-testing/spec.md
@@ -1,0 +1,154 @@
+## ADDED Requirements
+
+### Requirement: Test infrastructure provides shared mock factories
+The test suite SHALL provide reusable mock factories for commonly used DI dependencies (`ILogger`, `IAuthService`, `IRouter`, RPC service clients) in `test/helpers/`.
+
+#### Scenario: Creating a mock logger
+- **WHEN** a test imports `createMockLogger` from `test/helpers/mock-logger`
+- **THEN** it SHALL return an object implementing `ILogger` with all methods as Vitest spies (`debug`, `info`, `warn`, `error`, `scopeTo`)
+
+#### Scenario: Creating a mock auth service
+- **WHEN** a test imports `createMockAuth` from `test/helpers/mock-auth`
+- **THEN** it SHALL return an object implementing `IAuthService` with configurable `isAuthenticated`, `user`, and spy methods for `signIn`, `signOut`, `register`, `handleCallback`
+
+#### Scenario: Creating a test DI container
+- **WHEN** a test calls `createTestContainer` with mock registrations
+- **THEN** it SHALL return an Aurelia `IContainer` with the provided mocks registered and `ILogger` pre-registered
+
+### Requirement: Color generator produces deterministic colors
+The `artistColor` function SHALL produce a valid HSL color string deterministically from any input string.
+
+#### Scenario: Same input produces same color
+- **WHEN** `artistColor` is called twice with the same artist name
+- **THEN** both calls SHALL return identical HSL color strings
+
+#### Scenario: Different inputs produce different colors
+- **WHEN** `artistColor` is called with different artist names
+- **THEN** the returned HSL hue values SHALL differ
+
+#### Scenario: Empty string input
+- **WHEN** `artistColor` is called with an empty string
+- **THEN** it SHALL return a valid HSL color string without throwing
+
+### Requirement: Dashboard service groups concerts by date
+The `DashboardService.loadDashboardEvents` method SHALL fetch followed artists, retrieve concerts for each artist in parallel, convert them to `LiveEvent` objects, and group them by date.
+
+#### Scenario: Multiple artists with concerts
+- **WHEN** the user follows 2 artists and each has concerts on different dates
+- **THEN** the returned `DateGroup[]` SHALL contain entries sorted by date, each containing the corresponding `LiveEvent` objects
+
+#### Scenario: No followed artists
+- **WHEN** the user follows no artists
+- **THEN** `loadDashboardEvents` SHALL return an empty `DateGroup[]`
+
+#### Scenario: RPC call failure for one artist
+- **WHEN** concert fetching fails for one artist but succeeds for another
+- **THEN** the service SHALL return events from the successful artist (using `Promise.allSettled` resilience)
+
+### Requirement: Loading sequence service orchestrates data aggregation
+The `LoadingSequenceService.aggregateData` method SHALL fetch followed artists (with retry), search concerts in batches, and enforce timeout and minimum display constraints.
+
+#### Scenario: Successful aggregation
+- **WHEN** `aggregateData` is called and all RPC calls succeed
+- **THEN** it SHALL complete after at least MINIMUM_DISPLAY_MS (3000ms)
+
+#### Scenario: Artist fetch retry on failure
+- **WHEN** the first call to list followed artists fails
+- **THEN** the service SHALL retry once before giving up
+
+#### Scenario: Concert search batching
+- **WHEN** the user follows more than BATCH_SIZE (5) artists
+- **THEN** concert searches SHALL be executed in batches of BATCH_SIZE
+
+#### Scenario: Global timeout
+- **WHEN** data aggregation exceeds GLOBAL_TIMEOUT_MS (10000ms)
+- **THEN** the operation SHALL abort via AbortSignal
+
+### Requirement: Onboarding service routes based on completion status
+The `OnboardingService` SHALL check whether the user has completed onboarding and redirect to the appropriate route.
+
+#### Scenario: User has completed onboarding
+- **WHEN** `hasCompletedOnboarding` is called and the user has at least one followed artist
+- **THEN** it SHALL return `true`
+
+#### Scenario: User has not completed onboarding
+- **WHEN** `hasCompletedOnboarding` is called and the user has no followed artists
+- **THEN** it SHALL return `false`
+
+#### Scenario: Redirect authenticated user with completed onboarding
+- **WHEN** `redirectBasedOnStatus` is called for an authenticated user who has completed onboarding
+- **THEN** the router SHALL navigate to `dashboard`
+
+#### Scenario: Redirect authenticated user without onboarding
+- **WHEN** `redirectBasedOnStatus` is called for an authenticated user who has not completed onboarding
+- **THEN** the router SHALL navigate to `onboarding/discover`
+
+### Requirement: Toast notification service manages toast lifecycle
+The `ToastNotification.show` method SHALL add a toast, animate it visible, auto-dismiss after the specified duration, and remove it after the exit animation.
+
+#### Scenario: Show a toast
+- **WHEN** `show` is called with a message
+- **THEN** a toast item SHALL be added to `toasts` array and become `visible` after the next animation frame
+
+#### Scenario: Auto-dismiss after duration
+- **WHEN** `durationMs` elapses after showing a toast
+- **THEN** the toast `visible` SHALL be set to `false`
+
+#### Scenario: Remove after exit animation
+- **WHEN** 400ms elapses after a toast is dismissed
+- **THEN** the toast SHALL be removed from the `toasts` array
+
+### Requirement: Event card computes display properties
+The `EventCard` component SHALL compute background color from artist name and format dates in Japanese locale.
+
+#### Scenario: Background color from artist name
+- **WHEN** an `EventCard` is rendered with an event
+- **THEN** `backgroundColor` SHALL return the HSL color from `artistColor(event.artistName)`
+
+#### Scenario: Click dispatches event-selected
+- **WHEN** the user clicks the event card
+- **THEN** a bubbling `CustomEvent` named `event-selected` SHALL be dispatched with `{ event }` in `detail`
+
+### Requirement: Live highway displays grouped events
+The `LiveHighway` component SHALL render date groups and delegate event selection.
+
+#### Scenario: Empty state
+- **WHEN** `dateGroups` is an empty array
+- **THEN** `isEmpty` SHALL return `true`
+
+#### Scenario: Event selection delegation
+- **WHEN** `onEventSelected` is called with a custom event containing a `LiveEvent`
+- **THEN** it SHALL call `detailSheet.open` with that event
+
+### Requirement: Auth status delegates to auth service
+The `AuthStatus` component SHALL delegate sign-in, sign-up, and sign-out actions to `IAuthService`.
+
+#### Scenario: Sign in
+- **WHEN** `signIn` is called
+- **THEN** it SHALL call `auth.signIn()`
+
+#### Scenario: Sign up
+- **WHEN** `signUp` is called
+- **THEN** it SHALL call `auth.register()`
+
+#### Scenario: Sign out
+- **WHEN** `signOut` is called
+- **THEN** it SHALL call `auth.signOut()`
+
+### Requirement: MyApp showNav hides navigation on fullscreen routes
+The `MyApp.showNav` getter SHALL return `false` for fullscreen routes and `true` for other routes.
+
+#### Scenario: Fullscreen route
+- **WHEN** the active route path is `welcome`, `onboarding/discover`, `onboarding/loading`, or `auth/callback`
+- **THEN** `showNav` SHALL return `false`
+
+#### Scenario: Non-fullscreen route
+- **WHEN** the active route path is `dashboard` or `about`
+- **THEN** `showNav` SHALL return `true`
+
+### Requirement: Coverage reporting is configured
+Vitest SHALL be configured with V8 coverage reporting.
+
+#### Scenario: Running tests with coverage
+- **WHEN** `vitest --coverage` is executed
+- **THEN** a coverage report SHALL be generated showing statement, branch, and function coverage

--- a/openspec/changes/archive/2026-02-19-frontend-unit-testing/tasks.md
+++ b/openspec/changes/archive/2026-02-19-frontend-unit-testing/tasks.md
@@ -1,0 +1,35 @@
+## 1. Test Infrastructure Setup
+
+- [x] 1.1 Create `test/helpers/mock-logger.ts` with `createMockLogger()` factory returning ILogger mock with all methods as vi.fn()
+- [x] 1.2 Create `test/helpers/mock-auth.ts` with `createMockAuth()` factory returning IAuthService mock with configurable state
+- [x] 1.3 Create `test/helpers/mock-rpc-clients.ts` with mock factories for IConcertService, IArtistServiceClient, IArtistDiscoveryService
+- [x] 1.4 Create `test/helpers/create-container.ts` with `createTestContainer()` helper that sets up DI container with pre-registered ILogger
+- [x] 1.5 Configure Vitest coverage reporting in `vitest.config.ts` (add @vitest/coverage-v8)
+
+## 2. Pure Unit Tests
+
+- [x] 2.1 Create `test/components/live-highway/color-generator.spec.ts` - test determinism, different inputs, empty string
+- [x] 2.2 Create `test/my-app.spec.ts` - add showNav tests for fullscreen vs non-fullscreen routes (enhance existing file)
+
+## 3. Service Tests
+
+- [x] 3.1 Create `test/services/dashboard-service.spec.ts` - test loadDashboardEvents with multiple artists, no artists, partial RPC failure
+- [ ] 3.2 Create `test/services/loading-sequence-service.spec.ts` - test aggregateData with fake timers: success, retry, batching, timeout → [Issue #24](https://github.com/liverty-music/frontend/issues/24)
+- [x] 3.3 Create `test/services/onboarding-service.spec.ts` - test hasCompletedOnboarding and redirectBasedOnStatus branching
+- [x] 3.4 Create `test/services/toast-notification.spec.ts` - test show/dismiss lifecycle with fake timers
+- [ ] 3.5 Create `test/services/artist-discovery-service.spec.ts` - test follow state, dedup, orbIntensity calculation → [Issue #24](https://github.com/liverty-music/frontend/issues/24)
+
+## 4. Bug Fix
+
+- [x] 4.1 Fix `src/services/artist-discovery-service.ts` - add missing `this.` prefix to `artistClient` in `listFollowedFromBackend`
+
+## 5. Component Integration Tests
+
+- [x] 5.1 Create `test/components/auth-status.spec.ts` - test signIn/signUp/signOut delegation via createFixture
+- [x] 5.2 Create `test/components/live-highway/event-card.spec.ts` - test backgroundColor, formattedDate, click event dispatch
+- [x] 5.3 Create `test/components/live-highway/live-highway.spec.ts` - test isEmpty getter and onEventSelected delegation
+
+## 6. Verification
+
+- [x] 6.1 Run full test suite (`npm test`) and verify all tests pass
+- [x] 6.2 Run coverage report and document baseline coverage numbers

--- a/openspec/specs/artist-discovery-dna-orb-ui/spec.md
+++ b/openspec/specs/artist-discovery-dna-orb-ui/spec.md
@@ -116,6 +116,19 @@ The system SHALL implement smooth, natural bubble movement using physics simulat
 
 ---
 
+### Requirement: List followed artists from backend
+The `ArtistDiscoveryService.listFollowedFromBackend` method SHALL use the instance's `artistClient` to fetch followed artists from the backend.
+
+#### Scenario: Fetching followed artists
+- **WHEN** `listFollowedFromBackend` is called
+- **THEN** it SHALL call `this.artistClient.listFollowed()` (not the unscoped `artistClient` variable)
+
+#### Scenario: Bug fix verification
+- **WHEN** a test calls `listFollowedFromBackend`
+- **THEN** it SHALL NOT throw a `ReferenceError` for undefined `artistClient`
+
+---
+
 ## Technical Context
 
 This specification defines the Artist Discovery UI for Liverty Music MVP, featuring:

--- a/openspec/specs/frontend-testing/spec.md
+++ b/openspec/specs/frontend-testing/spec.md
@@ -1,0 +1,162 @@
+# Frontend Testing
+
+## Purpose
+
+Establish comprehensive test coverage for the Aurelia 2 frontend application, including test infrastructure, service tests, component tests, and coverage reporting.
+
+This capability ensures code quality, prevents regressions, and enables confident refactoring through automated testing.
+
+## Requirements
+
+### Requirement: Test infrastructure provides shared mock factories
+The test suite SHALL provide reusable mock factories for commonly used DI dependencies (`ILogger`, `IAuthService`, `IRouter`, RPC service clients) in `test/helpers/`.
+
+#### Scenario: Creating a mock logger
+- **WHEN** a test imports `createMockLogger` from `test/helpers/mock-logger`
+- **THEN** it SHALL return an object implementing `ILogger` with all methods as Vitest spies (`debug`, `info`, `warn`, `error`, `scopeTo`)
+
+#### Scenario: Creating a mock auth service
+- **WHEN** a test imports `createMockAuth` from `test/helpers/mock-auth`
+- **THEN** it SHALL return an object implementing `IAuthService` with configurable `isAuthenticated`, `user`, and spy methods for `signIn`, `signOut`, `signUp`, `handleCallback`
+
+#### Scenario: Creating a test DI container
+- **WHEN** a test calls `createTestContainer` with mock registrations
+- **THEN** it SHALL return an Aurelia `IContainer` with the provided mocks registered and `ILogger` pre-registered
+
+### Requirement: Color generator produces deterministic colors
+The `artistColor` function SHALL produce a valid HSL color string deterministically from any input string.
+
+#### Scenario: Same input produces same color
+- **WHEN** `artistColor` is called twice with the same artist name
+- **THEN** both calls SHALL return identical HSL color strings
+
+#### Scenario: Different inputs produce different colors
+- **WHEN** `artistColor` is called with different artist names
+- **THEN** the returned HSL hue values SHALL differ
+
+#### Scenario: Empty string input
+- **WHEN** `artistColor` is called with an empty string
+- **THEN** it SHALL return a valid HSL color string without throwing
+
+### Requirement: Dashboard service groups concerts by date
+The `DashboardService.loadDashboardEvents` method SHALL fetch followed artists, retrieve concerts for each artist in parallel, convert them to `LiveEvent` objects, and group them by date.
+
+#### Scenario: Multiple artists with concerts
+- **WHEN** the user follows 2 artists and each has concerts on different dates
+- **THEN** the returned `DateGroup[]` SHALL contain entries sorted by date, each containing the corresponding `LiveEvent` objects
+
+#### Scenario: No followed artists
+- **WHEN** the user follows no artists
+- **THEN** `loadDashboardEvents` SHALL return an empty `DateGroup[]`
+
+#### Scenario: RPC call failure for one artist
+- **WHEN** concert fetching fails for one artist but succeeds for another
+- **THEN** the service SHALL return events from the successful artist (using `Promise.allSettled` resilience)
+
+### Requirement: Loading sequence service orchestrates data aggregation
+The `LoadingSequenceService.aggregateData` method SHALL fetch followed artists (with retry), search concerts in batches, and enforce timeout and minimum display constraints.
+
+#### Scenario: Successful aggregation
+- **WHEN** `aggregateData` is called and all RPC calls succeed
+- **THEN** it SHALL complete after at least MINIMUM_DISPLAY_MS (3000ms)
+
+#### Scenario: Artist fetch retry on failure
+- **WHEN** the first call to list followed artists fails
+- **THEN** the service SHALL retry once before giving up
+
+#### Scenario: Concert search batching
+- **WHEN** the user follows more than BATCH_SIZE (5) artists
+- **THEN** concert searches SHALL be executed in batches of BATCH_SIZE
+
+#### Scenario: Global timeout
+- **WHEN** data aggregation exceeds GLOBAL_TIMEOUT_MS (10000ms)
+- **THEN** the operation SHALL abort via AbortSignal
+
+### Requirement: Onboarding service routes based on completion status
+The `OnboardingService` SHALL check whether the user has completed onboarding and redirect to the appropriate route.
+
+#### Scenario: User has completed onboarding
+- **WHEN** `hasCompletedOnboarding` is called and the user has at least one followed artist
+- **THEN** it SHALL return `true`
+
+#### Scenario: User has not completed onboarding
+- **WHEN** `hasCompletedOnboarding` is called and the user has no followed artists
+- **THEN** it SHALL return `false`
+
+#### Scenario: Redirect authenticated user with completed onboarding
+- **WHEN** `redirectBasedOnStatus` is called for an authenticated user who has completed onboarding
+- **THEN** the router SHALL navigate to `dashboard`
+
+#### Scenario: Redirect authenticated user without onboarding
+- **WHEN** `redirectBasedOnStatus` is called for an authenticated user who has not completed onboarding
+- **THEN** the router SHALL navigate to `onboarding/discover`
+
+### Requirement: Toast notification service manages toast lifecycle
+The `ToastNotification.show` method SHALL add a toast, animate it visible, auto-dismiss after the specified duration, and remove it after the exit animation.
+
+#### Scenario: Show a toast
+- **WHEN** `show` is called with a message
+- **THEN** a toast item SHALL be added to `toasts` array and become `visible` after the next animation frame
+
+#### Scenario: Auto-dismiss after duration
+- **WHEN** `durationMs` elapses after showing a toast
+- **THEN** the toast `visible` SHALL be set to `false`
+
+#### Scenario: Remove after exit animation
+- **WHEN** 400ms elapses after a toast is dismissed
+- **THEN** the toast SHALL be removed from the `toasts` array
+
+### Requirement: Event card computes display properties
+The `EventCard` component SHALL compute background color from artist name and format dates in Japanese locale.
+
+#### Scenario: Background color from artist name
+- **WHEN** an `EventCard` is rendered with an event
+- **THEN** `backgroundColor` SHALL return the HSL color from `artistColor(event.artistName)`
+
+#### Scenario: Click dispatches event-selected
+- **WHEN** the user clicks the event card
+- **THEN** a bubbling `CustomEvent` named `event-selected` SHALL be dispatched with `{ event }` in `detail`
+
+### Requirement: Live highway displays grouped events
+The `LiveHighway` component SHALL render date groups and delegate event selection.
+
+#### Scenario: Empty state
+- **WHEN** `dateGroups` is an empty array
+- **THEN** `isEmpty` SHALL return `true`
+
+#### Scenario: Event selection delegation
+- **WHEN** `onEventSelected` is called with a custom event containing a `LiveEvent`
+- **THEN** it SHALL call `detailSheet.open` with that event
+
+### Requirement: Auth status delegates to auth service
+The `AuthStatus` component SHALL delegate sign-in, sign-up, and sign-out actions to `IAuthService`.
+
+#### Scenario: Sign in
+- **WHEN** `signIn` is called
+- **THEN** it SHALL call `auth.signIn()`
+
+#### Scenario: Sign up
+- **WHEN** `signUp` is called
+- **THEN** it SHALL call `auth.signUp()`
+
+#### Scenario: Sign out
+- **WHEN** `signOut` is called
+- **THEN** it SHALL call `auth.signOut()`
+
+### Requirement: MyApp showNav hides navigation on fullscreen routes
+The `MyApp.showNav` getter SHALL return `false` for fullscreen routes and `true` for other routes.
+
+#### Scenario: Fullscreen route
+- **WHEN** the active route path is `welcome`, `onboarding/discover`, `onboarding/loading`, or `auth/callback`
+- **THEN** `showNav` SHALL return `false`
+
+#### Scenario: Non-fullscreen route
+- **WHEN** the active route path is `dashboard` or `about`
+- **THEN** `showNav` SHALL return `true`
+
+### Requirement: Coverage reporting is configured
+Vitest SHALL be configured with V8 coverage reporting.
+
+#### Scenario: Running tests with coverage
+- **WHEN** `vitest --coverage` is executed
+- **THEN** a coverage report SHALL be generated showing statement, branch, and function coverage


### PR DESCRIPTION
## 🔗 Related Issue

Closes #25

## 📝 Summary of Changes

Archives the completed `frontend-unit-testing` OpenSpec change and syncs its delta specs into the main spec files.

### Archived Change (`openspec/changes/archive/2026-02-19-frontend-unit-testing/`)
- Research notes: Aurelia testing API, current test state analysis, testability analysis
- Proposal and delta specs for `frontend-testing` and `artist-discovery` capabilities
- Tasks list (16/18 complete — 2 deferred to Issue #24 for complex service tests)
- Updated `design.md` to reflect actual DI container approach for component tests (deviation from original `createFixture` plan)

### Synced Main Specs
- **Created** `openspec/specs/frontend-testing/spec.md` — new capability with 11 requirements covering test infrastructure, service tests, component tests, and coverage configuration
- **Updated** `openspec/specs/artist-discovery-dna-orb-ui/spec.md` — added `listFollowedFromBackend` bug fix requirement (missing `this.` prefix)

### Implementation Results (in `liverty-music/frontend` PR #26)
- 50 tests (up from 8), 22.15% coverage
- 4 mock factories, DI container helper
- CI workflow with lint + test jobs
- Bug fix: `ArtistDiscoveryService.listFollowedFromBackend`

## ✅ Self-Checklist

- [x] I have linked the related issue.
- [x] I have updated the relevant documentation (e.g., `README.md`) if needed.
- [ ] I have run `buf lint` and `buf format` locally and all checks have passed.
- [x] My proto definitions follow the project's style guidelines and validation rules.
- [ ] Breaking changes have been justified and documented if applicable.