### PR TITLE
docs(spec): sync and archive optimize-k8s-dev-resources change

### DIFF
--- a/openspec/changes/archive/2026-02-22-optimize-k8s-dev-resources/.openspec.yaml
+++ b/openspec/changes/archive/2026-02-22-optimize-k8s-dev-resources/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-02-21

--- a/openspec/changes/archive/2026-02-22-optimize-k8s-dev-resources/design.md
+++ b/openspec/changes/archive/2026-02-22-optimize-k8s-dev-resources/design.md
@@ -1,0 +1,76 @@
+## Context
+
+The dev GKE Autopilot cluster (v1.33, Bursting supported) runs 15 pods across 6 namespaces. Billing data shows Kubernetes Engine at ¥4,910/month with all workloads over-provisioned by 5-50x on CPU and 2-17x on memory. The cluster uses `cloud.google.com/compute-class: autopilot-spot` for cost savings, but coverage is incomplete.
+
+Current resource allocation strategy uses uniform defaults (50m CPU / 256Mi memory request) regardless of actual workload characteristics. GKE Autopilot with Bursting (1.29+) allows requests as low as 50m CPU / 52MiB memory per container, with actual usage allowed to burst beyond requests.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Reduce Kubernetes Engine costs by 50-70% through resource right-sizing
+- Ensure 100% Spot VM coverage for all dev workloads
+- Remove unused ArgoCD components to reduce pod count
+- Establish per-workload resource policies based on observed usage
+
+**Non-Goals:**
+- Optimizing non-K8s costs (Gemini API, Cloud Monitoring, Cloud SQL, Networking)
+- Changing production or staging resource configurations
+- Implementing VPA (Vertical Pod Autoscaler) — manual right-sizing is sufficient for dev
+- Modifying application code or behavior
+
+## Decisions
+
+### D1: Resource request strategy — Autopilot minimum (50m CPU) for all idle workloads
+
+All workloads with actual CPU usage <10m will use 50m CPU request (Autopilot Bursting minimum). Memory requests will be set to ~1.5-2x of observed peak usage, with a floor of 52MiB (Autopilot minimum).
+
+**Why not set requests even lower?** 50m is the Autopilot Bursting minimum — requests below this are automatically rounded up, so there is no benefit.
+
+**Why not use actual usage (e.g., 5m)?** Same reason — Autopilot enforces 50m minimum regardless of what the manifest says.
+
+### D2: ArgoCD component control via Helm values
+
+Disable dex and notifications via `values.yaml` in the ArgoCD base, since these components are not used in any environment.
+
+```yaml
+dex:
+  enabled: false
+notifications:
+  enabled: false
+```
+
+**Alternative considered:** Disable only in dev overlay. Rejected because these components are not used in any environment — no reason to keep them enabled in base.
+
+### D3: Backend replica reduction via dev overlay patch
+
+Reduce backend server replicas from 2 to 1 in the dev overlay only, using a Kustomize strategic merge patch.
+
+**Why not change base?** Base defines the production-ready default (2 replicas for availability). Dev overrides this for cost savings.
+
+### D4: CronJob Spot VM coverage via additional patch target
+
+Extend the backend dev overlay's spot-vm patch to target both `Deployment` and `CronJob` kinds. This requires adding a second patch entry in the kustomization.yaml since Kustomize patches target a single kind per entry.
+
+### D5: Memory values — conservative approach for ArgoCD application-controller
+
+The application-controller shows ~200MiB actual usage (highest among ArgoCD components) due to in-memory caching of cluster state. Its memory request will be set to 128MiB with a 384MiB limit to accommodate GC spikes, while other ArgoCD components use 64MiB or less.
+
+## Risks / Trade-offs
+
+- **[Pod eviction on burst]** With requests at minimum (50m CPU), heavy burst usage could cause scheduling pressure → Mitigated by Autopilot's automatic node scaling and the fact that actual usage is well below current requests
+- **[ArgoCD dex re-enablement]** If SSO is needed later, dex must be re-enabled in values.yaml → Low risk, simple config change
+- **[CronJob on Spot VM preemption]** Spot VMs can be preempted mid-job → Mitigated by CronJob's built-in retry mechanism and the job's non-critical nature (concert discovery)
+
+## Migration Plan
+
+1. Apply all manifest changes in a single PR to `cloud-provisioning` repository
+2. ArgoCD auto-syncs changes to the dev cluster
+3. Verify all pods are running and healthy after sync
+4. Monitor resource usage for 1 week to validate right-sizing
+
+**Rollback:** Revert the PR. ArgoCD auto-syncs back to previous state.
+
+## Open Questions
+
+- Should we investigate Gemini API costs (¥6,496/month, 37% of total) as a follow-up change?
+- Is Cloud Monitoring Prometheus collection intentionally enabled, or can it be disabled for dev?

