### PR TITLE
fix(spec): add concert dedup change artifacts

### DIFF
--- a/openspec/changes/fix-concert-dedup/.openspec.yaml
+++ b/openspec/changes/fix-concert-dedup/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-09

--- a/openspec/changes/fix-concert-dedup/design.md
+++ b/openspec/changes/fix-concert-dedup/design.md
@@ -1,0 +1,89 @@
+## Context
+
+The `SearchNewConcerts` pipeline has three stages: Gemini API call → application-level dedup → event publish → DB insert. The dedup stage (L2) and the DB insert stage (L4) both fail to prevent duplicates:
+
+- **L2 (getUniqueKey)**: Uses `date + startTime.Format(RFC3339)` as the key. RFC3339 includes the timezone offset, so `18:00:00+09:00` (Gemini) ≠ `09:00:00Z` (pgx readback) even though they represent the same instant. The key also omits the venue name, so distinct concerts at different venues on the same date are incorrectly collapsed.
+- **L4 (DB)**: `ON CONFLICT (event_id) DO NOTHING` only protects on the synthetic UUID primary key. Since `CreateFromDiscovered` generates a new UUID per run, every duplicate passes through.
+
+The CronJob runs every ~24h (searchLog TTL), and each run that bypasses dedup adds a full copy of all concerts for every artist. Production data shows 97,041 rows for 484 unique concerts (41 affected artists, ~220 duplicates each).
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Fix the application-level dedup key to use `(local_event_date, listed_venue_name, start_at_utc)` with correct nil-handling.
+- Add a DB-level UNIQUE constraint as a final safety net.
+- Change INSERT to UPSERT so newly discovered `start_at` values update existing records.
+- Clean up the 97,041 duplicate rows in a migration.
+
+**Non-Goals:**
+
+- Fuzzy venue name matching (e.g., "Zepp Tokyo" vs "Zepp東京"). Exact string match is sufficient; the venue normalization pipeline handles canonical name resolution separately.
+- Changing the CronJob schedule or searchLog TTL.
+- Modifying the `concert.discovered.v1` event schema or the Watermill messaging pipeline.
+
+## Decisions
+
+### Decision 1: New dedup key — `(local_event_date, listed_venue_name, start_at_utc)`
+
+**Choice**: Replace `getUniqueKey(date, startTime)` with a new function that includes `listed_venue_name` and normalizes `startTime` to UTC before formatting.
+
+**Rationale**: The venue name is the most stable identifier from Gemini — it rarely varies across runs for the same concert. Adding it to the key simultaneously fixes two bugs: (a) same-venue/same-date concerts are no longer differentiated only by an unreliable `startTime`, and (b) different-venue concerts on the same date are no longer incorrectly collapsed.
+
+**Alternatives considered**:
+- `(date, title)`: Titles vary too much across Gemini runs (trailing whitespace, subtitle changes).
+- `(date, venue)` only: Would collapse matinee/evening shows at the same venue. Adding UTC-normalized `start_at` preserves these.
+
+### Decision 2: Nil start_at comparison semantics
+
+**Choice**: When the scraped `start_at` is nil, treat it as a wildcard that matches any existing `start_at` at the same (date, venue). When the existing `start_at` is nil and scraped is non-nil, publish for UPSERT update.
+
+**Rationale**: Gemini's inability to extract `start_at` in one run does not mean the concert is different. The information asymmetry is one-directional: nil → "I don't know" (match any), non-nil → "I know this" (new info to persist).
+
+**Implementation**: The `seen` map key format will be `"YYYY-MM-DD|venue_name|HH:MM:SSZ"` when `start_at` is non-nil (UTC-normalized), or `"YYYY-MM-DD|venue_name"` (no start_at segment) when nil. Lookup logic:
+1. Build `seen` set from existing concerts with their full keys.
+2. Also build a `seenDateVenue` set with just `"YYYY-MM-DD|venue_name"` for nil-match.
+3. For each scraped concert:
+   - If scraped `start_at` is nil → check `seenDateVenue` → if hit, skip (dedup).
+   - If scraped `start_at` is non-nil → check `seen` with full UTC key → if hit, skip.
+   - If scraped `start_at` is non-nil → check `seenDateVenue` for existing nil records → if hit AND existing had nil start_at, publish (UPSERT will fill start_at).
+   - Otherwise → publish (genuinely new).
+
+### Decision 3: DB UNIQUE constraint with NULLS NOT DISTINCT
+
+**Choice**: Add `UNIQUE NULLS NOT DISTINCT (venue_id, local_event_date, start_at)` on the `events` table.
+
+**Rationale**: PostgreSQL 15+ supports `NULLS NOT DISTINCT`, which treats two NULL `start_at` values as equal for uniqueness purposes. This matches our business rule: two events at the same venue on the same date with unknown start times are the same event.
+
+**Why `venue_id` instead of `listed_venue_name`**: The DB constraint uses the normalized `venue_id` FK (already resolved during `CreateFromDiscovered`), not the raw text. Multiple raw names can map to the same venue (e.g., "Zepp Tokyo" and "Zepp 東京" after normalization). Using `venue_id` provides stronger uniqueness.
+
+### Decision 4: UPSERT with COALESCE for time fields
+
+**Choice**: Change `ON CONFLICT DO NOTHING` to `ON CONFLICT (venue_id, local_event_date, start_at) DO UPDATE SET start_at = COALESCE(EXCLUDED.start_at, events.start_at), open_at = COALESCE(EXCLUDED.open_at, events.open_at)`.
+
+**Rationale**: COALESCE ensures that non-NULL values are never overwritten by NULL (Gemini regression), while previously-NULL fields are updated when new information arrives.
+
+### Decision 5: Cleanup migration — delete-then-constrain
+
+**Choice**: A single migration that (1) deletes duplicate rows keeping the richest/earliest per natural key, then (2) adds the UNIQUE constraint.
+
+**Rationale**: The constraint cannot be added while duplicates exist. Performing both in one migration ensures atomicity — if the constraint fails, the transaction rolls back and no data is lost.
+
+## Risks / Trade-offs
+
+- **[Risk] Matinee/evening shows with start_at=nil**: If both shows are first scraped without start_at, only one row will exist (nil+nil dedup). When Gemini later returns start_at for the second show, the UPSERT will update the existing row rather than creating a new one. → **Mitigation**: This is an acceptable data loss for a very rare edge case. The next CronJob run will discover the second show with a distinct start_at and insert it as a new row.
+
+- **[Risk] Venue name mismatch between runs**: If Gemini returns "Zepp Tokyo" in one run and "ZEPP TOKYO" in another, the application-level dedup will treat them as different venues. → **Mitigation**: The DB constraint uses `venue_id` (post-normalization), so the DB layer catches this. The duplicate will be silently skipped by the UPSERT.
+
+- **[Risk] Migration on 97K rows**: The cleanup DELETE may lock the `events` table briefly. → **Mitigation**: The `events` table is only written by the consumer process (async), not by user-facing RPCs. A brief lock during migration is acceptable for the dev environment. For production, the migration runs via Atlas Operator before the backend deployment starts.
+
+## Migration Plan
+
+1. **Generate migration**: `atlas migrate diff --env local fix_concert_dedup`
+2. **Local validation**: Apply locally, verify row count drops from ~97K to ~484.
+3. **Deploy order**: Migration runs first (Atlas Operator sync wave), then new backend code deploys.
+4. **Rollback**: The UNIQUE constraint can be dropped and the migration reverted. Deleted duplicate data is not recoverable but is fully reproducible by re-running the CronJob.
+
+## Open Questions
+
+(none)

