### PR TITLE
feat(openspec): add extract-concert-venue change artifacts

### DIFF
--- a/openspec/changes/extract-concert-venue/.openspec.yaml
+++ b/openspec/changes/extract-concert-venue/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-02-20

--- a/openspec/changes/extract-concert-venue/design.md
+++ b/openspec/changes/extract-concert-venue/design.md
@@ -1,0 +1,67 @@
+## Context
+
+The Gemini-based concert searcher currently extracts 6 fields per event (artist name, event name, venue, date, start time, source URL). The `venue` field is a raw text string (e.g., "Zepp Osaka Bayside") that is stored as `venues.name` and used as the deduplication key for venue lookup/creation.
+
+Two gaps block the upcoming location-based dashboard feature:
+
+1. **No geographic area on the venue** — there is no way to associate a concert with a prefecture or state to power the "My City" / "My Region" lane filtering.
+2. **Raw venue name lost after processing** — once the venue is matched/created by name, the original scraped text is discarded. This prevents future normalization workflows (e.g., matching against Google Maps or MusicBrainz to get a canonical name).
+
+## Goals / Non-Goals
+
+**Goals:**
+- Extend Gemini extraction to return `admin_area` (都道府県-level administrative division)
+- Persist `admin_area` on the `venues` table
+- Preserve the raw scraped venue name as `listed_venue_name` on the `events` table
+- Rename `ScrapedConcert.VenueName` → `ListedVenueName` throughout the pipeline for semantic clarity
+
+**Non-Goals:**
+- Normalization of venue names via Google Maps / MusicBrainz (future change)
+- Making `venues.name` nullable (deferred to normalization change)
+- Filtering concerts by `admin_area` in the API (separate frontend change)
+- User `admin_area` profile field (separate onboarding change)
+
+## Decisions
+
+### D1: Field name `AdminArea` over `Prefecture`
+
+`Prefecture` is Japan-specific. `AdminArea` maps to `administrative_area_level_1` in the Google Maps Geocoding API and works equally for US states, Canadian provinces, German Bundesländer, etc. Chosen for international extensibility.
+
+**Alternatives considered:**
+- `Prefecture`: Semantically precise for Japan MVP, but a breaking rename when internationalizing.
+- `Region`: Conflicts with the dashboard's "地方" concept (a grouping of prefectures), which is derived — not stored — at the application layer.
+- `State`/`Province`: Country-specific terminology; not universal.
+
+### D2: `admin_area` is nullable (`*string` in Go, `TEXT` in Postgres)
+
+Gemini cannot always determine the venue's location with confidence. The extraction rule is: populate only when explicitly stated or unambiguously inferable from the venue name or page context; otherwise return empty string (stored as `NULL`). A wrong value is strictly worse than `NULL`, since it would silently misroute concerts in the dashboard.
+
+### D3: `ListedVenueName` lives on `Event`, not `Venue`
+
+The listed name is tied to a specific source/scrape — two sources might list the same venue differently ("Zepp Osaka" vs "Zepp Osaka Bayside"). It is a property of the *event occurrence* (how it was advertised), not of the venue entity itself. Storing it on `events` preserves provenance and enables future normalization without altering the venue deduplication key.
+
+### D4: `venues.name` stays `NOT NULL` for this change
+
+`Venue.Name` currently holds the listed name and acts as the deduplication key in `GetByName`. Making it nullable now would require null-safe SQL comparisons and nil-checks throughout the codebase without delivering any feature value. When the normalization change arrives, it will introduce a dedicated `listed_name NOT NULL` column for lookups and make `name` nullable via a separate migration.
+
+### D5: Gemini prompt uses "confident or empty" framing
+
+The prompt instructs Gemini: populate `admin_area` only when explicitly stated or clearly inferable from the venue name (e.g., "Zepp Nagoya" → "愛知県"); return `""` if there is any ambiguity. The `eventSchema` marks `admin_area` as optional (not in `Required` array) so the model can omit it cleanly.
+
+## Risks / Trade-offs
+
+- **Gemini hallucination on ambiguous venues** → Mitigated by strict prompt wording ("wrong value is worse than empty") and nullable storage. Dashboard filtering treats NULL as "unknown" and places the concert in the "Others" lane.
+- **Existing venue records have no `admin_area`** → The `admin_area` column is `NULL` for all existing rows. Acceptable: no existing venue data exists in production at this stage.
+- **`listed_venue_name` is NULL for pre-migration concert records** → Column is nullable; historical rows are unaffected. New rows always carry the value.
+- **`VenueName` → `ListedVenueName` rename is a breaking change in test fixtures** → All occurrences in `concert_uc_test.go` and `searcher_test.go` must be updated. Low risk (internal, no API surface change).
+
+## Migration Plan
+
+1. Deploy Go changes (entity, usecase, gemini, repo — backward-compatible until migration runs)
+2. Run migration: `ALTER TABLE venues ADD COLUMN admin_area TEXT` and `ALTER TABLE events ADD COLUMN listed_venue_name TEXT`
+3. New concert discoveries automatically populate both columns going forward
+4. Rollback: drop the two columns (no data loss beyond the new fields)
+
+## Open Questions
+
+_(none — all design decisions resolved in exploration phase)_

