### PR TITLE
feat: add user-creation-webhook OpenSpec change

### DIFF
--- a/openspec/changes/user-creation-webhook/.openspec.yaml
+++ b/openspec/changes/user-creation-webhook/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-02-25

--- a/openspec/changes/user-creation-webhook/design.md
+++ b/openspec/changes/user-creation-webhook/design.md
@@ -1,0 +1,95 @@
+## Context
+
+Users currently register via Zitadel's hosted registration form. After OIDC callback, the frontend calls the backend `Create` RPC to provision a local user record. The backend extracts identity from validated JWT claims (`sub`, `email`, `name`). This works but only captures minimal profile data — fields like `preferred_language` remain empty despite having DB columns for them.
+
+Zitadel Actions v2 provides an event-driven webhook mechanism that fires on `user.human.added` events with rich profile data including `displayName`, `firstName`, `lastName`, `preferredLanguage`, and `userName`.
+
+The Zitadel instance is hosted on Zitadel Cloud (`dev-svijfm.us1.zitadel.cloud`). Actions v2 requires feature flag activation.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Add a Zitadel webhook endpoint that provisions or enriches user records on `user.human.added` events
+- Populate `preferred_language` and `name` with richer data from the webhook payload
+- Maintain the existing Create RPC as the primary provisioning path (no frontend changes)
+- Ensure idempotent handling regardless of which path (RPC or webhook) arrives first
+
+**Non-Goals:**
+- Replacing the existing Create RPC flow — it remains the primary mechanism
+- Handling other Zitadel event types (email verified, user locked, etc.) — future work
+- Real-time push notification to the frontend after webhook processing
+- Migrating existing users to backfill preferred_language
+
+## Decisions
+
+### Decision 1: Webhook as complementary path, not replacement
+
+The webhook endpoint runs alongside the existing Create RPC. Both paths write to the same `users` table using `external_id` as the correlation key.
+
+- Create RPC: `INSERT` with `ALREADY_EXISTS` on conflict (existing behavior, unchanged)
+- Webhook handler: `UPSERT` — INSERT if user doesn't exist, UPDATE to enrich if user already exists
+
+**Rationale**: Eliminates race condition concerns entirely. The frontend flow doesn't depend on webhook timing. Webhook failures are non-fatal — worst case, the user has less profile data.
+
+**Alternative considered**: Replace Create RPC with webhook-only provisioning. Rejected because of race condition between async webhook and synchronous OIDC callback, and unclear retry guarantees in Zitadel Actions v2.
+
+### Decision 2: Separate HTTP handler, not Connect-RPC
+
+The webhook endpoint is a plain `net/http` handler mounted at `/webhooks/zitadel`, not a Connect-RPC service.
+
+**Rationale**: Zitadel sends a standard HTTP POST with HMAC-signed JSON body. It doesn't speak Connect protocol. The handler needs different auth (HMAC verification vs JWT validation) and different request/response semantics. Keeping it as a plain HTTP handler avoids shoehorning an external integration into the RPC framework.
+
+**Alternative considered**: Create a separate Connect-RPC `WebhookService`. Rejected because Zitadel cannot be configured to speak Connect protocol.
+
+### Decision 3: HMAC signature verification
+
+Verify webhook authenticity using the `ZITADEL-Signature` header with the signing key returned when creating the Zitadel Target.
+
+**Rationale**: Simplest and most reliable option. JWT signing requires JWKS endpoint rotation handling. JWE adds unnecessary encryption complexity for an internal-to-cluster call.
+
+The signing key will be stored in GCP Secret Manager and synced to K8s via External Secrets Operator, consistent with existing secret management patterns.
+
+### Decision 4: UPSERT with COALESCE for enrichment
+
+```sql
+INSERT INTO users (external_id, email, name, preferred_language, country, time_zone, is_active)
+VALUES ($1, $2, $3, $4, $5, $6, true)
+ON CONFLICT (external_id) DO UPDATE SET
+  name = COALESCE(NULLIF(EXCLUDED.name, ''), users.name),
+  preferred_language = COALESCE(NULLIF(EXCLUDED.preferred_language, ''), users.preferred_language)
+RETURNING id
+```
+
+**Rationale**: `COALESCE(NULLIF(...))` ensures webhook data only overwrites when it has non-empty values, preventing data loss if the webhook payload is missing fields. This handles both orderings (RPC-first and webhook-first) correctly.
+
+### Decision 5: Adapter layer placement
+
+The webhook handler lives at `internal/adapter/webhook/zitadel_handler.go`, following the existing pattern where `internal/adapter/rpc/` contains Connect-RPC handlers. The `webhook` package is a sibling adapter for HTTP webhook integrations.
+
+### Decision 6: New use case method
+
+Add `UpsertFromWebhook(ctx, params)` to the user use case layer. This is distinct from `Create()` because:
+- It uses UPSERT semantics (not INSERT-only)
+- It receives pre-validated data from webhook payload (not JWT claims)
+- It has different error handling (no `AlreadyExists` error — conflicts are expected)
+
+## Risks / Trade-offs
+
+- **[Zitadel Actions v2 has no documented retry policy]** → Mitigation: The Create RPC remains the primary path. Webhook is best-effort enrichment. Missing webhook data is non-fatal.
+- **[Signing key rotation]** → Mitigation: Patching a Zitadel Target regenerates the signing key. Store in Secret Manager with External Secrets Operator for rotation support.
+- **[Webhook endpoint exposed to internet]** → Mitigation: HMAC signature verification rejects forged requests. Additionally, the endpoint only performs UPSERT with validated fields — no destructive operations.
+- **[Feature flag availability on Zitadel Cloud]** → Mitigation: Verified that Actions v2 is available on Zitadel Cloud via System API feature flag activation.
+
+## Migration Plan
+
+1. Deploy backend with new webhook endpoint (no traffic yet)
+2. Enable Actions v2 feature flag on Zitadel Cloud instance
+3. Create Zitadel Target (Webhook type) pointing to the backend webhook URL
+4. Create Zitadel Execution binding `user.human.added` event to the target
+5. Store the Target signing key in GCP Secret Manager
+6. Test with a new user registration — verify both Create RPC and webhook fire, and user record is enriched
+7. Rollback: Delete the Zitadel Execution to stop webhook delivery. No backend changes needed.
+
+## Open Questions
+
+- Should the webhook endpoint be exposed via the same GKE Gateway ingress or a separate internal-only route? (If Zitadel Cloud needs to reach it, it must be external.)

