### PR TITLE
docs(openspec): archive fix-image-updater-digest-tracking change

### DIFF
--- a/openspec/changes/archive/2026-03-07-fix-image-updater-digest-tracking/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-07-fix-image-updater-digest-tracking/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-07

--- a/openspec/changes/archive/2026-03-07-fix-image-updater-digest-tracking/design.md
+++ b/openspec/changes/archive/2026-03-07-fix-image-updater-digest-tracking/design.md
@@ -1,0 +1,43 @@
+## Context
+
+The ArgoCD backend Application (`k8s/argocd-apps/dev/backend.yaml`) uses `argocd-image-updater` with `write-back-method: argocd` to track container images via digest strategy. The Kustomize bases for server, consumer, and concert-discovery all use short alias names in `images[].name` (e.g., `consumer`) mapped to full registry paths via `newName`.
+
+When image-updater writes back to `spec.source.kustomize.images`, it uses the full registry path as the override key. This doesn't match the short Kustomize `name`, so the override is silently ignored for images that were never bootstrapped. Server works by accident (likely bootstrapped during initial setup), but consumer and concert-discovery were never written.
+
+## Goals / Non-Goals
+
+**Goals:**
+- All three backend images (server, consumer, concert-discovery) are automatically rolled out when new `main`-tagged images are pushed
+- Explicit `kustomize.image-name` mapping for all images to prevent future regression
+
+**Non-Goals:**
+- Changing the write-back method (argocd → git) — current method is fine
+- Modifying Kustomize base structure or image naming conventions
+- Adding image tracking for other environments (staging/prod)
+
+## Decisions
+
+### Use `kustomize.image-name` annotation (not change Kustomize names)
+
+**Choice**: Add `<alias>.kustomize.image-name` annotations to map image-updater aliases to Kustomize short names.
+
+**Alternative considered**: Change `images[].name` in Kustomize bases to use full registry paths and update `deployment.yaml` image references. Rejected because it would require changes across multiple files, break the clean separation of image name from registry path, and potentially disrupt existing deployments.
+
+**Alternative considered**: Manually bootstrap the consumer/concert-discovery entries in the live Application object. Rejected because it's fragile — any full sync or Application recreation would lose the entries.
+
+### Add concert-discovery to image-list
+
+**Choice**: Include `concert-discovery` in the `image-list` annotation with the same digest strategy and `main` tag filter as the other images.
+
+**Rationale**: The deploy workflow already pushes `concert-discovery` with the `main` tag. Without image-updater tracking, the CronJob continues running stale images after backend merges.
+
+### Add kustomize.image-name for server too
+
+**Choice**: Add `server.kustomize.image-name: server` even though server currently works.
+
+**Rationale**: Server works by coincidence (bootstrapped entry). Making the mapping explicit prevents regression if the Application is recreated or the entry is lost during a sync.
+
+## Risks / Trade-offs
+
+- **[Risk] concert-discovery CronJob may have different update cadence needs** → Mitigation: Using the same `main` tag filter as server/consumer. If a different strategy is needed later, the annotation can be updated independently.
+- **[Risk] image-updater processes more images per check interval** → Mitigation: Adding one more image (concert-discovery) has negligible performance impact on image-updater polling.

--- a/openspec/changes/archive/2026-03-07-fix-image-updater-digest-tracking/proposal.md
+++ b/openspec/changes/archive/2026-03-07-fix-image-updater-digest-tracking/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+The argocd-image-updater is configured to track `server`, `consumer`, and `concert-discovery` images via digest strategy, but only `server` gets its digest written to the ArgoCD Application's `spec.source.kustomize.images`. The consumer and concert-discovery deployments are never rolled out when new images are pushed. This is because the image-updater uses the full registry path as the kustomize override key, which doesn't match the short alias (`consumer`, `concert-discovery`) defined in each Kustomize base's `images[].name`.
+
+## What Changes
+
+- Add `kustomize.image-name` annotations for `server`, `consumer`, and `concert-discovery` to the ArgoCD backend Application, mapping each image alias to its short Kustomize name.
+- Add `concert-discovery` to the `image-list` annotation with digest strategy and `main` tag filter, so it is also tracked by argocd-image-updater.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+(none - this is an infrastructure/configuration fix, no spec-level behavior changes)
+
+## Impact
+
+- **ArgoCD Application**: `k8s/argocd-apps/dev/backend.yaml` (annotation changes only)
+- **Affected deployments**: `consumer-app` Deployment and `concert-discovery-app` CronJob will now be automatically rolled out on new image pushes, matching the existing `server-app` behavior.
+- **No breaking changes**: The server image tracking continues to work as before; annotations are additive.

--- a/openspec/changes/archive/2026-03-07-fix-image-updater-digest-tracking/specs/no-spec-changes.md
+++ b/openspec/changes/archive/2026-03-07-fix-image-updater-digest-tracking/specs/no-spec-changes.md
@@ -1,0 +1,1 @@
+No spec-level changes. This is an infrastructure configuration fix with no new or modified capabilities.

--- a/openspec/changes/archive/2026-03-07-fix-image-updater-digest-tracking/tasks.md
+++ b/openspec/changes/archive/2026-03-07-fix-image-updater-digest-tracking/tasks.md
@@ -1,0 +1,13 @@
+## 1. Update ArgoCD Application Annotations
+
+- [x] 1.1 Add `concert-discovery` to `image-list` annotation in `k8s/argocd-apps/dev/backend.yaml`
+- [x] 1.2 Add `concert-discovery.update-strategy: digest` annotation
+- [x] 1.3 Add `concert-discovery.allow-tags: regexp:^main$` annotation
+- [x] 1.4 Add `server.kustomize.image-name: server` annotation
+- [x] 1.5 Add `consumer.kustomize.image-name: consumer` annotation
+- [x] 1.6 Add `concert-discovery.kustomize.image-name: concert-discovery` annotation
+
+## 2. Validate
+
+- [x] 2.1 Run `kubectl kustomize k8s/namespaces/backend/overlays/dev` to verify Kustomize renders without errors
+- [x] 2.2 Verify the ArgoCD Application YAML is valid (no syntax errors in annotations)


### PR DESCRIPTION
## Summary
- Archive proposal, design, and tasks for the image-updater digest tracking fix
- No spec-level changes (infrastructure configuration fix only)

## Context
Implementation PR: liverty-music/cloud-provisioning#137

Refs: liverty-music/cloud-provisioning#136