### PR TITLE
feat: add tag field to ListTopRequest for genre filtering

### DIFF
--- a/openspec/changes/discover-page/tasks.md
+++ b/openspec/changes/discover-page/tasks.md
@@ -3,20 +3,20 @@
 ## Tasks
 
 ### Bubble UI Re-experience
-- [ ] Extract/refactor ArtistDiscovery component from onboarding for reuse on Discover tab
-- [ ] Create DiscoverPage component hosting the Bubble UI and search bar
-- [ ] Implement genre/tag chips above bubble area
-- [ ] Implement genre selection to regenerate bubbles via ArtistService.ListTop with tag filter
-- [ ] Add visual indicator for already-followed artists in bubbles (dimmed/checkmark)
-- [ ] Implement physics pause/resume on tab activation/deactivation
+- [x] Extract/refactor ArtistDiscovery component from onboarding for reuse on Discover tab
+- [x] Create DiscoverPage component hosting the Bubble UI and search bar
+- [x] Implement genre/tag chips above bubble area
+- [x] Implement genre selection to regenerate bubbles via ArtistService.ListTop with tag filter
+- [x] Add visual indicator for already-followed artists in bubbles (dimmed/checkmark)
+- [x] Implement physics pause/resume on tab activation/deactivation
 
 ### Manual Search
-- [ ] Add search bar at top of Discover page
-- [ ] Implement search mode toggle (hide bubbles, show list results)
-- [ ] Integrate artist search API (Last.fm artist.search or existing backend)
-- [ ] Display search results as a list with follow action button
-- [ ] Apply DNA Orb absorption effect on follow from search results
-- [ ] Show followed indicator for already-followed artists in search results
+- [x] Add search bar at top of Discover page
+- [x] Implement search mode toggle (hide bubbles, show list results)
+- [x] Integrate artist search API (Last.fm artist.search or existing backend)
+- [x] Display search results as a list with follow action button
+- [x] Apply DNA Orb absorption effect on follow from search results
+- [x] Show followed indicator for already-followed artists in search results
 
 ### Integration
-- [ ] Replace Discover stub page from bottom-navigation-shell with full implementation
+- [x] Replace Discover stub page from bottom-navigation-shell with full implementation

--- a/proto/liverty_music/rpc/artist/v1/artist_service.proto
+++ b/proto/liverty_music/rpc/artist/v1/artist_service.proto
@@ -182,6 +182,10 @@ message ListTopRequest {
   // Optional. ISO 3166-1 country name (e.g., "Japan").
   // If empty, the system returns a global chart.
   string country = 1;
+
+  // Optional. Filter top artists by genre or tag (e.g., "rock", "pop", "anime").
+  // When empty, returns top artists across all genres.
+  string tag = 2 [(buf.validate.field).string.max_len = 50];
 }
 
 // ListTopResponse contains the chart of popular artists.


### PR DESCRIPTION
## 🔗 Related Issue

Part of the Discover Page feature (cross-repo: backend, frontend, specification).

## 📝 Summary of Changes

Add an optional `tag` field to `ListTopRequest` in the Artist Service proto definition.
This enables clients to filter top artists by genre tag (e.g. rock, pop, jazz) via
Last.fm's `tag.gettopartists` API, in addition to the existing country-based filtering.

- Add `string tag = 2` with `max_len = 50` validation to `ListTopRequest`
- Mark discover-page OpenSpec tasks as complete

## ✅ Self-Checklist

- [x] I have linked the related issue.
- [x] I have updated the relevant documentation (e.g., `README.md`) if needed.
- [x] I have run `buf lint` and `buf format` locally and all checks have passed.
- [x] My proto definitions follow the project's style guidelines and validation rules.
- [ ] Breaking changes have been justified and documented if applicable.