### PR TITLE
docs(specs): sync specs for onboarding mock replacement

### DIFF
--- a/openspec/changes/archive/2026-03-03-replace-onboarding-mocks/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-03-replace-onboarding-mocks/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-02

--- a/openspec/changes/archive/2026-03-03-replace-onboarding-mocks/design.md
+++ b/openspec/changes/archive/2026-03-03-replace-onboarding-mocks/design.md
@@ -1,0 +1,57 @@
+## Context
+
+During onboarding, the Discover page (Step 1) lets guest users follow artists stored in localStorage. The Loading screen (Step 2) skips `SearchNewConcerts` entirely (3-second delay only) because it requires authentication. This means no concert data is written to the database, so the Dashboard (Step 3) displays an empty state.
+
+Separately, `ArtistDiscoveryService.checkLiveEvents()` uses a hash-based mock to simulate whether an artist has upcoming events (~30% return true). The TS Connect-RPC client for `ConcertService/List` is already available and used elsewhere.
+
+The backend already has a `publicProcedures` mechanism in `di/provider.go` that allows specific RPC endpoints to bypass JWT authentication. Four endpoints are already public: `ArtistService/{ListTop,ListSimilar,Search}` and `ConcertService/List`.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Populate concert data in the database during onboarding so the Dashboard shows real content.
+- Replace the `checkLiveEvents` mock with a real `ConcertService/List` call.
+- Keep the change minimal — use existing infrastructure (`publicProcedures`, `searchLog` cache).
+
+**Non-Goals:**
+- Changing the onboarding step order (signup remains at Step 6).
+- Adding rate limiting or bot protection (searchLog 24h cache is sufficient for now).
+- Changing the Loading screen behavior (remains 3-second delay).
+- Modifying the `SearchNewConcerts` RPC signature or backend logic.
+
+## Decisions
+
+### D1: Make `SearchNewConcerts` a public procedure
+
+Add `ConcertService/SearchNewConcerts` to the `publicProcedures` map in `di/provider.go`.
+
+**Why this over alternatives:**
+- The `publicProcedures` pattern already exists and is proven.
+- `SearchNewConcerts` has built-in abuse protection via `searchLog` (24h TTL per artist).
+- No proto changes needed, no new endpoints, no breaking changes.
+
+### D2: Fire-and-forget `SearchNewConcerts` on follow during Discover
+
+In `ArtistDiscoveryService.followArtist()`, after the localStorage write and optimistic UI update, call `ConcertServiceClient.searchNewConcerts(artistId)` without awaiting the result. Log errors to console only.
+
+**Why fire-and-forget:**
+- The user spends significant time on the Discover page selecting multiple artists. By the time they reach Loading (Step 2) and Dashboard (Step 3), the async event consumers have had enough time to write concert data to the DB.
+- Awaiting would slow down the bubble absorption animation and degrade UX.
+
+**Why call from `ArtistDiscoveryService` (not `ArtistServiceClient.follow()`):**
+- `ArtistServiceClient.follow()` during onboarding only writes to localStorage — it has no dependency on `IConcertService`. Adding it there would create a circular dependency or require injecting a new service.
+- `ArtistDiscoveryService` already has access to both artist and concert concerns and is the right orchestration point.
+
+### D3: Replace `checkLiveEvents` mock with `ConcertService/List`
+
+Change `checkLiveEvents(artistName)` signature to `checkLiveEvents(artistId)` and call `ConcertServiceClient.listConcerts(artistId)`. Return `true` if the result array is non-empty.
+
+**Why change the parameter from `artistName` to `artistId`:**
+- `ConcertService/List` requires `artist_id`, not name.
+- The callers (`discover-page.ts`, `artist-discovery-page.ts`) already have access to `artist.id` on the `ArtistBubble` object.
+
+## Risks / Trade-offs
+
+- **[Race condition] Concert data may not be ready when Dashboard loads** → Mitigated by the natural delay: users spend time on Discover selecting multiple artists, then 3 seconds on Loading. For the first artist followed, this gives 30+ seconds for the async consumer to process. If some data is still missing, the user will see a partial dashboard (better than empty).
+- **[Public API abuse] Unauthenticated `SearchNewConcerts` calls** → Mitigated by `searchLog` 24h TTL: duplicate calls for the same artist are no-ops. Creating new artist IDs requires other RPCs. Accepted risk for current scale.
+- **[Breaking test changes] `checkLiveEvents` signature change** → Callers and test mocks need updating from `artistName` to `artistId`. Small scope: 3 call sites, 2 test files, 1 mock helper.

