### PR TITLE
docs(openspec): archive remove-audit-timestamps change

### DIFF
--- a/openspec/changes/archive/2026-02-24-remove-audit-timestamps/.openspec.yaml
+++ b/openspec/changes/archive/2026-02-24-remove-audit-timestamps/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-02-23

--- a/openspec/changes/archive/2026-02-24-remove-audit-timestamps/design.md
+++ b/openspec/changes/archive/2026-02-24-remove-audit-timestamps/design.md
@@ -1,0 +1,44 @@
+## Context
+
+Proto, Go entity, DB schema の各レイヤーに `created_at` / `updated_at` メタデータタイムスタンプが存在するが、ビジネスロジックでは使用されていない。`artists` と `concerts` テーブルは既に migration `20260221130000` で削除済み。残り 6 テーブルと Proto/Go 層の整理が必要。
+
+併せて `Nullifier.UsedAt` の命名が他の `XxxTime` パターンと不一致のため修正する。
+
+## Goals / Non-Goals
+
+**Goals:**
+- 全テーブルから `created_at` / `updated_at` メタデータカラムを削除
+- `user.proto` から `create_time` フィールドを削除
+- Go entity / mapper / repo から関連コードを削除
+- `Nullifier.UsedAt` → `UseTime` にリネーム
+- テストの関連アサーションを修正
+
+**Non-Goals:**
+- ビジネスタイムスタンプ (`minted_at`, `start_at`, `open_at`, `searched_at`, `scheduled_at`, `sent_at`, `used_at`) には触れない
+- 監査ログの代替実装（別途対応）
+- DB カラム `used_at` のリネーム（DB 層は `_at` が慣習、Go 層のみ修正）
+
+## Decisions
+
+### 1. Proto フィールド番号を reserved にする
+
+`user.proto` から `create_time` (field number 3) を削除した後、将来の誤用を防ぐため `reserved 3;` を追加する。
+
+**理由**: Proto のフィールド番号再利用は wire format の互換性を壊すため、Google AIP のベストプラクティスに従う。
+
+### 2. マイグレーションは 1 ファイルで全テーブルをまとめる
+
+6 テーブルの `DROP COLUMN` を 1 つのマイグレーションファイルにまとめる。
+
+**理由**: 全て同じ理由（メタデータタイムスタンプ削除）であり、原子的に適用すべき。既存の `20260221130000_drop_artists_timestamps.sql` と同じパターン。
+
+### 3. Go entity の `UsedAt` → `UseTime` リネームは DB カラム名を変えない
+
+Go struct フィールド名のみ変更し、DB カラム `used_at` はそのまま。repo のスキャン先を調整する。
+
+**理由**: DB カラムは `_at` サフィックスが PostgreSQL の慣習。Go 側のみ `XxxTime` パターンに統一する。
+
+## Risks / Trade-offs
+
+- **[Breaking API Change]** `User.create_time` を削除するため、既存 API クライアントに影響 → 現在フロントエンドでは未使用を確認済み。Proto の `reserved` で将来の誤用を防止。
+- **[DB Migration]** `DROP COLUMN` は PostgreSQL ではメタデータ操作のみでテーブルリライトは発生しない → リスク低い。ただし `DEFAULT NOW()` のトリガーがある場合は確認が必要。

--- a/openspec/changes/archive/2026-02-24-remove-audit-timestamps/proposal.md
+++ b/openspec/changes/archive/2026-02-24-remove-audit-timestamps/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+Proto, Go entity, DB schema の各レイヤーに `created_at` / `updated_at` 系のメタデータタイムスタンプが散在しているが、アプリケーションのビジネスロジックで使用されていない。監査ログは別途対応するため、これらを全て削除してスキーマを簡素化する。併せて `UsedAt` → `UseTime` へリネームし、Go entity の命名規則を `XxxTime` パターンに統一する。
+
+## What Changes
+
+- **BREAKING** Proto: `user.proto` の `create_time` フィールドを削除
+- Go Entity: `User.CreateTime`, `User.UpdateTime` フィールドを削除
+- Go Entity: `Nullifier.UsedAt` を `Nullifier.UseTime` にリネーム（命名一貫性）
+- Go Mapper: `User` の `timestamppb` 変換コードを削除
+- Go Repo: `user_repo.go` の SELECT/INSERT から `created_at`, `updated_at` カラム参照を除去
+- DB: 6 テーブルから `created_at` / `updated_at` カラムを DROP
+  - `users`, `events`, `venues`, `artist_official_site`, `followed_artists`, `notifications`
+- DB: `schema.sql` から該当カラム定義を削除
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `user-account-sync`: `User` エンティティから `create_time` を削除。API レスポンスの変更。
+- `database`: 6 テーブルからタイムスタンプカラムを DROP するマイグレーション追加。
+
+## Impact
+
+- **Proto/API**: `User` メッセージから `create_time` フィールドが消えるため、API クライアントに breaking change
+- **Backend**: entity, mapper, repo, テストの修正
+- **DB**: 新規マイグレーションファイルが必要（ALTER TABLE ... DROP COLUMN）
+- **Frontend**: `create_time` を参照していないため影響なし