--- a/openspec/changes/archive/2026-02-22-optimize-k8s-dev-resources/proposal.md
+++ b/openspec/changes/archive/2026-02-22-optimize-k8s-dev-resources/proposal.md
@@ -1,0 +1,35 @@
+## Why
+
+The dev environment GKE Autopilot cluster costs ¥18,119/month (forecast), with Kubernetes Engine accounting for ¥4,910 (28%). Analysis of actual resource usage shows all workloads are over-provisioned by 5-50x on CPU and 2-17x on memory. Additionally, unused ArgoCD components (dex, notifications) are consuming resources, the backend runs unnecessary replicas for dev, and the concert-discovery CronJob is missing Spot VM scheduling.
+
+## What Changes
+
+- Reduce CPU/memory requests and limits for all workloads to match actual usage (with safety margin), leveraging GKE Autopilot Bursting support (confirmed: GKE 1.33)
+- Disable ArgoCD dex-server (SSO not in use)
+- Disable ArgoCD notifications-controller (notifications not configured)
+- Reduce backend server replicas from 2 to 1 for dev environment
+- Add Spot VM nodeSelector to concert-discovery CronJob (currently missing from patch target)
+
+### Not in scope
+
+- Gemini API cost reduction (¥6,496/month, 37% of total — separate investigation needed)
+- Cloud Monitoring / Prometheus Samples Ingested optimization (¥2,034/month)
+- Networking / Load Balancer cost reduction (¥2,103/month)
+- Cloud SQL optimization (¥1,702/month)
+
+## Capabilities
+
+### New Capabilities
+
+- `k8s-resource-right-sizing`: Defines resource request/limit policies for dev environment workloads based on actual usage data and GKE Autopilot constraints (Bursting minimum: 50m CPU / 52MiB memory)
+
+### Modified Capabilities
+
+- `continuous-delivery`: ArgoCD component configuration changes (disable dex, notifications) and dev overlay patching strategy update (CronJob Spot VM coverage)
+- `deployment-infrastructure`: Backend replica count policy for dev environment; Spot VM nodeSelector coverage for all workload kinds
+
+## Impact
+
+- **K8s manifests**: `k8s/namespaces/argocd/base/values.yaml`, `k8s/namespaces/backend/`, `k8s/namespaces/frontend/`, `k8s/namespaces/external-secrets/`, `k8s/namespaces/reloader/` — all dev overlays
+- **Cost**: Estimated 50-70% reduction in Kubernetes Engine costs (¥4,910 → ~¥1,500-2,500/month)
+- **Risk**: Low — dev environment only, all changes are reversible, Bursting allows actual usage to exceed requests

--- a/openspec/changes/archive/2026-02-22-optimize-k8s-dev-resources/specs/continuous-delivery/spec.md
+++ b/openspec/changes/archive/2026-02-22-optimize-k8s-dev-resources/specs/continuous-delivery/spec.md
@@ -1,0 +1,16 @@
+## MODIFIED Requirements
+
+### Requirement: ArgoCD Manifests
+
+The system SHALL provide Kustomize-based manifests for installing ArgoCD. The ArgoCD deployment SHALL NOT include the dex-server or notifications-controller components, as SSO and notification features are not in use.
+
+#### Scenario: Manifest Availability
+
+- **WHEN** checking the `src/k8s` directory
+- **THEN** a `argocd` directory exists with a valid `kustomization.yaml`
+
+#### Scenario: Unused components are disabled
+
+- **WHEN** rendering the ArgoCD base manifests
+- **THEN** dex-server SHALL NOT be deployed (dex.enabled: false)
+- **AND** notifications-controller SHALL NOT be deployed (notifications.enabled: false)

