### PR TITLE
docs(openspec): add migration rebase guard and atlas alert changes

### DIFF
--- a/openspec/changes/add-atlas-migration-alert/.openspec.yaml
+++ b/openspec/changes/add-atlas-migration-alert/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-05

--- a/openspec/changes/add-atlas-migration-alert/design.md
+++ b/openspec/changes/add-atlas-migration-alert/design.md
@@ -1,0 +1,50 @@
+## Context
+
+Cloud Monitoring currently has log-based alert policies for backend workloads (server, consumer, concert-discovery) that filter on `severity="ERROR"` in the `backend` namespace. Atlas Operator logs migration events as Kubernetes events with `type: "Warning"` and reasons like `TransientErr` and `BackoffLimitExceeded`. These appear in Cloud Logging under `resource.type="k8s_container"` in the `atlas-operator` namespace.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Detect Atlas Operator migration failures within minutes via Cloud Monitoring
+- Send Slack notifications using existing notification channels
+- Manage as IaC in the existing `MonitoringComponent`
+
+**Non-Goals:**
+- Alerting on Atlas Operator pod health (OOM, CrashLoopBackOff) — covered by GKE default monitoring
+- Alerting on migration duration or performance
+- Creating new Slack notification channels
+
+## Decisions
+
+### 1. Log filter strategy
+
+**Decision**: Filter on atlas-operator container logs containing error keywords rather than Kubernetes events.
+
+Atlas Operator logs migration errors at `DEBUG` level with event type `Warning`. The log entries contain identifiable strings: `TransientErr`, `BackoffLimitExceeded`, and `Error:`.
+
+Filter:
+```
+resource.type="k8s_container"
+resource.labels.namespace_name="atlas-operator"
+resource.labels.container_name="manager"
+textPayload=~"TransientErr|BackoffLimitExceeded"
+```
+
+**Alternative considered**: Filtering on `severity="ERROR"`. Rejected because Atlas Operator logs these events as DEBUG with event type Warning, not as ERROR severity.
+
+### 2. Alert policy structure
+
+**Decision**: Add a single alert policy for Atlas migration failures, separate from the existing workload error alerts.
+
+**Rationale**: Atlas Operator is infrastructure (not a backend workload), so it needs a different log filter, different label extractors, and different documentation. Adding it to the existing workload loop would conflate concerns.
+
+### 3. Implementation location
+
+**Decision**: Add to `MonitoringComponent` as a separate alert policy alongside the existing workload alerts.
+
+The component already handles alert policies and notification channels. Adding another `gcp.monitoring.AlertPolicy` resource follows the established pattern.
+
+## Risks / Trade-offs
+
+- **[Risk] Atlas Operator log format changes across versions** → Pin to known log patterns. Review on operator upgrades.
+- **[Risk] Alert fatigue from repeated failures** → Same 12-hour rate limit as existing alerts. Atlas Operator also has a `backoffLimit` that stops retries.

