### PR TITLE
docs: add openspec artifacts for refine-web-app

### DIFF
--- a/openspec/changes/archive/2026-03-02-fix-onboarding-bubble-counter/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-02-fix-onboarding-bubble-counter/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-02-28

--- a/openspec/changes/archive/2026-03-02-fix-onboarding-bubble-counter/design.md
+++ b/openspec/changes/archive/2026-03-02-fix-onboarding-bubble-counter/design.md
@@ -1,0 +1,62 @@
+## Context
+
+Onboarding の Artist Discovery ページ (`/onboarding/discover`) で、バブルをタップしてアーティストをフォローしてもカウンター (0/3) が更新されない。
+
+DevTools で調査した結果:
+- `localStorage['guest.followedArtists']` には正しくデータが保存されている (5件)
+- `localClient.listFollowed()` を直接呼ぶと 5 件返る
+- しかし `localClient.followedCount` getter は 0 を返す
+- 原因: Aurelia 2 のリアクティビティシステムが getter をキャッシュしており、localStorage への書き込みは observation の外にあるためキャッシュが再評価されない
+
+加えて UX 上の課題:
+- ガイダンスオーバーレイ「Tap bubbles to follow artists」が 5 秒で消え、復帰しない
+- 数字 (0/3) だけでは何をすべきか分からない
+- バブルをタップしたときの達成フィードバックが弱い
+
+## Goals / Non-Goals
+
+**Goals:**
+- `followedCount` が localStorage への書き込みと同期し、UI がリアルタイムに更新される
+- ガイダンスがユーザーを段階的に導く (初回タップ前 → 進捗中 → 完了)
+- タップ時のフィードバックで達成感を演出する
+
+**Non-Goals:**
+- バブル UI 自体の抜本的な変更 (カテゴリステップ分割など)
+- サウンドやハプティクスの追加
+- coach-mark コンポーネントの onboarding 統合 (将来の改善として残す)
+
+## Decisions
+
+### 1. `@observable` による followedCount の同期
+
+**選択**: `LocalArtistClient.followedCount` を getter から `@observable` プロパティに変更し、`follow()` / `unfollow()` / `clearAll()` で明示的に値を更新する。
+
+**代替案**:
+- **EventAggregator パターン**: `follow` イベントを publish → subscribe で再計算。疎結合だが、onboarding でしか使わないカウンターのために過剰。
+- **getter を廃止してメソッド `getFollowedCount()` に変更**: 呼び出し側で毎回呼ぶ必要があり、Aurelia のバインディングと相性が悪い。
+- **`IObserverLocator` でカスタム observer を登録**: Aurelia の internal API に依存し過ぎる。
+
+**理由**: `@observable` は Aurelia 2 の標準的なリアクティビティ機構で、setter が呼ばれると自動的にバインディングが再評価される。影響範囲が `LocalArtistClient` 内に閉じる。
+
+### 2. 段階的ガイダンスメッセージ
+
+**選択**: `artist-discovery-page` に段階的なメッセージ表示を追加する。
+
+```
+0/3: 「好きなアーティストを3組タップしよう！」(初期表示、消えない)
+1/3: 「いいね！あと2組！」
+2/3: 「あと1組！」
+3/3: 「準備完了！」→ 完了ボタンをハイライト
+```
+
+ガイダンスオーバーレイの auto-dismiss (5秒タイマー) は削除し、ユーザーが最初のバブルをタップするまで表示し続ける。
+
+### 3. プログレスバーの常時表示
+
+**選択**: プログレスバーとカウンターを onboarding 時は常に表示し、完了ボタンが表示されるまでの進捗を視覚的にフィードバックする。現在のコードでは `if.bind="isOnboarding"` で既に制御されているが、カウンター値が更新されないため機能していなかった。Decision 1 の修正で自然に動作するようになる。
+
+## Risks / Trade-offs
+
+- **[Risk] `@observable` と既存の getter の競合**: Aurelia が既にプロトタイプ getter をラップしている可能性がある → `@observable` に変更する際、getter を完全に削除して plain property + 手動更新に置き換えることでクリアに解決。
+- **[Risk] 初期化時の followedCount 不整合**: ページ表示時に localStorage に既にデータがある場合 → コンストラクタまたは初期化時に `this.followedCount = this.listFollowed().length` を実行して同期。
+- **[Trade-off] ガイダンスメッセージの日本語ハードコード**: i18n 対応が今後必要になる → 現時点では日本語で実装し、i18n 対応は別変更で行う。

--- a/openspec/changes/archive/2026-03-02-fix-onboarding-bubble-counter/proposal.md
+++ b/openspec/changes/archive/2026-03-02-fix-onboarding-bubble-counter/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+Onboarding の Artist Discovery ページで、バブルをタップしてもカウンター (0/3) が増えない。
+原因は Aurelia 2 のリアクティビティシステムが `LocalArtistClient.followedCount` getter をキャッシュしており、localStorage への書き込みが observation の外にあるためキャッシュが再評価されないこと。
+加えて、ガイダンスオーバーレイが 5 秒で自動消去された後は復帰しないため、ユーザーは何をすべきか分からず離脱しやすい。
+
+## What Changes
+
+- `LocalArtistClient` の `followedCount` getter を `@observable` プロパティに変更し、`follow()` / `unfollow()` 時に明示的に値を更新する
+- ガイダンス表示を改善し、バブルタップの視覚フィードバックと段階的な進捗メッセージを追加する
+- `coach-mark` コンポーネント (既存だが未使用) を onboarding ステップで活用する
+
+## Capabilities
+
+### New Capabilities
+- `onboarding-guidance`: バブル選択のインタラクティブなガイダンスと段階的フィードバック
+
+### Modified Capabilities
+(なし — 既存の spec はまだない)
+
+## Impact
+
+- `src/services/local-artist-client.ts` — followedCount のリアクティビティ修正
+- `src/routes/artist-discovery/artist-discovery-page.ts` — ガイダンス表示ロジック改善
+- `src/routes/artist-discovery/artist-discovery-page.html` — ガイダンス UI 追加
+- `src/components/dna-orb/dna-orb-canvas.ts` — フォロー済みカウント連動の確認
+- `src/components/coach-mark/` — onboarding での活用