--- a/openspec/changes/fix-concert-dedup/proposal.md
+++ b/openspec/changes/fix-concert-dedup/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+`SearchNewConcerts` fails to deduplicate concerts across repeated CronJob runs, causing the same real-world concert to be stored hundreds of times with different `event_id` values. The root cause is that `getUniqueKey(date, startTime)` compares `startTime` as an RFC3339 string — timezone differences between Gemini API responses (e.g., `+09:00`) and pgx DB readback (always UTC) produce different strings for the same instant, bypassing dedup on every run. Additionally, the key does not include the venue name, so distinct concerts at different venues on the same date are incorrectly collapsed, while same-venue concerts with `startTime` fluctuations pass through as "new". In production, 97,041 event rows exist for only 484 unique concerts (200× bloat across 41 artists).
+
+## What Changes
+
+- Replace the dedup key from `(local_event_date, start_at_rfc3339)` to `(local_event_date, listed_venue_name, start_at_utc)` with explicit nil-handling rules for `start_at`.
+- Add a DB-level UNIQUE constraint on the `events` table as a final safety net against duplicate inserts.
+- Change the INSERT strategy from `ON CONFLICT (event_id) DO NOTHING` to an UPSERT on the natural key, allowing `start_at` / `open_at` updates when new information is discovered.
+- Provide a one-time data cleanup migration to deduplicate the 97,041 existing rows down to 484.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `concert-search`: Add a new requirement defining the dedup natural key, start_at comparison semantics, and nil-handling rules for the dedup logic in `executeSearch`.
+- `concert-service`: Add a new requirement defining the DB-level natural key constraint and UPSERT behavior in `ConcertRepository.Create`.
+
+## Impact
+
+- **Backend**: `internal/usecase/concert_uc.go` (dedup logic), `internal/infrastructure/database/rdb/concert_repo.go` (INSERT → UPSERT), `internal/infrastructure/database/rdb/schema/schema.sql` (UNIQUE constraint).
+- **Database**: New migration to add UNIQUE constraint and clean up existing duplicates. Migration must run before the new code deploys.
+- **Frontend**: No changes — the API contract is unchanged; the frontend will simply stop receiving duplicate rows.

