### PR TITLE
feat(proto): add ListByFollower RPC to ConcertService

### DIFF
--- a/openspec/changes/fix-n-plus-1-concert-rpc/.openspec.yaml
+++ b/openspec/changes/fix-n-plus-1-concert-rpc/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-02-23

--- a/openspec/changes/fix-n-plus-1-concert-rpc/design.md
+++ b/openspec/changes/fix-n-plus-1-concert-rpc/design.md
@@ -1,0 +1,66 @@
+## Context
+
+The dashboard currently fetches concerts by calling `ConcertService.List(artist_id)` once per followed artist (N+1 pattern). The authenticated user's identity is already available in RPC context via JWT claims, and the `followed_artists` table links users to artists. The `ArtistService.ListFollowed` handler demonstrates the established pattern for user-scoped queries.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Reduce dashboard concert loading from N+1 RPC calls to 1
+- Follow established auth-context patterns (`auth.GetUserID`)
+- Keep the existing `List` RPC unchanged
+
+**Non-Goals:**
+- Adding `passion_level` to the response (future enhancement)
+- Pagination or cursor-based fetching
+- Caching or materialized views
+
+## Decisions
+
+### Decision 1: `ListByFollower` RPC on ConcertService
+
+Add a new RPC rather than extending the existing `List` RPC.
+
+- **Rationale**: `List` filters by a single artist — a fundamentally different query shape than "all concerts for a user's followed artists." Mixing both into one RPC adds conditional logic and unclear validation rules.
+- **Alternative considered**: `ListByArtists(repeated artist_ids)` — still requires 2 RPC calls (ListFollowed + ListByArtists) and leaks orchestration to the frontend.
+
+### Decision 2: Empty request message, auth from context
+
+`ListByFollowerRequest` has no fields. The user identity comes from the JWT claims in the RPC context, following the same pattern as `ArtistService.ListFollowed`.
+
+- **Rationale**: Consistent with existing patterns. Prevents one user from querying another user's followed concerts.
+
+### Decision 3: Single SQL JOIN query
+
+The repository method joins `concerts`, `events`, `venues`, and `followed_artists` in one query filtered by `user_id`.
+
+```sql
+SELECT c.event_id, c.artist_id, e.venue_id, e.title, e.listed_venue_name,
+       e.local_event_date, e.start_at, e.open_at, e.source_url,
+       v.id, v.name, v.admin_area
+FROM concerts c
+JOIN events e ON c.event_id = e.id
+JOIN venues v ON e.venue_id = v.id
+JOIN followed_artists fa ON c.artist_id = fa.artist_id
+WHERE fa.user_id = $1
+ORDER BY e.local_event_date ASC
+```
+
+- **Rationale**: `followed_artists` has an index on `user_id`. The query reuses the same column set as `listConcertsByArtistQuery`, so existing row-scanning logic applies.
+
+### Decision 4: Flat response with `repeated Concert`
+
+The response is `repeated entity.v1.Concert` — no grouping by artist.
+
+- **Rationale**: Each `Concert` already contains `artist_id`. The frontend can group client-side if needed. A `map<string, ArtistConcerts>` structure adds proto complexity with no benefit.
+
+### Decision 5: Backend resolves external_id → internal UUID
+
+The handler calls `auth.GetUserID(ctx)` to get the Zitadel external ID, then `resolveUserID` maps it to the internal UUID for the SQL query. This follows the `ListFollowed` pattern.
+
+- **Rationale**: Concert usecase needs a `userRepo` dependency to resolve the user. Since `artistUseCase` already does this, the concert usecase can follow the same pattern.
+
+## Risks / Trade-offs
+
+- **[Cross-domain JOIN]** ConcertService queries `followed_artists`, which is conceptually in the artist/follow domain. → Acceptable in a monolithic DB; revisit only if services split.
+- **[Large result sets]** A user following many artists with many concerts could return a large payload. → Mitigated by the practical upper bound of followed artists. Pagination can be added later if needed.
+- **[New dependency]** Concert usecase gains a `userRepo` dependency for `resolveUserID`. → Minimal coupling; single method interface.