--- a/openspec/changes/add-atlas-migration-alert/design.md
+++ b/openspec/changes/add-atlas-migration-alert/design.md
@@ -20,7 +20,7 @@ Cloud Monitoring currently has log-based alert policies for backend workloads (s
 
 **Decision**: Filter on atlas-operator container logs containing error keywords rather than Kubernetes events.
 
-Atlas Operator logs migration errors at `DEBUG` level with event type `Warning`. The log entries contain identifiable strings: `TransientErr`, `BackoffLimitExceeded`, and `Error:`.
+Atlas Operator logs migration errors at `DEBUG` level with event type `Warning`. The log entries contain identifiable strings: `TransientErr` and `BackoffLimitExceeded`.
 
 Filter:
 ```
@@ -31,6 +31,8 @@ textPayload=~"TransientErr|BackoffLimitExceeded"
 ```
 
 **Alternative considered**: Filtering on `severity="ERROR"`. Rejected because Atlas Operator logs these events as DEBUG with event type Warning, not as ERROR severity.
+
+**Alternative considered**: Including `Error:` as a filter keyword. Rejected because `Error:` is too generic and appears in non-failure log lines (e.g., error field labels in structured debug output), which would cause false-positive alerts.
 
 ### 2. Alert policy structure
 

--- a/openspec/changes/add-atlas-migration-alert/design.md
+++ b/openspec/changes/add-atlas-migration-alert/design.md
@@ -22,15 +22,19 @@ Cloud Monitoring currently has log-based alert policies for backend workloads (s
 
 Atlas Operator logs migration errors at `DEBUG` level with event type `Warning`. The log entries contain identifiable strings: `TransientErr` and `BackoffLimitExceeded`.
 
-Filter:
+**Important**: Atlas Operator uses controller-runtime with zap for structured JSON logging. In Cloud Logging, structured JSON logs arrive as `jsonPayload`, not `textPayload`. The exact payload field (`jsonPayload.msg`, `jsonPayload.error`, or another field) must be verified against actual Cloud Logging entries during implementation. The filter below is a placeholder that must be updated based on the verified log structure.
+
+Filter (placeholder — verify payload field during implementation):
 ```
 resource.type="k8s_container"
 resource.labels.namespace_name="atlas-operator"
 resource.labels.container_name="manager"
-textPayload=~"TransientErr|BackoffLimitExceeded"
+jsonPayload.msg=~"TransientErr|BackoffLimitExceeded"
 ```
 
 **Alternative considered**: Filtering on `severity="ERROR"`. Rejected because Atlas Operator logs these events as DEBUG with event type Warning, not as ERROR severity.
+
+**Alternative considered**: Using `textPayload` filter. Rejected because Atlas Operator emits structured JSON logs via zap, which Cloud Logging stores as `jsonPayload`. A `textPayload` filter would silently never match.
 
 **Alternative considered**: Including `Error:` as a filter keyword. Rejected because `Error:` is too generic and appears in non-failure log lines (e.g., error field labels in structured debug output), which would cause false-positive alerts.
 

--- a/openspec/changes/add-atlas-migration-alert/proposal.md
+++ b/openspec/changes/add-atlas-migration-alert/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+Atlas Operator migration failures on the dev cluster went undetected for a week (2026-02-28 to 2026-03-05), blocking all schema changes. The existing Cloud Monitoring alerts only cover backend application workloads (server, consumer, concert-discovery) in the `backend` namespace. Atlas Operator runs in `atlas-operator` namespace and has no alerting.
+
+## What Changes
+
+- Add a Cloud Monitoring log-based alert policy for Atlas Operator migration failures in `cloud-provisioning/src/gcp/components/monitoring.ts`
+- The alert detects WARNING-level events from the Atlas Operator containing migration errors (e.g., `TransientErr`, `BackoffLimitExceeded`)
+- Notifications sent to the same Slack channel used by existing backend error alerts
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `app-error-log-alerting`: Extend alerting scope to include Atlas Operator migration failures in the `atlas-operator` namespace
+
+## Impact
+
+- `cloud-provisioning/src/gcp/components/monitoring.ts`: Add new alert policy for atlas-operator namespace
+- Cloud Monitoring: New alert policy created via Pulumi
+- Slack: Migration failure notifications sent to existing alert channel

--- a/openspec/changes/add-atlas-migration-alert/specs/app-error-log-alerting/spec.md
+++ b/openspec/changes/add-atlas-migration-alert/specs/app-error-log-alerting/spec.md
@@ -1,0 +1,36 @@
+## ADDED Requirements
+
+### Requirement: Atlas Operator migration failure detection
+
+The system SHALL detect Atlas Operator migration failures using a Cloud Monitoring Log-Based Alert Policy.
+
+The Alert Policy SHALL filter logs by:
+- `resource.type = "k8s_container"`
+- `resource.labels.namespace_name = "atlas-operator"`
+- `resource.labels.container_name = "manager"`
+- `textPayload` matching `TransientErr` or `BackoffLimitExceeded`
+
+#### Scenario: Atlas migration fails with non-linear error
+
+- **WHEN** Atlas Operator logs a `TransientErr` event for a migration failure
+- **THEN** the Alert Policy SHALL detect the log entry and open an Incident
+- **AND** a Slack notification SHALL be sent to the configured channel
+
+#### Scenario: Atlas migration exceeds backoff limit
+
+- **WHEN** Atlas Operator logs a `BackoffLimitExceeded` event
+- **THEN** the Alert Policy SHALL detect the log entry and open an Incident
+
+#### Scenario: Atlas migration succeeds
+
+- **WHEN** Atlas Operator successfully applies migrations
+- **THEN** no Alert Policy SHALL fire
+
+### Requirement: Atlas migration alert uses same notification and rate limiting as backend alerts
+
+The Atlas migration Alert Policy SHALL use the same Slack notification channels, 12-hour rate limit, and 1-hour auto-close settings as the existing backend workload alerts.
+
+#### Scenario: Multiple migration failures within 12 hours
+
+- **WHEN** multiple migration failure log entries occur within a 12-hour window
+- **THEN** only the first occurrence SHALL trigger a Slack notification

--- a/openspec/changes/add-atlas-migration-alert/specs/app-error-log-alerting/spec.md
+++ b/openspec/changes/add-atlas-migration-alert/specs/app-error-log-alerting/spec.md
@@ -10,7 +10,7 @@ The Alert Policy SHALL filter logs by:
 - `resource.labels.container_name = "manager"`
 - `textPayload` matching `TransientErr` or `BackoffLimitExceeded`
 
-#### Scenario: Atlas migration fails with non-linear error
+#### Scenario: Atlas migration fails with a transient error
 
 - **WHEN** Atlas Operator logs a `TransientErr` event for a migration failure
 - **THEN** the Alert Policy SHALL detect the log entry and open an Incident

--- a/openspec/changes/add-atlas-migration-alert/specs/app-error-log-alerting/spec.md
+++ b/openspec/changes/add-atlas-migration-alert/specs/app-error-log-alerting/spec.md
@@ -8,7 +8,7 @@ The Alert Policy SHALL filter logs by:
 - `resource.type = "k8s_container"`
 - `resource.labels.namespace_name = "atlas-operator"`
 - `resource.labels.container_name = "manager"`
-- `textPayload` matching `TransientErr` or `BackoffLimitExceeded`
+- `jsonPayload` field matching `TransientErr` or `BackoffLimitExceeded` (exact field name to be verified against actual Cloud Logging entries during implementation)
 
 #### Scenario: Atlas migration fails with a transient error
 
@@ -20,6 +20,7 @@ The Alert Policy SHALL filter logs by:
 
 - **WHEN** Atlas Operator logs a `BackoffLimitExceeded` event
 - **THEN** the Alert Policy SHALL detect the log entry and open an Incident
+- **AND** a Slack notification SHALL be sent to the configured channel
 
 #### Scenario: Atlas migration succeeds
 

--- a/openspec/changes/add-atlas-migration-alert/tasks.md
+++ b/openspec/changes/add-atlas-migration-alert/tasks.md
@@ -1,7 +1,8 @@
 ## 1. Add Atlas Migration Alert Policy
 
+- [ ] 1.0 Verify Atlas Operator log structure in Cloud Logging: determine whether logs use `textPayload` or `jsonPayload`, and identify the exact field containing `TransientErr`/`BackoffLimitExceeded` keywords
 - [ ] 1.1 Add `gcp.monitoring.AlertPolicy` for Atlas Operator migration failures in `monitoring.ts`
-- [ ] 1.2 Use log filter: `resource.type="k8s_container"`, `namespace_name="atlas-operator"`, `container_name="manager"`, `textPayload=~"TransientErr|BackoffLimitExceeded"`
+- [ ] 1.2 Use log filter: `resource.type="k8s_container"`, `namespace_name="atlas-operator"`, `container_name="manager"`, and the verified `jsonPayload` field matching `TransientErr|BackoffLimitExceeded`
 - [ ] 1.3 Use same notification channels, rate limit (12h), and auto-close (1h) as existing workload alerts
 - [ ] 1.4 Add documentation/triage steps specific to Atlas migration failures
 

--- a/openspec/changes/add-atlas-migration-alert/tasks.md
+++ b/openspec/changes/add-atlas-migration-alert/tasks.md
@@ -1,0 +1,11 @@
+## 1. Add Atlas Migration Alert Policy
+
+- [ ] 1.1 Add `gcp.monitoring.AlertPolicy` for Atlas Operator migration failures in `monitoring.ts`
+- [ ] 1.2 Use log filter: `resource.type="k8s_container"`, `namespace_name="atlas-operator"`, `container_name="manager"`, `textPayload=~"TransientErr|BackoffLimitExceeded"`
+- [ ] 1.3 Use same notification channels, rate limit (12h), and auto-close (1h) as existing workload alerts
+- [ ] 1.4 Add documentation/triage steps specific to Atlas migration failures
+
+## 2. Deploy and Verify
+
+- [ ] 2.1 Run `pulumi preview` to verify the new alert policy resource
+- [ ] 2.2 Deploy with `pulumi up` after user approval

--- a/openspec/changes/add-migration-rebase-guard/.openspec.yaml
+++ b/openspec/changes/add-migration-rebase-guard/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-05

--- a/openspec/changes/add-migration-rebase-guard/design.md
+++ b/openspec/changes/add-migration-rebase-guard/design.md
@@ -32,10 +32,10 @@ The existing `scripts/check-migration-drift.sh` handles kustomization sync, sche
 
 **Algorithm**:
 1. `git diff --name-only --diff-filter=A origin/main -- k8s/atlas/base/migrations/*.sql` to find added files
-2. Extract the latest timestamp from `origin/main`'s `atlas.sum` (last entry's version prefix)
-3. If any added file's timestamp ≤ main's latest → out-of-order detected
+2. List migration filenames on `origin/main` and take the lexicographic maximum version prefix as the latest timestamp
+3. If any added file's timestamp < main's latest → out-of-order detected
 
-**Alternative considered**: Parsing `atlas.sum` directly. Rejected because `atlas.sum` on the branch already includes the new files, making comparison harder.
+**Alternative considered**: Extracting the latest version from `atlas.sum` (last entry). Rejected because `atlas.sum` uses insertion order, not sorted order — after a prior `atlas migrate rebase` that merged to main, the last entry may not be the highest version.
 
 ### 3. Auto-fix with `atlas migrate rebase`
 

--- a/openspec/changes/add-migration-rebase-guard/design.md
+++ b/openspec/changes/add-migration-rebase-guard/design.md
@@ -39,22 +39,26 @@ The existing `scripts/check-migration-drift.sh` handles kustomization sync, sche
 
 ### 3. Auto-fix with `atlas migrate rebase`
 
-**Decision**: When `--fix` is passed and out-of-order files are detected, run `atlas migrate rebase <version>` for each offending file, then update `kustomization.yaml`.
+**Decision**: When `--fix` is passed and out-of-order files are detected, run `atlas migrate rebase <version> --env local` where `<version>` is the version prefix of each out-of-order migration file (e.g., `20260227000000` from `20260227000000_add_feature.sql`). Because `atlas migrate rebase` renames the file and rewrites `atlas.sum`, previously collected identifiers become stale after each invocation. The loop must re-scan for out-of-order files after each rebase.
 
 **Flow**:
 1. Detect out-of-order files
-2. Run `atlas migrate rebase <version> --env local` for each
-3. The rebase renames the file and updates `atlas.sum`
+2. Take the first out-of-order file and extract its version prefix
+3. Run `atlas migrate rebase <version> --env local` (this renames the file and updates `atlas.sum`)
 4. Update `kustomization.yaml`: replace old filename with new filename in the `configMapGenerator.files` list
+5. Re-scan for remaining out-of-order files; repeat from step 2 until none remain
 
 ### 4. Hook integration
 
-**Decision**: Add a Claude Code hook in `backend/.claude/settings.json` (PostToolUse on Bash when command matches `git rebase`) that runs `scripts/check-migration-drift.sh --fix`.
+**Decision**: Add a Claude Code hook in `backend/.claude/settings.json` (PostToolUse on Bash when command matches `git rebase origin`) that runs `scripts/check-migration-drift.sh --fix`.
 
-**Rationale**: This catches the most common scenario (rebasing onto main before push) automatically. The hook only fires when migrations exist on the branch.
+**Pattern**: The hook pattern is narrowed to `git rebase origin` to avoid firing on `git rebase --abort`, `git rebase --continue`, or interactive rebases. The script also checks for mid-rebase state (`.git/rebase-merge` or `.git/rebase-apply` directory) and exits early if the rebase did not complete successfully.
+
+**Rationale**: This catches the most common scenario (rebasing onto main before push) automatically. The hook only fires when migrations exist on the branch. Running `--fix` during a failed or aborted rebase could corrupt `atlas.sum` and migration files, so the guard is essential.
 
 ## Risks / Trade-offs
 
 - **[Risk] `atlas migrate rebase` changes file content hash** → This is expected. The `atlas.sum` is recalculated, and CI's `atlas migrate validate` will verify integrity.
-- **[Risk] Hook runs on every `git rebase`, even non-migration branches** → The script exits quickly (Check 4 is skipped) when no new migration files are detected. Negligible overhead.
+- **[Risk] Hook runs on every `git rebase origin`, even non-migration branches** → The script exits quickly (Check 4 is skipped) when no new migration files are detected. Negligible overhead.
+- **[Risk] Hook fires after a failed rebase** → The script checks for `.git/rebase-merge` or `.git/rebase-apply` directories and exits early if the rebase is incomplete. This prevents corrupting migration files during conflict resolution.
 - **[Risk] `origin/main` not fetched** → The script should `git fetch origin main` before comparison, or document that the hook assumes a recent fetch. Decision: require the caller to fetch first (the rebase hook already implies `git fetch`).

--- a/openspec/changes/add-migration-rebase-guard/design.md
+++ b/openspec/changes/add-migration-rebase-guard/design.md
@@ -1,0 +1,60 @@
+## Context
+
+Atlas Operator applies versioned migrations in strict linear order. When parallel branches create migration files with timestamps that predate already-applied migrations on `main`, Atlas rejects them as "non-linear" and stalls indefinitely. This happened on 2026-02-28 and went undetected for a week.
+
+The existing `scripts/check-migration-drift.sh` handles kustomization sync, schema drift, and hash validation, but does not check timestamp ordering. Atlas provides `atlas migrate rebase` to fix ordering issues.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Automatically detect out-of-order migration timestamps after `git rebase origin/main`
+- Automatically fix ordering via `atlas migrate rebase` when `--fix` is passed
+- Automatically update `kustomization.yaml` file references after rebase
+- Block PRs in CI when out-of-order migrations are detected
+- Integrate into existing `check-migration-drift.sh` as Check 4
+
+**Non-Goals:**
+- Changing Atlas Operator configuration (e.g., `exec-order`)
+- Handling merge conflicts in migration files (git-level concern)
+- Modifying the CI workflow structure beyond adding the new check
+
+## Decisions
+
+### 1. Extend existing script vs. new script
+
+**Decision**: Extend `check-migration-drift.sh` with Check 4.
+
+**Rationale**: The script already handles migration consistency checks and is called from hooks and CI. Adding another check keeps the single entry point. A new script would require separate hook/CI integration.
+
+### 2. Detection method
+
+**Decision**: Compare timestamps of new migration files (files not on `origin/main`) against the latest timestamp on `origin/main`.
+
+**Algorithm**:
+1. `git diff --name-only --diff-filter=A origin/main -- k8s/atlas/base/migrations/*.sql` to find added files
+2. Extract the latest timestamp from `origin/main`'s `atlas.sum` (last entry's version prefix)
+3. If any added file's timestamp ≤ main's latest → out-of-order detected
+
+**Alternative considered**: Parsing `atlas.sum` directly. Rejected because `atlas.sum` on the branch already includes the new files, making comparison harder.
+
+### 3. Auto-fix with `atlas migrate rebase`
+
+**Decision**: When `--fix` is passed and out-of-order files are detected, run `atlas migrate rebase <version>` for each offending file, then update `kustomization.yaml`.
+
+**Flow**:
+1. Detect out-of-order files
+2. Run `atlas migrate rebase <version> --env local` for each
+3. The rebase renames the file and updates `atlas.sum`
+4. Update `kustomization.yaml`: replace old filename with new filename in the `configMapGenerator.files` list
+
+### 4. Hook integration
+
+**Decision**: Add a Claude Code hook in `backend/.claude/settings.json` (PostToolUse on Bash when command matches `git rebase`) that runs `scripts/check-migration-drift.sh --fix`.
+
+**Rationale**: This catches the most common scenario (rebasing onto main before push) automatically. The hook only fires when migrations exist on the branch.
+
+## Risks / Trade-offs
+
+- **[Risk] `atlas migrate rebase` changes file content hash** → This is expected. The `atlas.sum` is recalculated, and CI's `atlas migrate validate` will verify integrity.
+- **[Risk] Hook runs on every `git rebase`, even non-migration branches** → The script exits quickly (Check 4 is skipped) when no new migration files are detected. Negligible overhead.
+- **[Risk] `origin/main` not fetched** → The script should `git fetch origin main` before comparison, or document that the hook assumes a recent fetch. Decision: require the caller to fetch first (the rebase hook already implies `git fetch`).

