### PR TITLE
ci: add skip-job pattern to prevent Required Check merge blocks

### DIFF
--- a/.github/workflows/buf-pr-checks.yml
+++ b/.github/workflows/buf-pr-checks.yml
@@ -23,7 +23,7 @@ jobs:
               - "proto/**"
               - "buf.yaml"
               - "buf.gen.yaml"
-              - ".github/workflows/buf-pr-checks.yml"
+              - ".github/workflows/**"
 
   buf-checks:
     needs: changes
@@ -52,3 +52,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: echo "No relevant changes, skipping Buf PR checks"
+
+  ci-success:
+    name: CI Success
+    runs-on: ubuntu-latest
+    needs: [changes, buf-checks, buf-checks-skip]
+    if: always()
+    steps:
+      - uses: re-actors/alls-green@release/v1
+        with:
+          allowed-skips: buf-checks, buf-checks-skip
+          jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
## Summary

- Replace single workflow file filter (`.github/workflows/buf-pr-checks.yml`) with `.github/workflows/**` to ensure CI reruns when any workflow changes
- Add `re-actors/alls-green` `ci-success` aggregation job as a single stable Required Status Check gate

## Related

- Part of the cross-repo branch protection improvement (liverty-music/cloud-provisioning#78, liverty-music/frontend#36)