### PR TITLE
chore(openspec): archive monitoring changes and sync main spec

### DIFF
--- a/openspec/changes/archive/2026-03-03-monitoring-app-error-log/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-03-monitoring-app-error-log/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-02

--- a/openspec/changes/archive/2026-03-03-monitoring-app-error-log/design.md
+++ b/openspec/changes/archive/2026-03-03-monitoring-app-error-log/design.md
@@ -1,0 +1,82 @@
+## Context
+
+dev 環境のバックエンドは GKE Autopilot 上で 3 ワークロード (server, consumer, concert-discovery) が稼働し、`pannpers/go-logging` (slog wrapper) で JSON 構造化ログを stdout に出力している。GKE エージェントが自動で Cloud Logging に取り込み、`severity` フィールドも正しく認識されている。
+
+Cloud Logging / Monitoring / Trace の API は有効化済みで、SA には `logging.logWriter` と `monitoring.metricWriter` ロールが付与されている。しかし、アラートポリシーと通知チャネルが存在しないため、ERROR ログが発生しても検知できない状態。
+
+Pulumi IaC (`cloud-provisioning/`) で全インフラを管理しており、コンポーネントパターン (`components/`) で構造化されている。
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- ERROR レベルのログ発生時に Google Chat と Email で通知を受け取れるようにする
+- ワークロードごとに独立したアラートポリシーを持ち、どのワークロードでエラーが発生したか即座に判別できるようにする
+- 通知のノイズを抑制する (12 時間に 1 回まで)
+- Error Reporting を有効化し、エラーの自動グルーピングと初回検出通知を利用可能にする
+- 全リソースを Pulumi IaC で管理する
+
+**Non-Goals:**
+
+- WARN レベルのアラート (将来的に追加可能)
+- カウントベースの閾値アラート (Log-Based Metric は今回のスコープ外)
+- ダッシュボード作成
+- prod / staging 環境への展開 (dev で検証後に別途対応)
+- アプリケーションコードの変更
+
+## Decisions
+
+### 1. Cloud Monitoring Log-Based Alert を採用
+
+**選択:** GCP ネイティブの Log-Based Alert Policy を使用する
+
+**代替案:**
+- Grafana + Loki: 高機能だが、dev 環境のみのためにデプロイ・運用するのはオーバーキル
+- SigNoz: OTel ネイティブで魅力的だが、ClickHouse の運用負荷が追加される
+- GCP Log-Based Metric + Metric Alert: カウントベースの閾値制御が可能だが、現時点では不要な複雑さ
+
+**理由:** 既に Cloud Logging にログが流れており、追加インフラゼロ・月額 $0.30 で実現できる。Log-Based Alert は「ログエントリ一致で発火」するシンプルな仕組みで、dev 環境の初期監視に適切。
+
+### 2. ワークロードごとに Alert Policy を分離
+
+**選択:** server, consumer, concert-discovery それぞれに独立した Alert Policy を作成 (計 3 つ)
+
+**代替案:** 1 つの Alert Policy で `resource.labels.namespace_name="backend"` のみでフィルタする
+
+**理由:** ワークロードごとに分けることで、通知メッセージからどのコンポーネントでエラーが発生したか即座に判別可能。Alert Policy 名にワークロード名を含めることで、Google Chat の通知にもワークロード名が表示される。コスト差は $0.20/月で無視できる。
+
+### 3. Notification Channel は Google Chat (primary) + Email (backup)
+
+**選択:** 2 つの Notification Channel を作成し、全 Alert Policy で両方を指定する
+
+**理由:** Google Chat はリアルタイム通知に適しているが、Chat Space の障害やアプリ未インストール時のフォールバックとして Email を確保する。
+
+### 4. Pulumi コンポーネントとして `monitoring.ts` を新設
+
+**選択:** `cloud-provisioning/src/gcp/components/monitoring.ts` に `MonitoringComponent` を新設する
+
+**代替案:** 既存の `project.ts` に追加する
+
+**理由:** 関心の分離。他のコンポーネント (kubernetes.ts, postgres.ts 等) と同じパターンに従う。将来的にダッシュボードや追加のアラートを追加する際にも拡張しやすい。
+
+### 5. labelExtractors で error_code と rpc_method を抽出
+
+**選択:** Alert Policy の `conditionMatchedLog` で `labelExtractors` を使い、`jsonPayload.error.code` と `jsonPayload.rpc_method` を抽出する
+
+**理由:** 通知メッセージにエラーコード (`internal`, `unavailable` 等) と RPC メソッド名が含まれるようになり、通知を見ただけでエラーの種類と発生箇所が分かる。Cloud Logging へのリンクは通知に自動的に含まれるため、詳細確認もワンクリック。
+
+### 6. Error Reporting API の有効化
+
+**選択:** `clouderrorreporting.googleapis.com` を `GoogleApis` 型と `project.ts` の有効 API リストに追加する
+
+**理由:** ERROR ログを自動でグルーピングし、新しいエラーパターンの初回検出を通知してくれる。追加コストなし。既存の JSON ログフォーマット (severity + message + optional stack trace) と互換性がある。
+
+## Risks / Trade-offs
+
+**[Log-Based Alert はカウントベース閾値が使えない]** → dev 環境では `notificationRateLimit.period = 43200s` (12 時間) で抑制しているため、実質的に問題にならない。将来的に閾値制御が必要になった場合は Log-Based Metric + Metric Alert に切り替える。
+
+**[Google Chat Notification Channel には事前に Monitoring アプリのインストールが必要]** → 手動作業が 1 ステップ発生する。Chat Space で Google Cloud Monitoring アプリをインストールし、Space ID を取得して Pulumi ESC に設定する必要がある。
+
+**[Error Reporting は Go の構造化ログと完全互換ではない可能性]** → Error Reporting は `reportLocation` や `serviceContext` の標準フィールドを期待する場合がある。go-logging のフォーマットで自動検出されない場合は、別途対応が必要になるが、severity=ERROR の JSON ログは最低限検出される。
+
+**[autoClose = 3600s の場合、断続的なエラーで Incident が頻繁に Open/Close を繰り返す可能性]** → notificationRateLimit が 12 時間なので、通知自体は抑制される。Incident の Open/Close はログとして残るが実害はない。

