### PR TITLE
docs(openspec): sync and archive official-site-search change

### DIFF
--- a/openspec/changes/archive/2026-02-21-official-site-search/.openspec.yaml
+++ b/openspec/changes/archive/2026-02-21-official-site-search/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-02-20

--- a/openspec/changes/archive/2026-02-21-official-site-search/design.md
+++ b/openspec/changes/archive/2026-02-21-official-site-search/design.md
@@ -1,0 +1,102 @@
+## Context
+
+The concert discovery job calls `concertUseCase.SearchNewConcerts(artistID)`, which in turn calls `artistRepo.GetOfficialSite(artistID)`. If no record exists in `artist_official_site`, this returns a `NotFound` error and the job skips (or fails for) that artist. Since the Follow RPC never creates an official site record, all newly-followed artists are invisible to the discovery job.
+
+MusicBrainz exposes official site URLs via the `url-rels` include parameter (`GET /ws/2/artist/{mbid}?inc=url-rels`). The existing `musicbrainz.client` already handles MBID-based lookups and rate-limit throttling, making it the natural place to add this resolution.
+
+The existing `entity.ArtistIdentityManager` interface is already injected into `artistUseCase`, but it only covers name normalization (`GetArtist`). Rather than extending that interface with an unrelated concern, a new focused interface is more appropriate.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Automatically persist an artist's official site URL when a user follows them.
+- Degrade gracefully: Follow succeeds regardless of whether URL resolution succeeds.
+- Allow the Gemini concert search to proceed even without a known URL.
+- Select the most relevant URL when MusicBrainz returns multiple `official homepage` relations.
+
+**Non-Goals:**
+- Updating an existing official site record (no re-resolution on re-follow).
+- Supporting official site types other than `official homepage` (social, streaming, etc.).
+- Exposing the resolution status to the caller via the Follow RPC response.
+- Implementing a full async queue / Pub-Sub (deferred to a future change).
+
+## Decisions
+
+### Decision 1: New `OfficialSiteResolver` interface instead of extending `ArtistIdentityManager`
+
+**Chosen**: Add `entity.OfficialSiteResolver` with a single method:
+```go
+ResolveOfficialSiteURL(ctx context.Context, mbid string) (string, error)
+```
+`musicbrainz.client` implements both `ArtistIdentityManager` and `OfficialSiteResolver`. `artistUseCase` gains a new `siteResolver OfficialSiteResolver` field injected at construction.
+
+**Alternative considered**: Extend `ArtistIdentityManager` with the new method.
+**Why rejected**: `ArtistIdentityManager` is about identity normalization (name/MBID). Adding a URL-resolution concern violates single responsibility and forces unrelated mock updates in tests.
+
+---
+
+### Decision 2: Goroutine with `context.WithoutCancel` for async resolution
+
+**Chosen**: After `artistRepo.Follow()` succeeds, spawn a goroutine using `context.WithoutCancel(ctx)` to resolve and persist the official site. The Follow RPC returns immediately.
+
+```
+Follow(ctx) {
+    artistRepo.Follow(userID, artistID)    // must succeed
+    bgCtx := context.WithoutCancel(ctx)
+    go resolveAndPersistOfficialSite(bgCtx, artist)
+    return nil
+}
+```
+
+**Why `context.WithoutCancel`**: The HTTP request context is cancelled when the response is sent. Using it directly in the goroutine causes `GetOfficialSite` to fail immediately after the response is flushed. `context.WithoutCancel` (Go 1.21+) preserves deadlines/values while detaching cancellation.
+
+**Alternative considered**: Synchronous resolution within the Follow RPC.
+**Why rejected**: MusicBrainz enforces 1 req/sec. Blocking the Follow response for an external API call degrades UX. The throttler queue could introduce 1–2+ second latency under concurrent load.
+
+**Alternative considered**: Dedicated Pub/Sub message.
+**Why rejected**: Requires additional infrastructure (Cloud Pub/Sub topic, subscriber). The goroutine approach is sufficient for current scale and is explicitly called out as a stepping stone.
+
+---
+
+### Decision 3: Skip `CreateOfficialSite` if record already exists
+
+**Chosen**: The goroutine calls `artistRepo.GetOfficialSite(artistID)` first. If the record exists (`NotFound` is the only "proceed" signal; any other result aborts), it skips creation. This prevents duplicate-key errors on re-follow scenarios.
+
+---
+
+### Decision 4: `official homepage` URL selection from MusicBrainz url-rels
+
+MusicBrainz can return multiple `official homepage` relations for one artist (e.g., current band site, label page, former band name site).
+
+**Selection priority** (first match wins):
+1. `ended = false` AND `source-credit` matches `artist.Name` (case-insensitive) → artist's own current site
+2. `ended = false` AND `source-credit` is empty → unattributed current site
+3. `ended = false` → any active site (fallback)
+4. No match → return empty string (no error)
+
+**Rationale**: The `source-credit` field in MusicBrainz identifies which name the relation belongs to. An artist with a former name (e.g., "phatmans after school" → "saji") will have relations from both identities. Matching current name avoids returning an obsolete site. `ended = true` relations are always excluded.
+
+---
+
+### Decision 5: `ConcertSearcher.Search()` accepts nil `officialSite`
+
+**Chosen**: Change `officialSite *entity.OfficialSite` to be nil-safe. When nil, use an alternate prompt variant:
+
+- **With URL**: `"Focus on information related to the official site ({url}) and the provided search results."`
+- **Without URL**: `"Search the official website of \"{name}\" and related sources to find concert information."`
+
+`SearchNewConcerts` in `concertUseCase` changes `GetOfficialSite` error handling: `NotFound` → continue with `site = nil`; other errors → still propagate.
+
+## Risks / Trade-offs
+
+- **Goroutine leak on shutdown**: The background goroutine is fire-and-forget. If the process shuts down before MusicBrainz responds, the operation is silently lost. Mitigation: the next Follow attempt (or a future periodic reconciliation job) can re-trigger resolution.
+
+- **No resolution retry**: If MusicBrainz returns an error (rate limit, network), the site remains unresolved. Mitigation: the `SearchNewConcerts` nil-site path allows the job to proceed with degraded quality, and resolution can be retried by implementing a reconciliation job later.
+
+- **Gemini quality degradation**: Without a known URL, Gemini must discover the official site itself, which may increase hallucination risk or miss site-specific schedule pages. Mitigation: this is explicitly a best-effort fallback path, acceptable for MVP.
+
+- **Race on re-follow**: If a user unfollows and re-follows quickly, two goroutines may attempt `CreateOfficialSite` concurrently. The second will encounter `AlreadyExists`. Mitigation: the goroutine checks existence before inserting; any remaining race is handled by treating `AlreadyExists` as a no-op.
+
+## Open Questions
+
+- Should we add a periodic reconciliation job to backfill official sites for artists that were followed before this change? (Scoped out for now — can be a follow-up change.)

