### PR TITLE
feat!: remove create_time from User proto entity

### DIFF
--- a/proto/liverty_music/entity/v1/user.proto
+++ b/proto/liverty_music/entity/v1/user.proto
@@ -3,8 +3,6 @@ syntax = "proto3";
 package liverty_music.entity.v1;
 
 import "buf/validate/validate.proto";
-import "google/api/field_behavior.proto";
-import "google/protobuf/timestamp.proto";
 
 // UserId is a globally unique identifier for a platform user.
 message UserId {
@@ -34,8 +32,7 @@ message User {
   // The primary email address used for account identity and notifications.
   UserEmail email = 2 [(buf.validate.field).required = true];
 
-  // The time when the user was created.
-  google.protobuf.Timestamp create_time = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
+  reserved 3;
 
   // The identity provider's user identifier (Zitadel sub claim).
   // Used to link the external identity to the local user record.


### PR DESCRIPTION
## 🔗 Related Issue

Closes #99

## 📝 Summary of Changes

Remove the `create_time` field from `User` proto message. This metadata timestamp is not used by any business logic; audit logging will be handled separately.

- Remove `create_time` (field 3) from `User` message and add `reserved 3;` to prevent field number reuse
- Remove unused `google/protobuf/timestamp.proto` and `google/api/field_behavior.proto` imports

**BREAKING CHANGE**: `User.create_time` field is removed from API responses.

## ✅ Self-Checklist

- [x] I have linked the related issue.
- [x] I have updated the relevant documentation (e.g., `README.md`) if needed.
- [x] I have run `buf lint` and `buf format` locally and all checks have passed.
- [x] My proto definitions follow the project's style guidelines and validation rules.
- [x] Breaking changes have been justified and documented if applicable.