### PR TITLE
docs(openspec): add 5 UX navigation changes

### DIFF
--- a/openspec/changes/bottom-navigation-shell/design.md
+++ b/openspec/changes/bottom-navigation-shell/design.md
@@ -1,0 +1,56 @@
+# Design: Bottom Navigation Shell
+
+## Architecture
+
+```
+┌─────────────────────────────────────┐
+│           Route Content             │
+│                                     │
+│   /dashboard  → DashboardPage       │
+│   /discover   → DiscoverPage (stub) │
+│   /my-artists → MyArtistsPage (stub)│
+│   /settings   → SettingsPage (stub) │
+│                                     │
+├─────────────────────────────────────┤
+│  [🏠 Home] [🔍 Discover] [🎸 My Artists] [⚙️ Settings]  │
+│           Bottom Navigation Bar     │
+└─────────────────────────────────────┘
+```
+
+## Component Structure
+
+### BottomNavBar Component
+
+- Fixed to bottom of viewport (`position: fixed; bottom: 0`)
+- 4 equally spaced tab items
+- Each item: icon + label text
+- Active state: accent color highlight, inactive: muted color
+- Safe area padding for devices with home indicator (iOS)
+- Z-index above page content, below modals/bottom sheets
+- Dark themed, consistent with design system
+
+### Conditional Visibility
+
+Reuse the existing conditional navigation logic from `app-shell-layout`:
+- **Hidden**: Landing Page, Artist Discovery, Loading Sequence (onboarding flow)
+- **Visible**: Dashboard and all post-onboarding routes
+
+### Routing
+
+- Tab switches trigger route navigation (not just component swap)
+- URL reflects current tab for deep linking and browser back support
+- Default route after onboarding: `/dashboard` (Home tab)
+
+## Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Navigation type | Bottom Tab Bar | Mobile-first PWA, thumb-reachable, modern standard |
+| Top nav bar | Remove or repurpose as header | Bottom nav replaces primary navigation role |
+| Tab switching | Route-based | Enables deep linking, browser history, shareable URLs |
+| Stub pages | Minimal placeholder with tab title | Allows parallel development of tab content |
+
+## Risks
+
+- **Layout shift**: Adding fixed bottom bar reduces available content height. Dashboard layout may need minor padding adjustment at bottom.
+- **Existing top nav**: Need to coordinate removal/simplification of existing top navigation to avoid duplicate navigation patterns.

--- a/openspec/changes/bottom-navigation-shell/proposal.md
+++ b/openspec/changes/bottom-navigation-shell/proposal.md
@@ -1,0 +1,47 @@
+# Proposal: Bottom Navigation Shell
+
+## Problem
+
+The Liverty Music PWA currently uses a top navigation bar with conditional display logic (hidden during onboarding, shown on dashboard). As the app grows beyond the single-page dashboard into multiple primary screens (Discover, My Artists, Settings), the top navigation pattern does not scale. Mobile UX best practices dictate that primary navigation should use a bottom tab bar for thumb-reachable, always-visible access.
+
+## Solution
+
+Replace the current top navigation approach with a **Bottom Navigation Bar (Tab Bar)** as the primary navigation structure. This change creates the shell infrastructure—the tab bar component, routing integration, and placeholder content for each tab—without implementing the full content of each tab.
+
+### Tabs
+
+1. **Home** — Routes to the existing Live Highway Dashboard
+2. **Discover** — Placeholder (implemented in a separate change)
+3. **My Artists** — Placeholder (implemented in a separate change)
+4. **Settings** — Placeholder (implemented in a separate change)
+
+## Scope
+
+### In Scope
+
+- Bottom Navigation Bar component with 4 tabs
+- Route configuration for each tab
+- Active tab state indication
+- Tab bar hidden during onboarding routes (Landing, Artist Discovery, Loading Sequence)
+- Tab bar visible on all post-onboarding routes
+- Mobile-first responsive design
+
+### Out of Scope
+
+- Full content for Discover, My Artists, Settings tabs (separate changes)
+- Mutation UI on Dashboard (separate change: passion-level)
+- Any backend changes
+
+## Impact
+
+- Modifies: `app-shell-layout` spec (navigation changes from top bar to bottom tab bar)
+- New routes: `/discover`, `/my-artists`, `/settings`
+- Existing Dashboard route remains at `/dashboard`
+
+## Dependencies
+
+- None (this is the foundation change)
+
+## Blocked By
+
+- Nothing

--- a/openspec/changes/bottom-navigation-shell/specs/app-shell-layout/spec.md
+++ b/openspec/changes/bottom-navigation-shell/specs/app-shell-layout/spec.md
@@ -1,0 +1,48 @@
+# App Shell Layout (Delta)
+
+## Changed Requirements
+
+### Requirement: Bottom Navigation Bar
+The system SHALL use a Bottom Navigation Bar as the primary navigation structure for post-onboarding routes.
+
+#### Scenario: Tab bar layout
+- **WHEN** the user is on any post-onboarding route
+- **THEN** the system SHALL display a fixed Bottom Navigation Bar at the bottom of the viewport
+- **AND** the bar SHALL contain exactly 4 tabs: Home, Discover, My Artists, Settings
+- **AND** each tab SHALL display an icon and a text label
+- **AND** the bar SHALL use the dark surface palette from the design system
+
+#### Scenario: Active tab indication
+- **WHEN** a tab corresponds to the current route
+- **THEN** the tab icon and label SHALL be highlighted using the brand accent color
+- **AND** all other tabs SHALL use a muted/secondary color
+
+#### Scenario: Tab navigation
+- **WHEN** a user taps a tab
+- **THEN** the system SHALL navigate to the corresponding route
+- **AND** the URL SHALL update to reflect the active tab (e.g., `/dashboard`, `/discover`, `/my-artists`, `/settings`)
+- **AND** browser back/forward navigation SHALL work correctly between tabs
+
+#### Scenario: Safe area handling
+- **WHEN** the device has a home indicator or system gesture bar (e.g., iPhone with notch)
+- **THEN** the Bottom Navigation Bar SHALL include appropriate safe area padding at the bottom
+
+---
+
+### Requirement: Tab bar conditional visibility
+The system SHALL hide the Bottom Navigation Bar during onboarding flows.
+
+#### Scenario: Tab bar hidden during onboarding
+- **WHEN** the user is on the Landing Page, Artist Discovery, or Loading Sequence routes
+- **THEN** the system SHALL NOT display the Bottom Navigation Bar
+
+#### Scenario: Tab bar visible after onboarding
+- **WHEN** the user is on the Dashboard or any post-onboarding route
+- **THEN** the system SHALL display the Bottom Navigation Bar
+
+---
+
+### Removed Requirements
+
+- **Conditional Navigation Display** (top navigation bar): Replaced by Bottom Navigation Bar. The top navigation bar is no longer the primary navigation element.
+- **Auth Status UI Redesign** (sign-out in top nav): Sign-out moves to Settings tab.