--- a/openspec/changes/archive/2026-03-03-replace-onboarding-mocks/proposal.md
+++ b/openspec/changes/archive/2026-03-03-replace-onboarding-mocks/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+During onboarding, the Loading screen (Step 2) skips `SearchNewConcerts` entirely, which is the only mechanism that populates concert data in the database. As a result, the Dashboard (Step 3) always shows an empty state because `ConcertService/List` reads from an empty DB. Additionally, `checkLiveEvents()` in `ArtistDiscoveryService` uses a hash-based mock instead of calling the real `ConcertService/List` RPC, even though the TS Connect client is already available.
+
+## What Changes
+
+- Make `ConcertService/SearchNewConcerts` accessible without authentication by adding it to `publicProcedures` in the backend DI provider.
+- Call `SearchNewConcerts` fire-and-forget on each artist follow during the Discover step (Step 1), so concert data is populated in the background while the user continues selecting artists.
+- Replace the `checkLiveEvents()` mock implementation with a real `ConcertService/List` RPC call to check whether an artist has upcoming concerts.
+
+## Capabilities
+
+### New Capabilities
+
+_None._
+
+### Modified Capabilities
+
+- `concert-search`: `SearchNewConcerts` RPC gains public (unauthenticated) access. The 24-hour search log cache provides sufficient protection against abuse.
+- `frontend-onboarding-flow`: Artist follow during discovery triggers a background `SearchNewConcerts` call in addition to the existing localStorage write.
+- `live-events`: `checkLiveEvents()` replaces its mock with a real `ConcertService/List` call.
+
+## Impact
+
+- **Backend**: `backend/internal/di/provider.go` — add one entry to `publicProcedures` map.
+- **Frontend**: `frontend/src/services/artist-discovery-service.ts` — add `SearchNewConcerts` fire-and-forget on follow, replace `checkLiveEvents` mock with `ConcertService/List` call.
+- **Frontend**: `frontend/src/services/concert-service.ts` — may need a public-facing `searchNewConcerts` call path (no auth header).
+- **Security**: `SearchNewConcerts` becomes publicly accessible. Mitigated by existing `searchLog` 24-hour TTL cache that skips Gemini API calls for recently searched artists.

