### PR TITLE
docs(spec): add css-linting spec and update modern-css-platform

### DIFF
--- a/openspec/changes/archive/2026-03-06-introduce-stylelint/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-06-introduce-stylelint/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-06

--- a/openspec/changes/archive/2026-03-06-introduce-stylelint/design.md
+++ b/openspec/changes/archive/2026-03-06-introduce-stylelint/design.md
@@ -1,0 +1,92 @@
+## Context
+
+The frontend uses Biome for JS/TS linting and formatting but lacks automated CSS quality enforcement. The `modern-css-platform` spec mandates Container Queries, Logical Properties, OKLCH color, and View Transitions, yet no tooling prevents developers from using legacy patterns. The codebase already has Stylelint v16 + `stylelint-config-standard` installed with a minimal configuration. This change expands that configuration into a comprehensive modern CSS enforcement layer.
+
+Current state:
+- 11 CSS files under `frontend/src/`
+- ~66 `rgb()`/`rgba()` usages (partial OKLCH migration already started)
+- ~14 physical directional property usages (`margin-left`, `top`, `left`, etc.)
+- 1 viewport-width `@media` query that should be `@container`
+- 0 `z-index`, 0 `float`, 0 `!important` usages (already clean)
+- Biome handles CSS parsing/formatting (`tailwindDirectives: true`); Stylelint handles CSS linting
+
+## Goals / Non-Goals
+
+**Goals:**
+- Enforce modern CSS standards (OKLCH, Logical Properties, Container Queries) via lint rules
+- Prevent anti-patterns (z-index, !important, float, high specificity) from entering the codebase
+- Standardize property declaration ordering for readability
+- Migrate all existing CSS to comply with the new rules in a single pass
+- Zero CI configuration changes (existing `make lint` pipeline already invokes `npm run lint:css`)
+
+**Non-Goals:**
+- Replacing Biome's CSS formatting — Biome handles formatting, Stylelint handles linting
+- SCSS/Sass support — the project uses plain CSS + Tailwind v4
+- Custom Stylelint plugin development — use only built-in rules and maintained community plugins
+- Enforcing `@container` over `@media` for non-width features (e.g., `prefers-reduced-motion`, `prefers-color-scheme` remain as `@media`)
+
+## Decisions
+
+### Decision 1: Stylelint over alternatives
+
+**Choice**: Stylelint with `stylelint-config-standard`
+
+**Alternatives considered**:
+| Option | Pros | Cons |
+|--------|------|------|
+| Biome CSS linting | Already installed, single tool | Only a handful of CSS lint rules; no property order, no specificity, no function disallow |
+| @eslint/css | Baseline browser compat checking (`use-baseline`) | ~6 rules total; ESLint not used in this project; would add a third linter |
+| Stylelint | 170+ rules, mature ecosystem, property order plugin, active maintenance | Additional tool alongside Biome |
+
+**Rationale**: Stylelint is the only tool with sufficient rule coverage to enforce modern CSS standards. Biome's CSS linting is too immature. Adding ESLint solely for CSS is unjustified when the project already uses Biome for JS/TS.
+
+### Decision 2: Error severity for all rules (no warning phase)
+
+**Choice**: All custom rules emit errors, not warnings. Existing code is migrated in the same PR.
+
+**Rationale**: The codebase is small (11 files). A phased warning-to-error approach adds unnecessary process overhead. Migrating rgb/rgba to oklch in one pass is feasible and delivers immediate value.
+
+### Decision 3: Full physical property ban including positional properties
+
+**Choice**: Ban `top`, `right`, `bottom`, `left` in addition to `margin-*`, `padding-*`, `border-*` physical variants.
+
+**Alternatives considered**:
+- Ban only margin/padding/border physicals, allow positional (`top`/`left`)
+- Ban nothing, rely on code review
+
+**Rationale**: `inset-block-start`, `inset-inline-start`, and `inset` shorthand are Baseline Widely Available (Chrome 87+, Firefox 63+, Safari 14.1+). The codebase already uses `inset: 0` extensively. The 5 remaining `top`/`left`/`bottom` usages have direct logical equivalents. Full ban prevents future regression.
+
+### Decision 4: Property ordering via `stylelint-config-clean-order`
+
+**Choice**: Use `stylelint-config-clean-order` (wraps `stylelint-order` plugin).
+
+**Rationale**: Provides an opinionated, logical grouping (Interaction > Position > Layout > Box Model > Typography > Appearance > Transition) with autofix support. Avoids maintaining a custom order list. One-time `stylelint --fix` reformats all files.
+
+### Decision 5: Viewport-width media features disallowed
+
+**Choice**: Disallow `width`, `min-width`, `max-width` in `@media` via `media-feature-name-disallowed-list`.
+
+**Rationale**: Aligns with `modern-css-platform` spec requirement for Container Queries. `@media` with `prefers-reduced-motion`, `prefers-color-scheme`, and other non-width features remain allowed. Only 1 existing usage needs migration.
+
+### Decision 6: Tailwind v4 at-rule compatibility
+
+**Choice**: Whitelist `@theme`, `@layer`, `@container`, `@starting-style`, `@property` in `at-rule-no-unknown`.
+
+**Rationale**: Tailwind v4 uses CSS-native `@theme` directive. Modern CSS features (`@starting-style`, `@property`, `@container`) are already in use in the codebase and must not be flagged as unknown.
+
+## Risks / Trade-offs
+
+**[Risk] OKLCH color conversion accuracy** — Converting 66+ `rgb()`/`rgba()` values to `oklch()` may introduce subtle color shifts.
+  - Mitigation: Use a conversion tool and visually verify key screens (discover page starfield, loading sequence gradients). OKLCH is perceptually uniform, so differences should be minimal.
+
+**[Risk] Property order autofix changes large diffs** — Running `stylelint --fix` for property ordering will reformat all 11 CSS files.
+  - Mitigation: Apply ordering fix in a dedicated commit before other changes, making code review clearer.
+
+**[Risk] `text-align: center` flagged as physical property** — `center` is not directional (unlike `left`/`right`).
+  - Mitigation: Only `text-align: left` and `text-align: right` need migration to `start`/`end`. `text-align: center` is not affected by `property-disallowed-list` since we ban physical properties, not values.
+
+**[Risk] `env(safe-area-inset-bottom)` uses physical naming** — The environment variable name is a browser API, not changeable.
+  - Mitigation: The containing property changes to logical (`padding-block-end`) while the env() value remains as-is. This is acceptable.
+
+**[Trade-off] Longer property names** — `margin-block-start` is more verbose than `margin-top`.
+  - Accepted: Shorthand forms (`margin-block`, `padding-inline`, `inset`) reduce verbosity. RTL/i18n correctness outweighs brevity.