--- a/openspec/changes/add-migration-rebase-guard/proposal.md
+++ b/openspec/changes/add-migration-rebase-guard/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+Parallel development branches frequently create migration files with timestamps that conflict when merged in different order than their timestamps suggest. This caused Atlas Operator to stall for a week (2026-02-28 to 2026-03-05) with a non-linear error, blocking all pending migrations on the dev DB. We need automated prevention and detection to avoid recurrence.
+
+## What Changes
+
+- Extend `scripts/check-migration-drift.sh` with a new check that detects out-of-order migration timestamps relative to `origin/main`
+- Add `--fix` mode that automatically runs `atlas migrate rebase` and updates `kustomization.yaml` when out-of-order files are detected
+- Add a Claude Code hook (PostToolUse: git rebase) in the backend repo to run the script automatically after rebasing onto main
+
+## Capabilities
+
+### New Capabilities
+
+- `migration-rebase-guard`: Automated detection and correction of out-of-order Atlas migration timestamps caused by parallel branch development
+
+### Modified Capabilities
+
+- `database-migration`: Add migration rebase guard to the development workflow and CI pipeline
+
+## Impact
+
+- `backend/scripts/check-migration-drift.sh`: Extended with Check 4 (timestamp ordering) and `--fix` mode
+- `backend/.claude/hooks/` or `backend/.claude/settings.json`: New hook for post-rebase migration check
+- `backend/.github/workflows/atlas-ci.yml`: CI runs the ordering check on PRs (detect-only mode)
+- Development workflow: Developers no longer need to manually detect/fix migration ordering issues

