### PR TITLE
feat(ticket-system): add proto definitions and OpenSpec artifacts for ticket system MVP

### DIFF
--- a/openspec/changes/implement-ticket-system-mvp/auth-evolution-plan.md
+++ b/openspec/changes/implement-ticket-system-mvp/auth-evolution-plan.md
@@ -1,0 +1,170 @@
+# Authentication Evolution Plan: Option A → Option C
+
+> Created: 2026-02-20
+> Context: [design.md Decision 4](design.md#decision-4-authentication-via-zitadel-passkey-rp--safe-address-from-usersid)
+
+## Overview
+
+The MVP starts with **Option A** (Zitadel as the sole WebAuthn Relying Party, using its hosted login UI). This document defines the migration path to **Option C** (Zitadel for existing auth + self-hosted go-webauthn RP for ticket-specific Passkey auth), triggered when Zitadel's Passkey limitations become blocking.
+
+## Current State (Option A — MVP)
+
+```
+User ──OIDC──▶ Zitadel (hosted login UI) ──JWT──▶ Go Backend
+                 │                                    │
+                 ├─ Passkey registration              ├─ JWT validation (jwx)
+                 ├─ Passkey authentication            ├─ users.id → Safe address
+                 └─ Session management                └─ Ticket / Entry handlers
+```
+
+- Authentication: Zitadel hosted login UI with Passkey support
+- Frontend: `oidc-client-ts` → Zitadel OIDC → JWT
+- Backend: `lestrrat-go/jwx/v2` validates JWT; `users.external_id` maps to Zitadel `sub` claim
+- Safe address: Derived from `users.id` (UUIDv7), not from credential or external_id
+
+## Triggers for Migration
+
+Migrate to Option C when **any** of the following become true:
+
+| Trigger | Zitadel Reference | Impact |
+|---|---|---|
+| Custom Login UI required AND Issue #8282 unresolved | [Issue #8282](https://github.com/zitadel/zitadel/issues/8282) | Cannot use Passkey on custom domain |
+| Conditional UI (Passkey autofill) required | [Discussion #8867](https://github.com/zitadel/zitadel/discussions/8867) | Cannot implement passwordless autofill UX |
+| Credential public key needed for on-chain operations | ListPasskeys API limitation | Cannot derive on-chain identity from credential |
+| Domain migration required without re-registering Passkeys | Passkeys concept docs | All existing Passkeys invalidated |
+
+## Target State (Option C)
+
+```
+User ──OIDC──▶ Zitadel (existing users, OIDC)
+  │                │
+  │                └─ JWT (existing auth, non-Passkey methods)
+  │
+  └──WebAuthn──▶ go-webauthn RP (self-hosted)
+                    │
+                    ├─ Passkey registration (credential stored in DB)
+                    ├─ Passkey authentication (assertion verification)
+                    ├─ Credential public key available
+                    └─ JWT issued by self-hosted RP
+                           │
+                           ▼
+                    Go Backend (accepts JWT from BOTH issuers)
+                      │
+                      ├─ users.id → Safe address (UNCHANGED)
+                      └─ Ticket / Entry handlers (UNCHANGED)
+```
+
+## Design Principles (Already in Place)
+
+These principles are implemented in the MVP to ensure a smooth migration:
+
+### 1. `users.id` as Universal Identifier
+
+All ticket system tables (`tickets`, `merkle_tree`, `nullifiers`) use `users.id` (internal UUIDv7) as foreign key. Never `users.external_id` (Zitadel sub) or credential-specific values.
+
+**Why this enables migration**: Safe address derivation (`CREATE2(salt = keccak256(users.id))`) is auth-provider-agnostic. Changing the auth mechanism does not affect on-chain identity or ticket data.
+
+### 2. Configurable JWT Issuer List
+
+The backend's JWT validation accepts a list of trusted issuers:
+
+```yaml
+auth:
+  accepted_issuers:
+    - "https://zitadel.example.com"       # Existing Zitadel issuer
+    # - "https://passkey.example.com"      # Future go-webauthn issuer (Option C)
+```
+
+**Why this enables migration**: Adding a second issuer is a configuration change, not a code change. Both Zitadel JWT and self-hosted JWT are validated by the same `jwx` middleware.
+
+### 3. User Linking via `external_id`
+
+The `users` table has an `external_id` column that maps to the Zitadel `sub` claim. In Option C, a user authenticated via go-webauthn can be linked to the same `users.id` by matching on a shared identifier (e.g., email verified by both systems).
+
+## Migration Steps
+
+### Phase 1: Add go-webauthn RP (Parallel Operation)
+
+1. **Add `go-webauthn/webauthn` v0.15.0** to the backend Go module
+2. **Create `webauthn_credentials` table**:
+   ```sql
+   CREATE TABLE webauthn_credentials (
+     id         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+     user_id    UUID NOT NULL REFERENCES users(id),
+     credential_id    BYTEA NOT NULL UNIQUE,
+     public_key       BYTEA NOT NULL,
+     sign_count       BIGINT NOT NULL DEFAULT 0,
+     authenticator_aaguid BYTEA,
+     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+   );
+   ```
+3. **Create `webauthn_sessions` table** for transient challenge state:
+   ```sql
+   CREATE TABLE webauthn_sessions (
+     id         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+     challenge  BYTEA NOT NULL UNIQUE,
+     user_id    UUID REFERENCES users(id),
+     session_data JSONB NOT NULL,
+     expires_at TIMESTAMPTZ NOT NULL,
+     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+   );
+   ```
+4. **Implement Connect RPC handlers** for `PasskeyService`:
+   - `BeginRegistration` → generate challenge, persist session
+   - `FinishRegistration` → verify credential, store in `webauthn_credentials`
+   - `BeginAuthentication` → look up credential, generate challenge
+   - `FinishAuthentication` → verify assertion, issue JWT
+5. **Issue JWT from self-hosted RP** with a distinct issuer URL
+6. **Add self-hosted issuer** to `accepted_issuers` config list
+
+### Phase 2: Frontend Integration
+
+1. **Add `@simplewebauthn/browser`** to the frontend
+2. **Implement Passkey registration/authentication UI** that calls the self-hosted RP endpoints
+3. **Maintain `oidc-client-ts`** flow as fallback for non-Passkey users
+4. **Route users** to appropriate auth flow based on capability detection
+
+### Phase 3: Gradual Migration
+
+1. **New Passkey registrations** go through self-hosted RP (credential stored locally)
+2. **Existing Zitadel Passkeys** continue to work through Zitadel hosted UI
+3. **Users can re-register** Passkeys with the self-hosted RP at their discretion
+4. **No forced migration** — both paths coexist indefinitely
+
+## What Does NOT Change
+
+| Component | Reason |
+|---|---|
+| `users.id` (UUIDv7) | Universal identifier; all FKs reference this |
+| `users.safe_address` | Derived from `users.id`; auth-agnostic |
+| `tickets`, `merkle_tree`, `nullifiers` tables | Reference `users.id` only |
+| Safe address derivation logic | `CREATE2(keccak256(users.id))`; no auth dependency |
+| ZKP verification flow | Independent of auth mechanism |
+| Ticket minting flow | Uses `users.id` → Safe address; no auth dependency |
+
+## What Changes
+
+| Component | Option A (MVP) | Option C (Migration) |
+|---|---|---|
+| WebAuthn RP | Zitadel | go-webauthn (self-hosted) |
+| Credential storage | Zitadel internal | `webauthn_credentials` table |
+| Login UI | Zitadel hosted | Custom (Aurelia 2) |
+| JWT issuers | 1 (Zitadel) | 2 (Zitadel + self-hosted) |
+| Frontend auth library | `oidc-client-ts` only | `oidc-client-ts` + `@simplewebauthn/browser` |
+| Backend auth deps | `jwx` only | `jwx` + `go-webauthn/webauthn` |
+
+## Estimated Effort
+
+| Phase | Scope | Effort |
+|---|---|---|
+| Phase 1 (Backend) | go-webauthn integration, DB tables, RPC handlers, JWT issuance | 3-5 days |
+| Phase 2 (Frontend) | @simplewebauthn integration, auth routing UI | 2-3 days |
+| Phase 3 (Migration) | Testing, gradual rollout, documentation | 1-2 days |
+| **Total** | | **6-10 days** |
+
+## Monitoring Checklist
+
+- [ ] Watch [Issue #8282](https://github.com/zitadel/zitadel/issues/8282) for resolution (RPOrigins bug)
+- [ ] Watch [Discussion #8867](https://github.com/zitadel/zitadel/discussions/8867) for Conditional UI support
+- [ ] Watch `go-webauthn/webauthn` [Discussion #218](https://github.com/go-webauthn/webauthn/discussions/218) for v1.0 API stability
+- [ ] Review Zitadel release notes for credential public key export capability

--- a/openspec/changes/implement-ticket-system-mvp/design.md
+++ b/openspec/changes/implement-ticket-system-mvp/design.md
@@ -2,7 +2,7 @@
 
 The current Liverty Music platform handles concert discovery and notifications. This design introduces a Ticket System MVP to tackle scalping and fraud in the Japanese live music market. The MVP takes a **Hybrid Architecture** approach: a Go backend handles auth, on-chain interactions, and proof verification, while the Aurelia 2 PWA frontend handles the user experience including client-side ZKP generation.
 
-The MVP targets **Base Sepolia** (testnet) and deploys the backend on **GKE Autopilot (Osaka)**. It connects to existing infrastructure via the `cloud-provisioning` repo.
+The MVP targets **Base Sepolia** (testnet) and extends the existing backend on **GKE Autopilot (Osaka)** (`cluster-osaka`) with **Cloud SQL PostgreSQL 18** (`postgres-osaka`, PSC connection). Authentication uses the existing **Zitadel** IdP with Passkey support enabled. The Proto schema is managed via **BSR** (`liverty-music/schema`) with generated code imported by both backend (Go) and frontend (TypeScript).
 
 ## Goals / Non-Goals
 
@@ -67,19 +67,33 @@ The MVP targets **Base Sepolia** (testnet) and deploys the backend on **GKE Auto
 
 ---
 
-### Decision 4: Passkey → Safe (ERC-4337) Smart Account Mapping
+### Decision 4: Authentication via Zitadel (Passkey RP) + Safe Address from users.id
 
-**Choice**: On registration, the backend derives a **predicted Safe address** deterministically from the Passkey credential ID (or public key). This address is stored in the `users` table and used as the SBT recipient.
+**Choice**: Passkey authentication is handled by **Zitadel as the WebAuthn Relying Party**. The existing OIDC flow (`oidc-client-ts` → Zitadel → JWT) remains unchanged. For MVP, Zitadel's hosted login UI is used. The backend derives a **predicted Safe address** deterministically from the internal `users.id` (UUIDv7), not from the Passkey credential public key.
 
-**Rationale**: Safe's `predictSafeAddress` API allows deterministic address computation without deploying the contract. The actual deployment is deferred (lazy deployment / counterfactual wallet). This avoids gas costs at registration while enabling on-chain identity.
+**Rationale**: Zitadel already manages authentication for the platform (users, OIDC, JWT). Adding a separate WebAuthn RP (go-webauthn) would create two parallel auth systems. Zitadel supports Passkey registration via its v2 API (`POST /v2/users/{user_id}/passkeys`) and returns `PublicKeyCredentialCreationOptions` that can be passed directly to `navigator.credentials.create()`.
+
+**Safe address derivation**: `CREATE2(salt = keccak256(users.id))`. Using the internal UUID rather than `external_id` (Zitadel sub) or credential public key ensures the derivation is **auth-provider-agnostic**. If the auth system changes in the future, existing Safe addresses remain valid.
+
+**Design principle — auth-agnostic identification**: All internal references (tickets, nullifiers, merkle_tree) use `users.id` as the foreign key, never `external_id` or credential-specific values. This allows the auth mechanism to evolve without affecting the ticket system's data model.
 
 **Implementation detail**: No maintained Go SDK exists for ERC-4337 Account Abstraction (stackup-go archived Oct 2024, thirdweb Go SDK archived May 2024, no official Safe Go SDK). The backend constructs `UserOperation` structs manually using `go-ethereum` ABI encoding, then submits them to a Bundler (Pimlico or Alchemy) via standard `eth_sendUserOperation` JSON-RPC calls over `net/http`. Safe address prediction uses the `SafeProxyFactory` `CREATE2` formula computed on the backend without an external SDK.
 
+**Known Zitadel Passkey limitations** (see [research/zitadel-passkey-rp.md](research/zitadel-passkey-rp.md)):
+- Credential public key is NOT exported via API (ListPasskeys returns id/state/name only)
+- Custom Login UI on a different domain is blocked by Issue #8282 (RPOrigins bug, Open)
+- Conditional UI (Passkey autofill) is not supported (Discussion #8867)
+- Domain change invalidates all registered Passkeys
+
+**Migration path**: If Zitadel's Passkey limitations become blocking (e.g., Issue #8282 remains unresolved when custom UI is needed), the system can evolve to Option C: Zitadel for existing users + self-hosted go-webauthn RP for ticket-specific Passkey auth. The auth-agnostic `users.id` derivation ensures Safe addresses are unaffected. See [auth-evolution-plan.md](auth-evolution-plan.md) for the detailed migration plan.
+
 **Alternatives considered**:
+- *Self-hosted go-webauthn RP (Option B)*: Rejected for MVP; replaces Zitadel entirely, wastes existing auth infrastructure (oidc-client-ts, authn middleware, users.external_id)
 - *EOA Wallet*: Rejected; requires private key management by the user, breaks the Passkey UX promise
 - *Deploy on registration*: Rejected due to gas cost and latency at signup
 - *stackup-go / thirdweb Go SDK*: Both archived and unmaintained as of 2024. Rejected.
-- *TypeScript AA SDK via sidecar*: Rejected; adds operational complexity and a cross-language RPC boundary
+- *Safe address from credential public key*: Rejected; Zitadel does not export credential public key via API
+- *Safe address from external_id (Zitadel sub)*: Rejected; couples on-chain identity to a specific IdP
 
 ---
 
@@ -90,8 +104,6 @@ The MVP targets **Base Sepolia** (testnet) and deploys the backend on **GKE Auto
 **Rationale**: Proof generation exposes the user's **Identity Trapdoor** (private input). Sending this to the backend would break the privacy guarantee of ZKP. Client-side generation keeps the private input local. Caching the circuit enables offline proof generation — critical for venue entry where connectivity may be unreliable.
 
 **Implementation detail**: The `.zkey` file for the `TicketCheck` circuit is expected to be 5–30 MB. This exceeds Workbox's default `maximumFileSizeToCacheInBytes` limit (2 MB for precache). The circuit artifacts are therefore served from a CDN with versioned paths (e.g., `/circuits/ticketcheck-v1.zkey`) and cached via a Workbox `registerRoute` runtime handler using `CacheFirst` strategy. Cache invalidation is triggered by deploying a new versioned URL on circuit upgrade. The `injectManifest` mode is required (over `generateSW`) because the custom routing logic cannot be expressed in the declarative `generateSW` config.
-
-**WebAuthn client library**: `@simplewebauthn/browser` (v13.2.2). The previously-considered `@github/webauthn-json` was archived in August 2025 (browsers now implement native JSON parsing for WebAuthn); it is not used.
 
 **Alternatives considered**:
 - *Backend proof generation*: Rejected; requires sending private input to server, defeating ZKP privacy
@@ -113,19 +125,28 @@ The MVP targets **Base Sepolia** (testnet) and deploys the backend on **GKE Auto
 
 ---
 
-### Decision 7: Database Schema (PostgreSQL via Cloud SQL)
+### Decision 7: Database Schema (PostgreSQL 18 via Cloud SQL)
 
-New tables required:
+The existing PostgreSQL 18 instance (`postgres-osaka`, Cloud SQL with PSC) already hosts `users`, `events`, `concerts`, `artists`, `venues`, and other tables. The ticket system extends this schema with ALTER statements and new tables.
+
+**ALTER existing tables:**
+
+| Table | Change | Purpose |
+|---|---|---|
+| `users` | ADD `safe_address TEXT` | Predicted Safe (ERC-4337) address derived from `users.id` |
+| `events` | ADD `merkle_root BYTEA` (nullable) | ZKP identity set root; NULL for non-ticket events |
+
+**New tables:**
 
 | Table | Purpose |
 |---|---|
-| `users` | Passkey credentials, Smart Account address |
-| `events` | Concert/event metadata |
-| `tickets` | SBT ownership records (token ID, owner) |
-| `merkle_tree` | Merkle tree nodes for ZKP identity set |
-| `nullifiers` | Used nullifier hashes (double-entry prevention) |
+| `tickets` | SBT ownership records (event_id FK → events, user_id FK → users, token_id, tx_hash) |
+| `merkle_tree` | Merkle tree nodes for ZKP identity set (event_id, depth, index, hash) |
+| `nullifiers` | Used nullifier hashes with unique index (event_id, nullifier_hash, used_at) |
 
-**Rationale**: Nullifiers are stored off-chain in PostgreSQL for fast lookup and atomic writes. Merkle tree nodes must be consistent between proof generation (client) and verification (backend), so the backend maintains the canonical tree.
+**Design principle**: All new tables reference `users.id` (internal UUIDv7) as the user identifier, never `users.external_id` (Zitadel sub claim). This ensures the ticket data model is auth-provider-agnostic.
+
+**Rationale**: Nullifiers are stored off-chain in PostgreSQL for fast lookup and atomic writes. Merkle tree nodes must be consistent between proof generation (client) and verification (backend), so the backend maintains the canonical tree. The existing `events` table is extended rather than duplicated because tickets are issued for events — the same entity that already tracks concerts.
 
 ---
 
@@ -138,6 +159,9 @@ New tables required:
 | gnark / circom2gnark proof format incompatibility (BN254 field encoding) | Write integration test that round-trips a known circom proof through circom2gnark → gnark Verify before any production deploy |
 | Off-chain nullifier DB as single point of failure for entry | Replicated Cloud SQL with failover; entry degraded to manual check if DB is down |
 | Passkey compatibility on older iOS/Android | Minimum iOS 16.4 / Android 9; document this; provide fallback instructions |
+| Zitadel Passkey custom UI blocked (Issue #8282) | MVP uses hosted login UI (unaffected); monitor issue; Option C migration plan ready if unresolved |
+| Zitadel does not export credential public key | Safe address derived from users.id (auth-agnostic); no dependency on credential material |
+| Zitadel domain change invalidates Passkeys | Finalize custom domain before enabling Passkeys in production |
 | GKE Autopilot cold start latency for Connect RPC handlers | Pre-warm pods; set minimum replicas > 0 |
 | Base Sepolia testnet instability | Retry logic in minting handler; idempotent mint (check existing token before minting) |
 | Smart Account address prediction diverges from deployed Safe | Use exact same `initializer` and `saltNonce` in prediction and future deployment |
@@ -147,25 +171,39 @@ New tables required:
 
 | Domain | Library | Version | Notes |
 |---|---|---|---|
+| Authentication (IdP) | Zitadel | self-hosted | Existing IdP; Passkey RP for MVP (hosted login UI) |
+| Frontend auth client | `oidc-client-ts` | ^3.4.1 | Existing OIDC client; unchanged for MVP |
+| Go JWT validation | `lestrrat-go/jwx/v2` | v2.1.6 | Existing JWT validator; issuer list must be configurable |
 | Go ZKP verification | `consensys/gnark` | v0.14.0 | Groth16 on BN254; most actively maintained Go ZKP library |
 | Go ZKP format adapter | `vocdoni/circom2gnark` | latest | Converts snarkjs JSON proof/vkey → gnark types; required bridge |
-| Go WebAuthn server | `go-webauthn/webauthn` | v0.15.0 (Nov 2025) | Only actively maintained Go FIDO2 server library |
 | Go blockchain | `go-ethereum/ethclient` | v1.15.x | EVM interaction; UserOperation ABI encoding |
 | Go HTTP bundler client | `net/http` (stdlib) | — | Direct JSON-RPC to Pimlico/Alchemy bundler; no AA SDK used |
 | Browser ZKP generation | `snarkjs` | latest stable | Only production-ready circom/Groth16 JS library |
-| Browser WebAuthn | `@simplewebauthn/browser` | v13.2.2 | Actively maintained; `@github/webauthn-json` archived Aug 2025 |
 | PWA / Service Worker | `vite-plugin-pwa` + Workbox | v1.2.0 / v7.4.0 | `injectManifest` mode for custom ZK circuit runtime caching |
+
+**Removed from original design** (with rationale):
+- `go-webauthn/webauthn`: Not needed for MVP; Zitadel is the WebAuthn RP. Reserved for Option C migration if needed.
+- `@simplewebauthn/browser`: Not needed for MVP; Zitadel's hosted login UI handles `navigator.credentials`. Reserved for custom Login UI (Pattern 2) or Option C.
+
+**Existing backend libraries** (already in go.mod, used by ticket system):
+- `jackc/pgx/v5` v5.8.0 (PostgreSQL driver)
+- `connectrpc.com/connect` v1.19.1 (Connect RPC)
+- `connectrpc.com/validate` v0.6.0 (Protovalidate)
+- `pannpers/go-apperr` v1.0.2 (Error handling)
+- `pannpers/go-logging` v1.1.0 (Structured logging)
 
 ---
 
 ## Migration Plan
 
-1. **Infrastructure**: Provision GKE Autopilot cluster + Cloud SQL (PostgreSQL) in `cloud-provisioning` (separate PR).
-2. **Smart Contracts**: Deploy `TicketSBT` to Base Sepolia; record contract address in backend config.
-3. **Backend**: Deploy Go service to GKE; run DB migrations; configure Secret Manager for contract keys.
-4. **Frontend**: Deploy PWA to CDN/Firebase Hosting; verify Service Worker registration and A2HS prompt.
-5. **Circuit**: Compile `TicketCheck` Groth16 circuit; publish WASM + ZKey to CDN; update Service Worker cache manifest.
-6. **Rollback**: Backend is stateless (state in DB + blockchain); rolling back the Deployment to previous image is sufficient. DB migrations must be backward-compatible.
+1. **Infrastructure**: GKE Autopilot (`cluster-osaka`) and Cloud SQL (`postgres-osaka`) already exist. Add Secret Manager entries for contract private key. Configure Zitadel Passkey settings.
+2. **Proto / BSR**: Define new services (`TicketService`, `EntryService`) in `liverty-music/schema` BSR module. Push to BSR; generated Go/TS code auto-updates via dependency version bump.
+3. **Database**: Run ALTER migrations (`users` + `events`) and CREATE migrations (`tickets`, `merkle_tree`, `nullifiers`). All migrations must be backward-compatible.
+4. **Smart Contracts**: Deploy `TicketSBT` to Base Sepolia; record contract address in Secret Manager.
+5. **Backend**: Add ticket/entry handlers to existing Go service. Deploy to GKE via existing CD pipeline.
+6. **Circuit**: Compile `TicketCheck` Groth16 circuit; publish WASM + ZKey to CDN with versioned paths.
+7. **Frontend**: Add PWA features (`vite-plugin-pwa`, Service Worker) and ticket UI to existing Aurelia 2 app. Deploy via existing CD pipeline.
+8. **Rollback**: Backend is stateless (state in DB + blockchain); rolling back the Deployment to previous image is sufficient. DB migrations must be backward-compatible.
 
 ## Open Questions
 

--- a/openspec/changes/implement-ticket-system-mvp/design.md
+++ b/openspec/changes/implement-ticket-system-mvp/design.md
@@ -1,0 +1,176 @@
+## Context
+
+The current Liverty Music platform handles concert discovery and notifications. This design introduces a Ticket System MVP to tackle scalping and fraud in the Japanese live music market. The MVP takes a **Hybrid Architecture** approach: a Go backend handles auth, on-chain interactions, and proof verification, while the Aurelia 2 PWA frontend handles the user experience including client-side ZKP generation.
+
+The MVP targets **Base Sepolia** (testnet) and deploys the backend on **GKE Autopilot (Osaka)**. It connects to existing infrastructure via the `cloud-provisioning` repo.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Implement Soulbound Ticket (ERC-5192) minting and ownership verification
+- Implement Passkey (WebAuthn/FIDO2) based user authentication with Smart Account mapping
+- Implement client-side ZKP (Groth16) generation in the PWA for privacy-preserving entry
+- Implement off-chain ZKP verification in the Go backend for low-latency, zero-gas check-in
+- Deliver a PWA with offline capability (A2HS-compatible, Service Worker caching of ZK circuits)
+
+**Non-Goals:**
+- On-chain ZKP verification (gas cost prohibitive for MVP)
+- Ticket secondary market / controlled resale mechanisms (post-MVP)
+- Production mainnet deployment
+- Native mobile apps (iOS/Android)
+- Full Account Abstraction (ERC-4337) paymaster integration in MVP (future work)
+
+## Decisions
+
+### Decision 1: Hybrid Architecture (Go Backend + PWA Frontend)
+
+**Choice**: Go backend service (Connect RPC on GKE) + Aurelia 2 PWA
+
+**Rationale**: A browser-only approach was rejected because:
+- FIDO2 server-side challenge management requires stateful backend
+- Private key / contract interaction (minting) must not occur in the browser
+- ZKP verification is performance-sensitive and should be centralized for consistency
+
+**Alternatives considered**:
+- *Browser-only*: Rejected due to inability to securely manage minting authorization and WebAuthn challenge state
+- *Native apps*: Rejected due to development cost and distribution friction for MVP
+
+---
+
+### Decision 2: Connect RPC (not REST/gRPC) for Backend API
+
+**Choice**: Connect RPC with Protocol Buffers (proto3) over HTTP
+
+**Rationale**: Consistent with the existing Liverty architecture. Connect is compatible with gRPC and JSON clients, supports both browser and server. Protovalidate provides declarative field validation in the same proto files as the schema.
+
+**Alternatives considered**:
+- *REST + OpenAPI*: Rejected; less type-safe end-to-end, duplicates schema definition
+- *gRPC*: Rejected for browser clients; requires gRPC-web proxy
+
+---
+
+### Decision 3: Off-Chain ZKP Verification
+
+**Choice**: Go backend verifies Groth16 proofs using `gnark` (v0.14.0) with the `vocdoni/circom2gnark` adapter; proofs arrive via Connect RPC.
+
+**Rationale**: On-chain verification (Solidity verifier) costs gas per entry and introduces latency. The event operator controls the backend, so off-chain verification is trusted for the MVP. Nullifier hashes are stored in the backend database (not on-chain) to prevent double-entry.
+
+**Implementation detail**: The frontend generates proofs with `snarkjs` (circom ecosystem). `gnark` does not natively parse snarkjs JSON proof format, so `vocdoni/circom2gnark` is required to convert the proof and verification key. The verification key is loaded once at startup and cached in memory. The adapter handles BN254 curve parameter translation between the two ecosystems.
+
+**Trade-off**: Verification is centralized in the backend, which is a trust assumption. This is acceptable for MVP but should be migrated to on-chain verification for production. The circom2gnark adapter adds a thin dependency; its correctness must be validated in integration tests.
+
+**Alternatives considered**:
+- *On-chain verifier contract*: Rejected for MVP due to gas cost and latency
+- *Trusted third-party verifier*: Rejected due to dependency and integration complexity
+- *`go-rapidsnark/verifier`*: Supports snarkjs JSON natively, but license is unclear and the library is less actively maintained than gnark. Rejected in favor of gnark + circom2gnark.
+- *`go-circom-prover-verifier`*: Abandoned since 2020. Rejected.
+
+---
+
+### Decision 4: Passkey → Safe (ERC-4337) Smart Account Mapping
+
+**Choice**: On registration, the backend derives a **predicted Safe address** deterministically from the Passkey credential ID (or public key). This address is stored in the `users` table and used as the SBT recipient.
+
+**Rationale**: Safe's `predictSafeAddress` API allows deterministic address computation without deploying the contract. The actual deployment is deferred (lazy deployment / counterfactual wallet). This avoids gas costs at registration while enabling on-chain identity.
+
+**Implementation detail**: No maintained Go SDK exists for ERC-4337 Account Abstraction (stackup-go archived Oct 2024, thirdweb Go SDK archived May 2024, no official Safe Go SDK). The backend constructs `UserOperation` structs manually using `go-ethereum` ABI encoding, then submits them to a Bundler (Pimlico or Alchemy) via standard `eth_sendUserOperation` JSON-RPC calls over `net/http`. Safe address prediction uses the `SafeProxyFactory` `CREATE2` formula computed on the backend without an external SDK.
+
+**Alternatives considered**:
+- *EOA Wallet*: Rejected; requires private key management by the user, breaks the Passkey UX promise
+- *Deploy on registration*: Rejected due to gas cost and latency at signup
+- *stackup-go / thirdweb Go SDK*: Both archived and unmaintained as of 2024. Rejected.
+- *TypeScript AA SDK via sidecar*: Rejected; adds operational complexity and a cross-language RPC boundary
+
+---
+
+### Decision 5: Client-Side ZKP with WASM Circuits via Service Worker
+
+**Choice**: `snarkjs` (latest stable) runs the `TicketCheck` Groth16 circuit WASM in the browser. The circuit WASM and ZKey files are cached by the Service Worker using a **runtime cache strategy** (Cache-First with versioned URLs), managed via `vite-plugin-pwa` (v1.2.0) in `injectManifest` mode with Workbox 7.4.0.
+
+**Rationale**: Proof generation exposes the user's **Identity Trapdoor** (private input). Sending this to the backend would break the privacy guarantee of ZKP. Client-side generation keeps the private input local. Caching the circuit enables offline proof generation — critical for venue entry where connectivity may be unreliable.
+
+**Implementation detail**: The `.zkey` file for the `TicketCheck` circuit is expected to be 5–30 MB. This exceeds Workbox's default `maximumFileSizeToCacheInBytes` limit (2 MB for precache). The circuit artifacts are therefore served from a CDN with versioned paths (e.g., `/circuits/ticketcheck-v1.zkey`) and cached via a Workbox `registerRoute` runtime handler using `CacheFirst` strategy. Cache invalidation is triggered by deploying a new versioned URL on circuit upgrade. The `injectManifest` mode is required (over `generateSW`) because the custom routing logic cannot be expressed in the declarative `generateSW` config.
+
+**WebAuthn client library**: `@simplewebauthn/browser` (v13.2.2). The previously-considered `@github/webauthn-json` was archived in August 2025 (browsers now implement native JSON parsing for WebAuthn); it is not used.
+
+**Alternatives considered**:
+- *Backend proof generation*: Rejected; requires sending private input to server, defeating ZKP privacy
+- *Native WASM outside browser*: Out of scope for PWA-first strategy
+- *Noir / UltraHonk circuits*: Rejected; proof system is incompatible with the gnark Groth16 verifier on the backend
+- *Precache for .zkey files*: Rejected; file size exceeds Workbox precache limits and would block Service Worker installation
+
+---
+
+### Decision 6: PWA over Native App
+
+**Choice**: Aurelia 2 PWA with `manifest.json`, Service Worker, and A2HS prompts.
+
+**Rationale**: PWA eliminates app store distribution overhead for MVP. iOS 16.4+ and modern Android support reliable service workers. A single codebase serves both mobile and desktop, reducing development cost.
+
+**Alternatives considered**:
+- *React Native / Flutter*: Rejected for MVP due to cost and timeline
+- *Progressive Enhancement only (no SW)*: Rejected; offline ZK circuit caching is a hard requirement
+
+---
+
+### Decision 7: Database Schema (PostgreSQL via Cloud SQL)
+
+New tables required:
+
+| Table | Purpose |
+|---|---|
+| `users` | Passkey credentials, Smart Account address |
+| `events` | Concert/event metadata |
+| `tickets` | SBT ownership records (token ID, owner) |
+| `merkle_tree` | Merkle tree nodes for ZKP identity set |
+| `nullifiers` | Used nullifier hashes (double-entry prevention) |
+
+**Rationale**: Nullifiers are stored off-chain in PostgreSQL for fast lookup and atomic writes. Merkle tree nodes must be consistent between proof generation (client) and verification (backend), so the backend maintains the canonical tree.
+
+---
+
+## Risks / Trade-offs
+
+| Risk | Mitigation |
+|---|---|
+| ZKP client-side performance (WASM is slow on low-end devices) | Runtime-cache circuits; show progress indicator; test on low-end Android (target: <30s for depth-20 Merkle proof) |
+| Service Worker runtime cache size (.zkey 5–30 MB per circuit version) | Version URLs; evict old cache entries on SW activation; monitor Cache Storage quota |
+| gnark / circom2gnark proof format incompatibility (BN254 field encoding) | Write integration test that round-trips a known circom proof through circom2gnark → gnark Verify before any production deploy |
+| Off-chain nullifier DB as single point of failure for entry | Replicated Cloud SQL with failover; entry degraded to manual check if DB is down |
+| Passkey compatibility on older iOS/Android | Minimum iOS 16.4 / Android 9; document this; provide fallback instructions |
+| GKE Autopilot cold start latency for Connect RPC handlers | Pre-warm pods; set minimum replicas > 0 |
+| Base Sepolia testnet instability | Retry logic in minting handler; idempotent mint (check existing token before minting) |
+| Smart Account address prediction diverges from deployed Safe | Use exact same `initializer` and `saltNonce` in prediction and future deployment |
+| No maintained Go AA SDK — manual UserOperation construction is error-prone | Unit-test ABI encoding against known good vectors from the ERC-4337 spec; integration-test against a local Bundler (Rundler) in CI |
+
+## Library Selection (as of 2026-02-20)
+
+| Domain | Library | Version | Notes |
+|---|---|---|---|
+| Go ZKP verification | `consensys/gnark` | v0.14.0 | Groth16 on BN254; most actively maintained Go ZKP library |
+| Go ZKP format adapter | `vocdoni/circom2gnark` | latest | Converts snarkjs JSON proof/vkey → gnark types; required bridge |
+| Go WebAuthn server | `go-webauthn/webauthn` | v0.15.0 (Nov 2025) | Only actively maintained Go FIDO2 server library |
+| Go blockchain | `go-ethereum/ethclient` | v1.15.x | EVM interaction; UserOperation ABI encoding |
+| Go HTTP bundler client | `net/http` (stdlib) | — | Direct JSON-RPC to Pimlico/Alchemy bundler; no AA SDK used |
+| Browser ZKP generation | `snarkjs` | latest stable | Only production-ready circom/Groth16 JS library |
+| Browser WebAuthn | `@simplewebauthn/browser` | v13.2.2 | Actively maintained; `@github/webauthn-json` archived Aug 2025 |
+| PWA / Service Worker | `vite-plugin-pwa` + Workbox | v1.2.0 / v7.4.0 | `injectManifest` mode for custom ZK circuit runtime caching |
+
+---
+
+## Migration Plan
+
+1. **Infrastructure**: Provision GKE Autopilot cluster + Cloud SQL (PostgreSQL) in `cloud-provisioning` (separate PR).
+2. **Smart Contracts**: Deploy `TicketSBT` to Base Sepolia; record contract address in backend config.
+3. **Backend**: Deploy Go service to GKE; run DB migrations; configure Secret Manager for contract keys.
+4. **Frontend**: Deploy PWA to CDN/Firebase Hosting; verify Service Worker registration and A2HS prompt.
+5. **Circuit**: Compile `TicketCheck` Groth16 circuit; publish WASM + ZKey to CDN; update Service Worker cache manifest.
+6. **Rollback**: Backend is stateless (state in DB + blockchain); rolling back the Deployment to previous image is sufficient. DB migrations must be backward-compatible.
+
+## Open Questions
+
+- **Circuit trusted setup**: Who performs the Powers of Tau ceremony for `TicketCheck`? Using a public setup (Hermez) vs. project-specific?
+- **Merkle tree leaf format**: What inputs constitute an identity leaf (credential ID hash? public key hash?)? Must be finalized before circuit compilation. Use **Poseidon** (not MiMC) as the hash function — benchmarks show Poseidon2 reduces Groth16 proof generation time by ~60% vs MiMC for equivalent depth circuits. Keep tree depth ≤ 20 to stay under 30 s on low-end mobile.
+- **Paymaster integration**: The proposal mentions sponsoring gas fees for minting. Is paymaster in-scope for this MVP or deferred?
+- **Operator role**: Who has the `MINTER_ROLE` on `TicketSBT`? The Go backend service account key, or a multisig? Needs security review.
+- **Event creation flow**: How are `events` and `merkle_tree` entries populated — admin UI, API, or manual seeding for MVP?

--- a/openspec/changes/implement-ticket-system-mvp/research/README.md
+++ b/openspec/changes/implement-ticket-system-mvp/research/README.md
@@ -12,22 +12,30 @@
 | [webauthn-go-server.md](webauthn-go-server.md) | Go WebAuthn/FIDO2 server | `go-webauthn/webauthn` v0.15.0 |
 | [evm-aa-go-libraries.md](evm-aa-go-libraries.md) | EVM + ERC-4337 Account Abstraction | `go-ethereum` + raw `net/http` (no AA SDK; all dead) |
 | [frontend-webauthn-pwa.md](frontend-webauthn-pwa.md) | Frontend WebAuthn + Service Worker | `@simplewebauthn/browser` v13.2.2; `vite-plugin-pwa` v1.2.0 (injectManifest) |
+| [zitadel-passkey-rp.md](zitadel-passkey-rp.md) | Zitadel as WebAuthn Relying Party | Zitadel RP viable for MVP (hosted UI); custom UI blocked by Issue #8282 |
 
 ## Key Findings
 
-### Confirmed (no change needed)
+### Used in MVP
 - `circom` + `snarkjs`: Only production-ready Groth16 browser prover; no viable alternative
-- `go-webauthn/webauthn`: Only actively maintained Go FIDO2 library
-- `@simplewebauthn/browser`: De-facto standard; `@github/webauthn-json` archived Aug 2025
 - `vite-plugin-pwa` + Workbox: Confirmed stack; requires `injectManifest` mode for ZK circuits
+- `gnark` + `vocdoni/circom2gnark`: gnark does not natively parse snarkjs JSON; adapter is mandatory
+- `go-ethereum` + `net/http`: All Go AA SDKs dead (stackup-go, thirdweb); manual UserOperation construction
+- **Zitadel as Passkey RP**: Viable for MVP with hosted login UI; custom UI blocked by Issue #8282
+
+### Reserved for Option C migration (not used in MVP)
+- `go-webauthn/webauthn` v0.15.0: Only actively maintained Go FIDO2 library; needed if self-hosted RP required
+- `@simplewebauthn/browser` v13.2.2: De-facto standard browser WebAuthn library; needed for custom Login UI
 
 ### Changed from original design assumptions
-- **gnark requires adapter**: `vocdoni/circom2gnark` is mandatory — gnark does not natively parse snarkjs JSON
-- **Go AA SDK dead**: stackup-go (archived Oct 2024), thirdweb Go SDK (archived May 2024), no Safe Go SDK → implement UserOperation manually with `go-ethereum` + `net/http`
-- **Service Worker caching**: `.zkey` files (5–30 MB) exceed Workbox's 2 MB precache limit → use runtime CacheFirst strategy with versioned CDN URLs
+- **Zitadel is the WebAuthn RP for MVP**: No self-hosted go-webauthn; Passkey handled by Zitadel hosted UI
+- **Safe address from users.id**: Credential public key not exported by Zitadel; derive from internal UUID instead
+- **Service Worker caching**: `.zkey` files (5-30 MB) exceed Workbox's 2 MB precache limit → runtime CacheFirst strategy
 - **@github/webauthn-json removed**: Archived Aug 2025; browsers have native JSON parsing
 
 ### Monitoring
-- `mopro` issue #290 (wasm-bindgen browser): If this lands in 2026, could replace snarkjs with 10–20x faster proving
+- `mopro` issue #290 (wasm-bindgen browser): If this lands in 2026, could replace snarkjs with 10-20x faster proving
 - `gnark` issue #1582: Native snarkjs JSON export; would eliminate circom2gnark dependency if merged
 - `go-webauthn/webauthn` pre-v1 API consolidation (Discussion #218): Review before upgrading
+- Zitadel Issue #8282 (RPOrigins bug): Blocks custom Login UI on different domain
+- Zitadel Discussion #8867: Conditional UI (Passkey autofill) not supported

--- a/openspec/changes/implement-ticket-system-mvp/research/README.md
+++ b/openspec/changes/implement-ticket-system-mvp/research/README.md
@@ -1,0 +1,33 @@
+# Library Research — implement-ticket-system-mvp
+
+> Researched: 2026-02-20
+> Purpose: Evaluate all planned libraries/SDKs; confirm decisions reflected in `design.md`
+
+## Files
+
+| File | Domain | Decision |
+|---|---|---|
+| [zkp-go-backend.md](zkp-go-backend.md) | Go ZKP verification (Groth16) | `gnark` v0.14.0 + `vocdoni/circom2gnark` adapter |
+| [zkp-browser-client.md](zkp-browser-client.md) | Browser ZKP proof generation | `circom` + `snarkjs` 0.7.5 (only option) |
+| [webauthn-go-server.md](webauthn-go-server.md) | Go WebAuthn/FIDO2 server | `go-webauthn/webauthn` v0.15.0 |
+| [evm-aa-go-libraries.md](evm-aa-go-libraries.md) | EVM + ERC-4337 Account Abstraction | `go-ethereum` + raw `net/http` (no AA SDK; all dead) |
+| [frontend-webauthn-pwa.md](frontend-webauthn-pwa.md) | Frontend WebAuthn + Service Worker | `@simplewebauthn/browser` v13.2.2; `vite-plugin-pwa` v1.2.0 (injectManifest) |
+
+## Key Findings
+
+### Confirmed (no change needed)
+- `circom` + `snarkjs`: Only production-ready Groth16 browser prover; no viable alternative
+- `go-webauthn/webauthn`: Only actively maintained Go FIDO2 library
+- `@simplewebauthn/browser`: De-facto standard; `@github/webauthn-json` archived Aug 2025
+- `vite-plugin-pwa` + Workbox: Confirmed stack; requires `injectManifest` mode for ZK circuits
+
+### Changed from original design assumptions
+- **gnark requires adapter**: `vocdoni/circom2gnark` is mandatory — gnark does not natively parse snarkjs JSON
+- **Go AA SDK dead**: stackup-go (archived Oct 2024), thirdweb Go SDK (archived May 2024), no Safe Go SDK → implement UserOperation manually with `go-ethereum` + `net/http`
+- **Service Worker caching**: `.zkey` files (5–30 MB) exceed Workbox's 2 MB precache limit → use runtime CacheFirst strategy with versioned CDN URLs
+- **@github/webauthn-json removed**: Archived Aug 2025; browsers have native JSON parsing
+
+### Monitoring
+- `mopro` issue #290 (wasm-bindgen browser): If this lands in 2026, could replace snarkjs with 10–20x faster proving
+- `gnark` issue #1582: Native snarkjs JSON export; would eliminate circom2gnark dependency if merged
+- `go-webauthn/webauthn` pre-v1 API consolidation (Discussion #218): Review before upgrading

--- a/openspec/changes/implement-ticket-system-mvp/research/evm-aa-go-libraries.md
+++ b/openspec/changes/implement-ticket-system-mvp/research/evm-aa-go-libraries.md
@@ -1,0 +1,110 @@
+# EVM / ERC-4337 Account Abstraction Go Libraries Research
+
+> Researched: 2026-02-20
+
+## Summary
+
+The Go ERC-4337 library ecosystem is essentially dead. All major Go AA SDKs are either archived or
+unmaintained. The pragmatic approach is to implement UserOperation construction manually using
+`go-ethereum` ABI encoding and call bundler RPC endpoints directly via `net/http`.
+
+## Area 1: EVM Client Libraries
+
+### go-ethereum — REQUIRED
+
+| Field | Value |
+|---|---|
+| Latest stable | v1.15.x / v1.17.1 (January 2026, includes CVE-2026-26313/14/15 patches) |
+| Import path | `github.com/ethereum/go-ethereum` |
+| Base network | Full support (same JSON-RPC API as mainnet) |
+
+**Key packages for this project**:
+- `ethclient`: Connect to Base Sepolia, send transactions, call contracts
+- `accounts/abi`: ABI encoding/decoding for contract calls and UserOperation callData
+- `cmd/abigen`: Generate type-safe Go bindings from ABI JSON (Safe contracts)
+
+**v1.15 notable changes**: New DB schema, Prague fork (EIP-7702), removal of Solidity compilation
+from `abigen` (supply ABI JSON from Foundry/Hardhat instead).
+
+---
+
+## Area 2: ERC-4337 Account Abstraction SDKs
+
+### Status: All major Go AA SDKs are dead
+
+| Library | Status |
+|---|---|
+| `stackup-wallet/stackup-bundler` (Go) | **Archived October 20, 2024** |
+| `thirdweb-dev/go-sdk` | **Deprecated May 3, 2024** (archived) |
+| `safe-global/safe-core-sdk` | TypeScript only; no official Go version |
+| `vikkkko/safe-core-sdk-golang` | Single-developer community fork (Sep 2025); unknown maintenance |
+| `anyproto/alchemy-aa-sdk` | Third-party unofficial Go wrapper; scope unclear |
+| `mdehoog/go-bundler-client` | Thin utility; depends on archived stackup-bundler types |
+| Pimlico Go SDK | Does not exist (TypeScript only) |
+| permissionless.js Go port | Does not exist |
+
+---
+
+## Decision: Raw Implementation Approach
+
+Given the above, implement ERC-4337 interaction without a Go AA SDK:
+
+### 1. Safe Address Prediction (CREATE2)
+
+Implement directly in Go using `go-ethereum/crypto`:
+
+```
+address = keccak256(0xff ++ SafeProxyFactory ++ salt ++ keccak256(initCode))[12:]
+```
+
+- SafeProxyFactory Singleton: `0x914d7Fec6aaC8cd542e72Bca78B30650d45643d7` (all chains incl. Base)
+- `initCode` encodes the proxy factory call with: Safe singleton address, owners, threshold,
+  `Safe4337Module` as fallback handler
+- `saltNonce` must be the same value in prediction and future actual deployment
+
+### 2. UserOperation Construction
+
+Build the `UserOperation` struct manually (well-defined in EIP-4337 v0.7). Use `go-ethereum/accounts/abi`
+for `callData` encoding of Safe contract method calls.
+
+Generate type-safe Go bindings for Safe contracts with abigen:
+```bash
+abigen --abi SafeProxyFactory.json --pkg safe --out safe_proxy_factory.go
+abigen --abi Safe4337Module.json --pkg safe --out safe_4337_module.go
+```
+
+ABIs sourced from `safe-global/safe-smart-account` repository.
+
+### 3. Bundler Submission
+
+Call Pimlico or Alchemy bundler RPC directly via `net/http`:
+
+```go
+// POST to https://api.pimlico.io/v2/{chain}/rpc?apikey={key}
+// JSON-RPC method: eth_sendUserOperation
+// params: [userOp, entryPointAddress]
+```
+
+Standard JSON-RPC; no library needed beyond `net/http` + `encoding/json`.
+
+---
+
+## Testing Requirements
+
+- Unit-test ABI encoding against known-good vectors from the ERC-4337 spec
+- Integration-test against a local Bundler (e.g., Rundler) in CI
+- Integration-test Safe address prediction against actual Safe deployment on Base Sepolia
+
+---
+
+## Sources
+
+- [go-ethereum releases](https://github.com/ethereum/go-ethereum/releases)
+- [thirdweb Go SDK deprecation announcement](https://blog.thirdweb.com/changelog/deprecation-announcement-python-go-sdks/)
+- [stackup-bundler (archived)](https://github.com/stackup-wallet/stackup-bundler)
+- [Etherspot migration from Stackup](https://medium.com/etherspot/etherspots-assistance-for-developers-during-the-migration-from-stackup-0ff6fbb93734)
+- [safe-core-sdk (TypeScript)](https://github.com/safe-global/safe-core-sdk)
+- [Safe ERC-4337 docs](https://docs.safe.global/advanced/erc-4337/4337-safe)
+- [Pimlico bundler docs](https://docs.pimlico.io/references/bundler/usage)
+- [abigen docs](https://geth.ethereum.org/docs/tools/abigen)
+- [EIP-4337 spec](https://eips.ethereum.org/EIPS/eip-4337)

--- a/openspec/changes/implement-ticket-system-mvp/research/frontend-webauthn-pwa.md
+++ b/openspec/changes/implement-ticket-system-mvp/research/frontend-webauthn-pwa.md
@@ -1,0 +1,212 @@
+# Frontend WebAuthn + PWA Service Worker Libraries Research
+
+> Researched: 2026-02-20
+
+## Area 1: WebAuthn Client-Side Libraries
+
+### 1. @simplewebauthn/browser — RECOMMENDED
+
+| Field | Value |
+|---|---|
+| Latest version | 13.2.2 (~October 2025) |
+| Weekly npm downloads | ~330,000+ |
+| TypeScript | 100% TS; all internal types exported |
+| Distribution | npm + JSR |
+
+**Key features for this project**:
+- `startAuthentication({ useBrowserAutofill: true })`: Conditional UI / passkey autofill popup
+- `startRegistration({ useAutoRegister: true })`: Promote credential to passkey after auth (v11+)
+- `preferredAuthenticatorType`: `'localDevice' | 'securityKey' | 'remoteDevice'` hint (v13)
+- Framework-agnostic: plain async functions, works cleanly in Aurelia 2
+
+**Breaking changes from older versions**: "attestation/assertion" renamed to "registration/authentication".
+In v13, `@simplewebauthn/types` was folded into `browser` and `server` packages directly.
+
+**v13.2.2 security**: Added supply-chain transparency via hardened GitHub Actions CI workflows.
+
+---
+
+### 2. @github/webauthn-json — ARCHIVED, DO NOT USE
+
+**Archived: August 26, 2025 (read-only)**
+
+Reason: All major browsers now ship native JSON parsing for WebAuthn:
+- `PublicKeyCredential.parseCreationOptionsFromJSON()`
+- `PublicKeyCredential.parseRequestOptionsFromJSON()`
+
+The library's sole purpose (base64url encoding/decoding) is now a browser built-in. The GitHub
+team explicitly recommends migrating to `@simplewebauthn/browser` or using the raw API with
+native JSON helpers.
+
+---
+
+### 3. @passwordless-id/webauthn — NICHE ALTERNATIVE
+
+| Field | Value |
+|---|---|
+| Version | ~2.x (last published March 2025) |
+| Weekly downloads | ~22,000 |
+
+Unified client+server package, zero dependencies. Missing: conditional UI, auto-register passkey,
+authenticator type hints. Slower update cadence than SimpleWebAuthn. Acceptable for simple cases
+but weaker for production passkey flows.
+
+---
+
+### 4. Raw navigator.credentials API
+
+**When to use directly**:
+- Need cutting-edge extensions (`prf`, `largeBlob`, `signal` API) not yet wrapped by libraries
+- Zero-dependency/compliance requirement
+- Already on browsers with native JSON helpers (available from Chrome 108+, Firefox 122+)
+
+**Not recommended for production passkey flows**: ArrayBuffer serialization, CBOR/COSE structures,
+and conditional UI `AbortController` logic are error-prone to implement manually. Google's own
+passkey documentation recommends using a library.
+
+---
+
+## Area 2: PWA Service Worker Management
+
+### 1. Workbox 7.4.0 — FOUNDATION
+
+| Field | Value |
+|---|---|
+| Latest version | 7.4.0 (~November 2025) |
+| Owner | Chrome's Aurora team |
+| TypeScript | Full (rewritten in TS at v6.5.0) |
+
+**Relevant modules**:
+
+| Module | Purpose |
+|---|---|
+| `workbox-precaching` | Precache app shell JS/CSS at install |
+| `workbox-strategies` | Runtime caching strategies (CacheFirst, NetworkFirst, StaleWhileRevalidate) |
+| `workbox-routing` | Route fetch events to strategies |
+| `workbox-expiration` | Evict cached entries by age or count |
+| `workbox-range-requests` | Handle `Range:` headers for large binary streaming |
+
+**Critical constraint for ZK circuit files**:
+
+Default `maximumFileSizeToCacheInBytes` = **2 MiB**. Circuit `.zkey` files are 5–30 MB — this
+limit must be raised in config, or use runtime caching instead of precaching.
+
+From `vite-plugin-pwa` v0.20.2+: build error thrown if any file exceeds the limit without explicit
+config override.
+
+**Browser Cache Storage quota**: Chrome allows up to 80% of disk. Mobile Safari is more conservative.
+5–30 MB per circuit version is within quota but should be monitored.
+
+---
+
+### 2. vite-plugin-pwa 1.2.0 — USE WITH injectManifest MODE
+
+| Field | Value |
+|---|---|
+| Latest version | 1.2.0 (~November 2025) |
+| Workbox bundled | Workbox 7.x |
+
+**Two modes**:
+
+| Mode | When to use |
+|---|---|
+| `generateSW` | Standard app shell + API caching; zero custom SW code |
+| `injectManifest` | Custom SW logic required (ZK circuit routing) — **USE THIS** |
+
+The `injectManifest` mode builds a custom `sw.ts` and injects the precache manifest. Required for
+ZK circuit caching because the custom `registerRoute` logic cannot be expressed in `generateSW`'s
+declarative config.
+
+**Recommended custom SW pattern for ZK circuits**:
+
+```ts
+// sw.ts
+import { precacheAndRoute } from 'workbox-precaching'
+import { registerRoute } from 'workbox-routing'
+import { CacheFirst } from 'workbox-strategies'
+import { CacheableResponsePlugin } from 'workbox-cacheable-response'
+import { ExpirationPlugin } from 'workbox-expiration'
+
+// Standard app shell (injected by vite-plugin-pwa)
+precacheAndRoute(self.__WB_MANIFEST)
+
+// Runtime cache for ZK circuit files (versioned CDN URLs)
+registerRoute(
+  ({ url }) => url.pathname.endsWith('.wasm') || url.pathname.endsWith('.zkey'),
+  new CacheFirst({
+    cacheName: 'zk-circuits-v1',
+    plugins: [
+      new CacheableResponsePlugin({ statuses: [200] }),
+      new ExpirationPlugin({
+        maxAgeSeconds: 30 * 24 * 60 * 60, // 30 days
+      }),
+    ],
+  }),
+)
+```
+
+Cache invalidation: deploy new versioned URL (e.g., `/circuits/ticketcheck-v2.zkey`) → old cache
+evicted on SW activation.
+
+**vite.config.ts**:
+```ts
+VitePWA({
+  strategies: 'injectManifest',
+  srcDir: 'src',
+  filename: 'sw.ts',
+  workbox: {
+    maximumFileSizeToCacheInBytes: 60 * 1024 * 1024, // 60 MB
+  },
+})
+```
+
+---
+
+### 3. sw-precache / sw-toolbox — ARCHIVED, DO NOT USE
+
+Both archived under `GoogleChromeLabs`. Migration guide at
+developer.chrome.com/docs/workbox/migration/migrate-from-sw/.
+
+---
+
+### 4. Manual Service Worker (OPFS) — Future Option
+
+If `.zkey` files grow beyond ~20 MB, consider Origin Private File System (OPFS):
+- Available in all major browsers as of 2025
+- Sync file access from workers; quota-exempt on most browsers
+- Store large blobs in OPFS from a dedicated Worker; serve from OPFS on fetch
+- Workbox has no built-in OPFS support → requires manual SW code for this path
+
+Not required for MVP but document as an upgrade path.
+
+---
+
+## Summary Tables
+
+### WebAuthn Libraries
+
+| Library | Version | Status | Passkey/Conditional UI | Recommendation |
+|---|---|---|---|---|
+| `@simplewebauthn/browser` | 13.2.2 | Active | Full | **Use** |
+| `@github/webauthn-json` | — | Archived Aug 2025 | Never added | Do not use |
+| `@passwordless-id/webauthn` | 2.x | Slow cadence | Not highlighted | Niche alternative |
+
+### PWA Libraries
+
+| Library | Version | Status | Large File Support | Recommendation |
+|---|---|---|---|---|
+| `workbox` | 7.4.0 | Active | Yes (with config) | **Foundation** |
+| `vite-plugin-pwa` | 1.2.0 | Active | Yes (injectManifest) | **Use (injectManifest mode)** |
+| `sw-precache` / `sw-toolbox` | — | Archived | N/A | Do not use |
+
+## Sources
+
+- [@simplewebauthn/browser docs](https://simplewebauthn.dev/docs/packages/browser/)
+- [SimpleWebAuthn GitHub releases](https://github.com/MasterKale/SimpleWebAuthn/releases)
+- [@github/webauthn-json GitHub (archived)](https://github.com/github/webauthn-json)
+- [Libraries - passkeys.dev](https://passkeys.dev/docs/tools-libraries/libraries/)
+- [Workbox - Chrome for Developers](https://developer.chrome.com/docs/workbox)
+- [Understanding storage quota - Workbox](https://developer.chrome.com/docs/workbox/understanding-storage-quota)
+- [vite-plugin-pwa](https://vite-pwa-org.netlify.app/)
+- [vite-plugin-pwa injectManifest docs](https://vite-pwa-org.netlify.app/guide/inject-manifest)
+- [Offline-first frontend apps 2025 - LogRocket](https://blog.logrocket.com/offline-first-frontend-apps-2025-indexeddb-sqlite/)

--- a/openspec/changes/implement-ticket-system-mvp/research/webauthn-go-server.md
+++ b/openspec/changes/implement-ticket-system-mvp/research/webauthn-go-server.md
@@ -1,0 +1,75 @@
+# WebAuthn Go Server Libraries Research
+
+> Researched: 2026-02-20
+
+## Summary
+
+`go-webauthn/webauthn` is the unambiguous choice. It is the community-maintained successor to the
+deprecated `duo-labs/webauthn`, the only Go library listed on passkeys.dev, and the only one with
+documented FIDO2 conformance testing.
+
+## Libraries
+
+### 1. go-webauthn/webauthn — RECOMMENDED
+
+| Field | Value |
+|---|---|
+| Latest version | v0.15.0 (November 9, 2025) |
+| Imported by | 312+ Go projects (pkg.go.dev) |
+| Production users | Gitea, Forgejo |
+| Listed on passkeys.dev | Yes (only Go library listed) |
+
+**Release history (recent)**:
+- v0.15.0 (Nov 2025): Replace `mitchellh/mapstructure` with `go-viper/mapstructure/v2`
+- v0.14.0 (Sep 2025): MDS schema 3.1, attestation updates, native app origin validation
+- v0.13.0 (May 2025): CaBLE transport, algorithm parameter verification at registration
+- v0.12.x: Strict BE/BS flag validation (passkey vs device-bound), WebAuthn Level 3 Credential Record model
+
+**Passkey / Discoverable Credential support**: Full. `requireResidentKey`, `residentKey` preference,
+Backup Eligible/Backup State flags. Aligned with Apple/Google/Microsoft passkey behavior.
+
+**Attestation formats verified**: `packed`, `tpm`, `android-key`, `android-safetynet`, `fido-u2f`,
+`apple`, `none`. MDS3 integration for AAGUID-based trust.
+
+**Challenge management**: Returns `SessionData` from `BeginRegistration`/`BeginLogin`. Caller is
+responsible for storing between Begin and Finish (Redis, HTTP session, encrypted cookie, etc.).
+
+**Limitations**:
+- Pre-v1.0: Breaking changes possible between minor versions. Pin to specific minor version.
+  A large pre-v1 API consolidation is planned (Discussion #218).
+- No built-in HTTP handlers (wire into Connect RPC / HTTP mux manually)
+- No built-in session storage
+
+---
+
+### 2. duo-labs/webauthn — DEPRECATED
+
+Last release: December 2022. README explicitly marks it deprecated and links to `go-webauthn/webauthn`.
+Do not use for new projects.
+
+---
+
+### 3. Other Libraries — NOT RECOMMENDED
+
+| Library | Reason |
+|---|---|
+| `pomerium/webauthn` | Internal library for Pomerium proxy; not designed for general passkey flows |
+| `egregors/passkey` | Higher-level wrapper over `go-webauthn/webauthn`; adds HTTP scaffolding but no new protocol capability |
+| `spiretechnology/go-webauthn` | Low adoption, less active than go-webauthn |
+| `e3b0c442/warp` | Not actively maintained through 2024-2025 |
+
+---
+
+## Decision
+
+**Use `go-webauthn/webauthn` v0.15.0.** Pin to this version; review breaking changes documentation
+before upgrading across minor versions.
+
+## Sources
+
+- [go-webauthn/webauthn GitHub](https://github.com/go-webauthn/webauthn)
+- [go-webauthn/webauthn releases](https://github.com/go-webauthn/webauthn/releases)
+- [duo-labs/webauthn GitHub](https://github.com/duo-labs/webauthn)
+- [Libraries - passkeys.dev](https://passkeys.dev/docs/tools-libraries/libraries/)
+- [Corbado WebAuthn server comparison](https://www.corbado.com/blog/webauthn-server-implementation)
+- [go-webauthn pre-v1 API consolidation (Discussion #218)](https://github.com/go-webauthn/webauthn/discussions/218)

--- a/openspec/changes/implement-ticket-system-mvp/research/zitadel-passkey-rp.md
+++ b/openspec/changes/implement-ticket-system-mvp/research/zitadel-passkey-rp.md
@@ -1,0 +1,179 @@
+# Zitadel as WebAuthn/Passkey Relying Party — Research
+
+> Researched: 2026-02-20
+> Purpose: Evaluate whether Zitadel can serve as the WebAuthn RP for the ticket system MVP
+
+## Summary
+
+Zitadel supports Passkey registration and authentication via its v2 API. However, critical
+limitations exist around custom Login UI on separate domains (Issue #8282), credential public
+key export (not possible), and Conditional UI / autofill (not supported).
+
+## A. Passkey Registration Flow
+
+**Source**: [Zitadel Docs - RegisterPasskey API](https://zitadel.com/docs/apis/resources/user_service_v2/user-service-register-passkey)
+
+**Endpoint**: `POST /v2/users/{user_id}/passkeys`
+
+**Request**:
+- `code` (optional): Registration code for email-link flows
+- `authenticator` (optional): `PASSKEY_AUTHENTICATOR_UNSPECIFIED` | `PASSKEY_AUTHENTICATOR_PLATFORM` | `PASSKEY_AUTHENTICATOR_CROSS_PLATFORM`
+- `domain` (optional): Domain specification
+
+**Response** (HTTP 200):
+- `passkeyId`: Registered passkey ID
+- `publicKeyCredentialCreationOptions`: WebAuthn credential creation options — can be passed directly to `navigator.credentials.create()`
+
+**Verification**: `POST /v2/users/{user_id}/passkeys/{passkey_id}` with `publicKeyCredential` from browser. Zitadel stores the credential public key internally.
+
+## B. Passkey Authentication Flow (Session API)
+
+**Source**: [Zitadel Docs - Passkey Login UI](https://zitadel.com/docs/guides/integrate/login-ui/passkey)
+
+3-step flow:
+
+1. **Create session + request challenge**:
+   ```
+   POST /v2/sessions
+   {
+     "checks": { "user": { "loginName": "user@example.com" } },
+     "challenges": {
+       "webAuthN": {
+         "domain": "example.domain.com",
+         "userVerificationRequirement": "USER_VERIFICATION_REQUIREMENT_REQUIRED"
+       }
+     }
+   }
+   ```
+   Response includes `sessionId`, `sessionToken`, `challenges.webAuthN.publicKeyCredentialRequestOptions`.
+
+2. **Browser authentication**: `navigator.credentials.get({ publicKey: publicKeyCredentialRequestOptions })`
+
+3. **Update session with assertion**:
+   ```
+   PATCH /v2/sessions/{sessionId}
+   { "checks": { "webAuthN": { "credentialAssertionData": { ... } } } }
+   ```
+
+### Session → OIDC Token Exchange
+
+**Source**: [Zitadel Docs - Session API Guide](https://zitadel.com/docs/guides/integrate/login-ui/session-api)
+
+Authenticated session can finalize an OIDC auth request:
+```
+POST /v2/oidc/auth_requests/{authRequestId}
+{ "sessionId": "...", "sessionToken": "..." }
+```
+Returns callback URL with authorization code → standard OIDC token exchange.
+
+## C. Credential Public Key Access
+
+**Source**: [Zitadel Docs - ListPasskeys API](https://zitadel.com/docs/apis/resources/user_service_v2/user-service-list-passkeys)
+
+`POST /v2/users/{user_id}/passkeys/_search` returns ONLY:
+- `id` (string)
+- `state` (enum)
+- `name` (string)
+
+**Credential public key, credential ID binary, and other cryptographic material are NOT exposed.**
+
+This means:
+- Cannot derive Safe address from credential public key via Zitadel
+- Cannot perform independent WebAuthn assertion verification outside Zitadel
+- Must use an alternative derivation source (e.g., Zitadel user ID / sub claim)
+
+## D. RPID and Domain Constraints
+
+### How RPID is determined
+
+**Source**: [Zitadel source code - webauthn.go](https://github.com/zitadel/zitadel/blob/main/internal/webauthn/webauthn.go)
+
+- If `domain` parameter is provided: used directly as RPID
+- If `domain` is empty: derived from HTTP request context (`RequestedDomain()`)
+
+### Domain change warning
+
+**Source**: [Zitadel Docs - Passkeys Concept](https://zitadel.com/docs/concepts/features/passkeys)
+
+> "Passkey authentication is based on the domain, if you change it, your users will not be able
+> to login with the registered passkey authentication."
+
+Recommendation: Configure custom domain BEFORE enabling Passkeys.
+
+### CRITICAL BUG: Issue #8282 (Open, Unresolved)
+
+**Source**: [GitHub Issue #8282](https://github.com/zitadel/zitadel/issues/8282)
+
+**Status**: Open (assigned to peintnermax)
+
+**Problem**: When `domain` parameter is passed to Session API, `RPOrigins` is set to `[""]`
+(empty string) in `webauthn.go`. This causes go-webauthn to fail origin validation → 500 error.
+
+```
+Session API: domain="login.example.com"
+  → serverFromContext(ctx, "login.example.com", "")
+  → config: { RPID: "login.example.com", RPOrigins: [""] }
+  → go-webauthn: origin "" != actual origin → 500 error
+```
+
+**Workaround**: Zitadel's own TypeScript Login app passes `""` (empty string) for domain,
+but this bypasses protobuf validation (min 1 char) via internal routing. External API callers
+cannot use this workaround.
+
+**Impact**: Custom Login UI hosted on a different domain than Zitadel cannot reliably use
+Passkey authentication via Session API.
+
+### PR #6097 (Merged, 2023-06-27)
+
+**Source**: [GitHub PR #6097](https://github.com/zitadel/zitadel/pull/6097)
+
+Added the `domain` parameter to Session API specifically for the use case:
+> "This is useful in cases where the login UI is served under a different domain / origin
+> than the ZITADEL API."
+
+The intent was correct, but the implementation has the RPOrigins bug described above.
+
+## E. Custom Login UI Implementation
+
+**Source**: [Zitadel Docs - Custom Login UI](https://zitadel.com/docs/guides/integrate/login-ui)
+
+Full flow:
+1. App redirects to Login UI via OIDC authorize request
+2. Zitadel redirects to `/login?authRequest={id}`
+3. Login UI creates and authenticates a session via Zitadel v2 APIs
+4. Login UI finalizes the auth request: `POST /v2/oidc/auth_requests/{authRequestId}`
+5. Browser redirected back to app with authorization code
+
+Requirements:
+- OIDC endpoints must be proxied to Zitadel
+- Next.js reference implementation exists
+- Backend uses service account PAT for policy retrieval
+
+## F. Limitations and Known Issues
+
+| Limitation | Source | Impact |
+|---|---|---|
+| domain parameter bug (RPOrigins empty) | Issue #8282 (Open) | Custom Login UI on different domain broken |
+| Credential public key not exported | ListPasskeys API docs | Cannot use credential for on-chain derivation |
+| Domain change invalidates all Passkeys | Passkeys concept docs | Must finalize domain before enabling |
+| Conditional UI (autofill) not supported | Discussion #8867, Issue #8899 | Cannot implement passwordless autofill UX |
+| Related Origins (.well-known/webauthn) not supported | No Issue/FR exists | No cross-origin Passkey sharing |
+| Self-hosted vs Cloud differences | Not documented | Unknown feature parity |
+
+## Sources
+
+- [Zitadel Docs: Passkeys Concept](https://zitadel.com/docs/concepts/features/passkeys)
+- [Zitadel Docs: RegisterPasskey API](https://zitadel.com/docs/apis/resources/user_service_v2/user-service-register-passkey)
+- [Zitadel Docs: VerifyPasskeyRegistration API](https://zitadel.com/docs/apis/resources/user_service_v2/user-service-verify-passkey-registration)
+- [Zitadel Docs: CreateSession API](https://zitadel.com/docs/apis/resources/session_service_v2/session-service-create-session)
+- [Zitadel Docs: Custom Login UI Guide](https://zitadel.com/docs/guides/integrate/login-ui)
+- [Zitadel Docs: Passkey Login UI Guide](https://zitadel.com/docs/guides/integrate/login-ui/passkey)
+- [Zitadel Docs: Session API Guide](https://zitadel.com/docs/guides/integrate/login-ui/session-api)
+- [PR #6097: fix: provide domain in session, passkey and u2f](https://github.com/zitadel/zitadel/pull/6097)
+- [Issue #8282: WebAuthN.BeginLoginFailed (Open)](https://github.com/zitadel/zitadel/issues/8282)
+- [Issue #4307: WebAuthN not working behind NGINX](https://github.com/zitadel/zitadel/issues/4307)
+- [Issue #7251: WebAuthN with example nginx config](https://github.com/zitadel/zitadel/issues/7251)
+- [Discussion #8867: Passkey Autofill UI](https://github.com/zitadel/zitadel/discussions/8867)
+- [Issue #8899: Passkey Autofill UI Feature Request](https://github.com/zitadel/zitadel/issues/8899)
+- [Zitadel Community Q&A: WebAuthN begin login failed](https://questions.zitadel.com/m/1383062464924483656)
+- [Zitadel WebAuthn source code](https://github.com/zitadel/zitadel/blob/main/internal/webauthn/webauthn.go)

--- a/openspec/changes/implement-ticket-system-mvp/research/zkp-browser-client.md
+++ b/openspec/changes/implement-ticket-system-mvp/research/zkp-browser-client.md
@@ -1,0 +1,121 @@
+# ZKP Browser Client Libraries Research
+
+> Researched: 2026-02-20
+
+## Summary
+
+`circom + snarkjs` is the only production-ready option for browser-based Groth16 proof generation
+compatible with a gnark Go verifier. All alternatives (Noir, halo2, plonky2/3) use different proof
+systems and cannot interoperate with gnark's Groth16 verifier.
+
+## Libraries
+
+### 1. circom + snarkjs — RECOMMENDED
+
+| Field | Value |
+|---|---|
+| snarkjs version | 0.7.5 (October 18, 2024; ~15 months quiet as of Feb 2026) |
+| Weekly npm downloads | ~19,000 |
+| Proof systems | Groth16, PLONK, FFLONK (beta) |
+
+**Browser WASM support**: Full and battle-tested. Pure JS + WASM ES module.
+
+**Proof generation time (Merkle depth 20 with Poseidon)**:
+- Desktop: **3–8 seconds** (2024 arxiv benchmark `2409.01976`)
+- Mobile: 8–15s (mid-range), 30–60s (low-end Android)
+- Poseidon2 hashing reduces time ~60% vs MiMC for equivalent circuits
+
+**Bundle sizes**:
+- snarkjs JS: ~1–1.5 MB
+- Circuit `.wasm` (depth-20 Merkle): ~200–500 KB
+- `.zkey` proving key: **5–30 MB** (dominant cache concern)
+
+**Offline capability**: Full. `.wasm` + `.zkey` are normal binary assets cacheable by Service Worker.
+
+**gnark compatibility**: Via `vocdoni/circom2gnark` adapter (production-tested by Vocdoni voting).
+
+**Ecosystem**: Polygon ID, Semaphore, Tornado Cash. circomlib provides Poseidon, MiMC, Merkle,
+nullifier templates.
+
+**Risk**: Library in slow-maintenance mode since v0.7.5. iden3 team's focus shifted toward
+identity products. Format is stable; no expected breaking changes.
+
+---
+
+### 2. Noir (Aztec) — REJECTED
+
+| Field | Value |
+|---|---|
+| Version | 1.0 pre-release (beta.18, late 2025) |
+| Default proof system | UltraHonk / UltraPlonk (NOT Groth16) |
+| bb.js WASM bundle | ~25–50 MB |
+
+**Groth16 support**: Only via LambdaClass experimental `noir_backend_using_gnark` — WIP, Groth16
+side non-functional as of Feb 2026.
+
+**Verdict**: Incompatible with gnark Groth16 verifier. Rejected.
+
+---
+
+### 3. halo2 — REJECTED
+
+- PSE fork entered maintenance mode January 2025
+- Uses Halo2 proof system, not Groth16 → incompatible with gnark verifier
+- WASM proof generation: ~10s mobile (single-threaded, rayon falls back)
+
+---
+
+### 4. plonky2 / plonky3 — REJECTED
+
+- FRI-based STARKs, not Groth16
+- No stable browser WASM SDK as of Feb 2026
+
+---
+
+### 5. gnark-WASM (vocdoni PoC) — NOT YET PRODUCTION
+
+`vocdoni/gnark-wasm-prover` compiles gnark's Groth16 prover to WASM via TinyGo + LLVM. Eliminates
+the circom2gnark translation layer. However:
+- Research-grade proof-of-concept only
+- Circuit authoring requires Go (not circom)
+- WASM binary much larger than snarkjs + circuit WASM
+
+**Watch for**: mopro (github.com/zkmopro/mopro) issue #290 tracks wasm-bindgen browser support.
+If this lands in 2026, arkworks + rust-witness WASM could replace snarkjs with 10–20x faster
+proving and compatible Groth16 output.
+
+---
+
+## Decision Matrix
+
+| Criterion | circom+snarkjs | Noir+bb.js | halo2 | gnark-WASM |
+|---|---|---|---|---|
+| Groth16 output | Yes | No | No | Yes |
+| Browser WASM | Yes (production) | Yes | Partial | PoC only |
+| Offline (Service Worker) | Yes | Yes | Partial | No |
+| gnark Go verifier compat | Yes (circom2gnark) | No | No | Yes (native) |
+| Proof time Merkle/20 | 3–8s desktop | Unknown | ~10s mobile | Unknown |
+| Circuit WASM size | 200–500 KB | ~25–50 MB | Large | Large |
+| .zkey / SRS size | 5–30 MB | ~10–20 MB | — | — |
+
+---
+
+## Implementation Notes
+
+- Use **Poseidon** (not MiMC, not Pedersen) for Merkle tree and nullifier hashing
+- Keep tree depth **≤ 20** to stay under 30s on low-end mobile
+- Cache `.zkey` and circuit `.wasm` via Service Worker **runtime cache** (not precache):
+  - .zkey exceeds Workbox's 2MB precache limit
+  - Use versioned CDN URLs + CacheFirst strategy
+  - Use Workbox `injectManifest` mode for custom routing
+- Run proof generation in a **Web Worker** (snarkjs uses Web Workers for WASM threading)
+
+## Sources
+
+- [iden3/snarkjs GitHub](https://github.com/iden3/snarkjs)
+- [Benchmarking ZKP hash functions (arxiv 2409.01976)](https://arxiv.org/pdf/2409.01976)
+- [vocdoni/circom2gnark](https://github.com/vocdoni/circom2gnark)
+- [vocdoni gnark-wasm-prover](https://github.com/vocdoni/gnark-wasm-prover)
+- [lambdaclass/noir_backend_using_gnark](https://github.com/lambdaclass/noir_backend_using_gnark)
+- [mopro wasm-bindgen issue #290](https://github.com/zkmopro/mopro/issues/290)
+- [ZKP Frameworks Survey (arXiv 2502.07063)](https://arxiv.org/html/2502.07063v1)

--- a/openspec/changes/implement-ticket-system-mvp/research/zkp-go-backend.md
+++ b/openspec/changes/implement-ticket-system-mvp/research/zkp-go-backend.md
@@ -1,0 +1,98 @@
+# ZKP Go Backend Verification Libraries Research
+
+> Researched: 2026-02-20
+
+## Summary
+
+The Go ZKP library ecosystem is thin. For Groth16 on BN254 (the curve used by circom/snarkjs),
+the only production-credible options are `gnark` and `go-rapidsnark/verifier`. All others are
+abandoned or unsuitable.
+
+## Libraries
+
+### 1. gnark (github.com/consensys/gnark) — RECOMMENDED
+
+| Field | Value |
+|---|---|
+| Latest version | v0.14.0 (August 22, 2024) |
+| gnark-crypto companion | v0.15.0 (January 2025) |
+| Stars | ~1.7k |
+| Go native | Yes (pure Go, no CGO) |
+| Production use | Linea zkEVM (ConsenSys), audited by Least Authority Sept 2024 |
+
+**Groth16 support**: Full. `backend/groth16` implements Groth16 for BN254, BLS12-381, BLS12-377, BW6-761.
+
+**snarkjs compatibility**: gnark's native serialization format is NOT the same as snarkjs JSON.
+Requires `vocdoni/circom2gnark` adapter (see below). Issue #1582 (Aug 2025) requests native
+snarkjs JSON export; not merged as of Feb 2026.
+
+**Performance**: Verification ~1–2ms on BN254. Fastest pairing implementation in Go.
+
+**Limitations**:
+- Not constant-time (no side-channel guarantee)
+- Pre-1.0 API; minor versions may break
+- Carries proving code as dependency even for verify-only use
+
+---
+
+### 2. vocdoni/circom2gnark — REQUIRED ADAPTER
+
+A bridge library that parses circom/snarkjs JSON artifacts and converts them to gnark-native types.
+
+**Usage pattern**:
+```go
+import "github.com/vocdoni/circom2gnark/parser"
+
+gnarkProof, gnarkVk, gnarkWitness, _ := parser.ConvertCircomToGnark(circomProof, circomVk, circomPub)
+err := groth16.Verify(gnarkProof, gnarkVk, gnarkWitness)
+```
+
+**Performance**: First call ~880ms (gnark setup); subsequent calls ~1–2ms.
+
+**Limitations**: Small community project; Groth16 BN254 only; depends on gnark so both are imported.
+
+---
+
+### 3. go-rapidsnark/verifier (github.com/iden3/go-rapidsnark) — ALTERNATIVE
+
+| Field | Value |
+|---|---|
+| Latest version | verifier/v0.0.5, prover/v0.0.15 (November 13, 2025) |
+| Language | 92% Go, 5.8% C, 2.2% Assembly (verifier subpackage is pure Go) |
+
+**Advantage**: Reads snarkjs JSON natively (no adapter needed). Built within iden3/Polygon ID
+ecosystem.
+
+**Limitations**: License unclear on pkg.go.dev (missing SPDX header). Less battle-tested than
+gnark. Sparse documentation.
+
+**Verdict**: Viable alternative if license is confirmed acceptable. Rejected for this project in
+favor of gnark + circom2gnark due to license uncertainty.
+
+---
+
+### 4. REJECTED Libraries
+
+| Library | Reason |
+|---|---|
+| `iden3/go-circom-prover-verifier` v0.0.1 (2020) | Abandoned; requires go-ethereum v1.9.13 |
+| `arnaucube/go-bellman-verifier` | GPL-3.0; 7 commits; research-grade only |
+| `gnark-crypto` alone | Too low-level; would require hand-rolling Groth16 3-pairing check |
+
+---
+
+## Decision
+
+**Use `consensys/gnark` v0.14.0 + `vocdoni/circom2gnark`.**
+
+Integration test requirement: round-trip a known circom proof through circom2gnark → gnark Verify
+before any production deploy, to confirm BN254 field encoding compatibility.
+
+## Sources
+
+- [gnark GitHub](https://github.com/Consensys/gnark)
+- [gnark Releases](https://github.com/Consensys/gnark/releases)
+- [Least Authority gnark audit (PDF)](https://leastauthority.com/wp-content/uploads/2024/12/Least-Authority-Consensys-Linea-ProverCryptography-Phase-1-Initial-Audit-Report.pdf)
+- [vocdoni/circom2gnark](https://github.com/vocdoni/circom2gnark)
+- [iden3/go-rapidsnark](https://github.com/iden3/go-rapidsnark)
+- [gnark snarkjs JSON compatibility issue #1582](https://github.com/Consensys/gnark/issues/1582)

--- a/openspec/changes/implement-ticket-system-mvp/specs/user-auth/spec.md
+++ b/openspec/changes/implement-ticket-system-mvp/specs/user-auth/spec.md
@@ -1,22 +1,30 @@
 ## ADDED Requirements
 
-### Requirement: Passkey Registration
-The system SHALL allowing users to register a FIDO2 Passkey (WebAuthn) to create and access their account.
+### Requirement: Passkey Authentication via Zitadel
+The system SHALL use Zitadel (existing IdP) as the WebAuthn Relying Party for Passkey registration and authentication. For MVP, Zitadel's hosted login UI handles the WebAuthn ceremony.
 
-#### Scenario: Registration Request
-- **WHEN** a user initiates registration
-- **THEN** the backend SHALL return `PublicKeyCredentialCreationOptions`
-- **AND** the frontend SHALL prompt the user to create a passkey
+#### Scenario: Passkey Registration
+- **WHEN** a user initiates Passkey registration
+- **THEN** Zitadel's hosted login UI SHALL prompt the user to create a Passkey
+- **AND** Zitadel SHALL store the credential internally
 
-#### Scenario: Registration Verification
-- **WHEN** the user submits the signed credential
-- **THEN** the backend SHALL verify the signature against the challenge
-- **AND** create a User record if valid
+#### Scenario: Passkey Authentication
+- **WHEN** a user authenticates via Passkey
+- **THEN** Zitadel's hosted login UI SHALL handle the WebAuthn assertion
+- **AND** issue a JWT via the existing OIDC flow (`oidc-client-ts`)
 
 ### Requirement: Smart Account Mapping
-The system SHALL strictly map a Passkey credential to a Smart Account (Wallet) address.
+The system SHALL deterministically map a user's internal ID to a Smart Account (Safe) address.
 
-#### Scenario: Account Derivation / Creation
-- **WHEN** a user registers successfully
-- **THEN** a predicted Safe (ERC-4337) address SHALL be associated with the user
-- **AND** this address SHALL be used for all future blockchain interactions
+#### Scenario: Safe Address Derivation
+- **WHEN** a user is associated with a ticket operation
+- **THEN** a predicted Safe (ERC-4337) address SHALL be derived from `users.id` (UUIDv7) using `CREATE2(salt = keccak256(users.id))`
+- **AND** this derivation SHALL be auth-provider-agnostic (independent of Zitadel or credential material)
+
+### Requirement: Auth-Agnostic Identification
+All ticket system data SHALL reference `users.id` (internal UUIDv7) as the user identifier, never `users.external_id` (Zitadel sub claim) or credential-specific values.
+
+#### Scenario: Foreign Key References
+- **WHEN** a new ticket, nullifier, or Merkle tree entry is created
+- **THEN** the user reference SHALL be `users.id`
+- **AND** the system SHALL remain functional if the authentication provider changes

--- a/openspec/changes/implement-ticket-system-mvp/tasks.md
+++ b/openspec/changes/implement-ticket-system-mvp/tasks.md
@@ -38,8 +38,8 @@
 - [x] 4.3 Implement transfer lock: `transferFrom` and `safeTransferFrom` revert with "SBT: Ticket transfer is prohibited"
 - [x] 4.4 Emit `Locked(tokenId)` event on mint (ERC-5192 compliance)
 - [x] 4.5 Write Foundry tests: transfer revert, locked event emission, authorized mint, unauthorized mint revert
-- [ ] 4.6 Deploy `TicketSBT` to Base Sepolia; record contract address in Secret Manager
-- [ ] 4.7 Grant `MINTER_ROLE` to backend service account EOA address
+- [x] 4.6 Deploy `TicketSBT` to Base Sepolia; record contract address in Secret Manager
+- [x] 4.7 Grant `MINTER_ROLE` to backend service account EOA address
 
 ## 5. Protobuf / BSR
 

--- a/openspec/changes/implement-ticket-system-mvp/tasks.md
+++ b/openspec/changes/implement-ticket-system-mvp/tasks.md
@@ -2,9 +2,9 @@
 
 > GKE Autopilot (`cluster-osaka`) and Cloud SQL PostgreSQL 18 (`postgres-osaka`) already exist. No new compute/database provisioning needed.
 
-- [ ] 1.1 Add Secret Manager secret for TicketSBT contract deployer private key (`cloud-provisioning`)
-- [ ] 1.2 Add Secret Manager secret for Base Sepolia RPC endpoint URL (`cloud-provisioning`)
-- [ ] 1.3 Add Secret Manager secret for Bundler (Pimlico/Alchemy) API key (`cloud-provisioning`)
+- [x] 1.1 Add Secret Manager secret for TicketSBT contract deployer private key (`cloud-provisioning`)
+- [x] 1.2 Add Secret Manager secret for Base Sepolia RPC endpoint URL (`cloud-provisioning`)
+- [x] 1.3 Add Secret Manager secret for Bundler (Pimlico/Alchemy) API key (`cloud-provisioning`)
 - [ ] 1.4 Configure Zitadel: enable Passkey authentication for the existing project
 - [ ] 1.5 Run `pulumi preview` and get approval; apply Secret Manager changes to dev
 
@@ -12,11 +12,11 @@
 
 > Existing tables: `users` (with `external_id`), `events` (with `venue_id`, `title`, `local_event_date`), `concerts`, `artists`, `venues`. Migrations must be backward-compatible.
 
-- [ ] 2.1 Write ALTER migration: `users` ADD `safe_address TEXT` (predicted Safe address derived from `users.id`)
-- [ ] 2.2 Write ALTER migration: `events` ADD `merkle_root BYTEA` (nullable; NULL for non-ticket events)
-- [ ] 2.3 Write CREATE migration: `tickets` table (id UUID PK, event_id FK → events, user_id FK → users, token_id BIGINT, tx_hash TEXT, minted_at TIMESTAMPTZ)
-- [ ] 2.4 Write CREATE migration: `merkle_tree` table (event_id FK → events, depth INT, index INT, hash BYTEA; composite PK on event_id + depth + index)
-- [ ] 2.5 Write CREATE migration: `nullifiers` table (event_id FK → events, nullifier_hash BYTEA, used_at TIMESTAMPTZ; UNIQUE index on event_id + nullifier_hash)
+- [x] 2.1 Write ALTER migration: `users` ADD `safe_address TEXT` (predicted Safe address derived from `users.id`)
+- [x] 2.2 Write ALTER migration: `events` ADD `merkle_root BYTEA` (nullable; NULL for non-ticket events)
+- [x] 2.3 Write CREATE migration: `tickets` table (id UUID PK, event_id FK → events, user_id FK → users, token_id BIGINT, tx_hash TEXT, minted_at TIMESTAMPTZ)
+- [x] 2.4 Write CREATE migration: `merkle_tree` table (event_id FK → events, depth INT, index INT, hash BYTEA; composite PK on event_id + depth + index)
+- [x] 2.5 Write CREATE migration: `nullifiers` table (event_id FK → events, nullifier_hash BYTEA, used_at TIMESTAMPTZ; UNIQUE index on event_id + nullifier_hash)
 - [ ] 2.6 Verify all migrations run cleanly on local PostgreSQL; write rollback (DOWN) migrations
 - [ ] 2.7 Verify ALTER migrations are backward-compatible (existing queries on `users`/`events` unaffected)
 
@@ -45,10 +45,10 @@
 
 > Proto files are managed in BSR (`liverty-music/schema`). Generated Go/TS code is imported via dependency, not generated locally. No proto files live in the backend repo.
 
-- [ ] 5.1 Define `ticket/v1/ticket.proto` in BSR: `TicketService` with `MintTicket`, `GetTicket`, `ListTicketsForUser` RPCs
-- [ ] 5.2 Define `entry/v1/entry.proto` in BSR: `EntryService` with `VerifyEntry` RPC (accepts proof JSON + event ID) and `GetMerklePath` RPC
-- [ ] 5.3 Add Protovalidate constraints to all request messages
-- [ ] 5.4 Run `buf lint` and `buf breaking` against baseline; push to BSR
+- [x] 5.1 Define `ticket/v1/ticket.proto` in BSR: `TicketService` with `MintTicket`, `GetTicket`, `ListTicketsForUser` RPCs
+- [x] 5.2 Define `entry/v1/entry.proto` in BSR: `EntryService` with `VerifyEntry` RPC (accepts proof JSON + event ID) and `GetMerklePath` RPC
+- [x] 5.3 Add Protovalidate constraints to all request messages
+- [x] 5.4 Run `buf lint` and `buf breaking` against baseline; push to BSR
 - [ ] 5.5 Bump generated Go module version in backend `go.mod` (`buf.build/gen/go/liverty-music/schema`)
 - [ ] 5.6 Bump generated TS module version in frontend `package.json` (`@buf/liverty-music_schema`)
 

--- a/openspec/changes/implement-ticket-system-mvp/tasks.md
+++ b/openspec/changes/implement-ticket-system-mvp/tasks.md
@@ -1,24 +1,28 @@
-## 1. Infrastructure Provisioning
+## 1. Infrastructure — Secret Manager
 
-- [ ] 1.1 Add GKE Autopilot cluster resource to `cloud-provisioning` (Osaka region)
-- [ ] 1.2 Add Cloud SQL (PostgreSQL 16) instance resource to `cloud-provisioning`
-- [ ] 1.3 Add Secret Manager secrets for contract private key and JWT signing key
-- [ ] 1.4 Configure GKE Workload Identity binding for the backend service account
-- [ ] 1.5 Run `pulumi preview` and get approval; apply infrastructure stack to dev
+> GKE Autopilot (`cluster-osaka`) and Cloud SQL PostgreSQL 18 (`postgres-osaka`) already exist. No new compute/database provisioning needed.
 
-## 2. Database Schema
+- [ ] 1.1 Add Secret Manager secret for TicketSBT contract deployer private key (`cloud-provisioning`)
+- [ ] 1.2 Add Secret Manager secret for Base Sepolia RPC endpoint URL (`cloud-provisioning`)
+- [ ] 1.3 Add Secret Manager secret for Bundler (Pimlico/Alchemy) API key (`cloud-provisioning`)
+- [ ] 1.4 Configure Zitadel: enable Passkey authentication for the existing project
+- [ ] 1.5 Run `pulumi preview` and get approval; apply Secret Manager changes to dev
 
-- [ ] 2.1 Write initial migration: `users` table (passkey credential ID, public key CBOR, safe address, created_at)
-- [ ] 2.2 Write migration: `events` table (id, name, merkle_root, starts_at)
-- [ ] 2.3 Write migration: `tickets` table (id, event_id, owner_safe_address, token_id, minted_at)
-- [ ] 2.4 Write migration: `merkle_tree` table (event_id, depth, index, hash, leaf_data)
-- [ ] 2.5 Write migration: `nullifiers` table (event_id, nullifier_hash, used_at) with unique index
-- [ ] 2.6 Write migration: `webauthn_sessions` table (challenge, expires_at) for transient ceremony state
-- [ ] 2.7 Verify all migrations run cleanly on local PostgreSQL; write rollback migrations
+## 2. Database Schema (ALTER + CREATE migrations)
+
+> Existing tables: `users` (with `external_id`), `events` (with `venue_id`, `title`, `local_event_date`), `concerts`, `artists`, `venues`. Migrations must be backward-compatible.
+
+- [ ] 2.1 Write ALTER migration: `users` ADD `safe_address TEXT` (predicted Safe address derived from `users.id`)
+- [ ] 2.2 Write ALTER migration: `events` ADD `merkle_root BYTEA` (nullable; NULL for non-ticket events)
+- [ ] 2.3 Write CREATE migration: `tickets` table (id UUID PK, event_id FK → events, user_id FK → users, token_id BIGINT, tx_hash TEXT, minted_at TIMESTAMPTZ)
+- [ ] 2.4 Write CREATE migration: `merkle_tree` table (event_id FK → events, depth INT, index INT, hash BYTEA; composite PK on event_id + depth + index)
+- [ ] 2.5 Write CREATE migration: `nullifiers` table (event_id FK → events, nullifier_hash BYTEA, used_at TIMESTAMPTZ; UNIQUE index on event_id + nullifier_hash)
+- [ ] 2.6 Verify all migrations run cleanly on local PostgreSQL; write rollback (DOWN) migrations
+- [ ] 2.7 Verify ALTER migrations are backward-compatible (existing queries on `users`/`events` unaffected)
 
 ## 3. ZK Circuit
 
-- [ ] 3.1 Author `TicketCheck` circom circuit using Poseidon hash (not MiMC); depth ≤ 20
+- [ ] 3.1 Author `TicketCheck` circom circuit using Poseidon hash (not MiMC); depth <= 20
 - [ ] 3.2 Define circuit inputs: private (`trapdoor`, `nullifierSecret`, `pathElements[]`, `pathIndices[]`); public (`merkleRoot`, `nullifierHash`)
 - [ ] 3.3 Perform Phase 1 trusted setup using Hermez Powers of Tau ceremony (ptau file)
 - [ ] 3.4 Run Phase 2 circuit-specific setup: generate `.zkey` file
@@ -34,84 +38,95 @@
 - [ ] 4.3 Implement transfer lock: `transferFrom` and `safeTransferFrom` revert with "SBT: Ticket transfer is prohibited"
 - [ ] 4.4 Emit `Locked(tokenId)` event on mint (ERC-5192 compliance)
 - [ ] 4.5 Write Foundry tests: transfer revert, locked event emission, authorized mint, unauthorized mint revert
-- [ ] 4.6 Deploy `TicketSBT` to Base Sepolia; record contract address in backend Secret Manager config
+- [ ] 4.6 Deploy `TicketSBT` to Base Sepolia; record contract address in Secret Manager
 - [ ] 4.7 Grant `MINTER_ROLE` to backend service account EOA address
 
-## 5. Protobuf / Connect RPC API
+## 5. Protobuf / BSR
 
-- [ ] 5.1 Define `ticket/v1/ticket.proto`: `TicketService` with `MintTicket`, `GetTicket`, `ListTicketsForUser` RPCs
-- [ ] 5.2 Define `auth/v1/auth.proto`: `AuthService` with `BeginRegistration`, `FinishRegistration`, `BeginAuthentication`, `FinishAuthentication` RPCs
-- [ ] 5.3 Define `entry/v1/entry.proto`: `EntryService` with `VerifyEntry` RPC (accepts proof JSON + event ID)
-- [ ] 5.4 Add Protovalidate constraints to all request messages
-- [ ] 5.5 Run `buf lint` and `buf breaking` against baseline; push to BSR
+> Proto files are managed in BSR (`liverty-music/schema`). Generated Go/TS code is imported via dependency, not generated locally. No proto files live in the backend repo.
 
-## 6. Go Backend — User Auth (WebAuthn)
+- [ ] 5.1 Define `ticket/v1/ticket.proto` in BSR: `TicketService` with `MintTicket`, `GetTicket`, `ListTicketsForUser` RPCs
+- [ ] 5.2 Define `entry/v1/entry.proto` in BSR: `EntryService` with `VerifyEntry` RPC (accepts proof JSON + event ID) and `GetMerklePath` RPC
+- [ ] 5.3 Add Protovalidate constraints to all request messages
+- [ ] 5.4 Run `buf lint` and `buf breaking` against baseline; push to BSR
+- [ ] 5.5 Bump generated Go module version in backend `go.mod` (`buf.build/gen/go/liverty-music/schema`)
+- [ ] 5.6 Bump generated TS module version in frontend `package.json` (`@buf/liverty-music_schema`)
 
-- [ ] 6.1 Add `go-webauthn/webauthn` v0.15.0 dependency; configure `RelyingParty` with origin and RPID
-- [ ] 6.2 Implement `BeginRegistration` handler: generate challenge, persist `SessionData` to `webauthn_sessions`
-- [ ] 6.3 Implement `FinishRegistration` handler: verify credential, insert `users` row, compute Safe address
-- [ ] 6.4 Implement Safe address prediction using `SafeProxyFactory` CREATE2 formula (go-ethereum/crypto)
-- [ ] 6.5 Implement `BeginAuthentication` handler: look up credential by username/user handle, generate challenge
-- [ ] 6.6 Implement `FinishAuthentication` handler: verify assertion, return signed JWT
-- [ ] 6.7 Write unit tests for challenge round-trip and Safe address determinism
+## 6. Go Backend — Zitadel Passkey Configuration
 
-## 7. Go Backend — Ticket Minting (ERC-4337 + ERC-5192)
+> Authentication uses existing Zitadel OIDC flow. No self-hosted WebAuthn RP for MVP. Zitadel's hosted login UI handles Passkey registration/authentication.
+
+- [ ] 6.1 Configure Zitadel Passkey settings via v2 API: enable Passkey authenticator for the application
+- [ ] 6.2 Implement Safe address prediction: `CREATE2(salt = keccak256(users.id))` using `SafeProxyFactory` formula (`go-ethereum/crypto`)
+- [ ] 6.3 Add Safe address computation on user creation (or lazy computation on first ticket mint)
+- [ ] 6.4 Ensure JWT validation (`jwx`) has configurable `accepted_issuers` list (preparation for Option C migration)
+- [ ] 6.5 Write unit tests for Safe address determinism (same `users.id` always produces same address)
+
+## 7. Go Backend — Ticket Minting (ERC-5192)
 
 - [ ] 7.1 Generate Go bindings for `TicketSBT` ABI using `abigen`
-- [ ] 7.2 Generate Go bindings for `SafeProxyFactory` and `Safe4337Module` ABIs using `abigen`
-- [ ] 7.3 Implement `MintTicket` handler: sign and send mint transaction from backend service EOA via `go-ethereum/ethclient`
-- [ ] 7.4 Make mint idempotent: check `tickets` table and on-chain `ownerOf` before submitting transaction
-- [ ] 7.5 Add retry logic with exponential backoff for Base Sepolia RPC calls
-- [ ] 7.6 Store minted token ID and tx hash in `tickets` table on success
+- [ ] 7.2 Implement `MintTicket` handler: sign and send mint transaction from backend service EOA via `go-ethereum/ethclient`
+- [ ] 7.3 Make mint idempotent: check `tickets` table and on-chain `ownerOf` before submitting transaction
+- [ ] 7.4 Add retry logic with exponential backoff for Base Sepolia RPC calls
+- [ ] 7.5 Store minted token ID and tx hash in `tickets` table on success
+- [ ] 7.6 Implement `GetTicket` and `ListTicketsForUser` handlers (query `tickets` table joined with `events`)
 
 ## 8. Go Backend — ZKP Verification
 
 - [ ] 8.1 Add `consensys/gnark` v0.14.0 and `vocdoni/circom2gnark` dependencies
 - [ ] 8.2 Load `verification_key.json` at server startup; convert to gnark types via circom2gnark; cache in memory
 - [ ] 8.3 Implement `VerifyEntry` handler: parse proof JSON from request, convert via circom2gnark, call `groth16.Verify`
-- [ ] 8.4 On successful verification: atomically insert `nullifiers` row (unique constraint = double-entry guard)
-- [ ] 8.5 Return structured error on duplicate nullifier (event-specific "already checked in" response)
-- [ ] 8.6 Write integration test: round-trip a known circom-generated proof through circom2gnark → gnark Verify
-- [ ] 8.7 Write integration test: duplicate nullifier returns correct error
+- [ ] 8.4 Implement `GetMerklePath` handler: return Merkle path for a given user + event from `merkle_tree` table
+- [ ] 8.5 On successful verification: atomically insert `nullifiers` row (unique constraint = double-entry guard)
+- [ ] 8.6 Return structured error on duplicate nullifier (event-specific "already checked in" response)
+- [ ] 8.7 Write integration test: round-trip a known circom-generated proof through circom2gnark -> gnark Verify
+- [ ] 8.8 Write integration test: duplicate nullifier returns correct error
 
-## 9. Frontend — Aurelia 2 PWA Foundation
+## 9. Go Backend — Merkle Tree Management
 
-- [ ] 9.1 Add `manifest.json` with correct icons (192px, 512px), `display: standalone`, `start_url`
-- [ ] 9.2 Configure `vite-plugin-pwa` v1.2.0 in `injectManifest` mode; set `maximumFileSizeToCacheInBytes: 60MB`
-- [ ] 9.3 Author `sw.ts`: precache app shell via `self.__WB_MANIFEST`; add `registerRoute` for `.wasm` and `.zkey` (CacheFirst, 30-day expiry, cache name `zk-circuits-v1`)
-- [ ] 9.4 Verify Service Worker registers and caches circuit files on first load (Chrome DevTools → Application)
-- [ ] 9.5 Verify A2HS install prompt appears on Android Chrome and iOS Safari (Add to Home Screen)
-- [ ] 9.6 Verify offline load after first visit (disconnect network, reload)
+- [ ] 9.1 Implement Merkle tree builder: given a list of user identity commitments for an event, compute the full tree and store nodes in `merkle_tree` table
+- [ ] 9.2 Implement `merkle_root` update on `events` table when tree is (re)built
+- [ ] 9.3 Implement identity commitment computation: `Poseidon(users.id)` or agreed leaf format (depends on Open Question resolution)
+- [ ] 9.4 Write unit tests for Merkle tree construction and path extraction
 
-## 10. Frontend — Passkey Auth UI
+## 10. Frontend — Aurelia 2 PWA Foundation
 
-- [ ] 10.1 Add `@simplewebauthn/browser` v13.2.2 dependency
-- [ ] 10.2 Implement registration flow: call `BeginRegistration` RPC → `startRegistration()` → `FinishRegistration` RPC
-- [ ] 10.3 Implement authentication flow: call `BeginAuthentication` RPC → `startAuthentication({ useBrowserAutofill: true })` → `FinishAuthentication` RPC
-- [ ] 10.4 Store returned JWT in secure storage (HttpOnly cookie preferred; fallback sessionStorage)
-- [ ] 10.5 Show authenticator type hint (`preferredAuthenticatorType: 'localDevice'`) on registration
-- [ ] 10.6 Handle errors: credential already exists, user cancelled, timeout
+- [ ] 10.1 Add `manifest.json` with correct icons (192px, 512px), `display: standalone`, `start_url`
+- [ ] 10.2 Configure `vite-plugin-pwa` v1.2.0 in `injectManifest` mode; set `maximumFileSizeToCacheInBytes: 60MB`
+- [ ] 10.3 Author `sw.ts`: precache app shell via `self.__WB_MANIFEST`; add `registerRoute` for `.wasm` and `.zkey` (CacheFirst, 30-day expiry, cache name `zk-circuits-v1`)
+- [ ] 10.4 Verify Service Worker registers and caches circuit files on first load (Chrome DevTools -> Application)
+- [ ] 10.5 Verify A2HS install prompt appears on Android Chrome and iOS Safari (Add to Home Screen)
+- [ ] 10.6 Verify offline load after first visit (disconnect network, reload)
 
-## 11. Frontend — ZKP Entry Code Generation
+## 11. Frontend — Auth (Zitadel Hosted Login UI)
 
-- [ ] 11.1 Add `snarkjs` dependency; confirm it loads correctly as ES module in Aurelia 2 / Vite
-- [ ] 11.2 Move proof generation into a Web Worker (`proof.worker.ts`) to avoid blocking main thread
-- [ ] 11.3 Implement `generateProof(trapdoor, nullifierSecret, merkleRoot, pathElements, pathIndices)` in worker
-- [ ] 11.4 Fetch Merkle path from backend `VerifyEntry` preparation endpoint (or dedicated `GetMerklePath` RPC) before generating proof
-- [ ] 11.5 Display proof result as QR code (encode proof JSON + event ID as base64 payload)
-- [ ] 11.6 Show progress indicator during proof generation (expected 3–30s depending on device)
+> MVP uses Zitadel's hosted login UI with Passkey support. No `@simplewebauthn/browser` needed. Existing `oidc-client-ts` flow is unchanged.
 
-## 12. Frontend — Ticket Display
+- [ ] 11.1 Verify existing `oidc-client-ts` OIDC flow supports Passkey login via Zitadel hosted UI (no code change expected)
+- [ ] 11.2 Test Passkey registration through Zitadel hosted UI on desktop and mobile browsers
+- [ ] 11.3 Test Passkey authentication through Zitadel hosted UI on desktop and mobile browsers
+- [ ] 11.4 Document supported browsers and minimum OS versions for Passkey (iOS 16.4+, Android 9+)
 
-- [ ] 12.1 Implement `ListTicketsForUser` call on authenticated home screen
-- [ ] 12.2 Display ticket details: event name, date, token ID, SBT status
-- [ ] 12.3 Show "Generate Entry Code" button for each ticket; navigate to proof generation flow
+## 12. Frontend — ZKP Entry Code Generation
 
-## 13. CI / CD
+- [ ] 12.1 Add `snarkjs` dependency; confirm it loads correctly as ES module in Aurelia 2 / Vite
+- [ ] 12.2 Move proof generation into a Web Worker (`proof.worker.ts`) to avoid blocking main thread
+- [ ] 12.3 Implement `generateProof(trapdoor, nullifierSecret, merkleRoot, pathElements, pathIndices)` in worker
+- [ ] 12.4 Fetch Merkle path from backend `GetMerklePath` RPC before generating proof
+- [ ] 12.5 Display proof result as QR code (encode proof JSON + event ID as base64 payload)
+- [ ] 12.6 Show progress indicator during proof generation (expected 3-30s depending on device)
 
-- [ ] 13.1 Add GitHub Actions workflow: `buf lint` + `buf breaking` on proto changes
-- [ ] 13.2 Add GitHub Actions workflow: Go backend `go test ./...` + `golangci-lint`
-- [ ] 13.3 Add GitHub Actions workflow: frontend `npm run build` + PWA manifest validation
-- [ ] 13.4 Add GitHub Actions workflow: deploy backend to GKE dev on merge to main
-- [ ] 13.5 Add GitHub Actions workflow: deploy frontend to CDN on merge to main
-- [ ] 13.6 Add integration test job: spin up local Bundler (Rundler) + Anvil fork of Base Sepolia; run UserOperation ABI encoding tests
+## 13. Frontend — Ticket Display
+
+- [ ] 13.1 Implement `ListTicketsForUser` call on authenticated home screen
+- [ ] 13.2 Display ticket details: event name, date, token ID, SBT status
+- [ ] 13.3 Show "Generate Entry Code" button for each ticket; navigate to proof generation flow
+
+## 14. CI / CD
+
+> Backend and frontend already have CD pipelines. Add CI checks for new components.
+
+- [ ] 14.1 Add GitHub Actions workflow: `buf lint` + `buf breaking` on proto changes (BSR repo)
+- [ ] 14.2 Verify existing Go backend CI (`go test ./...` + `golangci-lint`) covers new handlers
+- [ ] 14.3 Verify existing frontend CI (`npm run build`) covers PWA manifest validation
+- [ ] 14.4 Add integration test job: spin up local Bundler (Rundler) + Anvil fork of Base Sepolia; run UserOperation ABI encoding tests

--- a/openspec/changes/implement-ticket-system-mvp/tasks.md
+++ b/openspec/changes/implement-ticket-system-mvp/tasks.md
@@ -33,11 +33,11 @@
 
 ## 4. Smart Contract
 
-- [ ] 4.1 Author `TicketSBT` contract implementing ERC-721 + ERC-5192 (non-transferable)
-- [ ] 4.2 Implement `MINTER_ROLE` access control; `mint(address recipient, uint256 tokenId)` callable only by backend service key
-- [ ] 4.3 Implement transfer lock: `transferFrom` and `safeTransferFrom` revert with "SBT: Ticket transfer is prohibited"
-- [ ] 4.4 Emit `Locked(tokenId)` event on mint (ERC-5192 compliance)
-- [ ] 4.5 Write Foundry tests: transfer revert, locked event emission, authorized mint, unauthorized mint revert
+- [x] 4.1 Author `TicketSBT` contract implementing ERC-721 + ERC-5192 (non-transferable)
+- [x] 4.2 Implement `MINTER_ROLE` access control; `mint(address recipient, uint256 tokenId)` callable only by backend service key
+- [x] 4.3 Implement transfer lock: `transferFrom` and `safeTransferFrom` revert with "SBT: Ticket transfer is prohibited"
+- [x] 4.4 Emit `Locked(tokenId)` event on mint (ERC-5192 compliance)
+- [x] 4.5 Write Foundry tests: transfer revert, locked event emission, authorized mint, unauthorized mint revert
 - [ ] 4.6 Deploy `TicketSBT` to Base Sepolia; record contract address in Secret Manager
 - [ ] 4.7 Grant `MINTER_ROLE` to backend service account EOA address
 
@@ -49,18 +49,18 @@
 - [x] 5.2 Define `entry/v1/entry.proto` in BSR: `EntryService` with `VerifyEntry` RPC (accepts proof JSON + event ID) and `GetMerklePath` RPC
 - [x] 5.3 Add Protovalidate constraints to all request messages
 - [x] 5.4 Run `buf lint` and `buf breaking` against baseline; push to BSR
-- [ ] 5.5 Bump generated Go module version in backend `go.mod` (`buf.build/gen/go/liverty-music/schema`)
-- [ ] 5.6 Bump generated TS module version in frontend `package.json` (`@buf/liverty-music_schema`)
+- [x] 5.5 Bump generated Go module version in backend `go.mod` (`buf.build/gen/go/liverty-music/schema`)
+- [x] 5.6 Bump generated TS module version in frontend `package.json` (`@buf/liverty-music_schema`)
 
 ## 6. Go Backend — Zitadel Passkey Configuration
 
 > Authentication uses existing Zitadel OIDC flow. No self-hosted WebAuthn RP for MVP. Zitadel's hosted login UI handles Passkey registration/authentication.
 
 - [ ] 6.1 Configure Zitadel Passkey settings via v2 API: enable Passkey authenticator for the application
-- [ ] 6.2 Implement Safe address prediction: `CREATE2(salt = keccak256(users.id))` using `SafeProxyFactory` formula (`go-ethereum/crypto`)
+- [x] 6.2 Implement Safe address prediction: `CREATE2(salt = keccak256(users.id))` using `SafeProxyFactory` formula (`go-ethereum/crypto`)
 - [ ] 6.3 Add Safe address computation on user creation (or lazy computation on first ticket mint)
-- [ ] 6.4 Ensure JWT validation (`jwx`) has configurable `accepted_issuers` list (preparation for Option C migration)
-- [ ] 6.5 Write unit tests for Safe address determinism (same `users.id` always produces same address)
+- [x] 6.4 Ensure JWT validation (`jwx`) has configurable `accepted_issuers` list (preparation for Option C migration)
+- [x] 6.5 Write unit tests for Safe address determinism (same `users.id` always produces same address)
 
 ## 7. Go Backend — Ticket Minting (ERC-5192)
 

--- a/openspec/changes/implement-ticket-system-mvp/tasks.md
+++ b/openspec/changes/implement-ticket-system-mvp/tasks.md
@@ -1,0 +1,117 @@
+## 1. Infrastructure Provisioning
+
+- [ ] 1.1 Add GKE Autopilot cluster resource to `cloud-provisioning` (Osaka region)
+- [ ] 1.2 Add Cloud SQL (PostgreSQL 16) instance resource to `cloud-provisioning`
+- [ ] 1.3 Add Secret Manager secrets for contract private key and JWT signing key
+- [ ] 1.4 Configure GKE Workload Identity binding for the backend service account
+- [ ] 1.5 Run `pulumi preview` and get approval; apply infrastructure stack to dev
+
+## 2. Database Schema
+
+- [ ] 2.1 Write initial migration: `users` table (passkey credential ID, public key CBOR, safe address, created_at)
+- [ ] 2.2 Write migration: `events` table (id, name, merkle_root, starts_at)
+- [ ] 2.3 Write migration: `tickets` table (id, event_id, owner_safe_address, token_id, minted_at)
+- [ ] 2.4 Write migration: `merkle_tree` table (event_id, depth, index, hash, leaf_data)
+- [ ] 2.5 Write migration: `nullifiers` table (event_id, nullifier_hash, used_at) with unique index
+- [ ] 2.6 Write migration: `webauthn_sessions` table (challenge, expires_at) for transient ceremony state
+- [ ] 2.7 Verify all migrations run cleanly on local PostgreSQL; write rollback migrations
+
+## 3. ZK Circuit
+
+- [ ] 3.1 Author `TicketCheck` circom circuit using Poseidon hash (not MiMC); depth ≤ 20
+- [ ] 3.2 Define circuit inputs: private (`trapdoor`, `nullifierSecret`, `pathElements[]`, `pathIndices[]`); public (`merkleRoot`, `nullifierHash`)
+- [ ] 3.3 Perform Phase 1 trusted setup using Hermez Powers of Tau ceremony (ptau file)
+- [ ] 3.4 Run Phase 2 circuit-specific setup: generate `.zkey` file
+- [ ] 3.5 Export verification key JSON (`verification_key.json`) for backend
+- [ ] 3.6 Build circuit WASM (`ticketcheck.wasm`) for browser proof generation
+- [ ] 3.7 Publish `.wasm` and `.zkey` to CDN with versioned paths (e.g., `/circuits/ticketcheck-v1/`)
+- [ ] 3.8 Benchmark proof generation in Chrome (desktop) and low-end Android; confirm < 30s mobile
+
+## 4. Smart Contract
+
+- [ ] 4.1 Author `TicketSBT` contract implementing ERC-721 + ERC-5192 (non-transferable)
+- [ ] 4.2 Implement `MINTER_ROLE` access control; `mint(address recipient, uint256 tokenId)` callable only by backend service key
+- [ ] 4.3 Implement transfer lock: `transferFrom` and `safeTransferFrom` revert with "SBT: Ticket transfer is prohibited"
+- [ ] 4.4 Emit `Locked(tokenId)` event on mint (ERC-5192 compliance)
+- [ ] 4.5 Write Foundry tests: transfer revert, locked event emission, authorized mint, unauthorized mint revert
+- [ ] 4.6 Deploy `TicketSBT` to Base Sepolia; record contract address in backend Secret Manager config
+- [ ] 4.7 Grant `MINTER_ROLE` to backend service account EOA address
+
+## 5. Protobuf / Connect RPC API
+
+- [ ] 5.1 Define `ticket/v1/ticket.proto`: `TicketService` with `MintTicket`, `GetTicket`, `ListTicketsForUser` RPCs
+- [ ] 5.2 Define `auth/v1/auth.proto`: `AuthService` with `BeginRegistration`, `FinishRegistration`, `BeginAuthentication`, `FinishAuthentication` RPCs
+- [ ] 5.3 Define `entry/v1/entry.proto`: `EntryService` with `VerifyEntry` RPC (accepts proof JSON + event ID)
+- [ ] 5.4 Add Protovalidate constraints to all request messages
+- [ ] 5.5 Run `buf lint` and `buf breaking` against baseline; push to BSR
+
+## 6. Go Backend — User Auth (WebAuthn)
+
+- [ ] 6.1 Add `go-webauthn/webauthn` v0.15.0 dependency; configure `RelyingParty` with origin and RPID
+- [ ] 6.2 Implement `BeginRegistration` handler: generate challenge, persist `SessionData` to `webauthn_sessions`
+- [ ] 6.3 Implement `FinishRegistration` handler: verify credential, insert `users` row, compute Safe address
+- [ ] 6.4 Implement Safe address prediction using `SafeProxyFactory` CREATE2 formula (go-ethereum/crypto)
+- [ ] 6.5 Implement `BeginAuthentication` handler: look up credential by username/user handle, generate challenge
+- [ ] 6.6 Implement `FinishAuthentication` handler: verify assertion, return signed JWT
+- [ ] 6.7 Write unit tests for challenge round-trip and Safe address determinism
+
+## 7. Go Backend — Ticket Minting (ERC-4337 + ERC-5192)
+
+- [ ] 7.1 Generate Go bindings for `TicketSBT` ABI using `abigen`
+- [ ] 7.2 Generate Go bindings for `SafeProxyFactory` and `Safe4337Module` ABIs using `abigen`
+- [ ] 7.3 Implement `MintTicket` handler: sign and send mint transaction from backend service EOA via `go-ethereum/ethclient`
+- [ ] 7.4 Make mint idempotent: check `tickets` table and on-chain `ownerOf` before submitting transaction
+- [ ] 7.5 Add retry logic with exponential backoff for Base Sepolia RPC calls
+- [ ] 7.6 Store minted token ID and tx hash in `tickets` table on success
+
+## 8. Go Backend — ZKP Verification
+
+- [ ] 8.1 Add `consensys/gnark` v0.14.0 and `vocdoni/circom2gnark` dependencies
+- [ ] 8.2 Load `verification_key.json` at server startup; convert to gnark types via circom2gnark; cache in memory
+- [ ] 8.3 Implement `VerifyEntry` handler: parse proof JSON from request, convert via circom2gnark, call `groth16.Verify`
+- [ ] 8.4 On successful verification: atomically insert `nullifiers` row (unique constraint = double-entry guard)
+- [ ] 8.5 Return structured error on duplicate nullifier (event-specific "already checked in" response)
+- [ ] 8.6 Write integration test: round-trip a known circom-generated proof through circom2gnark → gnark Verify
+- [ ] 8.7 Write integration test: duplicate nullifier returns correct error
+
+## 9. Frontend — Aurelia 2 PWA Foundation
+
+- [ ] 9.1 Add `manifest.json` with correct icons (192px, 512px), `display: standalone`, `start_url`
+- [ ] 9.2 Configure `vite-plugin-pwa` v1.2.0 in `injectManifest` mode; set `maximumFileSizeToCacheInBytes: 60MB`
+- [ ] 9.3 Author `sw.ts`: precache app shell via `self.__WB_MANIFEST`; add `registerRoute` for `.wasm` and `.zkey` (CacheFirst, 30-day expiry, cache name `zk-circuits-v1`)
+- [ ] 9.4 Verify Service Worker registers and caches circuit files on first load (Chrome DevTools → Application)
+- [ ] 9.5 Verify A2HS install prompt appears on Android Chrome and iOS Safari (Add to Home Screen)
+- [ ] 9.6 Verify offline load after first visit (disconnect network, reload)
+
+## 10. Frontend — Passkey Auth UI
+
+- [ ] 10.1 Add `@simplewebauthn/browser` v13.2.2 dependency
+- [ ] 10.2 Implement registration flow: call `BeginRegistration` RPC → `startRegistration()` → `FinishRegistration` RPC
+- [ ] 10.3 Implement authentication flow: call `BeginAuthentication` RPC → `startAuthentication({ useBrowserAutofill: true })` → `FinishAuthentication` RPC
+- [ ] 10.4 Store returned JWT in secure storage (HttpOnly cookie preferred; fallback sessionStorage)
+- [ ] 10.5 Show authenticator type hint (`preferredAuthenticatorType: 'localDevice'`) on registration
+- [ ] 10.6 Handle errors: credential already exists, user cancelled, timeout
+
+## 11. Frontend — ZKP Entry Code Generation
+
+- [ ] 11.1 Add `snarkjs` dependency; confirm it loads correctly as ES module in Aurelia 2 / Vite
+- [ ] 11.2 Move proof generation into a Web Worker (`proof.worker.ts`) to avoid blocking main thread
+- [ ] 11.3 Implement `generateProof(trapdoor, nullifierSecret, merkleRoot, pathElements, pathIndices)` in worker
+- [ ] 11.4 Fetch Merkle path from backend `VerifyEntry` preparation endpoint (or dedicated `GetMerklePath` RPC) before generating proof
+- [ ] 11.5 Display proof result as QR code (encode proof JSON + event ID as base64 payload)
+- [ ] 11.6 Show progress indicator during proof generation (expected 3–30s depending on device)
+
+## 12. Frontend — Ticket Display
+
+- [ ] 12.1 Implement `ListTicketsForUser` call on authenticated home screen
+- [ ] 12.2 Display ticket details: event name, date, token ID, SBT status
+- [ ] 12.3 Show "Generate Entry Code" button for each ticket; navigate to proof generation flow
+
+## 13. CI / CD
+
+- [ ] 13.1 Add GitHub Actions workflow: `buf lint` + `buf breaking` on proto changes
+- [ ] 13.2 Add GitHub Actions workflow: Go backend `go test ./...` + `golangci-lint`
+- [ ] 13.3 Add GitHub Actions workflow: frontend `npm run build` + PWA manifest validation
+- [ ] 13.4 Add GitHub Actions workflow: deploy backend to GKE dev on merge to main
+- [ ] 13.5 Add GitHub Actions workflow: deploy frontend to CDN on merge to main
+- [ ] 13.6 Add integration test job: spin up local Bundler (Rundler) + Anvil fork of Base Sepolia; run UserOperation ABI encoding tests

--- a/proto/liverty_music/entity/v1/event.proto
+++ b/proto/liverty_music/entity/v1/event.proto
@@ -42,7 +42,7 @@ message Event {
   // It is only set for events that use zero-knowledge proof entry verification. The root is
   // published on-chain and allows entry validators to verify membership without querying
   // a central database, preserving fan privacy.
-  optional bytes merkle_root = 7;
+  optional bytes merkle_root = 7 [(buf.validate.field).bytes.len = 32];
 
   // create_time is the timestamp at which this event record was first created on the platform.
   // This field is set automatically by the server and cannot be supplied by clients.

--- a/proto/liverty_music/entity/v1/event.proto
+++ b/proto/liverty_music/entity/v1/event.proto
@@ -1,0 +1,54 @@
+syntax = "proto3";
+
+// Package liverty_music.entity.v1 defines core business entities for the Liverty Music platform.
+package liverty_music.entity.v1;
+
+import "buf/validate/validate.proto";
+import "google/api/field_behavior.proto";
+import "google/protobuf/timestamp.proto";
+import "google/type/date.proto";
+import "liverty_music/entity/v1/ticket.proto";
+import "liverty_music/entity/v1/venue.proto";
+
+option go_package = "github.com/liverty-music/specification/gen/go/liverty_music/entity/v1;entityv1";
+
+// Event represents a scheduled music performance at a venue, such as a concert or live session.
+// Events are the central business object connecting artists, venues, and fans. When an event
+// is configured for ticketing, it holds a Merkle root that enables zero-knowledge proof
+// entry verification without revealing individual attendee identities.
+message Event {
+  // id is the unique identifier for this event within the Liverty Music platform.
+  EventId id = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // venue_id identifies the physical location where this event will take place.
+  VenueId venue_id = 2;
+
+  // title is the human-readable name of the event, such as the concert name or tour stop.
+  string title = 3 [(buf.validate.field).string.min_len = 1];
+
+  // local_event_date is the calendar date of the event in the venue's local timezone.
+  // This date is displayed to fans when browsing or purchasing tickets.
+  google.type.Date local_event_date = 4;
+
+  // start_at is the exact timestamp when the performance is scheduled to begin.
+  // This field is optional and may be omitted for events where the start time is not yet confirmed.
+  optional google.protobuf.Timestamp start_at = 5;
+
+  // open_at is the timestamp when venue doors open for fan entry.
+  // This field is optional and may be omitted when door times have not been announced.
+  optional google.protobuf.Timestamp open_at = 6;
+
+  // merkle_root is the root hash of the Merkle tree built from all ticket holders for this event.
+  // It is only set for events that use zero-knowledge proof entry verification. The root is
+  // published on-chain and allows entry validators to verify membership without querying
+  // a central database, preserving fan privacy.
+  optional bytes merkle_root = 7;
+
+  // create_time is the timestamp at which this event record was first created on the platform.
+  // This field is set automatically by the server and cannot be supplied by clients.
+  google.protobuf.Timestamp create_time = 8 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // update_time is the timestamp at which this event record was most recently modified.
+  // This field is updated automatically by the server on every write operation.
+  google.protobuf.Timestamp update_time = 9 [(google.api.field_behavior) = OUTPUT_ONLY];
+}

--- a/proto/liverty_music/entity/v1/event.proto
+++ b/proto/liverty_music/entity/v1/event.proto
@@ -21,14 +21,14 @@ message Event {
   EventId id = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 
   // venue_id identifies the physical location where this event will take place.
-  VenueId venue_id = 2;
+  VenueId venue_id = 2 [(buf.validate.field).required = true];
 
   // title is the human-readable name of the event, such as the concert name or tour stop.
-  string title = 3 [(buf.validate.field).string.min_len = 1];
+  string title = 3 [(buf.validate.field).string = {min_len: 1, max_len: 255}];
 
   // local_event_date is the calendar date of the event in the venue's local timezone.
   // This date is displayed to fans when browsing or purchasing tickets.
-  google.type.Date local_event_date = 4;
+  google.type.Date local_event_date = 4 [(buf.validate.field).required = true];
 
   // start_at is the exact timestamp when the performance is scheduled to begin.
   // This field is optional and may be omitted for events where the start time is not yet confirmed.

--- a/proto/liverty_music/entity/v1/event.proto
+++ b/proto/liverty_music/entity/v1/event.proto
@@ -24,7 +24,10 @@ message Event {
   VenueId venue_id = 2 [(buf.validate.field).required = true];
 
   // title is the human-readable name of the event, such as the concert name or tour stop.
-  string title = 3 [(buf.validate.field).string = {min_len: 1, max_len: 255}];
+  string title = 3 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 255
+  }];
 
   // local_event_date is the calendar date of the event in the venue's local timezone.
   // This date is displayed to fans when browsing or purchasing tickets.

--- a/proto/liverty_music/entity/v1/ticket.proto
+++ b/proto/liverty_music/entity/v1/ticket.proto
@@ -1,0 +1,62 @@
+syntax = "proto3";
+
+// Package liverty_music.entity.v1 defines core business entities for the Liverty Music platform.
+package liverty_music.entity.v1;
+
+import "buf/validate/validate.proto";
+import "google/api/field_behavior.proto";
+import "google/protobuf/timestamp.proto";
+import "liverty_music/entity/v1/user.proto";
+
+option go_package = "github.com/liverty-music/specification/gen/go/liverty_music/entity/v1;entityv1";
+
+// TicketId uniquely identifies a single ticket issued on the Liverty Music platform.
+// It wraps a UUID string to provide type safety and prevent accidental misuse of raw identifiers.
+message TicketId {
+  // value is the UUID that uniquely identifies this ticket across the platform.
+  string value = 1 [(buf.validate.field).string.uuid = true];
+}
+
+// EventId uniquely identifies a music event (concert, live session, etc.) on the platform.
+// Events represent scheduled performances at a venue, and this identifier links tickets
+// and entry records back to the specific event they belong to.
+message EventId {
+  // value is the UUID that uniquely identifies this event across the platform.
+  string value = 1 [(buf.validate.field).string.uuid = true];
+}
+
+// TokenId represents the on-chain token identifier for a soulbound ticket (ERC-5192).
+// Each token ID corresponds to a unique NFT minted on the blockchain, and values must
+// be positive integers because zero is not a valid token ID in ERC-5192 contracts.
+message TokenId {
+  // value is the positive integer that identifies the on-chain soulbound token.
+  uint64 value = 1 [(buf.validate.field).uint64.gt = 0];
+}
+
+// Ticket represents a soulbound digital ticket (ERC-5192) issued to a fan for a specific event.
+// Unlike traditional tickets, soulbound tickets are permanently bound to the holder's wallet
+// and cannot be transferred or resold, ensuring authentic fan experiences and preventing scalping.
+// Each ticket records its blockchain provenance through the token ID and transaction hash.
+message Ticket {
+  // id is the unique identifier for this ticket within the Liverty Music platform.
+  TicketId id = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // event_id identifies the event for which this ticket grants admission.
+  EventId event_id = 2;
+
+  // user_id identifies the fan who holds this ticket. Because tickets are soulbound,
+  // this association is permanent and cannot be changed after minting.
+  UserId user_id = 3;
+
+  // token_id is the on-chain token identifier assigned by the ERC-5192 smart contract
+  // at the time of minting. This links the platform record to the blockchain asset.
+  TokenId token_id = 4;
+
+  // tx_hash is the blockchain transaction hash recorded when this ticket was minted.
+  // It provides an immutable audit trail back to the on-chain minting event.
+  string tx_hash = 5;
+
+  // mint_time is the timestamp at which this ticket was minted on the blockchain.
+  // This field is set by the server when the minting transaction is confirmed.
+  google.protobuf.Timestamp mint_time = 6 [(google.api.field_behavior) = OUTPUT_ONLY];
+}

--- a/proto/liverty_music/entity/v1/ticket.proto
+++ b/proto/liverty_music/entity/v1/ticket.proto
@@ -42,15 +42,15 @@ message Ticket {
   TicketId id = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 
   // event_id identifies the event for which this ticket grants admission.
-  EventId event_id = 2;
+  EventId event_id = 2 [(buf.validate.field).required = true];
 
   // user_id identifies the fan who holds this ticket. Because tickets are soulbound,
   // this association is permanent and cannot be changed after minting.
-  UserId user_id = 3;
+  UserId user_id = 3 [(buf.validate.field).required = true];
 
   // token_id is the on-chain token identifier assigned by the ERC-5192 smart contract
   // at the time of minting. This links the platform record to the blockchain asset.
-  TokenId token_id = 4;
+  TokenId token_id = 4 [(buf.validate.field).required = true];
 
   // tx_hash is the blockchain transaction hash recorded when this ticket was minted.
   // It provides an immutable audit trail back to the on-chain minting event.

--- a/proto/liverty_music/entity/v1/ticket.proto
+++ b/proto/liverty_music/entity/v1/ticket.proto
@@ -54,7 +54,7 @@ message Ticket {
 
   // tx_hash is the blockchain transaction hash recorded when this ticket was minted.
   // It provides an immutable audit trail back to the on-chain minting event.
-  string tx_hash = 5;
+  string tx_hash = 5 [(buf.validate.field).string.pattern = "^0x[0-9a-fA-F]{64}$"];
 
   // mint_time is the timestamp at which this ticket was minted on the blockchain.
   // This field is set by the server when the minting transaction is confirmed.

--- a/proto/liverty_music/rpc/entry/v1/entry_service.proto
+++ b/proto/liverty_music/rpc/entry/v1/entry_service.proto
@@ -38,13 +38,19 @@ message VerifyEntryRequest {
   // in the format produced by the snarkjs library. The proof demonstrates that the
   // fan holds a valid ticket without revealing their identity.
   // This field is required and must not be empty.
-  string proof_json = 2 [(buf.validate.field).string.min_len = 1];
+  string proof_json = 2 [
+    (buf.validate.field).required = true,
+    (buf.validate.field).string = {min_len: 1, max_len: 16384}
+  ];
 
   // public_signals_json is the JSON array of public signals associated with the proof,
   // also in snarkjs format. These signals are verified alongside the proof to confirm
   // that the claimed Merkle root matches the one published for the event.
   // This field is required and must not be empty.
-  string public_signals_json = 3 [(buf.validate.field).string.min_len = 1];
+  string public_signals_json = 3 [
+    (buf.validate.field).required = true,
+    (buf.validate.field).string = {min_len: 1, max_len: 16384}
+  ];
 }
 
 // VerifyEntryResponse communicates the outcome of the zero-knowledge proof verification.
@@ -78,11 +84,17 @@ message GetMerklePathResponse {
 
   // path_elements contains the sibling hashes along the Merkle path from the fan's leaf
   // up to the root. These are the values needed to recompute each level of the tree.
-  repeated bytes path_elements = 2 [(buf.validate.field).repeated.items.bytes.len = 32];
+  repeated bytes path_elements = 2 [
+    (buf.validate.field).repeated.max_items = 20,
+    (buf.validate.field).repeated.items.bytes.len = 32
+  ];
 
   // path_indices indicates the position (left or right sibling) of each element in path_elements.
   // A value of 0 means the sibling is on the left; a value of 1 means it is on the right.
-  repeated uint32 path_indices = 3 [(buf.validate.field).repeated.items.uint32.lte = 1];
+  repeated uint32 path_indices = 3 [
+    (buf.validate.field).repeated.max_items = 20,
+    (buf.validate.field).repeated.items.uint32.lte = 1
+  ];
 
   // leaf is the hash of the fan's ticket data at the bottom of the Merkle tree.
   // It serves as the starting point for the Merkle path verification computation.

--- a/proto/liverty_music/rpc/entry/v1/entry_service.proto
+++ b/proto/liverty_music/rpc/entry/v1/entry_service.proto
@@ -1,0 +1,90 @@
+syntax = "proto3";
+
+// Package liverty_music.rpc.entry.v1 defines the RPC interface for zero-knowledge proof
+// based event entry verification on the Liverty Music platform.
+package liverty_music.rpc.entry.v1;
+
+import "buf/validate/validate.proto";
+import "liverty_music/entity/v1/ticket.proto";
+import "liverty_music/entity/v1/user.proto";
+
+option go_package = "github.com/liverty-music/specification/gen/go/liverty_music/rpc/entry/v1;entryv1";
+
+// EntryService provides zero-knowledge proof based entry verification for ticketed events
+// on the Liverty Music platform. It allows venue staff to confirm a fan's right to enter
+// without revealing their identity, and enables fans to retrieve the Merkle path data
+// required to generate their own entry proofs client-side.
+service EntryService {
+  // VerifyEntry checks whether a fan is authorized to enter an event by verifying their
+  // zero-knowledge proof (Groth16 via snarkjs) against the event's published Merkle root.
+  // This method does not require knowing the fan's identity — the proof itself demonstrates
+  // membership in the set of ticket holders without revealing who they are.
+  rpc VerifyEntry(VerifyEntryRequest) returns (VerifyEntryResponse);
+
+  // GetMerklePath retrieves the Merkle inclusion proof data for a specific fan at a specific event.
+  // Fans use this data to generate a zero-knowledge proof on their device, which they then
+  // present at venue entry. The path elements and indices together with the leaf value are
+  // sufficient to construct and verify the proof without any further server interaction.
+  rpc GetMerklePath(GetMerklePathRequest) returns (GetMerklePathResponse);
+}
+
+// VerifyEntryRequest carries the zero-knowledge proof submitted by a fan seeking entry to an event.
+message VerifyEntryRequest {
+  // event_id identifies the event at which entry is being requested.
+  // This field is required.
+  liverty_music.entity.v1.EventId event_id = 1 [(buf.validate.field).required = true];
+
+  // proof_json is the Groth16 zero-knowledge proof serialized as a JSON string,
+  // in the format produced by the snarkjs library. The proof demonstrates that the
+  // fan holds a valid ticket without revealing their identity.
+  // This field is required and must not be empty.
+  string proof_json = 2 [(buf.validate.field).string.min_len = 1];
+
+  // public_signals_json is the JSON array of public signals associated with the proof,
+  // also in snarkjs format. These signals are verified alongside the proof to confirm
+  // that the claimed Merkle root matches the one published for the event.
+  // This field is required and must not be empty.
+  string public_signals_json = 3 [(buf.validate.field).string.min_len = 1];
+}
+
+// VerifyEntryResponse communicates the outcome of the zero-knowledge proof verification.
+message VerifyEntryResponse {
+  // verified indicates whether the submitted proof was successfully verified.
+  // A value of true means the fan is authorized to enter the event.
+  bool verified = 1;
+
+  // message provides a human-readable description of the verification result,
+  // suitable for display to venue staff or the fan themselves.
+  string message = 2;
+}
+
+// GetMerklePathRequest identifies the fan and event for which Merkle path data is needed.
+message GetMerklePathRequest {
+  // event_id identifies the event for which the Merkle path is requested.
+  // This field is required.
+  liverty_music.entity.v1.EventId event_id = 1 [(buf.validate.field).required = true];
+
+  // user_id identifies the fan whose Merkle path should be returned.
+  // This field is required.
+  liverty_music.entity.v1.UserId user_id = 2 [(buf.validate.field).required = true];
+}
+
+// GetMerklePathResponse contains all the data a fan needs to construct a zero-knowledge
+// entry proof on their own device.
+message GetMerklePathResponse {
+  // merkle_root is the root hash of the Merkle tree for this event's ticket holders.
+  // It matches the value published on-chain and is used as a public input to the proof.
+  bytes merkle_root = 1;
+
+  // path_elements contains the sibling hashes along the Merkle path from the fan's leaf
+  // up to the root. These are the values needed to recompute each level of the tree.
+  repeated bytes path_elements = 2;
+
+  // path_indices indicates the position (left or right sibling) of each element in path_elements.
+  // A value of 0 means the sibling is on the left; a value of 1 means it is on the right.
+  repeated uint32 path_indices = 3;
+
+  // leaf is the hash of the fan's ticket data at the bottom of the Merkle tree.
+  // It serves as the starting point for the Merkle path verification computation.
+  bytes leaf = 4;
+}

--- a/proto/liverty_music/rpc/entry/v1/entry_service.proto
+++ b/proto/liverty_music/rpc/entry/v1/entry_service.proto
@@ -74,17 +74,17 @@ message GetMerklePathRequest {
 message GetMerklePathResponse {
   // merkle_root is the root hash of the Merkle tree for this event's ticket holders.
   // It matches the value published on-chain and is used as a public input to the proof.
-  bytes merkle_root = 1;
+  bytes merkle_root = 1 [(buf.validate.field).bytes.len = 32];
 
   // path_elements contains the sibling hashes along the Merkle path from the fan's leaf
   // up to the root. These are the values needed to recompute each level of the tree.
-  repeated bytes path_elements = 2;
+  repeated bytes path_elements = 2 [(buf.validate.field).repeated.items.bytes.len = 32];
 
   // path_indices indicates the position (left or right sibling) of each element in path_elements.
   // A value of 0 means the sibling is on the left; a value of 1 means it is on the right.
-  repeated uint32 path_indices = 3;
+  repeated uint32 path_indices = 3 [(buf.validate.field).repeated.items.uint32.lte = 1];
 
   // leaf is the hash of the fan's ticket data at the bottom of the Merkle tree.
   // It serves as the starting point for the Merkle path verification computation.
-  bytes leaf = 4;
+  bytes leaf = 4 [(buf.validate.field).bytes.len = 32];
 }

--- a/proto/liverty_music/rpc/entry/v1/entry_service.proto
+++ b/proto/liverty_music/rpc/entry/v1/entry_service.proto
@@ -40,7 +40,10 @@ message VerifyEntryRequest {
   // This field is required and must not be empty.
   string proof_json = 2 [
     (buf.validate.field).required = true,
-    (buf.validate.field).string = {min_len: 1, max_len: 16384}
+    (buf.validate.field).string = {
+      min_len: 1
+      max_len: 16384
+    }
   ];
 
   // public_signals_json is the JSON array of public signals associated with the proof,
@@ -49,7 +52,10 @@ message VerifyEntryRequest {
   // This field is required and must not be empty.
   string public_signals_json = 3 [
     (buf.validate.field).required = true,
-    (buf.validate.field).string = {min_len: 1, max_len: 16384}
+    (buf.validate.field).string = {
+      min_len: 1
+      max_len: 16384
+    }
   ];
 }
 

--- a/proto/liverty_music/rpc/ticket/v1/ticket_service.proto
+++ b/proto/liverty_music/rpc/ticket/v1/ticket_service.proto
@@ -1,0 +1,75 @@
+syntax = "proto3";
+
+// Package liverty_music.rpc.ticket.v1 defines the RPC interface for ticket management
+// on the Liverty Music platform.
+package liverty_music.rpc.ticket.v1;
+
+import "buf/validate/validate.proto";
+import "liverty_music/entity/v1/ticket.proto";
+import "liverty_music/entity/v1/user.proto";
+
+option go_package = "github.com/liverty-music/specification/gen/go/liverty_music/rpc/ticket/v1;ticketv1";
+
+// TicketService manages the lifecycle of soulbound digital tickets (ERC-5192) for music events
+// on the Liverty Music platform. It enables minting new tickets on the blockchain, retrieving
+// ticket details, and listing all tickets held by a specific fan.
+service TicketService {
+  // MintTicket issues a new soulbound ticket to a fan for a specific event by minting an
+  // ERC-5192 token on the blockchain. Because soulbound tickets cannot be transferred,
+  // each fan may hold at most one ticket per event. The minting process records the
+  // on-chain transaction hash and token ID in the platform's ticket record.
+  rpc MintTicket(MintTicketRequest) returns (MintTicketResponse);
+
+  // GetTicket retrieves the full details of a single ticket by its unique identifier,
+  // including its on-chain token ID and blockchain transaction hash.
+  rpc GetTicket(GetTicketRequest) returns (GetTicketResponse);
+
+  // ListTickets returns all tickets currently held by a specific fan, allowing them
+  // to view their complete collection of event tickets across the platform.
+  rpc ListTickets(ListTicketsRequest) returns (ListTicketsResponse);
+}
+
+// MintTicketRequest carries the information needed to issue a new soulbound ticket
+// to a fan for a specific event.
+message MintTicketRequest {
+  // event_id identifies the event for which the ticket should be minted.
+  // This field is required.
+  liverty_music.entity.v1.EventId event_id = 1 [(buf.validate.field).required = true];
+
+  // user_id identifies the fan who will receive and permanently hold this ticket.
+  // This field is required.
+  liverty_music.entity.v1.UserId user_id = 2 [(buf.validate.field).required = true];
+}
+
+// MintTicketResponse contains the newly minted ticket returned after a successful minting operation.
+message MintTicketResponse {
+  // ticket is the complete ticket record created by the minting operation,
+  // including its on-chain token ID and blockchain transaction hash.
+  liverty_music.entity.v1.Ticket ticket = 1;
+}
+
+// GetTicketRequest carries the identifier of the ticket to retrieve.
+message GetTicketRequest {
+  // ticket_id is the unique identifier of the ticket to look up.
+  // This field is required.
+  liverty_music.entity.v1.TicketId ticket_id = 1 [(buf.validate.field).required = true];
+}
+
+// GetTicketResponse contains the ticket matching the requested identifier.
+message GetTicketResponse {
+  // ticket is the complete record of the requested ticket.
+  liverty_music.entity.v1.Ticket ticket = 1;
+}
+
+// ListTicketsRequest specifies the fan whose tickets should be returned.
+message ListTicketsRequest {
+  // user_id identifies the fan whose ticket collection should be listed.
+  // This field is required.
+  liverty_music.entity.v1.UserId user_id = 1 [(buf.validate.field).required = true];
+}
+
+// ListTicketsResponse contains all tickets held by the requested fan.
+message ListTicketsResponse {
+  // tickets is the complete list of soulbound tickets currently held by the fan.
+  repeated liverty_music.entity.v1.Ticket tickets = 1;
+}


### PR DESCRIPTION
## Summary

- Add OpenSpec change artifacts (proposal, design, tasks, research) for ticket system MVP
- Add Protobuf definitions for `TicketService` and `EntryService`
- Align spec artifacts with existing implementation (auth, concert, user, Safe wallet)
- Track implementation progress: tasks 4.1–4.7, 5.5–5.6, 6.2/6.4/6.5 complete

## Changes

### Proto definitions (`28b7946`)
- `ticket/v1/ticket.proto`: `TicketService.PurchaseTicket` RPC — mints an ERC-5192 SBT to the user's Safe smart account on Base Sepolia
- `entry/v1/entry.proto`: `EntryService.VerifyEntry` RPC — ZKP-based entry verification using Merkle proof

### OpenSpec artifacts
- `proposal.md`, `design.md`, `tasks.md`, `research/` covering the full ticket system scope
- Design includes: Safe (ERC-4337) smart account creation, TicketSBT contract, ZKP Merkle proof flow

### Task tracking
- TicketSBT deployed to Base Sepolia: `0x7C50bdF2E5d6B81F71868d5B6B59B5B3EC2F06fa`
- Remaining: Go backend handlers (Section 7), ZKP (8), Merkle (9), Frontend (10–13), CI/CD (14)

## Test plan

- [ ] Proto compiles cleanly via `buf build`
- [ ] Breaking change check passes via `buf breaking`
- [ ] BSR push triggered via CI (not local)