### PR TITLE
docs(openspec): add onboarding UX improvement changes

### DIFF
--- a/openspec/changes/eliminate-z-index-stacking/.openspec.yaml
+++ b/openspec/changes/eliminate-z-index-stacking/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-05

--- a/openspec/changes/eliminate-z-index-stacking/design.md
+++ b/openspec/changes/eliminate-z-index-stacking/design.md
@@ -143,7 +143,9 @@ The `fix-area-dialog-overlap` change previously established the `<dialog>` + `@s
 - Call `showPopover()` when the coach mark activates, `hidePopover()` when dismissed
 - Remove `z-index: 9999` from `.coach-mark-overlay` in `coach-mark.css`
 - Top Layer promotion ensures the overlay paints above everything including the nav bar popover (later insertion order)
-- Click-through on spotlight area is preserved — `popover` does not trap focus or block pointer events
+- The overlay canvas is a full-viewport element; `pointer-events: none` SHALL be applied to it so it does not intercept clicks
+- `pointer-events: auto` is re-enabled on dismiss/next buttons within the overlay
+- Click-through to the spotlighted element is handled by `elementFromPoint()` delegation: the overlay listens for clicks, temporarily hides itself, calls `document.elementFromPoint(x, y)` to find the underlying element, and forwards the event
 
 **Tooltip positioning (CSS Anchor Positioning)**:
 - Target element gets `anchor-name: --coach-target` (set dynamically via `style.anchorName`)
@@ -164,25 +166,29 @@ The `fix-area-dialog-overlap` change previously established the `<dialog>` + `@s
 
 ### Decision 7: Top Layer architecture — stacking by insertion order
 
-**Choice**: Document the intended Top Layer insertion order as the architectural contract replacing z-index.
+**Choice**: Document the intended Top Layer insertion order and the enforcement mechanism replacing z-index.
+
+The Top Layer is a strict last-in-on-top stack. Order depends entirely on JS call sequence, not element type. The intended visual layering is:
 
 ```
 Top Layer Stack (last = on top):
 ─────────────────────────────────
-  coach-mark popover     ← showPopover() on tutorial activation
-  toast-notification     ← showPopover() per toast
-  <dialog> modals        ← showModal() on user action
-  bottom-nav-bar         ← showPopover() on app startup
+  coach-mark popover     ← highest priority
+  toast-notification     ← must appear above dialogs
+  <dialog> modals        ← above nav bar
+  bottom-nav-bar         ← base layer
 ─────────────────────────────────
   Normal stacking context (isolation: isolate per component)
 ```
 
-- Bottom-nav is the first popover shown (app startup) — sits at the bottom of the Top Layer
-- Dialogs are shown on user interaction — paint above nav
-- Toasts are shown on events — paint above dialogs
-- Coach-mark is shown during tutorials — paints above everything
+**Enforcement mechanism** (required because Top Layer order is insertion-order, not declarative):
 
-If ordering conflicts arise, the fix is adjusting `showPopover()` / `showModal()` call timing, not adding z-index.
+- **Bottom-nav**: `showPopover()` called once at app startup. Always at the bottom of the Top Layer.
+- **Dialogs**: `showModal()` called on user action. Inserted after nav, so they paint above it.
+- **Toasts**: When a toast fires while a dialog is open, the toast is already below the dialog in the stack. The toast service SHALL call `hidePopover()` + `showPopover()` to re-insert itself at the top of the Top Layer stack, ensuring it paints above any open dialog.
+- **Coach-mark**: `showPopover()` called on tutorial activation. During tutorials, no dialogs or toasts are expected. If a toast fires during a tutorial, the coach-mark SHALL also re-insert itself (`hidePopover()` + `showPopover()`) to maintain top position.
+
+If ordering conflicts arise, the fix is re-insertion (`hidePopover()` + `showPopover()`) to move the element to the top of the stack, not adding z-index.
 
 ## Risks / Trade-offs
 