--- a/openspec/changes/extract-concert-venue/proposal.md
+++ b/openspec/changes/extract-concert-venue/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+To support location-based dashboard filtering (showing users concerts near their home prefecture), the Gemini-extracted concert data must include the venue's administrative area (`admin_area`). Additionally, the raw venue name as listed on the artist's official site needs to be preserved on the Event entity, distinct from the future normalized `Venue.Name` that will come from Google Maps / MusicBrainz.
+
+## What Changes
+
+- Add `admin_area` field to the Gemini JSON schema and prompt, instructing the model to extract the prefecture-level location (or international equivalent) from the venue name or surrounding page context. If uncertain, the field is left empty — wrong values are strictly forbidden.
+- Rename `ScrapedConcert.VenueName` → `ListedVenueName` to distinguish the raw scraped name from the normalized `Venue.Name`.
+- Add `ScrapedConcert.AdminArea *string` to carry the extracted area through the processing pipeline.
+- Add `Venue.AdminArea *string` and persist it in the `venues` table.
+- Add `Event.ListedVenueName string` and persist it in the `events` table, preserving the original source text for future normalization workflows.
+
+## Capabilities
+
+### New Capabilities
+
+_(none)_
+
+### Modified Capabilities
+
+- `concert-search`: Gemini extraction now returns `admin_area` in addition to existing fields. `ScrapedConcert` gains `ListedVenueName` (renamed from `VenueName`) and `AdminArea *string`.
+- `concert-service`: Venue creation includes `AdminArea`; Event creation includes `ListedVenueName`. DB schema gains `venues.admin_area` and `events.listed_venue_name` columns.
+
+## Impact
+
+- **Backend Go**: `entity`, `usecase`, `infrastructure/gcp/gemini`, `infrastructure/database/rdb` packages
+- **Proto / API**: `venue.proto` — add `admin_area` field; `mapper/concert.go` updated
+- **Database**: New migration — `ALTER TABLE venues ADD COLUMN admin_area TEXT`, `ALTER TABLE events ADD COLUMN listed_venue_name TEXT`
+- **Tests**: `concert_uc_test.go`, `venue_repo_test.go`, `searcher_test.go` — field rename and new field assertions

