### PR TITLE
Add OTel Collector OpenSpec artifacts and sync specs

### DIFF
--- a/openspec/changes/archive/2026-03-06-introduce-otel-collector/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-06-introduce-otel-collector/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-06

--- a/openspec/changes/archive/2026-03-06-introduce-otel-collector/design.md
+++ b/openspec/changes/archive/2026-03-06-introduce-otel-collector/design.md
@@ -1,0 +1,100 @@
+## Context
+
+The backend and frontend both integrate the OpenTelemetry SDK and generate trace data. However, no collector or trace viewer is configured, so traces are created and immediately discarded. The backend uses `otlptracehttp` to export spans when `TELEMETRY_OTLP_ENDPOINT` is set (currently empty). The frontend initializes a `WebTracerProvider` with `OTLPTraceExporter` when `VITE_OTEL_EXPORTER_URL` is set (currently empty).
+
+The GCP project already has `cloudtrace.googleapis.com` enabled, and the `backend-app` GCP service account already has `roles/cloudtrace.agent` bound. The infrastructure uses GKE Autopilot with ArgoCD (App of Apps pattern), Kustomize base/overlays, and Workload Identity for GCP authentication.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Deploy an OTel Collector to GKE that receives OTLP traces from the backend and exports them to Cloud Trace.
+- Make backend traces visible in the GCP Console (Cloud Trace).
+- Simplify the frontend by removing OTLP export while retaining `traceparent` propagation for distributed trace correlation.
+
+**Non-Goals:**
+- Metrics or logs collection via the OTel Collector (traces only for now).
+- Tail-based sampling (use head-based `AlwaysSample` at the current traffic scale).
+- Frontend span export to Cloud Trace.
+- Self-hosted trace viewer (Jaeger, Tempo, etc.) — Cloud Trace is the viewer.
+
+## Decisions
+
+### 1. Viewer: Cloud Trace
+
+**Decision**: Use Google Cloud Trace as the trace viewer.
+
+**Rationale**: The GCP API is already enabled, the backend SA already has `cloudtrace.agent` role, and Cloud Trace provides 2.5M spans/month free tier. No additional infrastructure to host or maintain. Integrates with existing Cloud Logging and Cloud Monitoring alert policies.
+
+**Alternatives considered**:
+- **Jaeger**: Requires hosting in GKE (additional resource cost and maintenance). Better UI for dependency graphs, but overkill for current needs.
+- **Grafana Tempo + Grafana**: Powerful TraceQL and unified observability, but requires deploying both Tempo and Grafana. Premature — no Prometheus/Grafana stack exists yet.
+- **SigNoz Cloud**: SaaS cost ($199/mo+) not justified at this stage.
+
+### 2. Collector Deployment Mode: Deployment (not DaemonSet)
+
+**Decision**: Deploy the OTel Collector as a single-replica Kubernetes `Deployment` in a dedicated `otel-collector` namespace.
+
+**Rationale**: GKE Autopilot has restrictions on DaemonSets (requires specific resource class annotations, cannot use `hostNetwork`). A Deployment is simpler and sufficient for the current traffic volume. The Collector processes traces in-memory with a `batch` processor — no persistent state required.
+
+**Scaling**: If throughput grows, add HPA based on CPU/memory. If per-node collection is needed later (e.g., for host metrics), switch to DaemonSet.
+
+### 3. Collector Distribution: `otel/opentelemetry-collector-contrib`
+
+**Decision**: Use the `contrib` distribution of the OTel Collector.
+
+**Rationale**: The `googlecloud` exporter is only available in the `contrib` distribution, not in the core distribution.
+
+### 4. Frontend: Remove OTLP Export, Keep traceparent
+
+**Decision**: Remove `OTLPTraceExporter`, `BatchSpanProcessor`, and the `@opentelemetry/exporter-trace-otlp-http` dependency from the frontend. Keep `WebTracerProvider` (without exporter) and `FetchInstrumentation` for `traceparent` header generation.
+
+**Rationale**: The frontend only needs to generate trace context headers for backend request correlation. Exporting browser spans adds complexity (CORS, Collector public exposure) with minimal value — backend spans are sufficient for debugging API flows.
+
+**What is retained**:
+- `WebTracerProvider` (registered without span processors that export)
+- `FetchInstrumentation` (injects `traceparent` into API requests)
+- `OtelLogSink` (local span creation for error diagnostics — no export needed)
+- Connect-RPC tracing interceptor
+
+### 5. Workload Identity: Dedicated GCP SA for OTel Collector
+
+**Decision**: Create a dedicated GCP service account `otel-collector` with `roles/cloudtrace.agent`, bound to the K8s SA `otel-collector` in namespace `otel-collector` via Workload Identity.
+
+**Rationale**: Follows the existing pattern (e.g., `backend-app` SA, `k8s-external-secrets` SA). Principle of least privilege — the Collector only needs trace write access, not the broader permissions of `backend-app`.
+
+### 6. OTel Collector Pipeline Configuration
+
+**Decision**: Minimal pipeline — `otlp` receiver → `batch` processor → `googlecloud` exporter.
+
+```yaml
+receivers:
+  otlp:
+    protocols:
+      http:
+        endpoint: 0.0.0.0:4318
+      grpc:
+        endpoint: 0.0.0.0:4317
+
+processors:
+  batch:
+    timeout: 5s
+    send_batch_size: 512
+
+exporters:
+  googlecloud: {}
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [googlecloud]
+```
+
+**Rationale**: Simplest working configuration. The `batch` processor improves throughput by buffering spans before export. No sampling processor needed — `AlwaysSample` at the SDK level is fine at current scale.
+
+## Risks / Trade-offs
+
+- **Single point of failure**: One Collector replica means trace loss during restarts or OOM. → Acceptable for dev/staging. For prod, add a second replica or HPA.
+- **Backend-only traces in Cloud Trace**: Without frontend span export, Cloud Trace shows only backend spans. Frontend-to-backend latency is not directly measurable. → Acceptable trade-off — backend spans include the full RPC processing time, which is the primary debugging need.
+- **GKE Autopilot resource costs**: The Collector pod adds resource cost. → Mitigate with tight resource requests/limits and Spot VM nodeSelector (consistent with dev cost optimization policy).