--- a/openspec/changes/archive/2026-03-02-fix-onboarding-bubble-counter/specs/onboarding-guidance/spec.md
+++ b/openspec/changes/archive/2026-03-02-fix-onboarding-bubble-counter/specs/onboarding-guidance/spec.md
@@ -1,0 +1,54 @@
+## ADDED Requirements
+
+### Requirement: Followed count reflects localStorage state
+The `LocalArtistClient.followedCount` property SHALL be an `@observable` that is updated whenever `follow()`, `unfollow()`, or `clearAll()` is called, so that Aurelia bindings re-evaluate immediately.
+
+#### Scenario: Initial page load with existing guest data
+- **WHEN** the user navigates to `/onboarding/discover` and `localStorage['guest.followedArtists']` contains 3 artists
+- **THEN** the counter SHALL display `3/3` and the complete button SHALL be visible
+
+#### Scenario: Follow an artist during onboarding
+- **WHEN** the user taps a bubble to follow an artist
+- **THEN** the counter SHALL increment by 1 within the same frame (e.g., `0/3` → `1/3`)
+- **AND** the progress bar fill width SHALL update accordingly
+
+#### Scenario: Unfollow an artist
+- **WHEN** the user unfollows a previously followed artist
+- **THEN** the counter SHALL decrement by 1 immediately
+
+### Requirement: Persistent guidance until first interaction
+The onboarding guidance message SHALL remain visible until the user taps their first bubble. The 5-second auto-dismiss timer SHALL be removed.
+
+#### Scenario: Page load without prior interactions
+- **WHEN** the user arrives at the discovery page for the first time (followedCount = 0)
+- **THEN** the guidance message "好きなアーティストを3組タップしよう！" SHALL be displayed
+- **AND** the message SHALL NOT auto-dismiss after any timeout
+
+#### Scenario: First bubble tap dismisses guidance
+- **WHEN** the user taps their first bubble
+- **THEN** the guidance message SHALL fade out (400ms transition)
+- **AND** a progress-specific message SHALL appear in its place
+
+### Requirement: Staged progress messages
+The system SHALL display contextual progress messages that change as the user follows more artists.
+
+#### Scenario: After following 1 artist
+- **WHEN** followedCount becomes 1
+- **THEN** the guidance area SHALL display "いいね！あと2組！"
+
+#### Scenario: After following 2 artists
+- **WHEN** followedCount becomes 2
+- **THEN** the guidance area SHALL display "あと1組！"
+
+#### Scenario: After following 3 or more artists
+- **WHEN** followedCount reaches 3 (TUTORIAL_FOLLOW_TARGET)
+- **THEN** the guidance area SHALL display "準備完了！"
+- **AND** the complete button SHALL become visible and visually highlighted
+
+### Requirement: Orb pulse on follow
+The central Music DNA orb SHALL pulse each time an artist is followed, providing visual feedback that the selection was registered.
+
+#### Scenario: Bubble tap triggers orb pulse
+- **WHEN** a bubble is tapped and the follow operation succeeds
+- **THEN** the `DnaOrbCanvas.followedCountChanged` callback SHALL fire
+- **AND** the orb SHALL play a pulse animation

--- a/openspec/changes/archive/2026-03-02-fix-onboarding-bubble-counter/tasks.md
+++ b/openspec/changes/archive/2026-03-02-fix-onboarding-bubble-counter/tasks.md
@@ -1,0 +1,20 @@
+## 1. Fix followedCount Reactivity
+
+- [x] 1.1 Change `LocalArtistClient.followedCount` from getter to `@observable` property
+- [x] 1.2 Initialize `followedCount` from `listFollowed().length` in constructor
+- [x] 1.3 Update `followedCount` in `follow()`, `unfollow()`, and `clearAll()` methods
+- [x] 1.4 Verify `ArtistDiscoveryPage.followedCount` getter correctly propagates the observable value
+
+## 2. Improve Onboarding Guidance
+
+- [x] 2.1 Remove the 5-second auto-dismiss timer from guidance overlay in `ArtistDiscoveryPage.attached()`
+- [x] 2.2 Keep guidance visible until the user taps their first bubble (dismiss in `onArtistSelected`)
+- [x] 2.3 Change initial guidance message to "好きなアーティストを3組タップしよう！"
+- [x] 2.4 Add staged progress messages (1/3: "いいね！あと2組！", 2/3: "あと1組！", 3/3: "準備完了！")
+- [x] 2.5 Update `artist-discovery-page.html` template to bind staged messages
+
+## 3. Verify End-to-End
+
+- [x] 3.1 Confirm orb pulse fires on each follow (followedCountChanged callback)
+- [x] 3.2 Test fresh onboarding flow: guidance shows → tap 3 bubbles → counter increments → complete button appears
+- [x] 3.3 Test page reload with existing localStorage data: counter reflects saved state on load

--- a/openspec/changes/archive/2026-03-04-unify-discover-page/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-04-unify-discover-page/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-03