--- a/openspec/changes/fix-concert-dedup/specs/concert-search/spec.md
+++ b/openspec/changes/fix-concert-dedup/specs/concert-search/spec.md
@@ -1,0 +1,131 @@
+## ADDED Requirements
+
+### Requirement: Concert Deduplication Natural Key
+
+The `executeSearch` dedup logic SHALL use the natural key `(local_event_date, listed_venue_name, start_at_utc)` to determine whether a scraped concert already exists in the database. The comparison SHALL normalize timezone differences and handle `start_at` nil states according to the rules defined below. The dedup SHALL apply both when comparing scraped concerts against existing DB records and when comparing scraped concerts within the same batch.
+
+#### Scenario: Same instant expressed in different timezones
+
+- **WHEN** a scraped concert has `start_at = 2026-06-01T18:00:00+09:00` (JST)
+- **AND** an existing concert has `start_at = 2026-06-01T09:00:00Z` (UTC)
+- **AND** both have the same `local_event_date` and `listed_venue_name`
+- **THEN** the scraped concert SHALL be treated as a duplicate
+- **AND** SHALL NOT be published in the `concert.discovered.v1` event
+
+#### Scenario: Scraped concert has nil start_at, existing has start_at
+
+- **WHEN** a scraped concert has `start_at = nil`
+- **AND** an existing concert has a non-nil `start_at`
+- **AND** both have the same `local_event_date` and `listed_venue_name`
+- **THEN** the scraped concert SHALL be treated as a duplicate
+- **AND** SHALL NOT be published
+- **AND** the nil `start_at` SHALL NOT overwrite the existing value (the existing record already has richer information)
+
+#### Scenario: Scraped concert has start_at, existing has nil
+
+- **WHEN** a scraped concert has a non-nil `start_at`
+- **AND** an existing concert has `start_at = nil`
+- **AND** both have the same `local_event_date` and `listed_venue_name`
+- **THEN** the scraped concert SHALL be published in the `concert.discovered.v1` event
+- **AND** the downstream UPSERT SHALL update the existing record's `start_at` with the newly discovered value
+
+#### Scenario: Both have non-nil start_at representing different instants
+
+- **WHEN** a scraped concert has a non-nil `start_at`
+- **AND** an existing concert has a non-nil `start_at`
+- **AND** both have the same `local_event_date` and `listed_venue_name`
+- **AND** the two `start_at` values represent different instants after UTC normalization (e.g., matinee 13:00 UTC vs evening 18:00 UTC)
+- **THEN** the scraped concert SHALL be treated as a distinct event (separate show)
+- **AND** SHALL be published in the `concert.discovered.v1` event
+
+#### Scenario: Both have nil start_at, same date and venue
+
+- **WHEN** a scraped concert has `start_at = nil`
+- **AND** an existing concert has `start_at = nil`
+- **AND** both have the same `local_event_date` and `listed_venue_name`
+- **THEN** the scraped concert SHALL be treated as a duplicate
+- **AND** SHALL NOT be published
+
+#### Scenario: Same date, different venue
+
+- **WHEN** a scraped concert has the same `local_event_date` as an existing concert
+- **AND** the `listed_venue_name` values differ
+- **THEN** the scraped concert SHALL be treated as a distinct event
+- **AND** SHALL be published regardless of `start_at` values
+
+#### Scenario: Different date, same venue
+
+- **WHEN** a scraped concert has a different `local_event_date` from an existing concert
+- **AND** the `listed_venue_name` values match
+- **THEN** the scraped concert SHALL be treated as a distinct event
+- **AND** SHALL be published regardless of `start_at` values
+
+#### Scenario: Within-batch dedup — same instant in different timezones
+
+- **WHEN** two scraped concerts in the same Gemini response have the same `local_event_date` and `listed_venue_name`
+- **AND** their `start_at` values represent the same instant after UTC normalization
+- **THEN** only the first concert SHALL be included in the `concert.discovered.v1` event
+- **AND** the second SHALL be discarded as a within-batch duplicate
+
+#### Scenario: Within-batch — genuinely different start_at at same venue
+
+- **WHEN** two scraped concerts in the same Gemini response have the same `local_event_date` and `listed_venue_name`
+- **AND** their `start_at` values represent different instants after UTC normalization
+- **THEN** both concerts SHALL be included in the `concert.discovered.v1` event (matinee/evening shows)
+
+### Requirement: Dedup Key Comparison for Existing Concerts
+
+The dedup logic SHALL build a lookup set from existing DB concerts using `ListByArtist(upcomingOnly=true)`. The `listed_venue_name` for existing concerts SHALL be read from `Event.ListedVenueName`. When `Event.ListedVenueName` is `nil` (legacy rows inserted before this field was added), the existing concert SHALL be excluded from the dedup set (it cannot match any scraped concert by venue name).
+
+#### Scenario: Existing concert with nil ListedVenueName is skipped
+
+- **WHEN** an existing concert has `ListedVenueName = nil` (legacy data)
+- **THEN** it SHALL NOT be added to the dedup lookup set
+- **AND** scraped concerts SHALL NOT be matched against it
+
+#### Scenario: Existing concert with non-nil ListedVenueName is included
+
+- **WHEN** an existing concert has a non-nil `ListedVenueName`
+- **THEN** it SHALL be added to the dedup lookup set using `(local_event_date, listed_venue_name, start_at_utc)` as the key
+
+### Requirement: Resilience to Gemini API Non-Determinism
+
+The Gemini API does not guarantee deterministic responses across calls. The dedup logic SHALL be resilient to the following known variations without creating duplicate records.
+
+#### Scenario: Title variation across runs
+
+- **WHEN** Gemini returns a concert with the same `local_event_date`, `listed_venue_name`, and `start_at` as an existing concert
+- **AND** the `title` differs slightly (e.g., trailing whitespace, different casing, added subtitle)
+- **THEN** the concert SHALL still be treated as a duplicate
+- **AND** SHALL NOT be published (title is not part of the dedup key)
+
+#### Scenario: open_at variation across runs
+
+- **WHEN** Gemini returns a concert with the same natural key as an existing concert
+- **AND** the `open_at` value differs
+- **THEN** the concert SHALL still be treated as a duplicate based on the natural key
+
+#### Scenario: source_url variation across runs
+
+- **WHEN** Gemini returns a concert with the same natural key as an existing concert
+- **AND** the `source_url` differs
+- **THEN** the concert SHALL still be treated as a duplicate based on the natural key
+
+#### Scenario: admin_area variation across runs
+
+- **WHEN** Gemini returns a concert with the same natural key as an existing concert
+- **AND** the `admin_area` value differs or is newly provided
+- **THEN** the concert SHALL still be treated as a duplicate based on the natural key
+
+#### Scenario: start_at becomes nil in a later run
+
+- **WHEN** Gemini previously returned `start_at = 18:00` for a concert
+- **AND** in a subsequent run Gemini returns `start_at = nil` for the same `local_event_date` and `listed_venue_name`
+- **THEN** the concert SHALL be treated as a duplicate (nil scraped start_at matches any existing start_at at the same date+venue)
+- **AND** the existing `start_at` value SHALL be preserved
+
+#### Scenario: start_at appears in a later run
+
+- **WHEN** an existing concert has `start_at = nil`
+- **AND** in a subsequent run Gemini returns `start_at = 18:00` for the same `local_event_date` and `listed_venue_name`
+- **THEN** the concert SHALL be published for UPSERT to fill in the previously unknown `start_at`

