### PR TITLE
docs(openspec): archive add-schema-lint and sync specs

### DIFF
--- a/openspec/changes/archive/2026-03-09-add-schema-lint/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-09-add-schema-lint/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-09

--- a/openspec/changes/archive/2026-03-09-add-schema-lint/design.md
+++ b/openspec/changes/archive/2026-03-09-add-schema-lint/design.md
@@ -1,0 +1,85 @@
+## Context
+
+The `database-schema-designer` skill defines schema policies, but enforcement is purely advisory — it relies on the AI agent reading the skill before writing SQL. The `homes` table was created with `created_at` and `updated_at` columns (not in the design doc) and `VARCHAR(n)` columns (should be `TEXT` + `CHECK`), proving the gap. A mechanical linter closes this gap by failing `make check` and CI on policy violations.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Enforce all statically-checkable `database-schema-designer` rules via `scripts/lint-schema.sh`
+- Integrate into `make check` (and therefore pre-commit hook) and CI `lint.yml`
+- Fix all existing violations in `schema.sql` and dependent Go code
+
+**Non-Goals:**
+- Runtime / live-DB linting (schemalint-style) — not needed for this project size
+- Atlas Pro custom schema rules — unnecessary cost for grep-based checks
+- Checking migration files — lint targets `schema.sql` only (the desired-state source of truth)
+- EAV pattern detection or JSONB index analysis — require semantic understanding beyond static grep
+
+## Decisions
+
+### Decision 1: Standalone shell script, not embedded in Makefile
+
+**Choice**: `scripts/lint-schema.sh` as a standalone script with a `lint-schema` Makefile target.
+
+**Alternatives considered**:
+- Inline in Makefile: Harder to read, test, and extend.
+- Go-based linter: Over-engineered for pattern matching on a single SQL file.
+
+**Rationale**: Consistent with `check-migration-drift.sh`. Easy to extend with new rules. Callable from both Makefile and CI independently.
+
+### Decision 2: Six lint rules
+
+**Choice**: Implement these checks as errors (exit 1):
+
+| # | Rule | Pattern | Rationale |
+|---|------|---------|-----------|
+| 1 | No SERIAL/BIGSERIAL | `\bSERIAL\b`, `\bBIGSERIAL\b` | UUIDv7 is mandatory for PKs |
+| 2 | No bare TIMESTAMP | `\bTIMESTAMP\b` (does not match TIMESTAMPTZ) | TIMESTAMPTZ is required |
+| 3 | No audit columns | `\b(created_at\|updated_at\|deleted_at)\b` | Prohibited unless design doc requires |
+| 4 | No VARCHAR(n) | `VARCHAR\(` | Use TEXT + CHECK constraint |
+| 5 | COMMENT ON TABLE coverage | Parse CREATE TABLE names, verify matching COMMENT ON TABLE | Mandatory per skill |
+| 6 | COMMENT ON COLUMN coverage | Count columns per table, compare to COMMENT ON COLUMN count | Mandatory per skill |
+
+**Rationale**: These six rules cover all statically-checkable constraints from `database-schema-designer`. Rules 1-4 are simple grep patterns. Rules 5-6 require lightweight parsing (extract table/column names, count matches).
+
+### Decision 3: `make check` integration via separate target
+
+**Choice**: `check: lint lint-schema test` — `lint-schema` as a peer of `lint`, not nested inside it.
+
+**Rationale**: `lint` is Go-specific (gofmt + golangci-lint). Schema linting is a different concern. Separate targets give clear error attribution. The pre-commit hook (`pre-commit-check.sh`) calls `make check`, so no hook changes needed.
+
+### Decision 4: CI `lint.yml` with per-job paths-filter
+
+**Choice**: Add `schema` output to the existing `dorny/paths-filter` step. Add `schema-lint` / `schema-lint-skip` jobs gated on `schema == 'true'`.
+
+**Alternatives considered**:
+- New `schema-lint.yml` workflow: Adds workflow count, separate CI Success gate.
+- Add to `atlas-ci.yml`: Schema lint is a lint concern, not a migration concern.
+
+**Rationale**: `lint.yml` is the natural home for all lint checks. Per-job filtering avoids running schema lint on Go-only changes. The `schema-lint` job needs only checkout + bash (no Go, no DB), so it's fast.
+
+### Decision 5: Fix existing violations in homes table
+
+**Choice**: In the same change, fix `homes` table violations:
+- Remove `created_at` and `updated_at` columns
+- Convert `country_code VARCHAR(2)` → `TEXT` + `CHECK (char_length(country_code) = 2)`
+- Convert `level_1 VARCHAR(6)` → `TEXT` + `CHECK (char_length(level_1) BETWEEN 2 AND 6)`
+- Convert `level_2 VARCHAR(20)` → `TEXT` + `CHECK (level_2 IS NULL OR char_length(level_2) <= 20)`
+
+**Rationale**: The linter must pass on the current schema to be useful. Fixing violations first ensures the linter is green from the start.
+
+### Decision 6: Remove `updated_at` from Go upsert query
+
+**Choice**: Remove `updated_at = now()` from `upsertHomeQuery` in `user_repo.go`. The upsert already updates the data columns via `EXCLUDED.*`, so the row change is tracked implicitly by PostgreSQL's `xmin`/transaction visibility if ever needed.
+
+**Rationale**: The column is being dropped from the table, so the query must be updated. No entity or use case changes needed — `created_at` and `updated_at` were never mapped to Go structs.
+
+## Risks / Trade-offs
+
+- **[grep false positives in comments]** → SQL comments could mention `SERIAL` or `TIMESTAMP` in prose. Mitigation: grep only non-comment lines (strip `--` prefixed lines before checking). Acceptable trade-off for simplicity.
+- **[COMMENT ON count mismatch on complex tables]** → Tables with constraints-only lines or multi-line column definitions could cause miscounts. Mitigation: count only lines matching the column definition pattern (indented, type keyword). Test against current schema.
+- **[VARCHAR may be intentional in future]** → The skill says "unless strictly required". Mitigation: if a legitimate case arises, add an inline `-- lint:ignore varchar` comment and update the script to respect it. Not implemented now (YAGNI).
+
+## Open Questions
+
+- None. All decisions were resolved during the explore session.