--- a/openspec/changes/archive/2026-03-04-unify-discover-page/design.md
+++ b/openspec/changes/archive/2026-03-04-unify-discover-page/design.md
@@ -1,0 +1,115 @@
+## Context
+
+Two page components serve the artist discovery experience: `ArtistDiscoveryPage` at `/onboarding/discover` and `DiscoverPage` at `/discover`. Both render the same `dna-orb-canvas` component and use `IArtistDiscoveryService`, but differ in:
+
+- Onboarding HUD (progress dots, guidance message) — onboarding only
+- Search bar and genre filter — normal only
+- CTA button behavior — different navigation targets
+- Follow code path — different service method calls
+- CSS — 95% duplicated starfield/container styles
+
+The onboarding/auth branching for follow persistence already lives in `ArtistServiceClient` (localStorage vs backend RPC), so the page-level split is redundant.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Single `DiscoverPage` component at `/discover` for both onboarding and normal use
+- Search bar and genre filter available during onboarding (reduces drop-off)
+- CTA button shown only during onboarding (bottom nav covers normal navigation)
+- Single follow code path through `discoveryService.followArtist()` → `ArtistServiceClient`
+- Delete `routes/artist-discovery/` entirely
+
+**Non-Goals:**
+- Refactoring `ArtistDiscoveryService` responsibilities (Phase 2: `decouple-discovery-service`)
+- Changing `dna-orb-canvas` to use bindables instead of service injection (Phase 2)
+- Modifying bubble physics or rendering
+
+## Decisions
+
+### 1. Route unification
+
+**Decision**: Single route `/discover` with `data: { auth: false }`.
+
+Onboarding users are unauthenticated and need access. The page itself is harmless for unauthenticated users — discovering artists without signing in is fine. `OnboardingService.isOnboarding` determines whether to show guidance HUD and CTA.
+
+```ts
+// my-app.ts — single route replaces two
+{
+  path: 'discover',
+  component: import('./routes/discover/discover-page'),
+  title: 'Discover',
+  data: { auth: false },
+}
+```
+
+`fullscreenRoutes` in `my-app.ts`: `/discover` should NOT be fullscreen in normal mode (bottom nav visible), but SHOULD be fullscreen during onboarding. This requires checking `isOnboarding` in the `showNav` getter rather than hardcoding path names.
+
+### 2. Onboarding HUD as conditional section
+
+**Decision**: Add the HUD (progress dots + guidance message) and CTA button to `discover-page.html` with `show.bind="isOnboarding"`.
+
+```html
+<!-- Onboarding guidance overlay -->
+<div show.bind="isOnboarding" class="onboarding-hud">
+  <div class="progress-dots">
+    <span class="dot ${followedCount >= 1 ? 'filled' : ''}"></span>
+    <span class="dot ${followedCount >= 2 ? 'filled' : ''}"></span>
+    <span class="dot ${followedCount >= 3 ? 'filled' : ''}"></span>
+  </div>
+  <p class="hud-message ${guidanceHiding ? 'hiding' : ''}">
+    ${guidanceMessage}
+  </p>
+</div>
+
+<!-- CTA — onboarding only (normal mode uses bottom nav) -->
+<div show.bind="showCompleteButton" class="complete-button-wrapper">
+  <button click.trigger="onViewSchedule()" class="complete-button tutorial-cta">
+    ${$this.i18n?.tr('discovery.generateDashboard') ?? ''}
+  </button>
+</div>
+```
+
+### 3. Unified follow flow
+
+**Decision**: `ArtistDiscoveryService.followArtist()` delegates persistence to `ArtistServiceClient.follow()` instead of calling `this.artistClient.follow()` directly.
+
+Current (broken separation):
+```
+DiscoverPage → discoveryService.followArtist() → artistClient.follow() (direct RPC)
+ArtistDiscoveryPage → artistService.follow() → localClient or RPC (branched)
+                    → discoveryService.markFollowed() (UI only)
+```
+
+Unified:
+```
+DiscoverPage → discoveryService.followArtist()
+                → optimistic UI update (existing)
+                → artistServiceClient.follow(id, name) (onboarding/auth branch inside)
+                → on failure: rollback (existing)
+```
+
+This removes the need for `markFollowed()` as a separate method and eliminates the `ArtistServiceClient` + `ILocalArtistClient` imports from the page.
+
+### 4. followedCount source
+
+**Decision**: Always use `discoveryService.followedArtists.length`. During onboarding, `followArtist()` still updates this array via optimistic UI, and `ArtistServiceClient.follow()` handles localStorage persistence internally.
+
+### 5. CTA button — onboarding only
+
+**Decision**: The CTA button (and `onViewSchedule()`) only renders during onboarding. In normal mode, the bottom navigation provides all needed transitions. The `showCompleteButton` getter becomes:
+
+```ts
+public get showCompleteButton(): boolean {
+  return this.isOnboarding && this.followedCount >= TUTORIAL_FOLLOW_TARGET
+}
+```
+
+### 6. Bottom nav visibility during onboarding
+
+**Decision**: Update `my-app.ts` `showNav` to check onboarding state rather than hardcoding `/discover` in `fullscreenRoutes`. When `isOnboarding` is true and on `/discover`, hide nav.
+
+## Risks / Trade-offs
+
+- **[Risk] `auth: false` on `/discover` exposes the page to unauthenticated non-onboarding users** — Acceptable; the page fetches from `ListTop` (public data) and follow attempts by unauthenticated users will fail at the RPC layer with an auth error, which is already handled by toast notification.
+- **[Risk] `followArtist()` rollback on error during onboarding** — `ArtistServiceClient.follow()` writes to localStorage synchronously and never throws during onboarding, so rollback will not trigger. Safe.
+- **[Trade-off] Slightly larger single component vs two focused ones** — The added onboarding logic is ~30 lines of template + ~20 lines of TS. Acceptable given the elimination of an entire duplicated page.

--- a/openspec/changes/archive/2026-03-04-unify-discover-page/proposal.md
+++ b/openspec/changes/archive/2026-03-04-unify-discover-page/proposal.md
@@ -1,0 +1,39 @@
+## Why
+
+The artist discovery UI is split into two separate page components: `ArtistDiscoveryPage` (onboarding) and `DiscoverPage` (normal). They share the same core UX — a `dna-orb-canvas` with artist bubbles — but diverge in accidental ways:
+
+1. **Onboarding lacks search bar and genre filter** — Users who cannot find their favorite artists in the random bubble pool have no way to search, increasing drop-off risk during onboarding.
+2. **Two separate follow code paths** — `ArtistDiscoveryPage` calls `artistService.follow()` + `discoveryService.markFollowed()` (two steps), while `DiscoverPage` calls `discoveryService.followArtist()` (one step with optimistic UI). The onboarding/auth branching already lives in `ArtistServiceClient`, making the page-level split redundant.
+3. **Duplicated CSS** — The starfield background, orb-label, and container layout are copy-pasted between the two CSS files.
+4. **Unnecessary route split** — `/onboarding/discover` vs `/discover` adds routing complexity when `OnboardingService.isOnboarding` already determines the mode.
+
+The only true onboarding-specific elements are the guidance HUD (progress dots + message) and the CTA button (needed because bottom nav is hidden during onboarding). These can be conditionally rendered with `show.bind="isOnboarding"`.
+
+## What Changes
+
+- Delete `routes/artist-discovery/` directory entirely (page, CSS, tests)
+- Merge onboarding HUD (progress dots, guidance message, CTA) into `DiscoverPage` template and CSS
+- Unify route to `/discover` with `data: { auth: false }` (accessible during onboarding without authentication)
+- Update all references from `onboarding/discover` to `discover` (welcome-page, loading-sequence, onboarding-service STEP_ROUTE_MAP, auth-hook, tests)
+- Unify follow flow: `discoveryService.followArtist()` delegates persistence to `ArtistServiceClient.follow()` instead of calling backend RPC directly
+- Remove CTA button for normal (non-onboarding) mode — bottom nav provides navigation
+- Add visibility change pause/resume (missing from old onboarding page)
+
+## Capabilities
+
+### Modified Capabilities
+
+- `onboarding-guidance`: Guidance HUD rendered inside unified `DiscoverPage` via `show.bind="isOnboarding"`; route changed from `/onboarding/discover` to `/discover`
+
+## Impact
+
+- `src/routes/artist-discovery/` — Deleted
+- `src/routes/discover/discover-page.ts` — Add onboarding HUD logic, CTA for onboarding, unified follow flow
+- `src/routes/discover/discover-page.html` — Add onboarding HUD template, conditional CTA
+- `src/routes/discover/discover-page.css` — Add onboarding HUD styles (from artist-discovery-page.css)
+- `src/services/artist-discovery-service.ts` — `followArtist()` delegates to `ArtistServiceClient` instead of direct RPC
+- `src/services/onboarding-service.ts` — Update `STEP_ROUTE_MAP[DISCOVER]` to `'discover'`
+- `src/my-app.ts` — Remove `onboarding/discover` route, update `discover` route data
+- `src/welcome-page.ts` — Update navigation target
+- `src/routes/onboarding-loading/loading-sequence.ts` — Update fallback redirect path
+- `test/` — Update affected test files

