### PR TITLE
feat!(proto): unify entity VOs and embed Venue in Concert/Event for concert-detail

### DIFF
--- a/openspec/changes/concert-detail/.openspec.yaml
+++ b/openspec/changes/concert-detail/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-02-21

--- a/openspec/changes/concert-detail/design.md
+++ b/openspec/changes/concert-detail/design.md
@@ -1,0 +1,92 @@
+## Context
+
+The dashboard (live-highway) fetches concerts via `ConcertService.List` and displays them in a three-lane layout (My City / My Region / Others). Currently:
+
+- `Concert` proto carries only `venue_id` — no venue name or admin area reaches the frontend
+- Frontend hardcodes `venueName: 'Venue TBD'` and `locationLabel: ''`
+- All events are placed in the `main` lane; `region` and `other` lanes are always empty
+- Tapping a concert card opens `EventDetailSheet` (bottom sheet) with no URL change — the detail is not shareable or directly linkable
+- Go `entity.Event` has `LocalEventDate` but proto uses inconsistent raw types (`google.type.Date`, `google.type.TimeOfDay`, plain `string`) instead of VO wrapper messages
+
+The Go entity layer is the source of truth. The proto layer needs to catch up.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Surface venue name (`listed_venue_name`) and admin area (`venue.admin_area`) in the `Concert` proto
+- VO-ify all raw-typed fields in `Concert` and `Event` proto to match Go entity conventions
+- Rename `LocalEventDate` → `LocalDate` in Go `entity.Event` and propagate
+- JOIN venues in `ListByArtist` SQL so each concert carries a resolved `Venue`
+- Enable dashboard lane assignment using `venue.admin_area` vs user's localStorage region
+- Add Concert Detail UI: hybrid bottom-sheet with URL sync at `/concerts/:id`
+
+**Non-Goals:**
+- `GetConcert` RPC — not needed; dashboard pre-fetches all concerts via `List`
+- Share action / Web Share API — deferred to post-MVP
+- Storing user region in DB (`users.admin_area`) — separate issue
+- Unifying `Event.start_at` Timestamp type with Concert's TimeOfDay — separate refactor
+
+## Decisions
+
+### 1. VO wrapper messages for all primitive fields
+
+**Decision:** Introduce shared VO messages (`LocalDate`, `StartTime`, `OpenTime`, `Title`, `SourceUrl`, `ListedVenueName`) in the proto entity layer, replacing raw `google.type.*` and `string` fields.
+
+**Rationale:** Go entity already uses named types with clear semantics. Proto should mirror this. VO wrappers enable per-field validation via protovalidate and make the schema self-documenting. Consistent with existing pattern (`ArtistId`, `VenueName`, `ConcertTitle`, etc.).
+
+**Alternatives considered:**
+- Keep raw types, add only new fields → leaves existing inconsistency, tech debt grows
+- Use `google.type.TimeOfDay` for `StartTime`/`OpenTime` → contradicts Go entity which uses `*time.Time` (full timestamp); mapper already converts `time.Time → TimeOfDay` as a lossy transform
+
+### 2. Embed `Venue` in `Concert` (not a sidecar map in `ListResponse`)
+
+**Decision:** Add `Venue venue = 9` directly on the `Concert` message, server-populated on every `List` call.
+
+**Rationale:** Venue data is always needed when displaying a concert (name, Maps link, lane assignment). Embedding follows the AIP principle: always-needed related resources should be inlined. The `venue_id` field is retained for backward compatibility.
+
+**Alternatives considered:**
+- `map<string, Venue> venues` in `ListResponse` → gRPC/Connect anti-pattern; client must join; not idiomatic
+- Separate `GetVenue` call from frontend → N+1 problem; unnecessary round-trips
+
+### 3. Embed `Venue` in `Event` (replace `venue_id`)
+
+**Decision:** Replace `VenueId venue_id` with `Venue venue` in `Event` proto, consistent with `Concert`.
+
+**Rationale:** `Event` (ticket/ZK domain) needs the same venue information. Inconsistency between `Concert` (embedded `Venue`) and `Event` (only `venue_id`) would create cognitive overhead. Go entity has `VenueID string` on `Event` — the proto should embed the full object since that's always resolved server-side.
+
+### 4. Remove `create_time` / `update_time` from `Event`
+
+**Decision:** Delete these fields from the `Event` proto.
+
+**Rationale:** Go `entity.Event` does not have these fields. They were in the proto but unused by any handler or mapper. Removing them aligns proto with the domain model and reduces noise.
+
+### 5. Hybrid Concert Detail: bottom-sheet + URL sync
+
+**Decision:** Retain the existing `EventDetailSheet` bottom-sheet UX, but sync the URL to `/concerts/:id` when the sheet opens and restore it on close.
+
+**Rationale:** Preserves the native app-like feel (slide-up animation, swipe-to-dismiss) while enabling linkability for future share features. A full-page navigation would break the dashboard scroll state. Aurelia Router supports programmatic URL updates without full navigation.
+
+**Alternatives considered:**
+- Full page navigation to `/concerts/:id` → loses scroll position, feels less native
+- No URL change → sheet is not linkable; share feature (future) would have no URL to share
+
+### 6. `LocalEventDate` → `LocalDate` rename in Go entity
+
+**Decision:** Rename `entity.Event.LocalEventDate` to `entity.LocalDate` and update all call sites.
+
+**Rationale:** Aligns Go entity field name with the new proto VO name `LocalDate`. Reduces the mapping mental model: same concept, same name across layers.
+
+## Risks / Trade-offs
+
+- **BSR breaking change** → `concert.proto` and `event.proto` field renames/type changes require a semver major bump on the BSR schema. All generated clients (Go backend, TypeScript frontend) must be regenerated. → Mitigation: coordinate proto change and client regeneration in a single PR.
+- **SQL JOIN on every List call** → `ListByArtist` now JOINs `venues`. For users following many artists this is N JOINs (one per artist). → Mitigation: the existing query already JOINs `events`; adding `venues` is one more indexed JOIN on `venue_id` (UUID PK). Acceptable at current scale.
+- **`TimeToTimeOfDayProto` becomes dead code** → mapper function that converts `*time.Time → TimeOfDay` will be unused after VO type change. → Remove it as part of the mapper update.
+
+## Migration Plan
+
+1. Update proto files (`concert.proto`, `event.proto`) with new VO messages and field changes
+2. Bump BSR schema version (breaking change)
+3. Regenerate Go and TypeScript clients from BSR
+4. Update Go backend: rename `LocalEventDate` in `entity.Event`, update SQL query, update mapper
+5. Update frontend: map new proto fields in `dashboard-service.ts`, implement lane assignment, add URL sync to `EventDetailSheet`
+6. Deploy backend before frontend (frontend is backward-compatible with old proto during rollout window)

