### PR TITLE
feat(concert): add GetSearchStatus RPC for async search polling

### DIFF
--- a/proto/liverty_music/rpc/concert/v1/concert_service.proto
+++ b/proto/liverty_music/rpc/concert/v1/concert_service.proto
@@ -33,12 +33,12 @@ service ConcertService {
   // - NOT_FOUND: The specified artist does not exist.
   rpc SearchNewConcerts(SearchNewConcertsRequest) returns (SearchNewConcertsResponse);
 
-  // GetSearchStatus returns the current search status for one or more artists.
+  // ListSearchStatuses returns the current search status for one or more artists.
   // Use this to poll for completion after calling SearchNewConcerts.
   //
   // Possible errors:
   // - INVALID_ARGUMENT: The artist IDs list is empty or contains invalid IDs.
-  rpc GetSearchStatus(GetSearchStatusRequest) returns (GetSearchStatusResponse);
+  rpc ListSearchStatuses(ListSearchStatusesRequest) returns (ListSearchStatusesResponse);
 }
 
 // ListRequest is the request for retrieving concerts associated with a specific artist.
@@ -78,14 +78,14 @@ message SearchNewConcertsResponse {
   reserved "concerts";
 }
 
-// GetSearchStatusRequest specifies the artists whose search status is queried.
-message GetSearchStatusRequest {
+// ListSearchStatusesRequest specifies the artists whose search status is queried.
+message ListSearchStatusesRequest {
   // Required. The artist identifiers to query search status for.
   repeated entity.v1.ArtistId artist_ids = 1 [(buf.validate.field).required = true];
 }
 
-// GetSearchStatusResponse contains the search status for each requested artist.
-message GetSearchStatusResponse {
+// ListSearchStatusesResponse contains the search status for each requested artist.
+message ListSearchStatusesResponse {
   // The search status for each requested artist.
   repeated ArtistSearchStatus statuses = 1;
 }

--- a/proto/liverty_music/rpc/concert/v1/concert_service.proto
+++ b/proto/liverty_music/rpc/concert/v1/concert_service.proto
@@ -24,15 +24,21 @@ service ConcertService {
   rpc ListByFollower(ListByFollowerRequest) returns (ListByFollowerResponse);
 
   // SearchNewConcerts triggers an asynchronous discovery process for new concerts.
-  // It scrapes external sources and publishes a concert.discovered.v1 event for
-  // downstream consumers. The response is empty; concert persistence happens
-  // asynchronously via event-driven consumers.
+  // It enqueues a background search job and returns immediately. The actual search
+  // runs asynchronously with a 120-second timeout and publishes a
+  // concert.discovered.v1 event for downstream consumers.
   //
   // Possible errors:
   // - INVALID_ARGUMENT: The artist ID is missing or invalid.
   // - NOT_FOUND: The specified artist does not exist.
-  // - INTERNAL: An error occurred during the discovery process.
   rpc SearchNewConcerts(SearchNewConcertsRequest) returns (SearchNewConcertsResponse);
+
+  // GetSearchStatus returns the current search status for one or more artists.
+  // Use this to poll for completion after calling SearchNewConcerts.
+  //
+  // Possible errors:
+  // - INVALID_ARGUMENT: The artist IDs list is empty or contains invalid IDs.
+  rpc GetSearchStatus(GetSearchStatusRequest) returns (GetSearchStatusResponse);
 }
 
 // ListRequest is the request for retrieving concerts associated with a specific artist.
@@ -70,4 +76,40 @@ message SearchNewConcertsRequest {
 message SearchNewConcertsResponse {
   reserved 1;
   reserved "concerts";
+}
+
+// GetSearchStatusRequest specifies the artists whose search status is queried.
+message GetSearchStatusRequest {
+  // Required. The artist identifiers to query search status for.
+  repeated entity.v1.ArtistId artist_ids = 1 [(buf.validate.field).required = true];
+}
+
+// GetSearchStatusResponse contains the search status for each requested artist.
+message GetSearchStatusResponse {
+  // The search status for each requested artist.
+  repeated ArtistSearchStatus statuses = 1;
+}
+
+// ArtistSearchStatus represents the current search status for a single artist.
+message ArtistSearchStatus {
+  // The artist identifier.
+  entity.v1.ArtistId artist_id = 1;
+
+  // The current search status.
+  SearchStatus status = 2;
+}
+
+// SearchStatus indicates the state of a concert search job for an artist.
+enum SearchStatus {
+  // Default value. No search log exists for this artist.
+  SEARCH_STATUS_UNSPECIFIED = 0;
+
+  // A search is currently in progress.
+  SEARCH_STATUS_PENDING = 1;
+
+  // The search completed successfully.
+  SEARCH_STATUS_COMPLETED = 2;
+
+  // The search failed after all retries.
+  SEARCH_STATUS_FAILED = 3;
 }

--- a/proto/liverty_music/rpc/concert/v1/concert_service.proto
+++ b/proto/liverty_music/rpc/concert/v1/concert_service.proto
@@ -81,7 +81,7 @@ message SearchNewConcertsResponse {
 // ListSearchStatusesRequest specifies the artists whose search status is queried.
 message ListSearchStatusesRequest {
   // Required. The artist identifiers to query search status for.
-  repeated entity.v1.ArtistId artist_ids = 1 [(buf.validate.field).required = true];
+  repeated entity.v1.ArtistId artist_ids = 1 [(buf.validate.field).repeated.min_items = 1];
 }
 
 // ListSearchStatusesResponse contains the search status for each requested artist.


### PR DESCRIPTION
## Summary
- Add `SearchStatus` enum (`UNSPECIFIED`, `PENDING`, `COMPLETED`, `FAILED`)
- Add `ArtistSearchStatus` message with artist ID and status
- Add `GetSearchStatus` RPC to `ConcertService` for batch status polling
- Update `SearchNewConcerts` doc comment to reflect async behavior

## Context
Part of the background concert search implementation to decouple Gemini API latency from the synchronous RPC lifecycle. Frontend will poll `GetSearchStatus` to track per-artist search progress during onboarding.

close: #130

## Breaking Change Note
The `SearchNewConcertsResponse` breaking change (reserved field) is pre-existing from a prior change — not introduced by this PR. Label `buf skip breaking` applied to pass CI.