--- a/openspec/changes/archive/2026-03-03-replace-onboarding-mocks/specs/concert-search/spec.md
+++ b/openspec/changes/archive/2026-03-03-replace-onboarding-mocks/specs/concert-search/spec.md
@@ -1,0 +1,42 @@
+## MODIFIED Requirements
+
+### Requirement: Search Concerts by Artist
+
+System must provide a way to search for future concerts of a specific artist using generative AI grounding. The system SHALL check the search log before calling the external API and skip the call if a recent search exists. The extracted concert data SHALL include the venue's administrative area (`admin_area`) when it can be determined with confidence. The `SearchNewConcerts` RPC SHALL be accessible without authentication to support guest onboarding flows.
+
+#### Scenario: Successful Search
+
+- **WHEN** `SearchNewConcerts` is called for an existing artist
+- **AND** no search log exists or the last search was more than 24 hours ago
+- **THEN** the system MUST call the external search API
+- **AND** return a list of upcoming concerts found on the web
+- **AND** each concert includes title, listed venue name, date, start time, and optionally `admin_area`
+- **AND** results exclude concerts that are already stored in the database
+
+#### Scenario: Skip search when recently searched
+
+- **WHEN** `SearchNewConcerts` is called for an artist
+- **AND** a search log exists with `searched_at` within the last 24 hours
+- **THEN** the system MUST NOT call the external search API
+- **AND** return an empty list
+
+#### Scenario: Filter Past Events
+
+- **WHEN** the search results include events with dates in the past
+- **THEN** the system MUST filter them out and only return future events
+
+#### Scenario: No Results
+
+- **WHEN** no upcoming concerts are found for the artist
+- **THEN** the system MUST return an empty list without error
+
+#### Scenario: Missing Artist ID
+
+- **WHEN** an `artist_id` is not provided
+- **THEN** the system MUST return an `INVALID_ARGUMENT` error
+
+#### Scenario: Unauthenticated access
+
+- **WHEN** `SearchNewConcerts` is called without a bearer token
+- **THEN** the system SHALL process the request normally (public procedure)
+- **AND** the search log cache SHALL prevent abuse by skipping external API calls for recently searched artists

--- a/openspec/changes/archive/2026-03-03-replace-onboarding-mocks/specs/frontend-onboarding-flow/spec.md
+++ b/openspec/changes/archive/2026-03-03-replace-onboarding-mocks/specs/frontend-onboarding-flow/spec.md
@@ -1,0 +1,26 @@
+## MODIFIED Requirements
+
+### Requirement: Interactive Artist Discovery (Bubble Network UI)
+
+The system SHALL provide an engaging, gamified interface for users to discover and follow artists using Last.fm API data. During the tutorial, followed artists are stored locally (not via backend RPC). Additionally, the system SHALL trigger a background concert search for each followed artist to pre-populate concert data for the Dashboard.
+
+#### Scenario: Initial artist bubble display
+
+- **WHEN** a user reaches the Artist Discovery step (Step 1)
+- **THEN** the system SHALL call Last.fm's `geo.getTopArtists` API with `country=japan`
+- **AND** the system SHALL display approximately 30 top artists as floating circular bubbles with physics-based animation
+
+#### Scenario: Guest user follows artist via bubble tap
+
+- **WHEN** a guest user (in tutorial) taps an artist bubble
+- **THEN** the system SHALL trigger the absorption animation
+- **AND** the system SHALL store the artist in `liverty:guest:followedArtists` in LocalStorage
+- **AND** the system SHALL NOT call any backend RPC for the follow operation itself
+- **AND** the system SHALL call `ConcertService/SearchNewConcerts` fire-and-forget in the background
+- **AND** errors from `SearchNewConcerts` SHALL be logged to console and NOT affect the follow operation or UI
+
+#### Scenario: Progress bar reaches target
+
+- **WHEN** the user has followed 3 or more artists
+- **THEN** the system SHALL display the progress bar at 100%
+- **AND** the system SHALL activate and highlight the [Generate Dashboard] CTA button

--- a/openspec/changes/archive/2026-03-03-replace-onboarding-mocks/specs/live-events/spec.md
+++ b/openspec/changes/archive/2026-03-03-replace-onboarding-mocks/specs/live-events/spec.md
@@ -1,0 +1,24 @@
+## MODIFIED Requirements
+
+### Requirement: Live Event Availability Check
+
+The system SHALL provide a mechanism to check whether an artist has upcoming live events by querying the `ConcertService/List` RPC. This replaces the previous hash-based mock implementation.
+
+#### Scenario: Artist has upcoming events
+
+- **WHEN** `checkLiveEvents` is called with an artist ID
+- **AND** `ConcertService/List` returns one or more concerts for that artist
+- **THEN** the system SHALL return `true`
+
+#### Scenario: Artist has no upcoming events
+
+- **WHEN** `checkLiveEvents` is called with an artist ID
+- **AND** `ConcertService/List` returns an empty list
+- **THEN** the system SHALL return `false`
+
+#### Scenario: Concert list call fails
+
+- **WHEN** `checkLiveEvents` is called with an artist ID
+- **AND** the `ConcertService/List` RPC call fails
+- **THEN** the system SHALL return `false`
+- **AND** the system SHALL log the error