--- a/openspec/changes/archive/2026-03-06-introduce-stylelint/proposal.md
+++ b/openspec/changes/archive/2026-03-06-introduce-stylelint/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+The frontend uses Biome for JavaScript/TypeScript linting and formatting, but has no automated enforcement of CSS coding standards. The `modern-css-platform` spec defines requirements for Container Queries, Logical Properties, OKLCH color, and View Transitions, yet nothing prevents developers from writing legacy `rgb()`, physical `margin-left`, or viewport-based `@media (width)` queries. Stylelint closes this gap by turning spec requirements into enforceable lint rules.
+
+## What Changes
+
+- Configure Stylelint with `stylelint-config-standard` + `stylelint-config-clean-order` to enforce modern CSS standards
+- Add rules that **disallow legacy patterns**:
+  - Legacy color functions (`rgb`, `rgba`, `hsl`, `hsla`, hex) in favor of `oklch()`
+  - Physical directional properties (`margin-left`, `top`, `float`, etc.) in favor of CSS Logical Properties (`margin-inline-start`, `inset-block-start`, etc.)
+  - Viewport-width media features (`width`, `min-width`, `max-width`) in `@media` in favor of `@container` queries
+  - `z-index`, `!important`, `float`, `clear` as anti-patterns
+- Add rules that **enforce quality**:
+  - Selector specificity ceiling (`0,4,0`), no ID selectors
+  - Property declaration ordering (Interaction > Position > Layout > Box > Typography > Visual > Animation)
+  - Precision limits, deprecated property/media-type detection
+- Migrate all existing CSS files (~66 `rgb`/`rgba` occurrences, ~14 physical property usages, 1 viewport media query) to comply with the new rules
+- Integrate Stylelint into `make lint` and `make check` (CI gate)
+
+## Capabilities
+
+### New Capabilities
+- `css-linting`: Defines Stylelint configuration, rule rationale, Tailwind v4 compatibility settings, and CI integration requirements
+
+### Modified Capabilities
+- `modern-css-platform`: Adds the enforcement mechanism (Stylelint rules) for existing requirements around Container Queries, Logical Properties, and OKLCH color. No new requirements, but the spec gains a "Tooling Enforcement" section linking rules to requirements.
+
+## Impact
+
+- **frontend repo**: All 11 CSS files under `src/` will be modified (color migration, logical properties, property reorder)
+- **Dependencies**: Add `stylelint-order` and `stylelint-config-clean-order` npm packages
+- **CI**: `make lint` / `make check` already calls `npm run lint:css`; no CI config change needed
+- **DX**: Developers writing new CSS will get immediate lint errors for legacy patterns

