### PR TITLE
feat(secret-manager): add secret management specs and archive change

### DIFF
--- a/openspec/changes/archive/2026-02-20-secret-manager/.openspec.yaml
+++ b/openspec/changes/archive/2026-02-20-secret-manager/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-02-15

--- a/openspec/changes/archive/2026-02-20-secret-manager/design.md
+++ b/openspec/changes/archive/2026-02-20-secret-manager/design.md
@@ -1,0 +1,97 @@
+## Context
+
+Runtime secrets for the backend are currently unmanaged. The backend reads `LASTFM_API_KEY` (and will read future API keys) via `os.Getenv()`, but there is no K8s Secret backing these values. All environment variables are served from a single ConfigMap, mixing sensitive and non-sensitive data.
+
+The infrastructure already uses:
+- **GKE Autopilot** (asia-northeast2) with Workload Identity
+- **Kustomize** base/overlay pattern for K8s manifests
+- **ArgoCD** for GitOps-based continuous delivery
+- **Pulumi** for GCP resource provisioning with ESC for IaC-time secrets
+- **IAM-based authentication** for Cloud SQL (no password management)
+
+The gap is a runtime secret delivery pipeline: GCP Secret Manager → K8s Pod environment variables.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Securely store and deliver runtime secrets (starting with `LASTFM_API_KEY`) to backend pods
+- Zero application code changes -- secrets consumed as environment variables via `os.Getenv()`
+- GitOps-compatible -- all K8s resources declarative in Kustomize manifests
+- Extensible pattern -- adding a new secret requires only GCP SM entry + ExternalSecret key addition
+- Rotation-ready -- secret updates in GCP SM propagate to pods automatically
+
+**Non-Goals:**
+- Application-level secret caching or hot-reload (Pod restart on rotation is acceptable)
+- Secrets for frontend or other non-backend workloads (future scope)
+- Migrating Pulumi ESC secrets to GCP Secret Manager (ESC remains for IaC-time config)
+- Secret generation or automated rotation scheduling in GCP (manual secret value management for now)
+
+## Decisions
+
+### Decision 1: External Secrets Operator (ESO) over GCP Secret Manager CSI Driver
+
+**Choice**: ESO
+
+**Rationale**:
+- ESO creates native K8s Secrets, consumed via `envFrom: secretRef` -- identical to existing ConfigMap pattern. No `config.go` changes needed.
+- CSI Driver mounts secrets as files, requiring either application changes or `syncSecret` workaround (adds complexity for the same result).
+- ESO provides clear error reporting via `ExternalSecret` status conditions. CSI Driver failures manifest as opaque Pod scheduling errors.
+- ESO is a CNCF Sandbox project with broad community support and multi-provider capability.
+- CSI Driver's only advantage (native GKE addon) is offset by ESO's straightforward Helm-based deployment under ArgoCD.
+
+**Alternatives considered**:
+- **CSI Driver**: Native GKE addon but requires file-based consumption or complex syncSecret configuration.
+- **Init Container (custom)**: Maximum flexibility but high maintenance cost and no standard rotation support.
+- **Pulumi ESC runtime integration**: ESC is designed for build/deploy time, not K8s pod runtime injection.
+
+### Decision 2: ESO deployed via ArgoCD Helm Application
+
+**Choice**: Manage ESO as an ArgoCD Application pointing to the ESO Helm chart.
+
+**Rationale**:
+- Consistent with existing ArgoCD-based GitOps workflow.
+- ESO controller runs in a dedicated namespace (e.g., `external-secrets`), separate from application workloads.
+- ArgoCD handles upgrades and drift detection for the operator itself.
+- Avoids Pulumi managing in-cluster operators (keeps Pulumi focused on GCP resources).
+
+### Decision 3: ClusterSecretStore scoped per environment
+
+**Choice**: One `ClusterSecretStore` per cluster (each cluster is single-environment), referencing the environment's GCP project via Workload Identity.
+
+**Rationale**:
+- GKE clusters are already environment-specific (`liverty-music-dev`, `liverty-music-prod`).
+- `ClusterSecretStore` avoids per-namespace SecretStore duplication.
+- Authentication uses existing Workload Identity binding -- the `backend-app` GCP SA gets `roles/secretmanager.secretAccessor`.
+
+### Decision 4: Secret naming convention in GCP Secret Manager
+
+**Choice**: Flat kebab-case name (e.g., `lastfm-api-key`). No environment prefix.
+
+**Rationale**:
+- GCP Secret Manager does not support `/` in secret IDs (only letters, numbers, hyphens, underscores are allowed). The original `{env}/{secret-name}` design was infeasible.
+- Environment isolation is provided by the GCP project boundary (`liverty-music-dev` vs `liverty-music-prod`). A per-environment prefix in the name is redundant.
+- Kebab-case secret names align with existing resource naming conventions.
+- Maps cleanly to ExternalSecret `remoteRef.key` field.
+- Secret value is sourced from Pulumi ESC config key `gcp.lastFmApiKey` (set with `--secret`).
+
+### Decision 5: Rotation via Reloader
+
+**Choice**: Deploy [Stakater Reloader](https://github.com/stakater/Reloader) to trigger rolling restarts when K8s Secrets change.
+
+**Rationale**:
+- Environment variables are only read at process startup; K8s Secret updates alone do not propagate to running pods.
+- Reloader watches for Secret changes and triggers Deployment rolling updates.
+- Annotation-based (`reloader.stakater.com/auto: "true"`) -- minimal manifest change.
+- Well-established pattern in the K8s ecosystem, lightweight DaemonSet.
+
+## Risks / Trade-offs
+
+- **[ESO operator availability]** → ESO controller downtime prevents secret sync. Mitigation: K8s Secrets persist independently; existing pods continue running. New pods may fail if Secret doesn't exist yet. ESO supports HA mode with multiple replicas.
+
+- **[Secret sync latency]** → ExternalSecret `refreshInterval` introduces delay between GCP SM update and K8s Secret update. Mitigation: Set reasonable interval (e.g., 1h for API keys). Manual `kubectl annotate externalsecret --overwrite` forces immediate refresh.
+
+- **[Reloader restart impact]** → Secret rotation triggers pod restarts, causing brief availability dip. Mitigation: Rolling update strategy with `maxUnavailable: 0` ensures zero-downtime rotation. API keys rotate infrequently (months/years).
+
+- **[Additional cluster components]** → ESO + Reloader add operational surface. Mitigation: Both are mature, well-maintained projects. Deployed via ArgoCD for consistent management. Can be removed if GKE natively supports env-var secret injection in the future.
+
+- **[etcd secret storage]** → K8s Secrets stored in etcd. Mitigation: GKE encrypts etcd at rest by default. For additional protection, GKE supports customer-managed encryption keys (CMEK) -- out of scope for now.

--- a/openspec/changes/archive/2026-02-20-secret-manager/proposal.md
+++ b/openspec/changes/archive/2026-02-20-secret-manager/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+Runtime secrets (starting with `LASTFM_API_KEY`) are currently unmanaged -- there is no secure mechanism to provision, store, or rotate API keys for Kubernetes workloads. The backend config (`config.go`) reads these values from environment variables, but no K8s Secret or secret store backs them. As the platform grows, more external API keys and credentials will be needed, making a centralized secret management solution essential now.
+
+## What Changes
+
+- Provision GCP Secret Manager resources via Pulumi (secret creation, IAM bindings for `backend-app` service account)
+- Deploy External Secrets Operator (ESO) into the GKE Autopilot cluster
+- Define `SecretStore` and `ExternalSecret` Kustomize manifests to sync GCP secrets into K8s Secrets
+- Update the backend Deployment to consume secrets via `envFrom: secretRef` alongside the existing ConfigMap
+- Establish a pattern for adding future secrets without application code changes
+
+## Capabilities
+
+### New Capabilities
+- `secret-management`: Secure provisioning, storage, and synchronization of runtime secrets from GCP Secret Manager to Kubernetes pods via External Secrets Operator
+
+### Modified Capabilities
+- `deployment-infrastructure`: Backend Deployment gains a `secretRef` in `envFrom` to load secrets from a K8s Secret managed by ESO
+
+## Impact
+
+- **Infrastructure (Pulumi)**: New GCP Secret Manager resources, IAM role bindings (`roles/secretmanager.secretAccessor`), ESO Helm release or ArgoCD Application
+- **Kubernetes manifests**: New CRDs (`SecretStore`, `ExternalSecret`) in `k8s/namespaces/backend/`, Deployment patch for `secretRef`
+- **Backend application**: No code changes -- `os.Getenv("LASTFM_API_KEY")` continues to work as-is
+- **ArgoCD**: ESO system components need to be managed (Helm chart or dedicated Application)
+- **Security**: Secrets stored in GCP Secret Manager (encrypted at rest), synced to K8s Secrets (GKE etcd encryption), accessed via Workload Identity (no static credentials)

--- a/openspec/changes/archive/2026-02-20-secret-manager/specs/deployment-infrastructure/spec.md
+++ b/openspec/changes/archive/2026-02-20-secret-manager/specs/deployment-infrastructure/spec.md
@@ -1,0 +1,15 @@
+## MODIFIED Requirements
+
+### Requirement: Dedicated CD Namespace
+
+The cluster SHALL support dedicated namespaces for Continuous Delivery tooling and cluster-level operators.
+
+#### Scenario: Namespace Existence
+
+- **WHEN** listing namespaces
+- **THEN** a namespace named `argocd` (or configured equivalent) is present
+
+#### Scenario: External Secrets namespace
+
+- **WHEN** listing namespaces
+- **THEN** a namespace named `external-secrets` is present for the ESO controller

--- a/openspec/changes/archive/2026-02-20-secret-manager/specs/secret-management/spec.md
+++ b/openspec/changes/archive/2026-02-20-secret-manager/specs/secret-management/spec.md
@@ -1,0 +1,117 @@
+## ADDED Requirements
+
+### Requirement: GCP Secret Manager provisioning
+
+The infrastructure SHALL provision GCP Secret Manager secrets via Pulumi (inline in `KubernetesComponent`) for each runtime secret required by backend workloads. Each secret MUST be created in the environment-specific GCP project. Secret names use kebab-case without an environment prefix (e.g., `lastfm-api-key`); environment isolation is provided by the GCP project itself.
+
+> **Note**: GCP Secret Manager does not support `/` in secret names. Environment isolation comes from the project boundary (`liverty-music-dev` vs `liverty-music-prod`), not the name.
+
+#### Scenario: LASTFM_API_KEY secret creation
+
+- **WHEN** the Pulumi dev stack is applied
+- **THEN** a GCP Secret Manager secret named `lastfm-api-key` is created in the `liverty-music-dev` project
+
+#### Scenario: Secret version provisioning
+
+- **WHEN** a secret resource exists in GCP Secret Manager
+- **THEN** a secret version SHALL be created with the actual secret value
+- **AND** the secret value MUST NOT appear in Pulumi state in plaintext (use `pulumi.requireSecret()`)
+- **AND** the secret value SHALL be read from Pulumi ESC config key `gcp.lastFmApiKey`
+
+### Requirement: IAM access control for secrets
+
+The `backend-app` GCP service account SHALL be granted `roles/secretmanager.secretAccessor` on secret resources it needs to access. No other service accounts SHALL have access unless explicitly provisioned.
+
+#### Scenario: Backend service account secret access
+
+- **WHEN** the backend-app pod authenticates via Workload Identity
+- **THEN** it can read secret versions from GCP Secret Manager for secrets in its environment project
+
+#### Scenario: Least privilege enforcement
+
+- **WHEN** a service account without `secretmanager.secretAccessor` role attempts to read a secret
+- **THEN** the request is denied
+
+### Requirement: External Secrets Operator deployment
+
+The cluster SHALL run External Secrets Operator (ESO) as a managed component deployed via ArgoCD.
+
+#### Scenario: ESO controller availability
+
+- **WHEN** listing pods in the `external-secrets` namespace
+- **THEN** the ESO controller pod is running and healthy
+
+#### Scenario: ESO CRDs installed
+
+- **WHEN** listing Custom Resource Definitions
+- **THEN** `externalsecrets.external-secrets.io`, `secretstores.external-secrets.io`, and `clustersecretstores.external-secrets.io` CRDs are present
+
+### Requirement: ClusterSecretStore configuration
+
+The cluster SHALL have a `ClusterSecretStore` resource that connects to GCP Secret Manager using Workload Identity authentication.
+
+#### Scenario: ClusterSecretStore creation
+
+- **WHEN** the backend Kustomize manifests are applied
+- **THEN** a `ClusterSecretStore` named `gcp-secret-manager` exists
+- **AND** it references the environment's GCP project ID
+- **AND** it uses Workload Identity for authentication (no static credentials)
+
+#### Scenario: ClusterSecretStore health
+
+- **WHEN** inspecting the ClusterSecretStore status
+- **THEN** the `Ready` condition is `True`
+
+### Requirement: ExternalSecret for backend secrets
+
+An `ExternalSecret` resource SHALL exist in the backend namespace that maps GCP Secret Manager secrets to a K8s Secret with environment variable keys matching `config.go` expectations.
+
+#### Scenario: ExternalSecret syncs LASTFM_API_KEY
+
+- **WHEN** the ExternalSecret is reconciled
+- **THEN** a K8s Secret named `backend-secrets` is created in the backend namespace
+- **AND** it contains a key `LASTFM_API_KEY` with the value from GCP Secret Manager secret `lastfm-api-key`
+
+#### Scenario: ExternalSecret refresh interval
+
+- **WHEN** a secret value is updated in GCP Secret Manager
+- **THEN** the ExternalSecret controller detects the change within the configured `refreshInterval`
+- **AND** the K8s Secret is updated with the new value
+
+#### Scenario: Adding a new secret
+
+- **WHEN** a new key-value pair is added to the ExternalSecret `data` array
+- **AND** the corresponding GCP Secret Manager secret exists
+- **THEN** the new key appears in the `backend-secrets` K8s Secret without application code changes
+
+### Requirement: Backend Deployment secret consumption
+
+The backend Deployment SHALL consume secrets from the K8s Secret via `envFrom: secretRef`, alongside the existing ConfigMap.
+
+#### Scenario: Pod receives secret as environment variable
+
+- **WHEN** a backend pod starts
+- **THEN** the `LASTFM_API_KEY` environment variable is populated from the `backend-secrets` K8s Secret
+- **AND** the application reads it via `os.Getenv("LASTFM_API_KEY")` without code changes
+
+#### Scenario: Pod startup failure on missing secret
+
+- **WHEN** the `backend-secrets` K8s Secret does not exist
+- **THEN** the pod fails to start with a clear error indicating the missing secret reference
+
+### Requirement: Secret rotation propagation
+
+Secret updates in GCP Secret Manager SHALL propagate to running backend pods via automatic Deployment rolling restart.
+
+#### Scenario: Rotation triggers pod restart
+
+- **WHEN** a secret value is updated in GCP Secret Manager
+- **AND** the ExternalSecret controller syncs the new value to the K8s Secret
+- **THEN** Reloader detects the Secret change
+- **AND** triggers a rolling restart of the backend Deployment
+- **AND** new pods start with the updated secret value
+
+#### Scenario: Zero-downtime rotation
+
+- **WHEN** a rolling restart is triggered by secret rotation
+- **THEN** the Deployment maintains availability with `maxUnavailable: 0`

--- a/openspec/changes/archive/2026-02-20-secret-manager/tasks.md
+++ b/openspec/changes/archive/2026-02-20-secret-manager/tasks.md
@@ -1,0 +1,36 @@
+## 1. GCP Secret Manager Resources (Pulumi)
+
+- [x] 1.1 Add Secret Manager resources inline in `KubernetesComponent` (`src/gcp/components/kubernetes.ts`) with secret + version + IAM binding
+- [x] 1.2 Add `secretmanager.googleapis.com` to enabled APIs in `api.ts`
+- [x] 1.3 Provision `lastfm-api-key` secret with version (value from Pulumi ESC config key `gcp.lastFmApiKey`)
+- [x] 1.4 Grant `roles/secretmanager.secretAccessor` to `backend-app` service account on the secret
+
+## 2. External Secrets Operator Deployment (ArgoCD)
+
+- [x] 2.1 Create ArgoCD Application manifest for ESO Helm chart (`k8s/namespaces/external-secrets/`) targeting `external-secrets` namespace
+- [x] 2.2 Configure ESO Helm values (replicas, resource requests for Autopilot, service account for Workload Identity)
+
+## 3. Kubernetes Secret Sync Manifests (Kustomize)
+
+- [x] 3.1 Create `ClusterSecretStore` resource referencing GCP Secret Manager with Workload Identity auth in `k8s/namespaces/external-secrets/base/`
+- [x] 3.2 Create `ExternalSecret` resource mapping `lastfm-api-key` → `LASTFM_API_KEY` key in `backend-secrets` K8s Secret
+- [x] 3.3 Add environment-specific `ClusterSecretStore` patches in `k8s/namespaces/external-secrets/overlays/dev/`
+- [x] 3.4 Add Kustomize resources entries for new manifests in `kustomization.yaml`
+
+## 4. Backend Deployment Update
+
+- [x] 4.1 Add `envFrom: secretRef: backend-secrets` to backend Deployment alongside existing ConfigMap
+- [x] 4.2 Remove `LASTFM_API_KEY` from ConfigMap if present (was never present — nothing to do)
+- [x] 4.3 Add Reloader annotation `reloader.stakater.com/auto: "true"` to Deployment metadata
+
+## 5. Reloader Deployment (ArgoCD)
+
+- [x] 5.1 Create ArgoCD Application manifest for Stakater Reloader Helm chart
+- [x] 5.2 Configure Reloader Helm values (resource requests for Autopilot, namespace scope)
+
+## 6. Verification
+
+- [x] 6.1 Run `pulumi preview` to verify GCP Secret Manager resources
+- [x] 6.2 Verify ESO controller is running and ClusterSecretStore reports Ready
+- [x] 6.3 Verify ExternalSecret syncs and `backend-secrets` K8s Secret is created with correct keys
+- [x] 6.4 Verify backend pod starts successfully and reads `LASTFM_API_KEY` from the Secret

--- a/openspec/specs/deployment-infrastructure/spec.md
+++ b/openspec/specs/deployment-infrastructure/spec.md
@@ -83,9 +83,14 @@ The `prod` stack MUST only be updated via manual action in the Pulumi Cloud Dash
 
 ### Requirement: Dedicated CD Namespace
 
-The cluster SHALL support a dedicated namespace for Continuous Delivery tooling.
+The cluster SHALL support dedicated namespaces for Continuous Delivery tooling and cluster-level operators.
 
 #### Scenario: Namespace Existence
 
 - **WHEN** listing namespaces
 - **THEN** a namespace named `argocd` (or configured equivalent) is present
+
+#### Scenario: External Secrets namespace
+
+- **WHEN** listing namespaces
+- **THEN** a namespace named `external-secrets` is present for the ESO controller

--- a/openspec/specs/secret-management/spec.md
+++ b/openspec/specs/secret-management/spec.md
@@ -1,0 +1,126 @@
+# secret-management Specification
+
+## Purpose
+
+Defines how runtime secrets are securely stored in GCP Secret Manager and delivered to backend pods as environment variables via External Secrets Operator (ESO), without application code changes.
+
+## Requirements
+
+### Requirement: GCP Secret Manager provisioning
+
+The infrastructure SHALL provision GCP Secret Manager secrets via Pulumi (inline in `KubernetesComponent`) for each runtime secret required by backend workloads. Each secret MUST be created in the environment-specific GCP project. Secret names use kebab-case without an environment prefix (e.g., `lastfm-api-key`); environment isolation is provided by the GCP project itself.
+
+> **Note**: GCP Secret Manager does not support `/` in secret names. Environment isolation comes from the project boundary (`liverty-music-dev` vs `liverty-music-prod`), not the name.
+
+#### Scenario: LASTFM_API_KEY secret creation
+
+- **WHEN** the Pulumi dev stack is applied
+- **THEN** a GCP Secret Manager secret named `lastfm-api-key` is created in the `liverty-music-dev` project
+
+#### Scenario: Secret version provisioning
+
+- **WHEN** a secret resource exists in GCP Secret Manager
+- **THEN** a secret version SHALL be created with the actual secret value
+- **AND** the secret value MUST NOT appear in Pulumi state in plaintext (use `pulumi.requireSecret()`)
+- **AND** the secret value SHALL be read from Pulumi ESC config key `gcp.lastFmApiKey`
+
+### Requirement: IAM access control for secrets
+
+The `backend-app` GCP service account SHALL be granted `roles/secretmanager.secretAccessor` on secret resources it needs to access. No other service accounts SHALL have access unless explicitly provisioned.
+
+#### Scenario: Backend service account secret access
+
+- **WHEN** the backend-app pod authenticates via Workload Identity
+- **THEN** it can read secret versions from GCP Secret Manager for secrets in its environment project
+
+#### Scenario: Least privilege enforcement
+
+- **WHEN** a service account without `secretmanager.secretAccessor` role attempts to read a secret
+- **THEN** the request is denied
+
+### Requirement: External Secrets Operator deployment
+
+The cluster SHALL run External Secrets Operator (ESO) as a managed component deployed via ArgoCD.
+
+ESO authenticates to GCP Secret Manager using Pod Identity (Application Default Credentials): the ESO controller's K8s service account (`external-secrets/external-secrets`) is annotated with a dedicated GCP service account (`k8s-external-secrets`) via Workload Identity Federation. No static credentials or `auth` section in the ClusterSecretStore are required.
+
+#### Scenario: ESO controller availability
+
+- **WHEN** listing pods in the `external-secrets` namespace
+- **THEN** the ESO controller pod is running and healthy
+
+#### Scenario: ESO CRDs installed
+
+- **WHEN** listing Custom Resource Definitions
+- **THEN** `externalsecrets.external-secrets.io`, `secretstores.external-secrets.io`, and `clustersecretstores.external-secrets.io` CRDs are present
+
+### Requirement: ClusterSecretStore configuration
+
+The cluster SHALL have a `ClusterSecretStore` resource that connects to GCP Secret Manager using Workload Identity authentication (Pod Identity / ADC). The store SHALL restrict access to the `backend` namespace via `spec.conditions.namespaces`.
+
+#### Scenario: ClusterSecretStore creation
+
+- **WHEN** the backend Kustomize manifests are applied
+- **THEN** a `ClusterSecretStore` named `google-secret-manager` exists
+- **AND** it references the environment's GCP project ID
+- **AND** it uses Workload Identity for authentication (no static credentials, no `clusterLocation`/`clusterName` fields)
+- **AND** `spec.conditions.namespaces` restricts ExternalSecret submissions to the `backend` namespace
+
+#### Scenario: ClusterSecretStore health
+
+- **WHEN** inspecting the ClusterSecretStore status
+- **THEN** the `Ready` condition is `True`
+
+### Requirement: ExternalSecret for backend secrets
+
+An `ExternalSecret` resource SHALL exist in the backend namespace that maps GCP Secret Manager secrets to a K8s Secret with environment variable keys matching `config.go` expectations.
+
+#### Scenario: ExternalSecret syncs LASTFM_API_KEY
+
+- **WHEN** the ExternalSecret is reconciled
+- **THEN** a K8s Secret named `backend-secrets` is created in the backend namespace
+- **AND** it contains a key `LASTFM_API_KEY` with the value from GCP Secret Manager secret `lastfm-api-key`
+
+#### Scenario: ExternalSecret refresh interval
+
+- **WHEN** a secret value is updated in GCP Secret Manager
+- **THEN** the ExternalSecret controller detects the change within the configured `refreshInterval`
+- **AND** the K8s Secret is updated with the new value
+
+#### Scenario: Adding a new secret
+
+- **WHEN** a new key-value pair is added to the ExternalSecret `data` array
+- **AND** the corresponding GCP Secret Manager secret exists
+- **THEN** the new key appears in the `backend-secrets` K8s Secret without application code changes
+
+### Requirement: Backend Deployment secret consumption
+
+The backend Deployment SHALL consume secrets from the K8s Secret via `envFrom: secretRef`, alongside the existing ConfigMap.
+
+#### Scenario: Pod receives secret as environment variable
+
+- **WHEN** a backend pod starts
+- **THEN** the `LASTFM_API_KEY` environment variable is populated from the `backend-secrets` K8s Secret
+- **AND** the application reads it via `os.Getenv("LASTFM_API_KEY")` without code changes
+
+#### Scenario: Pod startup failure on missing secret
+
+- **WHEN** the `backend-secrets` K8s Secret does not exist
+- **THEN** the pod fails to start with a clear error indicating the missing secret reference
+
+### Requirement: Secret rotation propagation
+
+Secret updates in GCP Secret Manager SHALL propagate to running backend pods via automatic Deployment rolling restart.
+
+#### Scenario: Rotation triggers pod restart
+
+- **WHEN** a secret value is updated in GCP Secret Manager
+- **AND** the ExternalSecret controller syncs the new value to the K8s Secret
+- **THEN** Reloader detects the Secret change
+- **AND** triggers a rolling restart of the backend Deployment
+- **AND** new pods start with the updated secret value
+
+#### Scenario: Zero-downtime rotation
+
+- **WHEN** a rolling restart is triggered by secret rotation
+- **THEN** the Deployment maintains availability with `maxUnavailable: 0`


### PR DESCRIPTION
## Summary

- Add `secret-management` capability spec (new)
- Update `deployment-infrastructure` spec: add External Secrets namespace scenario to "Dedicated CD Namespace" requirement
- Archive `secret-manager` change to `openspec/changes/archive/2026-02-20-secret-manager/`

## What was implemented

The `secret-manager` change established a runtime secret delivery pipeline:

| Component | Resource |
|-----------|----------|
| GCP Secret Manager | `lastfm-api-key` secret provisioned via Pulumi |
| ESO (ArgoCD Wave 0) | `external-secrets` namespace, `ClusterSecretStore google-secret-manager` |
| K8s Secret sync | `ExternalSecret` → `backend-secrets` Secret with `LASTFM_API_KEY` |
| Backend | `envFrom.secretRef: backend-secrets` + `reloader.stakater.com/auto: "true"` |
| Reloader (ArgoCD Wave 0) | Rolling restart on Secret change |
| ArgoCD config | `kustomize.buildOptions: --enable-helm` for Helm-in-Kustomize overlays |

## Verification (all passed in cluster)

- ✅ `ClusterSecretStore google-secret-manager` Ready: True
- ✅ `ExternalSecret server-backend-secrets` SecretSynced: True
- ✅ `backend-secrets` K8s Secret contains `LASTFM_API_KEY`
- ✅ backend pods Running with `envFrom.secretRef: backend-secrets`

Closes: #70