### PR TITLE
fix(specs): correct Aurelia 2 API docs and debounce requirements

### DIFF
--- a/openspec/changes/archive/2026-02-25-aurelia-best-practice/specs/aurelia-template-optimization/spec.md
+++ b/openspec/changes/archive/2026-02-25-aurelia-best-practice/specs/aurelia-template-optimization/spec.md
@@ -55,14 +55,13 @@ Conditional CSS class application SHALL use Aurelia 2's `.class` binding syntax 
 ### Requirement: Debounce on search inputs
 Text input fields that trigger search, filter, or API calls SHALL debounce the expensive operation to avoid excessive processing.
 
-#### Scenario: Artist search debounce with immediate UI feedback
-- **WHEN** the user types in the artist search input on `discover-page`
-- **AND** the handler requires immediate side effects (e.g., entering search mode, pausing animations)
-- **THEN** the input SHALL use `value.bind` without template-level `& debounce`
-- **AND** the component SHALL use `@watch` on the bound property to react immediately for UI state changes
-- **AND** the API call within the `@watch` handler SHALL be debounced via `setTimeout` (300ms)
+#### Scenario: Search with immediate UI feedback
+- **WHEN** the user types in a search input that requires instant visual response (e.g., entering search mode, pausing animations)
+- **THEN** the UI state change SHALL occur without debounce delay
+- **AND** the expensive operation (API call) SHALL be debounced by at least 300ms
+- **AND** the two concerns (immediate UI feedback vs debounced API call) SHALL NOT be delayed by the same mechanism
 
-#### Scenario: Simple search debounce without immediate side effects
+#### Scenario: Search without immediate UI side effects
 - **WHEN** a search input does not require immediate UI side effects (e.g., `area-selector-sheet`)
 - **THEN** the binding SHALL include `& debounce:300` to delay processing until 300ms after the last keystroke
 

--- a/openspec/changes/archive/2026-02-25-aurelia-best-practice/specs/aurelia-template-optimization/spec.md
+++ b/openspec/changes/archive/2026-02-25-aurelia-best-practice/specs/aurelia-template-optimization/spec.md
@@ -52,16 +52,19 @@ Conditional CSS class application SHALL use Aurelia 2's `.class` binding syntax 
 - **WHEN** two class groups are toggled by opposite conditions (active vs inactive)
 - **THEN** the template SHALL use two `.class` bindings: one for the active classes and one for the inactive classes with a negated condition
 
-### Requirement: Debounce binding behavior on search inputs
-Text input fields that trigger search, filter, or API calls SHALL use the `& debounce` binding behavior.
+### Requirement: Debounce on search inputs
+Text input fields that trigger search, filter, or API calls SHALL debounce the expensive operation to avoid excessive processing.
 
-#### Scenario: Artist search debounce
+#### Scenario: Artist search debounce with immediate UI feedback
 - **WHEN** the user types in the artist search input on `discover-page`
-- **THEN** the binding SHALL include `& debounce:300` to delay processing until 300ms after the last keystroke
+- **AND** the handler requires immediate side effects (e.g., entering search mode, pausing animations)
+- **THEN** the input SHALL use `value.bind` without template-level `& debounce`
+- **AND** the component SHALL use `@watch` on the bound property to react immediately for UI state changes
+- **AND** the API call within the `@watch` handler SHALL be debounced via `setTimeout` (300ms)
 
-#### Scenario: Area search debounce
-- **WHEN** the user types in the city search input on `area-selector-sheet`
-- **THEN** the binding SHALL include `& debounce:300`
+#### Scenario: Simple search debounce without immediate side effects
+- **WHEN** a search input does not require immediate UI side effects (e.g., `area-selector-sheet`)
+- **THEN** the binding SHALL include `& debounce:300` to delay processing until 300ms after the last keystroke
 
 ### Requirement: Throttle binding behavior on continuous event handlers
 Event handlers for continuous user interactions (touch move, scroll, resize) SHALL use the `& throttle` binding behavior.

--- a/openspec/specs/aurelia-template-optimization/spec.md
+++ b/openspec/specs/aurelia-template-optimization/spec.md
@@ -61,14 +61,13 @@ Conditional CSS class application SHALL use Aurelia 2's `.class` binding syntax 
 ### Requirement: Debounce on search inputs
 Text input fields that trigger search, filter, or API calls SHALL debounce the expensive operation to avoid excessive processing.
 