--- a/openspec/changes/user-creation-webhook/design.md
+++ b/openspec/changes/user-creation-webhook/design.md
@@ -84,11 +84,12 @@ Add `UpsertFromWebhook(ctx, params)` to the user use case layer. This is distinc
 
 1. Deploy backend with new webhook endpoint (no traffic yet)
 2. Enable Actions v2 feature flag on Zitadel Cloud instance
-3. Create Zitadel Target (Webhook type) pointing to the backend webhook URL
-4. Create Zitadel Execution binding `user.human.added` event to the target
-5. Store the Target signing key in GCP Secret Manager
-6. Test with a new user registration — verify both Create RPC and webhook fire, and user record is enriched
-7. Rollback: Delete the Zitadel Execution to stop webhook delivery. No backend changes needed.
+3. Create Zitadel Target (Webhook type) pointing to the backend webhook URL — note the returned signing key
+4. Store the Target signing key in GCP Secret Manager
+5. Wait for External Secrets Operator to sync the key to K8s, then restart/refresh the backend
+6. Create Zitadel Execution binding `user.human.added` event to the target (webhook delivery starts here)
+7. Test with a new user registration — verify both Create RPC and webhook fire, and user record is enriched
+8. Rollback: Delete the Zitadel Execution to stop webhook delivery. No backend changes needed.
 
 ## Open Questions
 

