### PR TITLE
feat(openspec): add split-workload-config change

### DIFF
--- a/openspec/changes/split-workload-config/.openspec.yaml
+++ b/openspec/changes/split-workload-config/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-06

--- a/openspec/changes/split-workload-config/design.md
+++ b/openspec/changes/split-workload-config/design.md
@@ -1,0 +1,164 @@
+## Context
+
+The backend has three workloads sharing a single `config.Config` struct:
+
+| Workload   | Entry point                        | Purpose                        |
+|------------|------------------------------------|--------------------------------|
+| **Server** | `cmd/server/main.go`               | Connect-RPC API server         |
+| **Job**    | `cmd/job/concert-discovery/main.go`| Batch concert discovery CronJob|
+| **Consumer**| `cmd/consumer/main.go`            | Watermill event consumer       |
+
+All three call `config.Load()` → `envconfig.Process("", &Config{})`, which requires every `required:"true"` field to be set regardless of whether the workload uses it. This causes startup failures when workload-specific env vars are absent.
+
+Actual field usage per workload (verified from DI code):
+
+```
+Field               Server  Job     Consumer
+Environment         x       x       x
+ShutdownTimeout     x       x       x
+Logging             x       x       x
+Database            x       x       x
+Telemetry           x       x       x
+GCP                 x       x       -
+NATS                x       x       x
+VAPID               x       -       x
+LastFMAPIKey        x       -       -
+GoogleMapsAPIKey    -       -       x
+Server (port etc)   x       -       -
+JWT                 x       -       -
+Blockchain          x       -       -
+ZKP                 x       -       -
+```
+
+Downstream functions that currently accept `*config.Config` but only use subsets:
+- `rdb.New` → uses `cfg.Database` + `cfg.IsLocal()`
+- `telemetry.SetupTelemetry` → uses `cfg.Telemetry` + `cfg.ShutdownTimeout`
+- `server.NewConnectServer` → uses `cfg.Server`
+
+## Goals / Non-Goals
+
+**Goals:**
+- Each workload loads only the environment variables it needs
+- `required:"true"` tags on workload-specific fields do not affect other workloads
+- Downstream functions accept narrow types instead of the full config struct
+- Adding a new workload requires defining its config type explicitly
+
+**Non-Goals:**
+- Changing environment variable names (all env var names remain identical)
+- Modifying ConfigMap/Secret manifests (they already contain only what each workload needs)
+- Introducing a config file format (stay with envconfig)
+
+## Decisions
+
+### 1. Embed-based config composition
+
+Define a `BaseConfig` with fields used by all three workloads, then compose workload-specific configs via struct embedding.
+
+```go
+type BaseConfig struct {
+    Environment     string        `envconfig:"ENVIRONMENT" default:"local"`
+    ShutdownTimeout time.Duration `envconfig:"SHUTDOWN_TIMEOUT" default:"30s"`
+    Logging         LoggingConfig
+    Database        DatabaseConfig
+    Telemetry       TelemetryConfig
+}
+
+type ServerConfig struct {
+    BaseConfig
+    Server          ServerSettings
+    JWT             JWTConfig
+    GCP             GCPConfig
+    NATS            NATSConfig
+    VAPID           VAPIDConfig
+    Blockchain      BlockchainConfig
+    ZKP             ZKPConfig
+    LastFMAPIKey    string `envconfig:"LASTFM_API_KEY"`
+}
+
+type JobConfig struct {
+    BaseConfig
+    GCP  GCPConfig
+    NATS NATSConfig
+}
+
+type ConsumerConfig struct {
+    BaseConfig
+    NATS             NATSConfig
+    VAPID            VAPIDConfig
+    GoogleMapsAPIKey string `envconfig:"GOOGLE_MAPS_API_KEY"`
+}
+```
+
+**Why embed over interface**: `kelseyhightower/envconfig` flattens embedded structs during `Process()`. No wrapper code needed — embedding just works. An interface-based approach would require manual field delegation.
+
+**Why NATS is not in BaseConfig**: Future workloads (e.g., migration tools, admin CLIs) may not need messaging. NATS is infrastructure for event-driven workloads, not a universal requirement.
+
+### 2. Generic `Load[T]` function
+
+```go
+type Loadable interface {
+    ServerConfig | JobConfig | ConsumerConfig
+}
+
+func Load[T Loadable]() (*T, error) {
+    var cfg T
+    if err := envconfig.Process("", &cfg); err != nil {
+        return nil, fmt.Errorf("failed to load configuration: %w", err)
+    }
+    return &cfg, nil
+}
+```
+
+**Why generic over separate functions**: Avoids three nearly-identical `LoadServer/LoadJob/LoadConsumer` functions. The type constraint documents which config types are valid. Adding a new workload means adding its type to the union constraint.
+
+### 3. Per-type `Validate()` with shared base
+
+```go
+func (c *BaseConfig) Validate() error {
+    // Environment, DB port, log level/format checks
+}
+
+func (c *ServerConfig) Validate() error {
+    if err := c.BaseConfig.Validate(); err != nil { return err }
+    // JWT issuer required, CORS required (non-local), server port range
+}
+
+func (c *JobConfig) Validate() error {
+    if err := c.BaseConfig.Validate(); err != nil { return err }
+    // NATS URL required (non-local)
+}
+
+func (c *ConsumerConfig) Validate() error {
+    if err := c.BaseConfig.Validate(); err != nil { return err }
+    // NATS URL required (non-local)
+}
+```
+
+Validation rules that currently exist in the monolithic `Validate()` are distributed to the appropriate type. Server-only checks (JWT, CORS) move to `ServerConfig.Validate()`.
+
+### 4. Narrow downstream function signatures
+
+| Function | Current | New |
+|----------|---------|-----|
+| `rdb.New` | `*config.Config` | `config.DatabaseConfig, bool` (isLocal) |
+| `telemetry.SetupTelemetry` | `*config.Config` | `config.TelemetryConfig, time.Duration` (shutdownTimeout) |
+| `server.NewConnectServer` | `*config.Config` | `config.ServerSettings` |
+| `provideLogger` | `*config.Config` | `config.LoggingConfig` |
+
+This eliminates the coupling between infrastructure packages and the full config struct.
+
+### 5. Rename `ServerConfig` (port/host) to `ServerSettings`
+
+The existing `ServerConfig` struct (port, host, timeouts, CORS) conflicts with the new top-level `ServerConfig` (the full server workload config). Rename the inner struct to `ServerSettings` to avoid ambiguity.
+
+### 6. Environment helper methods on BaseConfig
+
+`IsLocal()`, `IsDevelopment()`, etc. move from `Config` to `BaseConfig`, making them available to all workload config types via embedding.
+
+## Risks / Trade-offs
+
+**[Duplication of NATS/VAPID/GCP across config types]** → Acceptable trade-off. Each field appears in exactly the types that use it. The alternative (putting everything in BaseConfig) is what caused the original bug.
+
+**[envconfig embedding behavior]** → `kelseyhightower/envconfig` v1.4.0 supports embedded structs natively by flattening fields. Verified in the library source. No risk here.
+
+**[Breaking `provideLogger` and infrastructure function signatures]** → All callers are internal (`internal/di/`). No external consumers. The change is safe to make in one PR.