--- a/openspec/changes/concert-detail/proposal.md
+++ b/openspec/changes/concert-detail/proposal.md
@@ -1,0 +1,36 @@
+## Why
+
+Users discover concerts on the dashboard (live-highway) but tapping a concert item has no destination — there is no detail view. Additionally, venue information is never surfaced to the frontend (hardcoded as "Venue TBD"), making the dashboard's three-lane layout (My City / My Region / Others) non-functional.
+
+## What Changes
+
+- Add `Venue` embed and `listed_venue_name` to the `Concert` proto message so the frontend can display venue names and build Google Maps links
+- **BREAKING**: Rename and VO-ify raw-typed fields in `Concert` and `Event` proto messages to align with the Go entity layer:
+  - `date` → `local_date` (`LocalDate` VO)
+  - `start_time` / `open_time` → `StartTime` / `OpenTime` VO (Timestamp)
+  - `title` → `Title` VO (replaces `ConcertTitle`)
+  - `source_url` → `SourceUrl` VO
+  - `listed_venue_name` → `ListedVenueName` VO (new)
+  - `venue_id` in `Event` → `venue` (`Venue` embed)
+  - Remove `create_time` / `update_time` from `Event`
+- Rename `LocalEventDate` → `LocalDate` in Go `entity.Event`
+- Extend `ConcertRepository.ListByArtist` to JOIN venues and populate `Venue` on each concert
+- Add Concert Detail UI: hybrid bottom-sheet + URL sync (`/concerts/:id`) on the frontend
+- Enable dashboard lane assignment using `venue.admin_area` vs user's stored region
+
+## Capabilities
+
+### New Capabilities
+
+- `concert-detail`: Full concert detail view (hybrid sheet + URL) with venue name, Google Maps link, open/start times, and ticket source link
+
+### Modified Capabilities
+
+- `live-events`: Concert and Event entity definitions updated — VO-ify raw fields, embed Venue, rename `LocalEventDate` → `LocalDate`, remove `Event.create_time`/`update_time`
+- `concert-service`: `List` response now includes resolved `Venue` and `listed_venue_name` on each `Concert`
+
+## Impact
+
+- **Proto**: `concert.proto` (field renames + new fields), `event.proto` (field renames + Venue embed + field removals) — BSR breaking change
+- **Backend**: `concert_repo.go` (SQL JOIN venues), `mapper/concert.go` (new fields), `entity/event.go` (rename `LocalEventDate`)
+- **Frontend**: `dashboard-service.ts` (map venue data), `live-event.ts` (add `adminArea`), new concert-detail route + sheet URL sync, dashboard lane assignment logic

