### PR TITLE
fix(ci): grant pull-requests:write to claude-code-review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: read
       id-token: write
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -39,6 +39,7 @@ jobs:
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }} --comment'
+          claude_args: '--allowedTools "Bash(gh pr *),Bash(gh api *),Bash(git *),Write"'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 


### PR DESCRIPTION
## Summary
- Fix `pull-requests` permission from `read` to `write`

## Background
The `code-review` plugin posts comments via `gh` CLI using `GITHUB_TOKEN`.
All `gh pr comment` / `gh api .../reviews` calls were landing in `permission_denials`
because the `/install-github-app`-generated template only granted `pull-requests: read`.

## Test plan
- [ ] Open a new PR and verify Claude posts a review comment