--- a/openspec/changes/archive/2026-02-21-official-site-search/proposal.md
+++ b/openspec/changes/archive/2026-02-21-official-site-search/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+When a user follows an artist, no official site URL is stored. The concert discovery job (`SearchNewConcerts`) requires an official site to construct a targeted Gemini prompt, so any artist without a site record is silently skipped or errors out — meaning followed artists never get concert data.
+
+## What Changes
+
+- **New**: After a successful Follow, the backend asynchronously resolves the artist's official site URL from MusicBrainz (`url-rels`) and persists it via `CreateOfficialSite`.
+- **New**: A new `OfficialSiteResolver` interface is introduced in the entity layer, implemented by the MusicBrainz client, responsible for resolving an official site URL from an MBID.
+- **Modified**: `ConcertSearcher.Search()` accepts `officialSite *entity.OfficialSite` as nil-safe; when nil, the Gemini prompt instructs the model to find the official site itself rather than referencing a known URL.
+- **Modified**: `ConcertUseCase.SearchNewConcerts()` no longer hard-fails on `GetOfficialSite` NotFound — it continues with `site = nil`.
+
+## Capabilities
+
+### New Capabilities
+
+- `official-site-search`: Automatic resolution and persistence of an artist's official site URL, triggered asynchronously on Follow, using MusicBrainz url-rels with source-credit-based selection.
+
+### Modified Capabilities
+
+- `concert-service`: `SearchNewConcerts` no longer requires an official site to proceed; nil site is forwarded to the searcher as a degraded-but-functional path.
+- `artist-following`: Follow side-effect now triggers async official site resolution.
+
+## Impact
+
+- **Backend**: `entity`, `usecase`, `infrastructure/music/musicbrainz`, `infrastructure/gcp/gemini`
+- **No API/proto changes**: All changes are internal to the backend service.
+- **MusicBrainz rate limit**: The async goroutine respects the existing 1 req/sec throttler.
+- **Gemini prompt**: Prompt template gains a second variant (no-URL path), affecting search quality for artists without a resolved site.