--- a/openspec/changes/concert-detail/specs/concert-detail/spec.md
+++ b/openspec/changes/concert-detail/specs/concert-detail/spec.md
@@ -1,0 +1,50 @@
+## ADDED Requirements
+
+### Requirement: Concert Detail View
+
+The system SHALL provide a detail view for a selected concert that surfaces full event information and entry points for ticket purchase.
+
+#### Scenario: Open detail from dashboard
+
+- **WHEN** a user taps a concert card on the dashboard
+- **THEN** the system SHALL open a bottom sheet displaying the concert detail
+- **AND** the URL SHALL update to `/concerts/:id` without triggering full page navigation
+
+#### Scenario: Display venue information
+
+- **WHEN** the concert detail view is open
+- **THEN** it SHALL display the venue name (`listed_venue_name`) and administrative area (`venue.admin_area`) if available
+
+#### Scenario: Google Maps link
+
+- **WHEN** the concert detail view is open
+- **THEN** it SHALL render a tappable link that opens Google Maps with a query composed of venue name and admin area
+
+#### Scenario: Ticket / official info link
+
+- **WHEN** the concert detail view is open and `source_url` is present
+- **THEN** it SHALL render a "View Official Info" button linking to `source_url` in a new tab
+
+#### Scenario: Dismiss sheet
+
+- **WHEN** the user swipes down or taps the backdrop
+- **THEN** the sheet SHALL close and the URL SHALL revert to the dashboard URL
+
+### Requirement: Dashboard Lane Assignment
+
+The system SHALL assign concerts to one of three lanes — My City, My Region, Others — based on the concert's `venue.admin_area` relative to the user's stored region preference.
+
+#### Scenario: Concert in user's city/prefecture
+
+- **WHEN** a concert's `venue.admin_area` matches the user's stored region exactly
+- **THEN** the concert SHALL be placed in the `main` (My City) lane
+
+#### Scenario: Concert in a different prefecture
+
+- **WHEN** a concert's `venue.admin_area` does not match the user's stored region
+- **THEN** the concert SHALL be placed in the `other` lane
+
+#### Scenario: Venue admin area not available
+
+- **WHEN** a concert has no `venue.admin_area`
+- **THEN** the concert SHALL be placed in the `other` lane

--- a/openspec/changes/concert-detail/specs/concert-service/spec.md
+++ b/openspec/changes/concert-detail/specs/concert-service/spec.md
@@ -1,0 +1,47 @@
+## MODIFIED Requirements
+
+### Requirement: Concert Service
+
+The system SHALL provide a gRPC service to manage concerts and artists.
+
+#### Scenario: List Concerts by Artist
+
+- **WHEN** `List` is called with a valid `artist_id`
+- **THEN** it returns a list of concerts associated with that artist
+- **AND** each concert SHALL include a resolved `Venue` object with `name` and `admin_area` if available
+- **AND** each concert SHALL include `listed_venue_name` with the raw scraped venue name
+- **AND** returns an empty list if no concerts are found (not an error)
+
+#### Scenario: List All Artists
+
+- **WHEN** `ListArtists` is called
+- **THEN** it returns a list of all artists in the system
+
+#### Scenario: Create Artist
+
+- **WHEN** `CreateArtist` is called with a valid name
+- **THEN** a new artist is created and returned with a generated ID
+- **AND** the artist is persistable
+
+#### Scenario: Create Artist with Invalid Name
+
+- **WHEN** `CreateArtist` is called with an empty name
+- **THEN** it returns an `INVALID_ARGUMENT` error
+
+## ADDED Requirements
+
+### Requirement: Venue Resolution in Concert List
+
+The `ConcertRepository.ListByArtist` implementation SHALL JOIN the `venues` table so that every returned `Concert` carries a populated `Venue` with `name` and `admin_area`.
+
+#### Scenario: Venue JOIN in list query
+
+- **WHEN** `ListByArtist` is called
+- **THEN** the SQL query SHALL JOIN `events` and `venues` tables
+- **AND** `venue.name` and `venue.admin_area` SHALL be scanned into the returned entities
+
+#### Scenario: Concert mapper includes Venue
+
+- **WHEN** a `Concert` entity is mapped to proto
+- **THEN** `ConcertToProto` SHALL populate the `venue` field using `VenueToProto`
+- **AND** SHALL populate `listed_venue_name` from `Concert.Event.ListedVenueName`