--- a/openspec/changes/archive/2026-02-22-optimize-k8s-dev-resources/specs/deployment-infrastructure/spec.md
+++ b/openspec/changes/archive/2026-02-22-optimize-k8s-dev-resources/specs/deployment-infrastructure/spec.md
@@ -1,0 +1,24 @@
+## ADDED Requirements
+
+### Requirement: Dev backend runs single replica
+
+The backend server deployment in the dev environment SHALL run with 1 replica. Production and staging environments retain their default replica count.
+
+#### Scenario: Dev backend replica count
+
+- **WHEN** rendering the backend dev overlay manifests
+- **THEN** the server-app Deployment SHALL have replicas set to 1
+
+### Requirement: All dev workload kinds use Spot VM scheduling
+
+Every workload in the dev environment — including Deployments, StatefulSets, and CronJobs — SHALL include the Spot VM nodeSelector (`cloud.google.com/compute-class: autopilot-spot`).
+
+#### Scenario: CronJob Spot VM coverage
+
+- **WHEN** rendering the backend dev overlay manifests
+- **THEN** the concert-discovery CronJob pod template SHALL include nodeSelector `cloud.google.com/compute-class: autopilot-spot`
+
+#### Scenario: All dev workloads on Spot VMs
+
+- **WHEN** running `kubectl get pods -A -o json` on the dev cluster
+- **THEN** every pod SHALL be scheduled on nodes with compute class `autopilot-spot`

--- a/openspec/changes/archive/2026-02-22-optimize-k8s-dev-resources/specs/k8s-resource-right-sizing/spec.md
+++ b/openspec/changes/archive/2026-02-22-optimize-k8s-dev-resources/specs/k8s-resource-right-sizing/spec.md
@@ -1,0 +1,44 @@
+## ADDED Requirements
+
+### Requirement: Dev environment resource requests use Autopilot Bursting minimums
+
+All dev environment workloads with observed CPU usage below 50m SHALL set CPU request to 50m (GKE Autopilot Bursting minimum). Memory requests SHALL be set to 1.5-2x of observed peak usage, with a floor of 52MiB.
+
+#### Scenario: ArgoCD components resource requests
+
+- **WHEN** rendering the ArgoCD dev overlay manifests
+- **THEN** all ArgoCD container CPU requests SHALL be 50m
+- **AND** application-controller memory request SHALL be 128MiB
+- **AND** repo-server, server, applicationset-controller memory requests SHALL be 64MiB
+- **AND** redis, redisSecretInit memory requests SHALL be 52MiB
+
+#### Scenario: External Secrets components resource requests
+
+- **WHEN** rendering the external-secrets dev overlay manifests
+- **THEN** controller CPU request SHALL be 50m with memory request of 64MiB
+- **AND** webhook and cert-controller CPU requests SHALL be 50m with memory requests of 52MiB
+
+#### Scenario: Backend server resource requests
+
+- **WHEN** rendering the backend dev overlay manifests
+- **THEN** server-app CPU request SHALL be 50m with memory request of 64MiB
+
+#### Scenario: Frontend web-app resource requests
+
+- **WHEN** rendering the frontend dev overlay manifests
+- **THEN** web-app CPU request SHALL be 50m with memory request of 52MiB
+
+#### Scenario: Reloader resource requests
+
+- **WHEN** rendering the reloader dev overlay manifests
+- **THEN** reloader CPU request SHALL be 50m with memory request of 64MiB
+
+### Requirement: Resource limits provide burst headroom
+
+All dev environment workloads SHALL have CPU limits set to 2-10x of request and memory limits set to 2-4x of request, providing headroom for burst usage without excessive reservation.
+
+#### Scenario: Limits do not exceed original allocation
+
+- **WHEN** rendering any dev overlay manifest
+- **THEN** no container CPU limit SHALL exceed 500m
+- **AND** no container memory limit SHALL exceed 512MiB