--- a/openspec/changes/split-workload-config/proposal.md
+++ b/openspec/changes/split-workload-config/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+The backend uses a single `config.Config` struct loaded by all three workloads (API server, CronJob, consumer). Because `JWTConfig.Issuer` is tagged `required:"true"`, the CronJob and consumer fail at startup if `OIDC_ISSUER_URL` is not set — even though neither workload uses JWT authentication. This surfaced as a blocker during the EDA end-to-end verification (introduce-eda task 9.1). Splitting config by workload ensures each process loads only the environment variables it actually needs, preventing cross-workload configuration leaks.
+
+## What Changes
+
+- Extract a minimal `BaseConfig` struct containing only the fields shared by all workloads: `Environment`, `ShutdownTimeout`, `Logging`, `Database`, `Telemetry`.
+- Define `ServerConfig`, `JobConfig`, and `ConsumerConfig` that embed `BaseConfig` and add workload-specific fields (e.g., `JWT`, `Blockchain`, `ZKP` for server; `GCP`, `NATS` for job; `NATS`, `VAPID`, `GoogleMapsAPIKey` for consumer).
+- Replace the single `config.Load()` with a generic `config.Load[T]()` function so each DI initializer loads exactly its config type.
+- Split `Validate()` into per-type methods: `BaseConfig.Validate()` for shared rules, plus workload-specific validation on each config type.
+- Update downstream consumers (`rdb.New`, `telemetry.SetupTelemetry`, `server.NewConnectServer`) to accept narrow field types instead of `*config.Config`.
+
+## Capabilities
+
+### New Capabilities
+
+- `workload-config`: Per-workload configuration loading and validation for the backend.
+
+### Modified Capabilities
+
+(none — this is an internal refactor with no user-facing or API-level behavior changes)
+
+## Impact
+
+- `pkg/config/config.go` — restructure types and load functions
+- `pkg/config/config_test.go` — update tests for new types
+- `internal/di/provider.go`, `internal/di/job.go`, `internal/di/consumer.go` — use typed Load
+- `internal/infrastructure/database/rdb/postgres.go` — narrow signature
+- `pkg/telemetry/telemetry.go` — narrow signature
+- `internal/infrastructure/server/connect.go` — narrow signature
+- No API changes, no database changes, no Protobuf changes