--- a/openspec/changes/concert-detail/specs/live-events/spec.md
+++ b/openspec/changes/concert-detail/specs/live-events/spec.md
@@ -1,0 +1,86 @@
+## MODIFIED Requirements
+
+### Requirement: Concert Schedue Data Model
+
+The system MUST define standard data structures for core concert entities to ensure consistency across services.
+
+#### Scenario: Artist Definition
+
+- **WHEN** an artist is represented
+- **THEN** it MUST include a unique ID, name, and a list of official media channels.
+
+#### Scenario: Venue Definition
+
+- **WHEN** a venue is represented
+- **THEN** it MUST include a unique ID and name.
+- **AND** it MAY include an administrative area (`admin_area`) representing the prefecture or region.
+
+#### Scenario: Concert Definition
+
+- **WHEN** a concert is represented
+- **THEN** it MUST include the artist ID, venue ID, local date (`local_date`), title, and start time.
+- **AND** it MAY include open time, source URL, listed venue name, and an embedded `Venue` object.
+- **AND** all primitive scalar fields (date, time, title, URL, venue name) SHALL be represented as VO wrapper messages.
+
+#### Scenario: Event Definition
+
+- **WHEN** an event is represented
+- **THEN** it MUST include a unique ID, an embedded `Venue` object, title, and local date.
+- **AND** it MAY include start time, open time, and merkle root.
+- **AND** all primitive scalar fields SHALL be represented as VO wrapper messages.
+- **AND** it SHALL NOT include `create_time` or `update_time` fields.
+
+## ADDED Requirements
+
+### Requirement: Proto Value Object Consistency
+
+All primitive scalar fields on `Concert` and `Event` proto messages SHALL use VO wrapper messages to carry validation constraints and semantic meaning, matching the Go entity layer conventions.
+
+#### Scenario: LocalDate VO
+
+- **WHEN** a calendar date is represented in `Concert` or `Event`
+- **THEN** it SHALL use the `LocalDate` wrapper message containing a `google.type.Date` value.
+- **AND** the field SHALL be named `local_date`.
+
+#### Scenario: StartTime and OpenTime VOs
+
+- **WHEN** a start or open time is represented in `Concert` or `Event`
+- **THEN** it SHALL use `StartTime` or `OpenTime` wrapper messages containing a `google.protobuf.Timestamp` value.
+
+#### Scenario: Title VO
+
+- **WHEN** a title is represented in `Concert` or `Event`
+- **THEN** it SHALL use the `Title` wrapper message containing a non-empty string value.
+
+#### Scenario: SourceUrl VO
+
+- **WHEN** a source URL is represented in `Concert`
+- **THEN** it SHALL use the `SourceUrl` wrapper message containing a URI-validated string value.
+
+#### Scenario: ListedVenueName VO
+
+- **WHEN** a raw scraped venue name is represented in `Concert`
+- **THEN** it SHALL use the `ListedVenueName` wrapper message containing a string value.
+
+### Requirement: Venue Embedding in Concert and Event
+
+Both `Concert` and `Event` proto messages SHALL embed a resolved `Venue` object populated by the server, rather than relying solely on a `venue_id` reference.
+
+#### Scenario: Concert carries embedded Venue
+
+- **WHEN** a `Concert` is returned from any RPC
+- **THEN** the `venue` field SHALL be populated with the corresponding `Venue` entity including `name` and `admin_area` if available.
+
+#### Scenario: Event carries embedded Venue
+
+- **WHEN** an `Event` is returned from any RPC
+- **THEN** the `venue` field SHALL be populated with the corresponding `Venue` entity.
+
+### Requirement: Go Entity Field Name Alignment
+
+The Go domain entity `event.Event.LocalEventDate` SHALL be renamed to `LocalDate` to align with the proto VO field name.
+
+#### Scenario: LocalEventDate renamed to LocalDate
+
+- **WHEN** the Go `entity.Event` struct is used in backend code
+- **THEN** the date field SHALL be accessed as `LocalDate` (not `LocalEventDate`).