--- a/openspec/changes/add-migration-rebase-guard/specs/database-migration/spec.md
+++ b/openspec/changes/add-migration-rebase-guard/specs/database-migration/spec.md
@@ -1,0 +1,16 @@
+## MODIFIED Requirements
+
+### Requirement: The CI pipeline MUST validate migration file ordering
+
+The atlas-ci workflow SHALL verify that all new migration files have timestamps greater than the latest migration version on the base branch. PRs with out-of-order migrations SHALL fail CI.
+
+#### Scenario: PR with out-of-order migration file
+
+- **WHEN** a PR adds a migration file with a timestamp earlier than the latest on `main`
+- **THEN** the atlas-ci job SHALL fail with a descriptive error message
+- **AND** the error message SHALL suggest running `scripts/check-migration-drift.sh --fix`
+
+#### Scenario: PR with correctly ordered migration file
+
+- **WHEN** a PR adds a migration file with a timestamp later than the latest on `main`
+- **THEN** the atlas-ci job SHALL pass the ordering check

--- a/openspec/changes/add-migration-rebase-guard/specs/migration-rebase-guard/spec.md
+++ b/openspec/changes/add-migration-rebase-guard/specs/migration-rebase-guard/spec.md
@@ -1,0 +1,48 @@
+## ADDED Requirements
+
+### Requirement: The system MUST detect out-of-order migration timestamps
+
+The migration drift check script SHALL compare timestamps of newly added migration files against the latest migration version on `origin/main`. A file is out-of-order if its timestamp is less than or equal to the latest version on main.
+
+#### Scenario: Branch adds migration with older timestamp than main's latest
+
+- **WHEN** a branch adds `20260227000000_add_feature.sql` but main's latest is `20260227090313`
+- **THEN** the script SHALL report `20260227000000_add_feature.sql` as out-of-order
+- **AND** the script SHALL exit with non-zero status in detect-only mode
+
+#### Scenario: Branch adds migration with newer timestamp than main's latest
+
+- **WHEN** a branch adds `20260305120000_add_feature.sql` and main's latest is `20260304014803`
+- **THEN** the script SHALL report no ordering issues
+- **AND** the script SHALL exit with zero status
+
+#### Scenario: No new migration files on branch
+
+- **WHEN** a branch has no new migration files compared to `origin/main`
+- **THEN** the ordering check SHALL be skipped silently
+
+### Requirement: The system MUST auto-fix out-of-order migrations when --fix is passed
+
+When invoked with `--fix`, the script SHALL automatically rebase out-of-order migration files using `atlas migrate rebase` and update `kustomization.yaml` references.
+
+#### Scenario: Auto-fix renames and updates kustomization
+
+- **WHEN** `--fix` is passed and out-of-order files are detected
+- **THEN** the script SHALL run `atlas migrate rebase <version> --env local` for each out-of-order file
+- **AND** the script SHALL update `kustomization.yaml` to reference the new filenames
+- **AND** `atlas.sum` SHALL be recalculated by the rebase command
+
+#### Scenario: Auto-fix with no issues found
+
+- **WHEN** `--fix` is passed but no out-of-order files are detected
+- **THEN** the script SHALL take no action and exit with zero status
+
+### Requirement: The system MUST integrate with Claude Code hooks
+
+A Claude Code hook SHALL invoke the migration drift check with `--fix` after `git rebase` operations in the backend repository.
+
+#### Scenario: Developer rebases branch onto main via Claude Code
+
+- **WHEN** a `git rebase origin/main` command completes in the backend repo
+- **THEN** the hook SHALL run `scripts/check-migration-drift.sh --fix`
+- **AND** any out-of-order migrations SHALL be automatically rebased