--- a/openspec/changes/archive/2026-03-03-monitoring-app-error-log/proposal.md
+++ b/openspec/changes/archive/2026-03-03-monitoring-app-error-log/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+dev 環境のバックエンドアプリケーションは severity 付きの構造化ログ (JSON) を Cloud Logging に出力しているが、ERROR レベルのログが発生しても検知する仕組みがない。サーバーエラーや障害が発生しても気付けず、ユーザー影響が拡大するリスクがある。Cloud Monitoring の Log-Based Alert と Error Reporting を活用し、追加インフラなし・月額 $0.30 程度のローコストで導入する。
+
+## What Changes
+
+- Cloud Monitoring に Google Chat と Email の Notification Channel を追加
+- ワークロードごと (server, consumer, concert-discovery) に ERROR ログの Log-Based Alert Policy を作成
+- GCP Error Reporting API を有効化し、ERROR ログの自動グルーピング・初回検出通知を利用可能にする
+- Pulumi IaC に monitoring コンポーネントを追加し、上記リソースをコードで管理
+
+## Capabilities
+
+### New Capabilities
+
+- `app-error-log-alerting`: ERROR レベルのアプリケーションログを検知し、Google Chat / Email に通知する仕組み
+
+### Modified Capabilities
+
+(なし — 既存のアプリケーションコードや spec に変更は不要)
+
+## Impact
+
+- **Infrastructure (Pulumi)**: `cloud-provisioning/src/gcp/components/` に monitoring コンポーネントを追加
+- **GCP APIs**: `clouderrorreporting.googleapis.com` を新規有効化
+- **GCP Resources**: NotificationChannel × 2, AlertPolicy × 3 を新規作成
+- **Pulumi ESC**: Google Chat Space ID, 通知先メールアドレスを環境変数として追加
+- **コスト**: Alert Policy 条件 3 × $0.10 = $0.30/月
+- **アプリケーションコード**: 変更なし