--- a/openspec/changes/archive/2026-03-06-introduce-otel-collector/proposal.md
+++ b/openspec/changes/archive/2026-03-06-introduce-otel-collector/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+Both frontend and backend integrate the OpenTelemetry SDK and generate trace data, but no collector or viewer is deployed. Traces are created and discarded because `TELEMETRY_OTLP_ENDPOINT` (backend) and `VITE_OTEL_EXPORTER_URL` (frontend) are unset. Without trace visibility, debugging distributed request flows across the frontend-backend boundary is done entirely through log inspection.
+
+## What Changes
+
+- Deploy an OpenTelemetry Collector as a Kubernetes Deployment in GKE, configured to receive OTLP traces and export them to Google Cloud Trace via the `googlecloud` exporter.
+- Configure the backend to send traces to the in-cluster OTel Collector via `TELEMETRY_OTLP_ENDPOINT`.
+- **Simplify frontend observability**: Remove the OTLP/HTTP span exporter (`OTLPTraceExporter`, `BatchSpanProcessor`) and related dependencies. The frontend only needs to generate `traceparent` headers for backend request correlation — it does not need to export its own spans.
+- Retain the Connect-RPC tracing interceptor and `OtelLogSink` (they operate on the local tracer provider and remain useful for in-browser diagnostics).
+- Set up Workload Identity for the OTel Collector so it can authenticate to Cloud Trace without service account keys.
+
+## Capabilities
+
+### New Capabilities
+
+- `otel-collector-deployment`: Defines the OTel Collector Kubernetes deployment, configuration, service account, and Workload Identity binding for exporting traces to Cloud Trace.
+
+### Modified Capabilities
+
+- `frontend-observability`: Remove the OTLP/HTTP export requirement. The frontend SHALL generate trace context (`traceparent`) for backend request correlation but SHALL NOT export spans to an external collector.
+
+## Impact
+
+- **cloud-provisioning**: New K8s namespace `otel-collector` with Kustomize base/overlay, ArgoCD Application, Workload Identity IAM binding via Pulumi.
+- **backend**: Set `TELEMETRY_OTLP_ENDPOINT` environment variable in the backend Deployment manifests pointing to the in-cluster Collector service.
+- **frontend**: Remove `@opentelemetry/exporter-trace-otlp-http` dependency and `BatchSpanProcessor` initialization. `VITE_OTEL_EXPORTER_URL` is no longer needed.
+- **GCP**: Cloud Trace API is already enabled. Workload Identity binding for the Collector service account is required.