--- a/openspec/changes/user-creation-webhook/proposal.md
+++ b/openspec/changes/user-creation-webhook/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+The current user provisioning flow relies entirely on the frontend calling the `Create` RPC after OIDC callback. This means the backend only receives minimal user data available in JWT claims (sub, email, name). Zitadel's `user.human.added` event payload contains richer profile data (preferredLanguage, displayName, firstName, lastName) that we already have DB columns for but cannot populate. By adding a Zitadel Actions v2 webhook as a complementary provisioning path, the backend can capture richer user data at registration time while maintaining the existing frontend-driven flow as the primary mechanism.
+
+## What Changes
+
+- Add a new webhook HTTP endpoint on the backend to receive Zitadel Actions v2 `user.human.added` events
+- The webhook handler performs an UPSERT: INSERT on first arrival, UPDATE to enrich profile data if the user already exists via Create RPC
+- The existing `Create` RPC and frontend provisioning flow remain unchanged (primary path)
+- HMAC signature verification for webhook payload integrity
+- Enable Zitadel Actions v2 feature flag and configure Target + Execution on the Zitadel instance
+
+## Capabilities
+
+### New Capabilities
+- `zitadel-webhook-provisioning`: Webhook-based user provisioning from Zitadel Actions v2 events, providing profile enrichment as a complement to the existing RPC-based provisioning
+
+### Modified Capabilities
+- `user-account-sync`: Add webhook as a secondary provisioning path; UPSERT semantics to handle both Create RPC and webhook arriving in any order
+
+## Impact
+
+- **Backend**: New HTTP handler (outside Connect-RPC), HMAC signature verification middleware, UPSERT query in user repository
+- **Protobuf/API**: No changes to existing RPC definitions
+- **Database**: No schema changes (existing columns `preferred_language`, `name` will be populated by webhook)
+- **Infrastructure**: Zitadel Actions v2 Target and Execution configuration (Zitadel Cloud admin)
+- **Frontend**: No changes

--- a/openspec/changes/user-creation-webhook/specs/user-account-sync/spec.md
+++ b/openspec/changes/user-creation-webhook/specs/user-account-sync/spec.md
@@ -1,0 +1,26 @@
+## MODIFIED Requirements
+
+### Requirement: User Account Provisioning on Signup
+
+The system SHALL create a local user record in the application database when a user completes registration via Zitadel, linking the Zitadel identity (`sub` claim) to the local record via an `external_id` field (TEXT type). The system SHALL support two provisioning paths: the primary frontend-driven Create RPC path, and a complementary Zitadel webhook path that enriches user data.
+
+#### Scenario: Successful signup provisioning via Create RPC (primary path)
+
+- **WHEN** a user completes registration via Zitadel and the frontend receives the OIDC callback with `state.isRegistration === true`
+- **THEN** the frontend SHALL call the `Create` RPC with the user's `email` parameter only
+- **AND** the backend SHALL extract `external_id` (from JWT `sub` claim) and `name` (from JWT `name` claim)
+- **AND** the backend SHALL create a new user record with `external_id`, `email`, and `name` persisted
+- **AND** the backend SHALL return the created user
+
+#### Scenario: Successful signup provisioning via Zitadel webhook (complementary path)
+
+- **WHEN** a user completes registration via Zitadel
+- **THEN** Zitadel SHALL send a `user.human.added` event to the backend webhook endpoint
+- **AND** the backend SHALL UPSERT the user record with `external_id`, `email`, `name`, and `preferred_language` from the event payload
+- **AND** the UPSERT SHALL enrich existing records without overwriting non-empty values with empty strings
+
+#### Scenario: Duplicate provisioning attempt
+
+- **WHEN** the `Create` RPC is called with an `external_id` that already exists in the database
+- **THEN** the system SHALL return `connect.CodeAlreadyExists`
+- **AND** the frontend SHALL handle this error gracefully (treat as success since the user already exists)