--- a/openspec/changes/bottom-navigation-shell/tasks.md
+++ b/openspec/changes/bottom-navigation-shell/tasks.md
@@ -1,0 +1,12 @@
+# Tasks: Bottom Navigation Shell
+
+## Tasks
+
+- [ ] Create BottomNavBar component (icon + label for each of 4 tabs, dark themed)
+- [ ] Add route configuration for `/discover`, `/my-artists`, `/settings`
+- [ ] Create stub pages for Discover, MyArtists, Settings (minimal placeholder content)
+- [ ] Integrate BottomNavBar into app shell with conditional visibility (hidden during onboarding)
+- [ ] Remove or simplify existing top navigation bar (move sign-out to Settings stub)
+- [ ] Add bottom padding to Dashboard content to prevent overlap with fixed tab bar
+- [ ] Add safe area padding for devices with home indicator
+- [ ] Verify tab switching updates URL and browser history works correctly

--- a/openspec/changes/discover-page/design.md
+++ b/openspec/changes/discover-page/design.md
@@ -67,6 +67,22 @@ Search mode: Keyboard up, list results, bubbles hidden
 Back to Bubble UI mode
 ```
 
+## API Dependencies
+
+Genre filtering requires extending the existing `ListTopRequest` protobuf:
+
+```protobuf
+message ListTopRequest {
+  // ... existing fields ...
+
+  // Optional. Filter top artists by genre/tag (e.g., "rock", "pop", "anime").
+  // When empty, returns top artists across all genres.
+  string tag = 2;
+}
+```
+
+> **Note**: This schema change must be added to the specification repo and released via BSR before the Discover page can implement genre chips.
+
 ## Decisions
 
 | Decision | Choice | Rationale |

--- a/openspec/changes/discover-page/design.md
+++ b/openspec/changes/discover-page/design.md
@@ -77,7 +77,7 @@ message ListTopRequest {
 
   // Optional. Filter top artists by genre/tag (e.g., "rock", "pop", "anime").
   // When empty, returns top artists across all genres.
-  string tag = 2;
+  string tag = 2 [(buf.validate.field).string.max_len = 50];
 }
 ```
 

--- a/openspec/changes/discover-page/design.md
+++ b/openspec/changes/discover-page/design.md
@@ -1,0 +1,98 @@
+# Design: Discover Page
+
+## UI Structure
+
+```
+┌─────────────────────────────────┐
+│  🔍 Discover                    │
+├─────────────────────────────────┤
+│  [🔎 Search artists...       ] │  ← search bar
+│                                 │
+│  [Rock] [Pop] [Anime] [Jazz]   │  ← genre chips
+│  [Electronic] [Hip-Hop] ...    │
+│                                 │
+│      ┌───┐                     │
+│    ┌───┐ ┌───┐                 │
+│  ┌───┐     ┌───┐ ┌───┐        │
+│    ┌───┐ ┌───┐   ┌───┐        │  ← floating bubbles
+│  ┌───┐     ┌───┐               │
+│      ┌───┐   ┌───┐             │
+│                                 │
+│         ┌──────────┐           │
+│         │ Music DNA│           │  ← DNA Orb
+│         │  (orb)   │           │
+│         └──────────┘           │
+│                                 │
+├─────────────────────────────────┤
+│  [🏠] [🔍] [🎸] [⚙️]           │
+└─────────────────────────────────┘
+```
+
+## Search Mode
+
+```
+┌─────────────────────────────────┐
+│  🔍 Discover                    │
+├─────────────────────────────────┤
+│  [🔎 "BUMP OF CHICKEN"    ✕  ] │  ← active search
+│                                 │
+│  Search Results:                │
+│  ┌─────────────────────────┐   │
+│  │ ■ BUMP OF CHICKEN  [+]  │   │  ← tap to follow
+│  ├─────────────────────────┤   │
+│  │ ■ BUMP (similar)    [+]  │   │
+│  └─────────────────────────┘   │
+│                                 │
+│  Tap [+] triggers DNA Orb      │
+│  absorption animation           │
+│                                 │
+├─────────────────────────────────┤
+│  [🏠] [🔍] [🎸] [⚙️]           │
+└─────────────────────────────────┘
+```
+
+## Mode Switching
+
+```
+Default state: Bubble UI mode (fullscreen bubbles + genre chips)
+                    │
+         User taps search bar
+                    │
+                    ▼
+Search mode: Keyboard up, list results, bubbles hidden
+                    │
+         User clears search / taps ✕
+                    │
+                    ▼
+Back to Bubble UI mode
+```
+
+## Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Default mode | Bubble UI (not search) | Discovery is exploratory; search is targeted |
+| Bubble UI source | Reuse onboarding ArtistDiscovery component | DRY; same physics engine, animations, and orb |
+| Genre chips | Top-level filter, regenerates bubbles | Quick mood-based exploration |
+| Search results | Simple list (not bubbles) | Per UX spec; search is utilitarian |
+| Follow from search | Same DNA Orb absorption effect | Consistent follow UX across app |
+| Already-followed indicator | Dimmed or checkmark on bubble/row | Prevent confusion on re-follow |
+
+## Component Reuse
+
+The key insight is reusing the `ArtistDiscovery` component from onboarding:
+
+```
+Onboarding flow          Discover tab
+     │                        │
+     └── ArtistDiscovery ─────┘  (shared component)
+              │
+         Differences:
+         - Onboarding: auto-load top artists, has "View Schedule" CTA
+         - Discover: genre chips filter, no completion CTA, search bar overlay
+```
+
+## Risks
+
+- **Component adaptation**: The onboarding ArtistDiscovery component was built for a one-time flow. Extracting it for reuse may require refactoring its lifecycle and state management.
+- **Performance**: Running physics-based bubbles on a tab that users might switch to frequently. Need to pause/resume physics when tab is not active.

--- a/openspec/changes/discover-page/proposal.md
+++ b/openspec/changes/discover-page/proposal.md
@@ -1,0 +1,41 @@
+# Proposal: Discover Page
+
+## Problem
+
+After onboarding, users have no way to discover and follow new artists. The Bubble UI experience from onboarding is a one-time interaction. Users who want to explore new genres, find specific artists, or simply browse for inspiration have no dedicated space to do so.
+
+## Solution
+
+Implement the **Discover page** (Tab 2) with two modes:
+
+1. **Bubble UI (Re-experience)** — Reuse the onboarding DNA Orb Bubble UI in a fullscreen mode with genre/tag switching chips at the top. Users can re-experience the gamified discovery anytime.
+2. **Manual Search** — A text search bar (using existing artist search capabilities) for targeted artist lookup. Results displayed as a simple list with tap-to-follow using the same DNA Orb absorption effect.
+
+## Scope
+
+### In Scope
+
+- Discover page with Bubble UI re-experience mode
+- Genre/tag chips for filtering bubble content (Rock, Pop, Anime, etc.)
+- Manual text search bar
+- Search results as a list with follow action
+- Integration with existing ArtistService RPCs (ListTop, ListSimilar, Follow)
+
+### Out of Scope
+
+- New backend search API (reuses existing `artist.search` via Last.fm)
+- Recommendation algorithm changes
+- Social discovery (friend-based recommendations)
+
+## Impact
+
+- New spec: `discover`
+- Reuses: `artist-discovery-dna-orb-ui` spec (Bubble UI components)
+
+## Dependencies
+
+- `bottom-navigation-shell` (route `/discover` and tab must exist)
+
+## Blocked By
+
+- `bottom-navigation-shell`