--- a/openspec/changes/concert-detail/tasks.md
+++ b/openspec/changes/concert-detail/tasks.md
@@ -1,0 +1,70 @@
+## 1. Proto: Shared VO Messages
+
+- [x] 1.1 Add `LocalDate`, `StartTime`, `OpenTime`, `Title`, `SourceUrl`, `ListedVenueName` VO wrapper messages to `entity.proto` (or a new shared file)
+- [x] 1.2 Run `buf lint` and verify no style violations
+
+## 2. Proto: Update `concert.proto`
+
+- [x] 2.1 Replace `google.type.Date date` with `LocalDate local_date`
+- [x] 2.2 Replace `google.type.TimeOfDay start_time` with `StartTime start_time`
+- [x] 2.3 Replace `google.type.TimeOfDay open_time` with `OpenTime open_time`
+- [x] 2.4 Replace `ConcertTitle title` with `Title title`
+- [x] 2.5 Replace `string source_url` with `SourceUrl source_url`
+- [x] 2.6 Add `Venue venue = 9`
+- [x] 2.7 Add `ListedVenueName listed_venue_name = 10`
+- [ ] 2.8 Run `buf breaking` against previous version and confirm expected breaking changes only
+
+## 3. Proto: Update `event.proto`
+
+- [x] 3.1 Replace `VenueId venue_id` with `Venue venue`
+- [x] 3.2 Replace `string title` with `Title title`
+- [x] 3.3 Replace `google.type.Date local_event_date` with `LocalDate local_date`
+- [x] 3.4 Replace `optional Timestamp start_at` with `StartTime start_time`
+- [x] 3.5 Replace `optional Timestamp open_at` with `OpenTime open_time`
+- [x] 3.6 Remove `create_time` and `update_time` fields
+- [x] 3.7 Run `buf lint` to verify
+
+## 4. Proto: Publish to BSR
+
+- [ ] 4.1 Bump schema version (breaking change — semver major)
+- [ ] 4.2 Push updated proto to BSR
+- [ ] 4.3 Regenerate Go and TypeScript clients from BSR in backend and frontend repos
+
+## 5. Backend: Go Entity
+
+- [ ] 5.1 Rename `entity.Event.LocalEventDate` → `LocalDate` in [internal/entity/event.go](internal/entity/event.go)
+- [ ] 5.2 Update all references to `LocalEventDate` in backend (repo, mapper, use case, tests)
+
+## 6. Backend: Repository
+
+- [ ] 6.1 Extend `listConcertsByArtistQuery` and `listUpcomingConcertsByArtistQuery` in [internal/infrastructure/database/rdb/concert_repo.go](internal/infrastructure/database/rdb/concert_repo.go) to JOIN `venues` and SELECT `v.name`, `v.admin_area`
+- [ ] 6.2 Add `Venue` struct (or reuse `entity.Venue`) scan target in `ListByArtist`
+- [ ] 6.3 Populate `entity.Concert` with resolved `Venue` after scan
+
+## 7. Backend: Mapper
+
+- [ ] 7.1 Update `ConcertToProto` in [internal/adapter/rpc/mapper/concert.go](internal/adapter/rpc/mapper/concert.go) to populate `Venue`, `ListedVenueName`, and updated VO fields
+- [ ] 7.2 Remove `TimeToTimeOfDayProto` (now dead code) from mapper
+- [ ] 7.3 Update `VenueToProto` if needed for new field types
+
+## 8. Backend: Verification
+
+- [ ] 8.1 Run `go vet ./...` and `golangci-lint run`
+- [ ] 8.2 Run existing tests; fix any breakage from entity rename and proto changes
+
+## 9. Frontend: Data Layer
+
+- [ ] 9.1 Update `LiveEvent` interface in [src/components/live-highway/live-event.ts](src/components/live-highway/live-event.ts) — add `adminArea?: string`, fix `venueName` source
+- [ ] 9.2 Update `concertToLiveEvent` in [src/services/dashboard-service.ts](src/services/dashboard-service.ts) — map `concert.listedVenueName` → `venueName`, `concert.venue.adminArea` → `adminArea`; remove `'Venue TBD'` hardcode
+- [ ] 9.3 Implement lane assignment in `groupByDate` — compare `event.adminArea` vs `RegionSetupSheet.getStoredRegion()`
+
+## 10. Frontend: Concert Detail URL Sync
+
+- [ ] 10.1 Add `/concerts/:id` route configuration to Aurelia router (no new page component needed — handled by sheet)
+- [ ] 10.2 Update `EventDetailSheet.open()` to push `/concerts/:id` to router history
+- [ ] 10.3 Update `EventDetailSheet.close()` to restore previous URL (dashboard)
+
+## 11. Frontend: Event Detail Sheet — Venue & Maps
+
+- [ ] 11.1 Update `googleMapsUrl` getter in [src/components/live-highway/event-detail-sheet.ts](src/components/live-highway/event-detail-sheet.ts) to include `adminArea` in query when available
+- [ ] 11.2 Update sheet template to show `adminArea` below venue name if present

