### PR TITLE
docs(spec): add Resilient External Search requirement

### DIFF
--- a/openspec/changes/archive/2026-03-03-fix-concert-search-timeout/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-03-fix-concert-search-timeout/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-03

--- a/openspec/changes/archive/2026-03-03-fix-concert-search-timeout/design.md
+++ b/openspec/changes/archive/2026-03-03-fix-concert-search-timeout/design.md
@@ -1,0 +1,73 @@
+## Context
+
+The `SearchNewConcerts` RPC calls Gemini API with Google Search grounding to discover concerts. The frontend's Connect transport has no `timeoutMs` configured, so the client doesn't declare a deadline. The server uses a global `http.TimeoutHandler` at 5s (`config.go:153`, `connect.go:123`) as insurance, but 5s is too short for Gemini + grounding (typically 2–5s, peaks higher).
+
+The frontend already has a `createRetryInterceptor` (`connect-error-router.ts:49`) that retries `DeadlineExceeded` and `Unavailable` errors up to 3 times with exponential backoff (200ms/400ms/800ms). However, these retries hit the same 5s server wall, so they fail too.
+
+Current flow:
+```
+Frontend
+  createConnectTransport({baseUrl})         ← no timeoutMs
+  ├── retryInterceptor (3x, 200/400/800ms)  ← retries but server kills at 5s
+  └── searchNewConcerts(artistId)           ← no signal/timeout
+
+Backend
+  http.TimeoutHandler(5s)                   ← insurance, but acts as primary
+  └── ConcertSearcher.Search               ← Gemini API, no retry
+```
+
+## Goals / Non-Goals
+
+**Goals:**
+- Set client-side `timeoutMs` on `searchNewConcerts` so the client controls its own deadline (20s)
+- Raise the server's insurance `http.TimeoutHandler` to 30s so it doesn't pre-empt client deadlines
+- Add retry with exponential backoff in the Gemini caller so transient API failures are retried server-side
+
+**Non-Goals:**
+- Making `SearchNewConcerts` fully asynchronous
+- Adding per-route `http.TimeoutHandler` (the global insurance at 30s is sufficient)
+- Setting `timeoutMs` on all RPCs globally (only `searchNewConcerts` needs a long timeout)
+
+## Decisions
+
+### Decision 1: Client-side `timeoutMs: 20000` on `searchNewConcerts`
+
+**Approach:** Pass `{ timeoutMs: 20000 }` as the second argument to `this.concertClient.searchNewConcerts()` in `concert-service.ts:94`. This sends a `Connect-Timeout-Ms` header, letting the server know the client's deadline.
+
+**Why 20s:** Gemini + grounding takes 2–5s per attempt. With up to 3 server-side retries (1s, 2s backoff), worst case is ~15s. 20s gives headroom.
+
+**Why not set at transport level:** Other RPCs (List, ListByFollower) are fast (<1s). A global `timeoutMs` would be too generous for them or too tight for SearchNewConcerts.
+
+**Callers:**
+- `artist-discovery-service.ts:306` — fire-and-forget, no signal. The `timeoutMs` in `concert-service.ts` handles the deadline.
+- `loading-sequence-service.ts:136` — passes a signal from a 10s global timeout. The `timeoutMs: 20000` won't conflict because the signal will abort earlier if needed.
+
+### Decision 2: Raise `SERVER_HANDLER_TIMEOUT` from 5s to 30s
+
+**Approach:** Change the default in `config.go:153` from `5s` to `30s`.
+
+**Why 30s:** This is insurance, not the primary deadline. It must be higher than any client-declared `timeoutMs` (20s) to avoid pre-empting the client. 30s gives 10s of headroom.
+
+**Why not per-route:** `http.TimeoutHandler` wraps the entire HTTP mux. Per-route wrapping would require restructuring the server setup. Since 30s is still a reasonable insurance value for all RPCs (the client's `timeoutMs` provides the tight deadline), a global increase is simpler.
+
+**Risk:** Other RPCs without client `timeoutMs` could theoretically run for up to 30s. In practice, all other RPCs complete in <1s and are bounded by their own DB query timeouts.
+
+### Decision 3: Retry with exponential backoff in `ConcertSearcher.Search`
+
+**Approach:** Wrap the `client.Models.GenerateContent` call (`searcher.go:205`) in a retry loop:
+- Max attempts: 3
+- Backoff: 1s, 2s (exponential, base 1s, factor 2x)
+- Retryable: Gemini API errors — HTTP 504 (Gateway Timeout), 503 (Unavailable), 429 (Too Many Requests), 499 (Client Cancelled on Gemini side)
+- Non-retryable: `context.Canceled`, `context.DeadlineExceeded` from parent context, HTTP 400/401/403
+
+**Key distinction:** Before each retry, check `ctx.Err()`. If the parent context (from client's `timeoutMs`) is done, stop immediately — don't waste resources.
+
+**Where:** Inside `ConcertSearcher.Search`, wrapping only the `GenerateContent` call. Prompt construction, logging setup, and response parsing happen once.
+
+## Risks / Trade-offs
+
+**[Risk] Raising global `SERVER_HANDLER_TIMEOUT` to 30s weakens protection for other RPCs** → Mitigated by client-side `timeoutMs` on RPCs that need tight deadlines. Other RPCs complete in <1s and have DB-level timeouts. The 30s is purely insurance against runaway requests.
+
+**[Risk] Frontend `retryInterceptor` + backend retry = retry amplification** → The frontend retries on `DeadlineExceeded` (3x), and the backend retries Gemini calls (3x). Worst case: 3 frontend retries × 3 backend retries = 9 Gemini calls per artist follow. This is acceptable for fire-and-forget during onboarding (~3 artists). If this becomes a concern, the frontend retry for `searchNewConcerts` can be disabled by passing a custom `interceptors` option.
+
+**[Risk] `loading-sequence-service.ts` has a 10s global timeout but `timeoutMs` is 20s** → The AbortSignal from the 10s timeout will cancel the request before the 20s `timeoutMs` expires. This is correct — the loading sequence should be snappy, and the `timeoutMs` is just the per-RPC ceiling.

--- a/openspec/changes/archive/2026-03-03-fix-concert-search-timeout/proposal.md
+++ b/openspec/changes/archive/2026-03-03-fix-concert-search-timeout/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+The `SearchNewConcerts` RPC consistently times out in dev because the global HTTP handler timeout (`SERVER_HANDLER_TIMEOUT=5s`) is too short for Gemini API calls that use Google Search grounding. Gemini typically takes 2–5 seconds to respond, and under load it exceeds the 5s deadline, returning `DEADLINE_EXCEEDED` (504). The frontend does not set a `timeoutMs` on the RPC call, so the server's conservative 5s insurance timeout is the only deadline — and it's too short.
+
+## What Changes
+
+- **Frontend**: Set `timeoutMs: 20000` on `searchNewConcerts` RPC calls so the client explicitly declares how long it's willing to wait
+- **Backend**: Increase `SERVER_HANDLER_TIMEOUT` from 5s to 30s as an insurance safety net (the client's `timeoutMs` is the primary deadline)
+- **Backend**: Add retry logic with exponential backoff to the Gemini API caller so transient timeouts are retried automatically
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+(none — this is a client timeout + infrastructure resilience fix with no spec-level behavior change)
+
+## Impact
+
+- **Frontend**: `src/services/concert-service.ts` (add `timeoutMs`), `src/services/artist-discovery-service.ts` (pass through timeout), `src/services/loading-sequence-service.ts` (pass through timeout)
+- **Backend**: `internal/infrastructure/gcp/gemini/searcher.go` (retry logic), `pkg/config/config.go` (`SERVER_HANDLER_TIMEOUT` default change)
+- **Risk**: Low — fire-and-forget pattern means frontend is already resilient to failures; this improves success rate

--- a/openspec/changes/archive/2026-03-03-fix-concert-search-timeout/specs/concert-search/spec.md
+++ b/openspec/changes/archive/2026-03-03-fix-concert-search-timeout/specs/concert-search/spec.md
@@ -1,0 +1,26 @@
+## ADDED Requirements
+
+### Requirement: Resilient External Search
+
+The system SHALL retry transient failures from the external search API using exponential backoff before reporting an error. The `SearchNewConcerts` RPC SHALL have a dedicated timeout (≥15 seconds) independent of the global handler timeout to accommodate the latency of AI-grounded search.
+
+#### Scenario: Transient Gemini timeout is retried
+
+- **WHEN** `SearchNewConcerts` calls the external search API
+- **AND** the API returns a transient error (504 Gateway Timeout, 503 Unavailable, 429 Too Many Requests, or 499 Client Cancelled)
+- **THEN** the system MUST retry the call up to 2 additional times with exponential backoff
+- **AND** return results if any retry succeeds
+
+#### Scenario: All retries exhausted
+
+- **WHEN** `SearchNewConcerts` calls the external search API
+- **AND** all retry attempts fail with transient errors
+- **THEN** the system MUST return an error to the caller
+- **AND** log each failed attempt with the error details
+
+#### Scenario: Non-transient error is not retried
+
+- **WHEN** `SearchNewConcerts` calls the external search API
+- **AND** the API returns a non-transient error (400 Bad Request, 401 Unauthorized)
+- **THEN** the system MUST NOT retry the call
+- **AND** return the error immediately

--- a/openspec/changes/archive/2026-03-03-fix-concert-search-timeout/tasks.md
+++ b/openspec/changes/archive/2026-03-03-fix-concert-search-timeout/tasks.md
@@ -1,0 +1,19 @@
+## 1. Client-Side Timeout
+
+- [x] 1.1 Add `timeoutMs: 20000` to `searchNewConcerts` RPC call in `frontend/src/services/concert-service.ts`
+
+## 2. Server-Side Insurance Timeout
+
+- [x] 2.1 Change `SERVER_HANDLER_TIMEOUT` default from `5s` to `30s` in `backend/pkg/config/config.go`
+
+## 3. Gemini Retry Logic
+
+- [x] 3.1 Add `isRetryable` helper to classify transient Gemini errors (504, 503, 429) vs non-retryable in `backend/internal/infrastructure/gcp/gemini/errors.go`
+- [x] 3.2 Add retry loop with exponential backoff (max 3 attempts, 1s/2s delays) around `GenerateContent` call in `backend/internal/infrastructure/gcp/gemini/searcher.go`
+- [x] 3.3 Check `ctx.Err()` before each retry to bail out if parent context is cancelled
+
+## 4. Testing
+
+- [x] 4.1 Add unit tests for `isRetryable` error classification
+- [x] 4.2 Add unit tests for retry behavior (success on retry, all retries exhausted, non-retryable stops, context cancellation stops)
+- [x] 4.3 Run frontend tests (`npm test`) and backend tests (`golangci-lint`, `go test ./...`)

--- a/openspec/specs/concert-search/spec.md
+++ b/openspec/specs/concert-search/spec.md
@@ -66,3 +66,28 @@ The Gemini extraction pipeline SHALL attempt to identify the administrative area
 - **WHEN** the administrative area cannot be determined with confidence from the source text
 - **THEN** `admin_area` SHALL be omitted (empty string / `NULL`)
 - **AND** the system SHALL NOT guess or infer from partial information
+
+### Requirement: Resilient External Search
+
+The system SHALL retry transient failures from the external search API using exponential backoff before reporting an error. The `SearchNewConcerts` RPC SHALL have a dedicated timeout (≥15 seconds) independent of the global handler timeout to accommodate the latency of AI-grounded search.
+
+#### Scenario: Transient Gemini timeout is retried
+
+- **WHEN** `SearchNewConcerts` calls the external search API
+- **AND** the API returns a transient error (504 Gateway Timeout, 503 Unavailable, 429 Too Many Requests, or 499 Client Cancelled)
+- **THEN** the system MUST retry the call up to 2 additional times with exponential backoff
+- **AND** return results if any retry succeeds
+
+#### Scenario: All retries exhausted
+
+- **WHEN** `SearchNewConcerts` calls the external search API
+- **AND** all retry attempts fail with transient errors
+- **THEN** the system MUST return an error to the caller
+- **AND** log each failed attempt with the error details
+
+#### Scenario: Non-transient error is not retried
+
+- **WHEN** `SearchNewConcerts` calls the external search API
+- **AND** the API returns a non-transient error (400 Bad Request, 401 Unauthorized)
+- **THEN** the system MUST NOT retry the call
+- **AND** return the error immediately


### PR DESCRIPTION
## 🔗 Related Issue

Closes #128

## 📝 Summary of Changes

Add the "Resilient External Search" requirement to the concert-search capability spec, documenting:
- Retry behavior for transient Gemini API errors (504, 503, 429, 499)
- Maximum 3 attempts with exponential backoff
- Non-transient errors (400, 401) are not retried

Also archives the `fix-concert-search-timeout` change artifacts.

## 📋 Commit Log

- d2d480e docs(spec): add Resilient External Search requirement

## ✅ Self-Checklist

- [x] I have linked the related issue.
- [x] I have added or updated tests to cover my changes.
- [x] I have updated the relevant documentation (e.g., `README.md`, `CLAUDE.md`).
- [x] I have run `go test -race ./...` and `mise run lint` locally and all checks have passed.
- [x] My code follows the architecture and style guidelines of the project.