--- a/openspec/changes/add-migration-rebase-guard/specs/migration-rebase-guard/spec.md
+++ b/openspec/changes/add-migration-rebase-guard/specs/migration-rebase-guard/spec.md
@@ -2,7 +2,7 @@
 
 ### Requirement: The system MUST detect out-of-order migration timestamps
 
-The migration drift check script SHALL compare timestamps of newly added migration files against the latest migration version on `origin/main`. A file is out-of-order if its timestamp is less than or equal to the latest version on main.
+The migration drift check script SHALL compare timestamps of newly added migration files against the latest migration version on `origin/main`. The latest version SHALL be determined by taking the lexicographic maximum of migration filenames on `origin/main` (not from `atlas.sum`, which uses insertion order). A file is out-of-order if its timestamp is strictly less than the latest version on main.
 
 #### Scenario: Branch adds migration with older timestamp than main's latest
 

--- a/openspec/changes/add-migration-rebase-guard/specs/migration-rebase-guard/spec.md
+++ b/openspec/changes/add-migration-rebase-guard/specs/migration-rebase-guard/spec.md
@@ -28,7 +28,8 @@ When invoked with `--fix`, the script SHALL automatically rebase out-of-order mi
 #### Scenario: Auto-fix renames and updates kustomization
 
 - **WHEN** `--fix` is passed and out-of-order files are detected