--- a/openspec/changes/archive/2026-03-04-unify-discover-page/specs/onboarding-guidance/spec.md
+++ b/openspec/changes/archive/2026-03-04-unify-discover-page/specs/onboarding-guidance/spec.md
@@ -1,0 +1,27 @@
+## CHANGED Requirements
+
+### Requirement: Onboarding guidance rendered within unified DiscoverPage
+The onboarding guidance HUD (progress dots, guidance message, CTA button) SHALL be rendered as a conditional section within `DiscoverPage` at `/discover`, instead of in a separate `ArtistDiscoveryPage` at `/onboarding/discover`.
+
+#### Scenario: Onboarding user navigates to discover
+- **WHEN** `OnboardingService.isOnboarding` is `true` and the user navigates to `/discover`
+- **THEN** the onboarding HUD (progress dots + guidance message) SHALL be visible
+- **AND** the search bar and genre filter SHALL also be available
+
+#### Scenario: Normal user navigates to discover
+- **WHEN** `OnboardingService.isOnboarding` is `false` and the user navigates to `/discover`
+- **THEN** the onboarding HUD SHALL NOT be rendered
+- **AND** no CTA button SHALL be shown (bottom navigation provides transitions)
+
+#### Scenario: CTA button visibility during onboarding
+- **WHEN** `OnboardingService.isOnboarding` is `true` and `followedCount >= 3`
+- **THEN** the CTA button "ダッシュボードを生成する" SHALL be visible
+- **AND** tapping it SHALL navigate to `onboarding/loading`
+
+### Requirement: Search and genre filter available during onboarding
+The search bar and genre filter chips SHALL be visible and functional during onboarding, allowing users to find specific artists they already know.
+
+#### Scenario: Onboarding user searches for an artist
+- **WHEN** the user is in onboarding mode and types a query into the search bar
+- **THEN** search results SHALL appear and the user SHALL be able to follow artists from the results
+- **AND** the follow operation SHALL use the same unified flow (localStorage during onboarding)

--- a/openspec/changes/archive/2026-03-04-unify-discover-page/tasks.md
+++ b/openspec/changes/archive/2026-03-04-unify-discover-page/tasks.md
@@ -1,0 +1,8 @@
+- [x] 1. Unify follow flow: `ArtistDiscoveryService.followArtist()` delegates to `ArtistServiceClient.follow()` instead of direct RPC; remove `markFollowed()` as separate method
+- [x] 2. Add onboarding HUD (progress dots, guidance message, CTA) to `discover-page.html` and `discover-page.css`
+- [x] 3. Add onboarding logic to `discover-page.ts`: `isOnboarding`, `guidanceMessage`, `showCompleteButton`, `onViewSchedule()`, `dismissGuidance()`
+- [x] 4. Update `my-app.ts`: remove `onboarding/discover` route, set `discover` route to `auth: false`, update `showNav` to check onboarding state
+- [x] 5. Update `welcome-page.ts`, `loading-sequence.ts`, `onboarding-service.ts` STEP_ROUTE_MAP references from `onboarding/discover` to `discover`
+- [x] 6. Delete `src/routes/artist-discovery/` directory
+- [x] 7. Update tests: `my-app.spec.ts`, `loading-sequence.spec.ts`, `artist-discovery-page.spec.ts` (remove or migrate)
+- [x] 8. Update `onboarding-guidance` spec to reflect new route path

--- a/openspec/changes/decouple-discovery-service/.openspec.yaml
+++ b/openspec/changes/decouple-discovery-service/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-04

--- a/openspec/changes/decouple-discovery-service/design.md
+++ b/openspec/changes/decouple-discovery-service/design.md
@@ -1,0 +1,77 @@
+## Context
+
+After Phase 1 (`unify-discover-page`), the unified `DiscoverPage` still delegates to `ArtistDiscoveryService` which holds both data access logic and UI state. The `dna-orb-canvas` component directly injects this service to read `availableBubbles`, `orbIntensity`, and call `getSimilarArtists()` / `evictOldest()`. This tight coupling makes the canvas component untestable in isolation and creates bidirectional data flow.
+
+## Goals / Non-Goals
+
+**Goals:**
+- `dna-orb-canvas` has zero service injections; receives all data via `@bindable` and communicates via DOM events
+- Clear separation: data access (stateless) vs UI state (component-owned)
+- `DiscoverPage` is the single coordinator between data layer and canvas
+
+**Non-Goals:**
+- Changing the backend API or RPC definitions
+- Modifying bubble physics or rendering logic
+- Changing the visual design
+
+## Decisions
+
+### 1. Data access layer
+
+**Decision**: Consolidate RPC calls into `ArtistServiceClient` (already exists). Add `listTop()`, `listSimilar()`, `search()` methods that return plain data. Remove the duplicate `artistClient` from `ArtistDiscoveryService`.
+
+```
+ArtistServiceClient (singleton, stateless data access)
+  - follow(id, name)        — existing (onboarding/auth branch)
+  - unfollow(id)             — existing
+  - listFollowed()           — existing
+  - listTop(country, tag)    — moved from ArtistDiscoveryService
+  - listSimilar(artistId)    — moved from ArtistDiscoveryService
+  - search(query)            — moved from ArtistDiscoveryService
+```
+
+### 2. Bubble pool management
+
+**Decision**: Create a plain class `BubblePool` (not DI-registered) that manages the available bubbles array, deduplication sets, and eviction logic. Owned and instantiated by `DiscoverPage`.
+
+```ts
+class BubblePool {
+  availableBubbles: ArtistBubble[]
+  add(bubbles: ArtistBubble[]): string[]  // returns evicted IDs
+  remove(artistId: string): void
+  evictOldest(count: number): ArtistBubble[]
+  reset(): void
+}
+```
+
+This makes pool logic testable without DI, and the pool lifetime matches the page lifetime (not app lifetime).
+
+### 3. dna-orb-canvas bindable interface
+
+**Decision**: Replace service injection with bindables and events.
+
+```ts
+// Inputs (parent → canvas)
+@bindable artists: ArtistBubble[]        // replaces discoveryService.availableBubbles
+@bindable followedCount: number           // existing
+@bindable orbIntensity: number            // replaces discoveryService.orbIntensity
+@bindable showFollowedIndicator: boolean  // existing
+
+// Outputs (canvas → parent via DOM events)
+'artist-selected'              — existing
+'need-more-bubbles'            — new: { artistId, artistName, position }
+'similar-artists-unavailable'  — existing
+'similar-artists-error'        — existing
+```
+
+The `handleInteraction()` method in `dna-orb-canvas` will emit `need-more-bubbles` instead of calling `discoveryService.getSimilarArtists()` directly. The page handles fetching and passes new bubbles back via the `artists` bindable (or a dedicated `addBubbles()` method on the canvas ref).
+
+### 4. orbIntensity
+
+**Decision**: Computed in `DiscoverPage` as `Math.min(1, followedCount / 20)`. Passed to canvas via `@bindable`.
+
+## Risks / Trade-offs
+
+- **[Risk] Canvas needs to spawn bubbles at a specific position after follow** — The `need-more-bubbles` event includes the tap position. The page fetches similar artists and calls `dnaOrbCanvas.spawnBubblesAt(newBubbles, x, y)` via component ref. This preserves the existing spawn-at-position behavior.
+- **[Trade-off] More code in DiscoverPage** — The page becomes the coordinator, adding ~40 lines. But this is the correct place for orchestration in Aurelia 2's component model.
+- **[Trade-off] BubblePool as plain class vs DI service** — Plain class is intentional: pool lifetime should match page lifetime, not app lifetime. A singleton pool would leak state between navigations.