--- a/openspec/changes/fix-concert-dedup/specs/concert-service/spec.md
+++ b/openspec/changes/fix-concert-dedup/specs/concert-service/spec.md
@@ -1,0 +1,94 @@
+## ADDED Requirements
+
+### Requirement: Event Natural Key Constraint
+
+The `events` table SHALL have a composite UNIQUE constraint on the natural key `(venue_id, local_event_date, start_at)` to prevent duplicate event rows at the database level. This constraint serves as the final safety net when application-level dedup fails.
+
+#### Scenario: Duplicate event insert is rejected
+
+- **WHEN** a concert is inserted with the same `(venue_id, local_event_date, start_at)` as an existing event
+- **THEN** the database SHALL reject the insert via the UNIQUE constraint
+- **AND** the application SHALL handle this gracefully via UPSERT (not error)
+
+#### Scenario: NULL-safe equality for start_at in constraint
+
+- **WHEN** two events have the same `venue_id` and `local_event_date`
+- **AND** both have `start_at = NULL`
+- **THEN** the UNIQUE constraint SHALL treat them as duplicates
+- **AND** the constraint SHALL use a `UNIQUE NULLS NOT DISTINCT` clause or a partial unique index to handle NULL equality
+
+#### Scenario: Same venue and date with different start_at
+
+- **WHEN** two events have the same `venue_id` and `local_event_date`
+- **AND** different non-NULL `start_at` values
+- **THEN** the UNIQUE constraint SHALL allow both rows (matinee/evening shows)
+
+### Requirement: Concert UPSERT on Natural Key
+
+The `ConcertRepository.Create` bulk insert SHALL use `ON CONFLICT` on the natural key to perform an UPSERT. When a conflict is detected, the existing record's `open_at` SHALL be updated if the new value provides previously unknown information. Since `start_at` is part of the natural key, a conflict implies both rows have the same `start_at` value (including both NULL); therefore `start_at` updates happen via new row insertion, not UPSERT update.
+
+#### Scenario: Insert new event (no conflict)
+
+- **WHEN** `Create` is called with a concert whose natural key does not exist
+- **THEN** the event SHALL be inserted normally
+
+#### Scenario: Different start_at inserts new row (not UPSERT)
+
+- **WHEN** `Create` is called with a concert at the same `(venue_id, local_event_date)` as an existing event
+- **AND** the `start_at` values differ (e.g., existing is NULL, new is non-NULL; or both are non-NULL but different instants)
+- **THEN** the natural keys are distinct and no conflict occurs
+- **AND** the new concert SHALL be inserted as a separate event row
+
+#### Scenario: Conflict with richer open_at — update existing
+
+- **WHEN** `Create` is called with a concert whose natural key matches an existing event
+- **AND** the existing event has `open_at = NULL`
+- **AND** the new concert has a non-NULL `open_at`
+- **THEN** the existing event's `open_at` SHALL be updated to the new value via `COALESCE(EXCLUDED.open_at, events.open_at)`
+
+#### Scenario: Conflict does not overwrite existing non-NULL open_at with NULL
+
+- **WHEN** `Create` is called with a concert whose natural key matches an existing event
+- **AND** the existing event already has a non-NULL `open_at`
+- **AND** the new concert has `open_at = NULL`
+- **THEN** the existing event's `open_at` SHALL NOT be overwritten
+- **AND** SHALL retain its current value via `COALESCE(NULL, events.open_at)`
+
+#### Scenario: Concerts row skipped for UPSERTed events with different UUID
+
+- **WHEN** `Create` is called with a concert whose event UUID differs from the existing event at the same natural key
+- **THEN** the events UPSERT SHALL update the existing row (keeping the original UUID)
+- **AND** the input UUID SHALL NOT exist in the `events` table
+- **AND** the `concerts` INSERT SHALL skip this row via `WHERE EXISTS` (no duplicate concerts row created)
+
+### Requirement: Duplicate Data Cleanup Migration
+
+A one-time database migration SHALL remove duplicate event rows created by the bug, retaining only the earliest-inserted row per natural key.
+
+#### Scenario: Dedup retains earliest event per natural key
+
+- **WHEN** the migration runs
+- **AND** multiple events share the same `(venue_id, local_event_date, start_at)` (NULL-safe)
+- **THEN** only the event with the smallest `id` (earliest UUIDv7 timestamp) SHALL be retained
+- **AND** all other duplicates SHALL be deleted
+- **AND** corresponding `concerts` rows for deleted events SHALL be cascade-deleted
+
+#### Scenario: Dedup preserves richer start_at
+
+- **WHEN** the migration runs
+- **AND** duplicate events exist where some have `start_at = NULL` and others have a non-NULL `start_at`
+- **THEN** the retained event SHALL be the one with the non-NULL `start_at` (prefer richer data)
+- **AND** if multiple non-NULL values exist, the earliest-inserted one SHALL be retained
+
+#### Scenario: Migration is idempotent
+
+- **WHEN** the migration is run on a database with no duplicates
+- **THEN** no rows SHALL be deleted
+- **AND** the migration SHALL complete without error
+
+#### Scenario: UNIQUE constraint applied after cleanup
+
+- **WHEN** the migration runs
+- **THEN** it SHALL first delete duplicates
+- **AND** then add the UNIQUE constraint
+- **AND** the constraint addition SHALL succeed because duplicates have been removed