--- a/openspec/changes/extract-concert-venue/specs/concert-search/spec.md
+++ b/openspec/changes/extract-concert-venue/specs/concert-search/spec.md
@@ -1,0 +1,58 @@
+## MODIFIED Requirements
+
+### Requirement: Search Concerts by Artist
+
+System must provide a way to search for future concerts of a specific artist using generative AI grounding. The system SHALL check the search log before calling the external API and skip the call if a recent search exists. The extracted concert data SHALL include the venue's administrative area (`admin_area`) when it can be determined with confidence.
+
+#### Scenario: Successful Search
+
+- **WHEN** `SearchNewConcerts` is called for an existing artist
+- **AND** no search log exists or the last search was more than 24 hours ago
+- **THEN** the system MUST call the external search API
+- **AND** return a list of upcoming concerts found on the web
+- **AND** each concert includes title, listed venue name, date, start time, and optionally `admin_area`
+- **AND** results exclude concerts that are already stored in the database
+
+#### Scenario: Skip search when recently searched
+
+- **WHEN** `SearchNewConcerts` is called for an artist
+- **AND** a search log exists with `searched_at` within the last 24 hours
+- **THEN** the system MUST NOT call the external search API
+- **AND** return an empty list
+
+#### Scenario: Filter Past Events
+
+- **WHEN** the search results include events with dates in the past
+- **THEN** the system MUST filter them out and only return future events
+
+#### Scenario: No Results
+
+- **WHEN** no upcoming concerts are found for the artist
+- **THEN** the system MUST return an empty list without error
+
+#### Scenario: Missing Artist ID
+
+- **WHEN** an `artist_id` is not provided
+- **THEN** the system MUST return an `INVALID_ARGUMENT` error
+
+## ADDED Requirements
+
+### Requirement: Venue Administrative Area Extraction
+
+The Gemini extraction pipeline SHALL attempt to identify the administrative area (都道府県 / state / province) of each venue. Accuracy is prioritized over coverage — an incorrect value is strictly forbidden.
+
+#### Scenario: AdminArea explicitly stated in source
+
+- **WHEN** the source page or venue name explicitly includes the prefecture or state
+- **THEN** the extracted `admin_area` SHALL contain that value (e.g., `"大阪府"`, `"California"`)
+
+#### Scenario: AdminArea unambiguously inferable from venue name
+
+- **WHEN** the venue name unambiguously implies a known administrative area (e.g., "Zepp Nagoya" → "愛知県", "札幌ドーム" → "北海道")
+- **THEN** the extracted `admin_area` SHALL contain the inferred value
+
+#### Scenario: AdminArea uncertain or ambiguous
+
+- **WHEN** the administrative area cannot be determined with confidence from the source text
+- **THEN** `admin_area` SHALL be omitted (empty string / `NULL`)
+- **AND** the system SHALL NOT guess or infer from partial information

--- a/openspec/changes/extract-concert-venue/specs/concert-service/spec.md
+++ b/openspec/changes/extract-concert-venue/specs/concert-service/spec.md
@@ -1,0 +1,53 @@
+## MODIFIED Requirements
+
+### Requirement: Concert Persistence
+
+The system SHALL automatically persist any new concerts discovered via the search mechanism. The `ConcertRepository.Create` method SHALL accept a variadic number of concerts for bulk insert support.
+
+#### Scenario: Persist New Concerts
+
+- **WHEN** `SearchNewConcerts` is called and finds concerts not currently in the database
+- **THEN** the new concerts are saved to the persisted storage via a single bulk insert call
+- **AND** returned in the response with valid IDs
+
+#### Scenario: Persist Venues
+
+- **WHEN** a discovered concert has a venue that does not exist in the database
+- **THEN** a new venue is created dynamically based on the listed venue name provided by the source
+- **AND** if an `admin_area` was extracted for the concert, it SHALL be stored on the venue record
+- **AND** the new concert is associated with this new venue
+
+#### Scenario: Single concert creation
+
+- **WHEN** `Create` is called with a single concert argument
+- **THEN** it SHALL behave identically to the previous single-insert implementation
+
+## ADDED Requirements
+
+### Requirement: Listed Venue Name Preservation
+
+The system SHALL preserve the raw venue name as found on the artist's official site on the Event record, separate from the normalized `Venue.Name`. This ensures the original source text is available for future normalization workflows (e.g., matching against Google Maps or MusicBrainz).
+
+#### Scenario: Listed venue name stored on event creation
+
+- **WHEN** a new concert event is persisted
+- **THEN** the `listed_venue_name` field on the event SHALL contain the exact venue name string returned by the Gemini extraction
+
+#### Scenario: Listed venue name is non-empty for discovered concerts
+
+- **WHEN** Gemini returns a non-empty venue string for a concert
+- **THEN** `listed_venue_name` on the persisted event SHALL be that string
+
+### Requirement: Venue AdminArea Persistence
+
+The system SHALL store the administrative area extracted by Gemini on the Venue record when available.
+
+#### Scenario: AdminArea stored on new venue creation
+
+- **WHEN** a new venue is created and the scraped concert includes a non-empty `admin_area`
+- **THEN** the venue record SHALL have `admin_area` set to that value
+
+#### Scenario: AdminArea is NULL when not extracted
+
+- **WHEN** a new venue is created and the scraped concert has no `admin_area` (empty or absent)
+- **THEN** the venue record SHALL have `admin_area` set to `NULL`

--- a/openspec/changes/extract-concert-venue/tasks.md
+++ b/openspec/changes/extract-concert-venue/tasks.md
@@ -1,43 +1,43 @@
 ## 1. Entity Layer
 
