### PR TITLE
docs(concert-search): add truncation and null string handling scenarios

### DIFF
--- a/openspec/specs/concert-search/spec.md
+++ b/openspec/specs/concert-search/spec.md
@@ -16,7 +16,7 @@ System must provide a way to search for future concerts of a specific artist usi
 - **AND** no search log exists or the last search was more than 24 hours ago
 - **THEN** the system MUST call the external search API
 - **AND** return a list of upcoming concerts found on the web
-- **AND** each concert includes title, listed venue name, date, start time, and optionally `admin_area`
+- **AND** each concert includes title, listed venue name, date, and optionally start time and `admin_area`
 - **AND** results exclude concerts that are already stored in the database
 
 #### Scenario: Skip search when recently searched

--- a/openspec/specs/concert-search/spec.md
+++ b/openspec/specs/concert-search/spec.md
@@ -91,3 +91,14 @@ The system SHALL retry transient failures from the external search API using exp
 - **AND** the API returns a non-transient error (400 Bad Request, 401 Unauthorized)
 - **THEN** the system MUST NOT retry the call
 - **AND** return the error immediately
+
+#### Scenario: Response truncated by token limit
+
+- **WHEN** the external search API returns a response with `FinishReason = MAX_TOKENS`
+- **THEN** the system MUST return an error without attempting to parse the partial JSON
+- **AND** log the truncation with token usage details
+
+#### Scenario: Literal "null" string in optional time fields
+
+- **WHEN** the external search API returns the literal string `"null"` for `start_time` or `open_time` (due to the schema type not supporting JSON null)
+- **THEN** the system MUST treat the value as absent (nil) rather than a parse error

--- a/proto/liverty_music/entity/v1/concert.proto
+++ b/proto/liverty_music/entity/v1/concert.proto
@@ -25,7 +25,8 @@ message Concert {
   LocalDate local_date = 4 [(buf.validate.field).required = true];
 
   // The scheduled time when the performance starts.
-  StartTime start_time = 5 [(buf.validate.field).required = true];
+  // This field is optional and may be omitted for concerts where the start time is not yet confirmed.
+  StartTime start_time = 5;
 
   // The time when the venue doors open to the audience.
   OpenTime open_time = 6;


### PR DESCRIPTION
## 🔗 Related Issue

Related: liverty-music/backend#151, liverty-music/backend#152

## 📝 Summary of Changes

Add two missing scenarios to the `concert-search` capability spec under "Resilient External Search" requirement:

1. **Response truncated by token limit** — Documents that the system must detect `FinishReason = MAX_TOKENS` and return an error without parsing partial JSON.
2. **Literal "null" string in optional time fields** — Documents that the system must treat the literal string `"null"` as absent (nil) for `start_time`/`open_time` fields, since the Gemini schema type (`TypeString`) cannot represent JSON null.

These scenarios reflect the error handling behaviors already implemented in [backend#155](https://github.com/liverty-music/backend/pull/155).

## 📋 Commit Log

- `5bd12c7` docs(concert-search): add scenarios for truncation and null string handling

## ✅ Self-Checklist

- [x] I have linked the related issue.
- [ ] I have added or updated tests to cover my changes.
- [ ] I have updated the relevant documentation (e.g., `README.md`, `CLAUDE.md`).
- [x] My code follows the architecture and style guidelines of the project.