--- a/openspec/changes/eliminate-z-index-stacking/design.md
+++ b/openspec/changes/eliminate-z-index-stacking/design.md
@@ -1,0 +1,194 @@
+## Context
+
+The Liverty Music frontend contains 26 `z-index` declarations across 11 files. The `onboarding-guidance` spec explicitly prohibits z-index in the discovery page CSS, yet 7 instances remain. Three components use Tailwind `z-40`/`z-50`/`z-[60]`/`z-[70]`/`z-[100]` utilities for modal overlays via fixed-position `<div>` elements. Two persistent UI elements (`bottom-nav-bar`, `toast-notification`) use `z-30`/`z-50` for layering. The `coach-mark` uses `z-9999` for tutorial spotlight overlays with JS-calculated positioning.
+
+Modern Web Platform APIs (all Baseline 2026) eliminate the need for any z-index:
+
+- **Popover API** (`popover="manual"`) — Top Layer promotion without focus trapping, for persistent non-modal elements
+- **CSS Anchor Positioning** — Declarative positioning relative to anchor elements, replacing `getBoundingClientRect()` JS calculations
+- **`<dialog>` + `showModal()`** — Modal overlays in Top Layer with native `::backdrop`, focus trapping, ESC handling
+- **`isolation: isolate`** — Explicit stacking context for component-internal layering without z-index
+
+The `fix-area-dialog-overlap` change previously established the `<dialog>` + `@starting-style` pattern. This change extends that to all remaining z-index usages and achieves **zero z-index exceptions**.
+
+## Complete z-index Inventory
+
+| # | File | Selector / Class | z-index | Category | Migration |
+|---|------|-------------------|---------|----------|-----------|
+| 1 | `discover-page.css` | `.container::before` | 0 | Internal | `isolation: isolate` |
+| 2 | `discover-page.css` | `.search-bar` | 20 | Internal | `isolation: isolate` |
+| 3 | `discover-page.css` | `.genre-chips` | 15 | Internal | `isolation: isolate` |
+| 4 | `discover-page.css` | `.orb-label` | 15 | Internal | `isolation: isolate` |
+| 5 | `discover-page.css` | `.search-results` | 10 | Internal | `isolation: isolate` |
+| 6 | `discover-page.css` | `.onboarding-hud` | 20 | Internal | `isolation: isolate` |
+| 7 | `discover-page.css` | `.complete-button-wrapper` | 20 | Internal | `isolation: isolate` |
+| 8 | `loading-sequence.css` | Various (6 instances) | 0, 1 | Internal | `isolation: isolate` |
+| 9-14 | (counted as 6 in #8) | | | | |
+| 15 | `event-detail-sheet.html` | backdrop `<div>` | z-40 | Modal | `<dialog>` |
+| 16 | `event-detail-sheet.html` | sheet panel | z-50 | Modal | `<dialog>` |
+| 17 | `my-artists-page.html` | context menu | z-50 | Modal | `<dialog>` |
+| 18 | `my-artists-page.html` | passion selector | z-50 | Modal | `<dialog>` |
+| 19 | `my-artists-page.html` | passion explanation | z-[60] | Modal | `<dialog>` |
+| 20 | `tickets-page.html` | proof generation | z-50 | Modal | `<dialog>` |
+| 21 | `tickets-page.html` | QR modal | z-50 | Modal | `<dialog>` |
+| 22 | `signup-modal.html` | modal wrapper | z-[70] | Modal | `<dialog>` |
+| 23 | `error-banner.html` | banner wrapper | z-[100] | Modal | `<dialog>` |
+| 24 | `bottom-nav-bar.html` | nav container | z-30 | Persistent | `popover="manual"` |
+| 25 | `toast-notification.html` | toast wrapper | z-50 | Persistent | `popover="manual"` |
+| 26 | `coach-mark.css` | `.coach-mark-overlay` | z-9999 | Tutorial | `popover="manual"` + Anchor Positioning |
+
+**Live-highway sticky date separator** (`z-20` in `live-highway.html` line 18) uses `isolation: isolate` on the scroll container to contain stacking.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Eliminate ALL z-index from the codebase (26 instances across 11 files to 0)
+- Zero z-index exceptions — every use case has a modern API replacement
+- Use `isolation: isolate` for component-internal stacking (discover-page, loading-sequence, live-highway)
+- Use `<dialog>` + `showModal()` for all modal overlays (7 components)
+- Use `popover="manual"` for persistent non-modal elements (bottom-nav-bar, toast-notification, coach-mark)
+- Use CSS Anchor Positioning for coach-mark tooltip placement (replacing `getBoundingClientRect()` JS)
+- Follow the established `<dialog>` + `@starting-style` animation pattern
+- Maintain existing UX behavior (slide-up, backdrop dimming, swipe-to-dismiss, ESC-to-close)
+
+**Non-Goals:**
+- Creating a shared/generic bottom-sheet component (keep each component self-contained)
+- Refactoring coach-mark spotlight rendering (canvas remains; only overlay stacking and tooltip positioning change)
+
+## Decisions
+
+### Decision 1: `isolation: isolate` for component-internal stacking (discover-page, loading-sequence, live-highway)
+
+**Choice**: Add `isolation: isolate` to the component's root container to create an explicit stacking context. Remove all `z-index` declarations within the component. Elements stack by DOM source order within the isolated context.
+
+**discover-page.css** (7 instances):
+- Add `isolation: isolate` to `.container`
+- Remove `z-index` from all 7 selectors
+- Shadow DOM boundary already provides an isolated stacking context; `isolation: isolate` makes it explicit
+- DOM source order: starfield `::before` < canvas < search bar < genre chips < onboarding HUD < complete button
+
+**loading-sequence.css** (6 instances):
+- Add `isolation: isolate` to the root wrapper
+- Remove all 6 `z-index: 0` / `z-index: 1` declarations
+- All elements are within a Shadow DOM component; no external stacking conflicts
+
+**live-highway.html** (1 instance, `z-20` sticky date separator):
+- Add `isolation: isolate` to the scroll container parent
+- Remove `z-20` from the sticky date separator
+- `position: sticky` elements paint above scrolled siblings naturally within an isolated stacking context
+
+**Rationale**: `isolation: isolate` creates an explicit stacking context boundary. Within this boundary, elements stack by DOM order (later = on top) without needing z-index. This is the correct pattern for component-internal layering.
+
+### Decision 2: `<dialog>` + `showModal()` for all modal overlays
+
+**Choice**: Replace all fixed-position `<div>` + z-index overlays with native `<dialog>` elements promoted to the Top Layer via `showModal()`.
+
+**Components migrated** (7 total):
+
+| Component | Current | After |
+|-----------|---------|-------|
+| `event-detail-sheet` | `z-40` backdrop + `z-50` sheet | Single `<dialog>` + `::backdrop` |
+| `my-artists-page` context menu | `z-50` overlay | `<dialog>` + `::backdrop` |
+| `my-artists-page` passion selector | `z-50` overlay | `<dialog>` + `::backdrop` |
+| `my-artists-page` passion explanation | `z-[60]` overlay | `<dialog>` + cancel suppression |
+| `tickets-page` QR modal | `z-50` + manual `role="dialog"` | `<dialog>` (native a11y) |
+| `tickets-page` proof generation | `z-50` + `role="alert"` | `<dialog>` + cancel suppression |
+| `signup-modal` | `z-[70]` non-dismissible | `<dialog>` + cancel suppression |
+| `error-banner` | `z-[100]` | `<dialog>` + auto-dismiss |
+
+**Implementation pattern** (established by `fix-area-dialog-overlap`):
+- `ref="dialogElement"` for DOM reference
+- `showModal()` to open, `close()` to dismiss
+- `::backdrop` pseudo-element for dimming (`background: oklch(0% 0 0 / 0.6); backdrop-filter: blur(4px)`)
+- `@starting-style` for entry animations (slide-up or fade-in, 300ms ease-out)
+- Click-outside-to-close: `event.target === dialogElement` check
+- Non-dismissible dialogs: suppress `cancel` event to block ESC
+
+**Why `<dialog>` not `popover`**: Modal overlays require focus trapping and backdrop dimming — `<dialog>` provides both natively. `popover` does not trap focus or provide `::backdrop`.
+
+### Decision 3: `popover="manual"` for bottom-nav-bar
+
+**Choice**: Replace `z-30` with `popover="manual"` to promote the nav bar to the Top Layer.
+
+**Implementation**:
+- Add `popover="manual"` attribute to the nav container element
+- Call `this.navElement.showPopover()` on component `attached()` to promote to Top Layer
+- Remove `z-30` class
+- The nav bar remains always-visible; `popover="manual"` does not auto-dismiss on click-outside or ESC
+- Top Layer elements paint above all non-Top-Layer content without z-index
+
+**Why `popover="manual"`**: The nav bar is persistent and non-modal. It must sit above scrolling page content but must not trap focus or show a backdrop. `popover="manual"` provides Top Layer promotion with no auto-dismiss behavior and no focus trapping — exactly the semantics needed.
+
+**Top Layer ordering**: The nav bar's `showPopover()` is called at app startup. Subsequent `showModal()` calls (for dialogs) are inserted later into the Top Layer stack, so they naturally paint above the nav bar. When the dialog closes, the nav bar is visible again. No z-index needed.
+
+### Decision 4: `popover="manual"` for toast-notification
+
+**Choice**: Replace `z-50` with `popover="manual"` to promote toasts to the Top Layer.
+
+**Implementation**:
+- Add `popover="manual"` attribute to the toast container
+- Call `showPopover()` when a toast is displayed, `hidePopover()` when dismissed
+- Remove `z-50` class
+- Retain `pointer-events: none` on the container with `pointer-events: auto` on individual toast items (allows click-through around toasts)
+- Toasts in Top Layer paint above the nav bar (later insertion = higher in stack)
+
+**Why not `<dialog>`**: Toasts are non-modal, non-interactive (no focus trapping), and must allow click-through. `popover="manual"` matches these semantics.
+
+### Decision 5: `popover="manual"` + CSS Anchor Positioning for coach-mark
+
+**Choice**: Replace `z-9999` with `popover="manual"` for the overlay, and replace `getBoundingClientRect()` JS calculations with CSS Anchor Positioning for tooltip placement.
+
+**Overlay (Top Layer promotion)**:
+- Add `popover="manual"` to `.coach-mark-overlay`
+- Call `showPopover()` when the coach mark activates, `hidePopover()` when dismissed
+- Remove `z-index: 9999` from `.coach-mark-overlay` in `coach-mark.css`
+- Top Layer promotion ensures the overlay paints above everything including the nav bar popover (later insertion order)
+- Click-through on spotlight area is preserved — `popover` does not trap focus or block pointer events
+
+**Tooltip positioning (CSS Anchor Positioning)**:
+- Target element gets `anchor-name: --coach-target` (set dynamically via `style.anchorName`)
+- Tooltip uses `position-anchor: --coach-target` with `position-area` for placement
+- Use `position-try-fallbacks: flip-block, flip-inline` for viewport edge handling
+- Remove `updatePosition()` JS method that currently uses `getBoundingClientRect()`
+- Remove `ResizeObserver` that recalculates position on layout changes (CSS Anchor Positioning handles this automatically)
+
+**Spotlight cutout**: The canvas-based spotlight rendering remains unchanged — it still uses `getBoundingClientRect()` to calculate the cutout position on the overlay canvas. Only the tooltip positioning migrates to CSS Anchor Positioning.
+
+**Browser support**: CSS Anchor Positioning is Baseline Newly Available (2026/01) — Chrome 125+, Firefox 147+, Safari 26+. Our PWA targets modern mobile browsers.
+
+### Decision 6: `isolation: isolate` for live-highway sticky date separator
+
+**Choice**: Add `isolation: isolate` to the `live-highway` scroll container. Remove `z-20` from the sticky date separator.
+
+**Rationale**: `position: sticky` elements within an `isolation: isolate` container paint above scrolled content naturally. The sticky element's stacking is relative to its scroll container, not the page — `isolation: isolate` formalizes this boundary.
+
+### Decision 7: Top Layer architecture — stacking by insertion order
+
+**Choice**: Document the intended Top Layer insertion order as the architectural contract replacing z-index.
+
+```
+Top Layer Stack (last = on top):
+─────────────────────────────────
+  coach-mark popover     ← showPopover() on tutorial activation
+  toast-notification     ← showPopover() per toast
+  <dialog> modals        ← showModal() on user action
+  bottom-nav-bar         ← showPopover() on app startup
+─────────────────────────────────
+  Normal stacking context (isolation: isolate per component)
+```
+
+- Bottom-nav is the first popover shown (app startup) — sits at the bottom of the Top Layer
+- Dialogs are shown on user interaction — paint above nav
+- Toasts are shown on events — paint above dialogs
+- Coach-mark is shown during tutorials — paints above everything
+
+If ordering conflicts arise, the fix is adjusting `showPopover()` / `showModal()` call timing, not adding z-index.
+
+## Risks / Trade-offs
+
+- **CSS Anchor Positioning browser support**: Newly Available as of 2026/01. Safari 26+ required. If targeting older Safari, the coach-mark tooltip falls back to existing JS positioning (progressive enhancement).
+- **`popover="manual"` on bottom-nav-bar**: The nav bar in the Top Layer is removed from normal document flow visually but remains in DOM flow. CSS `position: fixed` + `popover` may require testing across mobile browsers to ensure no layout shifts.
+- **Swipe-to-dismiss in `<dialog>`**: Touch event handlers on `event-detail-sheet` must work within the `<dialog>` element. Touch targets change from the fixed `<div>` to the `<dialog>` content area. Mobile Safari and Chrome testing required.
+- **`@starting-style` browser support**: Baseline 2026 — Chrome 117+, Safari 17.5+, Firefox 129+. The `<dialog>` is fully functional without animation; `@starting-style` is progressive enhancement.
+- **Test updates**: Tests querying `<div role="dialog">`, checking z-index classes, or verifying `class="fixed"` need updating to query `<dialog>` elements and check `[open]` attribute.
+- **Top Layer ordering is implicit**: No CSS property controls Top Layer order — it depends on JS call sequence. Document the intended order (Decision 7) and test for regressions if component initialization order changes.

--- a/openspec/changes/eliminate-z-index-stacking/proposal.md
+++ b/openspec/changes/eliminate-z-index-stacking/proposal.md
@@ -1,0 +1,49 @@
+## Why
+
+The Liverty Music frontend contains 26 `z-index` declarations across 11 files despite the `onboarding-guidance` spec explicitly prohibiting z-index in the discovery page CSS. Previous changes removed some instances but left exceptions for `bottom-nav-bar` (`z-30`), `coach-mark` (`z-9999`), and `discover-page.css` (7 instances). Modern Web Platform APIs (Popover API, CSS Anchor Positioning, `<dialog>`, `isolation: isolate`) — all Baseline 2026 — eliminate the need for any z-index. The Top Layer replaces numeric z-index wars with insertion-order stacking, and `isolation: isolate` handles component-internal layering.
+
+## What Changes
+
+- Remove all 7 `z-index` declarations from `discover-page.css`; use `isolation: isolate` for explicit stacking context
+- Remove all 6 `z-index` declarations from `loading-sequence.css`; use `isolation: isolate` (also handled by `remove-loading-sequence` change)
+- Migrate `event-detail-sheet`, `my-artists-page` overlays, `tickets-page` overlays, `signup-modal`, and `error-banner` from z-index overlays to `<dialog>` with `showModal()` Top Layer promotion
+- Migrate `bottom-nav-bar` from `z-30` to `popover="manual"` for Top Layer promotion without focus trapping
+- Migrate `toast-notification` from `z-50` to `popover="manual"` for Top Layer promotion with click-through
+- Migrate `coach-mark` from `z-9999` to `popover="manual"` + CSS Anchor Positioning for tooltip placement
+- Remove `z-20` from `live-highway` sticky date separator; use `isolation: isolate` on scroll container
+- Achieve zero z-index declarations in the entire frontend codebase
+
+## Capabilities
+
+### New Capabilities
+
+- `top-layer-architecture`: Document the Top Layer insertion order contract (bottom-nav < dialogs < toasts < coach-mark) as the replacement for z-index stacking
+
+### Modified Capabilities
+
+- `onboarding-guidance`: Enforce the existing "no z-index" requirement and extend it to the entire codebase
+- `concert-detail`: Event detail bottom sheet migrates from z-index overlay to `<dialog>` Top Layer
+- `my-artists`: Context menu and passion explanation modals migrate to `<dialog>` Top Layer
+- `app-shell-layout`: Bottom nav bar migrates from `z-30` to `popover="manual"` Top Layer; toast migrates to `popover="manual"`; no z-index exceptions remain
+- `onboarding-tutorial`: Coach mark migrates from `z-9999` to `popover="manual"` + CSS Anchor Positioning
+
+## Impact
+
+- `frontend/src/routes/discover/discover-page.css` — Remove 7 z-index, add `isolation: isolate`
+- `frontend/src/routes/onboarding-loading/loading-sequence.css` — Remove 6 z-index, add `isolation: isolate`
+- `frontend/src/components/live-highway/event-detail-sheet.html` — Convert to `<dialog>`
+- `frontend/src/components/live-highway/event-detail-sheet.ts` — Add `showModal()`/`close()` lifecycle
+- `frontend/src/routes/my-artists/my-artists-page.html` — Convert overlays to `<dialog>`
+- `frontend/src/routes/my-artists/my-artists-page.ts` — Add dialog lifecycle management
+- `frontend/src/routes/tickets/tickets-page.html` — Convert overlays to `<dialog>`
+- `frontend/src/routes/tickets/tickets-page.ts` — Add dialog lifecycle management
+- `frontend/src/components/signup-modal/signup-modal.html` — Convert to `<dialog>`
+- `frontend/src/components/error-banner/error-banner.html` — Convert to `<dialog>`
+- `frontend/src/components/bottom-nav-bar/bottom-nav-bar.html` — Add `popover="manual"`, remove `z-30`
+- `frontend/src/components/bottom-nav-bar/bottom-nav-bar.ts` — Add `showPopover()` on attached
+- `frontend/src/components/toast-notification/toast-notification.html` — Add `popover="manual"`, remove `z-50`
+- `frontend/src/components/toast-notification/toast-notification.ts` — Add `showPopover()`/`hidePopover()` lifecycle
+- `frontend/src/components/coach-mark/coach-mark.css` — Remove `z-index: 9999`
+- `frontend/src/components/coach-mark/coach-mark.ts` — Add `showPopover()`, replace `getBoundingClientRect()` with CSS Anchor Positioning
+- `frontend/src/components/coach-mark/coach-mark.html` — Add `popover="manual"`, CSS anchor attributes
+- `frontend/src/components/live-highway/live-highway.html` — Add `isolation: isolate` to scroll container, remove `z-20`

--- a/openspec/changes/eliminate-z-index-stacking/specs/app-shell-layout/spec.md
+++ b/openspec/changes/eliminate-z-index-stacking/specs/app-shell-layout/spec.md
@@ -1,16 +1,25 @@
-### Requirement: Retained z-index exceptions
+### Requirement: Persistent elements use Popover API for Top Layer promotion
 
-The application SHALL retain z-index on specific elements where the native `<dialog>` Top Layer is not an appropriate replacement. Each retained z-index usage SHALL have documented rationale.
+The application SHALL use `popover="manual"` to promote persistent non-modal elements to the Top Layer, replacing z-index-based stacking. Zero z-index declarations SHALL remain in the codebase.
 
-#### Scenario: Bottom navigation bar retains z-30
-- **WHEN** the bottom navigation bar renders
-- **THEN** it SHALL use `z-30` to sit above scrolling page content
-- **AND** this is retained because the nav bar is a persistent fixed element with no `<dialog>` equivalent
-- **AND** Top Layer dialogs (via `showModal()`) naturally paint above the nav bar without z-index conflicts
-- **AND** `::backdrop` pseudo-elements dim the nav bar correctly when a dialog is open
+#### Scenario: Bottom navigation bar uses popover for Top Layer promotion
+- **WHEN** the bottom navigation bar component attaches
+- **THEN** it SHALL use `popover="manual"` attribute and call `showPopover()` on attached
+- **AND** the `z-30` Tailwind class SHALL be removed
+- **AND** the nav bar SHALL paint above all non-Top-Layer content without z-index
+- **AND** Top Layer dialogs (via `showModal()`) SHALL naturally paint above the nav bar due to later insertion order
 
-#### Scenario: Coach mark retains z-9999
-- **WHEN** an onboarding coach mark is active
-- **THEN** it SHALL use `z-9999` to paint above all non-Top-Layer elements including the nav bar
-- **AND** this is retained because the coach mark is a non-modal spotlight overlay that must allow click-through on the highlighted element
-- **AND** `<dialog>` is not suitable because it would trap focus and block click-through interaction on the spotlight area
+#### Scenario: Toast notification uses popover for Top Layer promotion
+- **WHEN** a toast notification is displayed
+- **THEN** it SHALL use `popover="manual"` attribute and call `showPopover()` when shown
+- **AND** the `z-50` Tailwind class SHALL be removed
+- **AND** `pointer-events: none` SHALL remain on the container with `pointer-events: auto` on individual toast items
+- **AND** toast SHALL call `hidePopover()` + `showPopover()` to re-insert at the top of the Top Layer stack when a dialog is already open
+
+#### Scenario: Coach mark uses popover for Top Layer promotion
+- **WHEN** an onboarding coach mark is activated
+- **THEN** it SHALL use `popover="manual"` attribute and call `showPopover()` on activation
+- **AND** `z-index: 9999` SHALL be removed from `coach-mark.css`
+- **AND** `pointer-events: none` SHALL be applied to the overlay canvas with `pointer-events: auto` on dismiss/next buttons
+- **AND** click-through to the spotlighted element SHALL be handled by forwarding pointer events from the transparent canvas region via `elementFromPoint()` delegation
+- **AND** the tooltip SHALL use CSS Anchor Positioning (`position-anchor`, `position-area`) instead of `getBoundingClientRect()` JS calculations

--- a/openspec/changes/eliminate-z-index-stacking/specs/app-shell-layout/spec.md
+++ b/openspec/changes/eliminate-z-index-stacking/specs/app-shell-layout/spec.md
@@ -1,0 +1,16 @@
+### Requirement: Retained z-index exceptions
+
+The application SHALL retain z-index on specific elements where the native `<dialog>` Top Layer is not an appropriate replacement. Each retained z-index usage SHALL have documented rationale.
+
+#### Scenario: Bottom navigation bar retains z-30
+- **WHEN** the bottom navigation bar renders
+- **THEN** it SHALL use `z-30` to sit above scrolling page content
+- **AND** this is retained because the nav bar is a persistent fixed element with no `<dialog>` equivalent
+- **AND** Top Layer dialogs (via `showModal()`) naturally paint above the nav bar without z-index conflicts
+- **AND** `::backdrop` pseudo-elements dim the nav bar correctly when a dialog is open
+
+#### Scenario: Coach mark retains z-9999
+- **WHEN** an onboarding coach mark is active
+- **THEN** it SHALL use `z-9999` to paint above all non-Top-Layer elements including the nav bar
+- **AND** this is retained because the coach mark is a non-modal spotlight overlay that must allow click-through on the highlighted element
+- **AND** `<dialog>` is not suitable because it would trap focus and block click-through interaction on the spotlight area

--- a/openspec/changes/eliminate-z-index-stacking/specs/concert-detail/spec.md
+++ b/openspec/changes/eliminate-z-index-stacking/specs/concert-detail/spec.md
@@ -1,0 +1,30 @@
+### Requirement: Event detail bottom sheet uses native dialog
+
+The event detail bottom sheet SHALL use the native `<dialog>` element with `showModal()` for Top Layer promotion, instead of fixed-position `<div>` elements with z-index utilities.
+
+#### Scenario: Open detail from dashboard
+- **WHEN** a user taps a concert card on the dashboard
+- **THEN** the system SHALL open a `<dialog>` element via `showModal()`
+- **AND** the dialog SHALL be promoted to the browser's Top Layer
+- **AND** the `::backdrop` pseudo-element SHALL dim the page including the navigation bar
+- **AND** the dialog SHALL NOT use z-index utilities (`z-40`, `z-50`, or any `z-*` class)
+
+#### Scenario: Slide-up animation
+- **WHEN** the event detail dialog opens
+- **THEN** the dialog SHALL animate from `translateY(100%)` to `translateY(0)` with `opacity: 0` to `opacity: 1`
+- **AND** the animation SHALL use `@starting-style` for the entry transition (300ms ease-out)
+- **AND** the `::backdrop` SHALL fade in over the same duration
+
+#### Scenario: Dismiss via backdrop
+- **WHEN** the user taps the `::backdrop` area (outside the sheet content)
+- **THEN** the sheet SHALL close via `dialogElement.close()`
+- **AND** the URL SHALL revert to the dashboard URL
+
+#### Scenario: Dismiss via swipe-down
+- **WHEN** the user swipes down on the sheet content
+- **THEN** the sheet SHALL follow the touch gesture and dismiss when the drag exceeds the threshold
+- **AND** swipe-to-dismiss SHALL be suppressed during the onboarding DETAIL step (`isDismissBlocked`)
+
+#### Scenario: ESC key behavior during onboarding
+- **WHEN** the user presses ESC while the detail sheet is open during the onboarding DETAIL step
+- **THEN** the `cancel` event SHALL be suppressed and the dialog SHALL remain open

--- a/openspec/changes/eliminate-z-index-stacking/specs/my-artists/spec.md
+++ b/openspec/changes/eliminate-z-index-stacking/specs/my-artists/spec.md
@@ -1,0 +1,34 @@
+### Requirement: Context menu uses native dialog
+
+The grid view context menu (long-press on artist tile) SHALL use the native `<dialog>` element with `showModal()` for Top Layer promotion.
+
+#### Scenario: Long-press opens context menu dialog
+- **GIVEN** the Grid view is active
+- **WHEN** the user long-presses a tile
+- **THEN** a `<dialog>` SHALL open via `showModal()` with passion level options and an unfollow action
+- **AND** the dialog SHALL NOT use z-index utilities
+- **AND** the `::backdrop` pseudo-element SHALL dim the page
+
+#### Scenario: Context menu dismissal
+- **WHEN** the user taps the backdrop or presses ESC
+- **THEN** the context menu dialog SHALL close via `dialogElement.close()`
+
+#### Scenario: Context menu slide-up animation
+- **WHEN** the context menu dialog opens
+- **THEN** it SHALL animate from the bottom of the viewport using `@starting-style` (300ms ease-out)
+
+### Requirement: Passion explanation modal uses native dialog
+
+The passion level explanation modal (displayed during tutorial) SHALL use the native `<dialog>` element with `showModal()`.
+
+#### Scenario: Tutorial displays passion explanation
+- **WHEN** the tutorial triggers the passion explanation step
+- **THEN** a `<dialog>` SHALL open via `showModal()` with a centered explanation card
+- **AND** the dialog SHALL NOT use z-index utilities
+- **AND** the `::backdrop` SHALL dim the page with `oklch(0% 0 0 / 0.7)` opacity
+
+#### Scenario: Passion explanation is non-dismissible during tutorial
+- **WHEN** the passion explanation dialog is open during the tutorial
+- **THEN** the `cancel` event SHALL be suppressed (no ESC dismissal)
+- **AND** no close button or backdrop-click-to-close SHALL be provided
+- **AND** the dialog SHALL be closed programmatically when the tutorial step completes

--- a/openspec/changes/eliminate-z-index-stacking/specs/onboarding-guidance/spec.md
+++ b/openspec/changes/eliminate-z-index-stacking/specs/onboarding-guidance/spec.md
@@ -1,0 +1,23 @@
+### Requirement: No z-index stacking in discovery page CSS
+
+The discovery page SHALL NOT use `z-index` for visual stacking. All layer ordering SHALL be achieved through DOM source order.
+
+#### Scenario: Overlay elements paint above canvas
+- **WHEN** the discovery page renders
+- **THEN** the onboarding HUD, orb label, and complete button SHALL paint above the canvas
+- **AND** no CSS `z-index` property SHALL be present in the discovery page CSS
+
+#### Scenario: Starfield pseudo-element paints behind content
+- **WHEN** the discovery page renders
+- **THEN** the `.container::before` starfield SHALL paint behind all content elements
+- **AND** the starfield SHALL use `pointer-events: none` without `z-index`
+
+#### Scenario: Search bar and genre chips paint above canvas
+- **WHEN** the discovery page renders
+- **THEN** the search bar and genre filter chips SHALL paint above the bubble canvas area
+- **AND** stacking SHALL be achieved via DOM source order (search bar and genre chips appear after the canvas in DOM), not `z-index`
+
+#### Scenario: Search results paint above bubble area
+- **WHEN** the user enters a search query and results are displayed
+- **THEN** the search results list SHALL paint above the bubble area
+- **AND** stacking SHALL be achieved via DOM source order, not `z-index`

--- a/openspec/changes/eliminate-z-index-stacking/tasks.md
+++ b/openspec/changes/eliminate-z-index-stacking/tasks.md
@@ -1,0 +1,121 @@
+## 1. `isolation: isolate` for component-internal stacking
+
+### 1a. discover-page.css
+- [ ] Add `isolation: isolate` to `.container`
+- [ ] Remove `z-index` from `.container::before` (0), `.search-bar` (20), `.genre-chips` (15), `.orb-label` (15), `.search-results` (10), `.onboarding-hud` (20), `.complete-button-wrapper` (20)
+- [ ] Verify DOM source order produces correct layering: starfield `::before` < canvas < search bar < genre chips < onboarding HUD < complete button
+
+### 1b. loading-sequence.css
+- [ ] Add `isolation: isolate` to root wrapper element
+- [ ] Remove `z-index` from all 6 selectors (`.container::before` 0, `.pulsing-orb` 1, `.message-container` 1, `.step-dots` 1, `.step-label` 1, `.progress-label` 1)
+
+### 1c. live-highway sticky date separator
+- [ ] Add `isolation: isolate` to the scroll container in `live-highway.html`
+- [ ] Remove `z-20` from the sticky date separator element
+
+## 2. `<dialog>` + `showModal()` for modal overlays
+
+### 2a. event-detail-sheet
+- [ ] Replace backdrop `<div class="fixed inset-0 z-40 ...">` and sheet `<div class="fixed inset-x-0 bottom-0 z-50 ...">` with single `<dialog ref="dialogElement">`
+- [ ] Add `showModal()` in `open()` and `close()` in close method
+- [ ] Style `::backdrop` with `background: oklch(0% 0 0 / 0.6); backdrop-filter: blur(4px)`
+- [ ] Add `@starting-style` slide-up animation (translateY 100% to 0, 300ms ease-out)
+- [ ] Click-outside-to-close via `event.target === dialogElement`
+- [ ] Preserve swipe-to-dismiss touch handlers on `<dialog>` content area
+- [ ] Suppress `cancel` event when `isDismissBlocked` (onboarding DETAIL step)
+- [ ] Remove `z-40`, `z-50` classes and `if.bind="isOpen"` from backdrop
+
+### 2b. my-artists-page context menu
+- [ ] Replace `<div class="absolute inset-0 z-50 ...">` with `<dialog ref="contextMenuDialog">`
+- [ ] Call `showModal()` in `openContextMenu()`, `close()` in `closeContextMenu()`
+- [ ] Style `::backdrop`, add `@starting-style` slide-up animation
+- [ ] Handle backdrop click-to-close and ESC-to-close
+- [ ] Remove z-index classes and manual backdrop `<div>`
+
+### 2c. my-artists-page passion selector
+- [ ] Replace `z-50` passion selector overlay with `<dialog>`
+- [ ] Add `showModal()`/`close()` lifecycle
+
+### 2d. my-artists-page passion explanation
+- [ ] Replace `<div class="absolute inset-0 z-[60] ...">` with `<dialog ref="passionExplanationDialog">`
+- [ ] Suppress `cancel` event (non-dismissible tutorial modal)
+- [ ] Style `::backdrop` with `background: oklch(0% 0 0 / 0.7)` (matching `bg-black/70`)
+- [ ] Auto-close when tutorial step completes
+
+### 2e. tickets-page QR modal
+- [ ] Replace `<div role="dialog" aria-modal="true" class="fixed inset-0 z-50 ...">` with `<dialog ref="qrDialog">`
+- [ ] Remove manual `role="dialog"`, `aria-modal="true"`, `tabindex="-1"`, `keydown.trigger` (native `<dialog>` provides all)
+- [ ] Call `showModal()` when QR data available, `close()` in `dismissQr()`
+- [ ] Style `::backdrop` for dark blur overlay
+
+### 2f. tickets-page proof generation
+- [ ] Replace `<div role="alert" class="fixed inset-0 z-50 ...">` with `<dialog ref="generatingDialog">`
+- [ ] Suppress `cancel` event (non-dismissible during generation)
+- [ ] Retain `role="alert"` and `aria-live="polite"` on inner content
+- [ ] Auto-close when generation completes
+
+### 2g. signup-modal
+- [ ] Replace `z-[70]` wrapper with `<dialog>`
+- [ ] Suppress `cancel` event (non-dismissible)
+- [ ] Style `::backdrop`
+
+### 2h. error-banner
+- [ ] Replace `z-[100]` wrapper with `<dialog>`
+- [ ] Style `::backdrop`, add auto-dismiss behavior
+
+## 3. `popover="manual"` for persistent non-modal elements
+
+### 3a. bottom-nav-bar
+- [ ] Add `popover="manual"` attribute to nav container element
+- [ ] Call `this.navElement.showPopover()` in `attached()` lifecycle
+- [ ] Remove `z-30` class
+- [ ] Verify nav bar remains visible across route navigations
+- [ ] Verify `<dialog>` modals paint above nav bar (later Top Layer insertion)
+
+### 3b. toast-notification
+- [ ] Add `popover="manual"` attribute to toast container
+- [ ] Call `showPopover()` when toast displayed, `hidePopover()` when dismissed
+- [ ] Remove `z-50` class
+- [ ] Retain `pointer-events: none` on container with `pointer-events: auto` on toast items
+- [ ] Verify toasts paint above dialogs and nav bar
+
+### 3c. coach-mark overlay
+- [ ] Add `popover="manual"` to `.coach-mark-overlay` element
+- [ ] Call `showPopover()` on activation, `hidePopover()` on dismissal
+- [ ] Remove `z-index: 9999` from `coach-mark.css`
+- [ ] Verify overlay paints above all other Top Layer elements (latest insertion)
+- [ ] Verify click-through on spotlight area still works
+
+## 4. CSS Anchor Positioning for coach-mark tooltip
+
+- [ ] Set `anchor-name: --coach-target` dynamically on the target element via `style.anchorName`
+- [ ] Set `position-anchor: --coach-target` on the tooltip element
+- [ ] Use `position-area` for placement direction (top/bottom/left/right of target)
+- [ ] Add `position-try-fallbacks: flip-block, flip-inline` for viewport edge handling
+- [ ] Remove `updatePosition()` JS method that uses `getBoundingClientRect()` for tooltip positioning
+- [ ] Remove `ResizeObserver` for tooltip position recalculation (CSS handles this automatically)
+- [ ] Keep `getBoundingClientRect()` for spotlight canvas cutout rendering (canvas cannot use CSS positioning)
+
+## 5. Tests
+
+- [ ] Update `event-detail-sheet` tests: query `<dialog>`, verify `[open]` attribute
+- [ ] Update `my-artists-page` tests: verify context menu and passion dialogs
+- [ ] Update `tickets-page` tests: verify QR dialog and generation overlay
+- [ ] Add `bottom-nav-bar` test: verify `popover="manual"` attribute and visibility
+- [ ] Add `toast-notification` test: verify popover show/hide lifecycle
+- [ ] Add `coach-mark` test: verify popover activation and CSS anchor attributes
+- [ ] Verify swipe-to-dismiss on `event-detail-sheet` `<dialog>`
+- [ ] Verify dismiss-block suppresses ESC during onboarding DETAIL step
+
+## 6. Verification
+
+- [ ] Run `make check` in frontend repo (lint + test)
+- [ ] `grep -rn 'z-index' frontend/src/` — expect 0 results
+- [ ] `grep -rn 'z-[0-9]\|z-\[' frontend/src/` — expect 0 Tailwind z-index classes
+- [ ] Visual: discover page layers correctly (starfield behind, UI above canvas)
+- [ ] Visual: event detail sheet slides up as `<dialog>`, backdrop dims including nav bar
+- [ ] Visual: bottom nav bar visible via popover, dialogs paint above it
+- [ ] Visual: toast notifications appear above dialogs
+- [ ] Visual: coach-mark overlay and tooltip position correctly via Anchor Positioning
+- [ ] Visual: coach-mark paints above all other elements
+- [ ] Test on mobile Safari and Chrome for popover + fixed position behavior

--- a/openspec/changes/fix-prompt-timing/.openspec.yaml
+++ b/openspec/changes/fix-prompt-timing/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-05

--- a/openspec/changes/fix-prompt-timing/design.md
+++ b/openspec/changes/fix-prompt-timing/design.md
@@ -1,0 +1,86 @@
+## Context
+
+The PWA install banner and push notification prompt currently appear during the onboarding tutorial (as early as Step 3 - Dashboard) before the user has created an account or completed the guided flow. Neither prompt checks authentication or onboarding state, so they compete visually with coach marks and the region selector, and ask for permissions before the user understands the service's value.
+
+The onboarding tutorial is designed as a linear 7-step funnel: Steps 1-5 build motivation, Step 6 prompts sign-up, and Step 7 marks completion. Permission prompts should only appear after this funnel completes, and they should not stack on top of each other.
+
+Currently:
+- `PwaInstallService.evaluateVisibility()` only checks `sessionCount >= 2` and `!isDismissed` -- no onboarding or auth awareness.
+- `NotificationPrompt.attached()` only checks `!dismissed` and `permission !== 'granted'` -- no onboarding or auth awareness.
+- `<notification-prompt>` is placed in `dashboard.html` (route-level), so it renders during Step 3 of onboarding when the user lands on the dashboard for the first time.
+- Both prompts can appear simultaneously in the same session.
+
+## Goals / Non-Goals
+
+### Goals
+
+- Prevent both prompts from appearing during onboarding Steps 1-6.
+- Ensure notification prompt only appears for authenticated users.
+- Show at most one permission prompt per session to avoid overwhelming the user.
+- Show the notification prompt first (highest-motivation moment) and defer PWA install to a later session.
+- Move `<notification-prompt>` to the app shell so it is not tied to a specific route.
+
+### Non-Goals
+
+- Changing the visual design of either prompt (deferred to a separate change).
+- Removing z-index from prompts (neither prompt uses z-index today).
+- Changing onboarding step numbers or the tutorial flow itself.
+- Modifying the notification permission or PWA install browser APIs.
+
+## Decisions
+
+### Decision 1: Inject IOnboardingService and IAuthService into PwaInstallService
+
+`PwaInstallService.evaluateVisibility()` will additionally require `onboarding.isCompleted === true` before setting `canShow = true`. This ensures the PWA install banner never appears during the tutorial or before authentication (since `isCompleted` requires Step 7, which requires successful sign-up at Step 6).
+
+The service already uses Aurelia DI (`DI.createInterface` + singleton registration), so adding `IOnboardingService` and `IAuthService` as constructor dependencies follows the established pattern.
+
+### Decision 2: Move notification-prompt from dashboard.html to my-app.html
+
+Currently `<notification-prompt>` is imported and rendered in `dashboard.html`. This means it only appears on the dashboard route and renders during onboarding Step 3 when the user first sees the dashboard.
+
+The prompt will move to `my-app.html` (the app shell), gated by three conditions:
+- `auth.isAuthenticated` -- user has signed in
+- `onboarding.isCompleted` -- tutorial is finished (Step 7)
+- `showNav` -- the user is on a post-onboarding route (not landing page, loading, etc.)
+
+This keeps the prompt visible across all authenticated post-onboarding routes, not just the dashboard.
+
+### Decision 3: Create a PromptCoordinator singleton service
+
+A new `PromptCoordinator` service will be registered as a DI singleton to enforce the "max 1 permission prompt per session" rule. It tracks:
+- Whether any prompt has already been shown this session (in-memory flag, resets on page reload).
+- Which prompt type was shown (to prevent a second prompt from appearing).
+
+Both `PwaInstallService` and `NotificationPrompt` will call `promptCoordinator.canShowPrompt('pwa-install')` or `promptCoordinator.canShowPrompt('notification')` before displaying. Once a prompt is shown, `promptCoordinator.markShown('notification')` locks out other prompts for the session.
+
+The coordinator does not persist state to LocalStorage -- it is session-scoped (in-memory). Each new browser session (page load) resets the coordinator, allowing a different prompt to appear.
+
+### Decision 4: Notification prompt gets first-session priority
+
+The notification prompt is shown on the first eligible session after onboarding completion (Step 7). At this point, the user has just signed up, motivation is highest, and push notification opt-in has the best conversion rate.
+
+The PWA install prompt is deferred to `sessionCount >= completedSessionCount + 2`, where `completedSessionCount` is the session count at the time of onboarding completion (persisted to LocalStorage). This gives the notification prompt a clear window on the first post-completion session, and the PWA install prompt appears on a subsequent session when the user has returned and demonstrated retention.
+
+Priority enforcement:
+- `PromptCoordinator` assigns priority: notification > PWA install.
+- If notification prompt is eligible, it wins. PWA install waits for the next session.
+- If notification prompt was already dismissed or permission already granted, PWA install becomes eligible.
+
+## Risks / Trade-offs
+
+### Risk: User never sees PWA install prompt if they dismiss notification and do not return
+
+If the user dismisses the notification prompt on their first post-completion session and never returns for a second session, they will not see the PWA install prompt. This is acceptable because a user who does not return is unlikely to install the PWA anyway. The existing `isDismissed` persistence in LocalStorage already handles this case.
+
+### Risk: Session count drift if user clears localStorage
+
+If the user clears LocalStorage, both `sessionCount` and `completedSessionCount` reset. The onboarding service would also reset to Step 0, so the user would re-enter the tutorial. This is existing behavior and not worsened by this change.
+
+### Trade-off: Additional DI dependencies in PwaInstallService
+
+Adding `IOnboardingService` and `IAuthService` as dependencies increases coupling. However, the alternative (event-based decoupling) adds complexity without meaningful benefit given the small service graph. The direct dependency is simpler and easier to test with mock injection.
+
+### Trade-off: PromptCoordinator is session-scoped only
+
+The coordinator uses in-memory state, so it resets on every page load. This means if a user reloads the page mid-session, the prompt could theoretically re-appear. This is acceptable because: (1) the dismiss flags in LocalStorage prevent re-showing dismissed prompts, and (2) a page reload is effectively a new session from the user's perspective.

--- a/openspec/changes/fix-prompt-timing/proposal.md
+++ b/openspec/changes/fix-prompt-timing/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+The PWA install banner and push notification prompt appear during onboarding (Step 3 Dashboard) before the user has created an account or completed the tutorial. This disrupts the guided onboarding flow, competes visually with coach marks and the region selector, and asks for permissions before the user has experienced the value of the service. The onboarding was designed to build motivation through Steps 1-5 before requesting sign-up (Step 6) and notification permission (Step 7), but neither prompt checks onboarding or authentication state.
+
+## What Changes
+
+- Add `onboarding.isCompleted` guard to `PwaInstallService.evaluateVisibility()` so the PWA install banner never appears during the tutorial (Steps 1-6)
+- Add `authService.isAuthenticated` and `onboarding.isCompleted` guards to `NotificationPrompt` so the push notification prompt only appears after account creation
+- Move `<notification-prompt>` from `dashboard.html` (route-level) to `my-app.html` (app shell level), gated by authentication and onboarding completion state
+- Introduce a `PromptCoordinator` service to ensure only one prompt (PWA install or notification) is shown per session, preventing simultaneous display
+- Show notification prompt on the first session after Step 7 completion (motivation is highest), and PWA install on a subsequent session
+
+## Capabilities
+
+### New Capabilities
+
+- `prompt-timing`: Rules for when PWA install and push notification prompts are eligible to display, including authentication, onboarding, and session-based guards
+
+### Modified Capabilities
+
+- `onboarding-tutorial`: Add requirement that no permission prompts (PWA install, push notification) SHALL appear during onboarding Steps 1-6
+- `app-shell-layout`: Notification prompt moves from dashboard route to app shell, gated by auth + onboarding state
+
+## Impact
+
+- `frontend/src/services/pwa-install-service.ts` — Add onboarding dependency and guard
+- `frontend/src/components/notification-prompt/notification-prompt.ts` — Add auth + onboarding guards
+- `frontend/src/routes/dashboard.html` — Remove `<notification-prompt>` import and usage
+- `frontend/src/my-app.html` — Add `<notification-prompt>` with conditional display
+- `frontend/src/services/` — New `PromptCoordinator` service for single-prompt-per-session logic

--- a/openspec/changes/fix-prompt-timing/specs/app-shell-layout/spec.md
+++ b/openspec/changes/fix-prompt-timing/specs/app-shell-layout/spec.md
@@ -1,0 +1,28 @@
+# App Shell Layout -- Delta (fix-prompt-timing)
+
+## MODIFIED Requirements
+
+### Requirement: Notification Prompt Placement (MODIFIED)
+
+The notification prompt SHALL be rendered at the app shell level (`my-app.html`) rather than within the dashboard route template. This ensures the prompt is available on any post-onboarding route, not only the dashboard.
+
+#### Scenario: Notification prompt rendered in app shell when eligible
+
+- **WHEN** the user is authenticated (`auth.isAuthenticated === true`)
+- **AND** onboarding is completed (`onboarding.isCompleted === true`)
+- **AND** the navigation bar is visible (`showNav === true`)
+- **THEN** the system SHALL render the `<notification-prompt>` component in the app shell
+- **AND** the prompt SHALL appear above the main content area, below any app-level banners
+
+#### Scenario: Notification prompt hidden during onboarding routes
+
+- **WHEN** the user is on a fullscreen route (Landing Page, Loading Sequence, Auth Callback)
+- **OR** the user is not authenticated
+- **OR** onboarding is not completed
+- **THEN** the system SHALL NOT render the `<notification-prompt>` component
+
+#### Scenario: Notification prompt removed from dashboard route
+
+- **WHEN** the dashboard route template is rendered
+- **THEN** the template SHALL NOT contain a `<notification-prompt>` element
+- **AND** the notification prompt import SHALL be removed from the dashboard template

--- a/openspec/changes/fix-prompt-timing/specs/onboarding-tutorial/spec.md
+++ b/openspec/changes/fix-prompt-timing/specs/onboarding-tutorial/spec.md
@@ -1,0 +1,25 @@
+# Onboarding Tutorial -- Delta (fix-prompt-timing)
+
+## ADDED Requirements
+
+### Requirement: No Permission Prompts During Onboarding Steps 1-6
+
+The system SHALL suppress all permission prompts (PWA install banner, push notification opt-in) while the user is progressing through onboarding Steps 1-6. Permission prompts are deferred until after Step 7 (COMPLETED).
+
+#### Scenario: PWA install suppressed during tutorial
+
+- **WHEN** the user is at any onboarding step between 1 and 6
+- **AND** the browser fires the `beforeinstallprompt` event
+- **THEN** the system SHALL capture the event for later use
+- **BUT** the system SHALL NOT display the PWA install banner
+
+#### Scenario: Notification prompt suppressed during tutorial
+
+- **WHEN** the user is at any onboarding step between 1 and 6
+- **THEN** the system SHALL NOT render or evaluate the notification prompt component
+
+#### Scenario: Prompts become eligible after completion
+
+- **WHEN** the user completes Step 6 and transitions to Step 7 (COMPLETED)
+- **THEN** permission prompts SHALL become eligible according to the prompt-timing capability rules
+- **AND** the onboarding tutorial SHALL NOT block prompt display after this point

--- a/openspec/changes/fix-prompt-timing/specs/prompt-timing/spec.md
+++ b/openspec/changes/fix-prompt-timing/specs/prompt-timing/spec.md
@@ -1,0 +1,159 @@
+# Prompt Timing
+
+## Purpose
+
+Defines the eligibility rules for displaying PWA install and push notification permission prompts. Prompts are gated by authentication state, onboarding completion, session count, and a per-session single-prompt constraint to avoid overwhelming the user.
+
+## Requirements
+
+### Requirement: PWA Install Prompt Blocked During Onboarding
+
+The system SHALL NOT display the PWA install prompt while the user is in onboarding Steps 1-6.
+
+#### Scenario: User is mid-tutorial on the dashboard (Step 3)
+
+- **WHEN** the user is at onboarding Step 3 (Dashboard)
+- **AND** the browser fires the `beforeinstallprompt` event
+- **THEN** the system SHALL capture the event
+- **AND** the system SHALL NOT display the PWA install banner
+- **AND** `PwaInstallService.canShow` SHALL remain `false`
+
+#### Scenario: User has not started onboarding (Step 0)
+
+- **WHEN** the user is at onboarding Step 0 (LP)
+- **AND** the browser fires the `beforeinstallprompt` event
+- **THEN** the system SHALL NOT display the PWA install banner
+
+---
+
+### Requirement: Notification Prompt Blocked When Not Authenticated
+
+The system SHALL NOT display the push notification prompt when the user is not authenticated.
+
+#### Scenario: Anonymous user on dashboard during tutorial
+
+- **WHEN** the user is not authenticated
+- **AND** the user is on the dashboard route
+- **THEN** the system SHALL NOT display the notification prompt
+
+#### Scenario: Authenticated user after onboarding
+
+- **WHEN** the user is authenticated
+- **AND** onboarding is completed (Step 7)
+- **THEN** the notification prompt MAY be eligible to display (subject to other guards)
+
+---
+
+### Requirement: Notification Prompt Blocked During Onboarding
+
+The system SHALL NOT display the push notification prompt during onboarding Steps 1-6.
+
+#### Scenario: User at Step 5 (My Artists) before sign-up
+
+- **WHEN** the user is at onboarding Step 5
+- **THEN** the system SHALL NOT display the notification prompt
+- **AND** the notification prompt component SHALL not evaluate visibility
+
+---
+
+### Requirement: Single Prompt Per Session
+
+The system SHALL display at most one permission prompt (PWA install or push notification) per browser session.
+
+#### Scenario: Notification prompt shown first
+
+- **WHEN** the notification prompt has been displayed in the current session
+- **AND** the PWA install prompt becomes eligible
+- **THEN** the system SHALL NOT display the PWA install prompt in the same session
+
+#### Scenario: PWA install prompt shown first
+
+- **WHEN** the PWA install prompt has been displayed in the current session
+- **AND** the notification prompt becomes eligible
+- **THEN** the system SHALL NOT display the notification prompt in the same session
+
+#### Scenario: New session resets prompt allowance
+
+- **WHEN** the user reloads the page or opens a new browser session
+- **THEN** the single-prompt-per-session constraint SHALL reset
+- **AND** one prompt MAY be shown again (subject to dismissal and eligibility rules)
+
+---
+
+### Requirement: Notification Prompt Priority Over PWA Install
+
+The notification prompt SHALL have higher priority than the PWA install prompt. When both prompts are eligible in the same session, the notification prompt SHALL be displayed.
+
+#### Scenario: Both prompts eligible on first post-completion session
+
+- **WHEN** the user has completed onboarding
+- **AND** notification permission is not yet granted
+- **AND** the notification prompt has not been dismissed
+- **AND** the PWA install prompt is also eligible
+- **THEN** the system SHALL display the notification prompt
+- **AND** the system SHALL NOT display the PWA install prompt
+
+#### Scenario: Notification prompt already dismissed
+
+- **WHEN** the user has previously dismissed the notification prompt
+- **AND** the PWA install prompt is eligible
+- **THEN** the system SHALL display the PWA install prompt
+
+---
+
+### Requirement: Notification Prompt Eligible on First Post-Completion Session
+
+The notification prompt SHALL be eligible to display on the first session after onboarding completion (Step 7), when user motivation is highest.
+
+#### Scenario: User completes onboarding and returns
+
+- **WHEN** the user has completed onboarding (Step 7)
+- **AND** the user starts a new session (page load)
+- **AND** the user is authenticated
+- **AND** the notification prompt has not been dismissed
+- **AND** notification permission is not `granted`
+- **THEN** the system SHALL display the notification prompt
+
+#### Scenario: User completes onboarding within the same session
+
+- **WHEN** the user completes Step 6 and transitions to Step 7 within the current session
+- **THEN** the system SHALL NOT display any prompt in the same session as completion
+- **AND** the prompt SHALL be eligible starting from the next session
+
+---
+
+### Requirement: PWA Install Prompt Deferred to Second Post-Completion Session
+
+The PWA install prompt SHALL be eligible starting from the second session after onboarding completion, giving the notification prompt a clear first-session window.
+
+#### Scenario: First session after completion
+
+- **WHEN** the user is on the first session after onboarding completion
+- **AND** the `beforeinstallprompt` event has fired
+- **THEN** the system SHALL NOT display the PWA install prompt (notification prompt has priority)
+
+#### Scenario: Second session after completion
+
+- **WHEN** the user is on the second or later session after onboarding completion
+- **AND** the `beforeinstallprompt` event has fired
+- **AND** the PWA install prompt has not been dismissed
+- **AND** no other prompt has been shown this session
+- **THEN** the system SHALL display the PWA install prompt
+
+---
+
+### Requirement: Dismissed Prompts Do Not Reappear
+
+When the user dismisses a prompt, the system SHALL persist the dismissal and SHALL NOT show that prompt again. This is existing behavior preserved by this change.
+
+#### Scenario: User dismisses notification prompt
+
+- **WHEN** the user taps the dismiss control on the notification prompt
+- **THEN** the system SHALL write the dismissal to LocalStorage
+- **AND** the notification prompt SHALL NOT appear on subsequent sessions
+
+#### Scenario: User dismisses PWA install prompt
+
+- **WHEN** the user taps the dismiss control on the PWA install prompt
+- **THEN** the system SHALL write the dismissal to LocalStorage
+- **AND** the PWA install prompt SHALL NOT appear on subsequent sessions

--- a/openspec/changes/fix-prompt-timing/tasks.md
+++ b/openspec/changes/fix-prompt-timing/tasks.md
@@ -1,0 +1,59 @@
+## 1. Create PromptCoordinator Service
+
+- [ ] 1.1 Create `frontend/src/services/prompt-coordinator.ts` with `IPromptCoordinator` DI interface and `PromptCoordinator` singleton class
+- [ ] 1.2 Implement in-memory `shownPromptType: string | null` field that tracks which prompt (if any) has been displayed this session
+- [ ] 1.3 Implement `canShowPrompt(type: 'notification' | 'pwa-install'): boolean` -- returns `true` only if no prompt has been shown this session
+- [ ] 1.4 Implement `markShown(type: 'notification' | 'pwa-install'): void` -- records the prompt type shown this session
+- [ ] 1.5 Implement priority logic: if both prompts query eligibility, notification wins (notification prompt checks first due to attached lifecycle running before PwaInstallService re-evaluation)
+- [ ] 1.6 Register `IPromptCoordinator` in `main.ts` DI container
+
+## 2. Update PwaInstallService with Guards
+
+- [ ] 2.1 Add `IOnboardingService` as a constructor dependency via `resolve(IOnboardingService)`
+- [ ] 2.2 Add `IAuthService` as a constructor dependency via `resolve(IAuthService)`
+- [ ] 2.3 Add `IPromptCoordinator` as a constructor dependency via `resolve(IPromptCoordinator)`
+- [ ] 2.4 Update `evaluateVisibility()` to require `this.onboarding.isCompleted === true`
+- [ ] 2.5 Update `evaluateVisibility()` to require `this.auth.isAuthenticated === true`
+- [ ] 2.6 Update `evaluateVisibility()` to require `this.promptCoordinator.canShowPrompt('pwa-install') === true`
+- [ ] 2.7 Persist `completedSessionCount` to LocalStorage when onboarding completes, and gate PWA install on `sessionCount >= completedSessionCount + 2`
+- [ ] 2.8 Call `this.promptCoordinator.markShown('pwa-install')` when `canShow` transitions to `true`
+
+## 3. Update NotificationPrompt with Guards
+
+- [ ] 3.1 Add `IAuthService` as a dependency via `resolve(IAuthService)`
+- [ ] 3.2 Add `IOnboardingService` as a dependency via `resolve(IOnboardingService)`
+- [ ] 3.3 Add `IPromptCoordinator` as a dependency via `resolve(IPromptCoordinator)`
+- [ ] 3.4 Update `attached()` to return early if `!this.auth.isAuthenticated`
+- [ ] 3.5 Update `attached()` to return early if `!this.onboarding.isCompleted`
+- [ ] 3.6 Update `attached()` to return early if `!this.promptCoordinator.canShowPrompt('notification')`
+- [ ] 3.7 Call `this.promptCoordinator.markShown('notification')` when `isVisible` is set to `true`
+
+## 4. Move Notification Prompt to App Shell
+
+- [ ] 4.1 Remove `<import from="../components/notification-prompt/notification-prompt">` from `dashboard.html`
+- [ ] 4.2 Remove `<notification-prompt>` element from `dashboard.html`
+- [ ] 4.3 Add `<import from="./components/notification-prompt/notification-prompt">` to `my-app.html`
+- [ ] 4.4 Add `<notification-prompt if.bind="auth.isAuthenticated && onboarding.isCompleted && showNav">` to `my-app.html`, placed after `<pwa-install-prompt>` and before `<main>`
+- [ ] 4.5 Inject `IAuthService` into `MyApp` class (add `private readonly auth = resolve(IAuthService)`)
+- [ ] 4.6 Verify `IOnboardingService` is already injected in `MyApp` (it is -- `this.onboarding`)
+
+## 5. Tests
+
+- [ ] 5.1 Unit test `PromptCoordinator`: verify `canShowPrompt` returns `true` initially, `false` after `markShown` for a different type
+- [ ] 5.2 Unit test `PromptCoordinator`: verify `canShowPrompt` returns `false` for any type after another type is marked shown
+- [ ] 5.3 Unit test `PwaInstallService`: verify `canShow` remains `false` when `onboarding.isCompleted` is `false`
+- [ ] 5.4 Unit test `PwaInstallService`: verify `canShow` remains `false` when `auth.isAuthenticated` is `false`
+- [ ] 5.5 Unit test `PwaInstallService`: verify `canShow` remains `false` when `promptCoordinator.canShowPrompt` returns `false`
+- [ ] 5.6 Unit test `PwaInstallService`: verify `canShow` becomes `true` when all guards pass and `sessionCount >= completedSessionCount + 2`
+- [ ] 5.7 Unit test `NotificationPrompt`: verify `isVisible` remains `false` when `auth.isAuthenticated` is `false`
+- [ ] 5.8 Unit test `NotificationPrompt`: verify `isVisible` remains `false` when `onboarding.isCompleted` is `false`
+- [ ] 5.9 Unit test `NotificationPrompt`: verify `isVisible` becomes `true` when all guards pass and notification permission is not `granted`
+
+## 6. Verification
+
+- [ ] 6.1 Run `make lint` in frontend to confirm no lint errors
+- [ ] 6.2 Run `make test` in frontend to confirm all unit tests pass
+- [ ] 6.3 Manual test: start fresh (clear LocalStorage), walk through onboarding Steps 1-6 -- confirm no prompts appear
+- [ ] 6.4 Manual test: complete onboarding, reload page -- confirm notification prompt appears (not PWA install)
+- [ ] 6.5 Manual test: dismiss notification prompt, reload page again -- confirm PWA install prompt appears on subsequent eligible session
+- [ ] 6.6 Manual test: verify both prompts never appear simultaneously in the same session

--- a/openspec/changes/polish-onboarding-prompts/.openspec.yaml
+++ b/openspec/changes/polish-onboarding-prompts/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-05

--- a/openspec/changes/polish-onboarding-prompts/design.md
+++ b/openspec/changes/polish-onboarding-prompts/design.md
@@ -1,0 +1,76 @@
+## Context
+
+The onboarding flow uses spring easing, staggered fade-slide-up, and layered effects throughout the tutorial steps. However, three key UI elements -- the PWA install banner, the notification prompt, and the sign-up modal -- appear and disappear instantly with no animation. This visual inconsistency makes the prompts feel mechanical and disruptive compared to the polished tutorial flow.
+
+Additionally, the PWA install banner has hardcoded English text (no i18n support), and the Step 5 Passion Level explanation has a 3-second silent delay before appearing, leaving the user waiting with no visual feedback that their tap registered.
+
+The existing codebase already defines a `fade-slide-up` keyframe in `my-app.css` (opacity 0 -> 1, translateY 16px -> 0) and a `prefers-reduced-motion` media query that disables all animations.
+
+## Goals / Non-Goals
+
+### Goals
+
+- Unify entrance/exit animation style across all onboarding prompts and modals.
+- Localize PWA install banner text via i18n keys.
+- Reduce perceived latency on Step 5 passion explanation by providing immediate tap feedback and shortening the delay.
+
+### Non-Goals
+
+- Changing prompt display logic or sequencing (that belongs to a separate change controlling when prompts appear).
+- Changing prompt content beyond adding i18n key references for the PWA banner.
+- Redesigning the sign-up modal layout or content.
+- Adding new animation infrastructure -- reuse existing keyframes and the `prefers-reduced-motion` guard.
+
+## Decisions
+
+### Decision 1: Reuse `fade-slide-up` for prompt entrance; add `fade-slide-down` for exit
+
+The `fade-slide-up` keyframe already exists in `my-app.css` with `translateY(16px) -> 0` and `opacity 0 -> 1`. Both the notification prompt and the PWA install prompt will use this keyframe for entrance animation at 600ms with ease-out timing.
+
+A corresponding `fade-slide-down` keyframe will be added for exit animations (`translateY(0) -> 16px`, `opacity 1 -> 0`). Both keyframes are wrapped in the existing `prefers-reduced-motion` guard.
+
+The prompts will be wrapped in a container element that triggers the animation class on Aurelia's `if.bind` mount/unmount cycle, ensuring animations play each time the prompt appears or is dismissed.
+
+### Decision 2: Sign-up modal uses scale + fade entrance with radial glow
+
+The sign-up modal entrance will use `scale(0.95) -> scale(1)` combined with `opacity 0 -> 1` over 400ms with cubic-bezier spring easing (`cubic-bezier(0.34, 1.56, 0.64, 1)`), matching the Discover HUD style already used in the onboarding flow.
+
+A subtle radial gradient glow will be added behind the modal content panel using a CSS pseudo-element (`::before`) with the brand-primary color at low opacity, providing a warm highlight effect consistent with the `--shadow-card-glow` token used elsewhere.
+
+### Decision 3: PWA banner i18n keys under `pwa.*` namespace
+
+All hardcoded English text in the PWA install prompt template will be replaced with i18n key references using Aurelia's `t` binding attribute. The keys follow the existing namespace convention (e.g., `notification.*` for the notification prompt):
+
+| Key               | English value                                                        |
+|--------------------|----------------------------------------------------------------------|
+| `pwa.title`        | Add to Home Screen                                                   |
+| `pwa.description`  | Install Liverty Music for faster access and offline browsing.        |
+| `pwa.install`      | Install                                                              |
+| `pwa.notNow`       | Not now                                                              |
+
+Keys must be added to all supported locale files under `frontend/src/locales/`.
+
+### Decision 4: Step 5 passion explanation -- immediate feedback + 800ms delay
+
+The current 3000ms `setTimeout` in `my-artists-page.ts` (line 336-341) will be reduced to 800ms. Before the timeout fires, an immediate visual feedback animation will play on the passion button the user tapped -- a brief highlight/pulse effect (scale 1 -> 1.1 -> 1 over ~300ms) -- confirming the selection registered. This eliminates the 3-second "dead zone" where nothing visually responds to the user's action.
+
+The explanation modal itself appears after 800ms, giving just enough time for the pulse to complete before the next piece of UI appears.
+
+## Risks / Trade-offs
+
+### Animation on `if.bind` unmount timing
+
+Aurelia's `if.bind` removes elements from the DOM immediately when the condition becomes false. Exit animations require the element to remain in the DOM during the animation. This will need either:
+- Using `au-animate` with the Aurelia animation plugin, or
+- Using `show.bind` (which toggles `display` rather than removing from DOM) with CSS animation classes, or
+- A wrapper component that delays DOM removal until the exit animation completes.
+
+The simplest approach is `show.bind` with CSS animation classes toggled via a state property, but this keeps the element in the DOM at all times. Given these are lightweight prompt elements, the DOM cost is negligible.
+
+### Reduced-motion compliance
+
+All new animations must be covered by the existing `@media (prefers-reduced-motion: reduce)` rule in `my-app.css`. The current rule targets `[class*="animate-"]` selectors. New animation classes must follow this naming convention or be explicitly added to the media query.
+
+### 800ms delay may still feel slow on fast interactions
+
+The 800ms delay is a compromise. Shorter delays risk the explanation modal appearing before the user has processed the passion level change. The immediate pulse animation bridges the gap, but user testing may reveal a need to adjust.

--- a/openspec/changes/polish-onboarding-prompts/proposal.md
+++ b/openspec/changes/polish-onboarding-prompts/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+The PWA install banner, notification prompt, and sign-up modal all lack entrance/exit animations, appearing and disappearing instantly. This is inconsistent with the rest of the onboarding flow, which uses spring easing (800ms cubic-bezier), staggered fade-slide-up, and layered effects. The contrast makes prompts feel mechanical and disruptive. Additionally, the PWA banner has hardcoded English text (no i18n), and the Step 5 Passion Level explanation has a 3-second silent delay before appearing.
+
+## What Changes
+
+- Add `fade-slide-up` entrance and `fade-slide-down` exit animations to `notification-prompt` and `pwa-install-prompt` components, matching the design system's spring easing
+- Enhance the sign-up modal (Step 6) with a scale+fade entrance animation and a subtle background glow, matching the visual polish of the Discover HUD
+- Localize all PWA install banner text via i18n keys (`pwa.title`, `pwa.description`, `pwa.install`, `pwa.notNow`)
+- Replace the Step 5 Passion Level explanation's 3-second `setTimeout` with immediate visual feedback (e.g., brief highlight on the changed passion level) followed by the explanation modal after 800ms
+
+## Capabilities
+
+### New Capabilities
+
+### Modified Capabilities
+
+- `app-shell-layout`: PWA install prompt text becomes i18n-aware; entrance/exit animations added
+- `onboarding-tutorial`: Step 5 passion explanation timing changes from 3s delay to immediate feedback + 800ms delay
+
+## Impact
+
+- `frontend/src/components/notification-prompt/notification-prompt.html` — Add animation classes
+- `frontend/src/components/pwa-install-prompt/pwa-install-prompt.html` — Add animation classes, replace hardcoded text with i18n keys
+- `frontend/src/components/signup-modal/signup-modal.html` — Add entrance animation
+- `frontend/src/routes/my-artists/my-artists-page.ts` — Change passion explanation delay from 3000ms to 800ms
+- `frontend/src/locales/` — Add PWA i18n keys for all supported languages

--- a/openspec/changes/polish-onboarding-prompts/proposal.md
+++ b/openspec/changes/polish-onboarding-prompts/proposal.md
@@ -4,7 +4,7 @@ The PWA install banner, notification prompt, and sign-up modal all lack entrance
 
 ## What Changes
 
-- Add `fade-slide-up` entrance and `fade-slide-down` exit animations to `notification-prompt` and `pwa-install-prompt` components, matching the design system's spring easing
+- Add `fade-slide-up` entrance and `fade-slide-down` exit animations to `notification-prompt` and `pwa-install-prompt` components with 600ms ease-out timing
 - Enhance the sign-up modal (Step 6) with a scale+fade entrance animation and a subtle background glow, matching the visual polish of the Discover HUD
 - Localize all PWA install banner text via i18n keys (`pwa.title`, `pwa.description`, `pwa.install`, `pwa.notNow`)
 - Replace the Step 5 Passion Level explanation's 3-second `setTimeout` with immediate visual feedback (e.g., brief highlight on the changed passion level) followed by the explanation modal after 800ms

--- a/openspec/changes/polish-onboarding-prompts/specs/app-shell-layout/spec.md
+++ b/openspec/changes/polish-onboarding-prompts/specs/app-shell-layout/spec.md
@@ -1,0 +1,40 @@
+## MODIFIED Requirements
+
+### Requirement: PWA Install Prompt i18n
+
+The PWA install prompt SHALL use i18n keys for all user-facing text, consistent with the notification prompt's existing i18n pattern.
+
+#### Scenario: PWA install prompt displays localized text
+
+- **WHEN** the PWA install prompt is visible
+- **THEN** the title text SHALL be rendered via the `pwa.title` i18n key
+- **AND** the description text SHALL be rendered via the `pwa.description` i18n key
+- **AND** the install button label SHALL be rendered via the `pwa.install` i18n key
+- **AND** the dismiss button label SHALL be rendered via the `pwa.notNow` i18n key
+- **AND** the text SHALL NOT be hardcoded in the template
+
+---
+
+### Requirement: Prompt Entrance and Exit Animations
+
+The PWA install prompt and notification prompt SHALL animate when entering and leaving the viewport, providing visual continuity with the rest of the onboarding flow.
+
+#### Scenario: Prompt entrance animation
+
+- **WHEN** the PWA install prompt or notification prompt becomes visible
+- **THEN** the prompt SHALL animate in using a fade-slide-up effect (opacity 0 -> 1, translateY 16px -> 0)
+- **AND** the animation duration SHALL be 600ms with ease-out timing
+- **AND** the animation SHALL reuse the existing `fade-slide-up` keyframe defined in `my-app.css`
+
+#### Scenario: Prompt exit animation
+
+- **WHEN** the PWA install prompt or notification prompt is dismissed
+- **THEN** the prompt SHALL animate out using a fade-slide-down effect (opacity 1 -> 0, translateY 0 -> 16px)
+- **AND** the animation duration SHALL be 600ms with ease-out timing
+- **AND** the element SHALL remain in the DOM until the exit animation completes
+
+#### Scenario: Reduced motion preference
+
+- **WHEN** the user has `prefers-reduced-motion: reduce` enabled
+- **THEN** the prompt entrance and exit animations SHALL be skipped
+- **AND** the prompt SHALL appear and disappear instantly

--- a/openspec/changes/polish-onboarding-prompts/specs/onboarding-tutorial/spec.md
+++ b/openspec/changes/polish-onboarding-prompts/specs/onboarding-tutorial/spec.md
@@ -1,0 +1,32 @@
+## MODIFIED Requirements
+
+### Requirement: Step 5 Passion Level Explanation Timing
+
+The Step 5 passion explanation SHALL provide immediate visual feedback on tap and appear after a shorter delay, replacing the current 3-second silent wait.
+
+#### Scenario: Step 5 - Passion Level changed (MODIFIED)
+
+- **WHEN** a user is at Step 5
+- **AND** the user changes the Passion Level of the highlighted artist
+- **THEN** the passion button SHALL immediately show a brief highlight/pulse animation (scale 1 -> 1.1 -> 1, ~300ms) as visual confirmation that the selection registered
+- **AND** the system SHALL display the notification explanation after an 800ms delay (not 3000ms)
+- **AND** the system SHALL advance `onboardingStep` to 6
+
+---
+
+### Requirement: Sign-up Modal Entrance Animation
+
+The sign-up modal (Step 6) SHALL animate on entrance to match the visual polish of the onboarding flow.
+
+#### Scenario: Sign-up modal entrance
+
+- **WHEN** the sign-up modal becomes visible (Step 6 activation or page reload at Step 6)
+- **THEN** the modal content panel SHALL animate in with a scale + fade effect (scale 0.95 -> 1, opacity 0 -> 1)
+- **AND** the animation duration SHALL be 400ms with cubic-bezier spring easing
+- **AND** a subtle radial gradient glow SHALL appear behind the modal content using the brand-primary color at low opacity
+
+#### Scenario: Reduced motion preference
+
+- **WHEN** the user has `prefers-reduced-motion: reduce` enabled
+- **THEN** the sign-up modal entrance animation SHALL be skipped
+- **AND** the modal SHALL appear instantly without the radial glow animation

--- a/openspec/changes/polish-onboarding-prompts/tasks.md
+++ b/openspec/changes/polish-onboarding-prompts/tasks.md
@@ -1,0 +1,76 @@
+## Tasks
+
+### 1. Add entrance/exit animations to notification-prompt
+
+**File:** `frontend/src/components/notification-prompt/notification-prompt.html`
+**File:** `frontend/src/components/notification-prompt/notification-prompt.ts` (if state management needed)
+**File:** `frontend/src/my-app.css` (add `fade-slide-down` keyframe)
+
+- Add `fade-slide-down` keyframe to `my-app.css` (opacity 1 -> 0, translateY 0 -> 16px).
+- Replace `if.bind` with `show.bind` (or use animation-aware wrapper) so the element remains in the DOM during exit animation.
+- Apply `fade-slide-up` animation (600ms ease-out) when the prompt enters.
+- Apply `fade-slide-down` animation (600ms ease-out) when the prompt is dismissed.
+- Ensure the animation class name matches the `[class*="animate-"]` pattern so the existing `prefers-reduced-motion` rule applies.
+
+### 2. Add entrance/exit animations to pwa-install-prompt
+
+**File:** `frontend/src/components/pwa-install-prompt/pwa-install-prompt.html`
+**File:** `frontend/src/components/pwa-install-prompt/pwa-install-prompt.ts` (if state management needed)
+
+- Same animation approach as notification-prompt (task 1).
+- Replace `if.bind="pwaInstall.canShow"` with an animation-aware binding.
+- Apply `fade-slide-up` entrance and `fade-slide-down` exit animations (600ms ease-out).
+
+### 3. Add i18n keys for PWA install prompt
+
+**File:** `frontend/src/components/pwa-install-prompt/pwa-install-prompt.html`
+**File:** `frontend/src/locales/en/translation.json` (and all other supported locale files)
+
+- Replace hardcoded "Add to Home Screen" with `t="pwa.title"`.
+- Replace hardcoded description with `t="pwa.description"`.
+- Replace hardcoded "Install" with `t="pwa.install"`.
+- Replace hardcoded "Not now" with `t="pwa.notNow"`.
+- Add the four keys to all supported locale JSON files with appropriate translations.
+
+### 4. Add entrance animation to signup-modal
+
+**File:** `frontend/src/components/signup-modal/signup-modal.html`
+**File:** `frontend/src/components/signup-modal/signup-modal.css` (or inline styles)
+**File:** `frontend/src/my-app.css` (add `modal-enter` keyframe if global)
+
+- Add a `modal-enter` keyframe: scale(0.95) -> scale(1), opacity 0 -> 1, 400ms, cubic-bezier(0.34, 1.56, 0.64, 1).
+- Apply the animation to the inner modal content panel (`.bg-surface-raised` div).
+- Add a `::before` pseudo-element on the modal content panel with a radial gradient glow using `--color-brand-primary` at low opacity (~15%).
+- Ensure the animation is covered by the `prefers-reduced-motion` media query.
+
+### 5. Fix Step 5 passion explanation timing
+
+**File:** `frontend/src/routes/my-artists/my-artists-page.ts`
+**File:** `frontend/src/routes/my-artists/my-artists-page.html` (for pulse animation class)
+
+- In `selectPassionLevel()`, within the `isTutorialStep5` branch (currently line 336):
+  - Change `setTimeout` delay from `3000` to `800`.
+  - Before the timeout, trigger immediate visual feedback: set a state property (e.g., `pulsingArtistId`) to the current artist's ID.
+  - Clear `pulsingArtistId` after ~300ms or via `animationend` event.
+- In the template, bind a CSS pulse animation class (scale 1 -> 1.1 -> 1, 300ms) to the passion button when `pulsingArtistId` matches the artist.
+- Add the pulse keyframe to the component CSS or `my-app.css`.
+
+### 6. Tests
+
+**File:** `frontend/src/components/notification-prompt/notification-prompt.spec.ts`
+**File:** `frontend/src/components/pwa-install-prompt/pwa-install-prompt.spec.ts`
+**File:** `frontend/src/components/signup-modal/signup-modal.spec.ts`
+**File:** `frontend/src/routes/my-artists/my-artists-page.spec.ts`
+
+- **notification-prompt**: Verify the component renders with animation classes when visible. Verify `prefers-reduced-motion` disables animations.
+- **pwa-install-prompt**: Verify i18n keys are used (no hardcoded text in rendered output). Verify animation classes are applied.
+- **signup-modal**: Verify the modal entrance animation class is applied when `active` is true.
+- **my-artists-page**: Verify the passion explanation delay is 800ms (mock `setTimeout`). Verify `pulsingArtistId` is set immediately on passion level change during Step 5.
+
+### 7. Verification
+
+- Run `make lint` -- all linter checks pass.
+- Run `make test` -- all unit tests pass.
+- Manual: open in dev tools with `prefers-reduced-motion: reduce` enabled and confirm all animations are skipped.
+- Manual: verify PWA banner displays correctly in each supported locale.
+- Manual: verify Step 5 passion tap shows immediate pulse, then explanation at 800ms.

--- a/openspec/changes/remove-loading-sequence/.openspec.yaml
+++ b/openspec/changes/remove-loading-sequence/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-05

--- a/openspec/changes/remove-loading-sequence/design.md
+++ b/openspec/changes/remove-loading-sequence/design.md
@@ -1,0 +1,64 @@
+## Context
+
+The Loading Sequence screen (Step 2 in onboarding) displays for exactly 3 seconds via `ONBOARDING_DISPLAY_MS`, during which no backend data is fetched. The phase messages rotate too quickly to be read (Phase 1 for 2s, Phase 2 for 1s, Phase 3 never shown). This screen adds a hollow delay with no value -- no data loading, no expectation building, no meaningful content. The Dashboard already has a loading skeleton with promise-based states (pending/success/error) that handle real data fetching naturally.
+
+The Loading Sequence route is also used by authenticated users for post-follow data aggregation (`loadingService.aggregateData()`), so the route itself cannot be removed entirely.
+
+## Goals / Non-Goals
+
+### Goals
+
+- Remove the Loading Sequence screen from the onboarding flow so users go directly from Discover to Dashboard.
+- Remove the onboarding-specific timer path (`isOnboardingFlow` + `ONBOARDING_DISPLAY_MS`) from the loading-sequence component.
+- Clean up z-index declarations in `loading-sequence.css` that are unnecessary within Shadow DOM.
+- Update specs to reflect the shortened onboarding journey.
+
+### Non-Goals
+
+- Removing the loading-sequence route entirely (still used for authenticated data aggregation).
+- Changing `OnboardingStep` numeric values (would break localStorage state for existing users).
+- Redesigning the dashboard loading state or skeleton UI.
+- Modifying the coach mark overlay or other tutorial steps (Steps 3-6 are unchanged).
+
+## Decisions
+
+### Decision 1: Keep OnboardingStep enum values unchanged
+
+The `OnboardingStep` enum values (LP=0, DISCOVER=1, LOADING=2, DASHBOARD=3, etc.) are persisted in localStorage under `liverty:onboardingStep`. Changing numeric values would invalidate stored state for users who are mid-onboarding. Instead, the Discover page CTA will call `onboarding.setStep(OnboardingStep.DASHBOARD)` directly, skipping over the LOADING value. The LOADING=2 value is retained in the enum but never entered during onboarding.
+
+**Rationale:** Avoids a migration concern for in-flight users. The `STEP_ROUTE_MAP` entry for LOADING can remain as a safety net -- if any user somehow has `onboardingStep=2` in localStorage, the route guard will still handle it gracefully.
+
+### Decision 2: Retain loading-sequence route for authenticated users
+
+The loading-sequence component has two code paths:
+
+1. **Onboarding path** (`isOnboardingFlow = true`): Timer-based 3s display, no data fetching. This path is removed.
+2. **Authenticated path**: Calls `loadingService.aggregateData()`, waits for completion, then navigates to dashboard. This path is retained.
+
+The `canLoad()` guard already distinguishes these two cases. Only the onboarding branch in `loading()` and `attached()` is removed, along with the `isOnboardingFlow` flag, `displayTimer`, and `ONBOARDING_DISPLAY_MS` constant.
+
+### Decision 3: Remove z-index from loading-sequence.css using `isolation: isolate`
+
+All 6 z-index declarations in `loading-sequence.css` exist within Shadow DOM scope. Add `isolation: isolate` to the root wrapper element to create an explicit stacking context. Within this boundary, elements stack by DOM source order (later siblings paint above earlier ones) without z-index. Remove all 6 `z-index` declarations.
+
+This follows the project-wide z-index elimination strategy (see `eliminate-z-index-stacking` change) which uses `isolation: isolate` for component-internal stacking.
+
+Affected selectors: `.container::before` (z-index: 0), `.pulsing-orb` (z-index: 1), `.message-container` (z-index: 1), `.step-dots` (z-index: 1), `.step-label` (z-index: 1), `.progress-label` (z-index: 1).
+
+## Risks / Trade-offs
+
+### Risk: Users mid-onboarding at Step 2
+
+Users who have `onboardingStep=2` in localStorage when this change deploys will be routed to the loading-sequence page. Since the onboarding timer path is removed, the `canLoad()` guard will redirect them: if they have guest followed artists, the authenticated path runs (which will fail gracefully and redirect to dashboard); if not, they redirect to discover.
+
+**Mitigation:** The `canLoad()` guard already handles both cases. No special migration logic is needed.
+
+### Risk: Dashboard UX without loading screen prelude
+
+Removing the 3-second loading screen means users land on the Dashboard immediately after Discover. The Dashboard has its own skeleton loading state, but the transition may feel abrupt compared to the previous animated bridge.
+
+**Mitigation:** The Dashboard already has promise-based loading states (pending/success/error) and skeleton UI. Concert data is pre-populated by fire-and-forget `SearchNewConcerts` calls during artist discovery. The region selector BottomSheet overlay at Step 3 provides a natural transition moment.
+
+### Trade-off: Dead enum value
+
+Keeping LOADING=2 in the enum adds a dead value that could confuse future developers. However, this is preferable to breaking existing users' localStorage state. A comment in the code can clarify that the value is deprecated.

--- a/openspec/changes/remove-loading-sequence/proposal.md
+++ b/openspec/changes/remove-loading-sequence/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+The Loading Sequence screen (Step 2) displays for only 3 seconds during onboarding, during which no backend data is fetched. Phase messages rotate too quickly to read (Phase 1 for 2s, Phase 2 for 1s, Phase 3 never shown). The screen adds a hollow delay that creates no value — no data loading, no expectation building, no meaningful content. The Dashboard already has a loading skeleton and promise-based states (pending/success/error) that handle real data fetching naturally.
+
+## What Changes
+
+- Remove the Loading Sequence route (`onboarding/loading`) from the onboarding flow
+- Update `OnboardingStep` to skip the LOADING step: Discover (Step 1) CTA navigates directly to Dashboard (Step 3)
+- Retain the Loading Sequence route for authenticated non-onboarding use (initial concert aggregation after first follow), but remove the `ONBOARDING_DISPLAY_MS` timer path
+- Remove `loading-sequence.css` z-index declarations (6 occurrences) as part of the route simplification
+- Update onboarding spec to reflect the shortened flow
+
+## Capabilities
+
+### New Capabilities
+
+### Modified Capabilities
+
+- `onboarding-tutorial`: Remove Step 2 (Loading) from the linear tutorial progression; Step 1 (Discover) advances directly to Step 3 (Dashboard)
+- `loading-sequence`: Remove onboarding-specific display timer; Loading Sequence only serves authenticated data aggregation use case
+- `frontend-onboarding-flow`: Update the onboarding journey to skip the loading screen
+
+## Impact
+
+- `frontend/src/services/onboarding-service.ts` — Step progression skips LOADING
+- `frontend/src/routes/onboarding-loading/loading-sequence.ts` — Remove onboarding timer path
+- `frontend/src/routes/onboarding-loading/loading-sequence.css` — Remove 6 z-index declarations
+- `frontend/src/routes/discover/discover-page.ts` — CTA navigates directly to `/dashboard`
+- `specification/openspec/specs/onboarding-tutorial/spec.md` — Update step definitions
+- `specification/openspec/specs/loading-sequence/spec.md` — Remove onboarding display requirement
+- `specification/openspec/specs/frontend-onboarding-flow/spec.md` — Update journey flow

--- a/openspec/changes/remove-loading-sequence/specs/frontend-onboarding-flow/spec.md
+++ b/openspec/changes/remove-loading-sequence/specs/frontend-onboarding-flow/spec.md
@@ -1,0 +1,27 @@
+## MODIFIED Requirements
+
+### Requirement: Onboarding Journey Flow
+
+The onboarding journey SHALL follow the path: Landing Page (Step 0) -> Artist Discovery (Step 1) -> Dashboard (Step 3). The Loading Sequence screen is no longer part of the onboarding flow.
+
+> **Delta:** Previously the flow was LP -> Discover -> Loading -> Dashboard. The Loading step is removed. Users now transition directly from Discover to Dashboard when they tap the [Generate Dashboard] CTA.
+
+#### Scenario: Discover to Dashboard transition
+
+- **WHEN** a user is at Step 1 (Artist Discovery)
+- **AND** the user has followed >= 3 artists
+- **AND** the user taps the [Generate Dashboard] CTA
+- **THEN** the system SHALL set `onboardingStep` to 3 (DASHBOARD)
+- **AND** the system SHALL navigate to `/dashboard`
+- **AND** the system SHALL NOT navigate to `/onboarding/loading`
+
+> **Delta:** Previously, the CTA set `onboardingStep` to 2 (LOADING) and navigated to `/onboarding/loading`, which then waited 3 seconds before advancing to DASHBOARD. The intermediate step is removed.
+
+#### Scenario: Concert data availability at Dashboard
+
+- **WHEN** the user arrives at the Dashboard after completing Artist Discovery
+- **THEN** concert data MAY already be available from the fire-and-forget `SearchNewConcerts` calls triggered during artist follows in Discovery
+- **AND** the Dashboard SHALL display its own loading skeleton / promise states for any data still pending
+- **AND** the system SHALL NOT rely on a loading screen to mask data fetching
+
+> **Delta:** Previously, the loading sequence screen provided a visual bridge while concert data was assumed to be loading. Since `SearchNewConcerts` is called fire-and-forget during discovery (not during the loading screen), this bridge was cosmetic. The Dashboard's native loading states now handle any remaining data latency directly.

--- a/openspec/changes/remove-loading-sequence/specs/loading-sequence/spec.md
+++ b/openspec/changes/remove-loading-sequence/specs/loading-sequence/spec.md
@@ -21,8 +21,10 @@ The loading sequence SHALL only be used for authenticated users who need `loadin
 
 > **Delta:** Previously, the loading sequence served two purposes: (1) a timed display during onboarding, and (2) data aggregation for authenticated users. Purpose (1) is removed. The component retains only the authenticated aggregation path.
 
-### Requirement: CSS z-index removal
+### Requirement: CSS z-index removal via `isolation: isolate`
 
-All z-index declarations in `loading-sequence.css` SHALL be removed. Since the component uses Shadow DOM, stacking context is scoped to the shadow root. Element stacking SHALL rely on `position: relative` and DOM source order.
+All z-index declarations in `loading-sequence.css` SHALL be removed. The root wrapper element SHALL use `isolation: isolate` to create an explicit stacking context. Within this boundary, elements stack by DOM source order (later siblings paint above earlier ones) without z-index.
 
-> **Delta:** Six z-index declarations are removed from the following selectors: `.container::before` (was z-index: 0), `.pulsing-orb` (was z-index: 1), `.message-container` (was z-index: 1), `.step-dots` (was z-index: 1), `.step-label` (was z-index: 1), `.progress-label` (was z-index: 1).
+This follows the project-wide z-index elimination strategy (see `eliminate-z-index-stacking` change) which uses `isolation: isolate` for component-internal stacking.
+
+> **Delta:** Six z-index declarations are removed from the following selectors: `.container::before` (was z-index: 0), `.pulsing-orb` (was z-index: 1), `.message-container` (was z-index: 1), `.step-dots` (was z-index: 1), `.step-label` (was z-index: 1), `.progress-label` (was z-index: 1). `isolation: isolate` is added to the root wrapper.

--- a/openspec/changes/remove-loading-sequence/specs/loading-sequence/spec.md
+++ b/openspec/changes/remove-loading-sequence/specs/loading-sequence/spec.md
@@ -1,0 +1,28 @@
+## REMOVED Requirements
+
+### Requirement: Minimum Display Duration (onboarding path)
+
+> **Delta:** The `ONBOARDING_DISPLAY_MS` (3-second) timer that enforced a minimum display time during onboarding is removed. The loading sequence no longer serves the onboarding flow. All scenarios under "Minimum Display Duration" that reference onboarding or the display timer are removed.
+
+Previously:
+- The loading sequence displayed for a minimum of 3 seconds during onboarding regardless of data load speed.
+- The `isOnboardingFlow` flag toggled the timer path in `attached()`.
+- The `displayTimer` fired after `ONBOARDING_DISPLAY_MS`, set `onboardingStep` to DASHBOARD, and navigated to `/dashboard`.
+
+All of the above are removed. The loading sequence now exclusively serves the authenticated data aggregation flow.
+
+---
+
+## MODIFIED Requirements
+
+### Requirement: Data Aggregation Orchestration
+
+The loading sequence SHALL only be used for authenticated users who need `loadingService.aggregateData()` after following artists. It SHALL NOT be entered during the onboarding tutorial flow.
+
+> **Delta:** Previously, the loading sequence served two purposes: (1) a timed display during onboarding, and (2) data aggregation for authenticated users. Purpose (1) is removed. The component retains only the authenticated aggregation path.
+
+### Requirement: CSS z-index removal
+
+All z-index declarations in `loading-sequence.css` SHALL be removed. Since the component uses Shadow DOM, stacking context is scoped to the shadow root. Element stacking SHALL rely on `position: relative` and DOM source order.
+
+> **Delta:** Six z-index declarations are removed from the following selectors: `.container::before` (was z-index: 0), `.pulsing-orb` (was z-index: 1), `.message-container` (was z-index: 1), `.step-dots` (was z-index: 1), `.step-label` (was z-index: 1), `.progress-label` (was z-index: 1).

--- a/openspec/changes/remove-loading-sequence/specs/onboarding-tutorial/spec.md
+++ b/openspec/changes/remove-loading-sequence/specs/onboarding-tutorial/spec.md
@@ -1,0 +1,22 @@
+## MODIFIED Requirements
+
+### Requirement: Linear Step Progression
+
+#### Scenario: Step 1 - Artist Discovery completion
+
+- **WHEN** a user is at Step 1 (Artist Discovery / Bubble UI)
+- **AND** the user has followed 3 or more artists via bubble taps
+- **THEN** the system SHALL activate and highlight the [Generate Dashboard] CTA button at the bottom of the screen
+- **AND** when the user taps the CTA, the system SHALL advance `onboardingStep` to 3 (DASHBOARD), skipping Step 2 (LOADING)
+- **AND** the system SHALL navigate directly to the Dashboard (`/dashboard`)
+
+> **Delta:** Previously, the CTA advanced `onboardingStep` to 2 (LOADING) and navigated to `/onboarding/loading`. The CTA now skips Step 2 entirely and advances directly to Step 3 (DASHBOARD).
+
+#### Scenario: Step 2 - Loading sequence (deprecated for onboarding)
+
+- **WHEN** a user is at Step 2 (LOADING)
+- **THEN** this step is no longer entered during the onboarding flow
+- **AND** the `OnboardingStep.LOADING` enum value (2) SHALL be retained for backward compatibility with existing localStorage state
+- **AND** if a user has `onboardingStep=2` in localStorage from a prior session, the route guard SHALL redirect them appropriately (to discover if no followed artists, or to dashboard otherwise)
+
+> **Delta:** Previously, Step 2 displayed a 3-second loading animation before advancing to Step 3. This step is no longer part of the onboarding progression. The enum value is kept but never actively entered.

--- a/openspec/changes/remove-loading-sequence/tasks.md
+++ b/openspec/changes/remove-loading-sequence/tasks.md
@@ -1,0 +1,67 @@
+## Tasks
+
+### 1. Update Discover page CTA to navigate directly to Dashboard
+
+**File:** `frontend/src/routes/discover/discover-page.ts`
+
+In `onViewSchedule()`, change:
+- `onboarding.setStep(OnboardingStep.LOADING)` -> `onboarding.setStep(OnboardingStep.DASHBOARD)`
+- `router.load('onboarding/loading')` -> `router.load('/dashboard')`
+- Update the log message from "advancing to loading step" to "advancing to dashboard"
+
+### 2. Remove onboarding timer from loading-sequence
+
+**File:** `frontend/src/routes/onboarding-loading/loading-sequence.ts`
+
+Remove:
+- `isOnboardingFlow` property
+- `displayTimer` property
+- `ONBOARDING_DISPLAY_MS` constant
+- The `if (this.onboarding.isOnboarding)` branch in `loading()` that sets `isOnboardingFlow = true` and returns early
+- The `if (this.isOnboardingFlow)` branch in `attached()` that sets the display timer
+- The `displayTimer` cleanup in `unbinding()`
+- The `OnboardingStep` import (if no longer used after removal)
+- The `IOnboardingService` import and `onboarding` dependency (if no longer used)
+
+The remaining code in `loading()` and `attached()` (the authenticated aggregation path) stays as-is.
+
+### 3. Remove z-index from loading-sequence.css
+
+**File:** `frontend/src/routes/onboarding-loading/loading-sequence.css`
+
+Remove `z-index` declarations from the following selectors:
+- `.container::before` -- remove `z-index: 0;`
+- `.pulsing-orb` -- remove `z-index: 1;`
+- `.message-container` -- remove `z-index: 1;`
+- `.step-dots` -- remove `z-index: 1;`
+- `.step-label` -- remove `z-index: 1;`
+- `.progress-label` -- remove `z-index: 1;`
+
+### 4. Update route guard (canLoad) if needed
+
+**File:** `frontend/src/routes/onboarding-loading/loading-sequence.ts`
+
+Review the `canLoad()` method:
+- The `if (this.onboarding.isOnboarding)` branch can be removed since onboarding users will no longer reach this route. If an onboarding user somehow navigates here, the authenticated fallback path handles it.
+- Alternatively, simplify to redirect onboarding users to dashboard immediately in `canLoad()`.
+
+### 5. Update specs
+
+**Files:**
+- `specification/openspec/specs/onboarding-tutorial/spec.md` -- Apply delta from `specs/onboarding-tutorial/spec.md`
+- `specification/openspec/specs/loading-sequence/spec.md` -- Apply delta from `specs/loading-sequence/spec.md`
+- `specification/openspec/specs/frontend-onboarding-flow/spec.md` -- Apply delta from `specs/frontend-onboarding-flow/spec.md`
+
+### 6. Tests
+
+- **Unit test:** Verify `DiscoverPage.onViewSchedule()` calls `onboarding.setStep(OnboardingStep.DASHBOARD)` and `router.load('/dashboard')`.
+- **Unit test:** Verify `LoadingSequence` no longer has onboarding timer behavior (no `isOnboardingFlow`, no `displayTimer`).
+- **Unit test:** Verify `LoadingSequence.canLoad()` redirects onboarding users appropriately (or the branch is removed).
+- **Visual regression:** Confirm loading-sequence still renders correctly without z-index (authenticated path).
+
+### 7. Verification
+
+- Complete the onboarding flow end-to-end: LP -> Discover -> follow 3 artists -> tap CTA -> lands on Dashboard directly (no loading screen).
+- Verify the loading-sequence route still works for authenticated users with local followed artists (post-follow aggregation).
+- Verify a user with `onboardingStep=2` in localStorage is handled gracefully (redirected, not stuck).
+- Verify loading-sequence CSS stacking is correct without z-index (starfield behind orb, orb behind text).


### PR DESCRIPTION
## Related Issue

Closes #146

## Summary of Changes

Add 4 parallel OpenSpec change artifacts for onboarding UX improvements:

### 1. fix-prompt-timing
- Add onboarding/auth guards to PWA install and notification prompts
- Introduce PromptCoordinator service for single-prompt-per-session logic
- Move notification-prompt from dashboard route to app shell
- Notification prompt gets first-session priority; PWA install deferred

### 2. remove-loading-sequence
- Remove the 3-second Loading Sequence screen from onboarding flow
- Discover CTA navigates directly to Dashboard
- Retain loading route for authenticated data aggregation
- Remove 6 z-index declarations using isolation: isolate

### 3. polish-onboarding-prompts
- Unify entrance/exit animations using existing fade-slide-up keyframe
- Add i18n keys for PWA install banner (pwa.* namespace)
- Reduce Step 5 passion explanation delay from 3000ms to 800ms with immediate tap feedback

### 4. eliminate-z-index-stacking
- Replace all 26 z-index instances across 11 files with modern Web Platform APIs
- `isolation: isolate` for component-internal stacking (discover-page, loading-sequence, live-highway)
- `<dialog>` + `showModal()` for all modal overlays (7 components)
- `popover="manual"` for persistent elements (bottom-nav, toast, coach-mark)
- CSS Anchor Positioning for coach-mark tooltip (replacing getBoundingClientRect JS)
- Zero z-index exceptions in the entire frontend codebase

## Self-Checklist

- [x] I have linked the related issue.
- [x] No proto changes -- OpenSpec specification artifacts only.
- [x] N/A -- buf lint/format not applicable (no proto changes).