--- a/openspec/changes/archive/2026-03-03-replace-onboarding-mocks/tasks.md
+++ b/openspec/changes/archive/2026-03-03-replace-onboarding-mocks/tasks.md
@@ -1,0 +1,21 @@
+## 1. Backend: Make SearchNewConcerts Public
+
+- [x] 1.1 Add `ConcertService/SearchNewConcerts` to `publicProcedures` map in `backend/internal/di/provider.go`
+- [x] 1.2 Add test case in `backend/internal/infrastructure/auth/authn_test.go` verifying unauthenticated `SearchNewConcerts` requests pass through (covered by existing generic public procedure tests)
+
+## 2. Frontend: Fire-and-forget SearchNewConcerts on Follow
+
+- [x] 2.1 Inject `IConcertService` into `ArtistDiscoveryService` and call `searchNewConcerts(artistId)` fire-and-forget inside `markFollowed()` after localStorage write
+- [x] 2.2 Update `artist-discovery-service` tests to verify `searchNewConcerts` is called on follow (no await, error does not reject)
+
+## 3. Frontend: Replace checkLiveEvents Mock
+
+- [x] 3.1 Change `checkLiveEvents(artistName: string)` signature to `checkLiveEvents(artistId: string)` and replace hash mock with `ConcertServiceClient.listConcerts(artistId)` call returning `concerts.length > 0`
+- [x] 3.2 Update callers in `discover-page.ts` and `artist-discovery-page.ts` to pass `artist.id` instead of `artist.name`
+- [x] 3.3 Update test mocks in `mock-rpc-clients.ts`, `discover-page.spec.ts`, and `artist-discovery-page.spec.ts`
+
+## 4. Verification
+
+- [x] 4.1 Run backend tests (`go test ./...`)
+- [x] 4.2 Run frontend tests (`npm test`)
+- [x] 4.3 Run linters and verify clean build

--- a/openspec/specs/concert-search/spec.md
+++ b/openspec/specs/concert-search/spec.md
@@ -8,7 +8,7 @@ To define the interface and behavior for discovering new concerts for artists, e
 
 ### Requirement: Search Concerts by Artist
 
-System must provide a way to search for future concerts of a specific artist using generative AI grounding. The system SHALL check the search log before calling the external API and skip the call if a recent search exists. The extracted concert data SHALL include the venue's administrative area (`admin_area`) when it can be determined with confidence.
+System must provide a way to search for future concerts of a specific artist using generative AI grounding. The system SHALL check the search log before calling the external API and skip the call if a recent search exists. The extracted concert data SHALL include the venue's administrative area (`admin_area`) when it can be determined with confidence. The `SearchNewConcerts` RPC SHALL be accessible without authentication to support guest onboarding flows.
 
 #### Scenario: Successful Search
 
@@ -40,6 +40,12 @@ System must provide a way to search for future concerts of a specific artist usi
 
 - **WHEN** an `artist_id` is not provided
 - **THEN** the system MUST return an `INVALID_ARGUMENT` error
+
+#### Scenario: Unauthenticated access
+
+- **WHEN** `SearchNewConcerts` is called without a bearer token
+- **THEN** the system SHALL process the request normally (public procedure)
+- **AND** the search log cache SHALL prevent abuse by skipping external API calls for recently searched artists
 
 ### Requirement: Venue Administrative Area Extraction
 