--- a/openspec/changes/archive/2026-03-06-introduce-stylelint/specs/css-linting/spec.md
+++ b/openspec/changes/archive/2026-03-06-introduce-stylelint/specs/css-linting/spec.md
@@ -1,0 +1,113 @@
+## ADDED Requirements
+
+### Requirement: Stylelint enforces modern color functions
+The linter SHALL disallow legacy color functions and hex notation, requiring OKLCH for all color definitions.
+
+#### Scenario: Legacy rgb/rgba rejected
+- **WHEN** a CSS file contains `rgb()`, `rgba()`, `hsl()`, or `hsla()` function calls
+- **THEN** Stylelint SHALL report an error via the `function-disallowed-list` rule
+
+#### Scenario: Hex colors rejected
+- **WHEN** a CSS file contains a hex color value (e.g., `#fff`, `#4f46e5`)
+- **THEN** Stylelint SHALL report an error via the `color-no-hex` rule
+
+#### Scenario: OKLCH accepted
+- **WHEN** a CSS file uses `oklch()` for color definitions
+- **THEN** Stylelint SHALL not report any color-related errors
+
+### Requirement: Stylelint enforces CSS Logical Properties
+The linter SHALL disallow physical directional properties, requiring their logical equivalents.
+
+#### Scenario: Physical margin/padding rejected
+- **WHEN** a CSS file contains `margin-left`, `margin-right`, `margin-top`, `margin-bottom`, `padding-left`, `padding-right`, `padding-top`, or `padding-bottom`
+- **THEN** Stylelint SHALL report an error via the `property-disallowed-list` rule
+
+#### Scenario: Physical positional properties rejected
+- **WHEN** a CSS file contains `top`, `right`, `bottom`, or `left` properties
+- **THEN** Stylelint SHALL report an error via the `property-disallowed-list` rule
+
+#### Scenario: Physical border properties rejected
+- **WHEN** a CSS file contains `border-left`, `border-right`, `border-top`, `border-bottom` or their longhand variants (`-width`, `-style`, `-color`)
+- **THEN** Stylelint SHALL report an error via the `property-disallowed-list` rule
+
+#### Scenario: Logical equivalents accepted
+- **WHEN** a CSS file uses `margin-inline-start`, `inset-block-end`, `padding-block`, `border-inline-start`, or `inset` shorthand
+- **THEN** Stylelint SHALL not report any property errors
+
+### Requirement: Stylelint enforces Container Queries over viewport-width media queries
+The linter SHALL disallow width-based media features in `@media` rules to enforce `@container` usage for component-level responsiveness.
+
+#### Scenario: Viewport-width media query rejected
+- **WHEN** a CSS file contains `@media (width ...)`, `@media (min-width: ...)`, or `@media (max-width: ...)`
+- **THEN** Stylelint SHALL report an error via the `media-feature-name-disallowed-list` rule
+
+#### Scenario: Preference media queries allowed
+- **WHEN** a CSS file contains `@media (prefers-reduced-motion: reduce)` or `@media (prefers-color-scheme: dark)`
+- **THEN** Stylelint SHALL not report any errors
+
+#### Scenario: Container queries allowed
+- **WHEN** a CSS file uses `@container (min-width: ...)` or `@container (max-width: ...)`
+- **THEN** Stylelint SHALL not report any errors
+
+### Requirement: Stylelint prevents CSS anti-patterns
+The linter SHALL disallow known anti-patterns that lead to maintainability issues.
+
+#### Scenario: z-index rejected
+- **WHEN** a CSS file contains a `z-index` declaration
+- **THEN** Stylelint SHALL report an error via the `property-disallowed-list` rule
+
+#### Scenario: !important rejected
+- **WHEN** a CSS file contains `!important` in a declaration
+- **THEN** Stylelint SHALL report an error via the `declaration-no-important` rule
+
+#### Scenario: Float layout rejected
+- **WHEN** a CSS file contains `float` or `clear` properties
+- **THEN** Stylelint SHALL report an error via the `property-disallowed-list` rule
+
+#### Scenario: ID selectors rejected
+- **WHEN** a CSS file contains an ID selector (e.g., `#my-id`)
+- **THEN** Stylelint SHALL report an error via the `selector-max-id` rule with a limit of 0
+
+#### Scenario: Excessive specificity rejected
+- **WHEN** a CSS selector exceeds specificity `0,4,0`
+- **THEN** Stylelint SHALL report an error via the `selector-max-specificity` rule
+
+#### Scenario: Deep selector nesting rejected
+- **WHEN** a CSS selector exceeds 4 compound selectors
+- **THEN** Stylelint SHALL report an error via the `selector-max-compound-selectors` rule
+
+### Requirement: Stylelint enforces property declaration ordering
+The linter SHALL enforce a consistent property declaration order grouped by function.
+
+#### Scenario: Properties ordered by group
+- **WHEN** a CSS declaration block is written
+- **THEN** properties SHALL be ordered in the following group sequence: Interaction, Positioning, Layout, Box Model, Typography, Appearance, Transition/Animation
+- **AND** `stylelint --fix` SHALL automatically reorder properties
+
+### Requirement: Stylelint compatible with Tailwind CSS v4
+The linter SHALL not flag valid Tailwind v4 directives or modern CSS at-rules as errors.
+
+#### Scenario: Tailwind at-rules accepted
+- **WHEN** a CSS file contains `@theme`, `@layer`, or `@apply` directives
+- **THEN** Stylelint SHALL not report unknown at-rule errors
+
+#### Scenario: Modern CSS at-rules accepted
+- **WHEN** a CSS file contains `@container`, `@starting-style`, or `@property` at-rules
+- **THEN** Stylelint SHALL not report unknown at-rule errors
+
+#### Scenario: Tailwind theme function accepted
+- **WHEN** a CSS file uses the `theme()` function
+- **THEN** Stylelint SHALL not report unknown function errors
+
+### Requirement: Stylelint integrated into CI pipeline
+The linter SHALL run as part of the standard CI lint check.
+
+#### Scenario: make lint runs Stylelint
+- **WHEN** a developer runs `make lint`
+- **THEN** Stylelint SHALL execute against all CSS files under `src/`
+- **AND** lint failures SHALL cause a non-zero exit code
+
+#### Scenario: make check gates commits
+- **WHEN** a developer runs `make check` (pre-commit)
+- **THEN** Stylelint SHALL execute as part of the check pipeline
+- **AND** any Stylelint error SHALL block the commit