-- [ ] 1.1 Rename `ScrapedConcert.VenueName` → `ListedVenueName` in `internal/entity/concert.go`
-- [ ] 1.2 Add `AdminArea *string` field to `ScrapedConcert` in `internal/entity/concert.go`
-- [ ] 1.3 Add `AdminArea *string` field to `Venue` in `internal/entity/venue.go`
-- [ ] 1.4 Add `ListedVenueName string` field to `Event` in `internal/entity/event.go`
+- [x] 1.1 Rename `ScrapedConcert.VenueName` → `ListedVenueName` in `internal/entity/concert.go`
+- [x] 1.2 Add `AdminArea *string` field to `ScrapedConcert` in `internal/entity/concert.go`
+- [x] 1.3 Add `AdminArea *string` field to `Venue` in `internal/entity/venue.go`
+- [x] 1.4 Add `ListedVenueName string` field to `Event` in `internal/entity/event.go`
 
 ## 2. Gemini Extraction
 
-- [ ] 2.1 Add `admin_area` field to `eventSchema` in `internal/infrastructure/gcp/gemini/searcher.go` (optional, not in `Required`)
-- [ ] 2.2 Add `AdminArea *string` to `ScrapedEvent` struct
-- [ ] 2.3 Update `promptTemplate` to instruct extraction of `admin_area` with "confident or empty" rule
-- [ ] 2.4 Update `parseEvents()` to rename `ev.Venue` → `ev.ListedVenueName` and map `ev.AdminArea` to `ScrapedConcert`
+- [x] 2.1 Add `admin_area` field to `eventSchema` in `internal/infrastructure/gcp/gemini/searcher.go` (optional, not in `Required`)
+- [x] 2.2 Add `AdminArea *string` to `ScrapedEvent` struct
+- [x] 2.3 Update `promptTemplate` to instruct extraction of `admin_area` with "confident or empty" rule
+- [x] 2.4 Update `parseEvents()` to rename `ev.Venue` → `ev.ListedVenueName` and map `ev.AdminArea` to `ScrapedConcert`
 
 ## 3. Database Migration
 
-- [ ] 3.1 Create new migration file adding `admin_area TEXT` column to `venues` table
-- [ ] 3.2 Add `listed_venue_name TEXT` column to `events` table in the same migration
-- [ ] 3.3 Update `schema.sql` to reflect the new columns
+- [x] 3.1 Create new migration file adding `admin_area TEXT` column to `venues` table
+- [x] 3.2 Add `listed_venue_name TEXT` column to `events` table in the same migration
+- [x] 3.3 Update `schema.sql` to reflect the new columns
 
 ## 4. Repository
 
-- [ ] 4.1 Update `insertVenueQuery` in `internal/infrastructure/database/rdb/venue_repo.go` to include `admin_area`
-- [ ] 4.2 Update `getVenueQuery` and `getVenueByNameQuery` to SELECT `admin_area`
-- [ ] 4.3 Update `Create()`, `Get()`, `GetByName()` Scan/Exec calls to include `AdminArea`
+- [x] 4.1 Update `insertVenueQuery` in `internal/infrastructure/database/rdb/venue_repo.go` to include `admin_area`
+- [x] 4.2 Update `getVenueQuery` and `getVenueByNameQuery` to SELECT `admin_area`
+- [x] 4.3 Update `Create()`, `Get()`, `GetByName()` Scan/Exec calls to include `AdminArea`
 
 ## 5. Use Case
 
-- [ ] 5.1 Update `concert_uc.go` to use `s.ListedVenueName` (renamed from `s.VenueName`) for venue lookup/creation key
-- [ ] 5.2 Pass `AdminArea: s.AdminArea` when constructing `entity.Venue`
-- [ ] 5.3 Pass `ListedVenueName: s.ListedVenueName` when constructing `entity.Event`
+- [x] 5.1 Update `concert_uc.go` to use `s.ListedVenueName` (renamed from `s.VenueName`) for venue lookup/creation key
+- [x] 5.2 Pass `AdminArea: s.AdminArea` when constructing `entity.Venue`
+- [x] 5.3 Pass `ListedVenueName: s.ListedVenueName` when constructing `entity.Event`
 
 ## 6. Proto & Mapper
 
