### PR TITLE
docs(openspec): propose artist search dedup and created event

### DIFF
--- a/openspec/changes/artist-created-event/design.md
+++ b/openspec/changes/artist-created-event/design.md
@@ -109,6 +109,8 @@ type ArtistNameConsumer struct {
 }
 
 func (h *ArtistNameConsumer) Handle(msg *message.Message) error {
+    ctx := context.Background()
+
     var data messaging.ArtistCreatedData
     if err := messaging.ParseCloudEventData(msg, &data); err != nil {
         return fmt.Errorf("parse artist.created event: %w", err)

--- a/openspec/changes/artist-created-event/design.md
+++ b/openspec/changes/artist-created-event/design.md
@@ -1,0 +1,178 @@
+## Architecture
+
+All changes are in the backend repository. Follows the existing EDA patterns established in `introduce-eda`.
+
+## Event Flow
+
+```
+  Search / ListSimilar / ListTop
+           │
+           ▼
+  persistArtists(ctx, artists)
+           │
+    ┌──────┴──────┐
+    │ ListByMBIDs │ → existing (skip)
+    └──────┬──────┘
+           │
+    ┌──────┴──────┐
+    │   Create    │ → newly inserted
+    └──────┬──────┘
+           │
+           ▼
+  for each new artist:
+    publish ARTIST.created  ← NEW
+           │
+           ▼
+  merge existing + created → return
+
+  ════════════════════════════════════
+  Consumer Process (async)
+  ════════════════════════════════════
+
+  ARTIST.created event
+         │
+         ▼
+  ArtistNameConsumer.Handle()
+         │
+         ▼
+  MusicBrainz GetArtist(mbid)     ← 1 req/sec (natural throttle)
+         │
+         ▼
+  if canonical name != current name:
+      artistRepo.UpdateName(id, canonicalName)
+  else:
+      no-op (ack message)
+```
+
+## ARTIST Stream Configuration
+
+```go
+// streams.go
+{
+    Name:       "ARTIST",
+    Subjects:   []string{"ARTIST.*"},
+    Retention:  nats.LimitsPolicy,
+    MaxAge:     7 * 24 * time.Hour,
+    Storage:    nats.FileStorage,
+    Discard:    nats.DiscardOld,
+    Replicas:   1,
+    Duplicates: 2 * time.Minute,
+}
+```
+
+Follows the same configuration pattern as `CONCERT` and `VENUE` streams.
+
+## Event Payload
+
+```go
+// events.go
+type ArtistCreatedData struct {
+    ArtistID   string `json:"artist_id"`
+    ArtistName string `json:"artist_name"`
+    MBID       string `json:"mbid"`
+}
+```
+
+Subject constant: `SubjectArtistCreated = "ARTIST.created"`
+
+## Publisher Integration in UseCase
+
+The `artistUseCase` gains a `message.Publisher` dependency. The `persistArtists` helper publishes after step 4 (Create missing):
+
+```go
+for _, a := range created {
+    msg, err := messaging.NewEvent(messaging.ArtistCreatedData{
+        ArtistID:   a.ID,
+        ArtistName: a.Name,
+        MBID:       a.MBID,
+    })
+    if err != nil {
+        uc.logger.Warn(ctx, "failed to create artist.created event", ...)
+        continue
+    }
+    if err := uc.publisher.Publish(messaging.SubjectArtistCreated, msg); err != nil {
+        uc.logger.Warn(ctx, "failed to publish artist.created event", ...)
+    }
+}
+```
+
+Event publish failures are logged and swallowed — they must not block the search response. The artist is already persisted; name resolution is best-effort enrichment.
+
+## ArtistNameConsumer
+
+```go
+// adapter/event/artist_consumer.go
+type ArtistNameConsumer struct {
+    artistRepo entity.ArtistRepository
+    idManager  entity.ArtistIdentityManager
+    logger     *logging.Logger
+}
+
+func (h *ArtistNameConsumer) Handle(msg *message.Message) error {
+    var data messaging.ArtistCreatedData
+    if err := messaging.ParseCloudEventData(msg, &data); err != nil {
+        return fmt.Errorf("parse artist.created event: %w", err)
+    }
+
+    canonical, err := h.idManager.GetArtist(ctx, data.MBID)
+    if err != nil {
+        return fmt.Errorf("resolve canonical name: %w", err)
+    }
+
+    if canonical.Name == data.ArtistName {
+        return nil // name already correct
+    }
+
+    if err := h.artistRepo.UpdateName(ctx, data.ArtistID, canonical.Name); err != nil {
+        return fmt.Errorf("update artist name: %w", err)
+    }
+
+    return nil
+}
+```
+
+Watermill retry middleware (3 retries, exponential backoff) handles MusicBrainz rate limit errors naturally. Failed messages go to the poison queue after max retries.
+
+## New Repository Method: `UpdateName`
+
+### Interface Addition
+
+```go
+// entity/artist.go — added to ArtistRepository interface
+
+// UpdateName updates the display name of an artist identified by ID.
+UpdateName(ctx context.Context, id string, name string) error
+```
+
+### SQL
+
+```sql
+UPDATE artists SET name = $2 WHERE id = $1
+```
+
+## DI Wiring
+
+### provider.go (server process)
+
+Pass `publisher` to `NewArtistUseCase` so `persistArtists` can publish events.
+
+### consumer.go (consumer process)
+
+```go
+artistNameConsumer := event.NewArtistNameConsumer(artistRepo, musicbrainzClient, logger)
+
+router.AddConsumerHandler(
+    "resolve-artist-name",
+    messaging.SubjectArtistCreated,
+    subscriber,
+    artistNameConsumer.Handle,
+)
+```
+
+The MusicBrainz client is already instantiated in `consumer.go` for venue enrichment. Reuse the same instance.
+
+## Decisions
+
+- **Fire-and-forget publishing**: Event publish errors are logged but do not fail the search. Artist data is already in the DB; name resolution is eventual enrichment.
+- **MusicBrainz rate limit**: The consumer processes one message at a time per consumer instance. At 1 req/sec MusicBrainz limit, this is naturally compliant. KEDA scaling should cap consumer replicas to avoid exceeding the rate limit.
+- **Idempotency**: Re-processing `ARTIST.created` is safe — `UpdateName` is a simple SET that converges to the correct state regardless of how many times it runs.

--- a/openspec/changes/artist-created-event/proposal.md
+++ b/openspec/changes/artist-created-event/proposal.md
@@ -1,0 +1,42 @@
+## Why
+
+When artists are persisted to the database via Last.fm search results, their display names come from Last.fm which may not match the canonical MusicBrainz name (e.g. Last.fm might store a popular but unofficial variant). There is currently no mechanism to resolve canonical names asynchronously after artist creation.
+
+Additionally, the `persistArtists` helper introduced in `deduplicate-artist-search` knows exactly which artists are newly created. Publishing an `artist.created` event enables downstream consumers to enrich artist data without blocking the search response.
+
+## What Changes
+
+- Add `ARTIST` JetStream stream with `ARTIST.*` subject pattern
+- Add `ARTIST.created` subject and `ArtistCreatedData` event payload
+- Extend the `persistArtists` helper in `artistUseCase` to publish `ARTIST.created` events for newly inserted artists
+- Add `message.Publisher` dependency to `artistUseCase`
+- Add `UpdateName` method to `ArtistRepository` for canonical name correction
+- Introduce `ArtistNameConsumer` that subscribes to `ARTIST.created`, resolves the canonical name from MusicBrainz, and updates the DB if it differs
+- Wire the new consumer into the Watermill Router
+
+## Prerequisites
+
+- `deduplicate-artist-search` must be merged first (provides the `persistArtists` helper and read-then-write pattern that identifies new artists)
+
+## Capabilities
+
+### New Capabilities
+- `artist-name-resolution`: Async consumer that resolves canonical artist names from MusicBrainz upon artist creation, keeping the `artists` table aligned with MusicBrainz identity data
+
+### Modified Capabilities
+- `event-messaging`: New `ARTIST` JetStream stream added alongside existing `CONCERT` and `VENUE` streams
+- `artist-discovery`: `persistArtists` helper now publishes events for newly created artists
+
+## Impact
+
+- **Backend**: Modified files: `usecase/artist_uc.go` (add publisher, publish events in helper), `entity/artist.go` (add `UpdateName` to interface), `infrastructure/database/rdb/artist_repo.go` (implement `UpdateName`), `infrastructure/messaging/streams.go` (add ARTIST stream), `infrastructure/messaging/cloudevents.go` (add subject constant), `infrastructure/messaging/events.go` (add payload type), `di/provider.go` (pass publisher to artist UC), `di/consumer.go` (wire new consumer). New files: `adapter/event/artist_consumer.go`. Mock regeneration required.
+- **Frontend**: No changes.
+- **Proto (RPC)**: No changes.
+- **Database**: No schema migration. `UpdateName` uses a simple `UPDATE artists SET name = $2 WHERE id = $1`.
+- **NATS**: New `ARTIST` stream auto-provisioned by `EnsureStreams`.
+
+## Out of Scope
+
+- Artist alias/variant tracking (storing multiple known names per MBID)
+- Batch backfill of canonical names for existing artists
+- `artist.followed` event (separate concern)

--- a/openspec/changes/artist-created-event/tasks.md
+++ b/openspec/changes/artist-created-event/tasks.md
@@ -1,0 +1,39 @@
+## Tasks
+
+All tasks target the `backend` repository. Requires `deduplicate-artist-search` to be merged first.
+
+### 1. Add `ARTIST` stream and event definitions
+
+- [ ] Add `ARTIST` stream config to `infrastructure/messaging/streams.go`
+- [ ] Add `SubjectArtistCreated = "ARTIST.created"` to `infrastructure/messaging/cloudevents.go`
+- [ ] Add `ArtistCreatedData` struct to `infrastructure/messaging/events.go`
+
+### 2. Add `UpdateName` to `ArtistRepository`
+
+- [ ] Add `UpdateName(ctx context.Context, id string, name string) error` to `ArtistRepository` interface in `entity/artist.go`
+- [ ] Implement in `infrastructure/database/rdb/artist_repo.go`
+- [ ] Add unit test in `artist_repo_test.go`
+- [ ] Regenerate mocks (`mockery`)
+
+### 3. Add publisher to `artistUseCase`
+
+- [ ] Add `message.Publisher` field to `artistUseCase` struct
+- [ ] Update `NewArtistUseCase` constructor signature
+- [ ] Update DI wiring in `di/provider.go` to pass publisher
+- [ ] Publish `ARTIST.created` events in `persistArtists` for newly created artists
+- [ ] Update unit tests (mock publisher)
+
+### 4. Implement `ArtistNameConsumer`
+
+- [ ] Create `adapter/event/artist_consumer.go` with `ArtistNameConsumer`
+- [ ] Implement `Handle`: parse event → MusicBrainz GetArtist → UpdateName if differs
+- [ ] Add unit tests in `artist_consumer_test.go`
+
+### 5. Wire consumer into Router
+
+- [ ] Add `ArtistNameConsumer` instantiation in `di/consumer.go`
+- [ ] Register `resolve-artist-name` handler on `SubjectArtistCreated`
+
+### 6. Verify
+
+- [ ] `make check` passes (lint + test)

--- a/openspec/changes/deduplicate-artist-search/design.md
+++ b/openspec/changes/deduplicate-artist-search/design.md
@@ -1,0 +1,163 @@
+## Architecture
+
+All changes are in the backend repository. No cross-repo coordination required.
+
+## Data Flow: Search (Before vs After)
+
+### Before
+
+```
+lastfm.Search("ヨルシカ")
+  → 11 results (duplicates, empty MBIDs)
+  → cache as-is
+  → return with ephemeral UUIDs (regenerated per call)
+```
+
+### After
+
+```
+lastfm.Search("ヨルシカ")
+  → 11 results
+  → filter: drop empty MBID          → 5 remain
+  → dedup: keep first per MBID       → 2 remain (ヨルシカ, suis from ヨルシカ)
+  → persistArtists(ctx, filtered)
+      1. ListByMBIDs(["abc","def"])   → find existing in DB
+      2. Create(missing only)         → insert new artists
+      3. merge existing + created     → preserve input order
+  → cache persisted results
+  → return with stable DB UUIDs
+```
+
+## Search Dedup Rules
+
+1. **Drop empty MBID**: Entries without a MusicBrainz ID are user-submitted Last.fm pages with no canonical identity. Liverty Music requires MBID for artist identity.
+2. **Dedup by MBID**: Keep the first occurrence per MBID. Last.fm returns results by popularity, so the first variant is the most recognized name.
+3. **Different MBID = different artist**: Even if names look related (e.g. "suis from ヨルシカ"), a distinct MBID means MusicBrainz recognizes it as a separate entity.
+
+## Shared Helper: `persistArtists`
+
+### Motivation
+
+Three UseCase methods fetch artists from external APIs and need to return them with stable DB UUIDs:
+
+| Method | Currently persists? | After |
+|--------|-------------------|-------|
+| `Search` | No | Yes, via helper |
+| `ListSimilar` | Yes, via `Create(all...)` | Yes, via helper |
+| `ListTop` | Yes, via `Create(all...)` | Yes, via helper |
+
+`ListSimilar` and `ListTop` currently call `Create(all...)` which issues INSERT for every artist (relying on ON CONFLICT DO NOTHING). The helper optimizes this by reading first, writing only missing.
+
+### Signature
+
+```go
+func (uc *artistUseCase) persistArtists(
+    ctx context.Context,
+    artists []*entity.Artist,
+) ([]*entity.Artist, error)
+```
+
+All input artists MUST have non-empty MBID (caller responsibility).
+
+### Algorithm
+
+```
+Input: [A(mbid:abc), B(mbid:def), C(mbid:ghi)]
+
+Step 1 — Collect MBIDs
+  mbids = ["abc", "def", "ghi"]
+
+Step 2 — Read existing
+  existing = artistRepo.ListByMBIDs(ctx, mbids)
+  → [{id:uuid-1, name:"ヨルシカ", mbid:"abc"}]
+  existingSet = {"abc"}
+
+Step 3 — Determine missing
+  missing = [B(mbid:def), C(mbid:ghi)]
+
+Step 4 — Create missing (only if non-empty)
+  created = artistRepo.Create(ctx, missing...)
+  → [{id:uuid-2, ...}, {id:uuid-3, ...}]
+
+Step 5 — Merge preserving input order
+  Build lookup map: mbid → *Artist (from existing + created)
+  Iterate input slice, lookup each mbid → result slice
+  → [uuid-1, uuid-2, uuid-3]
+```
+
+### Why read-then-write instead of Create-all?
+
+- Prepares for the follow-up change: the helper will know exactly which artists are new (step 4), enabling `artist.created` event publishing without modifying the repo contract.
+- Reduces unnecessary write pressure on the DB for frequently searched artists.
+
+## New Repository Method: `ListByMBIDs`
+
+### Interface Addition
+
+```go
+// entity/artist.go — added to ArtistRepository interface
+
+// ListByMBIDs retrieves artists matching the provided MusicBrainz IDs.
+// Returns only artists that exist in the database. The result order
+// matches the input mbids order. Unknown MBIDs are silently skipped.
+ListByMBIDs(ctx context.Context, mbids []string) ([]*Artist, error)
+```
+
+### SQL
+
+```sql
+SELECT a.id, a.name, COALESCE(a.mbid, '')
+FROM artists a
+JOIN unnest($1::varchar[]) WITH ORDINALITY AS t(mbid, ord)
+  ON a.mbid = t.mbid
+ORDER BY t.ord
+```
+
+This reuses the exact pattern of the existing `selectArtistsByMBIDsQuery` in `artist_repo.go`. The query leverages the existing partial unique index on `mbid`.
+
+## Refactored Methods
+
+### Search
+
+```
+func (uc *artistUseCase) Search(ctx, query) ([]*Artist, error)
+  1. Validate query
+  2. Check cache → return if hit
+  3. artistSearcher.Search(ctx, query)
+  4. Filter: remove entries with empty MBID
+  5. Dedup: keep first per MBID (seen map)
+  6. persistArtists(ctx, filtered)
+  7. Cache persisted results
+  8. Return
+```
+
+### ListSimilar (refactored)
+
+```
+func (uc *artistUseCase) ListSimilar(ctx, artistID, limit) ([]*Artist, error)
+  1. Check cache → return if hit
+  2. Get artist from DB
+  3. artistSearcher.ListSimilar(ctx, artist, limit)
+- 4. artistRepo.Create(ctx, artists...)   // OLD: write all
++ 4. Filter: remove entries with empty MBID
++ 5. persistArtists(ctx, filtered)        // NEW: read-then-write
+  6. Cache + return
+```
+
+### ListTop (refactored)
+
+```
+func (uc *artistUseCase) ListTop(ctx, country, tag, limit) ([]*Artist, error)
+  1. Check cache → return if hit
+  2. artistSearcher.ListTop(ctx, country, tag, limit)
+- 3. artistRepo.Create(ctx, artists...)   // OLD: write all
++ 3. Filter: remove entries with empty MBID
++ 4. persistArtists(ctx, filtered)        // NEW: read-then-write
+  5. Cache + return
+```
+
+## Decisions
+
+- **Empty MBID filtering applies to all three methods**, not just Search. This ensures consistency: Liverty Music only works with MusicBrainz-backed artists regardless of discovery path.
+- **No name heuristics needed**: MBID-based dedup is sufficient. Canonical name resolution will be handled asynchronously in the follow-up change.
+- **Cache stores post-dedup, post-persist results**: Subsequent cache hits return clean, stable data.

--- a/openspec/changes/deduplicate-artist-search/proposal.md
+++ b/openspec/changes/deduplicate-artist-search/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+The discovery page artist search returns duplicate entries for the same artist. Last.fm's `artist.search` API returns all name variants (e.g. "ヨルシカ", "ヨルシカ Live", "Yorushika(ヨルシカ)", "ヨルシカ - LIVE") as separate results. The backend passes these through without filtering, cluttering the UI with noise and making it hard for users to find and follow the correct artist.
+
+Additionally, `Search()` is inconsistent with `ListSimilar()` and `ListTop()`: it does not persist artists to the database before returning, so the frontend receives ephemeral UUIDs that are regenerated on every call rather than stable database IDs.
+
+## What Changes
+
+- Filter Last.fm search results: drop entries with empty MusicBrainz ID (MBID), then deduplicate by MBID keeping the first occurrence
+- Make `Search()` persist artists to the database before returning (consistent with `ListSimilar()` and `ListTop()`)
+- Extract a shared `persistArtists` helper in the UseCase layer used by all three methods (`Search`, `ListSimilar`, `ListTop`)
+- Add `ListByMBIDs` method to `ArtistRepository` for efficient lookup of existing artists
+- The helper uses a read-then-write pattern: `ListByMBIDs` to find existing artists, `Create` only for missing ones, then merge results preserving input order
+
+## Capabilities
+
+### Modified Capabilities
+- `artist-discovery`: Search results are deduplicated by MBID and filtered for MusicBrainz-backed entries only. All discovery methods (`Search`, `ListSimilar`, `ListTop`) return artists with stable database UUIDs via a shared persist helper.
+
+## Impact
+
+- **Backend**: Modified files: `usecase/artist_uc.go` (dedup logic, persist helper, refactor 3 methods), `entity/artist.go` (add `ListByMBIDs` to repository interface), `infrastructure/database/rdb/artist_repo.go` (implement `ListByMBIDs`). Mock regeneration required.
+- **Frontend**: No changes. The response shape (`[]*Artist`) is unchanged; IDs become stable.
+- **Proto (RPC)**: No changes.
+- **Database**: No schema migration required. `ListByMBIDs` uses the existing partial unique index on `mbid`.
+
+## Out of Scope
+
+- `artist.created` event publishing and async canonical name resolution via MusicBrainz (planned as a follow-up change)
+- Frontend-side deduplication or grouping

--- a/openspec/changes/deduplicate-artist-search/tasks.md
+++ b/openspec/changes/deduplicate-artist-search/tasks.md
@@ -1,0 +1,39 @@
+## Tasks
+
+All tasks target the `backend` repository.
+
+### 1. Add `ListByMBIDs` to `ArtistRepository`
+
+- [ ] Add `ListByMBIDs(ctx context.Context, mbids []string) ([]*Artist, error)` to `ArtistRepository` interface in `internal/entity/artist.go`
+- [ ] Implement in `internal/infrastructure/database/rdb/artist_repo.go` using `unnest + WITH ORDINALITY` pattern
+- [ ] Add unit test in `artist_repo_test.go`
+- [ ] Regenerate mocks (`mockery`)
+
+### 2. Extract `persistArtists` helper in UseCase
+
+- [ ] Add private method `persistArtists(ctx, []*entity.Artist) ([]*entity.Artist, error)` to `artistUseCase` in `internal/usecase/artist_uc.go`
+- [ ] Implement: ListByMBIDs → determine missing → Create missing → merge preserving input order
+- [ ] Add unit tests for the helper (all existing, all new, mixed, empty input)
+
+### 3. Refactor `Search` with dedup + persist
+
+- [ ] After `artistSearcher.Search()`, filter out entries with empty MBID
+- [ ] Dedup by MBID keeping first occurrence
+- [ ] Replace direct return with `persistArtists()` call
+- [ ] Update unit tests to verify dedup behavior and DB persistence
+
+### 4. Refactor `ListSimilar` to use helper
+
+- [ ] Filter out empty MBID entries from `artistSearcher.ListSimilar()` results
+- [ ] Replace `artistRepo.Create(ctx, artists...)` with `persistArtists()` call
+- [ ] Update unit tests
+
+### 5. Refactor `ListTop` to use helper
+
+- [ ] Filter out empty MBID entries from `artistSearcher.ListTop()` results
+- [ ] Replace `artistRepo.Create(ctx, artists...)` with `persistArtists()` call
+- [ ] Update unit tests
+
+### 6. Verify
+
+- [ ] `make check` passes (lint + test)

--- a/openspec/changes/deduplicate-artist-search/tasks.md
+++ b/openspec/changes/deduplicate-artist-search/tasks.md
@@ -4,14 +4,14 @@ All tasks target the `backend` repository.
 
 ### 1. Add `ListByMBIDs` to `ArtistRepository`
 
-- [ ] Add `ListByMBIDs(ctx context.Context, mbids []string) ([]*Artist, error)` to `ArtistRepository` interface in `internal/entity/artist.go`
-- [ ] Implement in `internal/infrastructure/database/rdb/artist_repo.go` using `unnest + WITH ORDINALITY` pattern
+- [ ] Add `ListByMBIDs(ctx context.Context, mbids []string) ([]*Artist, error)` to `ArtistRepository` interface in `entity/artist.go`
+- [ ] Implement in `infrastructure/database/rdb/artist_repo.go` using `unnest + WITH ORDINALITY` pattern
 - [ ] Add unit test in `artist_repo_test.go`
 - [ ] Regenerate mocks (`mockery`)
 
 ### 2. Extract `persistArtists` helper in UseCase
 
-- [ ] Add private method `persistArtists(ctx, []*entity.Artist) ([]*entity.Artist, error)` to `artistUseCase` in `internal/usecase/artist_uc.go`
+- [ ] Add private method `persistArtists(ctx, []*entity.Artist) ([]*entity.Artist, error)` to `artistUseCase` in `usecase/artist_uc.go`
 - [ ] Implement: ListByMBIDs → determine missing → Create missing → merge preserving input order
 - [ ] Add unit tests for the helper (all existing, all new, mixed, empty input)
 


### PR DESCRIPTION
## Related Issue

No existing issue — originates from discovery session investigating duplicate artist search results on the discovery page.

## Summary of Changes

Adds two OpenSpec change proposals for improving artist search quality:

### 1. `deduplicate-artist-search` (Change 1 — implement first)
- Filter Last.fm search results: drop entries with empty MusicBrainz ID, dedup by MBID
- Make `Search()` persist artists to DB before returning (consistent with `ListSimilar`/`ListTop`)
- Extract shared `persistArtists` helper used by all three discovery methods
- Add `ListByMBIDs` repository method

### 2. `artist-created-event` (Change 2 — depends on Change 1)
- Publish `ARTIST.created` events for newly inserted artists
- Add async `ArtistNameConsumer` that resolves canonical names from MusicBrainz
- Add `ARTIST` JetStream stream, `UpdateName` repository method

## Self-Checklist

- [x] No proto changes — OpenSpec docs only
- [x] No `buf lint` / `buf format` impact (markdown files only)
- [x] No breaking changes
