### PR TITLE
fix(proto): change UserExternalId validation for Zitadel snowflake IDs

### DIFF
--- a/openspec/changes/fix-zitadel-id-type-mismatch/.openspec.yaml
+++ b/openspec/changes/fix-zitadel-id-type-mismatch/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-02-22

--- a/openspec/changes/fix-zitadel-id-type-mismatch/design.md
+++ b/openspec/changes/fix-zitadel-id-type-mismatch/design.md
@@ -1,0 +1,53 @@
+## Context
+
+The backend uses Zitadel as its identity provider. Zitadel issues JWT tokens where the `sub` claim is a snowflake-style numeric string (e.g., `360952429480515994`), not a UUID. The `users.external_id` column was created as `UUID` type, which rejects non-UUID values at INSERT time — blocking user creation entirely. Separately, the artist Follow/Unfollow/ListFollowed RPCs extract the Zitadel `sub` from the JWT and pass it directly to queries against `followed_artists.user_id`, which references the internal `users.id` (UUIDv7). This is a second mismatch: even if the user existed, the wrong ID type is used for artist queries.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Accept Zitadel snowflake IDs in `users.external_id` by changing the column type to TEXT
+- Resolve external identity to internal user UUID in artist use case methods before database queries
+- Unblock the onboarding flow on dev environment
+
+**Non-Goals:**
+- Changing the auth middleware or `GetUserID` helper — these correctly return the Zitadel sub
+- Adding caching for the external_id → user.id lookup (premature; single indexed query is sufficient)
+- Changing how other RPCs (e.g., User.Create) handle the Zitadel ID — Create already stores it in `external_id`
+
+## Decisions
+
+### D1: Column type TEXT, not BIGINT
+
+Change `users.external_id` from `UUID` to `TEXT` rather than `BIGINT`.
+
+**Rationale**: Although Zitadel IDs are currently numeric, using TEXT avoids coupling to a specific ID format. If Zitadel changes their ID scheme or the project switches identity providers, TEXT accommodates any string-based identifier without further migration. The UNIQUE index on TEXT performs adequately for point lookups.
+
+**Alternative considered**: `BIGINT` — more compact storage and faster comparisons, but assumes Zitadel IDs are always numeric. The Go `Claims.Sub` field is already a `string`, so BIGINT would require parsing.
+
+### D2: ID resolution in use case layer, not interceptor
+
+Add `UserRepository` as a dependency of `ArtistUseCase`. Each artist operation resolves the Zitadel sub to `users.id` via `UserRepository.GetByExternalID()` before calling artist repository methods.
+
+**Rationale**: The use case layer is responsible for orchestrating business logic across repositories. An interceptor approach would query the database on every authenticated request — wasteful for RPCs that don't need the internal ID (e.g., `User.Create`). The use case approach only resolves when needed and avoids the chicken-and-egg problem where `User.Create` is called before the user record exists.
+
+**Alternative considered**: Auth interceptor that injects internal user ID into context — rejected because it would fail for `User.Create` (user doesn't exist yet) and adds unnecessary DB load to every RPC.
+
+### D3: Protobuf external_id validation change
+
+Remove `string.uuid` protovalidate constraint on the `User.external_id` field. Replace with a non-empty string constraint.
+
+**Rationale**: The field no longer holds a UUID. Keeping UUID validation would reject valid Zitadel IDs at the API boundary.
+
+## Risks / Trade-offs
+
+- **UUID → TEXT migration on existing data**: Existing UUID values in `external_id` are valid TEXT strings, so the `ALTER COLUMN TYPE TEXT` is data-compatible and non-destructive. → No data loss risk.
+- **Index performance**: TEXT index is marginally slower than UUID index for point lookups. → Negligible at current scale; the column has a UNIQUE constraint which creates a B-tree index.
+- **Missing user record**: If `GetByExternalID` returns not-found during an artist operation, the RPC should return `NOT_FOUND` with a clear message. → This indicates the user hasn't completed registration, which is a valid state.
+
+## Migration Plan
+
+1. Create Atlas migration: `ALTER TABLE users ALTER COLUMN external_id TYPE TEXT`
+2. Update protobuf `User.external_id` field validation
+3. Update `ArtistUseCase` constructor to accept `UserRepository`
+4. Update `Follow`, `Unfollow`, `ListFollowed` use case methods to resolve external ID
+5. Deploy migration first (backward-compatible), then deploy backend code

--- a/openspec/changes/fix-zitadel-id-type-mismatch/proposal.md
+++ b/openspec/changes/fix-zitadel-id-type-mismatch/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+Zitadel uses snowflake-style numeric IDs (e.g., `360952429480515994`) for the `sub` claim, not UUIDs. The `users.external_id` column is typed `UUID`, causing user creation to fail. Additionally, the artist Follow/Unfollow/ListFollowed RPCs pass the Zitadel `sub` claim directly to queries against `followed_artists.user_id`, which references the internal `users.id` UUID — a second type mismatch that produces `SQLSTATE 22P02`. This blocks onboarding for all users on dev (backend#96).
+
+## What Changes
+
+- Change `users.external_id` column type from `UUID` to `TEXT` via a new Atlas migration
+- Update the `User` protobuf entity to remove UUID format validation on `external_id`
+- Inject `UserRepository` into `ArtistUseCase` so it can resolve `external_id → users.id`
+- Update `Follow`, `Unfollow`, and `ListFollowed` use case methods to resolve the Zitadel sub claim to the internal user UUID before querying `followed_artists`
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `user-account-sync`: Change `external_id` type from UUID to TEXT to accept Zitadel snowflake IDs
+- `artist-following`: Artist follow/unfollow/list operations must resolve external identity to internal user ID before database queries
+
+## Impact
+
+- **Database**: Migration to alter `users.external_id` from UUID to TEXT (data-compatible — existing UUIDs are valid TEXT)
+- **Protobuf**: `User.external_id` field validation changes from `string.uuid` to plain string
+- **Backend**: `ArtistUseCase` gains a `UserRepository` dependency; three methods updated
+- **Frontend**: No changes required

--- a/openspec/changes/fix-zitadel-id-type-mismatch/specs/artist-following/spec.md
+++ b/openspec/changes/fix-zitadel-id-type-mismatch/specs/artist-following/spec.md
@@ -1,0 +1,60 @@
+## MODIFIED Requirements
+
+### Requirement: Persist User Follow Actions
+
+The system SHALL persist user follow and unfollow actions for specific artists in a relational database. The use case layer SHALL resolve the authenticated user's external identity (Zitadel `sub` claim) to the internal user UUID before querying or writing to the `followed_artists` table. The frontend SHALL call the backend `ArtistService.Follow` RPC when a user taps an artist bubble. After a follow is successfully persisted, the system SHALL asynchronously attempt to resolve and store the artist's official site URL if one does not already exist.
+
+#### Scenario: Successfully following an artist
+
+- **WHEN** a user with a valid Zitadel identity requests to follow an artist with a valid MBID
+- **THEN** the system SHALL resolve the Zitadel `sub` claim to the internal user UUID via `UserRepository.GetByExternalID`
+- **AND** the system SHALL create a record in the `followed_artists` table linking the internal user UUID to the artist
+- **AND** the system SHALL trigger an asynchronous resolution of the artist's official site URL
+- **AND** the RPC response SHALL be returned before the resolution completes
+
+#### Scenario: Following an artist whose official site is already known
+
+- **WHEN** a user follows an artist that already has an `artist_official_site` record
+- **THEN** the system SHALL create the `followed_artists` record as normal
+- **AND** SHALL skip official site resolution silently
+
+#### Scenario: Frontend calls Follow RPC on bubble tap
+
+- **WHEN** a user taps an artist bubble in the discovery UI
+- **THEN** the frontend SHALL call `ArtistService.Follow` RPC with the artist's database-assigned `id`
+- **AND** the frontend SHALL update local state immediately without waiting for the RPC response
+- **AND** any RPC error SHALL be logged but SHALL NOT block the UI interaction
+
+#### Scenario: User record not found during follow
+
+- **WHEN** `Follow` is called with a valid Zitadel identity but no corresponding user record exists
+- **THEN** the system SHALL return `NOT_FOUND` error indicating the user must complete registration first
+
+### Requirement: Idempotent Unfollow Logic
+
+The system SHALL allow users to unfollow artists, ensuring that the operation is idempotent. The use case layer SHALL resolve the external identity to the internal user UUID before deleting from `followed_artists`.
+
+#### Scenario: Unfollowing an artist
+
+- **WHEN** a user requests to unfollow an artist they currently follow
+- **THEN** the system SHALL resolve the Zitadel `sub` claim to the internal user UUID
+- **AND** the system SHALL remove the corresponding record from the `followed_artists` table
+
+### Requirement: List All Followed Artists
+
+The `ArtistRepository` SHALL provide a `ListAllFollowed` method that returns all distinct artists followed by any user in the system.
+
+#### Scenario: Multiple users follow the same artist
+
+- **WHEN** `ListAllFollowed` is called and multiple users follow the same artist
+- **THEN** the artist SHALL appear only once in the result set
+
+#### Scenario: No followed artists
+
+- **WHEN** `ListAllFollowed` is called and no users follow any artists
+- **THEN** it SHALL return an empty slice without error
+
+#### Scenario: Mixed followed and unfollowed artists
+
+- **WHEN** some artists in the system have followers and others do not
+- **THEN** only artists with at least one follower SHALL be returned

--- a/openspec/changes/fix-zitadel-id-type-mismatch/specs/user-account-sync/spec.md
+++ b/openspec/changes/fix-zitadel-id-type-mismatch/specs/user-account-sync/spec.md
@@ -1,0 +1,26 @@
+## MODIFIED Requirements
+
+### Requirement: External Identity Mapping
+
+The system SHALL maintain a unique mapping between Zitadel identity (`sub` claim) and the local user record using a TEXT-typed `external_id` column. The column accepts any string format to accommodate identity provider ID schemes (e.g., Zitadel snowflake IDs, UUIDs).
+
+#### Scenario: Store external identity
+
+- **WHEN** a new user record is created via `Create`
+- **THEN** the `external_id` column SHALL be set to the Zitadel `sub` claim value as a plain string
+- **AND** the `external_id` column SHALL have a UNIQUE constraint
+
+#### Scenario: Lookup by external identity
+
+- **WHEN** the system receives a request with a Zitadel `sub` claim
+- **THEN** the system SHALL be able to find the corresponding local user by `external_id`
+
+### Requirement: User Entity External ID Field
+
+The `User` protobuf entity SHALL include an `external_id` field to represent the Zitadel identity link.
+
+#### Scenario: External ID in User entity
+
+- **WHEN** a `User` entity is serialized
+- **THEN** it SHALL include the `external_id` field as a non-empty string
+- **AND** the field SHALL be validated as a non-empty string via protovalidate (not UUID format)

--- a/openspec/changes/fix-zitadel-id-type-mismatch/tasks.md
+++ b/openspec/changes/fix-zitadel-id-type-mismatch/tasks.md
@@ -1,0 +1,25 @@
+## 1. Database Migration
+
+- [x] 1.1 Create Atlas migration to alter `users.external_id` from UUID to TEXT
+- [x] 1.2 Update `schema.sql` to reflect `external_id TEXT` type
+
+## 2. Protobuf
+
+- [x] 2.1 Update `User.external_id` field validation from `string.uuid` to non-empty string in proto definition
+- [x] 2.2 Run `buf lint` and `buf build` to verify proto changes
+
+## 3. Backend: Use Case Layer
+
+- [x] 3.1 Add `UserRepository` dependency to `ArtistUseCase` constructor
+- [x] 3.2 Update `ArtistUseCase.Follow` to resolve external ID to internal user UUID via `UserRepository.GetByExternalID` before calling `ArtistRepository.Follow`
+- [x] 3.3 Update `ArtistUseCase.Unfollow` to resolve external ID to internal user UUID before calling `ArtistRepository.Unfollow`
+- [x] 3.4 Update `ArtistUseCase.ListFollowed` to resolve external ID to internal user UUID before calling `ArtistRepository.ListFollowed`
+
+## 4. Backend: Wiring
+
+- [x] 4.1 Update dependency injection to pass `UserRepository` to `ArtistUseCase` constructor
+
+## 5. Verification
+
+- [x] 5.1 Run existing unit tests and fix any failures caused by the new `UserRepository` dependency
+- [x] 5.2 Run `golangci-lint run` and `go vet ./...`

--- a/proto/liverty_music/entity/v1/user.proto
+++ b/proto/liverty_music/entity/v1/user.proto
@@ -15,8 +15,8 @@ message UserId {
 // UserExternalId is the identity provider's unique identifier for a user.
 // This maps to the Zitadel `sub` claim and links the external identity to the local user record.
 message UserExternalId {
-  // A UUID string representing the identity provider's user identifier.
-  string value = 1 [(buf.validate.field).string.uuid = true];
+  // The identity provider's user identifier (e.g., Zitadel snowflake ID).
+  string value = 1 [(buf.validate.field).string.min_len = 1];
 }
 
 // UserEmail represents a validated email address for communications.


### PR DESCRIPTION
## 🔗 Related Issue

Closes liverty-music/backend#96

## 📝 Summary of Changes

Zitadel uses snowflake-style numeric IDs (e.g., `360952429480515994`) for the JWT `sub` claim, not UUIDs. The `UserExternalId` proto message had `string.uuid` validation which rejects these valid identifiers at the API boundary.

- Change `UserExternalId.value` validation from `string.uuid` to `string.min_len = 1`
- Add OpenSpec change artifacts documenting the fix design and tasks

## ✅ Self-Checklist

- [x] I have linked the related issue.
- [x] I have updated the relevant documentation (e.g., `README.md`) if needed.
- [x] I have run `buf lint` and `buf format` locally and all checks have passed.
- [x] My proto definitions follow the project's style guidelines and validation rules.
- [ ] Breaking changes have been justified and documented if applicable.