--- a/openspec/changes/archive/2026-02-21-official-site-search/specs/artist-following/spec.md
+++ b/openspec/changes/archive/2026-02-21-official-site-search/specs/artist-following/spec.md
@@ -1,0 +1,18 @@
+## MODIFIED Requirements
+
+### Requirement: Persist User Follow Actions
+
+The system SHALL persist user follow and unfollow actions for specific artists in a relational database. After a follow is successfully persisted, the system SHALL asynchronously attempt to resolve and store the artist's official site URL if one does not already exist.
+
+#### Scenario: Successfully following an artist
+
+- **WHEN** a user with a valid ID requests to follow an artist with a valid MBID
+- **THEN** the system SHALL create a record in the `followed_artists` table linking the user to the artist
+- **AND** the system SHALL trigger an asynchronous resolution of the artist's official site URL
+- **AND** the RPC response SHALL be returned before the resolution completes
+
+#### Scenario: Following an artist whose official site is already known
+
+- **WHEN** a user follows an artist that already has an `artist_official_site` record
+- **THEN** the system SHALL create the `followed_artists` record as normal
+- **AND** SHALL skip official site resolution silently

--- a/openspec/changes/archive/2026-02-21-official-site-search/specs/concert-service/spec.md
+++ b/openspec/changes/archive/2026-02-21-official-site-search/specs/concert-service/spec.md
@@ -1,0 +1,37 @@
+## MODIFIED Requirements
+
+### Requirement: Search Concerts by Artist
+
+System must provide a way to search for future concerts of a specific artist using generative AI grounding. Error returns SHALL include contextual wrapping indicating which operation failed.
+
+#### Scenario: Successful Search with known official site
+
+- **WHEN** `SearchNewConcerts` is called for an existing artist
+- **AND** the artist has a persisted official site record
+- **THEN** the system returns a list of upcoming concerts found on the web
+- **AND** each concert includes title, venue, date, and start time
+- **AND** results exclude concerts that are already stored in the database
+
+#### Scenario: Successful Search without official site
+
+- **WHEN** `SearchNewConcerts` is called for an existing artist
+- **AND** the artist has no persisted official site record
+- **THEN** the system SHALL still perform the external search using the artist name
+- **AND** return a list of upcoming concerts if found
+- **AND** NOT return an error solely because the official site is missing
+
+#### Scenario: Filter Past Events
+
+- **WHEN** the search results include events with dates in the past
+- **THEN** the system must filter them out and only return future events
+
+#### Scenario: No Results
+
+- **WHEN** no upcoming concerts are found for the artist
+- **THEN** the system returns an empty list without error
+
+#### Scenario: Error context in failures
+
+- **WHEN** any internal operation fails (get artist, list existing concerts, search external API)
+- **THEN** the error SHALL be wrapped with `fmt.Errorf` indicating which step failed
+- **AND** the original error SHALL be preserved via `%w` verb