--- a/openspec/changes/decouple-discovery-service/proposal.md
+++ b/openspec/changes/decouple-discovery-service/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+`ArtistDiscoveryService` is a singleton service that mixes three distinct responsibilities:
+
+1. **Data access** — RPC calls to `ArtistService` (listTop, listSimilar, search, follow, listFollowed)
+2. **Bubble pool management** — Deduplication, eviction, pool size limits, seen-artist tracking
+3. **UI state** — `availableBubbles`, `followedArtists`, `orbIntensity`, `followedIds`
+
+This causes two problems:
+
+- **`dna-orb-canvas` injects the service directly** to read `availableBubbles`, `orbIntensity`, call `getSimilarArtists()`, and `evictOldest()`. This creates a bidirectional data flow between component and service, violating Aurelia 2's unidirectional data flow principle (parent → child via `@bindable`, child → parent via events).
+- **The service holds UI state that belongs to the page component.** `orbIntensity` and `followedArtists` are presentation concerns that should live in the component managing the view, not in a singleton service shared across the app lifecycle.
+
+## What Changes
+
+- Extract data access into a stateless `ArtistRepository` (or rename existing `ArtistServiceClient` to absorb this role)
+- Move bubble pool management (availableBubbles, dedup, eviction, seen sets) into `DiscoverPage` or a dedicated `BubblePoolManager` class (non-DI, owned by the page)
+- Remove `IArtistDiscoveryService` injection from `dna-orb-canvas`; pass data via `@bindable` properties and communicate via DOM events
+- Move `orbIntensity` to `DiscoverPage` (computed from followedCount)
+
+## Capabilities
+
+### Modified Capabilities
+
+- `artist-discovery-dna-orb-ui`: `dna-orb-canvas` receives artist data via `@bindable` instead of injecting a service; emits `need-more-bubbles` event instead of calling service methods directly
+
+## Impact
+
+- `src/services/artist-discovery-service.ts` — Split or significantly reduce; data access methods remain, state management removed
+- `src/components/dna-orb/dna-orb-canvas.ts` — Remove `IArtistDiscoveryService` injection; add `@bindable artists`, emit events for bubble requests
+- `src/routes/discover/discover-page.ts` — Takes ownership of bubble pool state; orchestrates data flow between service and canvas
+- Tests for all affected files

--- a/openspec/changes/decouple-discovery-service/tasks.md
+++ b/openspec/changes/decouple-discovery-service/tasks.md
@@ -1,0 +1,6 @@
+- [ ] 1. Move `listTop()`, `listSimilar()`, `search()` from `ArtistDiscoveryService` to `ArtistServiceClient`; remove duplicate `artistClient` from discovery service
+- [ ] 2. Extract `BubblePool` class (plain, non-DI) with dedup, eviction, and pool management logic from `ArtistDiscoveryService`
+- [ ] 3. Refactor `dna-orb-canvas`: remove `IArtistDiscoveryService` injection; add `@bindable artists`, `@bindable orbIntensity`; emit `need-more-bubbles` event instead of calling service
+- [ ] 4. Update `DiscoverPage` to own `BubblePool`, coordinate between `ArtistServiceClient` and `dna-orb-canvas` via bindables and event handlers
+- [ ] 5. Remove or reduce `ArtistDiscoveryService` (delete if fully absorbed, or keep as thin facade if other consumers exist)
+- [ ] 6. Update all tests for affected components and services

--- a/openspec/changes/fix-onboarding-ux-regressions/.openspec.yaml
+++ b/openspec/changes/fix-onboarding-ux-regressions/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-01