--- a/openspec/changes/discover-page/specs/discover/spec.md
+++ b/openspec/changes/discover-page/specs/discover/spec.md
@@ -1,0 +1,65 @@
+# Discover
+
+## Purpose
+
+Provides a dedicated space for users to discover and follow new artists after onboarding. Combines the gamified Bubble UI experience with a targeted text search, both accessible anytime via the Discover tab.
+
+## Requirements
+
+### Requirement: Bubble UI Re-experience
+The system SHALL provide the onboarding Bubble UI as a reusable discovery experience on the Discover tab.
+
+#### Scenario: Default Bubble UI display
+- **WHEN** the Discover tab is opened
+- **THEN** the system SHALL display the physics-based artist Bubble UI (same as onboarding)
+- **AND** the DNA Orb SHALL be displayed at the bottom
+- **AND** tapping a bubble SHALL trigger the absorption animation and call `ArtistService.Follow`
+
+#### Scenario: Genre filtering
+- **WHEN** the Bubble UI is displayed
+- **THEN** genre/tag chips SHALL be displayed above the bubble area (e.g., Rock, Pop, Anime, Jazz, Electronic, Hip-Hop)
+- **AND** tapping a genre chip SHALL regenerate bubbles with artists from that genre
+- **AND** the active genre chip SHALL be visually highlighted
+
+#### Scenario: Already-followed artists
+- **WHEN** an artist bubble represents an already-followed artist
+- **THEN** the bubble SHALL be visually distinguished (e.g., dimmed, checkmark overlay)
+- **AND** tapping it SHALL NOT trigger a duplicate follow action
+
+---
+
+### Requirement: Manual Search
+The system SHALL provide a text search for targeted artist discovery.
+
+#### Scenario: Search bar display
+- **WHEN** the Discover tab is opened
+- **THEN** a search bar SHALL be displayed at the top of the screen
+
+#### Scenario: Entering search mode
+- **WHEN** a user taps the search bar and begins typing
+- **THEN** the Bubble UI SHALL be hidden
+- **AND** search results SHALL appear as a vertical list below the search bar
+
+#### Scenario: Search results
+- **WHEN** search results are displayed
+- **THEN** each result SHALL show the artist name with a follow action button
+- **AND** tapping the follow button SHALL trigger the DNA Orb absorption effect
+- **AND** already-followed artists SHALL show a followed indicator instead of a follow button
+
+#### Scenario: Exiting search mode
+- **WHEN** a user clears the search text or taps the clear button
+- **THEN** the search results SHALL be hidden
+- **AND** the Bubble UI SHALL be restored
+
+---
+
+### Requirement: Performance on Tab Switch
+The system SHALL manage Bubble UI resources efficiently when the tab is not active.
+
+#### Scenario: Tab deactivation
+- **WHEN** the user navigates away from the Discover tab
+- **THEN** the physics simulation SHALL be paused to conserve resources
+
+#### Scenario: Tab reactivation
+- **WHEN** the user returns to the Discover tab
+- **THEN** the physics simulation SHALL resume from its paused state

--- a/openspec/changes/discover-page/tasks.md
+++ b/openspec/changes/discover-page/tasks.md
@@ -1,0 +1,22 @@
+# Tasks: Discover Page
+
+## Tasks
+
+### Bubble UI Re-experience
+- [ ] Extract/refactor ArtistDiscovery component from onboarding for reuse on Discover tab
+- [ ] Create DiscoverPage component hosting the Bubble UI and search bar
+- [ ] Implement genre/tag chips above bubble area
+- [ ] Implement genre selection to regenerate bubbles via ArtistService.ListTop with tag filter
+- [ ] Add visual indicator for already-followed artists in bubbles (dimmed/checkmark)
+- [ ] Implement physics pause/resume on tab activation/deactivation
+
+### Manual Search
+- [ ] Add search bar at top of Discover page
+- [ ] Implement search mode toggle (hide bubbles, show list results)
+- [ ] Integrate artist search API (Last.fm artist.search or existing backend)
+- [ ] Display search results as a list with follow action button
+- [ ] Apply DNA Orb absorption effect on follow from search results
+- [ ] Show followed indicator for already-followed artists in search results
+
+### Integration
+- [ ] Replace Discover stub page from bottom-navigation-shell with full implementation

--- a/openspec/changes/my-artists-list/design.md
+++ b/openspec/changes/my-artists-list/design.md
@@ -1,0 +1,76 @@
+# Design: My Artists List
+
+## UI Structure
+
+```
+┌─────────────────────────────────┐
+│  🎸 My Artists          (12)    │
+├─────────────────────────────────┤
+│                                 │
+│  ┌─────────────────────────┐   │
+│  │ ■ RADWIMPS              │   │  ← color accent from name
+│  ├─────────────────────────┤   │
+│  │ ■ ONE OK ROCK           │   │
+│  ├─────────────────────────┤   │
+│  │ ■ Aimer                 │   │
+│  ├─────────────────────────┤   │
+│  │ ■ King Gnu              │   │
+│  ├─────────────────────────┤   │
+│  │ ■ YOASOBI               │   │
+│  └─────────────────────────┘   │
+│         ...                     │
+│                                 │
+├─────────────────────────────────┤
+│  [🏠] [🔍] [🎸] [⚙️]           │
+└─────────────────────────────────┘
+```
+
+## Swipe-to-Unfollow
+
+```
+Normal state:
+┌─────────────────────────────┐
+│ ■ RADWIMPS                  │
+└─────────────────────────────┘
+
+Swiped left:
+┌──────────────────────┐┌─────┐
+│ ■ RADWIMPS           ││ ✕   │  ← red delete zone
+└──────────────────────┘└─────┘
+
+After unfollow (bottom toast):
+┌─────────────────────────────┐
+│ "RADWIMPS unfollowed"  [Undo]│
+└─────────────────────────────┘
+  ↑ auto-dismiss after 5 seconds
+```
+
+## Data Flow
+
+```
+MyArtistsPage
+  │
+  ├── on mount → ArtistService.ListFollowed() → populate list
+  │
+  └── on swipe/unfollow
+        ├── remove from local list immediately (optimistic)
+        ├── show Undo toast (5 sec timer)
+        │     ├── if Undo tapped → re-add to list, cancel RPC
+        │     └── if timer expires → ArtistService.Unfollow(artistId)
+        └── done
+```
+
+## Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| View mode | List only (no grid/festival) | MVP simplicity; grid view is post-MVP |
+| Unfollow UX | Swipe + Undo toast | Frictionless, no confirmation dialog (per UX spec) |
+| Unfollow timing | Delayed RPC (after undo window) | Allows recovery without extra API calls |
+| Color accent | Reuse Dashboard's deterministic HSL algorithm | Visual consistency across app |
+| Empty state | Friendly message + link to Discover tab | Guide users to follow artists |
+
+## Risks
+
+- **Swipe gesture conflicts**: Bottom sheet or other swipeable elements on the page could conflict. Since this page has no bottom sheets, risk is low.
+- **Long lists**: If a user follows hundreds of artists, virtualized list rendering may be needed. For MVP with typical follow counts (10-50), standard rendering suffices.

