### PR TITLE
feat!(proto): rename PassionLevel to HypeType with 4-tier enum

### DIFF
--- a/.github/workflows/buf-pr-checks.yml
+++ b/.github/workflows/buf-pr-checks.yml
@@ -44,8 +44,15 @@ jobs:
           token: ${{ secrets.BUF_TOKEN }}
           setup_only: true
 
-      - name: Run make lint
-        run: make lint
+      - name: Run buf lint
+        run: buf lint
+
+      - name: Check buf format
+        run: buf format -d --exit-code
+
+      - name: Check breaking changes
+        if: "!contains(github.event.pull_request.labels.*.name, 'buf skip breaking')"
+        run: buf breaking --against '.git#branch=origin/main'
 
   buf-checks-skip:
     needs: changes

--- a/openspec/changes/rename-passion-to-hype/.openspec.yaml
+++ b/openspec/changes/rename-passion-to-hype/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-09

--- a/openspec/changes/rename-passion-to-hype/design.md
+++ b/openspec/changes/rename-passion-to-hype/design.md
@@ -1,0 +1,120 @@
+## Context
+
+The current PassionLevel system (3 tiers: MUST_GO, LOCAL_ONLY, KEEP_AN_EYE) was implemented as a UI-only feature — the notification backend sends push notifications to all followers regardless of their passion level. This change renames the concept to "Hype", expands to 4 tiers with clear notification semantics, and implements the actual notification filtering logic.
+
+Current state:
+- Proto: `PassionLevel` enum in `entity/v1/artist.proto` with values 1-3
+- DB: `followed_artists.passion_level TEXT DEFAULT 'local_only'`
+- Backend: `NotifyNewConcerts()` sends to ALL followers, ignoring passion level
+- Frontend: Passion selector with 3 options on My Artists page
+
+## Goals / Non-Goals
+
+**Goals:**
+- Rename PassionLevel → HypeType (proto) / Hype (all other layers) with clear ascending semantics
+- Implement notification filtering: WATCH=off, HOME=home-area-only, ANYWHERE=all
+- Change default to ANYWHERE so new followers immediately receive notifications
+- Define NEARBY in proto for forward compatibility (Phase 2)
+
+**Non-Goals:**
+- NEARBY tier implementation (requires physical distance calculation — undefined)
+- NEARBY UI exposure (hidden from selector in Phase 1)
+- Dashboard Visual Mutation (large cards in Lane 2/3 for ANYWHERE artists)
+- Notification history or delivery tracking
+
+## Decisions
+
+### Decision 1: Naming convention — HypeType (proto) vs Hype (everywhere else)
+
+Proto enum follows Protobuf convention as a suffixed type name: `HypeType`. All other layers use the shorter domain term: `Hype`.
+
+| Layer | Name |
+|-------|------|
+| Proto enum | `HypeType` |
+| Proto field | `hype` (in `FollowedArtist` message) |
+| RPC | `SetHype` |
+| DB column | `hype` |
+| Go entity | `Hype` (type), `HypeWatch`, `HypeHome`, etc. (constants) |
+| Frontend | `hype` property, `hypeIcon()`, `HYPE_META` |
+| i18n key | `hype.watch`, `hype.home`, `hype.nearby`, `hype.anywhere` |
+
+**Rationale**: "Hype" is shorter, more evocative, and aligns with music culture. The `Type` suffix is only needed in proto where bare `Hype` would not follow enum naming conventions.
+
+### Decision 2: Enum value numbering — ascending hype order
+
+```protobuf
+enum HypeType {
+  HYPE_TYPE_UNSPECIFIED = 0;
+  HYPE_TYPE_WATCH    = 1;  // 👀 lowest hype
+  HYPE_TYPE_HOME     = 2;  // 🔥
+  HYPE_TYPE_NEARBY   = 3;  // 🔥🔥 (Phase 2)
+  HYPE_TYPE_ANYWHERE = 4;  // 🔥🔥🔥 highest hype
+}
+```
+
+**Rationale**: Ascending order enables natural comparisons (`hype >= HOME` means "at least home-level notifications"). The current PassionLevel uses descending order (MUST_GO=1 is highest) which is counterintuitive.
+
+**Alternative considered**: Keep descending order for backward compatibility. Rejected because this is a full rename anyway — a clean break is better than carrying over a confusing convention.
+
+### Decision 3: Notification filtering in NotifyNewConcerts
+
+The filtering logic is added to `NotifyNewConcerts()` in the push notification use case. The method must now:
+
+1. Retrieve followers WITH their hype level (new: `ListFollowersWithHype`)
+2. For each follower, evaluate whether to send based on hype:
+   - `WATCH` → skip
+   - `HOME` → send only if `concert.venue.adminArea == user.home.level_1`
+   - `NEARBY` → treat as ANYWHERE (Phase 1 fallback, not selectable in UI)
+   - `ANYWHERE` → send
+
+This requires a new repository method that joins `followed_artists` with `users` and `homes` to get hype + home area in one query.
+
+**Alternative considered**: Filter at the query level (only fetch followers who should be notified). Rejected for Phase 1 because the logic is simple enough in-memory and keeping the query simple makes it easier to extend for NEARBY later.
+
+### Decision 4: DB migration strategy — rename column in-place
+
+Single migration that:
+1. Renames column `passion_level` → `hype`
+2. Updates existing values: `must_go` → `anywhere`, `local_only` → `anywhere`, `keep_an_eye` → `watch`
+3. Drops old CHECK constraint, adds new one: `('watch', 'home', 'nearby', 'anywhere')`
+4. Changes DEFAULT to `'anywhere'`
+
+**Value mapping rationale**:
+- `must_go` → `anywhere`: Same intent (travel anywhere)
+- `local_only` → `anywhere`: Users who were on the old default should be bumped to the new default so they start receiving notifications. This aligns with the product goal of "experience notifications first".
+- `keep_an_eye` → `watch`: Same intent (no notifications)
+
+**Alternative considered**: Map `local_only` → `home`. Rejected because `local_only` users never actually received filtered notifications (the feature wasn't implemented), so they had no expectation of "home only" behavior. Mapping to `anywhere` gives them the intended new-user experience.
+
+### Decision 5: NEARBY in Phase 1 — proto-defined but UI-hidden
+
+NEARBY is included in the proto enum (value=3) and DB CHECK constraint but:
+- Frontend hype selector does NOT show NEARBY as an option
+- Backend treats NEARBY as ANYWHERE (fallback) if somehow set
+- No region/distance calculation is implemented
+
+**Rationale**: Including NEARBY in proto now avoids a breaking proto change in Phase 2. The enum is additive-safe but renumbering is not.
+
+### Decision 6: Default on follow — ANYWHERE
+
+When a user follows an artist, `hype` defaults to `'anywhere'` (DB DEFAULT). This means new followers immediately receive push notifications for all concerts.
+
+**Rationale**: The product goal is to let users experience notifications before deciding to tune them down. The selector UI makes it easy to change.
+
+## Risks / Trade-offs
+
+**[Risk] Notification volume spike** → Users who follow many artists will receive many notifications with the new ANYWHERE default. Mitigated by: (1) the hype selector is prominent and easy to use, (2) notifications are already batched per artist per discovery run, (3) users can unsubscribe from push entirely.
+
+**[Risk] Breaking proto change across repos** → Enum rename + value remapping requires coordinated release. Mitigated by: standard specification-first release process (spec PR → merge → Release → BSR gen → backend/frontend update).
+
+**[Risk] Data migration maps local_only → anywhere** → Existing `local_only` users may receive more notifications than before. Mitigated by: they weren't receiving any filtered notifications anyway (feature was unimplemented), so this is net-new behavior regardless.
+
+**[Trade-off] NEARBY fallback to ANYWHERE** → If a user somehow has NEARBY set (e.g., via direct DB edit), they get all notifications instead of filtered ones. Acceptable for Phase 1 since NEARBY is not exposed in UI.
+
+## Migration Plan
+
+1. **specification**: Create PR with proto changes (enum rename, field rename, RPC rename). Merge → Release → BSR publishes new types.
+2. **backend**: DB migration (column rename + value mapping + constraint + default). Update entity, repository, use case, handler, mapper. Add `ListFollowersWithHype` query. Update `NotifyNewConcerts` with filtering logic.
+3. **frontend**: Update service clients, My Artists component, i18n, onboarding to use new naming and 4-tier selector (NEARBY hidden).
+
+Rollback: Proto changes are breaking and not easily rolled back. DB migration can be reversed with an inverse migration. Backend/frontend changes are straightforward reverts.

--- a/openspec/changes/rename-passion-to-hype/proposal.md
+++ b/openspec/changes/rename-passion-to-hype/proposal.md
@@ -1,0 +1,36 @@
+## Why
+
+The current PassionLevel system has two problems: (1) it defines three tiers but the notification backend ignores them entirely — all followers receive all push notifications regardless of their passion level, and (2) the naming ("Passion Level", "Local Only", "Must Go") does not clearly communicate the relationship between user enthusiasm and notification scope. Renaming to "Hype" with semantically clear tier names (Watch, Home, Nearby, Anywhere) establishes a direct mapping between the user's intent and the system's notification behavior, while also preparing for a future Nearby tier based on physical distance.
+
+## What Changes
+
+- **BREAKING**: Rename `PassionLevel` enum to `HypeType` in proto; rename to `Hype` in all other layers (DB column, Go entity, frontend)
+- **BREAKING**: Expand from 3 tiers to 4 tiers with ascending hype order:
+  - `WATCH` (👀) — Dashboard only, no push notifications
+  - `HOME` (🔥) — Push notifications only for concerts in user's home area (ISO 3166-2 match)
+  - `NEARBY` (🔥🔥) — Reserved for Phase 2 (physical distance based); defined in proto but hidden from UI
+  - `ANYWHERE` (🔥🔥🔥) — Push notifications for all concerts nationwide
+- **BREAKING**: Change default on follow from `LOCAL_ONLY` to `ANYWHERE` so users immediately experience notifications
+- **BREAKING**: Rename `SetPassionLevel` RPC to `SetHype`; rename `FollowedArtist.passion_level` field to `hype`
+- Implement notification filtering in `NotifyNewConcerts()` based on hype and user home area
+- DB migration: rename column `passion_level` to `hype`, update CHECK constraint and default value
+
+## Capabilities
+
+### New Capabilities
+
+- `hype-notification-filter`: Notification filtering logic that evaluates a follower's hype and home area against a concert's venue location to determine whether to send a push notification
+
+### Modified Capabilities
+
+- `passion-level`: Replaced entirely by the new hype system — tiers, naming, enum values, default, and API all change
+- `artist-following`: FollowedArtist wrapper field renamed from `passion_level` to `hype`; default value changes to `anywhere`
+- `my-artists`: Passion selector UI renamed to Hype selector; icons and labels updated; NEARBY tier hidden in Phase 1
+- `push-notification`: NotifyNewConcerts must filter recipients by hype (WATCH excluded, HOME filtered by venue location)
+
+## Impact
+
+- **specification**: Proto enum rename + restructure, RPC rename, field renames across entity and RPC layers
+- **backend**: Entity types, use case logic, RPC handler/mapper, repository queries, DB migration (column rename + constraint + default)
+- **frontend**: Service clients, My Artists page component/template, i18n keys (EN/JA), onboarding step 5, passion explanation dialog
+- **Cross-repo coordination**: Specification PR must merge and release first; backend and frontend PRs depend on BSR-generated types

--- a/openspec/changes/rename-passion-to-hype/specs/artist-following/spec.md
+++ b/openspec/changes/rename-passion-to-hype/specs/artist-following/spec.md
@@ -1,0 +1,33 @@
+## MODIFIED Requirements
+
+### Requirement: Follow Relationship Data Model
+
+The system SHALL maintain a follow relationship between users and artists, stored in the followed_artists table. The use case layer SHALL resolve the authenticated user's external identity (Zitadel `sub` claim) to the internal user UUID before querying or writing to the `followed_artists` table.
+
+#### Scenario: Hype stored on follow relationship
+
+- **GIVEN** the followed_artists table
+- **WHEN** a follow relationship exists
+- **THEN** a `hype` column SHALL store the user's enthusiasm tier (watch, home, nearby, anywhere) with a default of `anywhere`
+
+#### Scenario: Successfully following an artist
+
+- **WHEN** a user with a valid Zitadel identity requests to follow an artist with a valid MBID
+- **THEN** the system SHALL resolve the Zitadel `sub` claim to the internal user UUID via `UserRepository.GetByExternalID`
+- **AND** the system SHALL create a record in the `followed_artists` table linking the internal user UUID to the artist
+- **AND** the `hype` column SHALL default to `anywhere`
+
+#### Scenario: User record not found during follow
+
+- **WHEN** `Follow` is called with a valid Zitadel identity but no corresponding user record exists
+- **THEN** the system SHALL return `NOT_FOUND` error indicating the user must complete registration first
+
+### Requirement: ListFollowed Response
+
+The system SHALL return the user's followed artists via the ListFollowed RPC.
+
+#### Scenario: Response uses FollowedArtist wrapper with hype
+
+- **GIVEN** a user calls ListFollowed
+- **WHEN** the response is returned
+- **THEN** each entry SHALL be a FollowedArtist wrapper containing the artist entity and the user's hype level (HypeType enum)

--- a/openspec/changes/rename-passion-to-hype/specs/hype-notification-filter/spec.md
+++ b/openspec/changes/rename-passion-to-hype/specs/hype-notification-filter/spec.md
@@ -1,0 +1,54 @@
+## ADDED Requirements
+
+### Requirement: Hype-Based Notification Filtering
+
+The system SHALL evaluate each follower's hype level and home area against a concert's venue location before sending a push notification. This filtering SHALL be applied within `NotifyNewConcerts()` after retrieving followers.
+
+#### Scenario: WATCH follower receives no notification
+
+- **WHEN** a new concert is discovered for an artist
+- **AND** a follower has hype set to WATCH
+- **THEN** the system SHALL skip push notification delivery for that follower
+
+#### Scenario: HOME follower receives notification for home-area concert
+
+- **WHEN** a new concert is discovered for an artist
+- **AND** a follower has hype set to HOME
+- **AND** the concert venue's adminArea matches the follower's home level_1 (ISO 3166-2)
+- **THEN** the system SHALL send a push notification to that follower
+
+#### Scenario: HOME follower does not receive notification for non-home concert
+
+- **WHEN** a new concert is discovered for an artist
+- **AND** a follower has hype set to HOME
+- **AND** the concert venue's adminArea does NOT match the follower's home level_1
+- **THEN** the system SHALL skip push notification delivery for that follower
+
+#### Scenario: HOME follower with no home set receives no notification
+
+- **WHEN** a new concert is discovered for an artist
+- **AND** a follower has hype set to HOME
+- **AND** the follower has not set a home area
+- **THEN** the system SHALL skip push notification delivery for that follower
+
+#### Scenario: ANYWHERE follower receives notification for all concerts
+
+- **WHEN** a new concert is discovered for an artist
+- **AND** a follower has hype set to ANYWHERE
+- **THEN** the system SHALL send a push notification to that follower regardless of venue location
+
+#### Scenario: NEARBY fallback in Phase 1
+
+- **WHEN** a new concert is discovered for an artist
+- **AND** a follower has hype set to NEARBY
+- **THEN** the system SHALL treat the follower as ANYWHERE and send the notification
+
+### Requirement: Followers With Hype Query
+
+The system SHALL provide a repository method to retrieve followers of an artist along with their hype level and home area, enabling the notification filter to make decisions without additional queries.
+
+#### Scenario: Retrieving followers with hype and home
+
+- **WHEN** `NotifyNewConcerts()` needs to evaluate notification recipients
+- **THEN** the system SHALL query followers joining `followed_artists`, `users`, and `homes` tables
+- **AND** return each follower's user ID, hype level, and home level_1 (nullable)

--- a/openspec/changes/rename-passion-to-hype/specs/my-artists/spec.md
+++ b/openspec/changes/rename-passion-to-hype/specs/my-artists/spec.md
@@ -1,0 +1,46 @@
+## MODIFIED Requirements
+
+### Requirement: Artist List Row
+
+Each artist row in the My Artists list view SHALL display the artist's name, color accent, and hype indicator.
+
+#### Scenario: Hype indicator displayed
+
+- **GIVEN** the My Artists list view
+- **WHEN** an artist row is rendered
+- **THEN** a hype icon SHALL appear next to the artist name (👀 for WATCH, 🔥 for HOME, 🔥🔥🔥 for ANYWHERE)
+
+#### Scenario: Tapping hype icon opens selector
+
+- **GIVEN** an artist row with a hype icon
+- **WHEN** the user taps the icon
+- **THEN** a bottom sheet SHALL appear with three hype options: WATCH, HOME, and ANYWHERE (NEARBY is hidden in Phase 1)
+
+#### Scenario: Selecting a hype level
+
+- **GIVEN** the hype bottom sheet is open
+- **WHEN** the user selects a level
+- **THEN** the UI SHALL update optimistically and call SetHype RPC
+- **AND** if the RPC fails, the UI SHALL roll back to the previous level
+
+### Requirement: Grid (Festival) View
+
+The Grid view SHALL display followed artists as poster-style tiles in a responsive grid layout.
+
+#### Scenario: ANYWHERE tiles are larger
+
+- **GIVEN** the Grid view is active
+- **WHEN** an artist has hype set to ANYWHERE
+- **THEN** their tile SHALL span 2 columns and 2 rows
+
+#### Scenario: Non-ANYWHERE tiles are standard size
+
+- **GIVEN** the Grid view is active
+- **WHEN** an artist has hype set to WATCH or HOME
+- **THEN** their tile SHALL span 1 column and 1 row
+
+#### Scenario: Long-press opens context menu
+
+- **GIVEN** the Grid view is active
+- **WHEN** the user long-presses a tile
+- **THEN** a context menu SHALL appear with hype options (WATCH, HOME, ANYWHERE) and an unfollow action

--- a/openspec/changes/rename-passion-to-hype/specs/passion-level/spec.md
+++ b/openspec/changes/rename-passion-to-hype/specs/passion-level/spec.md
@@ -1,0 +1,25 @@
+## REMOVED Requirements
+
+### Requirement: Passion Level Tiers
+
+**Reason**: Replaced by HypeType system with 4 tiers (WATCH, HOME, NEARBY, ANYWHERE) instead of 3 tiers (Must Go, Local Only, Keep an Eye). See new capability `hype-notification-filter` and modified capabilities `artist-following`, `my-artists`.
+
+**Migration**: All references to PassionLevel, passion_level, passion-level are renamed to HypeType (proto) / Hype (elsewhere). Tier mapping: must_go → anywhere, local_only → anywhere, keep_an_eye → watch.
+
+### Requirement: Passion Level Persistence
+
+**Reason**: Replaced by Hype persistence with identical cross-device sync behavior but different column name and values.
+
+**Migration**: DB column `passion_level` renamed to `hype`. Values migrate per tier mapping above.
+
+### Requirement: SetPassionLevel API
+
+**Reason**: Replaced by `SetHype` RPC with the same semantics but accepting HypeType enum values.
+
+**Migration**: RPC renamed from `SetPassionLevel` to `SetHype`. Request message renamed from `SetPassionLevelRequest` to `SetHypeRequest`.
+
+### Requirement: PassionLevel in ListFollowed Response
+
+**Reason**: Replaced by `hype` field in `FollowedArtist` message using `HypeType` enum.
+
+**Migration**: `FollowedArtist.passion_level` field renamed to `FollowedArtist.hype` with type `HypeType`.

--- a/openspec/changes/rename-passion-to-hype/specs/push-notification/spec.md
+++ b/openspec/changes/rename-passion-to-hype/specs/push-notification/spec.md
@@ -1,0 +1,19 @@
+## MODIFIED Requirements
+
+### Requirement: Deliver Push Notifications for New Concerts
+
+The system SHALL send Web Push notifications to followers of an artist when new concerts are discovered, filtered by each follower's hype level and home area. Notifications SHALL be batched per artist (one notification per artist per job run, regardless of how many concerts were found).
+
+#### Scenario: New concerts found for an artist with followers
+
+- **WHEN** `SearchNewConcerts` returns one or more new concerts for an artist
+- **AND** the artist has followers with active push subscriptions
+- **THEN** the system SHALL evaluate each follower's hype level against the concert's venue location
+- **AND** SHALL only send push notifications to followers whose hype level qualifies (ANYWHERE for all concerts, HOME for home-area matches only, WATCH receives none)
+- **AND** the notification payload SHALL include the artist name, the count of new concerts, and a URL to the artist's concert list
+
+#### Scenario: New concerts found but no qualifying followers
+
+- **WHEN** `SearchNewConcerts` returns new concerts for an artist
+- **AND** no followers qualify for notification after hype filtering (all are WATCH or HOME with non-matching area)
+- **THEN** the system SHALL skip notification delivery without error

--- a/openspec/changes/rename-passion-to-hype/tasks.md
+++ b/openspec/changes/rename-passion-to-hype/tasks.md
@@ -1,0 +1,65 @@
+## 1. Specification (Proto)
+
+- [x] 1.1 Rename `PassionLevel` enum to `HypeType` in `entity/v1/artist.proto` with values: UNSPECIFIED=0, WATCH=1, HOME=2, NEARBY=3, ANYWHERE=4
+- [x] 1.2 Rename `FollowedArtist.passion_level` field to `hype` (type `HypeType`) in `rpc/artist/v1/artist_service.proto`
+- [x] 1.3 Rename `SetPassionLevel` RPC to `SetHype`, rename request/response messages (`SetHypeRequest`, `SetHypeResponse`) in `rpc/artist/v1/artist_service.proto`
+- [x] 1.4 Update proto comments/documentation to reflect Hype terminology
+- [x] 1.5 Run `buf lint` and `buf format -w` to validate
+
+## 2. Backend — Database Migration
+
+- [x] 2.1 Create migration to rename `passion_level` column to `hype` on `followed_artists` table
+- [x] 2.2 Map existing values: `must_go` → `anywhere`, `local_only` → `anywhere`, `keep_an_eye` → `watch`
+- [x] 2.3 Drop old CHECK constraint, add new: `hype IN ('watch', 'home', 'nearby', 'anywhere')`
+- [x] 2.4 Change DEFAULT from `'local_only'` to `'anywhere'`
+- [x] 2.5 Update `schema.sql` to reflect new column name, constraint, and default
+
+## 3. Backend — Entity & Repository
+
+- [x] 3.1 Rename `PassionLevel` type to `Hype` in `entity/artist.go`, update constants: `HypeWatch`, `HypeHome`, `HypeNearby`, `HypeAnywhere`
+- [x] 3.2 Rename `FollowedArtist.PassionLevel` field to `Hype`
+- [x] 3.3 Update `ArtistRepository` interface: `SetPassionLevel` → `SetHype`
+- [x] 3.4 Update `artist_repo.go` queries and methods to use `hype` column name
+- [x] 3.5 Add `ListFollowersWithHype` repository method that joins `followed_artists` + `users` + `homes` to return follower ID, hype, and home level_1
+
+## 4. Backend — Use Case
+
+- [x] 4.1 Update `ArtistUseCase` interface: `SetPassionLevel` → `SetHype`
+- [x] 4.2 Update use case implementation to use new entity types and method names
+- [x] 4.3 Add hype filtering logic to `NotifyNewConcerts()`: call `ListFollowersWithHype`, filter by WATCH (skip), HOME (adminArea match), ANYWHERE (send all), NEARBY (fallback to ANYWHERE)
+- [x] 4.4 Update `PushNotificationUseCase` to accept concert venue adminArea for HOME filtering
+
+## 5. Backend — RPC Adapter
+
+- [x] 5.1 Rename `SetPassionLevel` handler to `SetHype` in `artist_handler.go`
+- [x] 5.2 Update mapper: `passionLevelToProto` → `hypeToProto`, `PassionLevelFromProto` → `HypeFromProto`
+- [x] 5.3 Update `FollowedArtistToProto` mapper to use `hype` field
+- [x] 5.4 Update handler validation and error messages
+
+## 6. Backend — Tests
+
+- [x] 6.1 Update existing passion level tests to use hype naming
+- [x] 6.2 Add unit tests for hype-based notification filtering (WATCH skip, HOME match/no-match/no-home, ANYWHERE send, NEARBY fallback)
+- [x] 6.3 Regenerate mocks with `mockery` for updated interfaces
+
+## 7. Frontend — Services & Data
+
+- [x] 7.1 Update `artist-service-client.ts`: rename `passionLevel` to `hype`, update RPC call from `setPassionLevel` to `setHype`
+- [x] 7.2 Update `FollowedArtistInfo` interface: `passionLevel` → `hype`
+- [x] 7.3 Update `mapLocalPassionLevel` → `mapLocalHype` for onboarding local data mapping
+
+## 8. Frontend — My Artists UI
+
+- [x] 8.1 Rename `PASSION_LEVEL_META` to `HYPE_META` with updated keys and icons: WATCH(👀), HOME(🔥), ANYWHERE(🔥🔥🔥); omit NEARBY from selector
+- [x] 8.2 Update `my-artists-page.ts`: rename all passion-related methods and properties (passionIcon → hypeIcon, openPassionSelector → openHypeSelector, selectPassionLevel → selectHype, etc.)
+- [x] 8.3 Update `my-artists-page.html`: rename template bindings and labels
+- [x] 8.4 Update Grid view: ANYWHERE tiles span 2x2 (previously Must Go)
+- [x] 8.5 Update context menu and bottom sheet to show 3 options (WATCH, HOME, ANYWHERE)
+
+## 9. Frontend — i18n & Onboarding
+
+- [x] 9.1 Replace `passionLevel.*` i18n keys with `hype.*` keys in EN translation: watch="Watch", home="Home", nearby="NearBy", anywhere="Anywhere"
+- [x] 9.2 Replace `passionLevel.*` i18n keys with `hype.*` keys in JA translation: watch="観測のみ", home="地元のみ", nearby="近郊まで", anywhere="遠征OK"
+- [x] 9.3 Update passion explanation dialog text to describe hype and notification scope
+- [x] 9.4 Update onboarding step 5 to use hype terminology and default to ANYWHERE visual demo
+- [x] 9.5 Update coach mark text for hype selector

--- a/proto/liverty_music/entity/v1/artist.proto
+++ b/proto/liverty_music/entity/v1/artist.proto
@@ -60,21 +60,25 @@ message OfficialSiteUrl {
   string value = 1 [(buf.validate.field).string.uri = true];
 }
 
-// PassionLevel represents the user's enthusiasm tier for a followed artist.
-// It determines dashboard visibility and notification behavior.
-enum PassionLevel {
+// HypeType represents the user's enthusiasm tier for a followed artist.
+// It controls push notification scope and dashboard rendering behavior.
+// Values are ordered by ascending enthusiasm: WATCH (lowest) to ANYWHERE (highest).
+enum HypeType {
   // Default value; must not be used in API requests.
-  PASSION_LEVEL_UNSPECIFIED = 0;
+  HYPE_TYPE_UNSPECIFIED = 0;
 
-  // The user will travel anywhere for this artist's concerts.
-  // Events in Lane 2 and Lane 3 render with Visual Mutation UI.
-  PASSION_LEVEL_MUST_GO = 1;
+  // Dashboard view only. No push notifications are sent for this artist.
+  HYPE_TYPE_WATCH = 1;
 
-  // The user is interested in local events only. This is the default tier
-  // assigned when a user first follows an artist.
-  PASSION_LEVEL_LOCAL_ONLY = 2;
+  // Push notifications only for concerts in the user's home area
+  // (ISO 3166-2 subdivision match). This is a moderate engagement tier.
+  HYPE_TYPE_HOME = 2;
 
-  // The user wants to see events on the Dashboard but does not want
-  // push notifications for this artist.
-  PASSION_LEVEL_KEEP_AN_EYE = 3;
+  // Push notifications for concerts within physical proximity of the user's
+  // home area. Reserved for Phase 2; not exposed in the UI selector.
+  HYPE_TYPE_NEARBY = 3;
+
+  // Push notifications for all concerts nationwide. This is the default tier
+  // assigned when a user first follows an artist. Die-hard fan level.
+  HYPE_TYPE_ANYWHERE = 4;
 }

--- a/proto/liverty_music/rpc/artist/v1/artist_service.proto
+++ b/proto/liverty_music/rpc/artist/v1/artist_service.proto
@@ -63,20 +63,19 @@ service ArtistService {
   rpc Unfollow(UnfollowRequest) returns (UnfollowResponse);
 
   // ListFollowed retrieves the list of artists currently followed by the authenticated user.
-  // Each entry includes the user's passion level preference for the artist.
+  // Each entry includes the user's hype preference for the artist.
   //
   // Possible errors:
   // - UNAUTHENTICATED: The user identity could not be verified.
   rpc ListFollowed(ListFollowedRequest) returns (ListFollowedResponse);
 
-  // SetPassionLevel updates the user's enthusiasm tier for a followed artist.
-  // The passion level affects how the artist's events are displayed on the
-  // Dashboard and whether push notifications are sent.
+  // SetHype updates the user's enthusiasm tier for a followed artist.
+  // The hype level controls push notification scope and dashboard rendering.
   //
   // Possible errors:
   // - NOT_FOUND: The user is not following the specified artist.
-  // - INVALID_ARGUMENT: The passion level value is invalid or unspecified.
-  rpc SetPassionLevel(SetPassionLevelRequest) returns (SetPassionLevelResponse);
+  // - INVALID_ARGUMENT: The hype value is invalid or unspecified.
+  rpc SetHype(SetHypeRequest) returns (SetHypeResponse);
 
   // ListSimilar retrieves artists similar to a specified artist using recommendation engines.
   //
@@ -170,40 +169,40 @@ message UnfollowResponse {}
 message ListFollowedRequest {}
 
 // ListFollowedResponse contains the collection of artists followed by the user,
-// enriched with per-user passion level metadata.
+// enriched with per-user hype metadata.
 message ListFollowedResponse {
-  // The collection of followed artists with their passion level preferences.
+  // The collection of followed artists with their hype preferences.
   repeated FollowedArtist artists = 1;
 }
 
 // FollowedArtist represents an artist with user-specific follow metadata.
-// This is an RPC-layer message (not an entity) because passion_level is
+// This is an RPC-layer message (not an entity) because hype is
 // per-user context, not an intrinsic property of the Artist entity.
 message FollowedArtist {
   // The artist entity.
   entity.v1.Artist artist = 1 [(buf.validate.field).required = true];
 
-  // The user's passion level for this artist.
-  entity.v1.PassionLevel passion_level = 2 [
+  // The user's hype level for this artist.
+  entity.v1.HypeType hype = 2 [
     (buf.validate.field).required = true,
     (buf.validate.field).enum.defined_only = true
   ];
 }
 
-// SetPassionLevelRequest provides the artist ID and the new passion level to set.
-message SetPassionLevelRequest {
+// SetHypeRequest provides the artist ID and the new hype level to set.
+message SetHypeRequest {
   // Required. The unique identifier of the artist.
   entity.v1.ArtistId artist_id = 1 [(buf.validate.field).required = true];
 
-  // Required. The new passion level tier.
-  entity.v1.PassionLevel passion_level = 2 [
+  // Required. The new hype tier.
+  entity.v1.HypeType hype = 2 [
     (buf.validate.field).required = true,
     (buf.validate.field).enum.defined_only = true
   ];
 }
 
-// SetPassionLevelResponse is returned upon a successful passion level update.
-message SetPassionLevelResponse {}
+// SetHypeResponse is returned upon a successful hype level update.
+message SetHypeResponse {}
 
 // ListSimilarRequest specifies the seed artist for discovery.
 message ListSimilarRequest {

--- a/proto/liverty_music/rpc/artist/v1/artist_service.proto
+++ b/proto/liverty_music/rpc/artist/v1/artist_service.proto
@@ -195,9 +195,13 @@ message SetHypeRequest {
   entity.v1.ArtistId artist_id = 1 [(buf.validate.field).required = true];
 
   // Required. The new hype tier.
+  // HYPE_TYPE_NEARBY (3) is rejected — not user-selectable in Phase 1.
   entity.v1.HypeType hype = 2 [
     (buf.validate.field).required = true,
-    (buf.validate.field).enum.defined_only = true
+    (buf.validate.field).enum = {
+      defined_only: true
+      not_in: [3]
+    }
   ];
 }
 


### PR DESCRIPTION
## 🔗 Related Issue

Closes #169

## 📝 Summary of Changes

Rename `PassionLevel` enum to `HypeType` and expand from 3 tiers to 4, with explicit notification filtering semantics:

| Old (PassionLevel) | New (HypeType) | Notification Behavior |
|---|---|---|
| KEEP_AN_EYE | **WATCH** | Dashboard only, no push notifications |
| LOCAL_ONLY | **HOME** | Push for concerts in user's home area (ISO 3166-2 match) |
| _(new)_ | **NEARBY** | Reserved for Phase 2 (falls back to ANYWHERE) |
| MUST_GO | **ANYWHERE** | Push for all concerts nationwide |

**Key changes:**
- `PassionLevel` → `HypeType` enum with values WATCH(1), HOME(2), NEARBY(3), ANYWHERE(4)
- `SetPassionLevel` RPC → `SetHype`
- `FollowedArtist.passion_level` field → `FollowedArtist.hype`
- Default tier changed from LOCAL_ONLY to ANYWHERE
- Values ordered by ascending enthusiasm (WATCH lowest → ANYWHERE highest)

**Breaking change:** All proto names are renamed. Downstream consumers (backend, frontend) must update after BSR gen publishes the new types.

Includes OpenSpec change artifacts: proposal, design decisions, capability specs, and completed task breakdown.

## ✅ Self-Checklist

- [x] I have linked the related issue.
- [x] I have updated the relevant documentation (e.g., `README.md`) if needed.
- [x] I have run `buf lint` and `buf format` locally and all checks have passed.
- [x] My proto definitions follow the project's style guidelines and validation rules.
- [x] Breaking changes have been justified and documented if applicable.