--- a/openspec/changes/archive/2026-02-24-remove-audit-timestamps/specs/database/spec.md
+++ b/openspec/changes/archive/2026-02-24-remove-audit-timestamps/specs/database/spec.md
@@ -1,0 +1,27 @@
+## ADDED Requirements
+
+### Requirement: Database tables SHALL NOT include metadata timestamp columns
+
+Application tables SHALL NOT include `created_at` or `updated_at` columns for audit purposes. Business-meaningful timestamps (e.g., `minted_at`, `start_at`, `open_at`, `searched_at`, `scheduled_at`, `sent_at`, `used_at`) SHALL be retained.
+
+#### Scenario: Metadata timestamps removed from all tables
+
+- **WHEN** the migration is applied
+- **THEN** the following columns SHALL be dropped:
+  - `users.created_at`, `users.updated_at`
+  - `events.created_at`, `events.updated_at`
+  - `venues.created_at`, `venues.updated_at`
+  - `artist_official_site.created_at`, `artist_official_site.updated_at`
+  - `followed_artists.created_at`
+  - `notifications.created_at`, `notifications.updated_at`
+- **AND** `schema.sql` SHALL NOT contain `created_at` or `updated_at` in any table definition
+
+#### Scenario: Business timestamps are preserved
+
+- **WHEN** the migration is applied
+- **THEN** the following columns SHALL remain unchanged:
+  - `tickets.minted_at`
+  - `events.start_at`, `events.open_at`
+  - `latest_search_logs.searched_at`
+  - `nullifiers.used_at`
+  - `notifications.scheduled_at`, `notifications.sent_at`

--- a/openspec/changes/archive/2026-02-24-remove-audit-timestamps/specs/user-account-sync/spec.md
+++ b/openspec/changes/archive/2026-02-24-remove-audit-timestamps/specs/user-account-sync/spec.md
@@ -1,0 +1,20 @@
+## MODIFIED Requirements
+
+### Requirement: User Account Provisioning on Signup
+
+The system SHALL create a local user record in the application database when a user completes registration via Zitadel, linking the Zitadel identity (`sub` claim) to the local record via an `external_id` field (TEXT type).
+
+#### Scenario: Successful signup provisioning
+
+- **WHEN** a user completes registration via Zitadel and the frontend receives the OIDC callback with `state.isRegistration === true`
+- **THEN** the frontend SHALL call the `Create` RPC with the user's `email` parameter only
+- **AND** the backend SHALL extract `external_id` (from JWT `sub` claim) and `name` (from JWT `name` claim)
+- **AND** the backend SHALL create a new user record with `external_id`, `email`, and `name` persisted
+- **AND** the backend SHALL return the created user without any `create_time` field
+
+## REMOVED Requirements
+
+### Requirement: User Create Time Tracking
+
+**Reason**: `create_time` is a metadata timestamp not used by any business logic. Audit logging will be handled separately.
+**Migration**: Remove `create_time` from `User` protobuf entity. Reserve field number 3 in `user.proto`. Remove `created_at` and `updated_at` columns from `users` table.