--- a/openspec/changes/archive/2026-03-09-add-schema-lint/proposal.md
+++ b/openspec/changes/archive/2026-03-09-add-schema-lint/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+The `database-schema-designer` skill defines schema design policies (no audit columns, no SERIAL, no VARCHAR, TIMESTAMPTZ only, COMMENT ON mandatory), but violations are only caught if the AI agent happens to read the skill file. The `homes` table was created with `created_at` and `updated_at` columns that violate the audit column policy, proving the skill-only approach is insufficient. A mechanical linter ensures violations are caught regardless of who or what writes the schema.
+
+## What Changes
+
+- Add `scripts/lint-schema.sh` that statically checks `schema.sql` against design policies:
+  - Prohibit `SERIAL` / `BIGSERIAL`
+  - Prohibit `TIMESTAMP` (without time zone)
+  - Prohibit audit columns (`created_at`, `updated_at`, `deleted_at`)
+  - Prohibit `VARCHAR(n)` (use `TEXT` + `CHECK` constraint instead)
+  - Detect missing `COMMENT ON TABLE` for each `CREATE TABLE`
+  - Detect missing `COMMENT ON COLUMN` (count mismatch per table)
+- Add `lint-schema` target to `Makefile`, included in `make check`
+- Add `schema.sql` to CI `lint.yml` paths-filter and add `schema-lint` job
+- Fix existing violations in `schema.sql` (`homes` table: remove `created_at`/`updated_at`, convert `VARCHAR` to `TEXT` + `CHECK`)
+
+## Capabilities
+
+### New Capabilities
+- `schema-lint`: Automated static analysis of schema.sql against database design policies
+
+### Modified Capabilities
+- `database-migration`: `make check` now includes `lint-schema` target; CI `lint.yml` gains a `schema-lint` job
+
+## Impact
+
+- `backend/scripts/lint-schema.sh` — new file
+- `backend/Makefile` — new `lint-schema` target added to `check`
+- `backend/.github/workflows/lint.yml` — paths-filter expanded, new job added
+- `backend/internal/infrastructure/database/rdb/schema/schema.sql` — `homes` table modified (drop audit columns, VARCHAR → TEXT + CHECK)
+- `backend/k8s/atlas/base/migrations/` — new migration for homes table changes
+- `backend/internal/infrastructure/database/rdb/` — Go repository code updated for removed columns and type changes