--- a/openspec/changes/split-workload-config/specs/workload-config/spec.md
+++ b/openspec/changes/split-workload-config/specs/workload-config/spec.md
@@ -1,0 +1,61 @@
+## ADDED Requirements
+
+### Requirement: Workload-specific configuration loading
+
+The system SHALL define separate configuration types for each backend workload (server, job, consumer). Each type SHALL contain only the environment variables that the workload actually references. A shared `BaseConfig` type SHALL contain fields common to all workloads: `Environment`, `ShutdownTimeout`, `Logging`, `Database`, and `Telemetry`. Workload-specific types SHALL embed `BaseConfig` and add their own fields.
+
+#### Scenario: CronJob starts without OIDC_ISSUER_URL
+- **WHEN** the concert-discovery CronJob starts and `OIDC_ISSUER_URL` is not set
+- **THEN** configuration loading SHALL succeed because `JobConfig` does not include JWT fields
+
+#### Scenario: Consumer starts without JWT or Blockchain config
+- **WHEN** the event consumer starts and `OIDC_ISSUER_URL`, `BASE_SEPOLIA_RPC_URL`, `ZKP_VERIFICATION_KEY_PATH` are not set
+- **THEN** configuration loading SHALL succeed because `ConsumerConfig` does not include JWT, Blockchain, or ZKP fields
+
+#### Scenario: Server requires OIDC_ISSUER_URL
+- **WHEN** the API server starts and `OIDC_ISSUER_URL` is not set
+- **THEN** configuration loading SHALL fail with a clear error indicating the missing field
+
+### Requirement: Generic configuration load function
+
+The system SHALL provide a generic `Load[T]()` function that loads environment variables into the specified configuration type. The type parameter SHALL be constrained to valid workload configuration types.
+
+#### Scenario: Load ServerConfig
+- **WHEN** `Load[ServerConfig]()` is called with all server environment variables set
+- **THEN** the function SHALL return a fully populated `*ServerConfig` with all embedded `BaseConfig` fields resolved
+
+#### Scenario: Load JobConfig
+- **WHEN** `Load[JobConfig]()` is called with only base + job-specific environment variables set
+- **THEN** the function SHALL return a fully populated `*JobConfig` without requiring server-specific variables
+
+### Requirement: Per-type validation
+
+Each workload configuration type SHALL implement a `Validate()` method. `BaseConfig.Validate()` SHALL check shared constraints (environment value, database port range, log level, log format). Workload-specific `Validate()` methods SHALL call `BaseConfig.Validate()` first, then check their own constraints.
+
+#### Scenario: ServerConfig validation enforces JWT
+- **WHEN** `ServerConfig.Validate()` is called and `JWT.Issuer` is empty
+- **THEN** validation SHALL return an error indicating JWT issuer is required
+
+#### Scenario: JobConfig validation does not check JWT
+- **WHEN** `JobConfig.Validate()` is called
+- **THEN** validation SHALL NOT check for JWT, Blockchain, ZKP, or Server fields
+
+#### Scenario: NATS URL required in non-local environments
+- **WHEN** `JobConfig.Validate()` or `ConsumerConfig.Validate()` is called with `Environment` not equal to `"local"` and `NATS.URL` is empty
+- **THEN** validation SHALL return an error indicating NATS URL is required
+
+### Requirement: Narrow downstream function signatures
+
+Infrastructure functions that accept `*config.Config` SHALL be refactored to accept only the fields they use. This eliminates coupling between infrastructure packages and the full configuration struct.
+
+#### Scenario: Database initialization accepts DatabaseConfig
+- **WHEN** `rdb.New` is called
+- **THEN** it SHALL accept `config.DatabaseConfig` and a `bool` indicating local environment, not the full config struct
+
+#### Scenario: Telemetry setup accepts TelemetryConfig
+- **WHEN** `telemetry.SetupTelemetry` is called
+- **THEN** it SHALL accept `config.TelemetryConfig` and a `time.Duration` for shutdown timeout, not the full config struct
+
+#### Scenario: Connect server accepts ServerSettings
+- **WHEN** `server.NewConnectServer` is called
+- **THEN** it SHALL accept `config.ServerSettings` (renamed from `ServerConfig`), not the full config struct