-- [ ] 6.1 Add `string admin_area = 3` field to `Venue` message in `proto/liverty_music/entity/v1/venue.proto`
-- [ ] 6.2 Update `VenueToProto()` in `internal/adapter/rpc/mapper/concert.go` to map `AdminArea`
+- [x] 6.1 Add `string admin_area = 3` field to `Venue` message in `proto/liverty_music/entity/v1/venue.proto`
+- [x] 6.2 Update `VenueToProto()` in `internal/adapter/rpc/mapper/concert.go` to map `AdminArea`
 
 ## 7. Tests
 
-- [ ] 7.1 Update `concert_uc_test.go`: rename all `VenueName` → `ListedVenueName` in `ScrapedConcert` literals
-- [ ] 7.2 Add test cases in `concert_uc_test.go` for `AdminArea` being stored on new venue creation
-- [ ] 7.3 Update `venue_repo_test.go` to include `AdminArea` field in test fixtures and assertions
-- [ ] 7.4 Update `searcher_test.go` (unit + integration) for new `admin_area` field in JSON schema and `ScrapedConcert` output
+- [x] 7.1 Update `concert_uc_test.go`: rename all `VenueName` → `ListedVenueName` in `ScrapedConcert` literals
+- [x] 7.2 Add test cases in `concert_uc_test.go` for `AdminArea` being stored on new venue creation
+- [x] 7.3 Update `venue_repo_test.go` to include `AdminArea` field in test fixtures and assertions
+- [x] 7.4 Update `searcher_test.go` (unit + integration) for new `admin_area` field in JSON schema and `ScrapedConcert` output

--- a/openspec/changes/extract-concert-venue/tasks.md
+++ b/openspec/changes/extract-concert-venue/tasks.md
@@ -1,0 +1,43 @@
+## 1. Entity Layer
+
+- [ ] 1.1 Rename `ScrapedConcert.VenueName` → `ListedVenueName` in `internal/entity/concert.go`
+- [ ] 1.2 Add `AdminArea *string` field to `ScrapedConcert` in `internal/entity/concert.go`
+- [ ] 1.3 Add `AdminArea *string` field to `Venue` in `internal/entity/venue.go`
+- [ ] 1.4 Add `ListedVenueName string` field to `Event` in `internal/entity/event.go`
+
+## 2. Gemini Extraction
+
+- [ ] 2.1 Add `admin_area` field to `eventSchema` in `internal/infrastructure/gcp/gemini/searcher.go` (optional, not in `Required`)
+- [ ] 2.2 Add `AdminArea *string` to `ScrapedEvent` struct
+- [ ] 2.3 Update `promptTemplate` to instruct extraction of `admin_area` with "confident or empty" rule
+- [ ] 2.4 Update `parseEvents()` to rename `ev.Venue` → `ev.ListedVenueName` and map `ev.AdminArea` to `ScrapedConcert`
+
+## 3. Database Migration
+
+- [ ] 3.1 Create new migration file adding `admin_area TEXT` column to `venues` table
+- [ ] 3.2 Add `listed_venue_name TEXT` column to `events` table in the same migration
+- [ ] 3.3 Update `schema.sql` to reflect the new columns
+
+## 4. Repository
+
+- [ ] 4.1 Update `insertVenueQuery` in `internal/infrastructure/database/rdb/venue_repo.go` to include `admin_area`
+- [ ] 4.2 Update `getVenueQuery` and `getVenueByNameQuery` to SELECT `admin_area`
+- [ ] 4.3 Update `Create()`, `Get()`, `GetByName()` Scan/Exec calls to include `AdminArea`
+
+## 5. Use Case
+
+- [ ] 5.1 Update `concert_uc.go` to use `s.ListedVenueName` (renamed from `s.VenueName`) for venue lookup/creation key
+- [ ] 5.2 Pass `AdminArea: s.AdminArea` when constructing `entity.Venue`
+- [ ] 5.3 Pass `ListedVenueName: s.ListedVenueName` when constructing `entity.Event`
+
+## 6. Proto & Mapper
+
+- [ ] 6.1 Add `string admin_area = 3` field to `Venue` message in `proto/liverty_music/entity/v1/venue.proto`
+- [ ] 6.2 Update `VenueToProto()` in `internal/adapter/rpc/mapper/concert.go` to map `AdminArea`
+
+## 7. Tests
+
+- [ ] 7.1 Update `concert_uc_test.go`: rename all `VenueName` → `ListedVenueName` in `ScrapedConcert` literals
+- [ ] 7.2 Add test cases in `concert_uc_test.go` for `AdminArea` being stored on new venue creation
+- [ ] 7.3 Update `venue_repo_test.go` to include `AdminArea` field in test fixtures and assertions
+- [ ] 7.4 Update `searcher_test.go` (unit + integration) for new `admin_area` field in JSON schema and `ScrapedConcert` output

