### PR TITLE
fix(gemini): approve PR when no issues found on re-review

### DIFF
--- a/.gemini/commands/github-actions-review.toml
+++ b/.gemini/commands/github-actions-review.toml
@@ -44,20 +44,18 @@ Find defects or say nothing. If no critical issues: output ONLY "LGTM".
 - Find CRITICAL issues per Focus Areas
 - Skip issues from Step 2
 
-**Step 4: Post Comments**
-- Format: **[Critical]** `file:line` followed by Issue and Fix
-- Severity: Critical (security/privacy, data corruption, missing public API docs) | Warning (schema design, incomplete docs, minor validation)
-- Call: `create_pending_pull_request_review` → `add_comment_to_pending_review` → `submit_pending_pull_request_review`
+**Step 4: Submit Review**
 
-## Output
-No issues found: `LGTM`
+**IF no issues found:**
+- Call `submit_pending_pull_request_review` with event `APPROVE` and empty body
+- Do NOT add any comment or body text
 
-Issues found:
-```
-**[Critical]** `file_path:line_number`
-Issue: [Brief explanation]
-Fix: [Actionable solution]
-```
+**IF issues found:**
+- Call `create_pending_pull_request_review` with event `REQUEST_CHANGES`
+- For each issue: call `add_comment_to_pending_review`
+  - Format: **[Critical]** `file:line` followed by Issue and Fix
+  - Severity: Critical (security/privacy, data corruption, missing public API docs) | Warning (schema design, incomplete docs, minor validation)
+- Call `submit_pending_pull_request_review`
 
 Do NOT add: summaries, praise, explanations of schema, breaking change comments, trivial suggestions.
 """


### PR DESCRIPTION
## Summary
- Gemini review now submits `APPROVE` when no critical issues are found, instead of just commenting "LGTM"
- When issues exist, explicitly uses `REQUEST_CHANGES` with inline comments
- Fixes stale `Changes requested` status blocking PR merges after fixes are pushed

## Test plan
- [ ] Open a PR with no issues and verify Gemini submits an APPROVE review
- [ ] Open a PR with a critical issue and verify Gemini submits REQUEST_CHANGES with inline comments