--- a/openspec/changes/archive/2026-03-06-introduce-otel-collector/specs/frontend-observability/spec.md
+++ b/openspec/changes/archive/2026-03-06-introduce-otel-collector/specs/frontend-observability/spec.md
@@ -1,0 +1,26 @@
+# Frontend Observability
+
+## MODIFIED Requirements
+
+### Requirement: OpenTelemetry Browser SDK Integration
+The system SHALL integrate OpenTelemetry browser SDK for distributed tracing, enabling request correlation between the frontend and Go backend via W3C Trace Context headers. The frontend SHALL NOT export spans to an external collector.
+
+#### Scenario: OTEL tracer provider is initialized at startup
+- **WHEN** the Aurelia 2 application starts
+- **THEN** the system SHALL initialize a `WebTracerProvider` without any span exporters
+- **AND** the system SHALL register the provider as the global tracer provider
+
+#### Scenario: Fetch requests include trace context headers
+- **WHEN** the browser makes a fetch request to the backend API domain
+- **THEN** the `instrumentation-fetch` package SHALL automatically inject `traceparent` and `tracestate` headers (W3C Trace Context)
+- **AND** the backend SHALL use these headers to continue the distributed trace
+- **AND** `propagateTraceHeaderCorsUrls` SHALL be configured to match the backend API origin
+
+#### Scenario: Non-API requests are not instrumented
+- **WHEN** the browser makes a fetch request to a third-party domain (e.g., Last.fm API, Zitadel)
+- **THEN** the system SHALL NOT inject trace context headers into that request
+
+#### Scenario: No spans are exported from the browser
+- **WHEN** the tracer provider is initialized
+- **THEN** no `BatchSpanProcessor` with an `OTLPTraceExporter` SHALL be configured
+- **AND** the `VITE_OTEL_EXPORTER_URL` environment variable SHALL NOT be required

--- a/openspec/changes/archive/2026-03-06-introduce-otel-collector/specs/otel-collector-deployment/spec.md
+++ b/openspec/changes/archive/2026-03-06-introduce-otel-collector/specs/otel-collector-deployment/spec.md
@@ -1,0 +1,72 @@
+# OTel Collector Deployment
+
+## Purpose
+
+Defines the OpenTelemetry Collector deployment on GKE for receiving OTLP traces from backend services and exporting them to Google Cloud Trace.
+
+## ADDED Requirements
+
+### Requirement: OTel Collector Kubernetes Deployment
+The system SHALL deploy an OpenTelemetry Collector as a Kubernetes Deployment in a dedicated `otel-collector` namespace, configured to receive traces via OTLP and export them to Cloud Trace.
+
+#### Scenario: Collector receives OTLP traces over HTTP
+- **WHEN** a backend service sends traces to the Collector's OTLP/HTTP endpoint
+- **THEN** the Collector SHALL accept the traces on port 4318
+- **AND** the Collector SHALL process them through the `batch` processor
+- **AND** the Collector SHALL export the traces to Google Cloud Trace via the `googlecloud` exporter
+
+#### Scenario: Collector receives OTLP traces over gRPC
+- **WHEN** a backend service sends traces to the Collector's OTLP/gRPC endpoint
+- **THEN** the Collector SHALL accept the traces on port 4317
+
+#### Scenario: Collector is reachable via in-cluster service
+- **WHEN** a backend pod needs to send traces
+- **THEN** a Kubernetes Service `otel-collector` in namespace `otel-collector` SHALL be available
+- **AND** the service SHALL expose ports 4317 (gRPC) and 4318 (HTTP)
+
+---
+
+### Requirement: Workload Identity for Cloud Trace Authentication
+The system SHALL use GKE Workload Identity to authenticate the OTel Collector to Cloud Trace without service account keys.
+
+#### Scenario: Collector authenticates via Workload Identity
+- **WHEN** the Collector pod starts
+- **THEN** the pod SHALL use the Kubernetes service account `otel-collector`
+- **AND** the K8s SA SHALL be annotated with the GCP service account email
+- **AND** the GCP SA SHALL have `roles/cloudtrace.agent` bound
+- **AND** the GCP SA SHALL have Workload Identity binding for the `otel-collector` namespace
+
+---
+
+### Requirement: Backend Trace Export Configuration
+The system SHALL configure backend deployments to send traces to the in-cluster OTel Collector.
+
+#### Scenario: Backend server sends traces to OTel Collector
+- **WHEN** the backend server deployment starts in a cluster with the OTel Collector deployed
+- **THEN** the `TELEMETRY_OTLP_ENDPOINT` environment variable SHALL be set to `otel-collector.otel-collector.svc.cluster.local:4318`
+- **AND** the backend SHALL export traces via OTLP/HTTP to this endpoint
+
+#### Scenario: Backend consumer sends traces to OTel Collector
+- **WHEN** the backend consumer deployment starts in a cluster with the OTel Collector deployed
+- **THEN** the `TELEMETRY_OTLP_ENDPOINT` environment variable SHALL be set to the same Collector endpoint as the server
+
+---
+
+### Requirement: Cost-Optimized Resource Configuration
+The Collector deployment SHALL follow the dev cost optimization policy for GKE Autopilot.
+
+#### Scenario: Collector uses Spot VMs and minimal resources
+- **WHEN** the Collector is deployed in the dev environment
+- **THEN** the pod SHALL have `nodeSelector: cloud.google.com/compute-class: autopilot-spot`
+- **AND** the container SHALL have explicit CPU and memory resource requests and limits
+
+---
+
+### Requirement: ArgoCD GitOps Management
+The Collector deployment SHALL be managed by ArgoCD following the App of Apps pattern.
+
+#### Scenario: ArgoCD Application for OTel Collector
+- **WHEN** the cloud-provisioning repository contains the OTel Collector manifests
+- **THEN** an ArgoCD Application `otel-collector` SHALL exist in namespace `argocd`
+- **AND** the Application SHALL point to `k8s/namespaces/otel-collector/overlays/dev`
+- **AND** the Application SHALL have automated sync with prune and self-heal enabled