--- a/openspec/changes/archive/2026-02-21-official-site-search/specs/official-site-search/spec.md
+++ b/openspec/changes/archive/2026-02-21-official-site-search/specs/official-site-search/spec.md
@@ -1,0 +1,58 @@
+## ADDED Requirements
+
+### Requirement: Resolve Official Site URL from MusicBrainz
+
+The system SHALL provide an `OfficialSiteResolver` interface that resolves an artist's official site URL from their MBID using the MusicBrainz url-rels API.
+
+#### Scenario: Artist has an active official homepage relation
+
+- **WHEN** `ResolveOfficialSiteURL` is called with a valid MBID
+- **AND** MusicBrainz returns one or more `official homepage` relations with `ended = false`
+- **THEN** the system SHALL return the URL whose `source-credit` matches the artist's current name (case-insensitive) as the first priority
+- **AND** fall back to an unattributed (`source-credit = ""`) active URL as the second priority
+- **AND** fall back to the first active URL if no name match is found
+
+#### Scenario: All official homepage relations are ended
+
+- **WHEN** `ResolveOfficialSiteURL` is called with a valid MBID
+- **AND** all `official homepage` relations have `ended = true`
+- **THEN** the system SHALL return an empty string without error
+
+#### Scenario: No official homepage relation exists
+
+- **WHEN** `ResolveOfficialSiteURL` is called with a valid MBID
+- **AND** MusicBrainz returns no relation with `type = "official homepage"`
+- **THEN** the system SHALL return an empty string without error
+
+#### Scenario: MusicBrainz API is unavailable
+
+- **WHEN** `ResolveOfficialSiteURL` is called and the MusicBrainz API returns an error
+- **THEN** the system SHALL return the error to the caller
+
+### Requirement: Async Official Site Persistence on Follow
+
+The system SHALL asynchronously resolve and persist the official site URL for an artist immediately after a user follow is recorded.
+
+#### Scenario: Official site is successfully resolved and persisted
+
+- **WHEN** a user successfully follows an artist that has no existing `artist_official_site` record
+- **AND** MusicBrainz returns a non-empty URL for the artist's MBID
+- **THEN** the system SHALL create an `artist_official_site` record with the resolved URL
+- **AND** the Follow RPC SHALL return success without waiting for resolution to complete
+
+#### Scenario: Official site already exists
+
+- **WHEN** a user follows an artist that already has an `artist_official_site` record
+- **THEN** the system SHALL skip resolution and creation silently
+
+#### Scenario: MusicBrainz returns no URL
+
+- **WHEN** resolution returns an empty string
+- **THEN** the system SHALL not create an `artist_official_site` record
+- **AND** SHALL NOT return an error to the Follow caller
+
+#### Scenario: Resolution fails with an error
+
+- **WHEN** the MusicBrainz API returns an error during async resolution
+- **THEN** the error SHALL be logged at WARN level
+- **AND** SHALL NOT affect the Follow RPC response

--- a/openspec/changes/archive/2026-02-21-official-site-search/tasks.md
+++ b/openspec/changes/archive/2026-02-21-official-site-search/tasks.md
@@ -1,0 +1,33 @@
+## 1. Entity Layer
+
+- [x] 1.1 Add `OfficialSiteResolver` interface to `internal/entity/artist.go` with `ResolveOfficialSiteURL(ctx, mbid string) (string, error)`
+
+## 2. MusicBrainz Client
+
+- [x] 2.1 Add `urlRelsResponse` struct to `internal/infrastructure/music/musicbrainz/client.go` to decode `url-rels` JSON (relations array with `type`, `url.resource`, `source-credit`, `ended`)
+- [x] 2.2 Implement `ResolveOfficialSiteURL` on `musicbrainz.client`: call `GET /ws/2/artist/{mbid}?inc=url-rels&fmt=json`, apply priority selection (source-credit match → empty credit → first active), return empty string if none found
+- [x] 2.3 Verify `musicbrainz.client` satisfies both `entity.ArtistIdentityManager` and `entity.OfficialSiteResolver` with compile-time checks
+
+## 3. Artist UseCase — Follow Side-Effect
+
+- [x] 3.1 Add `siteResolver entity.OfficialSiteResolver` field to `artistUseCase` struct and update `NewArtistUseCase` constructor signature
+- [x] 3.2 Implement `resolveAndPersistOfficialSite` helper on `artistUseCase`: check existing site, call resolver, call `CreateOfficialSite`, log errors at WARN without returning them
+- [x] 3.3 Update `Follow()` in `artist_uc.go`: after `artistRepo.Follow()` succeeds, spawn goroutine using `context.WithoutCancel(ctx)` calling `resolveAndPersistOfficialSite`
+- [x] 3.4 Update `artist_uc_test.go` to cover the new Follow side-effect scenarios (site already exists, resolver returns empty, resolver errors)
+
+## 4. Gemini Concert Searcher — Nil-Safe Official Site
+
+- [x] 4.1 Change `Search()` signature in `internal/infrastructure/gcp/gemini/searcher.go` to accept `officialSite *entity.OfficialSite` (nil-safe)
+- [x] 4.2 Add a second prompt template variant (no-URL path) and apply conditional branching on `officialSite == nil` in `Search()`
+- [x] 4.3 Update `entity.ConcertSearcher` interface signature in `internal/entity/concert.go` to match the nil-safe `officialSite` parameter
+- [x] 4.4 Update `searcher_test.go` and `searcher_integration_test.go` to cover the nil-site path
+
+## 5. Concert UseCase — Degrade Gracefully on Missing Site
+
+- [x] 5.1 Update `SearchNewConcerts()` in `internal/usecase/concert_uc.go`: change `GetOfficialSite` error handling so `NotFound` continues with `site = nil` instead of returning error
+- [x] 5.2 Update `concert_uc_test.go` to cover the no-official-site scenario
+
+## 6. Dependency Injection
+
+- [x] 6.1 Update `internal/di/provider.go`: pass `musicbrainzClient` as `OfficialSiteResolver` to `NewArtistUseCase`
+- [x] 6.2 Verify `internal/di/job.go` requires no changes (JobApp does not use `artistUseCase`)