--- a/openspec/changes/my-artists-list/proposal.md
+++ b/openspec/changes/my-artists-list/proposal.md
@@ -1,0 +1,40 @@
+# Proposal: My Artists List
+
+## Problem
+
+After onboarding, users have no way to view or manage their followed artists. The only interaction point is the Bubble UI during onboarding. Users need to see who they follow and be able to unfollow artists they are no longer interested in.
+
+## Solution
+
+Implement the **My Artists page** (Tab 3) with a list view showing all followed artists and swipe-to-unfollow functionality. The unfollow action uses a frictionless Undo toast pattern instead of a confirmation dialog.
+
+## Scope
+
+### In Scope
+
+- My Artists page with vertical list of followed artists
+- Each row: artist name (+ optional dynamically generated color accent)
+- Unfollow via swipe-left gesture or long-press
+- Undo toast (no confirmation dialog) for accidental unfollow recovery
+- Call existing `ArtistService.Unfollow` RPC
+- Call existing `ArtistService.ListFollowed` RPC to populate the list
+
+### Out of Scope
+
+- Passion Level (heat/enthusiasm) selector per artist (separate change: `passion-level`)
+- Grid/Festival view toggle (post-MVP)
+- Artist detail page
+- Any new backend API (uses existing RPCs)
+
+## Impact
+
+- New spec: `my-artists`
+- Uses existing: `artist-following` spec (ListFollowed, Unfollow RPCs)
+
+## Dependencies
+
+- `bottom-navigation-shell` (route `/my-artists` and tab must exist)
+
+## Blocked By
+
+- `bottom-navigation-shell`

--- a/openspec/changes/my-artists-list/specs/my-artists/spec.md
+++ b/openspec/changes/my-artists-list/specs/my-artists/spec.md
@@ -1,0 +1,55 @@
+# My Artists
+
+## Purpose
+
+Provides users with a view of all followed artists and the ability to manage (unfollow) them. This is the primary artist management screen, accessible via the My Artists tab in the Bottom Navigation Bar.
+
+## Requirements
+
+### Requirement: Followed Artists List
+The system SHALL display a list of all artists the user currently follows.
+
+#### Scenario: List population
+- **WHEN** the My Artists page is opened
+- **THEN** the system SHALL call `ArtistService.ListFollowed` to retrieve the user's followed artists
+- **AND** the system SHALL display each artist as a row in a vertical list
+- **AND** each row SHALL show the artist name with a color accent derived from the artist name (same algorithm as Dashboard cards)
+
+#### Scenario: Empty state
+- **WHEN** the user has no followed artists
+- **THEN** the system SHALL display a friendly empty state message (e.g., "No artists followed yet")
+- **AND** the system SHALL provide a call-to-action linking to the Discover tab
+
+#### Scenario: Artist count
+- **WHEN** the list contains followed artists
+- **THEN** the page header SHALL display the total count of followed artists
+
+---
+
+### Requirement: Unfollow with Undo
+The system SHALL allow users to unfollow artists with a frictionless, recoverable interaction.
+
+#### Scenario: Swipe to unfollow
+- **WHEN** a user swipes left on an artist row
+- **THEN** the system SHALL reveal an unfollow (delete) action zone
+- **AND** completing the swipe SHALL remove the artist from the visible list immediately (optimistic removal)
+
+#### Scenario: Long-press to unfollow (alternative)
+- **WHEN** a user long-presses on an artist row
+- **THEN** the system SHALL reveal an unfollow action button or menu
+
+#### Scenario: Undo toast
+- **WHEN** an artist is unfollowed
+- **THEN** the system SHALL display a toast notification at the bottom of the screen
+- **AND** the toast SHALL show "[Artist Name] unfollowed" with an "Undo" action button
+- **AND** the toast SHALL auto-dismiss after 5 seconds
+- **AND** the system SHALL NOT show a confirmation dialog before unfollowing
+
+#### Scenario: Undo action
+- **WHEN** a user taps "Undo" on the toast before it dismisses
+- **THEN** the system SHALL re-add the artist to the list in its original position
+- **AND** the system SHALL cancel the pending unfollow RPC call
+
+#### Scenario: Unfollow committed
+- **WHEN** the undo toast dismisses without user interaction (5 seconds elapsed)
+- **THEN** the system SHALL call `ArtistService.Unfollow` with the artist's ID to persist the removal

