### PR TITLE
feat(openspec): add venue-normalization change artifacts

### DIFF
--- a/.github/workflows/gemini.yml
+++ b/.github/workflows/gemini.yml
@@ -40,7 +40,7 @@ jobs:
           settings: |-
             {
               "model": {
-                "maxSessionTurns": 20,
+                "maxSessionTurns": 40,
                 "compressionThreshold": 0.4
               },
               "mcpServers": {

--- a/openspec/changes/venue-normalization/.openspec.yaml
+++ b/openspec/changes/venue-normalization/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-02-20

--- a/openspec/changes/venue-normalization/design.md
+++ b/openspec/changes/venue-normalization/design.md
@@ -1,0 +1,82 @@
+## Context
+
+The Gemini-based concert searcher extracts venue names as free-text strings (e.g., "日本武道館", "Nippon Budokan", "武道館"). These are stored directly as `venues.name` and used as the deduplication key via exact-match `GetByName`. Because the same physical venue can appear under multiple spellings across different artist pages or scrape runs, duplicate venue records accumulate in the database. Once PR #45 (extract-concert-venue) ships, `events.listed_venue_name` will preserve the original Gemini text, but `venues.name` continues to be used for deduplication — the core problem remains.
+
+This change introduces an async enrichment pipeline that resolves raw venue names to external canonical identities (MusicBrainz MBID or Google Maps place_id) and merges duplicate records.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Resolve venue names to canonical external IDs (MusicBrainz MBID or Google Maps place_id)
+- Update `venues.name` to the canonical name provided by the external source
+- Detect and merge duplicate venue records sharing the same external ID
+- Track enrichment state per venue via `enrichment_status` enum
+- Extend the existing MusicBrainz client with `place` endpoint support
+
+**Non-Goals:**
+- Exposing `mbid` / `google_place_id` in the public API (future change)
+- Rate-limit management for external APIs (noted as TODO — existing MusicBrainz throttler reused as-is)
+- Migrating job trigger to event-driven architecture (future follow-up)
+- Enriching venues that were created before this change is deployed (no backfill; status defaults to `pending` for all existing rows)
+
+## Decisions
+
+### D1: MusicBrainz first, Google Maps as fallback
+
+MusicBrainz is free and open, and its `place` entity includes alias records (e.g., "Nippon Budokan", "日本武道館", "武道館" all resolve to the same MBID). The existing codebase already has a MusicBrainz client and throttler. Google Maps has superior coverage for smaller venues but incurs per-request cost. The sequential strategy avoids unnecessary Maps API calls.
+
+**Alternatives considered:**
+- Google Maps only: Better coverage, but cost scales with venue volume and vendor lock-in.
+- Parallel lookup: Reduces latency but doubles cost on every request regardless of MB hit rate.
+
+### D2: `enrichment_status` enum with three states (`pending`, `enriched`, `failed`)
+
+A dedicated status column enables targeted queries (`WHERE enrichment_status = 'pending'`) and prevents the job from retrying permanently unresolvable venues (small live houses not in either database). `failed` makes the unresolvable set visible for future manual review or alternative strategies.
+
+**Alternatives considered:**
+- `mbid IS NULL AND google_place_id IS NULL` as implicit "pending": Works but conflates "not yet tried" with "tried and failed". Prevents safe retry logic.
+- `enrichment_attempted_at TIMESTAMPTZ`: More flexible for time-based retry, but adds complexity not needed now. Can be added later.
+
+### D3: Duplicate detection during enrichment (single pass)
+
+When the enrichment job resolves a venue to a canonical ID, it immediately checks for an existing venue record with the same ID. If found, it merges within the same transaction. This avoids a separate reconciliation pass and ensures duplicate records never remain in the DB longer than necessary.
+
+**Merge rules:**
+- Canonical venue: the record with the older `created_at` (first-seen wins)
+- `events.venue_id` references updated to point to canonical
+- `admin_area`: `COALESCE(canonical.admin_area, duplicate.admin_area)` — preserve any non-NULL value
+- Canonical `venues.name` updated to external canonical name; duplicate deleted
+
+### D4: Job piggybacks on `concert-discovery` CronJob
+
+Venue enrichment runs as a post-step in the existing `concert-discovery` job binary, after all artists have been processed. This avoids deploying a new CronJob resource and leverages already-initialized dependencies (DB, MusicBrainz client). A follow-up change will migrate to event-driven triggering once concert-search supports user-Follow-triggered execution.
+
+### D5: `admin_area` as search hint for external APIs
+
+When calling MusicBrainz or Google Maps, the job includes `venues.admin_area` (set by PR #45) in the search query if non-NULL. This improves match accuracy for venues with common names (e.g., "Zepp Nagoya" in "愛知県" vs other "Zepp" venues).
+
+## Risks / Trade-offs
+
+- **MusicBrainz coverage gaps** → Smaller Japanese live houses may not be registered. Mitigated by Google Maps fallback. Remaining `failed` venues are acceptable and visible.
+- **Google Maps cost at scale** → Only triggered after MB miss. Cost is bounded by the number of venues not in MusicBrainz. Rate-limit strategy deferred as TODO.
+- **Merge touching `events` table** → UPDATE on `events.venue_id` could be a large write if a duplicate venue has many events. Mitigated by running in a transaction; no user-facing downtime expected at current data volumes.
+- **`enrichment_status = 'pending'` for all pre-existing venues** → Existing venues will be enriched on the next job run. No immediate behavioral change; `venues.name` remains valid for `GetByName` until overwritten.
+
+## Migration Plan
+
+1. Deploy Go changes (entity, usecase, enrichment job step — all additive)
+2. Run migration:
+   ```sql
+   CREATE TYPE venue_enrichment_status AS ENUM ('pending', 'enriched', 'failed');
+   ALTER TABLE venues
+     ADD COLUMN mbid TEXT,
+     ADD COLUMN google_place_id TEXT,
+     ADD COLUMN enrichment_status venue_enrichment_status NOT NULL DEFAULT 'pending';
+   ```
+3. Enrichment runs automatically on the next concert-discovery CronJob execution
+4. Rollback: drop the three columns and the enum type (no data loss beyond new fields)
+
+## Open Questions
+
+- **Rate limiting for Google Maps**: What is the acceptable quota per job run? *(deferred as TODO)*
+- **Future event-driven trigger**: When concert-search supports Follow-triggered execution, venue enrichment should be triggered immediately after a new venue is created rather than waiting for the next cron cycle.

--- a/openspec/changes/venue-normalization/design.md
+++ b/openspec/changes/venue-normalization/design.md
@@ -17,7 +17,7 @@ This change introduces an async enrichment pipeline that resolves raw venue name
 - Exposing `mbid` / `google_place_id` in the public API (future change)
 - Rate-limit management for external APIs (noted as TODO — existing MusicBrainz throttler reused as-is)
 - Migrating job trigger to event-driven architecture (future follow-up)
-- Enriching venues that were created before this change is deployed (no backfill; status defaults to `pending` for all existing rows)
+- Running a dedicated backfill migration script — existing rows receive `enrichment_status = 'pending'` via the column default and will be processed organically on the next scheduled job run
 
 ## Decisions
 
@@ -55,6 +55,14 @@ Venue enrichment runs as a post-step in the existing `concert-discovery` job bin
 
 When calling MusicBrainz or Google Maps, the job includes `venues.admin_area` (set by PR #45) in the search query if non-NULL. This improves match accuracy for venues with common names (e.g., "Zepp Nagoya" in "愛知県" vs other "Zepp" venues).
 
+### D6: `raw_name` column to preserve original scraper-provided venue name
+
+When the enrichment pipeline overwrites `venues.name` with the canonical name (e.g., "Nippon Budokan"), the original scraper-provided name (e.g., "日本武道館") must be preserved for deduplication. Without this, the next scrape providing the same raw name would fail `GetByName` and create a new duplicate — leading to an infinite create-merge cycle. The `raw_name` column stores the original name before the first enrichment overwrite, and `GetByName` falls back to matching on `raw_name` when no `name` match is found.
+
+**Alternatives considered:**
+- Alias table (`venue_aliases`): More flexible for venues with many alternate names, but adds complexity (new table, new queries) beyond what's needed now. Can be added later if a single `raw_name` proves insufficient.
+- Skip name overwrite: Loses the benefit of canonical naming. The whole point of enrichment is normalizing venue names.
+
 ## Risks / Trade-offs
 
 - **MusicBrainz coverage gaps** → Smaller Japanese live houses may not be registered. Mitigated by Google Maps fallback. Remaining `failed` venues are acceptable and visible.
@@ -71,10 +79,14 @@ When calling MusicBrainz or Google Maps, the job includes `venues.admin_area` (s
    ALTER TABLE venues
      ADD COLUMN mbid TEXT,
      ADD COLUMN google_place_id TEXT,
-     ADD COLUMN enrichment_status venue_enrichment_status NOT NULL DEFAULT 'pending';
+     ADD COLUMN enrichment_status venue_enrichment_status NOT NULL DEFAULT 'pending',
+     ADD COLUMN raw_name TEXT;
+   UPDATE venues SET raw_name = name;
+   CREATE UNIQUE INDEX idx_venues_mbid ON venues (mbid) WHERE mbid IS NOT NULL;
+   CREATE UNIQUE INDEX idx_venues_google_place_id ON venues (google_place_id) WHERE google_place_id IS NOT NULL;
    ```
 3. Enrichment runs automatically on the next concert-discovery CronJob execution
-4. Rollback: drop the three columns and the enum type (no data loss beyond new fields)
+4. Rollback: drop the columns, indexes, and the enum type (no data loss beyond new fields)
 
 ## Open Questions
 

--- a/openspec/changes/venue-normalization/proposal.md
+++ b/openspec/changes/venue-normalization/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+`venues.name` currently stores the raw venue name extracted by Gemini (e.g., "日本武道館", "Nippon Budokan"), which creates duplicate venue records when the same physical location is expressed differently across sources. A normalization pipeline using MusicBrainz (with Google Maps as fallback) is needed to establish canonical venue identities and enable reliable deduplication.
+
+## What Changes
+
+- Add `mbid TEXT` and `google_place_id TEXT` columns to `venues` table (nullable, external identifiers)
+- Add `enrichment_status` enum column to `venues` table (`pending` / `enriched` / `failed`)
+- Implement a venue enrichment job that resolves raw venue names to canonical identities via MusicBrainz Place API, falling back to Google Maps Places Text Search
+- Duplicate venue records sharing the same external ID are detected during enrichment and merged atomically: events are re-pointed to the canonical venue, `admin_area` is preserved via `COALESCE`, and the duplicate is deleted
+- Enrichment job runs as a post-step of the existing `concert-discovery` job (piggyback); future migration to event-driven trigger is noted as a follow-up
+- Extend MusicBrainz client to support `place` endpoint in addition to existing `artist` endpoint
+
+## Capabilities
+
+### New Capabilities
+
+- `venue-normalization`: Async enrichment pipeline that resolves raw venue names to canonical external IDs (MusicBrainz MBID or Google Maps place_id), merges duplicate venue records, and updates `venues.name` to the canonical form
+
+### Modified Capabilities
+
+- `concert-service`: `Venue` entity gains `MBID`, `GooglePlaceID`, and `EnrichmentStatus` fields; persistence layer updated accordingly
+
+## Impact
+
+- **Backend Go**: `entity/venue.go`, `infrastructure/database/rdb/venue_repo.go`, `infrastructure/music/musicbrainz/client.go` (new `place` endpoint), new `infrastructure/maps/` Google Maps client, new `usecase/venue_enrichment_uc.go`, `cmd/job/` (new enrichment job step)
+- **Database**: New migration — `ALTER TYPE` or `CREATE TYPE venue_enrichment_status`, `ALTER TABLE venues ADD COLUMN mbid TEXT, google_place_id TEXT, enrichment_status venue_enrichment_status`
+- **Proto / API**: `venue.proto` — add `mbid`, `google_place_id`, `enrichment_status` fields
+- **Tests**: `venue_repo_test.go`, new `venue_enrichment_uc_test.go`, MusicBrainz place client tests

--- a/openspec/changes/venue-normalization/proposal.md
+++ b/openspec/changes/venue-normalization/proposal.md
@@ -24,6 +24,6 @@
 ## Impact
 
 - **Backend Go**: `entity/venue.go`, `infrastructure/database/rdb/venue_repo.go`, `infrastructure/music/musicbrainz/client.go` (new `place` endpoint), new `infrastructure/maps/` Google Maps client, new `usecase/venue_enrichment_uc.go`, `cmd/job/` (new enrichment job step)
-- **Database**: New migration — `ALTER TYPE` or `CREATE TYPE venue_enrichment_status`, `ALTER TABLE venues ADD COLUMN mbid TEXT, google_place_id TEXT, enrichment_status venue_enrichment_status`
-- **Proto / API**: `venue.proto` — add `mbid`, `google_place_id`, `enrichment_status` fields
+- **Database**: New migration — `CREATE TYPE venue_enrichment_status`, `ALTER TABLE venues ADD COLUMN mbid TEXT, google_place_id TEXT, enrichment_status venue_enrichment_status`
+- **Proto / API**: No changes — `mbid`, `google_place_id`, `enrichment_status` are internal fields only and are not exposed via the public API
 - **Tests**: `venue_repo_test.go`, new `venue_enrichment_uc_test.go`, MusicBrainz place client tests

--- a/openspec/changes/venue-normalization/specs/concert-service/spec.md
+++ b/openspec/changes/venue-normalization/specs/concert-service/spec.md
@@ -1,0 +1,23 @@
+## MODIFIED Requirements
+
+### Requirement: Persist Venues
+
+The system SHALL automatically persist any new concerts discovered via the search mechanism. The `ConcertRepository.Create` method SHALL accept a variadic number of concerts for bulk insert support.
+
+#### Scenario: Persist New Concerts
+
+- **WHEN** `SearchNewConcerts` is called and finds concerts not currently in the database
+- **THEN** the new concerts are saved to the persisted storage via a single bulk insert call
+- **AND** returned in the response with valid IDs
+
+#### Scenario: Persist Venues
+
+- **WHEN** a discovered concert has a venue that does not exist in the database
+- **THEN** a new venue is created dynamically based on the listed venue name provided by the source
+- **AND** the new venue SHALL have `enrichment_status` set to `'pending'`
+- **AND** the new concert is associated with this new venue
+
+#### Scenario: Single concert creation
+
+- **WHEN** `Create` is called with a single concert argument
+- **THEN** it SHALL behave identically to the previous single-insert implementation

--- a/openspec/changes/venue-normalization/specs/venue-normalization/spec.md
+++ b/openspec/changes/venue-normalization/specs/venue-normalization/spec.md
@@ -1,0 +1,90 @@
+## ADDED Requirements
+
+### Requirement: Venue Enrichment Pipeline
+
+The system SHALL provide an async enrichment pipeline that resolves raw venue names to canonical external identifiers (MusicBrainz MBID or Google Maps place_id) and updates venue records with canonical names.
+
+#### Scenario: Successful enrichment via MusicBrainz
+
+- **WHEN** the enrichment job processes a venue with `enrichment_status = 'pending'`
+- **AND** MusicBrainz place search returns a match
+- **THEN** the venue record SHALL be updated with the MusicBrainz MBID
+- **AND** `venues.name` SHALL be overwritten with the canonical name from MusicBrainz
+- **AND** `enrichment_status` SHALL be set to `'enriched'`
+
+#### Scenario: Successful enrichment via Google Maps fallback
+
+- **WHEN** the enrichment job processes a venue with `enrichment_status = 'pending'`
+- **AND** MusicBrainz place search returns no match
+- **AND** Google Maps Text Search returns a match
+- **THEN** the venue record SHALL be updated with the Google Maps place_id
+- **AND** `venues.name` SHALL be overwritten with the canonical name from Google Maps
+- **AND** `enrichment_status` SHALL be set to `'enriched'`
+
+#### Scenario: Both sources miss
+
+- **WHEN** the enrichment job processes a venue with `enrichment_status = 'pending'`
+- **AND** MusicBrainz returns no match
+- **AND** Google Maps returns no match
+- **THEN** `enrichment_status` SHALL be set to `'failed'`
+- **AND** `venues.name` SHALL remain unchanged
+- **AND** the venue SHALL NOT be retried in subsequent job runs
+
+#### Scenario: admin_area used as search hint
+
+- **WHEN** the enrichment job queries MusicBrainz or Google Maps for a venue
+- **AND** the venue has a non-NULL `admin_area`
+- **THEN** the `admin_area` value SHALL be included in the search query to improve match accuracy
+
+### Requirement: Venue Duplicate Merge
+
+The system SHALL detect and merge duplicate venue records that resolve to the same external canonical identifier during the enrichment pass.
+
+#### Scenario: Duplicate detected during enrichment
+
+- **WHEN** the enrichment job resolves a venue to an external ID (MBID or place_id)
+- **AND** another venue record already has the same external ID
+- **THEN** the two records SHALL be merged within a single atomic transaction
+- **AND** all `events.venue_id` references to the duplicate SHALL be updated to point to the canonical venue
+- **AND** the duplicate venue record SHALL be deleted
+- **AND** `admin_area` on the canonical record SHALL be set to `COALESCE(canonical.admin_area, duplicate.admin_area)`
+
+#### Scenario: Canonical venue selection on merge
+
+- **WHEN** two venue records are merged
+- **THEN** the record with the older `created_at` timestamp SHALL be designated as canonical
+
+#### Scenario: No duplicate exists
+
+- **WHEN** the enrichment job resolves a venue to an external ID
+- **AND** no other venue record shares that external ID
+- **THEN** only the current venue record is updated; no merge occurs
+
+### Requirement: Venue Enrichment Status Tracking
+
+Each venue record SHALL carry an `enrichment_status` field reflecting the current state of the normalization pipeline.
+
+#### Scenario: New venue defaults to pending
+
+- **WHEN** a new venue is created (e.g., during concert discovery)
+- **THEN** `enrichment_status` SHALL default to `'pending'`
+
+#### Scenario: Enriched venue not reprocessed
+
+- **WHEN** the enrichment job runs
+- **THEN** venues with `enrichment_status = 'enriched'` or `'failed'` SHALL be excluded from processing
+
+### Requirement: Enrichment Job Execution
+
+The venue enrichment job SHALL run as a post-step of the existing concert-discovery CronJob.
+
+#### Scenario: Enrichment runs after concert discovery completes
+
+- **WHEN** the concert-discovery job finishes processing all artists
+- **THEN** the venue enrichment step SHALL process all venues with `enrichment_status = 'pending'`
+
+#### Scenario: Enrichment step failure is non-fatal
+
+- **WHEN** the venue enrichment step encounters an error for an individual venue
+- **THEN** the job SHALL log the error and continue processing the remaining pending venues
+- **AND** the overall job SHALL still exit with status code 0

--- a/openspec/changes/venue-normalization/specs/venue-normalization/spec.md
+++ b/openspec/changes/venue-normalization/specs/venue-normalization/spec.md
@@ -56,7 +56,7 @@ The system SHALL detect and merge duplicate venue records that resolve to the sa
 - **WHEN** the enrichment job resolves a venue to an external ID (MBID or place_id)
 - **AND** another venue record already has the same external ID
 - **THEN** the two records SHALL be merged within a single atomic transaction
-- **AND** events in the duplicate venue that share the same `(artist_id, local_event_date)` as events already in the canonical venue SHALL be deleted to prevent duplicate event rows
+- **AND** events in the duplicate venue that share the same `(artist_id, local_event_date, start_at)` (using NULL-safe equality for `start_at`) as events already in the canonical venue SHALL be deleted to prevent duplicate event rows
 - **AND** all remaining `events.venue_id` references to the duplicate SHALL be updated to point to the canonical venue
 - **AND** the duplicate venue record SHALL be deleted
 - **AND** `admin_area` on the canonical record SHALL be set to `COALESCE(canonical.admin_area, duplicate.admin_area)`

--- a/openspec/changes/venue-normalization/specs/venue-normalization/spec.md
+++ b/openspec/changes/venue-normalization/specs/venue-normalization/spec.md
@@ -57,6 +57,8 @@ The system SHALL detect and merge duplicate venue records that resolve to the sa
 - **AND** all `events.venue_id` references to the duplicate SHALL be updated to point to the canonical venue
 - **AND** the duplicate venue record SHALL be deleted
 - **AND** `admin_area` on the canonical record SHALL be set to `COALESCE(canonical.admin_area, duplicate.admin_area)`
+- **AND** `mbid` on the canonical record SHALL be set to `COALESCE(canonical.mbid, duplicate.mbid)`
+- **AND** `google_place_id` on the canonical record SHALL be set to `COALESCE(canonical.google_place_id, duplicate.google_place_id)`
 
 #### Scenario: Canonical venue selection on merge
 

--- a/openspec/changes/venue-normalization/specs/venue-normalization/spec.md
+++ b/openspec/changes/venue-normalization/specs/venue-normalization/spec.md
@@ -9,6 +9,7 @@ The system SHALL provide an async enrichment pipeline that resolves raw venue na
 - **WHEN** the enrichment job processes a venue with `enrichment_status = 'pending'`
 - **AND** MusicBrainz place search returns a match
 - **THEN** the venue record SHALL be updated with the MusicBrainz MBID
+- **AND** `venues.raw_name` SHALL be set to the current `venues.name` (if `raw_name` is NULL) to preserve the original scraper-provided name
 - **AND** `venues.name` SHALL be overwritten with the canonical name from MusicBrainz
 - **AND** `enrichment_status` SHALL be set to `'enriched'`
 
@@ -18,6 +19,7 @@ The system SHALL provide an async enrichment pipeline that resolves raw venue na
 - **AND** MusicBrainz place search returns no match
 - **AND** Google Maps Text Search returns a match
 - **THEN** the venue record SHALL be updated with the Google Maps place_id
+- **AND** `venues.raw_name` SHALL be set to the current `venues.name` (if `raw_name` is NULL) to preserve the original scraper-provided name
 - **AND** `venues.name` SHALL be overwritten with the canonical name from Google Maps
 - **AND** `enrichment_status` SHALL be set to `'enriched'`
 
@@ -54,7 +56,8 @@ The system SHALL detect and merge duplicate venue records that resolve to the sa
 - **WHEN** the enrichment job resolves a venue to an external ID (MBID or place_id)
 - **AND** another venue record already has the same external ID
 - **THEN** the two records SHALL be merged within a single atomic transaction
-- **AND** all `events.venue_id` references to the duplicate SHALL be updated to point to the canonical venue
+- **AND** events in the duplicate venue that share the same `(artist_id, local_event_date)` as events already in the canonical venue SHALL be deleted to prevent duplicate event rows
+- **AND** all remaining `events.venue_id` references to the duplicate SHALL be updated to point to the canonical venue
 - **AND** the duplicate venue record SHALL be deleted
 - **AND** `admin_area` on the canonical record SHALL be set to `COALESCE(canonical.admin_area, duplicate.admin_area)`
 - **AND** `mbid` on the canonical record SHALL be set to `COALESCE(canonical.mbid, duplicate.mbid)`
@@ -99,3 +102,14 @@ The venue enrichment job SHALL run as a post-step of the existing concert-discov
 - **WHEN** the venue enrichment step encounters an error for an individual venue
 - **THEN** the job SHALL log the error and continue processing the remaining pending venues
 - **AND** the overall job SHALL still exit with status code 0
+
+### Requirement: Venue Deduplication During Discovery
+
+The concert discovery phase SHALL use `raw_name` as a fallback lookup when finding existing venue records to prevent re-creating venues that have been renamed by the enrichment pipeline.
+
+#### Scenario: Enriched venue found by raw_name
+
+- **WHEN** the concert discovery step attempts to find a venue by its scraped name
+- **AND** no venue record matches on `venues.name`
+- **AND** a venue record matches on `venues.raw_name`
+- **THEN** the existing venue record SHALL be used (no new record created)

--- a/openspec/changes/venue-normalization/specs/venue-normalization/spec.md
+++ b/openspec/changes/venue-normalization/specs/venue-normalization/spec.md
@@ -30,6 +30,15 @@ The system SHALL provide an async enrichment pipeline that resolves raw venue na
 - **AND** `venues.name` SHALL remain unchanged
 - **AND** the venue SHALL NOT be retried in subsequent job runs
 
+#### Scenario: Ambiguous results (multiple matches)
+
+- **WHEN** the enrichment job processes a venue with `enrichment_status = 'pending'`
+- **AND** MusicBrainz or Google Maps returns more than one candidate match
+- **THEN** the venue SHALL NOT be updated with any external identifier
+- **AND** `venues.name` SHALL remain unchanged
+- **AND** `enrichment_status` SHALL be set to `'failed'`
+- **AND** the ambiguity SHALL be logged for future manual review
+
 #### Scenario: admin_area used as search hint
 
 - **WHEN** the enrichment job queries MusicBrainz or Google Maps for a venue

--- a/openspec/changes/venue-normalization/tasks.md
+++ b/openspec/changes/venue-normalization/tasks.md
@@ -9,7 +9,7 @@
 
 - [ ] 2.1 Add `MBID string`, `GooglePlaceID string`, `EnrichmentStatus string`, `RawName string` fields to `Venue` in `internal/entity/venue.go`
 - [ ] 2.2 Add `VenueEnrichmentStatus` typed constants (`Pending`, `Enriched`, `Failed`) in `internal/entity/venue.go`
-- [ ] 2.3 Create `VenueEnrichmentRepository` interface in `internal/entity/venue.go` with `ListPending(ctx) ([]*Venue, error)`, `UpdateEnriched(ctx, venue) error`, `MarkFailed(ctx, id) error`, and `MergeVenues(ctx, canonicalID, duplicateID string, adminArea *string) error`
+- [ ] 2.3 Create `VenueEnrichmentRepository` interface in `internal/entity/venue.go` with `ListPending(ctx) ([]*Venue, error)`, `UpdateEnriched(ctx, venue) error`, `MarkFailed(ctx, id) error`, and `MergeVenues(ctx, canonicalID, duplicateID string) error`
 
 ## 3. MusicBrainz Client — Place Endpoint
 
@@ -33,7 +33,7 @@
 - [ ] 5.4 Implement `ListPending(ctx)` query: `SELECT … FROM venues WHERE enrichment_status = 'pending'`
 - [ ] 5.5 Implement `UpdateEnriched(ctx, venue)` query: copy current `name` to `raw_name` (if `raw_name` is NULL), UPDATE `name` to canonical, set `mbid` or `google_place_id`, set `enrichment_status = 'enriched'`
 - [ ] 5.6 Implement `MarkFailed(ctx, id)` query: UPDATE `enrichment_status = 'failed'`
-- [ ] 5.7 Implement `MergeVenues(ctx, canonicalID, duplicateID, adminArea)` — atomic transaction: UPDATE events, UPDATE canonical venue, DELETE duplicate
+- [ ] 5.7 Implement `MergeVenues(ctx, canonicalID, duplicateID string)` — atomic transaction: 1) DELETE events in the duplicate venue that share `(artist_id, local_event_date)` with the canonical venue; 2) UPDATE remaining `events.venue_id` to `canonicalID`; 3) UPDATE canonical venue fields using `COALESCE` for `admin_area`, `mbid`, `google_place_id`; 4) DELETE duplicate venue
 - [ ] 5.8 Update `venue_repo_test.go` to cover all new fields and methods
 
 ## 6. Venue Enrichment Use Case

--- a/openspec/changes/venue-normalization/tasks.md
+++ b/openspec/changes/venue-normalization/tasks.md
@@ -1,15 +1,15 @@
 ## 1. Database Migration
 
 - [ ] 1.1 Create `venue_enrichment_status` ENUM type (`pending`, `enriched`, `failed`) in a new migration file
-- [ ] 1.2 Add `mbid TEXT`, `google_place_id TEXT`, `enrichment_status venue_enrichment_status NOT NULL DEFAULT 'pending'` columns to `venues` table
+- [ ] 1.2 Add `mbid TEXT`, `google_place_id TEXT`, `enrichment_status venue_enrichment_status NOT NULL DEFAULT 'pending'`, `raw_name TEXT` columns to `venues` table (backfill `raw_name` from existing `name`: `UPDATE venues SET raw_name = name`)
 - [ ] 1.3 Add unique partial indexes: `CREATE UNIQUE INDEX ON venues (mbid) WHERE mbid IS NOT NULL` and `CREATE UNIQUE INDEX ON venues (google_place_id) WHERE google_place_id IS NOT NULL`
 - [ ] 1.4 Update `schema.sql` to reflect the new columns, enum type, and indexes
 
 ## 2. Entity Layer
 
-- [ ] 2.1 Add `MBID string`, `GooglePlaceID string`, `EnrichmentStatus string` fields to `Venue` in `internal/entity/venue.go`
+- [ ] 2.1 Add `MBID string`, `GooglePlaceID string`, `EnrichmentStatus string`, `RawName string` fields to `Venue` in `internal/entity/venue.go`
 - [ ] 2.2 Add `VenueEnrichmentStatus` typed constants (`Pending`, `Enriched`, `Failed`) in `internal/entity/venue.go`
-- [ ] 2.3 Create `VenueEnrichmentRepository` interface in `internal/entity/venue.go` with `ListPending(ctx) ([]*Venue, error)` and `UpdateEnriched(ctx, venue) error` and `MarkFailed(ctx, id) error`
+- [ ] 2.3 Create `VenueEnrichmentRepository` interface in `internal/entity/venue.go` with `ListPending(ctx) ([]*Venue, error)`, `UpdateEnriched(ctx, venue) error`, `MarkFailed(ctx, id) error`, and `MergeVenues(ctx, canonicalID, duplicateID string, adminArea *string) error`
 
 ## 3. MusicBrainz Client — Place Endpoint
 
@@ -27,11 +27,11 @@
 
 ## 5. Repository Layer
 
-- [ ] 5.1 Update `insertVenueQuery` in `venue_repo.go` to include `enrichment_status`, always binding `entity.Venue.EnrichmentStatus` (repository layer owns the default `entity.EnrichmentStatusPending`; usecase leaves the field at its zero-value)
-- [ ] 5.2 Update `getVenueQuery` and `getVenueByNameQuery` to SELECT `mbid`, `google_place_id`, `enrichment_status`
+- [ ] 5.1 Update `insertVenueQuery` in `venue_repo.go` to include `enrichment_status` and `raw_name`; if `Venue.EnrichmentStatus` is zero-value (`""`), the repository SHALL substitute `entity.EnrichmentStatusPending` before binding to avoid inserting an invalid ENUM value
+- [ ] 5.2 Update `getVenueQuery` and `getVenueByNameQuery` to SELECT `mbid`, `google_place_id`, `enrichment_status`, `raw_name`; update `GetByName` to also match on `raw_name` so enriched venues (renamed to canonical name) can still be found by the original scraper-provided name
 - [ ] 5.3 Update `Create()`, `Get()`, `GetByName()` Scan/Exec calls to include new fields
 - [ ] 5.4 Implement `ListPending(ctx)` query: `SELECT … FROM venues WHERE enrichment_status = 'pending'`
-- [ ] 5.5 Implement `UpdateEnriched(ctx, venue)` query: UPDATE `name`, `mbid` or `google_place_id`, set `enrichment_status = 'enriched'`
+- [ ] 5.5 Implement `UpdateEnriched(ctx, venue)` query: copy current `name` to `raw_name` (if `raw_name` is NULL), UPDATE `name` to canonical, set `mbid` or `google_place_id`, set `enrichment_status = 'enriched'`
 - [ ] 5.6 Implement `MarkFailed(ctx, id)` query: UPDATE `enrichment_status = 'failed'`
 - [ ] 5.7 Implement `MergeVenues(ctx, canonicalID, duplicateID, adminArea)` — atomic transaction: UPDATE events, UPDATE canonical venue, DELETE duplicate
 - [ ] 5.8 Update `venue_repo_test.go` to cover all new fields and methods
@@ -51,4 +51,4 @@
 
 ## 8. Concert Service — Venue Creation Update
 
-- [ ] 8.1 Confirm `concert_uc.go` does NOT set `EnrichmentStatus` on the `Venue` entity before calling `Create()` — the repository layer SHALL always INSERT `enrichment_status` using the Go constant `entity.EnrichmentStatusPending`, not relying on the DB default, to keep the entity and DB in sync
+- [ ] 8.1 Update `concert_uc.go` venue creation to set `EnrichmentStatus = entity.EnrichmentStatusPending` and `RawName = name` explicitly on the `Venue` entity before calling `Create()` — the repository layer's zero-value guard is a safety net, not the primary path

--- a/openspec/changes/venue-normalization/tasks.md
+++ b/openspec/changes/venue-normalization/tasks.md
@@ -33,7 +33,7 @@
 - [ ] 5.4 Implement `ListPending(ctx)` query: `SELECT … FROM venues WHERE enrichment_status = 'pending'`
 - [ ] 5.5 Implement `UpdateEnriched(ctx, venue)` query: copy current `name` to `raw_name` (if `raw_name` is NULL), UPDATE `name` to canonical, set `mbid` or `google_place_id`, set `enrichment_status = 'enriched'`
 - [ ] 5.6 Implement `MarkFailed(ctx, id)` query: UPDATE `enrichment_status = 'failed'`
-- [ ] 5.7 Implement `MergeVenues(ctx, canonicalID, duplicateID string)` — atomic transaction: 1) DELETE events in the duplicate venue that share `(artist_id, local_event_date)` with the canonical venue; 2) UPDATE remaining `events.venue_id` to `canonicalID`; 3) UPDATE canonical venue fields using `COALESCE` for `admin_area`, `mbid`, `google_place_id`; 4) DELETE duplicate venue
+- [ ] 5.7 Implement `MergeVenues(ctx, canonicalID, duplicateID string)` — atomic transaction: 1) DELETE events in the duplicate venue that share `(artist_id, local_event_date, start_at)` (NULL-safe equality via `IS NOT DISTINCT FROM`) with the canonical venue; 2) UPDATE remaining `events.venue_id` to `canonicalID`; 3) UPDATE canonical venue fields using `COALESCE` for `admin_area`, `mbid`, `google_place_id`; 4) DELETE duplicate venue
 - [ ] 5.8 Update `venue_repo_test.go` to cover all new fields and methods
 
 ## 6. Venue Enrichment Use Case

--- a/openspec/changes/venue-normalization/tasks.md
+++ b/openspec/changes/venue-normalization/tasks.md
@@ -1,0 +1,58 @@
+## 1. Database Migration
+
+- [ ] 1.1 Create `venue_enrichment_status` ENUM type (`pending`, `enriched`, `failed`) in a new migration file
+- [ ] 1.2 Add `mbid TEXT`, `google_place_id TEXT`, `enrichment_status venue_enrichment_status NOT NULL DEFAULT 'pending'` columns to `venues` table
+- [ ] 1.3 Update `schema.sql` to reflect the new columns and enum type
+
+## 2. Entity Layer
+
+- [ ] 2.1 Add `MBID string`, `GooglePlaceID string`, `EnrichmentStatus string` fields to `Venue` in `internal/entity/venue.go`
+- [ ] 2.2 Add `VenueEnrichmentStatus` typed constants (`Pending`, `Enriched`, `Failed`) in `internal/entity/venue.go`
+- [ ] 2.3 Create `VenueEnrichmentRepository` interface in `internal/entity/venue.go` with `ListPending(ctx) ([]*Venue, error)` and `UpdateEnriched(ctx, venue) error` and `MarkFailed(ctx, id) error`
+
+## 3. MusicBrainz Client — Place Endpoint
+
+- [ ] 3.1 Add `SearchPlace(ctx, name, adminArea string) (*Place, error)` method to MusicBrainz client in `internal/infrastructure/music/musicbrainz/client.go`
+- [ ] 3.2 Define `Place` response struct with `ID`, `Name` fields
+- [ ] 3.3 Add unit test for `SearchPlace` using `httptest` server in `client_test.go`
+
+## 4. Google Maps Client
+
+- [ ] 4.1 Create `internal/infrastructure/maps/google/` package with `Client` struct
+- [ ] 4.2 Implement `SearchPlace(ctx, name, adminArea string) (*Place, error)` using Places Text Search API
+- [ ] 4.3 Add `Place` response struct with `PlaceID`, `Name` fields
+- [ ] 4.4 Add unit test for `SearchPlace` using `httptest` server
+- [ ] 4.5 Wire Google Maps API key into config (`internal/di/`)
+
+## 5. Repository Layer
+
+- [ ] 5.1 Update `insertVenueQuery` in `venue_repo.go` to include `enrichment_status` (defaults to `pending`)
+- [ ] 5.2 Update `getVenueQuery` and `getVenueByNameQuery` to SELECT `mbid`, `google_place_id`, `enrichment_status`
+- [ ] 5.3 Update `Create()`, `Get()`, `GetByName()` Scan/Exec calls to include new fields
+- [ ] 5.4 Implement `ListPending(ctx)` query: `SELECT … FROM venues WHERE enrichment_status = 'pending'`
+- [ ] 5.5 Implement `UpdateEnriched(ctx, venue)` query: UPDATE `name`, `mbid` or `google_place_id`, set `enrichment_status = 'enriched'`
+- [ ] 5.6 Implement `MarkFailed(ctx, id)` query: UPDATE `enrichment_status = 'failed'`
+- [ ] 5.7 Implement `MergeVenues(ctx, canonicalID, duplicateID, adminArea)` — atomic transaction: UPDATE events, UPDATE canonical venue, DELETE duplicate
+- [ ] 5.8 Update `venue_repo_test.go` to cover all new fields and methods
+
+## 6. Venue Enrichment Use Case
+
+- [ ] 6.1 Create `internal/usecase/venue_enrichment_uc.go` with `VenueEnrichmentUseCase` interface and `venueEnrichmentUseCase` struct
+- [ ] 6.2 Implement `EnrichPendingVenues(ctx)`: iterate `ListPending`, call MB then Maps, merge duplicates or update, mark failed on both miss
+- [ ] 6.3 Implement duplicate detection: after resolving external ID, query for existing venue with same MBID/place_id; if found, call `MergeVenues`
+- [ ] 6.4 Write unit tests in `venue_enrichment_uc_test.go` covering: MB hit, Maps fallback hit, both miss, duplicate merge, admin_area COALESCE
+
+## 7. Concert Discovery Job Integration
+
+- [ ] 7.1 Add `VenueEnrichmentUseCase` to job DI initializer in `internal/di/job.go`
+- [ ] 7.2 Call `EnrichPendingVenues(ctx)` as a post-step after all artists are processed in the job entrypoint
+- [ ] 7.3 Ensure per-venue errors are logged and non-fatal (job exits with status 0)
+
+## 8. Concert Service — Venue Creation Update
+
+- [ ] 8.1 Update `concert_uc.go` venue creation to confirm `enrichment_status` is not explicitly set (relies on DB default `'pending'`)
+
+## 9. Proto & Mapper
+
+- [ ] 9.1 Add `string mbid = 3`, `string google_place_id = 4`, `string enrichment_status = 5` fields to `Venue` message in `proto/liverty_music/entity/v1/venue.proto`
+- [ ] 9.2 Update `VenueToProto()` mapper in `internal/adapter/rpc/mapper/concert.go` to map new fields

--- a/openspec/changes/venue-normalization/tasks.md
+++ b/openspec/changes/venue-normalization/tasks.md
@@ -2,7 +2,7 @@
 
 - [ ] 1.1 Create `venue_enrichment_status` ENUM type (`pending`, `enriched`, `failed`) in a new migration file
 - [ ] 1.2 Add `mbid TEXT`, `google_place_id TEXT`, `enrichment_status venue_enrichment_status NOT NULL DEFAULT 'pending'`, `raw_name TEXT` columns to `venues` table (backfill `raw_name` from existing `name`: `UPDATE venues SET raw_name = name`)
-- [ ] 1.3 Add unique partial indexes: `CREATE UNIQUE INDEX ON venues (mbid) WHERE mbid IS NOT NULL` and `CREATE UNIQUE INDEX ON venues (google_place_id) WHERE google_place_id IS NOT NULL`
+- [ ] 1.3 Add unique partial indexes: `CREATE UNIQUE INDEX ON venues (mbid) WHERE mbid IS NOT NULL` and `CREATE UNIQUE INDEX ON venues (google_place_id) WHERE google_place_id IS NOT NULL`; add non-unique index: `CREATE INDEX idx_venues_raw_name ON venues (raw_name)`
 - [ ] 1.4 Update `schema.sql` to reflect the new columns, enum type, and indexes
 
 ## 2. Entity Layer

--- a/openspec/changes/venue-normalization/tasks.md
+++ b/openspec/changes/venue-normalization/tasks.md
@@ -2,7 +2,8 @@
 
 - [ ] 1.1 Create `venue_enrichment_status` ENUM type (`pending`, `enriched`, `failed`) in a new migration file
 - [ ] 1.2 Add `mbid TEXT`, `google_place_id TEXT`, `enrichment_status venue_enrichment_status NOT NULL DEFAULT 'pending'` columns to `venues` table
-- [ ] 1.3 Update `schema.sql` to reflect the new columns and enum type
+- [ ] 1.3 Add unique partial indexes: `CREATE UNIQUE INDEX ON venues (mbid) WHERE mbid IS NOT NULL` and `CREATE UNIQUE INDEX ON venues (google_place_id) WHERE google_place_id IS NOT NULL`
+- [ ] 1.4 Update `schema.sql` to reflect the new columns, enum type, and indexes
 
 ## 2. Entity Layer
 
@@ -26,7 +27,7 @@
 
 ## 5. Repository Layer
 
-- [ ] 5.1 Update `insertVenueQuery` in `venue_repo.go` to include `enrichment_status` (defaults to `pending`)
+- [ ] 5.1 Update `insertVenueQuery` in `venue_repo.go` to include `enrichment_status`, always binding `entity.Venue.EnrichmentStatus` (repository layer owns the default `entity.EnrichmentStatusPending`; usecase leaves the field at its zero-value)
 - [ ] 5.2 Update `getVenueQuery` and `getVenueByNameQuery` to SELECT `mbid`, `google_place_id`, `enrichment_status`
 - [ ] 5.3 Update `Create()`, `Get()`, `GetByName()` Scan/Exec calls to include new fields
 - [ ] 5.4 Implement `ListPending(ctx)` query: `SELECT … FROM venues WHERE enrichment_status = 'pending'`
@@ -40,7 +41,7 @@
 - [ ] 6.1 Create `internal/usecase/venue_enrichment_uc.go` with `VenueEnrichmentUseCase` interface and `venueEnrichmentUseCase` struct
 - [ ] 6.2 Implement `EnrichPendingVenues(ctx)`: iterate `ListPending`, call MB then Maps, merge duplicates or update, mark failed on both miss
 - [ ] 6.3 Implement duplicate detection: after resolving external ID, query for existing venue with same MBID/place_id; if found, call `MergeVenues`
-- [ ] 6.4 Write unit tests in `venue_enrichment_uc_test.go` covering: MB hit, Maps fallback hit, both miss, duplicate merge, admin_area COALESCE
+- [ ] 6.4 Write unit tests in `venue_enrichment_uc_test.go` covering: MB hit, Maps fallback hit, both miss, ambiguous results (multiple matches → failed), duplicate merge (admin_area / mbid / google_place_id COALESCE)
 
 ## 7. Concert Discovery Job Integration
 
@@ -50,4 +51,4 @@
 
 ## 8. Concert Service — Venue Creation Update
 
-- [ ] 8.1 Update `concert_uc.go` venue creation to confirm `enrichment_status` is not explicitly set (relies on DB default `'pending'`)
+- [ ] 8.1 Confirm `concert_uc.go` does NOT set `EnrichmentStatus` on the `Venue` entity before calling `Create()` — the repository layer SHALL always INSERT `enrichment_status` using the Go constant `entity.EnrichmentStatusPending`, not relying on the DB default, to keep the entity and DB in sync

--- a/openspec/changes/venue-normalization/tasks.md
+++ b/openspec/changes/venue-normalization/tasks.md
@@ -51,8 +51,3 @@
 ## 8. Concert Service — Venue Creation Update
 
 - [ ] 8.1 Update `concert_uc.go` venue creation to confirm `enrichment_status` is not explicitly set (relies on DB default `'pending'`)
-
-## 9. Proto & Mapper
-
-- [ ] 9.1 Add `string mbid = 3`, `string google_place_id = 4`, `string enrichment_status = 5` fields to `Venue` message in `proto/liverty_music/entity/v1/venue.proto`
-- [ ] 9.2 Update `VenueToProto()` mapper in `internal/adapter/rpc/mapper/concert.go` to map new fields


### PR DESCRIPTION
## 🔗 Related Issue

Closes #

## 📝 Summary of Changes

Add OpenSpec change artifacts for `venue-normalization` — an async enrichment pipeline that resolves raw Gemini-extracted venue names to canonical external identities (MusicBrainz MBID or Google Maps place_id) and merges duplicate venue records.

**Context**: The concert searcher extracts venue names as free text (e.g., "日本武道館", "Nippon Budokan"). These are stored via exact-match `GetByName`, causing duplicate venue records when the same place appears under different spellings. This change designs the normalization pipeline that will resolve and deduplicate them.

**Key design decisions:**
- MusicBrainz `place` endpoint first (free, alias-aware), Google Maps Text Search as fallback
- `enrichment_status` enum (`pending` / `enriched` / `failed`) per venue — prevents infinite retry loops and makes unenrichable venues visible
- Duplicate detection during enrichment (single pass): atomic transaction updates `events.venue_id`, applies `COALESCE` on `admin_area`, deletes duplicate
- Canonical venue = oldest `created_at`; canonical name = value from whichever external source matched
- `admin_area` (introduced by `extract-concert-venue` / PR #45) used as a search hint to improve MB/Maps accuracy
- Enrichment job piggybacks on existing `concert-discovery` CronJob as a post-step; event-driven migration noted as future follow-up

## Artifacts

| File | Description |
|------|-------------|
| `proposal.md` | Motivation, what changes, impact scope |
| `design.md` | D1–D5 technical decisions with alternatives considered |
| `specs/venue-normalization/spec.md` | Enrichment pipeline, duplicate merge, status tracking, job execution requirements |
| `specs/concert-service/spec.md` | Delta — venue creation sets `enrichment_status = 'pending'` |
| `tasks.md` | 27 tasks across 9 layers: DB, entity, MusicBrainz client, Google Maps client, repo, use case, job integration, concert-service, proto |

## ✅ Self-Checklist

- [ ] I have linked the related issue.
- [ ] I have updated the relevant documentation (e.g., `README.md`) if needed.
- [ ] I have run `buf lint` and `buf format` locally and all checks have passed.
- [ ] My proto definitions follow the project's style guidelines and validation rules.
- [ ] Breaking changes have been justified and documented if applicable.