--- a/openspec/changes/archive/2026-03-06-introduce-stylelint/specs/modern-css-platform/spec.md
+++ b/openspec/changes/archive/2026-03-06-introduce-stylelint/specs/modern-css-platform/spec.md
@@ -1,0 +1,38 @@
+## MODIFIED Requirements
+
+### Requirement: CSS Logical Properties
+Layout, spacing, and positioning properties SHALL use CSS Logical Properties for internationalization readiness. Compliance SHALL be enforced by Stylelint via `property-disallowed-list`.
+
+#### Scenario: Margin and padding use logical properties
+- **WHEN** a CSS file contains margin or padding declarations
+- **THEN** the declarations SHALL use `margin-inline`, `margin-block`, `padding-inline`, `padding-block` (or their `-start`/`-end` longhands) instead of physical `margin-left`, `margin-top`, etc.
+- **AND** Stylelint SHALL reject physical margin/padding properties as errors
+
+#### Scenario: Border and positioning use logical properties
+- **WHEN** a CSS file contains border or positioning declarations
+- **THEN** the declarations SHALL use `border-inline-start`, `inset-inline`, `inset-block-end`, etc. instead of physical equivalents
+- **AND** Stylelint SHALL reject physical border/positioning properties as errors
+
+#### Scenario: All existing physical properties migrated
+- **WHEN** the Stylelint configuration is applied to the codebase
+- **THEN** all existing physical directional properties SHALL have been migrated to logical equivalents
+- **AND** `stylelint --fix` or manual migration SHALL have resolved all violations
+
+## ADDED Requirements
+
+### Requirement: OKLCH color enforcement
+All color definitions in CSS SHALL use the `oklch()` function. Legacy color functions and hex notation SHALL be rejected by Stylelint.
+
+#### Scenario: OKLCH used for solid colors
+- **WHEN** a CSS property requires a color value (e.g., `color`, `background-color`, `border-color`)
+- **THEN** the value SHALL use `oklch()` notation
+- **AND** Stylelint SHALL reject `rgb()`, `rgba()`, `hsl()`, `hsla()`, and hex colors
+
+#### Scenario: OKLCH used for transparency
+- **WHEN** a color requires an alpha/transparency component
+- **THEN** the value SHALL use `oklch(L C H / alpha)` syntax
+- **AND** legacy `rgba(R G B / alpha)` SHALL be rejected
+
+#### Scenario: Tailwind theme colors exempt
+- **WHEN** a color value is provided via Tailwind `theme()` function or CSS custom properties (e.g., `var(--color-brand-primary)`)
+- **THEN** the value SHALL not be subject to color function linting