--- a/openspec/changes/user-creation-webhook/specs/zitadel-webhook-provisioning/spec.md
+++ b/openspec/changes/user-creation-webhook/specs/zitadel-webhook-provisioning/spec.md
@@ -1,0 +1,60 @@
+## ADDED Requirements
+
+### Requirement: Webhook Endpoint for Zitadel Events
+
+The backend SHALL expose an HTTP POST endpoint at `/webhooks/zitadel` that receives Zitadel Actions v2 event payloads. The endpoint SHALL be separate from Connect-RPC services and use HMAC signature verification for authentication.
+
+#### Scenario: Receive valid user.human.added event
+
+- **WHEN** Zitadel sends a POST to `/webhooks/zitadel` with a valid `user.human.added` event payload and valid `ZITADEL-Signature` header
+- **THEN** the system SHALL parse the event payload and extract user data (`aggregateID`, `email`, `displayName`, `preferredLanguage`)
+- **AND** the system SHALL return HTTP 200
+
+#### Scenario: Reject request with invalid signature
+
+- **WHEN** a POST is received at `/webhooks/zitadel` with an invalid or missing `ZITADEL-Signature` header
+- **THEN** the system SHALL return HTTP 401 Unauthorized
+- **AND** the system SHALL NOT process the event payload
+
+#### Scenario: Ignore non-user events
+
+- **WHEN** Zitadel sends an event with `event_type` other than `user.human.added`
+- **THEN** the system SHALL return HTTP 200 without processing
+
+### Requirement: User UPSERT from Webhook
+
+The system SHALL perform an UPSERT operation when processing a `user.human.added` webhook event. If the user does not exist (by `external_id`), a new record SHALL be created. If the user already exists, the record SHALL be updated with richer profile data from the webhook payload.
+
+#### Scenario: Webhook arrives before Create RPC (new user)
+
+- **WHEN** a `user.human.added` event is received for an `aggregateID` that does not exist in the `users` table
+- **THEN** the system SHALL INSERT a new user record with `external_id` set to `aggregateID`, `email`, `name` set to `displayName`, and `preferred_language` set to `preferredLanguage`
+
+#### Scenario: Webhook arrives after Create RPC (enrich existing user)
+
+- **WHEN** a `user.human.added` event is received for an `aggregateID` that already exists in the `users` table
+- **THEN** the system SHALL UPDATE the existing record, setting `name` and `preferred_language` only when the webhook provides non-empty values
+- **AND** the system SHALL NOT overwrite existing non-empty values with empty strings
+
+#### Scenario: Create RPC arrives after webhook (idempotent)
+
+- **WHEN** the `Create` RPC is called for a user that was already created by the webhook
+- **THEN** the system SHALL return `connect.CodeAlreadyExists` (existing behavior, unchanged)
+- **AND** the frontend SHALL handle this as success (existing behavior, unchanged)
+
+### Requirement: Webhook Signing Key Management
+
+The Zitadel Target signing key SHALL be stored in GCP Secret Manager and synced to Kubernetes via External Secrets Operator, consistent with existing secret management patterns.
+
+#### Scenario: Signing key available at startup
+
+- **WHEN** the backend service starts
+- **THEN** it SHALL read the Zitadel webhook signing key from environment configuration
+- **AND** use it for HMAC signature verification of incoming webhook requests
+
+#### Scenario: Signing key rotation
+
+- **WHEN** the Zitadel Target is patched and a new signing key is generated
+- **THEN** the new key SHALL be stored in GCP Secret Manager
+- **AND** the External Secrets Operator SHALL sync the updated key to the Kubernetes Secret
+- **AND** the backend SHALL pick up the new key on next restart or secret refresh

