### PR TITLE
fix(ci): add push trigger so test merge commit gets CI Success

### DIFF
--- a/.github/workflows/buf-pr-checks.yml
+++ b/.github/workflows/buf-pr-checks.yml
@@ -1,6 +1,8 @@
 name: Buf PR Checks
 
 on:
+  push:
+    branches: [main]
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
 
@@ -27,7 +29,7 @@ jobs:
 
   buf-checks:
     needs: changes
-    if: needs.changes.outputs.src == 'true'
+    if: needs.changes.outputs.src == 'true' && github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -48,7 +50,7 @@ jobs:
 
   buf-checks-skip:
     needs: changes
-    if: needs.changes.outputs.src == 'false'
+    if: needs.changes.outputs.src == 'false' || github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
       - run: echo "No relevant changes, skipping Buf PR checks"


### PR DESCRIPTION
## Problem

GitHub evaluates Required Status Checks against the **test merge commit** (a virtual merge of head + base that GitHub creates internally), not the head commit alone.

Without a `push` trigger, `buf-pr-checks.yml` only runs on `pull_request` events, so the test merge commit never gets `Buf PR Checks / CI Success` reported — leaving all PRs permanently blocked with "Expected — Waiting for status to be reported".

## Fix

- Add `push: branches: [main]` trigger so the workflow runs on the test merge commit
- Gate `buf-checks` on `github.event_name == 'pull_request'` to avoid running breaking-change detection on push (where `github.base_ref` is empty)
- `buf-checks-skip` covers `push` events so `ci-success` always has its dependencies satisfied

## Related

- liverty-music/specification#50 (added ci-success job)
- liverty-music/cloud-provisioning#80 (strict: false)