### PR TITLE
fix(ci): revert claude-code-action to @v1

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           fetch-depth: 1
 
-      - uses: anthropics/claude-code-action@v1.0.42
+      - uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           track_progress: true

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -27,6 +27,6 @@ jobs:
         with:
           fetch-depth: 1
 
-      - uses: anthropics/claude-code-action@v1.0.42
+      - uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
## Summary
- Revert `anthropics/claude-code-action` from pinned v1.0.51 to `@v1` (latest)
- Pinning to older versions doesn't fix the AJV crash (see anthropics/claude-code-action#947)
- `@v1` resolves to v1.0.55 which bundles CLI v2.1.49, most likely to have the fix

## Test plan
- [ ] Claude auto-review triggers without AJV crash