### PR TITLE
docs(openspec): archive localstorage-key-naming-convention change

### DIFF
--- a/openspec/changes/archive/2026-02-26-localstorage-key-naming-convention/.openspec.yaml
+++ b/openspec/changes/archive/2026-02-26-localstorage-key-naming-convention/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-02-26

--- a/openspec/changes/archive/2026-02-26-localstorage-key-naming-convention/design.md
+++ b/openspec/changes/archive/2026-02-26-localstorage-key-naming-convention/design.md
@@ -1,0 +1,58 @@
+## Context
+
+The frontend stores 8 localStorage keys using 3 inconsistent patterns. All keys need to be renamed to follow a unified convention. There are no existing users, so no migration logic is needed.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Establish a single, consistent localStorage key naming convention
+- Align domain terms with Proto definitions (`admin_area` instead of `region`)
+- Centralize all key constants into one module for discoverability
+- Update all E2E tests to use the new keys
+
+**Non-Goals:**
+- Adding a localStorage abstraction layer or wrapper service
+- Changing stored values or serialization format
+- Backward-compatible migration logic (no users exist)
+
+## Decisions
+
+### 1. Convention: `[<scope>.]<camelCase>` (no namespace prefix)
+
+```
+onboardingStep                  # app-level (no scope)
+user.adminArea                  # authenticated user state
+guest.followedArtists           # anonymous/guest state
+pwa.sessionCount                # PWA-specific
+ui.notificationPromptDismissed  # UI preferences
+```
+
+**Rationale**: localStorage is scoped to the origin, so a namespace prefix is redundant. Dot-separated scopes are readable, sortable in DevTools, and group related keys logically.
+
+### 2. Single `storage-keys.ts` module
+
+All key constants are defined in `src/constants/storage-keys.ts` and exported as a flat object:
+
+```typescript
+export const StorageKeys = {
+  onboardingStep: 'onboardingStep',
+  userAdminArea: 'user.adminArea',
+  guestFollowedArtists: 'guest.followedArtists',
+  guestAdminArea: 'guest.adminArea',
+  userNotificationsEnabled: 'user.notificationsEnabled',
+  uiNotificationPromptDismissed: 'ui.notificationPromptDismissed',
+  pwaSessionCount: 'pwa.sessionCount',
+  pwaInstallPromptDismissed: 'pwa.installPromptDismissed',
+} as const
+```
+
+**Rationale**: A single registry prevents duplicate/divergent key definitions. Each consuming module imports from this one source.
+
+### 3. Domain term alignment: `region` → `adminArea`
+
+The Proto schema uses `admin_area` (from Google AIP `postal_address.admin_area`). The frontend `dashboard-service.ts` already uses `adminArea` internally. Renaming the localStorage key aligns the persistence layer with the domain model.
+
+## Risks / Trade-offs
+
+- **DevTools familiarity**: Developers accustomed to the old keys will need to update their mental model. The centralized `storage-keys.ts` module mitigates this.
+- **E2E test strings**: All E2E tests that hardcode localStorage key strings must be updated. Using `StorageKeys` import in tests would be ideal but may not work with `page.evaluate()` contexts — string literals are acceptable in E2E tests.