--- a/openspec/changes/fix-concert-dedup/tasks.md
+++ b/openspec/changes/fix-concert-dedup/tasks.md
@@ -1,0 +1,23 @@
+## 1. Fix Application-Level Dedup Logic
+
+- [x] 1.1 Replace `getUniqueKey(date, startTime)` with new function that uses `(local_event_date, listed_venue_name, start_at_utc)` with nil-handling rules per design
+- [x] 1.2 Update `executeSearch` dedup loop to use dual lookup sets (`seen` for full key, `seenDateVenue` for nil-match) per design Decision 2
+- [x] 1.3 Verify all 9 `TestSearchNewConcerts_Deduplication` test cases pass (5 currently failing)
+
+## 2. Database Migration — Cleanup and Constraint
+
+- [x] 2.1 Write cleanup SQL to delete duplicate events, keeping the richest/earliest row per `(venue_id, local_event_date, start_at)` natural key
+- [x] 2.2 Add `UNIQUE NULLS NOT DISTINCT (venue_id, local_event_date, start_at)` constraint on `events` table
+- [x] 2.3 Generate Atlas migration: `atlas migrate diff --env local fix_concert_dedup`
+- [x] 2.4 Update `schema.sql` with the new UNIQUE constraint
+- [x] 2.5 Add migration file to `k8s/atlas/base/kustomization.yaml`
+
+## 3. UPSERT in ConcertRepository
+
+- [x] 3.1 Change `insertEventsUnnestQuery` from `ON CONFLICT DO NOTHING` to `ON CONFLICT (venue_id, local_event_date, start_at) DO UPDATE SET start_at = COALESCE(EXCLUDED.start_at, events.start_at), open_at = COALESCE(EXCLUDED.open_at, events.open_at)`
+- [x] 3.2 Verify `insertConcertsUnnestQuery` handles the case where the event already exists (the `concerts` row may also already exist)
+
+## 4. Verification
+
+- [x] 4.1 Run `make check` (lint + full test suite)
+- [x] 4.2 Apply migration locally and verify duplicate cleanup reduces row count