--- a/openspec/changes/archive/2026-03-06-introduce-stylelint/tasks.md
+++ b/openspec/changes/archive/2026-03-06-introduce-stylelint/tasks.md
@@ -1,0 +1,38 @@
+## 1. Dependencies and Configuration
+
+- [x] 1.1 Install `stylelint-order` and `stylelint-config-clean-order` npm packages
+- [x] 1.2 Update `.stylelintrc.json` with full rule configuration: extends (standard + clean-order), function-disallowed-list, color-no-hex, property-disallowed-list (all physical properties + z-index + float + clear), media-feature-name-disallowed-list (width, min-width, max-width), declaration-no-important, selector-max-id, selector-max-specificity, selector-max-compound-selectors, number-max-precision, at-rule-no-unknown ignoreAtRules, function-no-unknown ignoreFunctions
+- [x] 1.3 Add `.stylelintrc.json` to `paths-filter` in `ci.yaml` so stylelint config-only changes trigger the lint job
+- [x] 1.4 Verify `npm run lint:css` executes successfully with the new configuration (expect violations in existing files)
+
+## 2. Color Migration (rgb/rgba/hex to oklch)
+
+- [x] 2.1 Migrate all `rgb()`/`rgba()` color values in `discover-page.css` to `oklch()`
+- [x] 2.2 Migrate all `rgb()`/`rgba()` color values in `loading-sequence.css` to `oklch()`
+- [x] 2.3 Migrate any remaining `rgb()`/`rgba()`/hex values in other CSS files (`dna-orb-canvas.css`, `coach-mark.css`, `my-app.css`, etc.) to `oklch()`
+- [x] 2.4 Verify no `function-disallowed-list` or `color-no-hex` violations remain
+
+## 3. Physical Property Migration (to Logical Properties)
+
+- [x] 3.1 Migrate `margin-left` in `discover-page.css` to `margin-inline-start`
+- [x] 3.2 Migrate `left: 50%` + `bottom: Xrem` positioning patterns in `discover-page.css` to `inset-inline-start` / `inset-block-end`
+- [x] 3.3 Migrate `top: 0; left: 0` in `loading-sequence.css` to `inset: 0` (or `inset-block-start` / `inset-inline-start`)
+- [x] 3.4 Migrate `margin-top` / `margin-bottom` in `loading-sequence.css` and `coach-mark.css` to `margin-block-start` / `margin-block-end`
+- [x] 3.5 Migrate `padding-top` / `padding-bottom` in `discover-page.css` to `padding-block-start` / `padding-block-end`
+- [x] 3.6 Verify no `property-disallowed-list` violations remain
+
+## 4. Media Query Migration (viewport-width to container)
+
+- [x] 4.1 Convert `@media (width <= 640px)` in `loading-sequence.css` to `@container` query (add `container-type: inline-size` to parent element)
+- [x] 4.2 Verify no `media-feature-name-disallowed-list` violations remain
+
+## 5. Property Order Autofix
+
+- [x] 5.1 Run `npx stylelint "src/**/*.css" --fix` to auto-sort property declaration order across all files
+- [x] 5.2 Review the property order changes for correctness (no semantic changes, only reordering)
+
+## 6. Validation
+
+- [x] 6.1 Run `npm run lint:css` and confirm zero violations
+- [x] 6.2 Run `make check` and confirm full pipeline passes (Biome + Stylelint + tests)
+- [x] 6.3 Visual smoke test: verify `npm start` renders key pages correctly (discover page starfield, loading sequence, coach-mark tooltip)