--- a/openspec/changes/archive/2026-02-26-localstorage-key-naming-convention/proposal.md
+++ b/openspec/changes/archive/2026-02-26-localstorage-key-naming-convention/proposal.md
@@ -1,0 +1,48 @@
+## Why
+
+Frontend localStorage keys use inconsistent naming conventions across three different patterns (`liverty:camelCase`, `liverty:guest:camelCase`, `liverty-music:kebab-case`). This makes keys hard to discover, group, and reason about. Since there are no existing users, now is the time to establish a unified convention before it becomes a breaking change.
+
+Additionally, the key `user-region` stores a prefecture/admin area value but doesn't align with the domain term `admin_area` used in Proto definitions (`Venue.admin_area`) and frontend code (`event.adminArea`).
+
+## What Changes
+
+- **BREAKING**: Rename all localStorage keys to follow a single `[<scope>.]<camelCase>` convention (no namespace prefix)
+- Align `user-region` → `userAdminArea` to match the Proto/domain term `admin_area`
+- Extract all key constants into a single `storage-keys.ts` module for discoverability
+- Update all references across services, components, and E2E tests
+
+### Key Mapping
+
+| Current Key | New Key |
+|---|---|
+| `liverty:onboardingStep` | `onboardingStep` |
+| `liverty:guest:followedArtists` | `guest.followedArtists` |
+| `liverty:guest:region` | `guest.adminArea` |
+| `liverty-music:user-region` | `user.adminArea` |
+| `liverty-music:notifications-enabled` | `user.notificationsEnabled` |
+| `liverty-music:notification-prompt-dismissed` | `ui.notificationPromptDismissed` |
+| `liverty-music:session-count` | `pwa.sessionCount` |
+| `liverty-music:install-prompt-dismissed` | `pwa.installPromptDismissed` |
+
+### Convention
+
+- **No namespace prefix**: localStorage is scoped to the origin, so a prefix is redundant
+- **Scope**: `user` (auth-required state), `guest` (anonymous state), `pwa` (PWA-specific), `ui` (UI preferences), no scope for app-level (e.g., `onboardingStep`)
+- **Name**: `camelCase`, aligned with Proto/domain terms where applicable
+- **Separator**: `.` (dot)
+
+## Capabilities
+
+### New Capabilities
+- `localstorage-naming`: Centralized localStorage key registry with consistent naming convention
+
+### Modified Capabilities
+_None — this is a refactor of key strings, not a behavioral change._
+
+## Impact
+
+- **Frontend services**: `onboarding-service.ts`, `pwa-install-service.ts`, `local-artist-client.ts`, `settings-page.ts`
+- **Frontend components**: `region-setup-sheet.ts`, `area-selector-sheet.ts`, `notification-prompt.ts`
+- **E2E tests**: All `pwa-*.spec.ts` files that reference localStorage keys
+- **No backend impact**: localStorage is frontend-only
+- **No migration needed**: No existing users

--- a/openspec/changes/archive/2026-02-26-localstorage-key-naming-convention/specs/localstorage-naming/spec.md
+++ b/openspec/changes/archive/2026-02-26-localstorage-key-naming-convention/specs/localstorage-naming/spec.md
@@ -1,0 +1,30 @@
+## ADDED Requirements
+
+### Requirement: Unified key naming convention
+All localStorage keys MUST follow the `[<scope>.]<camelCase>` pattern where scope is one of: `user`, `guest`, `pwa`, `ui`, or omitted for app-level keys. No namespace prefix is used since localStorage is scoped to the origin.
+
+#### Scenario: Key format validation
+- **WHEN** a localStorage key is defined in the codebase
+- **THEN** it MUST match the pattern `[<scope>.]<camelCase>` with dot separators
+
+### Requirement: Centralized key registry
+All localStorage key constants MUST be defined in a single `src/constants/storage-keys.ts` module and exported as a `StorageKeys` object.
+
+#### Scenario: New key addition
+- **WHEN** a developer needs a new localStorage key
+- **THEN** it MUST be added to `StorageKeys` in `storage-keys.ts` and imported from there
+
+#### Scenario: No inline key strings in source
+- **WHEN** a service or component accesses localStorage
+- **THEN** it MUST use a constant from `StorageKeys`, not a hardcoded string literal
+
+### Requirement: Domain term alignment
+Keys storing geographic administrative area data MUST use the term `adminArea` (matching Proto `admin_area` / `Venue.admin_area`), not `region`.
+
+#### Scenario: User admin area storage
+- **WHEN** the authenticated user's geographic preference is stored
+- **THEN** the key MUST be `user.adminArea`
+
+#### Scenario: Guest admin area storage
+- **WHEN** the anonymous user's geographic preference is stored
+- **THEN** the key MUST be `guest.adminArea`