--- a/proto/liverty_music/entity/v1/venue.proto
+++ b/proto/liverty_music/entity/v1/venue.proto
@@ -18,7 +18,7 @@ message Venue {
   // inferable from the venue name (e.g., "Zepp Nagoya" → "愛知県").
   // Absent when the area cannot be determined with confidence — an incorrect value is
   // strictly worse than an absent one.
-  optional string admin_area = 3 [(buf.validate.field).string.max_len = 100];
+  AdminArea admin_area = 3;
 }
 
 // VenueId is a globally unique identifier for a concert venue.
@@ -31,4 +31,15 @@ message VenueId {
 message VenueName {
   // The name string, required to be at least one character.
   string value = 1 [(buf.validate.field).string.min_len = 1];
+}
+
+// AdminArea represents the administrative division where a venue is located
+// (e.g., prefecture, state, province).
+// Present only when the area is determinable with confidence from the source data.
+message AdminArea {
+  // The area name, required to be at least one character when present.
+  string value = 1 [
+    (buf.validate.field).string.min_len = 1,
+    (buf.validate.field).string.max_len = 100
+  ];
 }

--- a/proto/liverty_music/entity/v1/venue.proto
+++ b/proto/liverty_music/entity/v1/venue.proto
@@ -14,9 +14,11 @@ message Venue {
   VenueName name = 2 [(buf.validate.field).required = true];
 
   // The administrative area (prefecture, state, province) where the venue is located.
-  // Populated only when determinable with confidence from the source data.
-  // Absent if the area could not be determined.
-  optional string admin_area = 3;
+  // Populated only when the area is explicitly stated in the source data or unambiguously
+  // inferable from the venue name (e.g., "Zepp Nagoya" → "愛知県").
+  // Absent when the area cannot be determined with confidence — an incorrect value is
+  // strictly worse than an absent one.
+  optional string admin_area = 3 [(buf.validate.field).string.max_len = 100];
 }
 
 // VenueId is a globally unique identifier for a concert venue.

--- a/proto/liverty_music/entity/v1/venue.proto
+++ b/proto/liverty_music/entity/v1/venue.proto
@@ -12,6 +12,11 @@ message Venue {
 
   // The official name or title of the music venue.
   VenueName name = 2 [(buf.validate.field).required = true];
+
+  // The administrative area (prefecture, state, province) where the venue is located.
+  // Populated only when determinable with confidence from the source data.
+  // Absent if the area could not be determined.
+  optional string admin_area = 3;
 }
 
 // VenueId is a globally unique identifier for a concert venue.


### PR DESCRIPTION
## Summary

- Add OpenSpec change artifacts for `extract-concert-venue`
- Captures design decisions and requirements explored in discussion:
  - `Venue.AdminArea` (`*string`, nullable) — prefecture/state-level geographic field, internationally named to avoid Japan-specificity
  - `Event.ListedVenueName` — raw venue name as listed on artist official site, preserved separately from future normalized `Venue.Name`
  - Rename `ScrapedConcert.VenueName` → `ListedVenueName` throughout the pipeline
  - Gemini extraction rule: populate `admin_area` only when confident; wrong value is strictly forbidden, empty string preferred

## Artifacts

| File | Description |
|------|-------------|
| `proposal.md` | Motivation and capability scope |
| `design.md` | Key design decisions (AdminArea naming, nullable strategy, ListedVenueName placement, migration plan) |
| `specs/concert-search/spec.md` | AdminArea extraction rules (confident-or-empty) |
| `specs/concert-service/spec.md` | Venue AdminArea persistence, Event ListedVenueName preservation |
| `tasks.md` | 23 implementation tasks across 7 layers |

## Test plan

- [ ] Review design decisions in `design.md` (AdminArea naming, nullable strategy)
- [ ] Verify specs cover extraction confidence rules
- [ ] Verify tasks cover all affected layers (entity, gemini, DB, repo, use case, proto, tests)