### PR TITLE
docs(openspec): add fix-sw-post-cache-error change

### DIFF
--- a/openspec/changes/fix-sw-post-cache-error/.openspec.yaml
+++ b/openspec/changes/fix-sw-post-cache-error/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-05

--- a/openspec/changes/fix-sw-post-cache-error/design.md
+++ b/openspec/changes/fix-sw-post-cache-error/design.md
@@ -1,0 +1,41 @@
+## Context
+
+The frontend PWA uses Workbox in `src/sw.ts` to manage caching strategies. PR #92 added two API caching routes:
+
+1. **Concert API** (`NetworkFirst`, no method filter) - intended for offline read access to concert lists
+2. **Artist API** (`NetworkFirst` + `BackgroundSyncPlugin`, `'POST'` filter) - intended for offline queuing of follow/unfollow operations
+
+Both routes target Connect-RPC endpoints which exclusively use POST. The Cache API only supports GET, creating a fundamental incompatibility.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Eliminate the `TypeError: Failed to execute 'put' on 'Cache'` error on Artist API calls
+- Remove dead code that never functioned (Concert API route, periodicSync, REFRESH_CONCERT_CACHE handler)
+- Preserve BackgroundSync functionality for Artist API offline queuing
+
+**Non-Goals:**
+- Implementing Concert API offline caching (requires `useHttpGet` transport change - separate change)
+- Changing Connect-RPC transport configuration
+- Modifying backend or proto definitions
+
+## Decisions
+
+### 1. Artist API: NetworkOnly instead of NetworkFirst
+
+**Decision**: Replace `NetworkFirst` with `NetworkOnly` on the Artist API route.
+
+**Rationale**: The Artist API route's purpose is BackgroundSync (queue failed mutations for replay), not response caching. `NetworkOnly` passes requests directly to the network without attempting cache operations. `BackgroundSyncPlugin` works with any strategy — it hooks into `fetchDidFail`, not `cacheDidUpdate`.
+
+**Alternative considered**: Custom plugin with `handlerDidRespond` to store in IndexedDB instead of Cache API. Rejected because the route's purpose is write operations (follow/unfollow), not read caching.
+
+### 2. Concert API: Remove entirely rather than fix
+
+**Decision**: Delete the Concert API route, `CONCERT_CACHE` constant, periodicSync handler (`sw.ts`), periodicSync registration and REFRESH_CONCERT_CACHE handler (`main.ts`).
+
+**Rationale**: This code has never functioned since it was merged. The route lacked `'POST'` in its method filter, so no requests ever matched and the cache was always empty. The periodicSync handler (including the dd9f231 fix) iterated over an empty cache. Fixing it by adding `'POST'` would just reproduce the same `cache.put` error that the Artist API route has. Properly solving Concert API offline caching requires `useHttpGet` transport changes — a cross-repo effort that belongs in a separate change.
+
+## Risks / Trade-offs
+
+- **[Loss of intent]** Removing Concert API caching code loses the expressed intent from PR #92. Mitigated by documenting the future `useHttpGet` path in the proposal and creating a follow-up issue.
+- **[BackgroundSync behavior unchanged]** `NetworkOnly` still triggers `BackgroundSyncPlugin` on network failure — verified by Workbox source: the plugin's `fetchDidFail` callback fires regardless of strategy.

--- a/openspec/changes/fix-sw-post-cache-error/proposal.md
+++ b/openspec/changes/fix-sw-post-cache-error/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+The Service Worker throws `TypeError: Failed to execute 'put' on 'Cache': Request method 'POST' is unsupported` on every Artist API call. The Cache API only supports GET requests, but Connect-RPC sends all RPCs as POST. The `NetworkFirst` strategy on the Artist API route attempts `cache.put()` on the POST response, causing this error.
+
+Additionally, the Concert API SW route was registered without a `'POST'` method filter, so it never matches actual Connect-RPC requests and is entirely dead code (along with the associated `periodicSync` handler and `REFRESH_CONCERT_CACHE` message handler in `main.ts`).
+
+## What Changes
+
+- **Artist API route**: Change strategy from `NetworkFirst` to `NetworkOnly` so no cache write is attempted. `BackgroundSyncPlugin` is retained for offline operation queuing.
+- **Concert API route**: Remove the dead `registerRoute` for ConcertService, the `CONCERT_CACHE` constant, the `periodicSync` event listener in `sw.ts`, and the `REFRESH_CONCERT_CACHE` message handler + `periodicSync.register()` call in `main.ts`.
+- **Workbox import**: Remove unused `NetworkFirst` import from `workbox-strategies` (only `CacheFirst` and `NetworkOnly` remain).
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+(none - this is a bug fix removing non-functional code; no spec-level behavior changes)
+
+## Impact
+
+- **Frontend (`src/sw.ts`)**: Strategy change + dead code removal
+- **Frontend (`src/main.ts`)**: Remove `periodicSync` registration and `REFRESH_CONCERT_CACHE` message listener
+- **No backend or proto changes required**
+- **Future**: Concert API offline caching will require a separate change introducing `useHttpGet` on the Connect transport (cross-repo: specification + frontend + backend)

--- a/openspec/changes/fix-sw-post-cache-error/specs/no-spec-changes/spec.md
+++ b/openspec/changes/fix-sw-post-cache-error/specs/no-spec-changes/spec.md
@@ -1,0 +1,5 @@
+## No Specification Changes
+
+This is a bug fix change. No capabilities are being added, modified, or removed at the specification level.
+
+See `proposal.md` for details.

--- a/openspec/changes/fix-sw-post-cache-error/tasks.md
+++ b/openspec/changes/fix-sw-post-cache-error/tasks.md
@@ -1,0 +1,20 @@
+## 1. Fix Artist API route in sw.ts
+
+- [ ] 1.1 Change Artist API route strategy from `NetworkFirst` to `NetworkOnly` in `src/sw.ts`
+- [ ] 1.2 Update workbox-strategies import: replace `NetworkFirst` with `NetworkOnly`
+
+## 2. Remove dead Concert API code from sw.ts
+
+- [ ] 2.1 Remove `CONCERT_CACHE` constant
+- [ ] 2.2 Remove Concert API `registerRoute` block
+- [ ] 2.3 Remove `periodicsync` event listener
+
+## 3. Remove dead Concert API code from main.ts
+
+- [ ] 3.1 Remove `periodicSync.register('concert-refresh', ...)` call from SW registration
+- [ ] 3.2 Remove `REFRESH_CONCERT_CACHE` message event listener (including the dynamic `oidc-client-ts` import)
+
+## 4. Verify
+
+- [ ] 4.1 Run `make check` (lint + test) in frontend
+- [ ] 4.2 Run `npm run build` to verify SW bundle compiles


### PR DESCRIPTION
## Summary
- Add OpenSpec change artifacts (proposal, design, tasks) for fixing SW cache.put TypeError on POST requests
- Documents removal of dead Concert API caching code that never functioned

## Test plan
- [x] openspec status shows all artifacts complete

Refs: liverty-music/frontend#117