--- a/openspec/changes/archive/2026-02-26-localstorage-key-naming-convention/tasks.md
+++ b/openspec/changes/archive/2026-02-26-localstorage-key-naming-convention/tasks.md
@@ -1,0 +1,28 @@
+## 1. Create centralized key registry
+
+- [x] 1.1 Create `src/constants/storage-keys.ts` with `StorageKeys` object containing all 8 key constants
+
+## 2. Update services
+
+- [x] 2.1 Update `src/services/onboarding-service.ts`: import `StorageKeys.onboardingStep`, remove local `STORAGE_KEY`
+- [x] 2.2 Update `src/services/pwa-install-service.ts`: import `StorageKeys.pwaSessionCount` and `StorageKeys.pwaInstallPromptDismissed`, remove local constants
+- [x] 2.3 Update `src/services/local-artist-client.ts`: import `StorageKeys.guestFollowedArtists` and `StorageKeys.guestAdminArea`, remove local constants, rename `REGION_KEY` references to `adminArea`
+
+## 3. Update components
+
+- [x] 3.1 Update `src/components/region-setup-sheet/region-setup-sheet.ts`: import `StorageKeys.userAdminArea`, remove local `REGION_STORAGE_KEY` export
+- [x] 3.2 Update `src/components/area-selector-sheet/area-selector-sheet.ts`: import from `storage-keys.ts` instead of `region-setup-sheet.ts`
+- [x] 3.3 Update `src/components/notification-prompt/notification-prompt.ts`: import `StorageKeys.uiNotificationPromptDismissed`, remove local constant
+- [x] 3.4 Update `src/routes/settings/settings-page.ts`: import `StorageKeys.userNotificationsEnabled`, remove local constant
+
+## 4. Update E2E tests
+
+- [x] 4.1 Update `e2e/pwa-install-prompt.spec.ts`: update all localStorage key strings in `ONBOARDING_SETUP` and `addInitScript` calls
+- [x] 4.2 Update `e2e/pwa-settings.spec.ts` if it references any localStorage keys (none found)
+- [x] 4.3 Update `e2e/pwa-offline-cache.spec.ts` if it references any localStorage keys (none found)
+
+## 5. Verify
+
+- [x] 5.1 Run `tsc --noEmit` to verify no type errors
+- [x] 5.2 Run unit tests
+- [x] 5.3 Run Playwright E2E tests for PWA specs (key strings updated; verified via CI)

--- a/openspec/specs/localstorage-naming/spec.md
+++ b/openspec/specs/localstorage-naming/spec.md
@@ -1,0 +1,30 @@
+## Requirements
+
+### Requirement: Unified key naming convention
+All localStorage keys MUST follow the `[<scope>.]<camelCase>` pattern where scope is one of: `user`, `guest`, `pwa`, `ui`, or omitted for app-level keys. No namespace prefix is used since localStorage is scoped to the origin.
+
+#### Scenario: Key format validation
+- **WHEN** a localStorage key is defined in the codebase
+- **THEN** it MUST match the pattern `[<scope>.]<camelCase>` with dot separators
+
+### Requirement: Centralized key registry
+All localStorage key constants MUST be defined in a single `src/constants/storage-keys.ts` module and exported as a `StorageKeys` object.
+
+#### Scenario: New key addition
+- **WHEN** a developer needs a new localStorage key
+- **THEN** it MUST be added to `StorageKeys` in `storage-keys.ts` and imported from there
+
+#### Scenario: No inline key strings in source
+- **WHEN** a service or component accesses localStorage
+- **THEN** it MUST use a constant from `StorageKeys`, not a hardcoded string literal
+
+### Requirement: Domain term alignment
+Keys storing geographic administrative area data MUST use the term `adminArea` (matching Proto `admin_area` / `Venue.admin_area`), not `region`.
+
+#### Scenario: User admin area storage
+- **WHEN** the authenticated user's geographic preference is stored
+- **THEN** the key MUST be `user.adminArea`
+
+#### Scenario: Guest admin area storage
+- **WHEN** the anonymous user's geographic preference is stored
+- **THEN** the key MUST be `guest.adminArea`


### PR DESCRIPTION
## Summary

- Add `localstorage-naming` main spec defining the unified localStorage key naming convention
- Archive completed `localstorage-key-naming-convention` change (all 14 tasks done)

### New spec: `localstorage-naming`
- Unified key pattern: `[<scope>.]<camelCase>` (scopes: `user`, `guest`, `pwa`, `ui`)
- Centralized `StorageKeys` registry in `src/constants/storage-keys.ts`
- Domain term alignment: `region` → `adminArea` (matching Proto `admin_area`)

### Related
- Frontend implementation: liverty-music/frontend#94 (merged)