--- a/openspec/specs/artist-following/spec.md
+++ b/openspec/specs/artist-following/spec.md
@@ -5,11 +5,19 @@ This capability enables users to follow and unfollow musical artists, creating a
 ## Requirements
 
 ### Requirement: Persist User Follow Actions
-The system SHALL persist user follow and unfollow actions for specific artists in a relational database. The frontend SHALL call the backend `ArtistService.Follow` RPC when a user taps an artist bubble.
+The system SHALL persist user follow and unfollow actions for specific artists in a relational database. The frontend SHALL call the backend `ArtistService.Follow` RPC when a user taps an artist bubble. After a follow is successfully persisted, the system SHALL asynchronously attempt to resolve and store the artist's official site URL if one does not already exist.
 
 #### Scenario: Successfully following an artist
 - **WHEN** a user with a valid ID requests to follow an artist with a valid MBID
 - **THEN** the system SHALL create a record in the `followed_artists` table linking the user to the artist
+- **AND** the system SHALL trigger an asynchronous resolution of the artist's official site URL
+- **AND** the RPC response SHALL be returned before the resolution completes
+
+#### Scenario: Following an artist whose official site is already known
+
+- **WHEN** a user follows an artist that already has an `artist_official_site` record
+- **THEN** the system SHALL create the `followed_artists` record as normal
+- **AND** SHALL skip official site resolution silently
 
 #### Scenario: Frontend calls Follow RPC on bubble tap
 - **WHEN** a user taps an artist bubble in the discovery UI

--- a/openspec/specs/concert-service/spec.md
+++ b/openspec/specs/concert-service/spec.md
@@ -36,12 +36,21 @@ The system SHALL provide a gRPC service to manage concerts and artists.
 
 System must provide a way to search for future concerts of a specific artist using generative AI grounding. Error returns SHALL include contextual wrapping indicating which operation failed.
 
-#### Scenario: Successful Search
+#### Scenario: Successful Search with known official site
 
 - **WHEN** `SearchNewConcerts` is called for an existing artist
+- **AND** the artist has a persisted official site record
 - **THEN** the system returns a list of upcoming concerts found on the web
 - **AND** each concert includes title, venue, date, and start time
 - **AND** results exclude concerts that are already stored in the database
+
+#### Scenario: Successful Search without official site
+
+- **WHEN** `SearchNewConcerts` is called for an existing artist
+- **AND** the artist has no persisted official site record
+- **THEN** the system SHALL still perform the external search using the artist name
+- **AND** return a list of upcoming concerts if found
+- **AND** NOT return an error solely because the official site is missing
 
 #### Scenario: Filter Past Events
 
@@ -55,7 +64,7 @@ System must provide a way to search for future concerts of a specific artist usi
 
 #### Scenario: Error context in failures
 
-- **WHEN** any internal operation fails (get artist, get official site, list existing concerts, search external API)
+- **WHEN** any internal operation fails (get artist, list existing concerts, search external API)
 - **THEN** the error SHALL be wrapped with `fmt.Errorf` indicating which step failed
 - **AND** the original error SHALL be preserved via `%w` verb
 