--- a/openspec/changes/fix-onboarding-ux-regressions/design.md
+++ b/openspec/changes/fix-onboarding-ux-regressions/design.md
@@ -1,0 +1,62 @@
+## Context
+
+The artist discovery page uses a full-viewport `<canvas>` element inside a Shadow DOM custom element (`dna-orb-canvas`). The canvas has `position: absolute; inset: 0` and registers `click` + `touchstart` event listeners. Overlay elements (onboarding HUD, complete button, orb label) are siblings of the canvas in the parent Shadow DOM and rely on `z-index` for stacking — which violates the project's CSS standards (web-app-specialist skill rejects z-index stacking hacks).
+
+On mobile, the canvas captures all touch events before they reach the complete button, making it unresponsive. Additionally, when a user follows an artist, `getSimilarArtists()` often returns artists that are fully deduplicated against the `seenArtistNames/Ids/Mbids` sets, causing no new bubbles to spawn and the canvas to empty.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Complete button must be tappable on all devices (desktop and mobile)
+- Remove all `z-index` declarations; use DOM source order for stacking
+- Keep the canvas populated after each follow so users can discover beyond 3 artists
+- Maintain existing visual design (cosmic HUD, orbital dots, translucent pill)
+
+**Non-Goals:**
+- Redesigning the bubble physics or absorption animation
+- Changing the ListSimilar API behavior on the backend
+- Fixing the ListSimilar deduplication logic itself (that's a backend concern)
+
+## Decisions
+
+### 1. Canvas pointer-events passthrough for overlay zones
+
+**Decision**: Add `pointer-events: none` to the canvas element, then re-enable `pointer-events: auto` only on the canvas via JavaScript for bubble areas. Alternatively, use CSS `pointer-events: none` on the canvas in the button zone.
+
+**Rejected approach**: The simpler approach is to keep the canvas click handler but add a coordinate check — if the click falls within the button's bounding rect, ignore it and let the event propagate. However, this tightly couples the canvas to the button layout.
+
+**Chosen approach**: Use `pointer-events: none` on the `dna-orb-canvas` host element from the parent CSS, and instead handle pointer events at the `.container` level, delegating to the canvas via `elementsFromPoint()`. This is fragile with Shadow DOM.
+
+**Final approach**: The most robust solution is to **move overlay elements (HUD, button, orb-label) outside the canvas stacking context** by placing them in a separate overlay `<div>` that is a sibling of `dna-orb-canvas`, and ensure this overlay div has `pointer-events: none` with `pointer-events: auto` only on interactive children (the button). DOM order ensures the overlay div paints on top of the canvas. No z-index needed.
+
+```
+<div class="container">          ← position: relative
+  <dna-orb-canvas />              ← paints first (behind)
+  <div class="overlay">           ← paints second (on top), pointer-events: none
+    <div class="onboarding-hud">  ← pointer-events: none (non-interactive)
+    <div class="orb-label">       ← pointer-events: none
+    <button class="complete-button"> ← pointer-events: auto (interactive)
+  </div>
+</div>
+```
+
+### 2. Remove z-index entirely
+
+**Decision**: Remove all `z-index` from `.container::before`, `.onboarding-hud`, `.complete-button-wrapper`, and `.orb-label`. Stacking is controlled by:
+- `.container::before` (pseudo-element, paints before children)
+- `<dna-orb-canvas>` (first child, paints first)
+- Overlay elements (later in DOM, paint on top)
+
+### 3. Bubble replenishment fallback
+
+**Decision**: When `getSimilarArtists()` returns zero new bubbles (all deduplicated), fall back to calling `loadInitialArtists()` again but filter against the `seenArtistIds` set. This reloads the top-50 artist pool and any unseen artists become new bubbles.
+
+**Why not a new API?**: Adding a "random artists" endpoint would be ideal long-term, but the existing `ListTop` RPC already returns 50 artists. On second and subsequent calls, many will be seen, but some new ones may appear due to popularity changes. This is a pragmatic client-side fallback.
+
+**Implementation**: In `dna-orb-canvas.ts`, after `getSimilarArtists()` returns an empty array, call `discoveryService.loadReplacementBubbles()` — a new method that calls `ListTop` and filters against seen artists, returning only fresh ones.
+
+## Risks / Trade-offs
+
+- **[Risk] Replacement bubbles may also be empty** — If the user has seen all 50 top artists, the fallback produces nothing. → Mitigation: Accept this gracefully; the user has explored the full initial pool and the complete button is already available.
+- **[Risk] DOM order stacking may break if elements are conditionally rendered** — `if.bind` removes elements from DOM, changing paint order. → Mitigation: Use `show.bind` instead of `if.bind` for the overlay container so it stays in DOM.
+- **[Risk] Canvas touchstart with `passive: true` cannot call preventDefault** — The touch event on the canvas propagates to the button area. → Mitigation: The overlay structure with `pointer-events: none` on the canvas's host element in the button zone handles this naturally since the button is a separate DOM tree.

--- a/openspec/changes/fix-onboarding-ux-regressions/proposal.md
+++ b/openspec/changes/fix-onboarding-ux-regressions/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+The onboarding artist discovery page has three UX issues:
+
+1. **Complete button unresponsive on mobile** — The "ダッシュボードを生成する" button does not respond to taps. The canvas element underneath consumes click/touch events before they reach the button, and z-index hacks used for stacking are unreliable across Shadow DOM boundaries.
+2. **z-index stacking violates project CSS standards** — The web-app-specialist skill explicitly rejects z-index stacking hacks. The current CSS uses z-index values (0, 15, 20, 30) for layer ordering, which should be replaced with DOM source order stacking.
+3. **Bubbles not replenished after follow** — When a user taps a bubble, `getSimilarArtists()` returns artists that are all deduplicated against the existing pool, so no new bubbles spawn. The screen empties after each tap, preventing continued discovery beyond 3 follows.
+
+## What Changes
+
+- Remove all `z-index` declarations from `artist-discovery-page.css`; rely on DOM source order for stacking
+- Reorder HTML elements in `artist-discovery-page.html` so that overlay elements (HUD, button) appear after the canvas in DOM order
+- Fix the complete button's tap target so it receives pointer events on mobile (ensure canvas does not capture events in the button's area)
+- Add a fallback bubble replenishment strategy in `dna-orb-canvas.ts`: when similar artists are fully deduplicated, reload a batch of random top artists to keep the canvas populated
+
+## Capabilities
+
+### New Capabilities
+
+- `bubble-replenishment`: Fallback strategy to keep the discovery canvas populated when similar-artist deduplication empties the pool
+
+### Modified Capabilities
+
+- `onboarding-guidance`: Complete button must be tappable on mobile; z-index stacking replaced with DOM order
+
+## Impact
+
+- `src/routes/artist-discovery/artist-discovery-page.css` — Remove z-index, reorder stacking via DOM
+- `src/routes/artist-discovery/artist-discovery-page.html` — Reorder elements for natural stacking
+- `src/components/dna-orb/dna-orb-canvas.ts` — Add fallback replenishment when similar artists are exhausted
+- `src/services/artist-discovery-service.ts` — May need a method to fetch replacement bubbles

--- a/openspec/changes/fix-onboarding-ux-regressions/specs/bubble-replenishment/spec.md
+++ b/openspec/changes/fix-onboarding-ux-regressions/specs/bubble-replenishment/spec.md
@@ -1,0 +1,19 @@
+## ADDED Requirements
+
+### Requirement: Canvas replenishes bubbles when similar artists are exhausted
+When a user follows an artist and the similar-artist API returns no new (unseen) artists, the system SHALL automatically fetch replacement bubbles from the top-artist pool to keep the canvas populated.
+
+#### Scenario: Similar artists fully deduplicated
+- **WHEN** user taps a bubble AND `getSimilarArtists()` returns zero new bubbles after deduplication
+- **THEN** the system SHALL call `loadReplacementBubbles()` to fetch fresh artists from the top-artist pool
+- **AND** any unseen artists SHALL be spawned as new bubbles near the absorption point
+
+#### Scenario: Top artist pool also exhausted
+- **WHEN** user taps a bubble AND both similar artists and replacement bubbles return zero new artists
+- **THEN** the system SHALL gracefully accept an empty canvas without errors
+- **AND** the complete button (if visible) SHALL remain functional
+
+#### Scenario: Replacement bubbles partially available
+- **WHEN** user taps a bubble AND similar artists are exhausted but 5 of 50 top artists are unseen
+- **THEN** the system SHALL spawn only the 5 unseen artists as new bubbles
+- **AND** the previously seen artists SHALL NOT reappear on the canvas