--- a/openspec/changes/fix-n-plus-1-concert-rpc/proposal.md
+++ b/openspec/changes/fix-n-plus-1-concert-rpc/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+The dashboard loads concerts by making one `ConcertService.List` RPC call per followed artist (N+1 problem). A user following 50 artists triggers 50 RPC round-trips and 50 SQL queries. This does not scale and wastes server resources. The fix is to add a single RPC that returns all concerts for the authenticated user's followed artists in one call.
+
+## What Changes
+
+- Add `ListByFollower` RPC to `ConcertService` that returns all concerts for the caller's followed artists in a single request
+- Add backend handler, usecase, and repository methods to support the new RPC with a single SQL query joining `concerts`, `events`, `venues`, and `followed_artists`
+- Replace the frontend dashboard's N parallel `ListConcerts` calls with one `ListByFollower` call
+
+## Capabilities
+
+### New Capabilities
+
+_(none — this extends existing capabilities)_
+
+### Modified Capabilities
+
+- `concert-service`: Add `ListByFollower` RPC that retrieves concerts for all artists followed by the authenticated user
+- `live-events`: Add scenario for listing concerts by follower
+
+## Impact
+
+- **Proto**: `concert_service.proto` — new RPC, request, and response messages
+- **Backend**: `concert_handler.go`, `concert_uc.go`, `concert_repo.go` — new methods
+- **Frontend**: `dashboard-service.ts`, `concert-service.ts` — replace N calls with 1
+- **No breaking changes**: Existing `List` RPC is unchanged

--- a/openspec/changes/fix-n-plus-1-concert-rpc/specs/concert-service/spec.md
+++ b/openspec/changes/fix-n-plus-1-concert-rpc/specs/concert-service/spec.md
@@ -1,0 +1,29 @@
+## ADDED Requirements
+
+### Requirement: List Concerts by Follower
+
+The system SHALL provide an RPC to retrieve all concerts for artists followed by the authenticated user in a single request.
+
+#### Scenario: Authenticated user with followed artists
+
+- **WHEN** `ListByFollower` is called by an authenticated user who follows one or more artists
+- **THEN** it SHALL return all concerts associated with those followed artists
+- **AND** each concert SHALL include a resolved `Venue` object with `name` and `admin_area` if available
+- **AND** each concert SHALL include `listed_venue_name` with the raw scraped venue name
+- **AND** concerts SHALL be ordered by `local_event_date` ascending
+
+#### Scenario: Authenticated user with no followed artists
+
+- **WHEN** `ListByFollower` is called by an authenticated user who follows no artists
+- **THEN** it SHALL return an empty list without error
+
+#### Scenario: Unauthenticated caller
+
+- **WHEN** `ListByFollower` is called without valid authentication
+- **THEN** it SHALL return an `UNAUTHENTICATED` error
+
+#### Scenario: Single SQL query execution
+
+- **WHEN** `ListByFollower` is called
+- **THEN** the backend SHALL execute a single SQL query joining `concerts`, `events`, `venues`, and `followed_artists` tables
+- **AND** the query SHALL filter by the authenticated user's internal ID

--- a/openspec/changes/fix-n-plus-1-concert-rpc/specs/live-events/spec.md
+++ b/openspec/changes/fix-n-plus-1-concert-rpc/specs/live-events/spec.md
@@ -1,0 +1,16 @@
+## MODIFIED Requirements
+
+### Requirement: Live Schedule Access
+
+The system MUST provide access to the collected schedule of concerts.
+
+#### Scenario: List Concerts
+
+- **WHEN** `ListConcerts` is called for a valid artist ID
+- **THEN** the system MUST return a chronologically sorted list of future concerts for that artist.
+
+#### Scenario: List Concerts by Follower
+
+- **WHEN** `ListByFollower` is called by an authenticated user
+- **THEN** the system MUST return a chronologically sorted list of concerts for all artists followed by that user
+- **AND** the result SHALL be retrieved in a single RPC call