--- a/openspec/changes/archive/2026-03-06-introduce-otel-collector/specs/otel-collector-deployment/spec.md
+++ b/openspec/changes/archive/2026-03-06-introduce-otel-collector/specs/otel-collector-deployment/spec.md
@@ -50,6 +50,10 @@ The system SHALL configure backend deployments to send traces to the in-cluster 
 - **WHEN** the backend consumer deployment starts in a cluster with the OTel Collector deployed
 - **THEN** the `TELEMETRY_OTLP_ENDPOINT` environment variable SHALL be set to the same Collector endpoint as the server
 
+#### Scenario: Backend concert-discovery CronJob sends traces to OTel Collector
+- **WHEN** the concert-discovery CronJob runs in a cluster with the OTel Collector deployed
+- **THEN** the `TELEMETRY_OTLP_ENDPOINT` environment variable SHALL be set to the same Collector endpoint as the server
+
 ---
 
 ### Requirement: Cost-Optimized Resource Configuration

--- a/openspec/changes/archive/2026-03-06-introduce-otel-collector/tasks.md
+++ b/openspec/changes/archive/2026-03-06-introduce-otel-collector/tasks.md
@@ -1,0 +1,30 @@
+## 1. GCP IAM (Pulumi)
+
+- [x] 1.1 Create GCP service account `otel-collector` with `roles/cloudtrace.agent` in the KubernetesComponent
+- [x] 1.2 Bind Workload Identity for K8s SA `otel-collector` in namespace `otel-collector` to the GCP SA
+
+## 2. OTel Collector K8s Manifests
+
+- [x] 2.1 Create `k8s/namespaces/otel-collector/base/` with Kustomization, ServiceAccount (annotated with GCP SA email placeholder), ConfigMap (collector config), Deployment, and Service
+- [x] 2.2 Create `k8s/namespaces/otel-collector/overlays/dev/` with Kustomization, GCP SA email patch, resource requests/limits patch, and Spot VM nodeSelector patch
+- [x] 2.3 Create ArgoCD Application `otel-collector` at `k8s/argocd-apps/dev/otel-collector.yaml`
+- [x] 2.4 Add `otel-collector` namespace to `k8s/init/namespaces.yaml`
+- [x] 2.5 Validate manifests with `kubectl kustomize k8s/namespaces/otel-collector/overlays/dev`
+
+## 3. Backend Configuration
+
+- [x] 3.1 Add `TELEMETRY_OTLP_ENDPOINT` env var to backend server Deployment overlay (dev) pointing to `otel-collector.otel-collector.svc.cluster.local:4318`
+- [x] 3.2 Add `TELEMETRY_OTLP_ENDPOINT` env var to backend consumer Deployment overlay (dev) pointing to the same endpoint
+- [x] 3.3 Add `TELEMETRY_OTLP_ENDPOINT` env var to backend concert-discovery CronJob overlay (dev) pointing to the same endpoint
+
+## 4. Frontend Simplification
+
+- [x] 4.1 Remove `OTLPTraceExporter` and `BatchSpanProcessor` from `otel-init.ts` — initialize `WebTracerProvider` without span processors
+- [x] 4.2 Remove `@opentelemetry/exporter-trace-otlp-http` from `package.json` and run `npm install`
+- [x] 4.3 Remove `VITE_OTEL_EXPORTER_URL` references from code and environment configs
+- [x] 4.4 Run `make check` in frontend to verify lint and tests pass
+
+## 5. Verification
+
+- [x] 5.1 Run `make check` in cloud-provisioning (lint-ts, lint-k8s)
+- [x] 5.2 Run `make check` in backend