--- a/proto/liverty_music/entity/v1/concert.proto
+++ b/proto/liverty_music/entity/v1/concert.proto
@@ -3,9 +3,8 @@ syntax = "proto3";
 package liverty_music.entity.v1;
 
 import "buf/validate/validate.proto";
-import "google/type/date.proto";
-import "google/type/timeofday.proto";
 import "liverty_music/entity/v1/artist.proto";
+import "liverty_music/entity/v1/entity.proto";
 import "liverty_music/entity/v1/venue.proto";
 
 // Concert represents a specific music live event.
@@ -19,32 +18,35 @@ message Concert {
   ArtistId artist_id = 2 [(buf.validate.field).required = true];
 
   // The unique identifier of the venue where the concert is hosted.
+  // Retained for backward compatibility; prefer the embedded `venue` field.
   VenueId venue_id = 3 [(buf.validate.field).required = true];
 
-  // The scheduled date of the concert event.
-  google.type.Date date = 4 [(buf.validate.field).required = true];
+  // The scheduled calendar date of the concert event in the venue's local timezone.
+  LocalDate local_date = 4 [(buf.validate.field).required = true];
 
   // The scheduled time when the performance starts.
-  google.type.TimeOfDay start_time = 5 [(buf.validate.field).required = true];
+  StartTime start_time = 5 [(buf.validate.field).required = true];
 
   // The time when the venue doors open to the audience.
-  google.type.TimeOfDay open_time = 6;
+  OpenTime open_time = 6;
 
   // The official title or name of the concert tour or event.
-  ConcertTitle title = 7 [(buf.validate.field).required = true];
+  Title title = 7 [(buf.validate.field).required = true];
 
   // The official source URL for the concert information.
-  string source_url = 8 [(buf.validate.field).string.uri = true];
+  SourceUrl source_url = 8;
+
+  // The resolved venue where the concert is hosted.
+  // Populated by the server on every response; includes name and admin_area when available.
+  Venue venue = 9;
+
+  // The raw venue name as scraped from the source.
+  // Preserves the original text separately from the normalised Venue.name.
+  ListedVenueName listed_venue_name = 10;
 }
 
 // ConcertId is a globally unique identifier for a concert.
 message ConcertId {
   // A UUID string representing the unique identity of the concert.
   string value = 1 [(buf.validate.field).string.uuid = true];
-}
-
-// ConcertTitle represents the official name of a concert or tour.
-message ConcertTitle {
-  // The title text, required to be at least one character in length.
-  string value = 1 [(buf.validate.field).string.min_len = 1];
 }