--- a/openspec/changes/archive/2026-02-22-optimize-k8s-dev-resources/tasks.md
+++ b/openspec/changes/archive/2026-02-22-optimize-k8s-dev-resources/tasks.md
@@ -1,0 +1,37 @@
+## 1. ArgoCD component cleanup
+
+- [x] 1.1 Disable dex-server in `k8s/namespaces/argocd/base/values.yaml` (`dex.enabled: false`)
+- [x] 1.2 Disable notifications-controller in `k8s/namespaces/argocd/base/values.yaml` (`notifications.enabled: false`)
+- [x] 1.3 Remove dex and notifications resource blocks from `values.yaml` (requests/limits no longer needed)
+
+## 2. ArgoCD resource right-sizing
+
+- [x] 2.1 Update `k8s/namespaces/argocd/base/values.yaml` resource requests/limits for remaining components: controller (50m/128Mi), repoServer (50m/64Mi), server (50m/64Mi), redis (50m/52Mi), redisSecretInit (50m/52Mi), applicationSet (50m/64Mi)
+- [x] 2.2 Verify rendered manifests with `kubectl kustomize --enable-helm k8s/namespaces/argocd/overlays/dev`
+
+## 3. Backend optimization
+
+- [x] 3.1 Add replicas patch to `k8s/namespaces/backend/overlays/dev/kustomization.yaml` to set server-app replicas to 1
+- [x] 3.2 Add resource request/limit patch for server-app in dev overlay (50m CPU / 64Mi memory request)
+- [x] 3.3 Add Spot VM nodeSelector patch targeting `kind: CronJob` in `k8s/namespaces/backend/overlays/dev/kustomization.yaml`
+- [x] 3.4 Verify rendered manifests with `kubectl kustomize k8s/namespaces/backend/overlays/dev`
+
+## 4. External Secrets resource right-sizing
+
+- [x] 4.1 Update `k8s/namespaces/external-secrets/base/values.yaml` resource requests/limits: controller (50m/64Mi), webhook (50m/52Mi), certController (50m/52Mi)
+- [x] 4.2 Verify rendered manifests with `kubectl kustomize --enable-helm k8s/namespaces/external-secrets/overlays/dev`
+
+## 5. Frontend resource right-sizing
+
+- [x] 5.1 Add resource request/limit patch for web-app in `k8s/namespaces/frontend/overlays/dev` (50m CPU / 52Mi memory request)
+- [x] 5.2 Verify rendered manifests with `kubectl kustomize k8s/namespaces/frontend/overlays/dev`
+
+## 6. Reloader resource right-sizing
+
+- [x] 6.1 Update `k8s/namespaces/reloader/base/values.yaml` resource requests/limits (50m CPU / 64Mi memory request)
+- [x] 6.2 Verify rendered manifests with `kubectl kustomize --enable-helm k8s/namespaces/reloader/overlays/dev`
+
+## 7. Final validation
+
+- [x] 7.1 Run kustomize dry-run for all dev overlays and confirm no errors
+- [x] 7.2 Verify all workloads have Spot VM nodeSelector in rendered output

--- a/openspec/specs/continuous-delivery/spec.md
+++ b/openspec/specs/continuous-delivery/spec.md
@@ -8,12 +8,18 @@ Defines the mechanism for GitOps-based continuous delivery using ArgoCD.
 
 ### Requirement: ArgoCD Manifests
 
-The system SHALL provide Kustomize-based manifests for installing ArgoCD.
+The system SHALL provide Kustomize-based manifests for installing ArgoCD. The ArgoCD deployment SHALL NOT include the dex-server or notifications-controller components, as SSO and notification features are not in use.
 
 #### Scenario: Manifest Availability
 
 - **WHEN** checking the `src/k8s` directory
 - **THEN** a `argocd` directory exists with a valid `kustomization.yaml`
+
+#### Scenario: Unused components are disabled
+
+- **WHEN** rendering the ArgoCD base manifests
+- **THEN** dex-server SHALL NOT be deployed (dex.enabled: false)
+- **AND** notifications-controller SHALL NOT be deployed (notifications.enabled: false)
 
 ### Requirement: Internal Web UI Access
 

--- a/openspec/specs/deployment-infrastructure/spec.md
+++ b/openspec/specs/deployment-infrastructure/spec.md
@@ -94,3 +94,26 @@ The cluster SHALL support dedicated namespaces for Continuous Delivery tooling a
 
 - **WHEN** listing namespaces
 - **THEN** a namespace named `external-secrets` is present for the ESO controller
+
+### Requirement: Dev backend runs single replica
+
+The backend server deployment in the dev environment SHALL run with 1 replica. Production and staging environments retain their default replica count.
+
+#### Scenario: Dev backend replica count
+
+- **WHEN** rendering the backend dev overlay manifests
+- **THEN** the server-app Deployment SHALL have replicas set to 1
+
+### Requirement: All dev workload kinds use Spot VM scheduling
+
+Every workload in the dev environment — including Deployments, StatefulSets, and CronJobs — SHALL include the Spot VM nodeSelector (`cloud.google.com/compute-class: autopilot-spot`).
+
+#### Scenario: CronJob Spot VM coverage
+
+- **WHEN** rendering the backend dev overlay manifests
+- **THEN** the concert-discovery CronJob pod template SHALL include nodeSelector `cloud.google.com/compute-class: autopilot-spot`
+
+#### Scenario: All dev workloads on Spot VMs
+
+- **WHEN** running `kubectl get pods -A -o json` on the dev cluster
+- **THEN** every pod SHALL be scheduled on nodes with compute class `autopilot-spot`