--- a/openspec/changes/split-workload-config/tasks.md
+++ b/openspec/changes/split-workload-config/tasks.md
@@ -1,0 +1,40 @@
+## 1. Define config types
+
+- [x] 1.1 Rename existing `ServerConfig` (port/host/timeouts/CORS) to `ServerSettings` in `pkg/config/config.go`
+- [x] 1.2 Define `BaseConfig` struct with `Environment`, `ShutdownTimeout`, `Logging`, `Database`, `Telemetry`
+- [x] 1.3 Move `IsLocal()`, `IsDevelopment()`, `IsStaging()`, `IsProduction()` methods to `BaseConfig`
+- [x] 1.4 Define `ServerConfig` embedding `BaseConfig` + `ServerSettings`, `JWT`, `GCP`, `NATS`, `VAPID`, `Blockchain`, `ZKP`, `LastFMAPIKey`
+- [x] 1.5 Define `JobConfig` embedding `BaseConfig` + `GCP`, `NATS`
+- [x] 1.6 Define `ConsumerConfig` embedding `BaseConfig` + `NATS`, `VAPID`, `GoogleMapsAPIKey`
+- [x] 1.7 Remove the old monolithic `Config` struct
+
+## 2. Load and validate functions
+
+- [x] 2.1 Replace `Load()` with generic `Load[T ServerConfig | JobConfig | ConsumerConfig]()` function
+- [x] 2.2 Create `BaseConfig.Validate()` with shared checks (environment, DB port, log level/format)
+- [x] 2.3 Create `ServerConfig.Validate()` calling base + JWT issuer, CORS (non-local), server port, NATS URL (non-local)
+- [x] 2.4 Create `JobConfig.Validate()` calling base + NATS URL (non-local)
+- [x] 2.5 Create `ConsumerConfig.Validate()` calling base + NATS URL (non-local)
+
+## 3. Narrow downstream signatures
+
+- [x] 3.1 Change `rdb.New` to accept `config.DatabaseConfig` + `bool` (isLocal) instead of `*config.Config`
+- [x] 3.2 Change `telemetry.SetupTelemetry` to accept `config.TelemetryConfig` + `time.Duration` instead of `*config.Config`
+- [x] 3.3 Change `server.NewConnectServer` to accept `config.ServerSettings` instead of `*config.Config`
+- [x] 3.4 Change `provideLogger` to accept `config.LoggingConfig` instead of `*config.Config`
+
+## 4. Update DI initializers
+
+- [x] 4.1 Update `InitializeApp` in `internal/di/provider.go` to use `config.Load[config.ServerConfig]()`
+- [x] 4.2 Update `InitializeJobApp` in `internal/di/job.go` to use `config.Load[config.JobConfig]()`
+- [x] 4.3 Update `InitializeConsumerApp` in `internal/di/consumer.go` to use `config.Load[config.ConsumerConfig]()`
+
+## 5. Update tests
+
+- [x] 5.1 Update `pkg/config/config_test.go` for new types, `Load[T]()`, and per-type `Validate()`
+- [x] 5.2 Update any integration tests that reference `config.Config` or `config.Load()`
+- [x] 5.3 Run `make check` in backend to verify all tests pass
+
+## 6. Verify in cluster
+
+- [ ] 6.1 Create a manual Job from CronJob and verify it starts successfully without `OIDC_ISSUER_URL`

--- a/openspec/changes/split-workload-config/tasks.md
+++ b/openspec/changes/split-workload-config/tasks.md
@@ -12,7 +12,7 @@
 
 - [x] 2.1 Replace `Load()` with generic `Load[T ServerConfig | JobConfig | ConsumerConfig]()` function
 - [x] 2.2 Create `BaseConfig.Validate()` with shared checks (environment, DB port, log level/format)
-- [x] 2.3 Create `ServerConfig.Validate()` calling base + JWT issuer, CORS (non-local), server port, NATS URL (non-local)
+- [x] 2.3 Create `ServerConfig.Validate()` calling base + JWT issuer, CORS (non-local), server port
 - [x] 2.4 Create `JobConfig.Validate()` calling base + NATS URL (non-local)
 - [x] 2.5 Create `ConsumerConfig.Validate()` calling base + NATS URL (non-local)
 


### PR DESCRIPTION
## 🔗 Related Issue

N/A — spec proposal for backend refactor

## 📝 Summary of Changes

Add OpenSpec change artifacts for `split-workload-config`:

- **Proposal**: Split `config.Load()` into per-workload typed functions (`Load[T]()`) to prevent cross-workload configuration leaks (e.g. CronJob/consumer requiring `OIDC_ISSUER_URL`)
- **Design**: `BaseConfig` + `ServerConfig`/`JobConfig`/`ConsumerConfig` with Go generics
- **Spec**: `workload-config` capability definition
- **Tasks**: 14 implementation tasks across config types, DI wiring, and tests

This surfaced during EDA E2E verification — the consumer couldn't start without JWT config it doesn't use.

## ✅ Self-Checklist

- [x] I have linked the related issue.
- [x] I have updated the relevant documentation (e.g., `README.md`) if needed.
- [x] I have run `buf lint` and `buf format` locally and all checks have passed.
- [x] My proto definitions follow the project's style guidelines and validation rules.
- [x] Breaking changes have been justified and documented if applicable.