--- a/openspec/changes/user-creation-webhook/tasks.md
+++ b/openspec/changes/user-creation-webhook/tasks.md
@@ -1,0 +1,41 @@
+## 1. Database Layer
+
+- [ ] 1.1 Add UPSERT query to `UserRepository` — `INSERT ... ON CONFLICT (external_id) DO UPDATE SET name = COALESCE(NULLIF(EXCLUDED.name, ''), users.name), preferred_language = COALESCE(NULLIF(EXCLUDED.preferred_language, ''), users.preferred_language) RETURNING id`
+- [ ] 1.2 Add `Upsert(ctx, params) (*entity.User, error)` method to `UserRepository` and `entity.UserRepository` interface
+
+## 2. Use Case Layer
+
+- [ ] 2.1 Add `UpsertFromWebhook(ctx, params *entity.NewUser) (*entity.User, error)` method to user use case
+- [ ] 2.2 Add structured logging for webhook-triggered upserts (distinguish from RPC-triggered creates)
+
+## 3. Webhook Handler
+
+- [ ] 3.1 Define Zitadel webhook event payload structs (ZitadelEvent, EventPayload) in `internal/adapter/webhook/`
+- [ ] 3.2 Implement HMAC signature verification middleware using `ZITADEL-Signature` header
+- [ ] 3.3 Implement `ZitadelWebhookHandler` HTTP handler — parse event, filter for `user.human.added`, call `UpsertFromWebhook`
+- [ ] 3.4 Add webhook signing key to backend configuration (`pkg/config/`)
+
+## 4. HTTP Server Integration
+
+- [ ] 4.1 Mount `/webhooks/zitadel` route on the existing HTTP server (alongside Connect-RPC mux)
+- [ ] 4.2 Wire `ZitadelWebhookHandler` with user use case dependency injection
+
+## 5. Secret Management & Infrastructure
+
+- [ ] 5.1 Add `zitadel-webhook-signing-key` secret to GCP Secret Manager via Pulumi (`cloud-provisioning`)
+- [ ] 5.2 Add ExternalSecret resource to sync signing key to K8s backend namespace
+- [ ] 5.3 Add signing key env var to backend Deployment manifest
+
+## 6. Zitadel Configuration
+
+- [ ] 6.1 Enable Actions v2 feature flag on Zitadel Cloud instance
+- [ ] 6.2 Create Zitadel Target (Webhook type) pointing to backend `/webhooks/zitadel` endpoint
+- [ ] 6.3 Create Zitadel Execution binding `user.human.added` event to the target
+- [ ] 6.4 Store the returned signing key in GCP Secret Manager
+
+## 7. Testing
+
+- [ ] 7.1 Unit test: HMAC signature verification (valid, invalid, missing)
+- [ ] 7.2 Unit test: Webhook handler event parsing and filtering
+- [ ] 7.3 Unit test: UPSERT repository method (insert new, update existing, empty value handling)
+- [ ] 7.4 Integration test: End-to-end webhook → UPSERT flow with test HTTP server

--- a/openspec/changes/user-creation-webhook/tasks.md
+++ b/openspec/changes/user-creation-webhook/tasks.md
@@ -30,8 +30,8 @@
 
 - [ ] 6.1 Enable Actions v2 feature flag on Zitadel Cloud instance
 - [ ] 6.2 Create Zitadel Target (Webhook type) pointing to backend `/webhooks/zitadel` endpoint
-- [ ] 6.3 Create Zitadel Execution binding `user.human.added` event to the target
-- [ ] 6.4 Store the returned signing key in GCP Secret Manager
+- [ ] 6.3 Store the returned signing key in GCP Secret Manager and wait for ESO sync to K8s
+- [ ] 6.4 Create Zitadel Execution binding `user.human.added` event to the target (must be after signing key is deployed)
 
 ## 7. Testing
 


### PR DESCRIPTION
## Summary

- Add OpenSpec change artifacts for Zitadel Actions v2 webhook-based user provisioning
- Hybrid approach: webhook as complementary enrichment path alongside existing Create RPC
- Webhook enriches user profiles with `preferredLanguage` and `displayName` from Zitadel event payload

## Artifacts

| File | Purpose |
|------|---------|
| `proposal.md` | Why: webhook enriches user data that JWT claims don't provide |
| `design.md` | How: plain HTTP handler, HMAC auth, UPSERT with COALESCE |
| `specs/zitadel-webhook-provisioning/spec.md` | New capability: webhook endpoint, UPSERT, signing key |
| `specs/user-account-sync/spec.md` | Modified: dual provisioning paths |
| `tasks.md` | 18 implementation tasks across 7 groups |

## Test plan

- [ ] Review proposal for alignment with product goals
- [ ] Review design decisions (HMAC vs JWT signing, handler placement)
- [ ] Review specs for completeness and testability
- [ ] Review tasks for correct dependency ordering