--- a/openspec/specs/k8s-resource-right-sizing/spec.md
+++ b/openspec/specs/k8s-resource-right-sizing/spec.md
@@ -1,0 +1,50 @@
+# k8s-resource-right-sizing Specification
+
+## Purpose
+
+Defines the resource request and limit policies for all Kubernetes workloads in the dev environment, targeting GKE Autopilot with Bursting support (v1.29+).
+
+## Requirements
+
+### Requirement: Dev environment resource requests use Autopilot Bursting minimums
+
+All dev environment workloads with observed CPU usage below 50m SHALL set CPU request to 50m (GKE Autopilot Bursting minimum). Memory requests SHALL be set to 1.5-2x of observed peak usage, with a floor of 52MiB.
+
+#### Scenario: ArgoCD components resource requests
+
+- **WHEN** rendering the ArgoCD dev overlay manifests
+- **THEN** all ArgoCD container CPU requests SHALL be 50m
+- **AND** application-controller memory request SHALL be 128MiB
+- **AND** repo-server, server, applicationset-controller memory requests SHALL be 64MiB
+- **AND** redis, redisSecretInit memory requests SHALL be 52MiB
+
+#### Scenario: External Secrets components resource requests
+
+- **WHEN** rendering the external-secrets dev overlay manifests
+- **THEN** controller CPU request SHALL be 50m with memory request of 64MiB
+- **AND** webhook and cert-controller CPU requests SHALL be 50m with memory requests of 52MiB
+
+#### Scenario: Backend server resource requests
+
+- **WHEN** rendering the backend dev overlay manifests
+- **THEN** server-app CPU request SHALL be 50m with memory request of 64MiB
+
+#### Scenario: Frontend web-app resource requests
+
+- **WHEN** rendering the frontend dev overlay manifests
+- **THEN** web-app CPU request SHALL be 50m with memory request of 52MiB
+
+#### Scenario: Reloader resource requests
+
+- **WHEN** rendering the reloader dev overlay manifests
+- **THEN** reloader CPU request SHALL be 50m with memory request of 64MiB
+
+### Requirement: Resource limits provide burst headroom
+
+All dev environment workloads SHALL have CPU limits set to 2-10x of request and memory limits set to 2-4x of request, providing headroom for burst usage without excessive reservation.
+
+#### Scenario: Limits do not exceed original allocation
+
+- **WHEN** rendering any dev overlay manifest
+- **THEN** no container CPU limit SHALL exceed 500m
+- **AND** no container memory limit SHALL exceed 512MiB


### PR DESCRIPTION
## 🔗 Related Issue

Closes #86

## 📝 Summary of Changes

Syncs delta specs from the `optimize-k8s-dev-resources` change to main specs and archives the completed change.

**Main specs updated:**

- **continuous-delivery**: Updated `ArgoCD Manifests` requirement to specify that dex-server and notifications-controller SHALL NOT be deployed, with a new "Unused components are disabled" scenario
- **deployment-infrastructure**: Added two new requirements — dev backend single replica (replicas=1) and Spot VM scheduling for all dev workload kinds including CronJobs
- **k8s-resource-right-sizing** (new): Created spec defining Autopilot Bursting minimum resource requests (50m CPU / 52MiB memory floor) and burst headroom limits for all dev workloads

**Archived:** `openspec/changes/archive/2026-02-22-optimize-k8s-dev-resources/`
- 17/17 tasks complete
- 4/4 artifacts complete (proposal, design, specs, tasks)

## ✅ Self-Checklist

- [x] I have linked the related issue.
- [x] I have updated the relevant documentation (e.g., `README.md`) if needed.
- [ ] I have run `buf lint` and `buf format` locally and all checks have passed.
- [ ] My proto definitions follow the project's style guidelines and validation rules.
- [ ] Breaking changes have been justified and documented if applicable.