### PR TITLE
docs(openspec): add db-trace-correlation spec

### DIFF
--- a/openspec/changes/archive/2026-03-06-correlate-otel-cloud-sql/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-06-correlate-otel-cloud-sql/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-06

--- a/openspec/changes/archive/2026-03-06-correlate-otel-cloud-sql/design.md
+++ b/openspec/changes/archive/2026-03-06-correlate-otel-cloud-sql/design.md
@@ -1,0 +1,95 @@
+## Context
+
+The backend uses `*pgxpool.Pool` directly in all repository implementations (`r.db.Pool.Query(ctx, sql, args...)`). OTel tracing is configured at the RPC layer (Connect-RPC `otelconnect` interceptor) and messaging layer (Watermill OTel middleware), but no instrumentation exists at the database query layer.
+
+Cloud SQL Query Insights is enabled and generates execution-plan spans (Seq Scan, Hash Join, etc.), but these are isolated — no `traceparent` is propagated from the application to Cloud SQL.
+
+pgx v5.8.0 (latest) provides a `QueryTracer` interface on `ConnConfig`, but it cannot modify SQL text — `TraceQueryStartData.SQL` is read-only. The `QueryRewriter` interface can rewrite SQL but must be passed as an argument to each query call, requiring changes to every repository method.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Create OTel spans for all database queries (Query, QueryRow, Exec) with SQL text and duration
+- Inject `traceparent` in sqlcommenter format so Cloud SQL Query Insights correlates its spans with the backend trace
+- Zero changes to repository code — instrumentation is transparent via pool wrapper
+- Support transactions (`Begin`) with trace context propagation
+
+**Non-Goals:**
+
+- Tracing `CopyFrom` or `SendBatch` operations (not used in this codebase)
+- Adding non-traceparent sqlcommenter fields (route, controller, framework) — can be added later
+- Configurable sampler for DB spans — follows the global `AlwaysSample` policy
+- Metrics collection (connection pool stats, query counts) — separate concern
+
+## Decisions
+
+### Decision 1: Pool wrapper vs. pgx Tracer interface
+
+**Chosen: Pool wrapper (`TracedPool` struct)**
+
+Alternatives considered:
+
+| Approach | Span creation | SQL comment injection | Repo changes |
+|----------|--------------|----------------------|--------------|
+| **A. Pool wrapper** | Yes (in wrapper) | Yes (in wrapper) | None |
+| B. pgx `QueryTracer` | Yes | No (SQL is read-only) | None |
+| C. pgx `QueryRewriter` | No | Yes | Every query call |
+| D. B + C combined | Yes | Yes | Every query call |
+| E. `otelpgx` library | Yes | No | None |
+| F. Switch to `database/sql` + `otelsql` | Yes | Yes (`WithSQLCommenter`) | Full rewrite |
+
+Rationale: Only the wrapper approach achieves both goals without touching repository code. The wrapper intercepts `Query`/`QueryRow`/`Exec`/`Begin` calls, prepends the sqlcommenter comment to the SQL string, creates an OTel span, delegates to the inner `*pgxpool.Pool`, and ends the span.
+
+### Decision 2: Interface vs. concrete wrapper type
+
+**Chosen: Concrete `*TracedPool` struct**
+
+The `Database.Pool` field changes from `*pgxpool.Pool` to `*TracedPool`. The wrapper exposes the same method signatures as `*pgxpool.Pool` for the methods used by repositories (`Query`, `QueryRow`, `Exec`, `Begin`, `Ping`, `Close`).
+
+An interface was considered but rejected: the codebase accesses `r.db.Pool` directly and only uses a fixed set of methods. A concrete type is simpler and avoids introducing a new interface that would need to be maintained. If testing requires a mock pool in the future, an interface can be extracted then.
+
+### Decision 3: SQL comment format and placement
+
+**Chosen: Prepend `/*traceparent='...'*/` before SQL text**
+
+Format follows the [sqlcommenter specification](https://google.github.io/sqlcommenter/spec/):
+
+```sql
+/*traceparent='00-{32hex_trace_id}-{16hex_span_id}-{2hex_flags}'*/ SELECT ...
+```
+
+- Comment is prepended (not appended) — Cloud SQL Query Insights parses both positions, but prepending is the sqlcommenter convention
+- Only `traceparent` key is included — minimal and sufficient for trace correlation
+- Values are URL-encoded per spec (traceparent uses only hex chars, so no encoding needed in practice)
+- Keys are sorted alphabetically (trivial with a single key)
+
+### Decision 4: Span attributes and naming
+
+Spans follow [OTel semantic conventions for database](https://opentelemetry.io/docs/specs/semconv/database/):
+
+- **Span name**: SQL operation extracted from the first keyword (e.g., `SELECT`, `INSERT`, `UPDATE`, `DELETE`), or `DB` as fallback
+- **`db.system`**: `postgresql`
+- **`db.query.text`**: Full SQL text (without the injected comment)
+- **`db.operation.name`**: Extracted operation (SELECT, INSERT, etc.)
+- **Span kind**: `Client`
+
+### Decision 5: Transaction tracing
+
+`Begin` returns a `pgx.Tx`. The wrapper creates a span for the `Begin` call itself, but individual queries within the transaction are executed through `pgx.Tx` methods — not through the pool wrapper.
+
+To trace queries within transactions, the wrapper returns a `TracedTx` that wraps `pgx.Tx` with the same span creation and comment injection logic.
+
+### Decision 6: File placement
+
+`TracedPool` lives in `internal/infrastructure/database/rdb/` alongside `postgres.go`, as it is tightly coupled to the database infrastructure layer. It is not a general-purpose telemetry utility — it specifically wraps pgxpool for this codebase's needs.
+
+## Risks / Trade-offs
+
+**[SQL comment adds bytes to every query]** → The traceparent comment is ~80 bytes. Negligible compared to typical query sizes. Cloud SQL's `max_query_length` for Query Insights defaults to 10KB, so the comment will not cause truncation.
+
+**[Span overhead on every DB call]** → Each span adds ~1-2μs of overhead (context propagation + span creation). With AlwaysSample, every query creates a span. This is acceptable for the current scale. If span volume becomes a concern, a DB-specific sampler can be added later.
+
+**[TracedTx wrapping complexity]** → `pgx.Tx` has methods like `Query`, `QueryRow`, `Exec`, `Commit`, `Rollback`, `CopyFrom`, `SendBatch`. We only wrap the methods actually used in the codebase. If new `pgx.Tx` methods are used in the future, they'll need to be added to `TracedTx`.
+
+**[No span for pool acquisition wait time]** → The wrapper creates a span that includes both pool acquisition and query execution time. Separating these would require using `pgxpool.AcquireTracer`, which adds complexity without clear immediate value.

--- a/openspec/changes/archive/2026-03-06-correlate-otel-cloud-sql/proposal.md
+++ b/openspec/changes/archive/2026-03-06-correlate-otel-cloud-sql/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+Backend traces reach Cloud Trace via the OTel Collector (see `otel-collector-deployment` spec), and Cloud SQL Query Insights independently generates execution-plan spans for SQL queries. These two trace streams are disconnected — they have different Trace IDs and cannot be correlated. This makes it impossible to trace a slow RPC call down to the specific SQL execution plan that caused the latency.
+
+## What Changes
+
+- Introduce a `TracedPool` wrapper around `*pgxpool.Pool` that transparently instruments all database calls
+- Create OTel child spans for every `Query`, `QueryRow`, `Exec`, and `Begin` call, capturing SQL text and duration
+- Inject `traceparent` as a SQL comment in [sqlcommenter](https://google.github.io/sqlcommenter/) format before each query, enabling Cloud SQL Query Insights to link its execution-plan spans to the same trace
+- Replace the concrete `*pgxpool.Pool` field in the `Database` struct with the wrapped pool so all repositories are instrumented without code changes
+
+## Capabilities
+
+### New Capabilities
+
+- `db-trace-correlation`: End-to-end trace correlation from backend RPC spans through database query spans to Cloud SQL Query Insights execution-plan spans, using pgxpool wrapper with OTel span creation and sqlcommenter traceparent injection.
+
+### Modified Capabilities
+
+(none)
+
+## Impact
+
+- **backend** repo: New `TracedPool` wrapper in infrastructure/database layer; `Database` struct field type changes from `*pgxpool.Pool` to `*TracedPool`; no repository code changes required
+- **Dependencies**: No new external dependencies — uses `go.opentelemetry.io/otel` (already in go.mod)
+- **Cloud SQL**: Query Insights must be enabled on the Cloud SQL instance (already enabled per `database` spec)
+- **Observability**: Cloud Trace will show a complete span tree: RPC → DB query → SQL execution plan

--- a/openspec/changes/archive/2026-03-06-correlate-otel-cloud-sql/specs/db-trace-correlation/spec.md
+++ b/openspec/changes/archive/2026-03-06-correlate-otel-cloud-sql/specs/db-trace-correlation/spec.md
@@ -36,7 +36,7 @@ The system SHALL inject a `traceparent` comment in sqlcommenter format into ever
 - **WHEN** a query is executed through the pool wrapper with an active OTel span in the context
 - **THEN** the SQL sent to PostgreSQL SHALL be prepended with a comment in the format `/*traceparent='00-{trace_id}-{span_id}-{flags}'*/`
 - **AND** the trace_id SHALL be the 32-character hex trace ID from the current span context
-- **AND** the span_id SHALL be the 16-character hex span ID from the current span context
+- **AND** the span_id SHALL be the 16-character hex span ID of the DB query span created by the wrapper (not the caller's incoming span)
 - **AND** the flags SHALL be the 2-character hex trace flags from the current span context
 
 #### Scenario: No comment injection when no active span
@@ -56,7 +56,8 @@ The system SHALL wrap the `*pgxpool.Pool` with a `TracedPool` that is transparen
 
 #### Scenario: Pool wrapper supports Begin for transactions
 - **WHEN** a repository calls `Begin` to start a transaction
-- **THEN** the wrapper SHALL return a traced transaction that applies span creation and comment injection to queries executed within the transaction
+- **THEN** an OTel span SHALL be created for the `Begin` call itself
+- **AND** the wrapper SHALL return a traced transaction that applies span creation and comment injection to queries executed within the transaction
 
 ---
 

--- a/openspec/changes/archive/2026-03-06-correlate-otel-cloud-sql/specs/db-trace-correlation/spec.md
+++ b/openspec/changes/archive/2026-03-06-correlate-otel-cloud-sql/specs/db-trace-correlation/spec.md
@@ -1,0 +1,73 @@
+# Database Trace Correlation
+
+## Purpose
+
+Defines the requirements for end-to-end trace correlation between backend application spans and Cloud SQL Query Insights execution-plan spans, using OTel span creation and sqlcommenter traceparent injection at the database query layer.
+
+## ADDED Requirements
+
+### Requirement: OTel span creation for database queries
+The system SHALL create an OpenTelemetry child span for every database query executed through the connection pool, capturing the SQL operation, query text, and execution duration.
+
+#### Scenario: SELECT query creates a client span
+- **WHEN** a repository method executes a SELECT query via the pool wrapper
+- **THEN** an OTel span SHALL be created with kind `Client`
+- **AND** the span name SHALL be the SQL operation name (e.g., `SELECT`)
+- **AND** the span SHALL have attribute `db.system` set to `postgresql`
+- **AND** the span SHALL have attribute `db.query.text` set to the original SQL text (without injected comments)
+- **AND** the span SHALL have attribute `db.operation.name` set to the extracted operation
+
+#### Scenario: INSERT query creates a client span
+- **WHEN** a repository method executes an INSERT query via the pool wrapper
+- **THEN** an OTel span SHALL be created with span name `INSERT`
+- **AND** the span SHALL record the duration of the query execution
+
+#### Scenario: Query execution error is recorded on the span
+- **WHEN** a database query fails with an error
+- **THEN** the span SHALL record the error
+- **AND** the span status SHALL be set to `Error`
+
+---
+
+### Requirement: sqlcommenter traceparent injection
+The system SHALL inject a `traceparent` comment in sqlcommenter format into every SQL query, enabling Cloud SQL Query Insights to correlate its execution-plan spans with the backend application trace.
+
+#### Scenario: traceparent comment is prepended to SQL
+- **WHEN** a query is executed through the pool wrapper with an active OTel span in the context
+- **THEN** the SQL sent to PostgreSQL SHALL be prepended with a comment in the format `/*traceparent='00-{trace_id}-{span_id}-{flags}'*/`
+- **AND** the trace_id SHALL be the 32-character hex trace ID from the current span context
+- **AND** the span_id SHALL be the 16-character hex span ID from the current span context
+- **AND** the flags SHALL be the 2-character hex trace flags from the current span context
+
+#### Scenario: No comment injection when no active span
+- **WHEN** a query is executed through the pool wrapper without an active OTel span in the context
+- **THEN** the SQL SHALL be sent to PostgreSQL unmodified (no comment prepended)
+
+---
+
+### Requirement: Transparent pool wrapping
+The system SHALL wrap the `*pgxpool.Pool` with a `TracedPool` that is transparent to repository code — repositories SHALL NOT require any code changes to be instrumented.
+
+#### Scenario: Repository uses pool wrapper without code changes
+- **WHEN** a repository calls `Query`, `QueryRow`, or `Exec` on the pool
+- **THEN** the call SHALL be intercepted by the wrapper for span creation and comment injection
+- **AND** the call SHALL be delegated to the underlying `*pgxpool.Pool`
+- **AND** the result SHALL be returned unmodified to the repository
+
+#### Scenario: Pool wrapper supports Begin for transactions
+- **WHEN** a repository calls `Begin` to start a transaction
+- **THEN** the wrapper SHALL return a traced transaction that applies span creation and comment injection to queries executed within the transaction
+
+---
+
+### Requirement: Transaction query tracing
+The system SHALL trace individual queries executed within a database transaction, applying the same span creation and comment injection as direct pool queries.
+
+#### Scenario: Query within transaction creates a span
+- **WHEN** a query is executed via a transaction obtained from `Begin`
+- **THEN** an OTel span SHALL be created for that query
+- **AND** the SQL SHALL be prepended with the traceparent comment
+
+#### Scenario: Commit and Rollback create spans
+- **WHEN** a transaction is committed or rolled back
+- **THEN** an OTel span SHALL be created for the Commit or Rollback operation

--- a/openspec/changes/archive/2026-03-06-correlate-otel-cloud-sql/tasks.md
+++ b/openspec/changes/archive/2026-03-06-correlate-otel-cloud-sql/tasks.md
@@ -1,0 +1,18 @@
+## 1. Core Implementation
+
+- [x] 1.1 Create `TracedPool` struct in `internal/infrastructure/database/rdb/traced_pool.go` wrapping `*pgxpool.Pool` with OTel tracer, implementing `Query`, `QueryRow`, `Exec`, `Begin`, `Ping`, `Close` methods
+- [x] 1.2 Implement sqlcommenter `traceparent` comment injection helper that extracts trace context from `context.Context` and formats `/*traceparent='00-{trace_id}-{span_id}-{flags}'*/`
+- [x] 1.3 Implement SQL operation name extraction helper (parses first keyword: SELECT, INSERT, UPDATE, DELETE, etc.) for span naming
+- [x] 1.4 Create `TracedTx` struct wrapping `pgx.Tx` with the same span creation and comment injection for `Query`, `QueryRow`, `Exec`, `Commit`, `Rollback`
+
+## 2. Integration
+
+- [x] 2.1 Change `Database.Pool` field type from `*pgxpool.Pool` to `*TracedPool` in `postgres.go`
+- [x] 2.2 Wrap the pool with `TracedPool` in the `New` constructor after `pgxpool.NewWithConfig` returns
+- [x] 2.3 Update `Ping` and `Close` methods on `Database` to delegate to `TracedPool`
+
+## 3. Testing
+
+- [x] 3.1 Write unit tests for sqlcommenter comment injection (with span, without span, format correctness)
+- [x] 3.2 Write unit tests for SQL operation name extraction (SELECT, INSERT, UPDATE, DELETE, CTE, unknown)
+- [x] 3.3 Verify existing integration tests pass with `TracedPool` (no repository code changes)

--- a/openspec/specs/db-trace-correlation/spec.md
+++ b/openspec/specs/db-trace-correlation/spec.md
@@ -1,0 +1,73 @@
+# Database Trace Correlation
+
+## Purpose
+
+Defines the requirements for end-to-end trace correlation between backend application spans and Cloud SQL Query Insights execution-plan spans, using OTel span creation and sqlcommenter traceparent injection at the database query layer.
+
+## Requirements
+
+### Requirement: OTel span creation for database queries
+The system SHALL create an OpenTelemetry child span for every database query executed through the connection pool, capturing the SQL operation, query text, and execution duration.
+
+#### Scenario: SELECT query creates a client span
+- **WHEN** a repository method executes a SELECT query via the pool wrapper
+- **THEN** an OTel span SHALL be created with kind `Client`
+- **AND** the span name SHALL be the SQL operation name (e.g., `SELECT`)
+- **AND** the span SHALL have attribute `db.system` set to `postgresql`
+- **AND** the span SHALL have attribute `db.query.text` set to the original SQL text (without injected comments)
+- **AND** the span SHALL have attribute `db.operation.name` set to the extracted operation
+
+#### Scenario: INSERT query creates a client span
+- **WHEN** a repository method executes an INSERT query via the pool wrapper
+- **THEN** an OTel span SHALL be created with span name `INSERT`
+- **AND** the span SHALL record the duration of the query execution
+
+#### Scenario: Query execution error is recorded on the span
+- **WHEN** a database query fails with an error
+- **THEN** the span SHALL record the error
+- **AND** the span status SHALL be set to `Error`
+
+---
+
+### Requirement: sqlcommenter traceparent injection
+The system SHALL inject a `traceparent` comment in sqlcommenter format into every SQL query, enabling Cloud SQL Query Insights to correlate its execution-plan spans with the backend application trace.
+
+#### Scenario: traceparent comment is prepended to SQL
+- **WHEN** a query is executed through the pool wrapper with an active OTel span in the context
+- **THEN** the SQL sent to PostgreSQL SHALL be prepended with a comment in the format `/*traceparent='00-{trace_id}-{span_id}-{flags}'*/`
+- **AND** the trace_id SHALL be the 32-character hex trace ID from the current span context
+- **AND** the span_id SHALL be the 16-character hex span ID from the current span context
+- **AND** the flags SHALL be the 2-character hex trace flags from the current span context
+
+#### Scenario: No comment injection when no active span
+- **WHEN** a query is executed through the pool wrapper without an active OTel span in the context
+- **THEN** the SQL SHALL be sent to PostgreSQL unmodified (no comment prepended)
+
+---
+
+### Requirement: Transparent pool wrapping
+The system SHALL wrap the `*pgxpool.Pool` with a `TracedPool` that is transparent to repository code — repositories SHALL NOT require any code changes to be instrumented.
+
+#### Scenario: Repository uses pool wrapper without code changes
+- **WHEN** a repository calls `Query`, `QueryRow`, or `Exec` on the pool
+- **THEN** the call SHALL be intercepted by the wrapper for span creation and comment injection
+- **AND** the call SHALL be delegated to the underlying `*pgxpool.Pool`
+- **AND** the result SHALL be returned unmodified to the repository
+
+#### Scenario: Pool wrapper supports Begin for transactions
+- **WHEN** a repository calls `Begin` to start a transaction
+- **THEN** the wrapper SHALL return a traced transaction that applies span creation and comment injection to queries executed within the transaction
+
+---
+
+### Requirement: Transaction query tracing
+The system SHALL trace individual queries executed within a database transaction, applying the same span creation and comment injection as direct pool queries.
+
+#### Scenario: Query within transaction creates a span
+- **WHEN** a query is executed via a transaction obtained from `Begin`
+- **THEN** an OTel span SHALL be created for that query
+- **AND** the SQL SHALL be prepended with the traceparent comment
+
+#### Scenario: Commit and Rollback create spans
+- **WHEN** a transaction is committed or rolled back
+- **THEN** an OTel span SHALL be created for the Commit or Rollback operation

--- a/openspec/specs/db-trace-correlation/spec.md
+++ b/openspec/specs/db-trace-correlation/spec.md
@@ -36,7 +36,7 @@ The system SHALL inject a `traceparent` comment in sqlcommenter format into ever
 - **WHEN** a query is executed through the pool wrapper with an active OTel span in the context
 - **THEN** the SQL sent to PostgreSQL SHALL be prepended with a comment in the format `/*traceparent='00-{trace_id}-{span_id}-{flags}'*/`
 - **AND** the trace_id SHALL be the 32-character hex trace ID from the current span context
-- **AND** the span_id SHALL be the 16-character hex span ID from the current span context
+- **AND** the span_id SHALL be the 16-character hex span ID of the DB query span created by the wrapper (not the caller's incoming span)
 - **AND** the flags SHALL be the 2-character hex trace flags from the current span context
 
 #### Scenario: No comment injection when no active span
@@ -56,7 +56,8 @@ The system SHALL wrap the `*pgxpool.Pool` with a `TracedPool` that is transparen
 
 #### Scenario: Pool wrapper supports Begin for transactions
 - **WHEN** a repository calls `Begin` to start a transaction
-- **THEN** the wrapper SHALL return a traced transaction that applies span creation and comment injection to queries executed within the transaction
+- **THEN** an OTel span SHALL be created for the `Begin` call itself
+- **AND** the wrapper SHALL return a traced transaction that applies span creation and comment injection to queries executed within the transaction
 
 ---
 


### PR DESCRIPTION
## 🔗 Related Issue

Closes #156

## 📝 Summary of Changes

- Add `db-trace-correlation` capability spec defining requirements for OTel span creation, sqlcommenter traceparent injection, transparent pool wrapping, and transaction query tracing
- Archive `correlate-otel-cloud-sql` change with all artifacts (proposal, design, specs, tasks)
- Sync delta spec to main specs at `openspec/specs/db-trace-correlation/`

## ✅ Self-Checklist

- [x] I have linked the related issue.
- [x] I have updated the relevant documentation (e.g., `README.md`) if needed.
- [x] I have run `buf lint` and `buf format` locally and all checks have passed.
- [x] My proto definitions follow the project's style guidelines and validation rules.
- [x] Breaking changes have been justified and documented if applicable.