--- a/openspec/changes/archive/2026-03-09-add-schema-lint/specs/schema-lint/spec.md
+++ b/openspec/changes/archive/2026-03-09-add-schema-lint/specs/schema-lint/spec.md
@@ -1,0 +1,109 @@
+## ADDED Requirements
+
+### Requirement: SERIAL and BIGSERIAL detection
+The schema linter SHALL detect usage of `SERIAL` or `BIGSERIAL` types in `schema.sql` and report an error.
+
+#### Scenario: Schema contains SERIAL column
+- **WHEN** `schema.sql` contains a column defined with `SERIAL` or `BIGSERIAL`
+- **THEN** the linter SHALL exit with code 1 and print the violating line number and content
+
+#### Scenario: Schema has no SERIAL columns
+- **WHEN** `schema.sql` contains no `SERIAL` or `BIGSERIAL` usage
+- **THEN** the linter SHALL pass this check without error
+
+### Requirement: Bare TIMESTAMP detection
+The schema linter SHALL detect usage of `TIMESTAMP` (without time zone) in `schema.sql` and report an error. The pattern `\bTIMESTAMP\b` SHALL be used, which does not match `TIMESTAMPTZ`.
+
+#### Scenario: Schema contains bare TIMESTAMP
+- **WHEN** `schema.sql` contains a column defined with `TIMESTAMP` (not `TIMESTAMPTZ`)
+- **THEN** the linter SHALL exit with code 1 and print the violating line number and content
+
+#### Scenario: Schema uses TIMESTAMPTZ correctly
+- **WHEN** `schema.sql` uses only `TIMESTAMPTZ` for temporal columns
+- **THEN** the linter SHALL pass this check without error
+
+### Requirement: Audit column detection
+The schema linter SHALL detect `created_at`, `updated_at`, or `deleted_at` columns in `schema.sql` and report an error.
+
+#### Scenario: Schema contains audit columns
+- **WHEN** `schema.sql` contains a column named `created_at`, `updated_at`, or `deleted_at`
+- **THEN** the linter SHALL exit with code 1 and print the violating line number and content
+
+#### Scenario: Schema has no audit columns
+- **WHEN** `schema.sql` contains no audit columns
+- **THEN** the linter SHALL pass this check without error
+
+### Requirement: VARCHAR detection
+The schema linter SHALL detect usage of `VARCHAR(n)` in `schema.sql` and report an error. The project convention is `TEXT` with `CHECK` constraints for length enforcement.
+
+#### Scenario: Schema contains VARCHAR column
+- **WHEN** `schema.sql` contains a column defined with `VARCHAR(`
+- **THEN** the linter SHALL exit with code 1 and print the violating line number and content
+
+#### Scenario: Schema uses TEXT with CHECK
+- **WHEN** `schema.sql` uses `TEXT` type with `CHECK` constraints for length validation
+- **THEN** the linter SHALL pass this check without error
+
+### Requirement: COMMENT ON TABLE coverage
+The schema linter SHALL verify that every `CREATE TABLE` statement has a corresponding `COMMENT ON TABLE` statement.
+
+#### Scenario: Table missing COMMENT ON TABLE
+- **WHEN** `schema.sql` defines a table via `CREATE TABLE` without a matching `COMMENT ON TABLE`
+- **THEN** the linter SHALL exit with code 1 and report the table name
+
+#### Scenario: All tables have comments
+- **WHEN** every `CREATE TABLE` in `schema.sql` has a corresponding `COMMENT ON TABLE`
+- **THEN** the linter SHALL pass this check without error
+
+### Requirement: COMMENT ON COLUMN coverage
+The schema linter SHALL verify that the number of columns defined in each table matches the number of `COMMENT ON COLUMN` statements for that table.
+
+#### Scenario: Table has missing column comments
+- **WHEN** a table in `schema.sql` has more column definitions than `COMMENT ON COLUMN` statements
+- **THEN** the linter SHALL exit with code 1 and report the table name with expected and actual counts
+
+#### Scenario: All columns have comments
+- **WHEN** every column in every table has a corresponding `COMMENT ON COLUMN`
+- **THEN** the linter SHALL pass this check without error
+
+### Requirement: Makefile integration
+The schema linter SHALL be invocable via `make lint-schema` and SHALL be included in `make check`.
+
+#### Scenario: make check runs schema lint
+- **WHEN** a developer runs `make check`
+- **THEN** `lint-schema` SHALL execute as part of the check pipeline
+
+#### Scenario: make lint-schema runs standalone
+- **WHEN** a developer runs `make lint-schema`
+- **THEN** the schema linter script SHALL execute and report results
+
+### Requirement: CI integration
+The schema linter SHALL run in CI via `lint.yml` when `schema.sql` is modified.
+
+#### Scenario: PR modifies schema.sql
+- **WHEN** a pull request modifies `schema.sql`
+- **THEN** the `schema-lint` CI job SHALL run and report results
+
+#### Scenario: PR does not modify schema.sql
+- **WHEN** a pull request does not modify `schema.sql`
+- **THEN** the `schema-lint` CI job SHALL be skipped
+
+### Requirement: Comment-line exclusion
+The schema linter SHALL ignore SQL comment lines (lines starting with `--`) when checking for pattern violations.
+
+#### Scenario: Prohibited keyword appears only in comment
+- **WHEN** `schema.sql` contains `-- Use SERIAL for legacy tables` as a comment
+- **THEN** the linter SHALL NOT report this as a violation
+
+#### Scenario: Prohibited keyword appears in active SQL
+- **WHEN** `schema.sql` contains `id SERIAL PRIMARY KEY` as active SQL
+- **THEN** the linter SHALL report this as a violation
+
+## MODIFIED Requirements
+
+### Requirement: Database migration workflow includes schema lint
+The `make check` target SHALL include `lint-schema` in addition to `lint` and `test`.
+
+#### Scenario: make check target composition
+- **WHEN** a developer runs `make check`
+- **THEN** `lint`, `lint-schema`, and `test` SHALL all execute