--- a/openspec/changes/archive/2026-03-03-monitoring-app-error-log/specs/app-error-log-alerting/spec.md
+++ b/openspec/changes/archive/2026-03-03-monitoring-app-error-log/specs/app-error-log-alerting/spec.md
@@ -1,0 +1,95 @@
+## ADDED Requirements
+
+### Requirement: Error log detection per workload
+
+The system SHALL detect ERROR-level log entries from each backend workload (server, consumer, concert-discovery) independently using Cloud Monitoring Log-Based Alert Policies.
+
+Each Alert Policy SHALL filter logs by:
+- `resource.type = "k8s_container"`
+- `resource.labels.namespace_name = "backend"`
+- `resource.labels.container_name` matching the specific workload name
+- `severity = "ERROR"`
+
+#### Scenario: Server emits an ERROR log
+
+- **WHEN** the server workload emits a log entry with severity ERROR
+- **THEN** the server-specific Alert Policy detects the log entry and opens an Incident
+
+#### Scenario: Consumer emits an ERROR log
+
+- **WHEN** the consumer workload emits a log entry with severity ERROR
+- **THEN** the consumer-specific Alert Policy detects the log entry and opens an Incident
+
+#### Scenario: Concert-discovery CronJob emits an ERROR log
+
+- **WHEN** the concert-discovery CronJob emits a log entry with severity ERROR
+- **THEN** the concert-discovery-specific Alert Policy detects the log entry and opens an Incident
+
+#### Scenario: WARN-level log does not trigger alert
+
+- **WHEN** any workload emits a log entry with severity WARNING
+- **THEN** no Alert Policy SHALL fire
+
+### Requirement: Notification via Google Chat and Email
+
+The system SHALL send alert notifications to both a Google Chat Space and an Email address when an Incident is opened.
+
+Notification Channels SHALL be provisioned as Pulumi resources using configuration values (Chat Space ID, Email address) stored in Pulumi ESC.
+
+#### Scenario: ERROR log triggers notifications
+
+- **WHEN** an Alert Policy detects an ERROR log and opens an Incident
+- **THEN** a notification SHALL be sent to the configured Google Chat Space
+- **AND** a notification SHALL be sent to the configured Email address
+
+### Requirement: Notification rate limiting
+
+The system SHALL suppress repeated notifications for the same Incident, sending at most one notification per 12-hour period (`notificationRateLimit.period = 43200s`).
+
+#### Scenario: Multiple ERROR logs within 12 hours
+
+- **WHEN** multiple ERROR log entries match the same Alert Policy within a 12-hour window
+- **THEN** only the first occurrence SHALL trigger a notification
+- **AND** subsequent occurrences within the same 12-hour window SHALL be suppressed
+
+### Requirement: Incident auto-close
+
+The system SHALL automatically close an Incident after 1 hour (`autoClose = 3600s`) of no matching ERROR log entries.
+
+#### Scenario: ERROR logs stop for 1 hour
+
+- **WHEN** an Incident is open and no matching ERROR log entries occur for 1 hour
+- **THEN** the Incident SHALL be automatically closed
+
+#### Scenario: New ERROR after auto-close
+
+- **WHEN** an Incident has been auto-closed and a new ERROR log entry is detected
+- **THEN** a new Incident SHALL be opened and a new notification SHALL be sent (subject to the 12-hour rate limit of the previous Incident's last notification)
+
+### Requirement: Error context in alert labels
+
+Each Alert Policy SHALL extract `error_code` and `rpc_method` labels from the matching log entry using `labelExtractors`, so that alert notifications include the error type and the RPC method where the error occurred.
+
+#### Scenario: Notification includes error context
+
+- **WHEN** an ERROR log entry contains `jsonPayload.error.code = "internal"` and `jsonPayload.rpc_method = "/liverty.v1.UserService/GetUser"`
+- **THEN** the alert notification SHALL include `error_code: internal` and `rpc_method: /liverty.v1.UserService/GetUser`
+
+### Requirement: Error Reporting API enabled
+
+The system SHALL have the `clouderrorreporting.googleapis.com` API enabled to allow automatic error grouping and first-seen detection for ERROR-level log entries.
+
+#### Scenario: Error Reporting detects errors
+
+- **WHEN** the `clouderrorreporting.googleapis.com` API is enabled
+- **AND** ERROR-level log entries are ingested by Cloud Logging
+- **THEN** Error Reporting SHALL automatically group and display the errors in the GCP Console
+
+### Requirement: Infrastructure as Code
+
+All monitoring resources (Notification Channels, Alert Policies, API enablement) SHALL be managed as Pulumi resources in `cloud-provisioning/src/gcp/components/monitoring.ts`.
+
+#### Scenario: Pulumi deployment creates monitoring resources
+
+- **WHEN** `pulumi up` is executed
+- **THEN** the Notification Channels, Alert Policies, and Error Reporting API enablement SHALL be created or updated as defined in the Pulumi code

--- a/openspec/changes/archive/2026-03-03-monitoring-app-error-log/tasks.md
+++ b/openspec/changes/archive/2026-03-03-monitoring-app-error-log/tasks.md
@@ -1,0 +1,25 @@
+## 1. GCP API 有効化
+
+- [x] 1.1 `GoogleApis` 型に `clouderrorreporting.googleapis.com` を追加 (`cloud-provisioning/src/gcp/services/api.ts`)
+- [x] 1.2 `project.ts` の有効化 API リストに `clouderrorreporting.googleapis.com` を追加
+
+## 2. Pulumi ESC 設定値の追加
+
+- [ ] 2.1 Google Chat Space ID を Pulumi ESC に追加 (事前に Chat Space で Google Cloud Monitoring アプリをインストールし Space ID を取得)
+- [ ] 2.2 通知先メールアドレスを Pulumi ESC に追加
+- [x] 2.3 `GcpConfig` 型に `monitoring` フィールド (`chatSpaceId`, `notificationEmail`) を追加
+
+## 3. MonitoringComponent の実装
+
+- [x] 3.1 `cloud-provisioning/src/gcp/components/monitoring.ts` を新規作成
+- [x] 3.2 Google Chat 用の `gcp.monitoring.NotificationChannel` を実装 (`type = "google_chat"`)
+- [x] 3.3 Email 用の `gcp.monitoring.NotificationChannel` を実装 (`type = "email"`)
+- [x] 3.4 server ワークロード用の `gcp.monitoring.AlertPolicy` を実装 (Log-Based Alert, `conditionMatchedLog` with `labelExtractors`)
+- [x] 3.5 consumer ワークロード用の `gcp.monitoring.AlertPolicy` を実装
+- [x] 3.6 concert-discovery ワークロード用の `gcp.monitoring.AlertPolicy` を実装
+- [x] 3.7 Alert Policy の `alertStrategy` に `notificationRateLimit.period = "43200s"` と `autoClose = "3600s"` を設定
+
+## 4. 統合
+
+- [x] 4.1 `Gcp` クラス (`cloud-provisioning/src/gcp/index.ts`) に `MonitoringComponent` のインスタンス化を追加
+- [x] 4.2 `pulumi preview` で差分を確認し、意図通りのリソースが作成されることを検証

--- a/openspec/changes/archive/2026-03-03-monitoring-slack-notification/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-03-monitoring-slack-notification/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-03

--- a/openspec/changes/archive/2026-03-03-monitoring-slack-notification/design.md
+++ b/openspec/changes/archive/2026-03-03-monitoring-slack-notification/design.md
@@ -1,0 +1,55 @@
+## Context
+
+monitoring-app-error-log change で MonitoringComponent を実装済み。Google Chat + Email の NotificationChannel と 3 つの AlertPolicy が Pulumi IaC で管理されている。しかし、現在の Google Workspace 環境ではメールと Chat が利用できないため、通知先を Slack に切り替える必要がある。
+
+現在の `MonitoringComponentArgs` は `chatSpaceId: string` と `notificationEmail: string` を受け取る構造。`GcpConfig.monitoring` も同様のフィールドを持つ。
+
+Slack App 自体は Pulumi/Terraform で管理できない (Provider が App 作成をサポートしていない) ため、手動で作成して Token を取得する必要がある。
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- 通知先を Google Chat + Email から Slack に変更する
+- Slack Bot OAuth Token を secret として安全に管理する
+- 既存の AlertPolicy ロジック (フィルタ、labelExtractors、alertStrategy) は変更しない
+- NotificationChannel を 2 → 1 に削減する (Slack のみ)
+
+**Non-Goals:**
+
+- Slack App の IaC 管理 (Provider が未対応のため手動)
+- 複数チャンネルへの通知振り分け
+- Slack のインタラクティブ機能 (ボタン、スレッド返信等)
+- prod / staging 環境への展開
+
+## Decisions
+
+### 1. Slack 通知チャネル 1 本に統合
+
+**選択:** Google Chat + Email の 2 チャネルを Slack 1 チャネルに統合
+
+**代替案:** Slack + Email の 2 チャネルを維持する
+
+**理由:** メールが利用できないため Email チャネルはそもそも使えない。Slack 側のチャンネル通知設定で十分なフォールバックが確保できる。将来的にバックアップチャネルが必要になれば追加可能。
+
+### 2. `sensitiveLabels.authToken` で Token を管理
+
+**選択:** Pulumi の `sensitiveLabels` ブロックを使用し、`authToken` を GCP API 上で秘匿化する
+
+**代替案:** `labels.auth_token` に直接 Token を格納する
+
+**理由:** `labels` に格納すると API レスポンスで Token が平文返却される。`sensitiveLabels` を使えば GCP 側で秘匿化され、Pulumi state でも `pulumi.secret()` で暗号化される。公式ドキュメントでもこの方法が推奨されている。
+
+### 3. `GcpConfig.monitoring` の型を Slack 向けに変更
+
+**選択:** `chatSpaceId` / `notificationEmail` を `slackChannelName` / `slackAuthToken` に置き換える
+
+**理由:** Chat/Email のフィールドが残っていると混乱の原因になる。monitoring-app-error-log の PR はマージ済みだが、ESC にまだ値を設定していないため、破壊的変更のリスクはない。
+
+## Risks / Trade-offs
+
+**[Slack App の手動管理]** → App の作成・権限設定は 1 回限りの作業。Token は長期間有効だが、Workspace の設定変更で失効する可能性がある。失効時は Slack App の OAuth & Permissions ページから再生成して ESC を更新する。
+
+**[sensitiveLabels は API で読み取り不可]** → Pulumi が upstream の変更を検出できない。GCP Console から手動で変更された場合、Pulumi の state と乖離する。IaC 以外からの変更を禁止する運用ルールで対応する。
+
+**[Slack の rate limit]** → Slack API には rate limit がある。しかし Cloud Monitoring 側の `notificationRateLimit.period = 43200s` で通知頻度を抑制しているため、Slack 側の rate limit に達する可能性は極めて低い。

--- a/openspec/changes/archive/2026-03-03-monitoring-slack-notification/proposal.md
+++ b/openspec/changes/archive/2026-03-03-monitoring-slack-notification/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+monitoring-app-error-log で導入した Cloud Monitoring の通知チャネルは Google Chat + Email を前提としていたが、現在の Google Workspace 環境ではメールと Chat が利用できないことが判明した。代わりに Slack に通知を送る必要がある。
+
+## What Changes
+
+- Google Chat Notification Channel を Slack Notification Channel に置き換える
+- Email Notification Channel を削除する (メールも利用不可のため)
+- `MonitoringComponentArgs` の `chatSpaceId` / `notificationEmail` を `slackChannelName` / `slackAuthToken` に変更
+- `GcpConfig.monitoring` の型定義を Slack 向けに変更
+- Pulumi ESC に Slack Bot OAuth Token を secret として格納する (viewable ではなく secret)
+
+## Capabilities
+
+### New Capabilities
+
+(なし — 既存の `app-error-log-alerting` の通知チャネルを変更するのみ)
+
+### Modified Capabilities
+
+- `app-error-log-alerting`: 通知先を Google Chat + Email から Slack に変更
+
+## Impact
+
+- **Infrastructure (Pulumi)**: `cloud-provisioning/src/gcp/components/monitoring.ts` の NotificationChannel を Slack 型に変更
+- **Pulumi ESC**: `chatSpaceId` / `notificationEmail` を `slackChannelName` / `slackAuthToken` に変更。`slackAuthToken` は secret として管理
+- **GCP Resources**: NotificationChannel が 2 (Chat + Email) から 1 (Slack) に変更。AlertPolicy × 3 は変更なし
+- **手動作業**: Slack App の作成、OAuth Token 取得、チャンネルへの Monitoring App 招待が必要 (1 回のみ)
+- **コスト**: 変更なし ($0.30/月)
+- **アプリケーションコード**: 変更なし

--- a/openspec/changes/archive/2026-03-03-monitoring-slack-notification/specs/app-error-log-alerting/spec.md
+++ b/openspec/changes/archive/2026-03-03-monitoring-slack-notification/specs/app-error-log-alerting/spec.md
@@ -1,0 +1,24 @@
+## MODIFIED Requirements
+
+### Requirement: Notification via Google Chat and Email
+
+The system SHALL send alert notifications to a configured Slack channel when an Incident is opened.
+
+A single Slack Notification Channel SHALL be provisioned as a Pulumi resource using configuration values (`slackChannelName`, `slackAuthToken`) stored in Pulumi ESC. The `authToken` SHALL be stored in `sensitiveLabels` to prevent exposure via GCP API responses.
+
+#### Scenario: ERROR log triggers Slack notification
+
+- **WHEN** an Alert Policy detects an ERROR log and opens an Incident
+- **THEN** a notification SHALL be sent to the configured Slack channel
+
+#### Scenario: Slack auth token is stored securely
+
+- **WHEN** the Slack Notification Channel is provisioned
+- **THEN** the `authToken` SHALL be stored in `sensitiveLabels` (not `labels`)
+- **AND** the token SHALL be wrapped with `pulumi.secret()` in the Pulumi state
+
+## REMOVED Requirements
+
+### Requirement: Notification via Google Chat and Email
+**Reason**: Google Workspace environment does not support Chat or Email. Replaced by Slack notification.
+**Migration**: Replace `chatSpaceId` / `notificationEmail` with `slackChannelName` / `slackAuthToken` in Pulumi ESC configuration.

--- a/openspec/changes/archive/2026-03-03-monitoring-slack-notification/tasks.md
+++ b/openspec/changes/archive/2026-03-03-monitoring-slack-notification/tasks.md
@@ -1,0 +1,24 @@
+## 1. Update GcpConfig type
+
+- [x] 1.1 Change `GcpConfig.monitoring` fields from `chatSpaceId` / `notificationEmail` to `slackChannelName: string` / `slackAuthToken: string` in `cloud-provisioning/src/gcp/components/project.ts`
+
+## 2. Update MonitoringComponentArgs
+
+- [x] 2.1 Replace `chatSpaceId` / `notificationEmail` with `slackChannelName` / `slackAuthToken` in `MonitoringComponentArgs` interface in `cloud-provisioning/src/gcp/components/monitoring.ts`
+
+## 3. Replace Notification Channels
+
+- [x] 3.1 Remove Google Chat `NotificationChannel` (`notification-google-chat`)
+- [x] 3.2 Remove Email `NotificationChannel` (`notification-email`)
+- [x] 3.3 Add Slack `NotificationChannel` with `type: "slack"`, `labels.channel_name`, and `sensitiveLabels.authToken`
+- [x] 3.4 Update `notificationChannels` array to reference the single Slack channel
+- [x] 3.5 Update `registerOutputs` to reflect the new channel structure
+
+## 4. Update Gcp class integration
+
+- [x] 4.1 Update `MonitoringComponent` instantiation in `cloud-provisioning/src/gcp/index.ts` to pass `slackChannelName` / `slackAuthToken` instead of `chatSpaceId` / `notificationEmail`
+
+## 5. Verification
+
+- [x] 5.1 Run lint and typecheck
+- [x] 5.2 Run `pulumi preview` to confirm resource changes (2 channels removed, 1 added, 3 policies updated)

--- a/openspec/specs/app-error-log-alerting/spec.md
+++ b/openspec/specs/app-error-log-alerting/spec.md
@@ -1,0 +1,105 @@
+# App Error Log Alerting
+
+## Requirements
+
+### Requirement: Error log detection per workload
+
+The system SHALL detect ERROR-level log entries from each backend workload (server, consumer, concert-discovery) independently using Cloud Monitoring Log-Based Alert Policies.
+
+Each Alert Policy SHALL filter logs by:
+- `resource.type = "k8s_container"`
+- `resource.labels.namespace_name = "backend"`
+- `labels.k8s-pod/app` matching the specific workload name
+- `severity = "ERROR"`
+
+#### Scenario: Server emits an ERROR log
+
+- **WHEN** the server workload emits a log entry with severity ERROR
+- **THEN** the server-specific Alert Policy detects the log entry and opens an Incident
+
+#### Scenario: Consumer emits an ERROR log
+
+- **WHEN** the consumer workload emits a log entry with severity ERROR
+- **THEN** the consumer-specific Alert Policy detects the log entry and opens an Incident
+
+#### Scenario: Concert-discovery CronJob emits an ERROR log
+
+- **WHEN** the concert-discovery CronJob emits a log entry with severity ERROR
+- **THEN** the concert-discovery-specific Alert Policy detects the log entry and opens an Incident
+
+#### Scenario: WARN-level log does not trigger alert
+
+- **WHEN** any workload emits a log entry with severity WARNING
+- **THEN** no Alert Policy SHALL fire
+
+### Requirement: Notification via Slack
+
+The system SHALL send alert notifications to a configured Slack channel when an Incident is opened.
+
+Slack Notification Channels MUST be created manually through the GCP Console because the GCP API requires an OAuth flow with Slack that cannot be performed via IaC tools (Pulumi/Terraform). The channel ID is then stored in Pulumi ESC and referenced by Pulumi alert policies.
+
+#### Scenario: ERROR log triggers Slack notification
+
+- **WHEN** an Alert Policy detects an ERROR log and opens an Incident
+- **THEN** a notification SHALL be sent to the configured Slack channel
+
+#### Scenario: Slack Notification Channel is created via GCP Console
+
+- **WHEN** a new environment needs Slack alerts
+- **THEN** the Slack Notification Channel SHALL be created via GCP Console (Monitoring > Alerting > Edit notification channels > Slack)
+- **AND** the channel ID SHALL be stored in Pulumi ESC under `monitoring.slackNotificationChannels.alertBackend`
+
+### Requirement: Notification rate limiting
+
+The system SHALL suppress repeated notifications for the same Incident, sending at most one notification per 12-hour period (`notificationRateLimit.period = 43200s`).
+
+#### Scenario: Multiple ERROR logs within 12 hours
+
+- **WHEN** multiple ERROR log entries match the same Alert Policy within a 12-hour window
+- **THEN** only the first occurrence SHALL trigger a notification
+- **AND** subsequent occurrences within the same 12-hour window SHALL be suppressed
+
+### Requirement: Incident auto-close
+
+The system SHALL automatically close an Incident after 1 hour (`autoClose = 3600s`) of no matching ERROR log entries.
+
+#### Scenario: ERROR logs stop for 1 hour
+
+- **WHEN** an Incident is open and no matching ERROR log entries occur for 1 hour
+- **THEN** the Incident SHALL be automatically closed
+
+#### Scenario: New ERROR after auto-close
+
+- **WHEN** an Incident has been auto-closed and a new ERROR log entry is detected
+- **THEN** a new Incident SHALL be opened and a new notification SHALL be sent (subject to the 12-hour rate limit of the previous Incident's last notification)
+
+### Requirement: Error context in alert labels
+
+Each Alert Policy SHALL extract `error_code` and `rpc_method` labels from the matching log entry using `labelExtractors`, so that alert notifications include the error type and the RPC method where the error occurred.
+
+#### Scenario: Notification includes error context
+
+- **WHEN** an ERROR log entry contains `jsonPayload.error.code = "internal"` and `jsonPayload.rpc_method = "/liverty.v1.UserService/GetUser"`
+- **THEN** the alert notification SHALL include `error_code: internal` and `rpc_method: /liverty.v1.UserService/GetUser`
+
+### Requirement: Error Reporting API enabled
+
+The system SHALL have the `clouderrorreporting.googleapis.com` API enabled to allow automatic error grouping and first-seen detection for ERROR-level log entries.
+
+#### Scenario: Error Reporting detects errors
+
+- **WHEN** the `clouderrorreporting.googleapis.com` API is enabled
+- **AND** ERROR-level log entries are ingested by Cloud Logging
+- **THEN** Error Reporting SHALL automatically group and display the errors in the GCP Console
+
+### Requirement: Infrastructure as Code
+
+All monitoring resources (Alert Policies, API enablement) SHALL be managed as Pulumi resources in `cloud-provisioning/src/gcp/components/monitoring.ts`.
+
+Slack Notification Channels are referenced (not created) by Pulumi. They are created manually via GCP Console and their channel IDs are stored in Pulumi ESC.
+
+#### Scenario: Pulumi deployment creates monitoring resources
+
+- **WHEN** `pulumi up` is executed
+- **THEN** the Alert Policies and Error Reporting API enablement SHALL be created or updated as defined in the Pulumi code
+- **AND** the Slack Notification Channel SHALL be referenced by its channel ID from Pulumi ESC


### PR DESCRIPTION
## 🔗 Related Issue

Refs: liverty-music/cloud-provisioning#123

## 📝 Summary of Changes

Archive completed OpenSpec changes for monitoring and create the merged main spec for `app-error-log-alerting`.

- **Delta spec sync**: Merge requirements from `monitoring-app-error-log` (ADDED) and `monitoring-slack-notification` (MODIFIED/REMOVED) into a single main spec reflecting the final implementation state
- **Main spec**: `openspec/specs/app-error-log-alerting/spec.md` - documents error log detection per workload, Slack notification (via GCP Console), rate limiting, auto-close, error context labels, Error Reporting API, and IaC
- **Archive**: Both `monitoring-app-error-log` and `monitoring-slack-notification` changes moved to `openspec/changes/archive/2026-03-03-*/`

## ✅ Self-Checklist

- [x] I have linked the related issue.
- [x] I have updated the relevant documentation (e.g., `README.md`) if needed.
- [x] I have run `buf lint` and `buf format` locally and all checks have passed.
- [x] My proto definitions follow the project's style guidelines and validation rules.
- [x] Breaking changes have been justified and documented if applicable.