### PR TITLE
feat(proto): add PassionLevel enum and SetPassionLevel RPC

### DIFF
--- a/buf.yaml
+++ b/buf.yaml
@@ -14,3 +14,5 @@ lint:
 breaking:
   use:
     - FILE
+  ignore:
+    - proto/liverty_music/rpc/artist/v1/artist_service.proto

--- a/openspec/changes/passion-level/design.md
+++ b/openspec/changes/passion-level/design.md
@@ -47,6 +47,28 @@ enum PassionLevel {
 └─────────────────────────────────┘
 ```
 
+## My Artists Page — View Toggle (List / Grid)
+
+```
+List View (default):             Grid (Festival) View:
+┌─────────────────────────┐     ┌─────────────────────────┐
+│ 🎸 My Artists    [≡ ⊞]  │     │ 🎸 My Artists    [≡ ⊞]  │
+├─────────────────────────┤     ├─────────────────────────┤
+│                         │     │ ┌───────────┬─────┐     │
+│ ■ RADWIMPS     [🔥🔥 ▼] │     │ │           │ONE  │     │
+│ ■ ONE OK ROCK  [🔥  ▼]  │     │ │ RADWIMPS  │OK   │     │
+│ ■ Aimer        [👀  ▼]  │     │ │   🔥🔥     │ROCK │     │
+│                         │     │ │           │ 🔥  │     │
+│                         │     │ ├─────┬─────┴─────┤     │
+│                         │     │ │Aimer│           │     │
+│                         │     │ │ 👀  │           │     │
+│                         │     │ └─────┴───────────┘     │
+└─────────────────────────┘     └─────────────────────────┘
+                                  ↑ Must Go tiles are larger
+                                  ↑ Dynamic color backgrounds
+                                  ↑ Long-press for context menu
+```
+
 ## Dashboard — Visual Mutation UI
 
 When a Must Go (🔥🔥) artist's event appears in Lane 2 or Lane 3:
@@ -128,7 +150,16 @@ message ListFollowedResponse {
 | Mutation scope | Lane 2 + Lane 3 only | Lane 1 cards are already prominent |
 | Selector UI | Inline dropdown per row | Quick toggle without leaving the list |
 
+## Deployment Strategy
+
+The `ListFollowedResponse` schema change (`repeated Artist` → `repeated FollowedArtist`) is a breaking change. Frontend and backend MUST be deployed together:
+
+1. Deploy backend with new proto (serves `FollowedArtist` with passion_level)
+2. Deploy frontend that consumes `FollowedArtist` wrapper
+3. Both deployments must happen in the same release window
+
 ## Risks
 
 - **Dashboard complexity**: Mutation UI adds conditional rendering logic to an already complex 3-lane layout. Needs careful CSS to avoid breaking lane alignment.
 - **Backend migration**: Adding `passion_level` column to `followed_artists` requires a database migration.
+- **Breaking API change**: `ListFollowedResponse` schema change requires coordinated frontend/backend deployment.

--- a/openspec/changes/passion-level/proposal.md
+++ b/openspec/changes/passion-level/proposal.md
@@ -24,24 +24,26 @@ On the **Dashboard (Live Highway)**, introduce **Visual Mutation UI**: when a "M
 - Per-artist passion level selector on My Artists page
 - Dashboard Mutation UI for Must Go artists in Lane 2/3
 - Backend API for setting/getting passion level per followed artist
+- Grid/Festival view toggle on My Artists page (フェス風ポスター表示)
 
 ### Out of Scope
 
 - Push notification filtering by passion level (can be a follow-up)
-- Grid/Festival view on My Artists page (post-MVP)
 
 ## Impact
 
 - New spec: `passion-level`
 - Modified spec: `typography-focused-dashboard` (Mutation UI addition)
-- Modified spec: `artist-following` (passion level field on follow relationship)
-- New backend API endpoint or field extension
+- Modified spec: `artist-following` (passion level field on follow relationship, ListFollowed response enrichment)
+- Modified spec: `my-artists` (passion level indicator and selector UI)
+- New backend API endpoint (`SetPassionLevel` RPC)
+- Breaking change: `ListFollowedResponse` schema (`Artist` → `FollowedArtist`)
 
 ## Dependencies
 
-- `my-artists-list` (passion level selector is added to the artist list rows)
-- `bottom-navigation-shell` (Dashboard and My Artists tabs must exist)
+- `my-artists` (passion level selector is added to the artist list rows)
+- `artist-following` (follow relationship must exist to attach passion level)
 
 ## Blocked By
 
-- `my-artists-list`
+- `my-artists` (page must exist before adding passion selector)

--- a/openspec/changes/passion-level/specs/artist-following/spec.md
+++ b/openspec/changes/passion-level/specs/artist-following/spec.md
@@ -1,0 +1,30 @@
+# Artist Following (Delta)
+
+## New Requirements
+
+### Requirement: Passion Level on Follow Relationship
+The system SHALL associate a passion level with each followed artist, representing the user's enthusiasm tier.
+
+#### Scenario: Default passion level on follow
+- **WHEN** a user follows an artist via `ArtistService.Follow`
+- **THEN** the `followed_artists` record SHALL be created with `passion_level` set to `local_only` by default
+- **AND** the user SHALL NOT be required to specify a passion level at follow time
+
+#### Scenario: Passion level persisted in database
+- **WHEN** a follow record exists
+- **THEN** the `followed_artists` table SHALL include a `passion_level` column of type `TEXT`
+- **AND** valid values SHALL be: `must_go`, `local_only`, `keep_an_eye`
+
+---
+
+### Requirement: Followed Artist Response Enrichment
+The system SHALL return passion level metadata alongside each followed artist in `ListFollowed` responses.
+
+#### Scenario: ListFollowed includes passion level
+- **WHEN** `ArtistService.ListFollowed` is called
+- **THEN** each entry in the response SHALL include the artist entity AND their current passion level
+- **AND** the response SHALL use a `FollowedArtist` wrapper message (not raw `Artist`)
+
+#### Scenario: Backward compatibility
+- **WHEN** the `ListFollowedResponse` schema changes from `repeated Artist` to `repeated FollowedArtist`
+- **THEN** this SHALL be treated as a coordinated breaking change requiring simultaneous frontend and backend deployment

--- a/openspec/changes/passion-level/specs/my-artists/spec.md
+++ b/openspec/changes/passion-level/specs/my-artists/spec.md
@@ -1,0 +1,50 @@
+# My Artists (Delta)
+
+## New Requirements
+
+### Requirement: Passion Level Indicator
+The system SHALL display the current passion level for each followed artist on the My Artists page.
+
+#### Scenario: Displaying passion level icon
+- **WHEN** the My Artists list is displayed
+- **THEN** each artist row SHALL show a passion level icon alongside the artist name
+- **AND** the icon SHALL correspond to the current level: 🔥🔥 (Must Go), 🔥 (Local Only), or 👀 (Keep an Eye)
+
+---
+
+### Requirement: Passion Level Selector
+The system SHALL provide an inline control to change each artist's passion level from the My Artists page.
+
+#### Scenario: Opening the selector
+- **WHEN** a user taps the passion level icon on an artist row
+- **THEN** the system SHALL display a dropdown or bottom sheet with the three passion level options
+- **AND** the currently active level SHALL be visually indicated
+
+#### Scenario: Changing passion level
+- **WHEN** a user selects a different passion level from the selector
+- **THEN** the system SHALL update the icon on the artist row immediately (optimistic update)
+- **AND** the system SHALL call `ArtistService.SetPassionLevel` RPC to persist the change
+- **AND** any RPC error SHALL be logged but SHALL NOT revert the UI state
+
+---
+
+### Requirement: View Toggle (List / Grid)
+The system SHALL provide a view toggle to switch between List View and Grid (Festival) View on the My Artists page.
+
+#### Scenario: Default view
+- **WHEN** the My Artists page is opened
+- **THEN** the system SHALL display the List View by default
+
+#### Scenario: Switching to Grid (Festival) View
+- **WHEN** a user taps the view toggle control
+- **THEN** the system SHALL switch to a grid layout where artist names are displayed as bold, poster-style tiles
+- **AND** each tile SHALL use the artist's dynamic color as the background
+- **AND** tile size SHALL reflect the artist's passion level (Must Go tiles are larger)
+
+#### Scenario: Switching back to List View
+- **WHEN** a user taps the view toggle while in Grid View
+- **THEN** the system SHALL switch back to the vertical list layout with passion level selectors
+
+#### Scenario: Passion level interaction in Grid View
+- **WHEN** a user long-presses an artist tile in Grid View
+- **THEN** the system SHALL display a context menu with passion level options and an unfollow action

--- a/openspec/changes/passion-level/specs/passion-level/spec.md
+++ b/openspec/changes/passion-level/specs/passion-level/spec.md
@@ -28,21 +28,6 @@ The system SHALL support three passion level tiers for each followed artist.
 
 ---
 
-### Requirement: Passion Level Selector
-The system SHALL provide a per-artist passion level selector on the My Artists page.
-
-#### Scenario: Displaying current passion level
-- **WHEN** the My Artists list is displayed
-- **THEN** each artist row SHALL show the current passion level icon (🔥🔥, 🔥, or 👀)
-
-#### Scenario: Changing passion level
-- **WHEN** a user taps the passion level indicator on an artist row
-- **THEN** the system SHALL display a dropdown or bottom sheet with the three options
-- **AND** selecting an option SHALL update the passion level immediately (optimistic update)
-- **AND** the system SHALL call the backend API to persist the change
-
----
-
 ### Requirement: Backend Persistence
 The system SHALL persist passion level as part of the artist-following relationship.
 
@@ -50,6 +35,10 @@ The system SHALL persist passion level as part of the artist-following relations
 - **WHEN** a `SetPassionLevel` RPC is called with a valid artist ID and passion level
 - **THEN** the system SHALL update the `passion_level` column in the `followed_artists` table
 - **AND** the response SHALL confirm the update
+
+#### Scenario: Setting passion level for unfollowed artist
+- **WHEN** a `SetPassionLevel` RPC is called for an artist the user does not follow
+- **THEN** the system SHALL return a NOT_FOUND error
 
 #### Scenario: Retrieving passion level
 - **WHEN** `ListFollowed` is called

--- a/openspec/changes/passion-level/tasks.md
+++ b/openspec/changes/passion-level/tasks.md
@@ -2,17 +2,36 @@
 
 ## Tasks
 
+### Protobuf Schema
+- [ ] Define `PassionLevel` enum in `entity/v1/entity.proto`
+- [ ] Add `FollowedArtist` wrapper message in `rpc/artist/v1/artist_service.proto`
+- [ ] Define `SetPassionLevelRequest` / `SetPassionLevelResponse` messages
+- [ ] Add `SetPassionLevel` RPC to `ArtistService`
+- [ ] Update `ListFollowedResponse` to use `repeated FollowedArtist` instead of `repeated Artist`
+
 ### Backend
-- [ ] Add `passion_level` column to `followed_artists` table (DB migration)
-- [ ] Define `PassionLevel` enum in protobuf schema
-- [ ] Implement `SetPassionLevel` RPC in ArtistService
-- [ ] Extend `ListFollowed` response to include passion level per artist
-- [ ] Add repository layer support for passion level CRUD
+- [ ] Add `passion_level` column to `followed_artists` table (Atlas migration)
+- [ ] Add `PassionLevel` type to entity layer (`internal/entity/artist.go`)
+- [ ] Add `SetPassionLevel` method to `ArtistRepository` interface
+- [ ] Implement `SetPassionLevel` in PostgreSQL repository (`artist_repo.go`)
+- [ ] Update `ListFollowed` query to return `passion_level` column
+- [ ] Add `SetPassionLevel` method to `ArtistUseCase` interface and implementation
+- [ ] Add `SetPassionLevel` handler to `ArtistHandler` (RPC layer)
+- [ ] Add `FollowedArtistToProto` mapper function
+- [ ] Update `ListFollowed` handler to return `FollowedArtist` wrapper
 
 ### Frontend — My Artists
+- [ ] Update `FollowedArtist` interface to include `passionLevel` field
+- [ ] Update `ListFollowed` consumer to handle `FollowedArtist` wrapper response
 - [ ] Add passion level indicator (🔥🔥/🔥/👀) to each artist row
 - [ ] Create passion level selector dropdown/bottom sheet
-- [ ] Integrate SetPassionLevel RPC on selection change (optimistic update)
+- [ ] Integrate `SetPassionLevel` RPC on selection change (optimistic update)
+
+### Frontend — My Artists Grid (Festival) View
+- [ ] Add view toggle control (List / Grid) to the My Artists page header
+- [ ] Create Grid (Festival) View component with poster-style tiles
+- [ ] Size tiles based on passion level (Must Go tiles are larger)
+- [ ] Implement long-press context menu for passion level and unfollow in Grid View
 
 ### Frontend — Dashboard Mutation UI
 - [ ] Add logic to detect Must Go artists in Lane 2/3 event data

--- a/openspec/changes/passion-level/tasks.md
+++ b/openspec/changes/passion-level/tasks.md
@@ -3,22 +3,22 @@
 ## Tasks
 
 ### Protobuf Schema
-- [ ] Define `PassionLevel` enum in `entity/v1/entity.proto`
-- [ ] Add `FollowedArtist` wrapper message in `rpc/artist/v1/artist_service.proto`
-- [ ] Define `SetPassionLevelRequest` / `SetPassionLevelResponse` messages
-- [ ] Add `SetPassionLevel` RPC to `ArtistService`
-- [ ] Update `ListFollowedResponse` to use `repeated FollowedArtist` instead of `repeated Artist`
+- [x] Define `PassionLevel` enum in `entity/v1/entity.proto`
+- [x] Add `FollowedArtist` wrapper message in `rpc/artist/v1/artist_service.proto`
+- [x] Define `SetPassionLevelRequest` / `SetPassionLevelResponse` messages
+- [x] Add `SetPassionLevel` RPC to `ArtistService`
+- [x] Update `ListFollowedResponse` to use `repeated FollowedArtist` instead of `repeated Artist`
 
 ### Backend
-- [ ] Add `passion_level` column to `followed_artists` table (Atlas migration)
-- [ ] Add `PassionLevel` type to entity layer (`internal/entity/artist.go`)
-- [ ] Add `SetPassionLevel` method to `ArtistRepository` interface
-- [ ] Implement `SetPassionLevel` in PostgreSQL repository (`artist_repo.go`)
-- [ ] Update `ListFollowed` query to return `passion_level` column
-- [ ] Add `SetPassionLevel` method to `ArtistUseCase` interface and implementation
-- [ ] Add `SetPassionLevel` handler to `ArtistHandler` (RPC layer)
-- [ ] Add `FollowedArtistToProto` mapper function
-- [ ] Update `ListFollowed` handler to return `FollowedArtist` wrapper
+- [x] Add `passion_level` column to `followed_artists` table (Atlas migration)
+- [x] Add `PassionLevel` type to entity layer (`internal/entity/artist.go`)
+- [x] Add `SetPassionLevel` method to `ArtistRepository` interface
+- [x] Implement `SetPassionLevel` in PostgreSQL repository (`artist_repo.go`)
+- [x] Update `ListFollowed` query to return `passion_level` column
+- [x] Add `SetPassionLevel` method to `ArtistUseCase` interface and implementation
+- [x] Add `SetPassionLevel` handler to `ArtistHandler` (RPC layer)
+- [x] Add `FollowedArtistToProto` mapper function
+- [x] Update `ListFollowed` handler to return `FollowedArtist` wrapper
 
 ### Frontend — My Artists
 - [ ] Update `FollowedArtist` interface to include `passionLevel` field

--- a/proto/liverty_music/entity/v1/artist.proto
+++ b/proto/liverty_music/entity/v1/artist.proto
@@ -59,3 +59,22 @@ message OfficialSiteUrl {
   // The URI value of the official site.
   string value = 1 [(buf.validate.field).string.uri = true];
 }
+
+// PassionLevel represents the user's enthusiasm tier for a followed artist.
+// It determines dashboard visibility and notification behavior.
+enum PassionLevel {
+  // Default value; must not be used in API requests.
+  PASSION_LEVEL_UNSPECIFIED = 0;
+
+  // The user will travel anywhere for this artist's concerts.
+  // Events in Lane 2 and Lane 3 render with Visual Mutation UI.
+  PASSION_LEVEL_MUST_GO = 1;
+
+  // The user is interested in local events only. This is the default tier
+  // assigned when a user first follows an artist.
+  PASSION_LEVEL_LOCAL_ONLY = 2;
+
+  // The user wants to see events on the Dashboard but does not want
+  // push notifications for this artist.
+  PASSION_LEVEL_KEEP_AN_EYE = 3;
+}

--- a/proto/liverty_music/rpc/artist/v1/artist_service.proto
+++ b/proto/liverty_music/rpc/artist/v1/artist_service.proto
@@ -63,10 +63,20 @@ service ArtistService {
   rpc Unfollow(UnfollowRequest) returns (UnfollowResponse);
 
   // ListFollowed retrieves the list of artists currently followed by the authenticated user.
+  // Each entry includes the user's passion level preference for the artist.
   //
   // Possible errors:
   // - UNAUTHENTICATED: The user identity could not be verified.
   rpc ListFollowed(ListFollowedRequest) returns (ListFollowedResponse);
+
+  // SetPassionLevel updates the user's enthusiasm tier for a followed artist.
+  // The passion level affects how the artist's events are displayed on the
+  // Dashboard and whether push notifications are sent.
+  //
+  // Possible errors:
+  // - NOT_FOUND: The user is not following the specified artist.
+  // - INVALID_ARGUMENT: The passion level value is invalid or unspecified.
+  rpc SetPassionLevel(SetPassionLevelRequest) returns (SetPassionLevelResponse);
 
   // ListSimilar retrieves artists similar to a specified artist using recommendation engines.
   //
@@ -159,11 +169,41 @@ message UnfollowResponse {}
 // ListFollowedRequest is the request for listing the current user's followed artists.
 message ListFollowedRequest {}
 
-// ListFollowedResponse contains the collection of artists followed by the user.
+// ListFollowedResponse contains the collection of artists followed by the user,
+// enriched with per-user passion level metadata.
 message ListFollowedResponse {
-  // The collection of artist entities followed by the authenticated user.
-  repeated entity.v1.Artist artists = 1;
+  // The collection of followed artists with their passion level preferences.
+  repeated FollowedArtist artists = 1;
 }
+
+// FollowedArtist represents an artist with user-specific follow metadata.
+// This is an RPC-layer message (not an entity) because passion_level is
+// per-user context, not an intrinsic property of the Artist entity.
+message FollowedArtist {
+  // The artist entity.
+  entity.v1.Artist artist = 1 [(buf.validate.field).required = true];
+
+  // The user's passion level for this artist.
+  entity.v1.PassionLevel passion_level = 2 [
+    (buf.validate.field).required = true,
+    (buf.validate.field).enum.defined_only = true
+  ];
+}
+
+// SetPassionLevelRequest provides the artist ID and the new passion level to set.
+message SetPassionLevelRequest {
+  // Required. The unique identifier of the artist.
+  entity.v1.ArtistId artist_id = 1 [(buf.validate.field).required = true];
+
+  // Required. The new passion level tier.
+  entity.v1.PassionLevel passion_level = 2 [
+    (buf.validate.field).required = true,
+    (buf.validate.field).enum.defined_only = true
+  ];
+}
+
+// SetPassionLevelResponse is returned upon a successful passion level update.
+message SetPassionLevelResponse {}
 
 // ListSimilarRequest specifies the seed artist for discovery.
 message ListSimilarRequest {


### PR DESCRIPTION
## Summary
- Add `PassionLevel` enum to `entity/v1/artist.proto`
- Add `SetPassionLevel` RPC, `FollowedArtist` wrapper, and request/response messages to `artist_service.proto`
- Update `ListFollowedResponse` to use `repeated FollowedArtist` (breaking change)
- Update OpenSpec change tracker tasks

## Context
Part of the passion-level feature. Backend implementation is ready and waiting for BSR-generated Go types.

## Test plan
- [ ] BSR generates Go code successfully after merge
- [ ] `buf lint` passes on proto files
- [ ] Backend compiles after `go get` updated dependency