### PR TITLE
ci: add skip-job pattern to prevent Required Check merge blocks

### DIFF
--- a/.github/workflows/buf-pr-checks.yml
+++ b/.github/workflows/buf-pr-checks.yml
@@ -3,18 +3,31 @@ name: Buf PR Checks
 on:
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
-    paths:
-      - "proto/**"
-      - "buf.yaml"
-      - "buf.gen.yaml"
-      - ".github/workflows/buf-pr-checks.yml"
 
 permissions:
   contents: read
   pull-requests: write
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      src: ${{ steps.filter.outputs.src }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            src:
+              - "proto/**"
+              - "buf.yaml"
+              - "buf.gen.yaml"
+              - ".github/workflows/buf-pr-checks.yml"
+
   buf-checks:
+    needs: changes
+    if: needs.changes.outputs.src == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -32,3 +45,10 @@ jobs:
           # This is more robust than comparing against the BSR, as it avoids
           # issues with synchronization delays between the main branch and the BSR.
           breaking_against: "https://github.com/${{ github.repository }}.git#branch=${{ github.base_ref }}"
+
+  buf-checks-skip:
+    needs: changes
+    if: needs.changes.outputs.src == 'false'
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "No relevant changes, skipping Buf PR checks"


### PR DESCRIPTION
## 🔗 Related Issue

Closes #

## 📝 Summary of Changes

Workflows with `paths` filters are **skipped entirely** when non-matching files are changed. GitHub treats skipped jobs as "not reported" rather than "success", which blocks merges when those jobs are configured as Required Status Checks.

This PR replaces the workflow-level `paths` filter in `buf-pr-checks.yml` with `dorny/paths-filter` at the job level, so a dedicated skip job always reports a success status to GitHub.

**Affected workflows:**
- `buf-pr-checks.yml` — Required Check: `Buf PR Checks / buf-checks`

## 📋 Commit Log

```
dae6d35 ci: add skip-job pattern to prevent Required Check merge blocks
```

## ✅ Self-Checklist

- [ ] I have linked the related issue.
- [ ] I have added or updated tests to cover my changes.
- [ ] I have updated the relevant documentation.
- [x] My code follows the architecture and style guidelines of the project.