--- a/openspec/changes/fix-n-plus-1-concert-rpc/tasks.md
+++ b/openspec/changes/fix-n-plus-1-concert-rpc/tasks.md
@@ -1,0 +1,35 @@
+## 1. Proto Schema
+
+- [x] 1.1 Add `ListByFollower` RPC to `ConcertService` in `concert_service.proto`
+- [x] 1.2 Define `ListByFollowerRequest` (empty message) and `ListByFollowerResponse` (repeated Concert)
+- [x] 1.3 Run `buf lint` and `buf format -w` to verify proto changes
+
+## 2. Backend Repository
+
+- [x] 2.1 Add `listConcertsByFollowerQuery` SQL constant in `concert_repo.go` joining concerts, events, venues, and followed_artists
+- [x] 2.2 Add `ListByFollower(ctx, userID string) ([]*entity.Concert, error)` method to `ConcertRepository`
+- [x] 2.3 Add `ListByFollower` to the concert repository interface
+
+## 3. Backend UseCase
+
+- [x] 3.1 Add `userRepo` dependency to `concertUseCase` struct and constructor
+- [x] 3.2 Add `resolveUserID` helper method (external ID → internal UUID)
+- [x] 3.3 Add `ListByFollower(ctx, externalUserID string) ([]*entity.Concert, error)` method to concert usecase
+- [x] 3.4 Add `ListByFollower` to the concert usecase interface
+
+## 4. Backend Handler
+
+- [x] 4.1 Add `ListByFollower` handler method to `ConcertHandler` extracting user ID from auth context
+- [x] 4.2 Register the new handler in Connect-RPC route setup
+
+## 5. Backend Tests
+
+- [x] 5.1 Add repository test for `ListByFollower` with followed artists returning concerts
+- [x] 5.2 Add repository test for `ListByFollower` with no followed artists returning empty list
+- [x] 5.3 Add handler test for unauthenticated `ListByFollower` returning UNAUTHENTICATED error
+
+## 6. Frontend
+
+- [x] 6.1 Add `listByFollower()` method to `ConcertService` calling the new RPC
+- [x] 6.2 Replace `fetchConcertsForArtists()` N-call loop in `DashboardService` with single `listByFollower()` call
+- [x] 6.3 Update `DashboardService` to map `Concert` responses with artist name resolution

--- a/proto/liverty_music/rpc/concert/v1/concert_service.proto
+++ b/proto/liverty_music/rpc/concert/v1/concert_service.proto
@@ -16,6 +16,13 @@ service ConcertService {
   // - NOT_FOUND: No concerts were found for the specified artist.
   rpc List(ListRequest) returns (ListResponse);
 
+  // ListByFollower retrieves all concerts for artists followed by the authenticated user.
+  // The caller's identity is determined from the authentication context.
+  //
+  // Possible errors:
+  // - UNAUTHENTICATED: The user identity could not be verified.
+  rpc ListByFollower(ListByFollowerRequest) returns (ListByFollowerResponse);
+
   // SearchNewConcerts triggers a discovery process to find new concerts for an artist.
   // It scrapes external sources and persists any newly found concerts.
   //
@@ -35,6 +42,17 @@ message ListRequest {
 // ListResponse contains the collection of concerts matching the ListRequest.
 message ListResponse {
   // The collection of concert events found.
+  repeated entity.v1.Concert concerts = 1;
+}
+
+// ListByFollowerRequest is the request for retrieving concerts for all artists
+// followed by the authenticated user. No fields are required; the user identity
+// is determined from the authentication context.
+message ListByFollowerRequest {}
+
+// ListByFollowerResponse contains the concerts for all artists followed by the caller.
+message ListByFollowerResponse {
+  // The collection of concert events, ordered by date ascending.
   repeated entity.v1.Concert concerts = 1;
 }
 


### PR DESCRIPTION
## 🔗 Related Issue

Closes #90

## 📝 Summary of Changes

Add `ListByFollower` RPC to `ConcertService` that retrieves all concerts for artists followed by the authenticated user in a single request.

- `ListByFollowerRequest`: empty message (user identity comes from auth context)
- `ListByFollowerResponse`: `repeated Concert` ordered by date ascending
- Documents `UNAUTHENTICATED` error for unauthenticated callers

This is the proto schema change for resolving the N+1 RPC problem on the dashboard. Backend and frontend PRs depend on this being merged first (BSR codegen).

## 📋 Commit Log

$(git log --oneline main..HEAD)

## ✅ Self-Checklist

- [x] I have linked the related issue.
- [x] I have added or updated tests to cover my changes.
- [x] I have updated the relevant documentation (e.g., `README.md`, `CLAUDE.md`).
- [x] I have run `buf lint` and `buf format` locally and all checks have passed.
- [x] My code follows the architecture and style guidelines of the project.