--- a/openspec/specs/frontend-observability/spec.md
+++ b/openspec/specs/frontend-observability/spec.md
@@ -7,12 +7,11 @@ Defines the OpenTelemetry-based observability infrastructure for the Aurelia 2 f
 ## Requirements
 
 ### Requirement: OpenTelemetry Browser SDK Integration
-The system SHALL integrate OpenTelemetry browser SDK for distributed tracing, enabling end-to-end request correlation between the frontend and Go backend.
+The system SHALL integrate OpenTelemetry browser SDK for distributed tracing, enabling request correlation between the frontend and Go backend via W3C Trace Context headers. The frontend SHALL NOT export spans to an external collector.
 
 #### Scenario: OTEL tracer provider is initialized at startup
 - **WHEN** the Aurelia 2 application starts
-- **THEN** the system SHALL initialize a `WebTracerProvider` with a `BatchSpanProcessor`
-- **AND** the system SHALL configure an OTLP/HTTP exporter targeting the configured collector endpoint
+- **THEN** the system SHALL initialize a `WebTracerProvider` without any span exporters
 - **AND** the system SHALL register the provider as the global tracer provider
 
 #### Scenario: Fetch requests include trace context headers
@@ -24,6 +23,11 @@ The system SHALL integrate OpenTelemetry browser SDK for distributed tracing, en
 #### Scenario: Non-API requests are not instrumented
 - **WHEN** the browser makes a fetch request to a third-party domain (e.g., Last.fm API, Zitadel)
 - **THEN** the system SHALL NOT inject trace context headers into that request
+
+#### Scenario: No spans are exported from the browser
+- **WHEN** the tracer provider is initialized
+- **THEN** no `BatchSpanProcessor` with an `OTLPTraceExporter` SHALL be configured
+- **AND** the `VITE_OTEL_EXPORTER_URL` environment variable SHALL NOT be required
 
 ---
 