-- **THEN** the script SHALL run `atlas migrate rebase <version> --env local` for each out-of-order file
+- **THEN** the script SHALL run `atlas migrate rebase <version> --env local` where `<version>` is the version prefix of the out-of-order file (e.g., `20260227000000`)
+- **AND** the script SHALL re-scan for remaining out-of-order files after each rebase invocation (since rebase renames files and rewrites `atlas.sum`)
 - **AND** the script SHALL update `kustomization.yaml` to reference the new filenames
 - **AND** `atlas.sum` SHALL be recalculated by the rebase command
 
@@ -39,10 +40,16 @@ When invoked with `--fix`, the script SHALL automatically rebase out-of-order mi
 
 ### Requirement: The system MUST integrate with Claude Code hooks
 
-A Claude Code hook SHALL invoke the migration drift check with `--fix` after `git rebase` operations in the backend repository.
+A Claude Code hook SHALL invoke the migration drift check with `--fix` after successful `git rebase origin` operations in the backend repository. The hook SHALL NOT fire on `git rebase --abort`, `git rebase --continue`, or interactive rebases.
 
 #### Scenario: Developer rebases branch onto main via Claude Code
 
-- **WHEN** a `git rebase origin/main` command completes in the backend repo
+- **WHEN** a `git rebase origin/main` command completes successfully in the backend repo
 - **THEN** the hook SHALL run `scripts/check-migration-drift.sh --fix`
 - **AND** any out-of-order migrations SHALL be automatically rebased