--- a/proto/liverty_music/entity/v1/concert.proto
+++ b/proto/liverty_music/entity/v1/concert.proto
@@ -38,7 +38,7 @@ message Concert {
 
   // The resolved venue where the concert is hosted.
   // Populated by the server on every response; includes name and admin_area when available.
-  Venue venue = 9;
+  Venue venue = 9 [(buf.validate.field).required = true];
 
   // The raw venue name as scraped from the source.
   // Preserves the original text separately from the normalised Venue.name.

--- a/proto/liverty_music/entity/v1/entity.proto
+++ b/proto/liverty_music/entity/v1/entity.proto
@@ -28,15 +28,15 @@ message LocalDate {
 // StartTime represents the timestamp when a performance is scheduled to begin.
 // Stored as a full timestamp; time-of-day extraction is the responsibility of the consumer.
 message StartTime {
-  // The start timestamp. Optional — may be absent when not yet confirmed.
-  google.protobuf.Timestamp value = 1;
+  // The start timestamp. Must be present when the message itself is set.
+  google.protobuf.Timestamp value = 1 [(buf.validate.field).required = true];
 }
 
 // OpenTime represents the timestamp when venue doors open for entry.
 // Stored as a full timestamp; time-of-day extraction is the responsibility of the consumer.
 message OpenTime {
-  // The open timestamp. Optional — may be absent when door times have not been announced.
-  google.protobuf.Timestamp value = 1;
+  // The open timestamp. Must be present when the message itself is set.
+  google.protobuf.Timestamp value = 1 [(buf.validate.field).required = true];
 }
 
 // Title represents the human-readable name of a concert or event.
@@ -50,14 +50,21 @@ message Title {
 
 // SourceUrl represents the official source URL where concert information was found.
 message SourceUrl {
-  // The URI value pointing to the official source. Must be a valid URI when present.
-  string value = 1 [(buf.validate.field).string.uri = true];
+  // The URI value pointing to the official source. Must be a valid URI between 1 and 2048 characters.
+  string value = 1 [(buf.validate.field).string = {
+    uri: true
+    min_len: 1
+    max_len: 2048
+  }];
 }
 
 // ListedVenueName represents the raw venue name as scraped from the source.
 // This preserves the original text separately from the normalized Venue.name,
 // which may have been corrected or standardised.
 message ListedVenueName {
-  // The raw scraped venue name string.
-  string value = 1 [(buf.validate.field).string.min_len = 1];
+  // The raw scraped venue name string. Must be between 1 and 255 characters.
+  string value = 1 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 255
+  }];
 }

--- a/proto/liverty_music/entity/v1/entity.proto
+++ b/proto/liverty_music/entity/v1/entity.proto
@@ -2,6 +2,10 @@ syntax = "proto3";
 
 package liverty_music.entity.v1;
 
+import "buf/validate/validate.proto";
+import "google/protobuf/timestamp.proto";
+import "google/type/date.proto";
+
 // Package liverty_music.entity.v1 provides core business entity definitions for the Liverty Music application.
 //
 // This package contains fundamental data structures that represent the primary business entities
@@ -13,3 +17,47 @@ package liverty_music.entity.v1;
 // - Domain-specific types encapsulate validation rules using protovalidate
 // - Entities reference other entities by identifier to maintain loose coupling
 // - All fields include comprehensive validation constraints for data integrity
+
+// LocalDate represents a calendar date local to the venue's timezone.
+// Used consistently across Concert and Event entities to avoid timezone ambiguity.
+message LocalDate {
+  // The calendar date value. Must be a valid calendar date.
+  google.type.Date value = 1 [(buf.validate.field).required = true];
+}
+
+// StartTime represents the timestamp when a performance is scheduled to begin.
+// Stored as a full timestamp; time-of-day extraction is the responsibility of the consumer.
+message StartTime {
+  // The start timestamp. Optional — may be absent when not yet confirmed.
+  google.protobuf.Timestamp value = 1;
+}
+
+// OpenTime represents the timestamp when venue doors open for entry.
+// Stored as a full timestamp; time-of-day extraction is the responsibility of the consumer.
+message OpenTime {
+  // The open timestamp. Optional — may be absent when door times have not been announced.
+  google.protobuf.Timestamp value = 1;
+}
+
+// Title represents the human-readable name of a concert or event.
+message Title {
+  // The title string. Must be between 1 and 255 characters.
+  string value = 1 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 255
+  }];
+}
+
+// SourceUrl represents the official source URL where concert information was found.
+message SourceUrl {
+  // The URI value pointing to the official source. Must be a valid URI when present.
+  string value = 1 [(buf.validate.field).string.uri = true];
+}
+
+// ListedVenueName represents the raw venue name as scraped from the source.
+// This preserves the original text separately from the normalized Venue.name,
+// which may have been corrected or standardised.
+message ListedVenueName {
+  // The raw scraped venue name string.
+  string value = 1 [(buf.validate.field).string.min_len = 1];
+}

--- a/proto/liverty_music/entity/v1/event.proto
+++ b/proto/liverty_music/entity/v1/event.proto
@@ -5,8 +5,7 @@ package liverty_music.entity.v1;
 
 import "buf/validate/validate.proto";
 import "google/api/field_behavior.proto";
-import "google/protobuf/timestamp.proto";
-import "google/type/date.proto";
+import "liverty_music/entity/v1/entity.proto";
 import "liverty_music/entity/v1/ticket.proto";
 import "liverty_music/entity/v1/venue.proto";
 