--- a/openspec/changes/fix-onboarding-ux-regressions/specs/onboarding-guidance/spec.md
+++ b/openspec/changes/fix-onboarding-ux-regressions/specs/onboarding-guidance/spec.md
@@ -1,0 +1,26 @@
+## MODIFIED Requirements
+
+### Requirement: Complete button is tappable on all devices
+The complete button ("ダッシュボードを生成する") SHALL be tappable on both desktop and mobile devices. The canvas element SHALL NOT intercept pointer events in the button's area.
+
+#### Scenario: Mobile tap on complete button
+- **WHEN** user taps the complete button on a mobile device
+- **THEN** the `onViewSchedule()` handler SHALL fire
+- **AND** the user SHALL be navigated to the loading sequence
+
+#### Scenario: Desktop click on complete button
+- **WHEN** user clicks the complete button on desktop
+- **THEN** the `onViewSchedule()` handler SHALL fire
+
+### Requirement: No z-index stacking in discovery page CSS
+The artist discovery page SHALL NOT use `z-index` for visual stacking. All layer ordering SHALL be achieved through DOM source order, following the web-app-specialist skill's CSS standards.
+
+#### Scenario: Overlay elements paint above canvas
+- **WHEN** the discovery page renders
+- **THEN** the onboarding HUD, orb label, and complete button SHALL paint above the canvas
+- **AND** no CSS `z-index` property SHALL be present in `artist-discovery-page.css`
+
+#### Scenario: Starfield pseudo-element paints behind content
+- **WHEN** the discovery page renders
+- **THEN** the `.container::before` starfield SHALL paint behind all content elements
+- **AND** the starfield SHALL use `pointer-events: none` without `z-index`

--- a/openspec/changes/fix-onboarding-ux-regressions/tasks.md
+++ b/openspec/changes/fix-onboarding-ux-regressions/tasks.md
@@ -1,0 +1,26 @@
+## 1. Remove z-index and fix stacking via DOM order
+
+- [x] 1.1 Remove all `z-index` declarations from `artist-discovery-page.css`
+- [x] 1.2 Remove `z-index: 0` from `.container::before` (pseudo-elements paint before children naturally)
+- [x] 1.3 Reorder HTML in `artist-discovery-page.html`: place `<dna-orb-canvas>` first, then overlay elements (HUD, orb-label, button) after it in DOM order
+- [x] 1.4 Verify overlay elements paint above canvas without z-index
+
+## 2. Fix complete button tap target
+
+- [x] 2.1 Add `pointer-events: none` to the overlay wrapper div (so canvas receives bubble taps through it)
+- [x] 2.2 Add `pointer-events: auto` to the complete button element (so it captures taps in its area)
+- [x] 2.3 Ensure onboarding HUD stays `pointer-events: none` (non-interactive, purely visual)
+- [x] 2.4 Verify button responds to tap/click on mobile and desktop
+
+## 3. Bubble replenishment fallback
+
+- [x] 3.1 Add `loadReplacementBubbles()` method to `ArtistDiscoveryService` that calls `ListTop`, filters against seen artists, and returns fresh bubbles
+- [x] 3.2 In `dna-orb-canvas.ts` `handleInteraction()`, call `loadReplacementBubbles()` when `getSimilarArtists()` returns empty
+- [x] 3.3 Spawn replacement bubbles near the absorption point, same as similar artists
+- [x] 3.4 Verify canvas stays populated after following artists during onboarding
+
+## 4. Verify end-to-end
+
+- [x] 4.1 Test full onboarding flow on mobile viewport: tap 3 bubbles, dots fill, button appears, button is tappable, navigates to loading
+- [x] 4.2 Test that bubbles replenish after each follow (canvas never empties until pool is truly exhausted)
+- [x] 4.3 Confirm no `z-index` present in `artist-discovery-page.css`

--- a/openspec/specs/bubble-replenishment/spec.md
+++ b/openspec/specs/bubble-replenishment/spec.md
@@ -1,0 +1,17 @@
+### Requirement: Canvas replenishes bubbles when similar artists are exhausted
+When a user follows an artist and the similar-artist API returns no new (unseen) artists, the system SHALL automatically fetch replacement bubbles from the top-artist pool to keep the canvas populated.
+
+#### Scenario: Similar artists fully deduplicated
+- **WHEN** user taps a bubble AND `getSimilarArtists()` returns zero new bubbles after deduplication
+- **THEN** the system SHALL call `loadReplacementBubbles()` to fetch fresh artists from the top-artist pool
+- **AND** any unseen artists SHALL be spawned as new bubbles near the absorption point
+
+#### Scenario: Top artist pool also exhausted
+- **WHEN** user taps a bubble AND both similar artists and replacement bubbles return zero new artists
+- **THEN** the system SHALL gracefully accept an empty canvas without errors
+- **AND** the complete button (if visible) SHALL remain functional
+
+#### Scenario: Replacement bubbles partially available
+- **WHEN** user taps a bubble AND similar artists are exhausted but 5 of 50 top artists are unseen
+- **THEN** the system SHALL spawn only the 5 unseen artists as new bubbles
+- **AND** the previously seen artists SHALL NOT reappear on the canvas

--- a/openspec/specs/onboarding-guidance/spec.md
+++ b/openspec/specs/onboarding-guidance/spec.md
@@ -1,7 +1,5 @@
-## CHANGED Requirements
-
 ### Requirement: Onboarding guidance rendered within unified DiscoverPage
-The onboarding guidance HUD (progress dots, guidance message, CTA button) SHALL be rendered as a conditional section within `DiscoverPage` at `/discover`, instead of in a separate `ArtistDiscoveryPage` at `/onboarding/discover`.
+The onboarding guidance HUD (progress dots, guidance message, CTA button) SHALL be rendered as a conditional section within `DiscoverPage` at `/discover`, instead of in a separate page.
 
 #### Scenario: Onboarding user navigates to discover
 - **WHEN** `OnboardingService.isOnboarding` is `true` and the user navigates to `/discover`
@@ -18,6 +16,59 @@ The onboarding guidance HUD (progress dots, guidance message, CTA button) SHALL 
 - **THEN** the CTA button "ダッシュボードを生成する" SHALL be visible
 - **AND** tapping it SHALL navigate to `onboarding/loading`
 