+
+#### Scenario: Rebase fails with merge conflicts
+
+- **WHEN** a `git rebase origin/main` command fails due to merge conflicts
+- **THEN** the script SHALL detect the incomplete rebase state (`.git/rebase-merge` or `.git/rebase-apply`)
+- **AND** the script SHALL exit early without modifying migration files

--- a/openspec/changes/add-migration-rebase-guard/tasks.md
+++ b/openspec/changes/add-migration-rebase-guard/tasks.md
@@ -1,12 +1,13 @@
 ## 1. Extend check-migration-drift.sh
 
 - [ ] 1.1 Add Check 4: detect out-of-order migration timestamps by comparing new files against `origin/main`'s latest version
-- [ ] 1.2 Add `--fix` mode that runs `atlas migrate rebase` for each out-of-order file
+- [ ] 1.2 Add `--fix` mode that runs `atlas migrate rebase <version> --env local` for each out-of-order file (re-scanning after each invocation since rebase renames files and rewrites `atlas.sum`)
 - [ ] 1.3 Add kustomization.yaml auto-update after rebase (replace old filename with new filename)
 
 ## 2. Hook Integration
 
-- [ ] 2.1 Add PostToolUse hook in `backend/.claude/settings.json` to run `scripts/check-migration-drift.sh --fix` after `git rebase` commands
+- [ ] 2.1 Add PostToolUse hook in `backend/.claude/settings.json` to run `scripts/check-migration-drift.sh --fix` after `git rebase origin` commands (pattern excludes `--abort`, `--continue`, interactive rebases)
+- [ ] 2.2 Add rebase-state guard in `check-migration-drift.sh` to exit early if `.git/rebase-merge` or `.git/rebase-apply` exists
 
 ## 3. CI Integration
 