--- a/openspec/specs/css-linting/spec.md
+++ b/openspec/specs/css-linting/spec.md
@@ -1,0 +1,119 @@
+# CSS Linting
+
+## Purpose
+
+Defines the Stylelint configuration and rules that enforce modern CSS standards across the Liverty Music frontend. Works alongside Biome (which handles CSS formatting) to provide comprehensive CSS quality enforcement.
+
+## Requirements
+
+### Requirement: Stylelint enforces modern color functions
+The linter SHALL disallow legacy color functions and hex notation, requiring OKLCH for all color definitions.
+
+#### Scenario: Legacy rgb/rgba rejected
+- **WHEN** a CSS file contains `rgb()`, `rgba()`, `hsl()`, or `hsla()` function calls
+- **THEN** Stylelint SHALL report an error via the `function-disallowed-list` rule
+
+#### Scenario: Hex colors rejected
+- **WHEN** a CSS file contains a hex color value (e.g., `#fff`, `#4f46e5`)
+- **THEN** Stylelint SHALL report an error via the `color-no-hex` rule
+
+#### Scenario: OKLCH accepted
+- **WHEN** a CSS file uses `oklch()` for color definitions
+- **THEN** Stylelint SHALL not report any color-related errors
+
+### Requirement: Stylelint enforces CSS Logical Properties
+The linter SHALL disallow physical directional properties, requiring their logical equivalents.
+
+#### Scenario: Physical margin/padding rejected
+- **WHEN** a CSS file contains `margin-left`, `margin-right`, `margin-top`, `margin-bottom`, `padding-left`, `padding-right`, `padding-top`, or `padding-bottom`
+- **THEN** Stylelint SHALL report an error via the `property-disallowed-list` rule
+
+#### Scenario: Physical positional properties rejected
+- **WHEN** a CSS file contains `top`, `right`, `bottom`, or `left` properties
+- **THEN** Stylelint SHALL report an error via the `property-disallowed-list` rule
+
+#### Scenario: Physical border properties rejected
+- **WHEN** a CSS file contains `border-left`, `border-right`, `border-top`, `border-bottom` or their longhand variants (`-width`, `-style`, `-color`)
+- **THEN** Stylelint SHALL report an error via the `property-disallowed-list` rule
+
+#### Scenario: Logical equivalents accepted
+- **WHEN** a CSS file uses `margin-inline-start`, `inset-block-end`, `padding-block`, `border-inline-start`, or `inset` shorthand
+- **THEN** Stylelint SHALL not report any property errors
+
+### Requirement: Stylelint enforces Container Queries over viewport-width media queries
+The linter SHALL disallow width-based media features in `@media` rules to enforce `@container` usage for component-level responsiveness.
+
+#### Scenario: Viewport-width media query rejected
+- **WHEN** a CSS file contains `@media (width ...)`, `@media (min-width: ...)`, or `@media (max-width: ...)`
+- **THEN** Stylelint SHALL report an error via the `media-feature-name-disallowed-list` rule
+
+#### Scenario: Preference media queries allowed
+- **WHEN** a CSS file contains `@media (prefers-reduced-motion: reduce)` or `@media (prefers-color-scheme: dark)`
+- **THEN** Stylelint SHALL not report any errors
+
+#### Scenario: Container queries allowed
+- **WHEN** a CSS file uses `@container (min-width: ...)` or `@container (max-width: ...)`
+- **THEN** Stylelint SHALL not report any errors
+
+### Requirement: Stylelint prevents CSS anti-patterns
+The linter SHALL disallow known anti-patterns that lead to maintainability issues.
+
+#### Scenario: z-index rejected
+- **WHEN** a CSS file contains a `z-index` declaration
+- **THEN** Stylelint SHALL report an error via the `property-disallowed-list` rule
+
+#### Scenario: !important rejected
+- **WHEN** a CSS file contains `!important` in a declaration
+- **THEN** Stylelint SHALL report an error via the `declaration-no-important` rule
+
+#### Scenario: Float layout rejected
+- **WHEN** a CSS file contains `float` or `clear` properties
+- **THEN** Stylelint SHALL report an error via the `property-disallowed-list` rule
+
+#### Scenario: ID selectors rejected
+- **WHEN** a CSS file contains an ID selector (e.g., `#my-id`)
+- **THEN** Stylelint SHALL report an error via the `selector-max-id` rule with a limit of 0
+
+#### Scenario: Excessive specificity rejected
+- **WHEN** a CSS selector exceeds specificity `0,4,0`
+- **THEN** Stylelint SHALL report an error via the `selector-max-specificity` rule
+
+#### Scenario: Deep selector nesting rejected
+- **WHEN** a CSS selector exceeds 4 compound selectors
+- **THEN** Stylelint SHALL report an error via the `selector-max-compound-selectors` rule
+
+### Requirement: Stylelint enforces property declaration ordering
+The linter SHALL enforce a consistent property declaration order grouped by function.
+
+#### Scenario: Properties ordered by group
+- **WHEN** a CSS declaration block is written
+- **THEN** properties SHALL be ordered in the following group sequence: Interaction, Positioning, Layout, Box Model, Typography, Appearance, Transition/Animation
+- **AND** `stylelint --fix` SHALL automatically reorder properties
+
+### Requirement: Stylelint compatible with Tailwind CSS v4
+The linter SHALL not flag valid Tailwind v4 directives or modern CSS at-rules as errors.
+
+#### Scenario: Tailwind at-rules accepted
+- **WHEN** a CSS file contains `@theme`, `@layer`, or `@apply` directives
+- **THEN** Stylelint SHALL not report unknown at-rule errors
+
+#### Scenario: Modern CSS at-rules accepted
+- **WHEN** a CSS file contains `@container`, `@starting-style`, or `@property` at-rules
+- **THEN** Stylelint SHALL not report unknown at-rule errors
+
+#### Scenario: Tailwind theme function accepted
+- **WHEN** a CSS file uses the `theme()` function
+- **THEN** Stylelint SHALL not report unknown function errors
+
+### Requirement: Stylelint integrated into CI pipeline
+The linter SHALL run as part of the standard CI lint check.
+
+#### Scenario: make lint runs Stylelint
+- **WHEN** a developer runs `make lint`
+- **THEN** Stylelint SHALL execute against all CSS files under `src/`
+- **AND** lint failures SHALL cause a non-zero exit code
+
+#### Scenario: make check gates commits
+- **WHEN** a developer runs `make check` (pre-commit)
+- **THEN** Stylelint SHALL execute as part of the check pipeline
+- **AND** any Stylelint error SHALL block the commit