-#### Scenario: Artist search debounce with immediate UI feedback
-- **WHEN** the user types in the artist search input on `discover-page`
-- **AND** the handler requires immediate side effects (e.g., entering search mode, pausing animations)
-- **THEN** the input SHALL use `value.bind` without template-level `& debounce`
-- **AND** the component SHALL use `@watch` on the bound property to react immediately for UI state changes
-- **AND** the API call within the `@watch` handler SHALL be debounced via `setTimeout` (300ms)
+#### Scenario: Search with immediate UI feedback
+- **WHEN** the user types in a search input that requires instant visual response (e.g., entering search mode, pausing animations)
+- **THEN** the UI state change SHALL occur without debounce delay
+- **AND** the expensive operation (API call) SHALL be debounced by at least 300ms
+- **AND** the two concerns (immediate UI feedback vs debounced API call) SHALL NOT be delayed by the same mechanism
 
-#### Scenario: Simple search debounce without immediate side effects
+#### Scenario: Search without immediate UI side effects
 - **WHEN** a search input does not require immediate UI side effects (e.g., `area-selector-sheet`)
 - **THEN** the binding SHALL include `& debounce:300` to delay processing until 300ms after the last keystroke
 

--- a/openspec/specs/aurelia-template-optimization/spec.md
+++ b/openspec/specs/aurelia-template-optimization/spec.md
@@ -58,16 +58,19 @@ Conditional CSS class application SHALL use Aurelia 2's `.class` binding syntax 
 - **WHEN** two class groups are toggled by opposite conditions (active vs inactive)
 - **THEN** the template SHALL use two `.class` bindings: one for the active classes and one for the inactive classes with a negated condition
 
-### Requirement: Debounce binding behavior on search inputs
-Text input fields that trigger search, filter, or API calls SHALL use the `& debounce` binding behavior.
+### Requirement: Debounce on search inputs
+Text input fields that trigger search, filter, or API calls SHALL debounce the expensive operation to avoid excessive processing.
 
-#### Scenario: Artist search debounce
+#### Scenario: Artist search debounce with immediate UI feedback
 - **WHEN** the user types in the artist search input on `discover-page`
-- **THEN** the binding SHALL include `& debounce:300` to delay processing until 300ms after the last keystroke
+- **AND** the handler requires immediate side effects (e.g., entering search mode, pausing animations)
+- **THEN** the input SHALL use `value.bind` without template-level `& debounce`
+- **AND** the component SHALL use `@watch` on the bound property to react immediately for UI state changes
+- **AND** the API call within the `@watch` handler SHALL be debounced via `setTimeout` (300ms)
 
-#### Scenario: Area search debounce
-- **WHEN** the user types in the city search input on `area-selector-sheet`
-- **THEN** the binding SHALL include `& debounce:300`
+#### Scenario: Simple search debounce without immediate side effects
+- **WHEN** a search input does not require immediate UI side effects (e.g., `area-selector-sheet`)
+- **THEN** the binding SHALL include `& debounce:300` to delay processing until 300ms after the last keystroke
 
 ### Requirement: Throttle binding behavior on continuous event handlers
 Event handlers for continuous user interactions (touch move, scroll, resize) SHALL use the `& throttle` binding behavior.


### PR DESCRIPTION
## Description

Fix inaccuracies in specs and archived artifacts found during PR #110 review:

- `@computed` is parameterless in Aurelia 2 (automatic dependency tracking), not `@computed('prop')` like Aurelia 1's `@computedFrom`
- Audit report `DateValueConverter` example passed `'relative'` as `dateStyle` to `Intl.DateTimeFormat` which throws `RangeError` — replaced with correct `Intl.RelativeTimeFormat` implementation
- Debounce spec prescribed `@watch + setTimeout` as implementation detail — rewritten to specify behavior requirements only (immediate UI feedback + debounced API as separate concerns)

## Type of Change

- [ ] feat: A new feature
- [x] fix: A bug fix
- [x] docs: Documentation only changes
- [ ] refactor: A code change that neither fixes a bug nor adds a feature
- [ ] test: Adding missing tests or correcting existing tests
- [ ] build: Changes that affect the build system or external dependencies
- [ ] chore: Other changes that don't modify src or test files

## Verification

### Automated Tests
- [x] `npm run lint` passed
- [x] `npm run test` passed
- [x] `npm run build` passed

### Manual Verification
Spec-only changes — verified content accuracy against Aurelia 2 official documentation.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

close: #