--- a/openspec/specs/otel-collector-deployment/spec.md
+++ b/openspec/specs/otel-collector-deployment/spec.md
@@ -1,0 +1,72 @@
+# OTel Collector Deployment
+
+## Purpose
+
+Defines the OpenTelemetry Collector deployment on GKE for receiving OTLP traces from backend services and exporting them to Google Cloud Trace.
+
+## Requirements
+
+### Requirement: OTel Collector Kubernetes Deployment
+The system SHALL deploy an OpenTelemetry Collector as a Kubernetes Deployment in a dedicated `otel-collector` namespace, configured to receive traces via OTLP and export them to Cloud Trace.
+
+#### Scenario: Collector receives OTLP traces over HTTP
+- **WHEN** a backend service sends traces to the Collector's OTLP/HTTP endpoint
+- **THEN** the Collector SHALL accept the traces on port 4318
+- **AND** the Collector SHALL process them through the `batch` processor
+- **AND** the Collector SHALL export the traces to Google Cloud Trace via the `googlecloud` exporter
+
+#### Scenario: Collector receives OTLP traces over gRPC
+- **WHEN** a backend service sends traces to the Collector's OTLP/gRPC endpoint
+- **THEN** the Collector SHALL accept the traces on port 4317
+
+#### Scenario: Collector is reachable via in-cluster service
+- **WHEN** a backend pod needs to send traces
+- **THEN** a Kubernetes Service `otel-collector` in namespace `otel-collector` SHALL be available
+- **AND** the service SHALL expose ports 4317 (gRPC) and 4318 (HTTP)
+
+---
+
+### Requirement: Workload Identity for Cloud Trace Authentication
+The system SHALL use GKE Workload Identity to authenticate the OTel Collector to Cloud Trace without service account keys.
+
+#### Scenario: Collector authenticates via Workload Identity
+- **WHEN** the Collector pod starts
+- **THEN** the pod SHALL use the Kubernetes service account `otel-collector`
+- **AND** the K8s SA SHALL be annotated with the GCP service account email
+- **AND** the GCP SA SHALL have `roles/cloudtrace.agent` bound
+- **AND** the GCP SA SHALL have Workload Identity binding for the `otel-collector` namespace
+
+---
+
+### Requirement: Backend Trace Export Configuration
+The system SHALL configure backend deployments to send traces to the in-cluster OTel Collector.
+
+#### Scenario: Backend server sends traces to OTel Collector
+- **WHEN** the backend server deployment starts in a cluster with the OTel Collector deployed
+- **THEN** the `TELEMETRY_OTLP_ENDPOINT` environment variable SHALL be set to `otel-collector.otel-collector.svc.cluster.local:4318`
+- **AND** the backend SHALL export traces via OTLP/HTTP to this endpoint
+
+#### Scenario: Backend consumer sends traces to OTel Collector
+- **WHEN** the backend consumer deployment starts in a cluster with the OTel Collector deployed
+- **THEN** the `TELEMETRY_OTLP_ENDPOINT` environment variable SHALL be set to the same Collector endpoint as the server
+
+---
+
+### Requirement: Cost-Optimized Resource Configuration
+The Collector deployment SHALL follow the dev cost optimization policy for GKE Autopilot.
+
+#### Scenario: Collector uses Spot VMs and minimal resources
+- **WHEN** the Collector is deployed in the dev environment
+- **THEN** the pod SHALL have `nodeSelector: cloud.google.com/compute-class: autopilot-spot`
+- **AND** the container SHALL have explicit CPU and memory resource requests and limits
+
+---
+
+### Requirement: ArgoCD GitOps Management
+The Collector deployment SHALL be managed by ArgoCD following the App of Apps pattern.
+
+#### Scenario: ArgoCD Application for OTel Collector
+- **WHEN** the cloud-provisioning repository contains the OTel Collector manifests
+- **THEN** an ArgoCD Application `otel-collector` SHALL exist in namespace `argocd`
+- **AND** the Application SHALL point to `k8s/namespaces/otel-collector/overlays/dev`
+- **AND** the Application SHALL have automated sync with prune and self-heal enabled

--- a/openspec/specs/otel-collector-deployment/spec.md
+++ b/openspec/specs/otel-collector-deployment/spec.md
@@ -50,6 +50,10 @@ The system SHALL configure backend deployments to send traces to the in-cluster 
 - **WHEN** the backend consumer deployment starts in a cluster with the OTel Collector deployed
 - **THEN** the `TELEMETRY_OTLP_ENDPOINT` environment variable SHALL be set to the same Collector endpoint as the server
 
+#### Scenario: Backend concert-discovery CronJob sends traces to OTel Collector
+- **WHEN** the concert-discovery CronJob runs in a cluster with the OTel Collector deployed
+- **THEN** the `TELEMETRY_OTLP_ENDPOINT` environment variable SHALL be set to the same Collector endpoint as the server
+
 ---
 
 ### Requirement: Cost-Optimized Resource Configuration


### PR DESCRIPTION
## Related Issue

Closes #153

## Summary of Changes

- Add OpenSpec change artifacts (proposal, design, specs, tasks) for the introduce-otel-collector change, archived at `openspec/changes/archive/2026-03-06-introduce-otel-collector/`
- Add new `otel-collector-deployment` capability spec defining OTel Collector K8s deployment, Workload Identity, backend config, cost optimization, and ArgoCD requirements
- Update `frontend-observability` spec: remove OTLP export requirement from `WebTracerProvider` initialization, add "No spans exported from browser" scenario

## Self-Checklist

- [x] I have linked the related issue.
- [x] I have updated the relevant documentation (e.g., `README.md`) if needed.
- [x] I have run `buf lint` and `buf format` locally and all checks have passed.
- [x] My proto definitions follow the project's style guidelines and validation rules.
- [x] Breaking changes have been justified and documented if applicable.