--- a/openspec/changes/add-migration-rebase-guard/tasks.md
+++ b/openspec/changes/add-migration-rebase-guard/tasks.md
@@ -1,0 +1,13 @@
+## 1. Extend check-migration-drift.sh
+
+- [ ] 1.1 Add Check 4: detect out-of-order migration timestamps by comparing new files against `origin/main`'s latest version
+- [ ] 1.2 Add `--fix` mode that runs `atlas migrate rebase` for each out-of-order file
+- [ ] 1.3 Add kustomization.yaml auto-update after rebase (replace old filename with new filename)
+
+## 2. Hook Integration
+
+- [ ] 2.1 Add PostToolUse hook in `backend/.claude/settings.json` to run `scripts/check-migration-drift.sh --fix` after `git rebase` commands
+
+## 3. CI Integration
+
+- [ ] 3.1 Add ordering check step to `.github/workflows/atlas-ci.yml` that runs `scripts/check-migration-drift.sh` (detect-only, no `--fix`)


### PR DESCRIPTION
## Summary

- Add two OpenSpec change proposals to address issues discovered during dev DB migration incident (2026-02-28 to 2026-03-05)

### 1. `add-migration-rebase-guard` (backend repo)
- Extend `check-migration-drift.sh` with timestamp ordering check (Check 4)
- Add `--fix` mode using `atlas migrate rebase` for auto-correction
- Add Claude Code hook for automatic rebase after `git rebase`
- Add CI guard in `atlas-ci.yml`

### 2. `add-atlas-migration-alert` (cloud-provisioning repo)
- Add Cloud Monitoring log-based alert for Atlas Operator migration failures
- Detect `TransientErr` and `BackoffLimitExceeded` in atlas-operator logs
- Send Slack notifications via existing channels

## Test plan

- [ ] OpenSpec artifacts are valid (`openspec status` shows all complete)
- [ ] No proto or schema changes (docs-only PR)