@@ -20,38 +19,28 @@ message Event {
   // id is the unique identifier for this event within the Liverty Music platform.
   EventId id = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 
-  // venue_id identifies the physical location where this event will take place.
-  VenueId venue_id = 2 [(buf.validate.field).required = true];
+  // venue is the physical location where this event will take place.
+  // Populated by the server; includes name and admin_area when available.
+  Venue venue = 2 [(buf.validate.field).required = true];
 
   // title is the human-readable name of the event, such as the concert name or tour stop.
-  string title = 3 [(buf.validate.field).string = {
-    min_len: 1
-    max_len: 255
-  }];
+  Title title = 3 [(buf.validate.field).required = true];
 
-  // local_event_date is the calendar date of the event in the venue's local timezone.
+  // local_date is the calendar date of the event in the venue's local timezone.
   // This date is displayed to fans when browsing or purchasing tickets.
-  google.type.Date local_event_date = 4 [(buf.validate.field).required = true];
+  LocalDate local_date = 4 [(buf.validate.field).required = true];
 
-  // start_at is the exact timestamp when the performance is scheduled to begin.
+  // start_time is the timestamp when the performance is scheduled to begin.
   // This field is optional and may be omitted for events where the start time is not yet confirmed.
-  optional google.protobuf.Timestamp start_at = 5;
+  StartTime start_time = 5;
 
-  // open_at is the timestamp when venue doors open for fan entry.
+  // open_time is the timestamp when venue doors open for fan entry.
   // This field is optional and may be omitted when door times have not been announced.
-  optional google.protobuf.Timestamp open_at = 6;
+  OpenTime open_time = 6;
 
   // merkle_root is the root hash of the Merkle tree built from all ticket holders for this event.
   // It is only set for events that use zero-knowledge proof entry verification. The root is
   // published on-chain and allows entry validators to verify membership without querying
   // a central database, preserving fan privacy.
   optional bytes merkle_root = 7 [(buf.validate.field).bytes.len = 32];
-
-  // create_time is the timestamp at which this event record was first created on the platform.
-  // This field is set automatically by the server and cannot be supplied by clients.
-  google.protobuf.Timestamp create_time = 8 [(google.api.field_behavior) = OUTPUT_ONLY];
-
-  // update_time is the timestamp at which this event record was most recently modified.
-  // This field is updated automatically by the server on every write operation.
-  google.protobuf.Timestamp update_time = 9 [(google.api.field_behavior) = OUTPUT_ONLY];
 }


### PR DESCRIPTION
## 🔗 Related Issue

Closes #55

## 📝 Summary of Changes

This PR introduces the proto schema changes required for the Concert Detail feature (#55).

**New shared VO wrapper messages** added to `entity.proto`:
- `LocalDate` — replaces raw `google.type.Date` for date fields
- `StartTime` / `OpenTime` — replaces raw `google.type.TimeOfDay` / `Timestamp` for time fields
- `Title` — replaces both `ConcertTitle` (Concert) and `string title` (Event)
- `SourceUrl` — replaces raw `string source_url`
- `ListedVenueName` — new field carrying raw scraped venue name

**`concert.proto`** changes:
- `date` → `local_date` (renamed + typed as `LocalDate`)
- `start_time` / `open_time` typed as `StartTime` / `OpenTime`
- `title` typed as shared `Title` VO (removes `ConcertTitle`)
- `source_url` typed as `SourceUrl`
- Added `venue` (field 9): resolved `Venue` embedded by server
- Added `listed_venue_name` (field 10): raw scraped venue name

**`event.proto`** changes:
- `venue_id` → `venue` (embedded `Venue` object)
- `title` typed as shared `Title` VO
- `local_event_date` → `local_date` (typed as `LocalDate`)
- `start_at` → `start_time`, `open_at` → `open_time` (typed as `StartTime`/`OpenTime`)
- Removed `create_time` and `update_time` (not present in Go entity layer)

All changes align the proto layer with the existing Go `entity.Event` / `entity.Concert` domain model, which is the source of truth.

## ✅ Self-Checklist

- [x] I have linked the related issue.
- [x] I have updated the relevant documentation (e.g., `README.md`) if needed.
- [x] I have run `buf lint` and `buf format` locally and all checks have passed.
- [x] My proto definitions follow the project's style guidelines and validation rules.
- [x] Breaking changes have been justified and documented if applicable.