--- a/openspec/specs/official-site-search/spec.md
+++ b/openspec/specs/official-site-search/spec.md
@@ -1,0 +1,64 @@
+# official-site-search Specification
+
+## Purpose
+
+This capability resolves and persists official website URLs for artists using the MusicBrainz url-rels API. It provides an `OfficialSiteResolver` that selects the most relevant active homepage from MusicBrainz relations, and triggers asynchronous persistence immediately after a user follow action.
+
+## Requirements
+
+### Requirement: Resolve Official Site URL from MusicBrainz
+
+The system SHALL provide an `OfficialSiteResolver` interface that resolves an artist's official site URL from their MBID using the MusicBrainz url-rels API.
+
+#### Scenario: Artist has an active official homepage relation
+
+- **WHEN** `ResolveOfficialSiteURL` is called with a valid MBID
+- **AND** MusicBrainz returns one or more `official homepage` relations with `ended = false`
+- **THEN** the system SHALL return the URL whose `source-credit` matches the artist's current name (case-insensitive) as the first priority
+- **AND** fall back to an unattributed (`source-credit = ""`) active URL as the second priority
+- **AND** fall back to the first active URL if no name match is found
+
+#### Scenario: All official homepage relations are ended
+
+- **WHEN** `ResolveOfficialSiteURL` is called with a valid MBID
+- **AND** all `official homepage` relations have `ended = true`
+- **THEN** the system SHALL return an empty string without error
+
+#### Scenario: No official homepage relation exists
+
+- **WHEN** `ResolveOfficialSiteURL` is called with a valid MBID
+- **AND** MusicBrainz returns no relation with `type = "official homepage"`
+- **THEN** the system SHALL return an empty string without error
+
+#### Scenario: MusicBrainz API is unavailable
+
+- **WHEN** `ResolveOfficialSiteURL` is called and the MusicBrainz API returns an error
+- **THEN** the system SHALL return the error to the caller
+
+### Requirement: Async Official Site Persistence on Follow
+
+The system SHALL asynchronously resolve and persist the official site URL for an artist immediately after a user follow is recorded.
+
+#### Scenario: Official site is successfully resolved and persisted
+
+- **WHEN** a user successfully follows an artist that has no existing `artist_official_site` record
+- **AND** MusicBrainz returns a non-empty URL for the artist's MBID
+- **THEN** the system SHALL create an `artist_official_site` record with the resolved URL
+- **AND** the Follow RPC SHALL return success without waiting for resolution to complete
+
+#### Scenario: Official site already exists
+
+- **WHEN** a user follows an artist that already has an `artist_official_site` record
+- **THEN** the system SHALL skip resolution and creation silently
+
+#### Scenario: MusicBrainz returns no URL
+
+- **WHEN** resolution returns an empty string
+- **THEN** the system SHALL not create an `artist_official_site` record
+- **AND** SHALL NOT return an error to the Follow caller
+
+#### Scenario: Resolution fails with an error
+
+- **WHEN** the MusicBrainz API returns an error during async resolution
+- **THEN** the error SHALL be logged at WARN level
+- **AND** SHALL NOT affect the Follow RPC response


### PR DESCRIPTION
## 🔗 Related Issue

Related to liverty-music/backend#70

## 📝 Summary of Changes

Syncs delta specs from the `official-site-search` change to main specs, and archives the completed change.

**Spec updates:**
- **artist-following**: Updated "Persist User Follow Actions" requirement to include async official site resolution; added "Following an artist whose official site is already known" scenario
- **concert-service**: Split "Successful Search" into two scenarios (with/without official site); updated error-context scenario to remove `get official site` step
- **official-site-search**: Created new spec with two requirements: `OfficialSiteResolver` (MusicBrainz url-rels lookup with priority selection) and async persistence on follow

**Archive:** Moved `openspec/changes/official-site-search` → `openspec/changes/archive/2026-02-21-official-site-search/`

## 📋 Commit Log

```
076353b docs(openspec): sync and archive official-site-search change
```

## ✅ Self-Checklist

- [x] Specs accurately reflect the implemented behavior
- [x] Delta specs synced to main specs
- [x] Change archived after implementation complete