--- a/openspec/changes/my-artists-list/tasks.md
+++ b/openspec/changes/my-artists-list/tasks.md
@@ -1,0 +1,14 @@
+# Tasks: My Artists List
+
+## Tasks
+
+- [ ] Create MyArtistsPage component with header showing artist count
+- [ ] Integrate ArtistService.ListFollowed RPC to populate artist list on mount
+- [ ] Implement artist list rows with name and color accent (reuse Dashboard's HSL algorithm)
+- [ ] Implement swipe-left gesture to reveal unfollow action
+- [ ] Implement long-press alternative for unfollow
+- [ ] Create UndoToast component (message + Undo button, 5-sec auto-dismiss)
+- [ ] Implement optimistic removal with delayed ArtistService.Unfollow RPC
+- [ ] Implement Undo action (re-add artist, cancel pending RPC)
+- [ ] Create empty state UI with link to Discover tab
+- [ ] Replace My Artists stub page from bottom-navigation-shell with full implementation

--- a/openspec/changes/passion-level/design.md
+++ b/openspec/changes/passion-level/design.md
@@ -9,6 +9,10 @@ followed_artists table (existing)
 ```
 
 ```protobuf
+// Package: liverty_music.entity.v1
+// PassionLevel is defined in the entity package alongside Artist,
+// and referenced as entity.v1.PassionLevel in RPC definitions.
+
 // PassionLevel represents the user's enthusiasm tier for a followed artist.
 // It determines dashboard visibility and notification behavior.
 enum PassionLevel {
@@ -80,14 +84,26 @@ message SetPassionLevelRequest {
   entity.v1.ArtistId artist_id = 1 [(buf.validate.field).required = true];
 
   // Required. The new passion level tier.
-  PassionLevel passion_level = 2 [(buf.validate.field).required = true];
+  entity.v1.PassionLevel passion_level = 2 [
+    (buf.validate.field).required = true,
+    (buf.validate.field).enum.defined_only = true
+  ];
 }
 
 // SetPassionLevelResponse is returned upon a successful update.
 message SetPassionLevelResponse {}
 ```
 
-The passion level is returned as part of the followed artist data in `ListFollowed`.
+The passion level is returned as part of the followed artist data in `ListFollowed`. The `FollowedArtist` response message is extended as follows:
+
+```protobuf
+message FollowedArtist {
+  // ... existing fields ...
+
+  // The user's passion level for this artist.
+  entity.v1.PassionLevel passion_level = 4;
+}
+```
 
 ## Decisions
 

--- a/openspec/changes/passion-level/design.md
+++ b/openspec/changes/passion-level/design.md
@@ -1,0 +1,94 @@
+# Design: Passion Level
+
+## Data Model
+
+```
+followed_artists table (existing)
+  + passion_level: TEXT  (default: 'local_only')
+    enum values: 'must_go', 'local_only', 'keep_an_eye'
+```
+
+```protobuf
+enum PassionLevel {
+  PASSION_LEVEL_UNSPECIFIED = 0;
+  PASSION_LEVEL_MUST_GO = 1;      // 🔥🔥 Travel anywhere
+  PASSION_LEVEL_LOCAL_ONLY = 2;    // 🔥 Default
+  PASSION_LEVEL_KEEP_AN_EYE = 3;  // 👀 No push notifications
+}
+```
+
+## My Artists Page — Passion Selector
+
+```
+┌─────────────────────────────────┐
+│  🎸 My Artists          (12)    │
+├─────────────────────────────────┤
+│                                 │
+│  ┌─────────────────────────┐   │
+│  │ ■ RADWIMPS      [🔥🔥 ▼]│   │  ← tappable selector
+│  ├─────────────────────────┤   │
+│  │ ■ ONE OK ROCK   [🔥  ▼] │   │
+│  ├─────────────────────────┤   │
+│  │ ■ Aimer         [👀  ▼] │   │
+│  └─────────────────────────┘   │
+│                                 │
+│  Selector dropdown:             │
+│  ┌─────────────────┐           │
+│  │ 🔥🔥 Must Go     │           │
+│  │ 🔥  Local Only   │           │
+│  │ 👀  Keep an Eye  │           │
+│  └─────────────────┘           │
+└─────────────────────────────────┘
+```
+
+## Dashboard — Visual Mutation UI
+
+When a Must Go (🔥🔥) artist's event appears in Lane 2 or Lane 3:
+
+```
+Normal Lane 2/3 card:        Mutated card (Must Go):
+┌──────────┐                 ┌──────────────────┐
+│ Artist   │                 │ 🔥 遠征チャンス    │  ← badge
+│ 福岡     │                 │                    │
+└──────────┘                 │  RADWIMPS          │  ← mega typography
+                             │  福岡              │
+                             │                    │
+                             └──────────────────────┘
+                               ↑ expanded size
+                               ↑ vivid accent color / stripe pattern
+```
+
+### Mutation Rules
+
+| Condition | Lane 1 | Lane 2 | Lane 3 |
+|-----------|--------|--------|--------|
+| Must Go 🔥🔥 | Normal (already prominent) | **MUTATE** — expand + badge | **MUTATE** — expand + badge |
+| Local Only 🔥 | Normal | Normal | Normal (compact) |
+| Keep an Eye 👀 | Normal | Normal | Normal (compact) |
+
+## API Design
+
+```
+rpc SetPassionLevel(SetPassionLevelRequest) returns (SetPassionLevelResponse);
+
+message SetPassionLevelRequest {
+  ArtistId artist_id = 1;
+  PassionLevel passion_level = 2;
+}
+```
+
+The passion level is returned as part of the followed artist data in `ListFollowed`.
+
+## Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Default level | Local Only (🔥) | Non-intrusive default; user opts in to more notifications |
+| Persistence | Backend (DB column) | Syncs across devices, used by notification system |
+| Mutation scope | Lane 2 + Lane 3 only | Lane 1 cards are already prominent |
+| Selector UI | Inline dropdown per row | Quick toggle without leaving the list |
+
+## Risks
+
+- **Dashboard complexity**: Mutation UI adds conditional rendering logic to an already complex 3-lane layout. Needs careful CSS to avoid breaking lane alignment.
+- **Backend migration**: Adding `passion_level` column to `followed_artists` requires a database migration.

--- a/openspec/changes/passion-level/design.md
+++ b/openspec/changes/passion-level/design.md
@@ -94,16 +94,27 @@ message SetPassionLevelRequest {
 message SetPassionLevelResponse {}
 ```
 
-The passion level is returned as part of the followed artist data in `ListFollowed`. The `FollowedArtist` response message is extended as follows:
+The passion level is returned as part of the followed artist data in `ListFollowed`. This requires introducing a new `FollowedArtist` wrapper message in `rpc/artist/v1/artist_service.proto` and updating `ListFollowedResponse` to use it instead of the raw `entity.v1.Artist`:
 
 ```protobuf
+// FollowedArtist represents an artist with user-specific follow metadata.
+// This is an RPC-layer message (not an entity) because passion_level is
+// per-user context, not an intrinsic property of the Artist entity.
 message FollowedArtist {
-  // ... existing fields ...
+  // The artist entity.
+  entity.v1.Artist artist = 1;
 
   // The user's passion level for this artist.
-  entity.v1.PassionLevel passion_level = 4;
+  entity.v1.PassionLevel passion_level = 2;
+}
+
+message ListFollowedResponse {
+  // Changed from: repeated entity.v1.Artist artists = 1;
+  repeated FollowedArtist artists = 1;
 }
 ```
+
+> **Note**: This is a breaking change to `ListFollowedResponse`. It must be coordinated with the frontend consumer.
 
 ## Decisions
 

--- a/openspec/changes/passion-level/design.md
+++ b/openspec/changes/passion-level/design.md
@@ -102,10 +102,13 @@ The passion level is returned as part of the followed artist data in `ListFollow
 // per-user context, not an intrinsic property of the Artist entity.
 message FollowedArtist {
   // The artist entity.
-  entity.v1.Artist artist = 1;
+  entity.v1.Artist artist = 1 [(buf.validate.field).required = true];
 
   // The user's passion level for this artist.
-  entity.v1.PassionLevel passion_level = 2;
+  entity.v1.PassionLevel passion_level = 2 [
+    (buf.validate.field).required = true,
+    (buf.validate.field).enum.defined_only = true
+  ];
 }
 
 message ListFollowedResponse {

--- a/openspec/changes/passion-level/design.md
+++ b/openspec/changes/passion-level/design.md
@@ -9,6 +9,8 @@ followed_artists table (existing)
 ```
 
 ```protobuf
+// PassionLevel represents the user's enthusiasm tier for a followed artist.
+// It determines dashboard visibility and notification behavior.
 enum PassionLevel {
   PASSION_LEVEL_UNSPECIFIED = 0;
   PASSION_LEVEL_MUST_GO = 1;      // 🔥🔥 Travel anywhere
@@ -68,13 +70,21 @@ Normal Lane 2/3 card:        Mutated card (Must Go):
 
 ## API Design
 
-```
+```protobuf
+// SetPassionLevel updates the user's preference for an artist's notification tier.
 rpc SetPassionLevel(SetPassionLevelRequest) returns (SetPassionLevelResponse);
 
+// SetPassionLevelRequest provides the artist ID and the new passion level to be set.
 message SetPassionLevelRequest {
-  ArtistId artist_id = 1;
-  PassionLevel passion_level = 2;
+  // Required. The unique identifier of the artist.
+  entity.v1.ArtistId artist_id = 1 [(buf.validate.field).required = true];
+
+  // Required. The new passion level tier.
+  PassionLevel passion_level = 2 [(buf.validate.field).required = true];
 }
+
+// SetPassionLevelResponse is returned upon a successful update.
+message SetPassionLevelResponse {}
 ```
 
 The passion level is returned as part of the followed artist data in `ListFollowed`.

--- a/openspec/changes/passion-level/proposal.md
+++ b/openspec/changes/passion-level/proposal.md
@@ -1,0 +1,47 @@
+# Proposal: Passion Level
+
+## Problem
+
+Currently, all followed artists are treated equally on the Dashboard. Users have no way to express different levels of enthusiasm for different artists. A die-hard fan willing to travel nationwide for a concert and a casual listener interested only in local events both see the same Dashboard layout. This means users might miss "must-go" concerts in distant cities or be overwhelmed by noise from artists they only casually follow.
+
+## Solution
+
+Introduce a **Passion Level** system with three tiers:
+
+- 🔥🔥 **Must Go** — Will travel anywhere. Events appear prominently across all Dashboard lanes.
+- 🔥 **Local Only** — Default. Events shown normally in nearby lanes only.
+- 👀 **Keep an Eye** — Display on Dashboard but exclude from push notifications.
+
+On the **My Artists page**, add a per-artist passion level selector.
+
+On the **Dashboard (Live Highway)**, introduce **Visual Mutation UI**: when a "Must Go" artist has an event in Lane 2 or Lane 3, the card breaks out of the normal compact rendering and becomes a large, visually striking "expedition alert" card.
+
+## Scope
+
+### In Scope
+
+- Passion Level data model (frontend + backend persistence)
+- Per-artist passion level selector on My Artists page
+- Dashboard Mutation UI for Must Go artists in Lane 2/3
+- Backend API for setting/getting passion level per followed artist
+
+### Out of Scope
+
+- Push notification filtering by passion level (can be a follow-up)
+- Grid/Festival view on My Artists page (post-MVP)
+
+## Impact
+
+- New spec: `passion-level`
+- Modified spec: `typography-focused-dashboard` (Mutation UI addition)
+- Modified spec: `artist-following` (passion level field on follow relationship)
+- New backend API endpoint or field extension
+
+## Dependencies
+
+- `my-artists-list` (passion level selector is added to the artist list rows)
+- `bottom-navigation-shell` (Dashboard and My Artists tabs must exist)
+
+## Blocked By
+
+- `my-artists-list`

--- a/openspec/changes/passion-level/specs/passion-level/spec.md
+++ b/openspec/changes/passion-level/specs/passion-level/spec.md
@@ -1,0 +1,56 @@
+# Passion Level
+
+## Purpose
+
+Enables users to express different levels of enthusiasm for followed artists, affecting how events are displayed on the Dashboard and whether push notifications are sent. This creates a personalized priority system where "must-go" artists get visually prominent treatment across all geographical lanes.
+
+## Requirements
+
+### Requirement: Passion Level Tiers
+The system SHALL support three passion level tiers for each followed artist.
+
+#### Scenario: Must Go level
+- **WHEN** a user sets an artist's passion level to Must Go (🔥🔥)
+- **THEN** the system SHALL treat that artist's events as high priority across all Dashboard lanes
+- **AND** events in Lane 2 and Lane 3 SHALL render with Visual Mutation UI (expanded, accented)
+- **AND** the artist SHALL be eligible for push notifications regardless of event location
+
+#### Scenario: Local Only level (default)
+- **WHEN** a user follows an artist without changing the passion level
+- **THEN** the passion level SHALL default to Local Only (🔥)
+- **AND** events SHALL render normally according to standard lane rules
+- **AND** the artist SHALL be eligible for push notifications for local events only
+
+#### Scenario: Keep an Eye level
+- **WHEN** a user sets an artist's passion level to Keep an Eye (👀)
+- **THEN** events SHALL render normally on the Dashboard
+- **AND** the artist SHALL NOT be included in push notifications
+
+---
+
+### Requirement: Passion Level Selector
+The system SHALL provide a per-artist passion level selector on the My Artists page.
+
+#### Scenario: Displaying current passion level
+- **WHEN** the My Artists list is displayed
+- **THEN** each artist row SHALL show the current passion level icon (🔥🔥, 🔥, or 👀)
+
+#### Scenario: Changing passion level
+- **WHEN** a user taps the passion level indicator on an artist row
+- **THEN** the system SHALL display a dropdown or bottom sheet with the three options
+- **AND** selecting an option SHALL update the passion level immediately (optimistic update)
+- **AND** the system SHALL call the backend API to persist the change
+
+---
+
+### Requirement: Backend Persistence
+The system SHALL persist passion level as part of the artist-following relationship.
+
+#### Scenario: Setting passion level via API
+- **WHEN** a `SetPassionLevel` RPC is called with a valid artist ID and passion level
+- **THEN** the system SHALL update the `passion_level` column in the `followed_artists` table
+- **AND** the response SHALL confirm the update
+
+#### Scenario: Retrieving passion level
+- **WHEN** `ListFollowed` is called
+- **THEN** each followed artist in the response SHALL include their current passion level

--- a/openspec/changes/passion-level/specs/typography-focused-dashboard/spec.md
+++ b/openspec/changes/passion-level/specs/typography-focused-dashboard/spec.md
@@ -1,0 +1,28 @@
+# Typography-Focused Dashboard (Delta)
+
+## New Requirements
+
+### Requirement: Visual Mutation UI for Must Go Artists
+The system SHALL render expanded, visually striking cards for Must Go (🔥🔥) artists when their events appear in Lane 2 or Lane 3.
+
+#### Scenario: Mutation card rendering in Lane 2
+- **WHEN** a Must Go artist has an event in the user's region (Lane 2)
+- **THEN** the card SHALL expand to Lane 1 card height (or larger)
+- **AND** the card SHALL use a vivid accent color or stripe pattern background
+- **AND** the artist name SHALL use extra-bold, mega-typography style
+- **AND** a "🔥 遠征チャンス (Must Go)" badge SHALL appear at the top of the card
+
+#### Scenario: Mutation card rendering in Lane 3
+- **WHEN** a Must Go artist has an event outside the user's region (Lane 3)
+- **THEN** the same Visual Mutation rendering rules as Lane 2 SHALL apply
+- **AND** the card SHALL break out of the compact text-only format normally used in Lane 3
+
+#### Scenario: Non-Must Go artists unaffected
+- **WHEN** an artist has Local Only (🔥) or Keep an Eye (👀) passion level
+- **THEN** their event cards SHALL render using the standard lane-specific format
+- **AND** no Visual Mutation SHALL be applied
+
+#### Scenario: Multiple mutated cards on same date
+- **WHEN** multiple Must Go artists have events on the same date in Lane 2 or Lane 3
+- **THEN** each SHALL render as a mutated card independently
+- **AND** the lane layout SHALL accommodate multiple expanded cards without horizontal overflow

--- a/openspec/changes/passion-level/tasks.md
+++ b/openspec/changes/passion-level/tasks.md
@@ -1,0 +1,21 @@
+# Tasks: Passion Level
+
+## Tasks
+
+### Backend
+- [ ] Add `passion_level` column to `followed_artists` table (DB migration)
+- [ ] Define `PassionLevel` enum in protobuf schema
+- [ ] Implement `SetPassionLevel` RPC in ArtistService
+- [ ] Extend `ListFollowed` response to include passion level per artist
+- [ ] Add repository layer support for passion level CRUD
+
+### Frontend — My Artists
+- [ ] Add passion level indicator (🔥🔥/🔥/👀) to each artist row
+- [ ] Create passion level selector dropdown/bottom sheet
+- [ ] Integrate SetPassionLevel RPC on selection change (optimistic update)
+
+### Frontend — Dashboard Mutation UI
+- [ ] Add logic to detect Must Go artists in Lane 2/3 event data
+- [ ] Create MutationCard component (expanded size, vivid color, badge)
+- [ ] Integrate Mutation cards into Lane 2 and Lane 3 rendering
+- [ ] Ensure layout handles multiple mutated cards on the same date without overflow

--- a/openspec/changes/settings-page/design.md
+++ b/openspec/changes/settings-page/design.md
@@ -64,8 +64,8 @@
 | My Area UI | Bottom sheet with 2-step selection | Reuses onboarding mental model |
 | Sign Out position | Bottom of page, red text | Convention for destructive actions |
 | Legal pages | External links (static pages) | No in-app rendering needed for MVP |
-| Area persistence | Frontend state (localStorage) for MVP | Backend preference API deferred to post-MVP |
+| Area persistence | Backend (user preference API) | Required for passion-level notification logic (Local Only tier needs server-side area) |
 
 ## Risks
 
-- **Area change without backend sync**: For MVP, area preference is stored locally. If user switches devices, area resets. Acceptable for MVP.
+- **Backend dependency**: My Area persistence requires a backend user preferences API or extending the existing user profile. This adds backend scope to what is primarily a frontend change.

--- a/openspec/changes/settings-page/design.md
+++ b/openspec/changes/settings-page/design.md
@@ -1,0 +1,71 @@
+# Design: Settings Page
+
+## UI Structure
+
+```
+┌─────────────────────────────────┐
+│  ⚙️ Settings                    │
+├─────────────────────────────────┤
+│                                 │
+│  PREFERENCES                    │
+│  ┌─────────────────────────┐   │
+│  │ 📍 My Area        関東 > │   │
+│  ├─────────────────────────┤   │
+│  │ 🔔 Notifications   [ON] │   │
+│  └─────────────────────────┘   │
+│                                 │
+│  ABOUT                          │
+│  ┌─────────────────────────┐   │
+│  │ Terms of Service      > │   │
+│  ├─────────────────────────┤   │
+│  │ Privacy Policy        > │   │
+│  ├─────────────────────────┤   │
+│  │ OSS Licenses          > │   │
+│  └─────────────────────────┘   │
+│                                 │
+│  ACCOUNT                        │
+│  ┌─────────────────────────┐   │
+│  │ 🚪 Sign Out             │   │
+│  └─────────────────────────┘   │
+│                                 │
+├─────────────────────────────────┤
+│  [🏠] [🔍] [🎸] [⚙️]           │
+└─────────────────────────────────┘
+```
+
+## My Area Bottom Sheet
+
+```
+┌─────────────────────────────────┐
+│  Change My Area                 │
+│                                 │
+│  Step 1: Select Region          │
+│  ┌──────┐ ┌──────┐ ┌──────┐   │
+│  │ 北海道 │ │ 東北  │ │ 関東  │   │
+│  └──────┘ └──────┘ └──────┘   │
+│  ┌──────┐ ┌──────┐ ┌──────┐   │
+│  │ 中部  │ │ 近畿  │ │ 中国  │   │
+│  └──────┘ └──────┘ └──────┘   │
+│  ┌──────┐ ┌──────┐            │
+│  │ 四国  │ │ 九州  │            │
+│  └──────┘ └──────┘            │
+│                                 │
+│  Step 2: Select Prefecture      │
+│  (filtered by selected region)  │
+│                                 │
+└─────────────────────────────────┘
+```
+
+## Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Layout style | Grouped list (iOS-style) | Clean, familiar settings pattern for mobile |
+| My Area UI | Bottom sheet with 2-step selection | Reuses onboarding mental model |
+| Sign Out position | Bottom of page, red text | Convention for destructive actions |
+| Legal pages | External links (static pages) | No in-app rendering needed for MVP |
+| Area persistence | Frontend state (localStorage) for MVP | Backend preference API deferred to post-MVP |
+
+## Risks
+
+- **Area change without backend sync**: For MVP, area preference is stored locally. If user switches devices, area resets. Acceptable for MVP.

--- a/openspec/changes/settings-page/proposal.md
+++ b/openspec/changes/settings-page/proposal.md
@@ -1,0 +1,43 @@
+# Proposal: Settings Page
+
+## Problem
+
+Users currently have limited access to account management and system preferences. Sign-out is embedded in the top navigation bar, and there is no UI for changing the registered area (prefecture) or managing push notification preferences. As the app transitions to a bottom tab bar navigation, a dedicated Settings tab is needed.
+
+## Solution
+
+Implement the **Settings page** (Tab 4) with the following sections:
+
+1. **My Area** — Change registered prefecture using the same 2-tap UI from onboarding (region → prefecture)
+2. **Push Notifications** — Global ON/OFF toggle for push notifications
+3. **About** — Links to Terms of Service, Privacy Policy, and OSS licenses
+4. **Account** — Sign Out button
+
+## Scope
+
+### In Scope
+
+- Settings page UI with grouped list layout
+- My Area change via bottom sheet (region → prefecture selector)
+- Push notification toggle
+- About section with static links
+- Sign Out button with existing auth flow integration
+
+### Out of Scope
+
+- Granular notification filtering (e.g., "Must Go only") — part of passion-level change
+- Profile editing, linked account management (post-MVP)
+- Backend changes for area/notification preferences (frontend-only state for MVP)
+
+## Impact
+
+- New spec: `settings`
+- Depends on: `bottom-navigation-shell` (provides the tab and route)
+
+## Dependencies
+
+- `bottom-navigation-shell` (route `/settings` and tab must exist)
+
+## Blocked By
+
+- `bottom-navigation-shell`

--- a/openspec/changes/settings-page/specs/settings/spec.md
+++ b/openspec/changes/settings-page/specs/settings/spec.md
@@ -1,0 +1,55 @@
+# Settings
+
+## Purpose
+
+Provides user access to account management, system preferences, and legal information. The Settings page is a grouped list UI accessible via the Bottom Navigation Bar's Settings tab.
+
+## Requirements
+
+### Requirement: My Area Preference
+The system SHALL allow users to change their registered area (prefecture) which determines the Live Highway Dashboard's geographical context.
+
+#### Scenario: Opening area selector
+- **WHEN** a user taps the "My Area" row in Settings
+- **THEN** the system SHALL display a bottom sheet with a 2-step selection UI
+- **AND** Step 1 SHALL show regions (e.g., Hokkaido, Tohoku, Kanto, Chubu, Kinki, Chugoku, Shikoku, Kyushu)
+- **AND** Step 2 SHALL show prefectures within the selected region
+
+#### Scenario: Changing area
+- **WHEN** a user selects a prefecture in Step 2
+- **THEN** the system SHALL update the user's registered area
+- **AND** the bottom sheet SHALL close
+- **AND** the Settings row SHALL reflect the new area
+- **AND** the Dashboard SHALL use the new area for Live Highway lane calculations on next load
+
+---
+
+### Requirement: Push Notification Toggle
+The system SHALL allow users to control push notification delivery.
+
+#### Scenario: Toggling notifications
+- **WHEN** a user toggles the Push Notifications switch
+- **THEN** the system SHALL update the notification preference
+- **AND** when OFF, the system SHALL NOT send any push notifications
+- **AND** when ON, the system SHALL send notifications based on followed artists and their passion levels
+
+---
+
+### Requirement: About Section
+The system SHALL provide access to legal and licensing information.
+
+#### Scenario: Legal links
+- **WHEN** the About section is displayed
+- **THEN** the system SHALL show links to Terms of Service, Privacy Policy, and OSS Licenses
+- **AND** tapping a link SHALL open the corresponding page (external or in-app webview)
+
+---
+
+### Requirement: Sign Out
+The system SHALL allow users to sign out of their account.
+
+#### Scenario: Sign out action
+- **WHEN** a user taps the "Sign Out" button
+- **THEN** the system SHALL clear the user's authentication session
+- **AND** the system SHALL navigate to the Landing Page
+- **AND** the Sign Out button SHALL be visually distinct (e.g., red text) and positioned at the bottom of the settings list

--- a/openspec/changes/settings-page/tasks.md
+++ b/openspec/changes/settings-page/tasks.md
@@ -8,5 +8,6 @@
 - [ ] Implement Push Notifications toggle switch
 - [ ] Add About section with links to Terms of Service, Privacy Policy, OSS Licenses
 - [ ] Implement Sign Out button (red text, bottom position) with existing auth flow integration
-- [ ] Store area and notification preferences in localStorage
+- [ ] Implement backend user preference API for area persistence (required by passion-level notifications)
+- [ ] Store notification preferences in localStorage (or backend if preference API supports it)
 - [ ] Replace Settings stub page from bottom-navigation-shell with full implementation

--- a/openspec/changes/settings-page/tasks.md
+++ b/openspec/changes/settings-page/tasks.md
@@ -1,0 +1,12 @@
+# Tasks: Settings Page
+
+## Tasks
+
+- [ ] Create SettingsPage component with grouped list layout (Preferences, About, Account sections)
+- [ ] Implement My Area row displaying current area with tap-to-change
+- [ ] Create AreaSelectorBottomSheet component (region → prefecture 2-step selection)
+- [ ] Implement Push Notifications toggle switch
+- [ ] Add About section with links to Terms of Service, Privacy Policy, OSS Licenses
+- [ ] Implement Sign Out button (red text, bottom position) with existing auth flow integration
+- [ ] Store area and notification preferences in localStorage
+- [ ] Replace Settings stub page from bottom-navigation-shell with full implementation


### PR DESCRIPTION
## Summary

UXデザインドキュメント (`tmp/ux-design-direction.md`) を分析し、適切な粒度で5つの OpenSpec changes に分割しました。

### Changes Created

| # | Change | Description | Depends On |
|---|--------|-------------|------------|
| 1 | `bottom-navigation-shell` | Bottom Tab Bar infrastructure (4 tabs, routing, conditional visibility) | — |
| 2 | `settings-page` | Settings tab: My Area, Push Notifications, About, Sign Out | 1 |
| 3 | `my-artists-list` | Followed artists list with swipe-to-unfollow + Undo toast | 1 |
| 4 | `passion-level` | Per-artist passion tiers (🔥🔥/🔥/👀) + Dashboard Mutation UI | 3 |
| 5 | `discover-page` | Bubble UI re-experience + manual artist search | 1 |

### Dependency Graph

```
[1] bottom-navigation-shell  ← foundation
 ├──▶ [2] settings-page       (parallel)
 ├──▶ [3] my-artists-list     (parallel)
 └──▶ [5] discover-page       (parallel)

[3] my-artists-list
 └──▶ [4] passion-level
```

### Implementation Priority

1. **Must have (MVP core)**: 1 → 2 + 3 (parallel)
2. **Should have**: 4 (passion level + Dashboard mutation)
3. **Nice to have**: 5 (Bubble UI re-experience)

### Artifacts per Change

Each change includes: `proposal.md`, `design.md`, `tasks.md`, and capability specs (new or delta).

## Test plan

- [x] All markdown files have valid structure
- [x] Dependency relationships are correctly documented
- [x] Delta specs reference existing specs accurately
- [x] No implementation code (spec-only change)