--- a/openspec/changes/archive/2026-02-24-remove-audit-timestamps/tasks.md
+++ b/openspec/changes/archive/2026-02-24-remove-audit-timestamps/tasks.md
@@ -1,0 +1,30 @@
+## 1. Proto 層
+
+- [x] 1.1 `user.proto` から `create_time` フィールド (field 3) を削除し、`reserved 3;` を追加。`google/protobuf/timestamp.proto` の import が不要なら削除
+- [x] 1.2 `buf build` / `buf lint` で Proto のビルド・リントが通ることを確認
+
+## 2. Go Entity 層
+
+- [x] 2.1 `entity/user.go` から `CreateTime`, `UpdateTime` フィールドを削除
+- [x] 2.2 `entity/entry.go` の `Nullifier.UsedAt` を `Nullifier.UseTime` にリネーム
+
+## 3. Go Mapper 層
+
+- [x] 3.1 `adapter/rpc/mapper/user.go` から `CreateTime` → `timestamppb` 変換コードを削除。`timestamppb` import が不要なら削除
+
+## 4. Go Repository 層
+
+- [x] 4.1 `rdb/user_repo.go` の SELECT/INSERT クエリから `created_at`, `updated_at` カラム参照を除去
+- [x] 4.2 `Nullifier.UsedAt` → `UseTime` リネームに伴う repo 内の参照を修正
+
+## 5. Go テスト
+
+- [x] 5.1 `User` 関連テストから `CreateTime`, `UpdateTime` のアサーション・参照を削除
+- [x] 5.2 `Nullifier` 関連テストの `UsedAt` → `UseTime` リネーム修正
+- [x] 5.3 `go build ./...` と `go test ./...` が通ることを確認
+
+## 6. DB マイグレーション
+
+- [x] 6.1 新規マイグレーションファイルを作成し、6 テーブルから `created_at` / `updated_at` を DROP
+- [x] 6.2 `schema.sql` から該当カラム定義とコメントを削除
+- [x] 6.3 `atlas migrate hash` でチェックサムを更新

--- a/openspec/specs/database/spec.md
+++ b/openspec/specs/database/spec.md
@@ -39,3 +39,29 @@ All application tables SHALL be created in the `app` schema. The backend applica
 - **THEN** the DSN SHALL include `search_path=app`
 - **AND** all unqualified table references SHALL resolve to the `app` schema
 - **AND** no application tables SHALL exist in the `public` schema
+
+### Requirement: Database tables SHALL NOT include metadata timestamp columns
+
+Application tables SHALL NOT include `created_at` or `updated_at` columns for audit purposes. Business-meaningful timestamps (e.g., `minted_at`, `start_at`, `open_at`, `searched_at`, `scheduled_at`, `sent_at`, `used_at`) SHALL be retained.
+
+#### Scenario: Metadata timestamps removed from all tables
+
+- **WHEN** the migration is applied
+- **THEN** the following columns SHALL be dropped:
+  - `users.created_at`, `users.updated_at`
+  - `events.created_at`, `events.updated_at`
+  - `venues.created_at`, `venues.updated_at`
+  - `artist_official_site.created_at`, `artist_official_site.updated_at`
+  - `followed_artists.created_at`
+  - `notifications.created_at`, `notifications.updated_at`
+- **AND** `schema.sql` SHALL NOT contain `created_at` or `updated_at` in any table definition
+
+#### Scenario: Business timestamps are preserved
+
+- **WHEN** the migration is applied
+- **THEN** the following columns SHALL remain unchanged:
+  - `tickets.minted_at`
+  - `events.start_at`, `events.open_at`
+  - `latest_search_logs.searched_at`
+  - `nullifiers.used_at`
+  - `notifications.scheduled_at`, `notifications.sent_at`


### PR DESCRIPTION
## 🔗 Related Issue

Closes #99

## 📝 Summary of Changes

Archive the completed `remove-audit-timestamps` OpenSpec change and sync the database spec with timestamp removal requirements.

- Add new database spec requirement: tables SHALL NOT include `created_at`/`updated_at` metadata columns
- Archive change artifacts (proposal, design, delta specs for database and user-account-sync, tasks)

## ✅ Self-Checklist

- [x] I have linked the related issue.
- [x] I have updated the relevant documentation (e.g., `README.md`) if needed.
- [x] I have run `buf lint` and `buf format` locally and all checks have passed.
- [x] My proto definitions follow the project's style guidelines and validation rules.
- [x] Breaking changes have been justified and documented if applicable.