--- a/openspec/specs/frontend-onboarding-flow/spec.md
+++ b/openspec/specs/frontend-onboarding-flow/spec.md
@@ -55,7 +55,7 @@ The system SHALL collect the user's primary residential area during the Dashboar
 
 ### Requirement: Interactive Artist Discovery (Bubble Network UI)
 
-The system SHALL provide an engaging, gamified interface for users to discover and follow artists using Last.fm API data. During the tutorial, followed artists are stored locally (not via backend RPC).
+The system SHALL provide an engaging, gamified interface for users to discover and follow artists using Last.fm API data. During the tutorial, followed artists are stored locally (not via backend RPC). Additionally, the system SHALL trigger a background concert search for each followed artist to pre-populate concert data for the Dashboard.
 
 #### Scenario: Initial artist bubble display
 
@@ -68,7 +68,9 @@ The system SHALL provide an engaging, gamified interface for users to discover a
 - **WHEN** a guest user (in tutorial) taps an artist bubble
 - **THEN** the system SHALL trigger the absorption animation
 - **AND** the system SHALL store the artist in `liverty:guest:followedArtists` in LocalStorage
-- **AND** the system SHALL NOT call any backend RPC
+- **AND** the system SHALL NOT call any backend RPC for the follow operation itself
+- **AND** the system SHALL call `ConcertService/SearchNewConcerts` fire-and-forget in the background
+- **AND** errors from `SearchNewConcerts` SHALL be logged to console and NOT affect the follow operation or UI
 
 #### Scenario: Progress bar reaches target
 

--- a/openspec/specs/live-events/spec.md
+++ b/openspec/specs/live-events/spec.md
@@ -181,3 +181,26 @@ The frontend SHALL convert ISO 3166-2 codes to human-readable names for display,
 - **WHEN** the region setup sheet presents area options to the user
 - **THEN** the options SHALL display localized names
 - **AND** the selected value sent to the backend SHALL be structured as a `Home` message with `country_code` and `level_1`
+
+### Requirement: Live Event Availability Check
+
+The system SHALL provide a mechanism to check whether an artist has upcoming live events by querying the `ConcertService/List` RPC. This replaces the previous hash-based mock implementation.
+
+#### Scenario: Artist has upcoming events
+
+- **WHEN** `checkLiveEvents` is called with an artist ID
+- **AND** `ConcertService/List` returns one or more concerts for that artist
+- **THEN** the system SHALL return `true`
+
+#### Scenario: Artist has no upcoming events
+
+- **WHEN** `checkLiveEvents` is called with an artist ID
+- **AND** `ConcertService/List` returns an empty list
+- **THEN** the system SHALL return `false`
+
+#### Scenario: Concert list call fails
+
+- **WHEN** `checkLiveEvents` is called with an artist ID
+- **AND** the `ConcertService/List` RPC call fails
+- **THEN** the system SHALL return `false`
+- **AND** the system SHALL log the error


### PR DESCRIPTION
## 🔗 Related Issue

Closes #126

## 📝 Summary of Changes

Sync main specs to reflect the `replace-onboarding-mocks` implementation and archive the change artifacts:

1. **concert-search**: Add unauthenticated access scenario, update requirement description for public procedure support
2. **frontend-onboarding-flow**: Add fire-and-forget `SearchNewConcerts` on follow to guest follow scenario
3. **live-events**: Add new "Live Event Availability Check" requirement with 3 scenarios (has events, no events, call fails)

## 📋 Commit Log

- `01697cc` chore(openspec): archive replace-onboarding-mocks change
- `b8e7066` docs(specs): sync specs for onboarding mock replacement

## ✅ Self-Checklist

- [x] I have linked the related issue.
- [x] I have updated the relevant documentation (e.g., `README.md`) if needed.
- [x] I have run `buf lint` and `buf format` locally and all checks have passed.
- [x] My proto definitions follow the project's style guidelines and validation rules.
- [x] Breaking changes have been justified and documented if applicable.