### PR TITLE
fix: add limit field and bubble pool lifecycle specs (#116)

### DIFF
--- a/openspec/changes/fix-bubble-pool-eviction/.openspec.yaml
+++ b/openspec/changes/fix-bubble-pool-eviction/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-02-26

--- a/openspec/changes/fix-bubble-pool-eviction/design.md
+++ b/openspec/changes/fix-bubble-pool-eviction/design.md
@@ -1,0 +1,57 @@
+## Context
+
+The artist discovery page uses a physics-based bubble UI where users tap artist bubbles to follow them. On tap, the system calls `ArtistService.ListSimilar` to fetch related artists and adds them to the bubble pool for continued exploration.
+
+The current implementation has a critical bug: `getSimilarArtists()` pushes ~80 new artists into `availableBubbles` before the overflow calculation runs, causing the eviction logic to remove nearly all existing bubbles. The result is that all bubbles visually disappear on first tap.
+
+Additionally, the initial load always fetches from `ListTop` regardless of whether the user already follows artists — missing the opportunity to show personalized recommendations.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Fix the bubble eviction bug so only a controlled number of oldest bubbles are removed on tap
+- Implement following-count-based branching for initial load (top chart vs seed-based similar)
+- Add `limit` parameter to `ListSimilar` and `ListTop` RPCs to control response size
+- Ensure all array mutations use reassignment for Aurelia 2 reactivity
+
+**Non-Goals:**
+- Changing the physics engine or rendering logic (Matter.js / Canvas)
+- Modifying the absorption animation or orb visual effects
+- Adding pagination or infinite scroll to the bubble pool
+- Changing the `ArtistService.Follow` or `ArtistService.Unfollow` RPCs
+
+## Decisions
+
+### 1. Pool management via `addToPool()` instead of direct mutation
+
+The new `addToPool(newBubbles)` method atomically evicts oldest bubbles and inserts new ones using array reassignment (`this.availableBubbles = [...]`). This replaces the split `evictOldest()` + manual `push()` pattern.
+
+**Rationale**: A single method eliminates the race between eviction and insertion that caused the bug. Array reassignment triggers Aurelia 2's property observation, which `push()`/`splice()` do not.
+
+**Alternative considered**: Aurelia's `@observable` decorator — not needed because array reassignment already triggers observation, and the service doesn't need `xxxChanged` callbacks.
+
+### 2. `getSimilarArtists()` as a pure fetch (no pool mutation)
+
+The method now returns new bubbles without modifying `availableBubbles`. The caller (`DnaOrbCanvas.handleInteraction()`) is responsible for calling `addToPool()`.
+
+**Rationale**: Separating fetch from pool mutation gives the caller control over eviction timing. This is the direct fix for the root cause — the old code mutated the pool inside the fetch, making overflow calculation stale.
+
+### 3. Seed-based initial load when followed > 0 (Step 1-b)
+
+When the user follows artists, randomly pick up to 5 seed artists and call `ListSimilar(limit = 50/seedCount)` in parallel. This replaces the unconditional `ListTop` call.
+
+**Rationale**: Users who already follow artists get personalized recommendations instead of generic charts. The random selection with `Promise.all` keeps latency comparable to a single RPC call.
+
+### 4. `limit` field added to proto messages (additive, non-breaking)
+
+`int32 limit` is added to `ListSimilarRequest` (field 2) and `ListTopRequest` (field 3) with validation `{gte: 0, lte: 100}`. When 0 or omitted, the server uses its default.
+
+**Rationale**: Additive field addition is backward-compatible. Existing clients that omit `limit` get the same behavior as before. The `lte: 100` constraint prevents abuse.
+
+## Risks / Trade-offs
+
+- **[Stale generated code]** The BSR-generated TypeScript and Go stubs won't include the `limit` field until the proto is published to BSR and regenerated. → Mitigation: Backend handler uses `0` placeholder with TODO comments until proto is regenerated. Frontend uses the field optimistically (Connect-RPC ignores unknown fields gracefully).
+
+- **[Seed selection randomness]** Step 1-b picks random seeds, so the bubble pool varies between page loads. → Acceptable: This adds variety to the discovery experience, which is desirable.
+
+- **[Promise.all failure mode]** If one seed's `ListSimilar` fails, that seed's results are lost but others proceed. → Mitigation: Each seed has an independent `.catch()` that returns `[]`, so partial failures degrade gracefully.

--- a/openspec/changes/fix-bubble-pool-eviction/proposal.md
+++ b/openspec/changes/fix-bubble-pool-eviction/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+When a user taps an artist bubble on the /discover or /onboarding/discover page, all bubbles disappear instead of just the tapped one. The root cause is that `getSimilarArtists()` pushes new artists into the `availableBubbles` array before the overflow calculation in `handleInteraction()`, causing `evictOldest()` to remove nearly all existing bubbles. This makes the discovery experience unusable after the first tap.
+
+## What Changes
+
+- **Fix bubble eviction ordering**: Evict oldest bubbles *before* adding similar artists to the pool, not after.
+- **Redesign initial load branching**: When the user already follows artists, seed the bubble pool from `ListSimilar` of random followed artists instead of `ListTop`.
+- **Add `limit` parameter to `ListSimilar` and `ListTop` RPCs**: Allow the frontend to control how many results are returned per call.
+- **Introduce `addToPool()` method**: Replace direct array mutation with a single method that handles eviction + insertion atomically, using array reassignment for Aurelia 2 reactivity.
+- **Remove `evictOldest()` and `maxBubbles` instance property**: Replace with `addToPool()` and `MAX_BUBBLES` static constant.
+
+## Capabilities
+
+### New Capabilities
+
+- `bubble-pool-lifecycle`: Defines the bubble pool initialization, eviction, deduplication, and tap-to-refill lifecycle for the artist discovery UI.
+
+### Modified Capabilities
+
+- `artist-discovery-dna-orb-ui`: The "Similar artist bubble spawning" scenario changes — `getSimilarArtists()` no longer pushes into the pool directly; the caller manages eviction and insertion via `addToPool()`. Initial load now branches based on followed-artist count.
+
+## Impact
+
+- **specification** (proto): `ListSimilarRequest` and `ListTopRequest` gain an `int32 limit` field.
+- **backend** (Go): `ArtistSearcher` interface, Last.fm client, and usecase layer accept and forward the `limit` parameter.
+- **frontend** (Aurelia 2): `ArtistDiscoveryService` rewritten — `loadInitialArtists()` branches on followed count, `getSimilarArtists()` becomes a pure fetch (no pool mutation), new `addToPool()` method handles capped insertion. `DnaOrbCanvas.handleInteraction()` updated to use the new API. All array mutations replaced with reassignment for Aurelia observation.

--- a/openspec/changes/fix-bubble-pool-eviction/specs/artist-discovery-dna-orb-ui/spec.md
+++ b/openspec/changes/fix-bubble-pool-eviction/specs/artist-discovery-dna-orb-ui/spec.md
@@ -1,0 +1,20 @@
+## MODIFIED Requirements
+
+### Requirement: Similar Artist Chain Reaction
+The system SHALL generate new artist recommendations dynamically using the backend ArtistService.ListSimilar RPC with a limit parameter. The frontend SHALL call the Follow RPC when a user taps an artist bubble. The fetch SHALL NOT directly mutate the bubble pool — the caller SHALL manage eviction and insertion via `addToPool()`.
+
+#### Scenario: Similar artist bubble spawning
+- **WHEN** a user taps an artist bubble
+- **THEN** the system SHALL call the backend `ArtistService.ListSimilar` RPC with the selected artist's ID and `limit=30`
+- **AND** the system SHALL deduplicate the results (excluding seen and followed artists)
+- **AND** the system SHALL add results to the pool via `addToPool()`, evicting oldest bubbles if the pool would exceed 50
+- **AND** evicted bubbles SHALL be faded out before new bubbles spawn
+- **AND** new bubbles representing similar artists SHALL spawn from the original bubble's position
+- **AND** the new bubbles SHALL appear with a "pop" emergence animation
+- **AND** the new bubbles SHALL integrate into the physics-based layout
+
+#### Scenario: Follow RPC called on bubble tap
+- **WHEN** a user taps an artist bubble
+- **THEN** the frontend SHALL call `this.artistClient.follow({ artistId: new ArtistId({ value: artist.id }) })`
+- **AND** the call SHALL be non-blocking (fire-and-forget with error logging)
+- **AND** the local state SHALL update immediately without waiting for the RPC response

--- a/openspec/changes/fix-bubble-pool-eviction/specs/bubble-pool-lifecycle/spec.md
+++ b/openspec/changes/fix-bubble-pool-eviction/specs/bubble-pool-lifecycle/spec.md
@@ -1,0 +1,92 @@
+## ADDED Requirements
+
+### Requirement: Bubble pool initialization based on followed-artist count
+The system SHALL initialize the bubble pool differently based on whether the user follows any artists.
+
+#### Scenario: No followed artists (Step 1-a)
+- **WHEN** the discovery page loads
+- **AND** the user follows zero artists
+- **THEN** the system SHALL call `ArtistService.ListTop` with `limit=50` and the user's country
+- **AND** the system SHALL populate the bubble pool with the response artists
+
+#### Scenario: User has followed artists (Step 1-b)
+- **WHEN** the discovery page loads
+- **AND** the user follows one or more artists
+- **THEN** the system SHALL randomly select up to 5 followed artists as seeds
+- **AND** the system SHALL call `ArtistService.ListSimilar` for each seed in parallel with the limit evenly distributed to fill 50 total (e.g., 5 seeds × limit=10, 2 seeds × limit=25)
+- **AND** the system SHALL populate the bubble pool with the combined results
+
+#### Scenario: Seed selection with fewer than 5 followed artists
+- **WHEN** the user follows fewer than 5 artists
+- **THEN** the system SHALL use all followed artists as seeds
+- **AND** the limit per seed SHALL be `floor(50 / followedCount)`
+
+---
+
+### Requirement: Bubble pool deduplication
+The system SHALL remove duplicate and already-followed artists from the bubble pool.
+
+#### Scenario: Deduplication on initial load (Step 2)
+- **WHEN** the bubble pool is populated from any source
+- **THEN** the system SHALL remove artists that match any already-seen artist by name (case-insensitive), internal ID, or MBID
+- **AND** the system SHALL remove artists that the user already follows
+- **AND** the system SHALL cap the pool at a maximum of 50 bubbles
+
+#### Scenario: Deduplication after tap refill (Step 5)
+- **WHEN** similar artists are added to the pool after a tap
+- **THEN** the system SHALL apply the same deduplication rules as Step 2
+- **AND** already-seen artists from prior fetches SHALL be excluded
+
+---
+
+### Requirement: Bubble pool cap and eviction on tap
+The system SHALL maintain a maximum pool size of 50 bubbles, evicting oldest entries when new ones are added.
+
+#### Scenario: Adding similar artists within capacity
+- **WHEN** the user taps a bubble and similar artists are fetched
+- **AND** the current pool size plus new artists does not exceed 50
+- **THEN** the system SHALL add all new artists to the pool
+- **AND** no existing bubbles SHALL be evicted
+
+#### Scenario: Adding similar artists exceeding capacity
+- **WHEN** the user taps a bubble and similar artists are fetched
+- **AND** the current pool size plus new artists exceeds 50
+- **THEN** the system SHALL evict the oldest bubbles first (FIFO) to make room
+- **AND** evicted bubbles SHALL be faded out via animation before removal
+- **AND** new bubbles SHALL be spawned from the tapped bubble's position
+
+---
+
+### Requirement: Tap-to-refill flow
+The system SHALL fetch similar artists on each bubble tap and manage the pool lifecycle.
+
+#### Scenario: Successful tap and refill (Steps 3-4)
+- **WHEN** a user taps an artist bubble
+- **THEN** the system SHALL follow the tapped artist
+- **AND** the system SHALL call `ArtistService.ListSimilar` with `limit=30` for the tapped artist
+- **AND** the system SHALL add deduplicated results to the pool via the eviction mechanism
+- **AND** the cycle SHALL repeat for subsequent taps (Step 6)
+
+#### Scenario: No similar artists found
+- **WHEN** the `ListSimilar` response returns zero artists
+- **THEN** the system SHALL NOT evict any existing bubbles
+- **AND** the system SHALL emit a `similar-artists-unavailable` event for user feedback
+
+#### Scenario: ListSimilar RPC failure
+- **WHEN** the `ListSimilar` call fails
+- **THEN** the system SHALL NOT evict any existing bubbles
+- **AND** the system SHALL emit a `similar-artists-error` event for user feedback
+
+---
+
+### Requirement: ListSimilar and ListTop limit parameter
+The `ArtistService.ListSimilar` and `ArtistService.ListTop` RPCs SHALL accept an optional `limit` parameter to control the maximum number of results.
+
+#### Scenario: Limit parameter provided
+- **WHEN** a client sends `ListSimilarRequest` or `ListTopRequest` with `limit > 0`
+- **THEN** the server SHALL return at most `limit` artists
+- **AND** the limit SHALL be validated as an integer between 0 and 100
+
+#### Scenario: Limit parameter omitted or zero
+- **WHEN** a client sends a request with `limit = 0` or omits the field
+- **THEN** the server SHALL use its default limit

--- a/openspec/changes/fix-bubble-pool-eviction/tasks.md
+++ b/openspec/changes/fix-bubble-pool-eviction/tasks.md
@@ -1,0 +1,36 @@
+## 1. Proto (specification)
+
+- [x] 1.1 Add `int32 limit` field to `ListSimilarRequest` (field 2, validation: gte=0, lte=100)
+- [x] 1.2 Add `int32 limit` field to `ListTopRequest` (field 3, validation: gte=0, lte=100)
+- [x] 1.3 Run `buf lint` and verify no breaking changes
+
+## 2. Backend (Go)
+
+- [x] 2.1 Update `ArtistSearcher` interface to accept `limit int32` in `ListSimilar` and `ListTop`
+- [x] 2.2 Update Last.fm client to pass `limit` param when > 0 to `artist.getsimilar`, `geo.gettopartists`, `tag.gettopartists`, `chart.gettopartists`
+- [x] 2.3 Update usecase layer to forward `limit` and include it in cache keys
+- [x] 2.4 Add TODO placeholder in handler (`0` until proto is regenerated from BSR)
+- [x] 2.5 Update all mocks and tests for new `limit` parameter signature
+
+## 3. Frontend - ArtistDiscoveryService
+
+- [x] 3.1 Add static constants `MAX_BUBBLES=50`, `SIMILAR_LIMIT_ON_TAP=30`, `MAX_SEED_ARTISTS=5`
+- [x] 3.2 Remove `maxBubbles` instance property and `evictOldest()` method
+- [x] 3.3 Rewrite `loadInitialArtists()` with following-count branching (Step 1-a / 1-b)
+- [x] 3.4 Add `fetchSeedSimilarArtists()` and `pickRandomSeeds()` helpers for Step 1-b
+- [x] 3.5 Add `dedup()` helper that filters by `isSeen()` and `isFollowed()`
+- [x] 3.6 Modify `getSimilarArtists()` to accept `limit` param and NOT mutate `availableBubbles`
+- [x] 3.7 Add `addToPool()` method that evicts oldest first, then inserts, using array reassignment
+- [x] 3.8 Replace all `push()` / `splice()` calls with array reassignment for Aurelia observation
+- [x] 3.9 Update `reloadWithTag()` to pass `limit` and use `dedup()`
+
+## 4. Frontend - DnaOrbCanvas
+
+- [x] 4.1 Update `handleInteraction()` to call `addToPool(similar)` instead of direct eviction + push
+- [x] 4.2 Fade out evicted bubbles before spawning new ones
+
+## 5. Testing
+
+- [x] 5.1 Update `artist-discovery-service.spec.ts` for new API (remove `evictOldest`/`maxBubbles` tests, add `addToPool`/`getSimilarArtists` limit/dedup tests, add Step 1-a/1-b tests)
+- [x] 5.2 Update `mock-rpc-clients.ts` to include `addToPool`, `isFollowed`, `searchArtists`, `reloadWithTag`
+- [x] 5.3 Run full test suite and verify 269/269 pass

--- a/proto/liverty_music/rpc/artist/v1/artist_service.proto
+++ b/proto/liverty_music/rpc/artist/v1/artist_service.proto
@@ -212,7 +212,10 @@ message ListSimilarRequest {
 
   // Optional. Maximum number of similar artists to return.
   // When 0 or omitted, the server applies its default limit.
-  int32 limit = 2 [(buf.validate.field).int32 = {gte: 0, lte: 100}];
+  int32 limit = 2 [(buf.validate.field).int32 = {
+    gte: 0
+    lte: 100
+  }];
 }
 
 // ListSimilarResponse contains recommendations based on a seed artist.
@@ -233,7 +236,10 @@ message ListTopRequest {
 
   // Optional. Maximum number of top artists to return.
   // When 0 or omitted, the server applies its default limit.
-  int32 limit = 3 [(buf.validate.field).int32 = {gte: 0, lte: 100}];
+  int32 limit = 3 [(buf.validate.field).int32 = {
+    gte: 0
+    lte: 100
+  }];
 }
 
 // ListTopResponse contains the chart of popular artists.

--- a/proto/liverty_music/rpc/artist/v1/artist_service.proto
+++ b/proto/liverty_music/rpc/artist/v1/artist_service.proto
@@ -209,6 +209,10 @@ message SetPassionLevelResponse {}
 message ListSimilarRequest {
   // Required. The unique identifier of the artist used as a seed for recommendations.
   entity.v1.ArtistId artist_id = 1 [(buf.validate.field).required = true];
+
+  // Optional. Maximum number of similar artists to return.
+  // When 0 or omitted, the server applies its default limit.
+  int32 limit = 2 [(buf.validate.field).int32 = {gte: 0, lte: 100}];
 }
 
 // ListSimilarResponse contains recommendations based on a seed artist.
@@ -226,6 +230,10 @@ message ListTopRequest {
   // Optional. Filter top artists by genre or tag (e.g., "rock", "pop", "anime").
   // When empty, returns top artists across all genres.
   string tag = 2 [(buf.validate.field).string.max_len = 50];
+
+  // Optional. Maximum number of top artists to return.
+  // When 0 or omitted, the server applies its default limit.
+  int32 limit = 3 [(buf.validate.field).int32 = {gte: 0, lte: 100}];
 }
 
 // ListTopResponse contains the chart of popular artists.


### PR DESCRIPTION
## Summary
- Add `int32 limit` field to `ListSimilarRequest` and `ListTopRequest` proto messages
- Add OpenSpec change artifacts (proposal, design, specs, tasks) for bubble pool eviction fix

## Changes
- **Proto**: `ListSimilarRequest.limit` (field 2), `ListTopRequest.limit` (field 3) with `{gte: 0, lte: 100}` validation
- **OpenSpec**: New `bubble-pool-lifecycle` spec + modified `artist-discovery-dna-orb-ui` delta spec

## Test plan
- [x] `buf lint` passes
- [x] `buf breaking` passes (additive field only)
- [ ] BSR publish triggers generated code update

Closes #116