--- a/openspec/changes/archive/2026-03-09-add-schema-lint/tasks.md
+++ b/openspec/changes/archive/2026-03-09-add-schema-lint/tasks.md
@@ -1,0 +1,38 @@
+## 1. Fix existing schema violations (backend repo)
+
+- [x] 1.1 Edit `schema.sql`: remove `created_at` and `updated_at` columns from `homes` table
+- [x] 1.2 Edit `schema.sql`: convert `homes.country_code` from `VARCHAR(2)` to `TEXT` with `CHECK (char_length(country_code) = 2)`
+- [x] 1.3 Edit `schema.sql`: convert `homes.level_1` from `VARCHAR(6)` to `TEXT` with `CHECK (char_length(level_1) BETWEEN 2 AND 6)`
+- [x] 1.4 Edit `schema.sql`: convert `homes.level_2` from `VARCHAR(20)` to `TEXT` with `CHECK (level_2 IS NULL OR char_length(level_2) <= 20)`
+- [x] 1.5 Remove `updated_at = now()` from `upsertHomeQuery` in `user_repo.go`
+- [x] 1.6 Generate Atlas migration: `atlas migrate diff --env local fix_homes_table_schema`
+- [x] 1.7 Add migration file to `k8s/atlas/base/kustomization.yaml`
+
+## 2. Create schema linter script (backend repo)
+
+- [x] 2.1 Create `scripts/lint-schema.sh` with comment-line stripping (exclude `--` lines)
+- [x] 2.2 Implement check: `SERIAL` / `BIGSERIAL` detection (`\bSERIAL\b`, `\bBIGSERIAL\b`)
+- [x] 2.3 Implement check: bare `TIMESTAMP` detection (`\bTIMESTAMP\b`)
+- [x] 2.4 Implement check: audit column detection (`created_at`, `updated_at`, `deleted_at`)
+- [x] 2.5 Implement check: `VARCHAR(` detection
+- [x] 2.6 Implement check: COMMENT ON TABLE coverage (every CREATE TABLE has matching COMMENT ON TABLE)
+- [x] 2.7 Implement check: COMMENT ON COLUMN coverage (column count matches COMMENT ON COLUMN count per table)
+- [x] 2.8 Verify `lint-schema.sh` passes against current `schema.sql`
+
+## 3. Makefile integration (backend repo)
+
+- [x] 3.1 Add `lint-schema` target to `Makefile` that runs `bash scripts/lint-schema.sh`
+- [x] 3.2 Update `check` target to `check: lint lint-schema test`
+- [x] 3.3 Add `lint-schema` to `.PHONY`
+
+## 4. CI integration (backend repo)
+
+- [x] 4.1 Add `schema` output to `dorny/paths-filter` in `lint.yml` matching `schema.sql` path
+- [x] 4.2 Add `schema-lint` job gated on `schema == 'true'` (checkout + `make lint-schema`)
+- [x] 4.3 Add `schema-lint-skip` job gated on `schema == 'false'`
+- [x] 4.4 Update `ci-success` job to include `schema-lint` and `schema-lint-skip` in `needs` and `allowed-skips`
+
+## 5. Validation (backend repo)
+
+- [x] 5.1 Run `make lint-schema` to verify linter passes
+- [x] 5.2 Run `bash scripts/check-migration-drift.sh` to verify migration integrity