+### Requirement: Followed count reflects localStorage state
+The `LocalArtistClient.followedCount` property SHALL be an `@observable` that is updated whenever `follow()`, `unfollow()`, or `clearAll()` is called, so that Aurelia bindings re-evaluate immediately.
+
+#### Scenario: Initial page load with existing guest data
+- **WHEN** the user navigates to `/discover` during onboarding and `localStorage['guest.followedArtists']` contains 3 artists
+- **THEN** the counter SHALL display `3/3` and the complete button SHALL be visible
+
+#### Scenario: Follow an artist during onboarding
+- **WHEN** the user taps a bubble to follow an artist
+- **THEN** the counter SHALL increment by 1 within the same frame (e.g., `0/3` → `1/3`)
+- **AND** the progress bar fill width SHALL update accordingly
+
+#### Scenario: Unfollow an artist
+- **WHEN** the user unfollows a previously followed artist
+- **THEN** the counter SHALL decrement by 1 immediately
+
+### Requirement: Persistent guidance until first interaction
+The onboarding guidance message SHALL remain visible until the user taps their first bubble. There SHALL be no auto-dismiss timer.
+
+#### Scenario: Page load without prior interactions
+- **WHEN** the user arrives at the discovery page for the first time (followedCount = 0)
+- **THEN** the guidance message "好きなアーティストを3組タップしよう！" SHALL be displayed
+- **AND** the message SHALL NOT auto-dismiss after any timeout
+
+#### Scenario: First bubble tap dismisses guidance
+- **WHEN** the user taps their first bubble
+- **THEN** the guidance message SHALL fade out (400ms transition)
+- **AND** a progress-specific message SHALL appear in its place
+
+### Requirement: Staged progress messages
+The system SHALL display contextual progress messages that change as the user follows more artists.
+
+#### Scenario: After following 1 artist
+- **WHEN** followedCount becomes 1
+- **THEN** the guidance area SHALL display "いいね！あと2組！"
+
+#### Scenario: After following 2 artists
+- **WHEN** followedCount becomes 2
+- **THEN** the guidance area SHALL display "あと1組！"
+
+#### Scenario: After following 3 or more artists
+- **WHEN** followedCount reaches 3 (TUTORIAL_FOLLOW_TARGET)
+- **THEN** the guidance area SHALL display "準備完了！"
+- **AND** the complete button SHALL become visible and visually highlighted
+
+### Requirement: Orb pulse on follow
+The central Music DNA orb SHALL pulse each time an artist is followed, providing visual feedback that the selection was registered.
+
+#### Scenario: Bubble tap triggers orb pulse
+- **WHEN** a bubble is tapped and the follow operation succeeds
+- **THEN** the `DnaOrbCanvas.followedCountChanged` callback SHALL fire
+- **AND** the orb SHALL play a pulse animation
+
 ### Requirement: Search and genre filter available during onboarding
 The search bar and genre filter chips SHALL be visible and functional during onboarding, allowing users to find specific artists they already know.
 
@@ -25,3 +76,28 @@ The search bar and genre filter chips SHALL be visible and functional during onb
 - **WHEN** the user is in onboarding mode and types a query into the search bar
 - **THEN** search results SHALL appear and the user SHALL be able to follow artists from the results
 - **AND** the follow operation SHALL use the same unified flow (localStorage during onboarding)
+
+### Requirement: Complete button is tappable on all devices
+The complete button ("ダッシュボードを生成する") SHALL be tappable on both desktop and mobile devices. The canvas element SHALL NOT intercept pointer events in the button's area.
+
+#### Scenario: Mobile tap on complete button
+- **WHEN** user taps the complete button on a mobile device
+- **THEN** the `onViewSchedule()` handler SHALL fire
+- **AND** the user SHALL be navigated to the loading sequence
+
+#### Scenario: Desktop click on complete button
+- **WHEN** user clicks the complete button on desktop
+- **THEN** the `onViewSchedule()` handler SHALL fire
+
+### Requirement: No z-index stacking in discovery page CSS
+The discovery page SHALL NOT use `z-index` for visual stacking. All layer ordering SHALL be achieved through DOM source order.
+
+#### Scenario: Overlay elements paint above canvas
+- **WHEN** the discovery page renders
+- **THEN** the onboarding HUD, orb label, and complete button SHALL paint above the canvas
+- **AND** no CSS `z-index` property SHALL be present in the discovery page CSS
+
+#### Scenario: Starfield pseudo-element paints behind content
+- **WHEN** the discovery page renders
+- **THEN** the `.container::before` starfield SHALL paint behind all content elements
+- **AND** the starfield SHALL use `pointer-events: none` without `z-index`

--- a/openspec/specs/onboarding-guidance/spec.md
+++ b/openspec/specs/onboarding-guidance/spec.md
@@ -1,0 +1,27 @@
+## CHANGED Requirements
+
+### Requirement: Onboarding guidance rendered within unified DiscoverPage
+The onboarding guidance HUD (progress dots, guidance message, CTA button) SHALL be rendered as a conditional section within `DiscoverPage` at `/discover`, instead of in a separate `ArtistDiscoveryPage` at `/onboarding/discover`.
+
+#### Scenario: Onboarding user navigates to discover
+- **WHEN** `OnboardingService.isOnboarding` is `true` and the user navigates to `/discover`
+- **THEN** the onboarding HUD (progress dots + guidance message) SHALL be visible
+- **AND** the search bar and genre filter SHALL also be available
+
+#### Scenario: Normal user navigates to discover
+- **WHEN** `OnboardingService.isOnboarding` is `false` and the user navigates to `/discover`
+- **THEN** the onboarding HUD SHALL NOT be rendered
+- **AND** no CTA button SHALL be shown (bottom navigation provides transitions)
+
+#### Scenario: CTA button visibility during onboarding
+- **WHEN** `OnboardingService.isOnboarding` is `true` and `followedCount >= 3`
+- **THEN** the CTA button "ダッシュボードを生成する" SHALL be visible
+- **AND** tapping it SHALL navigate to `onboarding/loading`
+
+### Requirement: Search and genre filter available during onboarding
+The search bar and genre filter chips SHALL be visible and functional during onboarding, allowing users to find specific artists they already know.
+
+#### Scenario: Onboarding user searches for an artist
+- **WHEN** the user is in onboarding mode and types a query into the search bar
+- **THEN** search results SHALL appear and the user SHALL be able to follow artists from the results
+- **AND** the follow operation SHALL use the same unified flow (localStorage during onboarding)


### PR DESCRIPTION
## 🔗 Related Issue

N/A — documentation-only changes for OpenSpec artifacts.

## 📝 Summary of Changes

Add OpenSpec artifacts for the refine-web-app frontend work:

- **Archived changes**: `fix-onboarding-bubble-counter` and `unify-discover-page` — both completed and implemented in frontend PR #113
- **New main spec**: `onboarding-guidance` — defines unified DiscoverPage behavior for onboarding and normal users (guidance HUD, CTA button, search/genre filter availability)
- **Active changes**: `decouple-discovery-service` and `fix-onboarding-ux-regressions` — upcoming work for further frontend improvements

## ✅ Self-Checklist

- [x] I have linked the related issue.
- [x] I have updated the relevant documentation (e.g., `README.md`) if needed.
- [x] I have run `buf lint` and `buf format` locally and all checks have passed.
- [x] My proto definitions follow the project's style guidelines and validation rules.
- [x] Breaking changes have been justified and documented if applicable.