--- a/openspec/specs/modern-css-platform/spec.md
+++ b/openspec/specs/modern-css-platform/spec.md
@@ -49,13 +49,36 @@ Parent elements that change styling based on child or sibling state SHALL use `:
 - **THEN** the parent container SHALL style itself using `:has(:invalid)` or `:has([aria-invalid="true"])`
 
 ### Requirement: CSS Logical Properties
-Layout and spacing properties SHALL use CSS Logical Properties for internationalization readiness.
+Layout, spacing, and positioning properties SHALL use CSS Logical Properties for internationalization readiness. Compliance SHALL be enforced by Stylelint via `property-disallowed-list`.
 
 #### Scenario: Margin and padding use logical properties
-- **WHEN** new CSS rules are written for component spacing
-- **THEN** the rules SHALL use `margin-inline`, `margin-block`, `padding-inline`, `padding-block` instead of physical `margin-left`, `margin-top`, etc.
-- **AND** existing physical properties SHALL be migrated opportunistically (when the file is already being modified)
+- **WHEN** a CSS file contains margin or padding declarations
+- **THEN** the declarations SHALL use `margin-inline`, `margin-block`, `padding-inline`, `padding-block` (or their `-start`/`-end` longhands) instead of physical `margin-left`, `margin-top`, etc.
+- **AND** Stylelint SHALL reject physical margin/padding properties as errors
 
 #### Scenario: Border and positioning use logical properties
-- **WHEN** new CSS rules define borders or positioning
-- **THEN** the rules SHALL use `border-inline-start`, `inset-inline`, etc. instead of physical equivalents
+- **WHEN** a CSS file contains border or positioning declarations
+- **THEN** the declarations SHALL use `border-inline-start`, `inset-inline`, `inset-block-end`, etc. instead of physical equivalents
+- **AND** Stylelint SHALL reject physical border/positioning properties as errors
+
+#### Scenario: All existing physical properties migrated
+- **WHEN** the Stylelint configuration is applied to the codebase
+- **THEN** all existing physical directional properties SHALL have been migrated to logical equivalents
+- **AND** `stylelint --fix` or manual migration SHALL have resolved all violations
+
+### Requirement: OKLCH color enforcement
+All color definitions in CSS SHALL use the `oklch()` function. Legacy color functions and hex notation SHALL be rejected by Stylelint.
+
+#### Scenario: OKLCH used for solid colors
+- **WHEN** a CSS property requires a color value (e.g., `color`, `background-color`, `border-color`)
+- **THEN** the value SHALL use `oklch()` notation
+- **AND** Stylelint SHALL reject `rgb()`, `rgba()`, `hsl()`, `hsla()`, and hex colors
+
+#### Scenario: OKLCH used for transparency
+- **WHEN** a color requires an alpha/transparency component
+- **THEN** the value SHALL use `oklch(L C H / alpha)` syntax
+- **AND** legacy `rgba(R G B / alpha)` SHALL be rejected
+
+#### Scenario: Tailwind theme colors exempt
+- **WHEN** a color value is provided via Tailwind `theme()` function or CSS custom properties (e.g., `var(--color-brand-primary)`)
+- **THEN** the value SHALL not be subject to color function linting


### PR DESCRIPTION
## Summary

- Add new `css-linting` capability spec defining 7 Stylelint enforcement requirements (OKLCH colors, logical properties, container queries, anti-patterns, property ordering, Tailwind v4 compat, CI integration)
- Update `modern-css-platform` spec: strengthen CSS Logical Properties requirement with Stylelint enforcement, add OKLCH color enforcement requirement
- Archive `introduce-stylelint` change (21/21 tasks complete)

Companion to liverty-music/frontend#129

## Test plan

- [x] Spec content matches implemented Stylelint configuration in frontend PR
- [x] All 21 tasks verified complete before archiving