### PR DESCRIPTION
## Related Issue

Refs: liverty-music/backend#167

## Summary of Changes

Add OpenSpec change artifacts for the concert deduplication fix. These artifacts document the analysis, design decisions, specifications, and implementation tasks for replacing the broken dedup key in `SearchNewConcerts`.

**Artifacts:**
- `proposal.md`: Root cause analysis (97K duplicate rows from 484 concerts due to RFC3339 TZ mismatch and missing venue name in dedup key)
- `design.md`: 5 key decisions — natural key `(date, venue, start_at_utc)`, nil start_at semantics, NULLS NOT DISTINCT constraint, UPSERT with COALESCE, cleanup migration
- `specs/concert-search/spec.md`: Dedup natural key requirements with 12 scenarios covering TZ normalization, nil handling, within-batch dedup, and Gemini API non-determinism resilience
- `specs/concert-service/spec.md`: DB UPSERT behavior requirements with 7 scenarios covering natural key constraint, COALESCE open_at, WHERE EXISTS filtering, and NULLS NOT DISTINCT
- `tasks.md`: 12/12 implementation tasks (all complete)

## Self-Checklist

- [x] I have linked the related issue.
- [x] I have updated the relevant documentation (e.g., `README.md`) if needed.
- [x] I have run `buf lint` and `buf format` locally and all checks have passed.
- [x] My proto definitions follow the project's style guidelines and validation rules.
- [ ] Breaking changes have been justified and documented if applicable.