--- a/openspec/specs/schema-lint/spec.md
+++ b/openspec/specs/schema-lint/spec.md
@@ -1,0 +1,105 @@
+### Requirement: SERIAL and BIGSERIAL detection
+The schema linter SHALL detect usage of `SERIAL` or `BIGSERIAL` types in `schema.sql` and report an error.
+
+#### Scenario: Schema contains SERIAL column
+- **WHEN** `schema.sql` contains a column defined with `SERIAL` or `BIGSERIAL`
+- **THEN** the linter SHALL exit with code 1 and print the violating line number and content
+
+#### Scenario: Schema has no SERIAL columns
+- **WHEN** `schema.sql` contains no `SERIAL` or `BIGSERIAL` usage
+- **THEN** the linter SHALL pass this check without error
+
+### Requirement: Bare TIMESTAMP detection
+The schema linter SHALL detect usage of `TIMESTAMP` (without time zone) in `schema.sql` and report an error. The pattern `\bTIMESTAMP\b` SHALL be used, which does not match `TIMESTAMPTZ`.
+
+#### Scenario: Schema contains bare TIMESTAMP
+- **WHEN** `schema.sql` contains a column defined with `TIMESTAMP` (not `TIMESTAMPTZ`)
+- **THEN** the linter SHALL exit with code 1 and print the violating line number and content
+
+#### Scenario: Schema uses TIMESTAMPTZ correctly
+- **WHEN** `schema.sql` uses only `TIMESTAMPTZ` for temporal columns
+- **THEN** the linter SHALL pass this check without error
+
+### Requirement: Audit column detection
+The schema linter SHALL detect `created_at`, `updated_at`, or `deleted_at` columns in `schema.sql` and report an error.
+
+#### Scenario: Schema contains audit columns
+- **WHEN** `schema.sql` contains a column named `created_at`, `updated_at`, or `deleted_at`
+- **THEN** the linter SHALL exit with code 1 and print the violating line number and content
+
+#### Scenario: Schema has no audit columns
+- **WHEN** `schema.sql` contains no audit columns
+- **THEN** the linter SHALL pass this check without error
+
+### Requirement: VARCHAR detection
+The schema linter SHALL detect usage of `VARCHAR(n)` in `schema.sql` and report an error. The project convention is `TEXT` with `CHECK` constraints for length enforcement.
+
+#### Scenario: Schema contains VARCHAR column
+- **WHEN** `schema.sql` contains a column defined with `VARCHAR(`
+- **THEN** the linter SHALL exit with code 1 and print the violating line number and content
+
+#### Scenario: Schema uses TEXT with CHECK
+- **WHEN** `schema.sql` uses `TEXT` type with `CHECK` constraints for length validation
+- **THEN** the linter SHALL pass this check without error
+
+### Requirement: COMMENT ON TABLE coverage
+The schema linter SHALL verify that every `CREATE TABLE` statement has a corresponding `COMMENT ON TABLE` statement.
+
+#### Scenario: Table missing COMMENT ON TABLE
+- **WHEN** `schema.sql` defines a table via `CREATE TABLE` without a matching `COMMENT ON TABLE`
+- **THEN** the linter SHALL exit with code 1 and report the table name
+
+#### Scenario: All tables have comments
+- **WHEN** every `CREATE TABLE` in `schema.sql` has a corresponding `COMMENT ON TABLE`
+- **THEN** the linter SHALL pass this check without error
+
+### Requirement: COMMENT ON COLUMN coverage
+The schema linter SHALL verify that the number of columns defined in each table matches the number of `COMMENT ON COLUMN` statements for that table.
+
+#### Scenario: Table has missing column comments
+- **WHEN** a table in `schema.sql` has more column definitions than `COMMENT ON COLUMN` statements
+- **THEN** the linter SHALL exit with code 1 and report the table name with expected and actual counts
+
+#### Scenario: All columns have comments
+- **WHEN** every column in every table has a corresponding `COMMENT ON COLUMN`
+- **THEN** the linter SHALL pass this check without error
+
+### Requirement: Makefile integration
+The schema linter SHALL be invocable via `make lint-schema` and SHALL be included in `make check`.
+
+#### Scenario: make check runs schema lint
+- **WHEN** a developer runs `make check`
+- **THEN** `lint-schema` SHALL execute as part of the check pipeline
+
+#### Scenario: make lint-schema runs standalone
+- **WHEN** a developer runs `make lint-schema`
+- **THEN** the schema linter script SHALL execute and report results
+
+### Requirement: CI integration
+The schema linter SHALL run in CI via `lint.yml` when `schema.sql` is modified.
+
+#### Scenario: PR modifies schema.sql
+- **WHEN** a pull request modifies `schema.sql`
+- **THEN** the `schema-lint` CI job SHALL run and report results
+
+#### Scenario: PR does not modify schema.sql
+- **WHEN** a pull request does not modify `schema.sql`
+- **THEN** the `schema-lint` CI job SHALL be skipped
+
+### Requirement: Comment-line exclusion
+The schema linter SHALL ignore SQL comment lines (lines starting with `--`) when checking for pattern violations.
+
+#### Scenario: Prohibited keyword appears only in comment
+- **WHEN** `schema.sql` contains `-- Use SERIAL for legacy tables` as a comment
+- **THEN** the linter SHALL NOT report this as a violation
+
+#### Scenario: Prohibited keyword appears in active SQL
+- **WHEN** `schema.sql` contains `id SERIAL PRIMARY KEY` as active SQL
+- **THEN** the linter SHALL report this as a violation
+
+### Requirement: Database migration workflow includes schema lint
+The `make check` target SHALL include `lint-schema` in addition to `lint` and `test`.
+
+#### Scenario: make check target composition
+- **WHEN** a developer runs `make check`
+- **THEN** `lint`, `lint-schema`, and `test` SHALL all execute


### PR DESCRIPTION
## Summary

Archive the `add-schema-lint` OpenSpec change and sync its capability spec to main specs.

- Archive: `openspec/changes/archive/2026-03-09-add-schema-lint/`
- New main spec: `openspec/specs/schema-lint/spec.md`

Companion PR: liverty-music/backend#165
