### PR TITLE
docs(loading-sequence): sync abort-error cancellation spec

### DIFF
--- a/openspec/changes/archive/2026-03-10-fix-abort-error-retry/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-10-fix-abort-error-retry/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-10

--- a/openspec/changes/archive/2026-03-10-fix-abort-error-retry/design.md
+++ b/openspec/changes/archive/2026-03-10-fix-abort-error-retry/design.md
@@ -1,0 +1,54 @@
+## Context
+
+The `loading-sequence-service.ts` orchestrates data aggregation with a 10-second global timeout using `AbortController`. When the timeout fires, in-flight requests are aborted. The `getFollowedArtistsWithRetry()` method catches all errors uniformly and retries up to `maxRetries` times, but does not check whether the error represents intentional cancellation.
+
+Two distinct error types represent cancellation in this codebase:
+1. **`AbortError`** — thrown by `fetch()` and by `delay()` when its signal is aborted
+2. **`ConnectError` with `Code.Canceled`** — thrown by the Connect-RPC transport when the underlying fetch is aborted
+
+The existing transport-level `createRetryInterceptor` already excludes `Code.Canceled` from retries, but the application-level retry in `getFollowedArtistsWithRetry()` has no such guard.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Immediately propagate cancellation errors without retrying in `getFollowedArtistsWithRetry()`
+- Eliminate false "Retrying followed artists fetch" log messages during timeout-triggered abort
+- Follow existing codebase conventions for error detection
+
+**Non-Goals:**
+- Refactoring the retry logic into a reusable utility (one call site only)
+- Adding cancellation handling to other retry sites (no others exist currently)
+- Modifying the transport-level interceptor chain
+
+## Decisions
+
+### Decision 1: Guard placement — early return at top of catch block
+
+Add a cancellation check as the first statement in the catch block, before `attempt++`. This ensures no retry counter increment, no misleading log, and no `delay()` call.
+
+**Alternative considered**: Checking after `attempt++` — rejected because it would still increment the counter and could log misleading retry messages on partial paths.
+
+### Decision 2: Dual error type detection
+
+Check both error types in a single guard:
+```typescript
+const isCanceled =
+    (err instanceof Error && err.name === 'AbortError') ||
+    (err instanceof ConnectError && err.code === Code.Canceled)
+if (isCanceled) throw err
+```
+
+**Rationale**: The Connect-RPC transport wraps `fetch` AbortError into `ConnectError(Code.Canceled)` for RPC calls, but `delay()` throws a raw `AbortError`. Both must be handled.
+
+**Alternative considered**: Only checking `AbortError` — rejected because the RPC call path throws `ConnectError(Code.Canceled)`, not `AbortError`.
+
+### Decision 3: Follow existing AbortError detection pattern
+
+Use `err instanceof Error && err.name === 'AbortError'` consistent with existing patterns in `dashboard.ts:63`, `tickets-page.ts:36,105`, and `my-artists-page.ts:125`.
+
+**Alternative considered**: `err instanceof DOMException && err.name === 'AbortError'` — rejected because the existing codebase uses the broader `Error` check, and `delay()` throws `new Error('Aborted')` which is not a `DOMException`. Note: the `delay()` error sets `name = 'AbortError'` explicitly, so the name check works for both native and synthetic abort errors.
+
+## Risks / Trade-offs
+
+- **[Risk] `delay()` may not set `err.name = 'AbortError'`** → Verify the `delay()` implementation. If it throws a plain `Error('Aborted')` without setting `.name`, the guard won't catch it, and the retry loop will still execute (same as current behavior, not worse). Mitigation: check and fix `delay()` if needed to set `.name = 'AbortError'`.
+- **[Risk] Future error types for cancellation** → If a new transport layer introduces a different cancellation error type, this guard would miss it. Mitigation: low risk; the Connect-RPC ecosystem is stable and the two types cover all known paths.

--- a/openspec/changes/archive/2026-03-10-fix-abort-error-retry/design.md
+++ b/openspec/changes/archive/2026-03-10-fix-abort-error-retry/design.md
@@ -50,5 +50,5 @@ Use `err instanceof Error && err.name === 'AbortError'` consistent with existing
 
 ## Risks / Trade-offs
 
-- **[Risk] `delay()` may not set `err.name = 'AbortError'`** → Verify the `delay()` implementation. If it throws a plain `Error('Aborted')` without setting `.name`, the guard won't catch it, and the retry loop will still execute (same as current behavior, not worse). Mitigation: check and fix `delay()` if needed to set `.name = 'AbortError'`.
+- ~~**[Risk] `delay()` may not set `err.name = 'AbortError'`**~~ **[Resolved — tasks 1.1/1.2]** Verified and updated `delay()` to set `.name = 'AbortError'` explicitly on both abort paths.
 - **[Risk] Future error types for cancellation** → If a new transport layer introduces a different cancellation error type, this guard would miss it. Mitigation: low risk; the Connect-RPC ecosystem is stable and the two types cover all known paths.

--- a/openspec/changes/archive/2026-03-10-fix-abort-error-retry/proposal.md
+++ b/openspec/changes/archive/2026-03-10-fix-abort-error-retry/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+The `getFollowedArtistsWithRetry()` method in `loading-sequence-service.ts` does not distinguish cancellation errors (AbortError / ConnectError with Code.Canceled) from retriable network errors. When the 10-second global timeout fires and aborts in-flight requests, the catch block treats AbortError as a retriable failure — incrementing the retry counter, emitting misleading "Retrying" log messages, and calling `delay()` with an already-aborted signal (which throws immediately). This creates a fast retry loop that burns through all retries before the error finally propagates, wasting resources and polluting logs.
+
+## What Changes
+
+- Add an early-return guard in the `getFollowedArtistsWithRetry()` catch block that immediately re-throws cancellation errors without retrying
+- The guard must detect both `AbortError` (from raw `fetch()` / `delay()`) and `ConnectError` with `Code.Canceled` (from Connect-RPC transport)
+- Follow the existing codebase pattern for AbortError detection: `(err as Error).name === 'AbortError'`
+
+## Capabilities
+
+### New Capabilities
+
+_None — this is a bug fix within existing capabilities._
+
+### Modified Capabilities
+
+- `loading-sequence`: The "Initial artist list retrieval failure" scenario's retry behavior is refined to exclude intentional cancellation from retriable errors. The spec currently says "the ListFollowedArtists RPC fails after retries" but does not specify that cancellation (abort) should bypass retries entirely.
+
+## Impact
+
+- **Code**: `frontend/src/services/loading-sequence-service.ts` — `getFollowedArtistsWithRetry()` catch block (~line 115-126)
+- **Dependencies**: Requires `ConnectError` and `Code` imports from `@connectrpc/connect`
+- **Behavior**: AbortError and Canceled errors now propagate immediately instead of being retried, resulting in faster cleanup when the global timeout fires
+- **Logs**: Eliminates false "Retrying followed artists fetch" log entries during intentional cancellation
+- **Risk**: Low — the fix only adds an early-exit path; all other error handling remains unchanged

--- a/openspec/changes/archive/2026-03-10-fix-abort-error-retry/specs/loading-sequence/spec.md
+++ b/openspec/changes/archive/2026-03-10-fix-abort-error-retry/specs/loading-sequence/spec.md
@@ -1,0 +1,29 @@
+## MODIFIED Requirements
+
+### Requirement: Data Aggregation Orchestration
+The system SHALL only be used for authenticated users who need `loadingService.aggregateData()` after following artists. It SHALL NOT be entered during the onboarding tutorial flow. The system SHALL trigger `SearchNewConcerts` for each followed artist in parallel during the loading sequence.
+
+#### Scenario: Successful aggregation for all artists
+- **WHEN** the loading sequence starts
+- **THEN** the system SHALL call `ListFollowedArtists` to retrieve the user's followed artists
+- **AND** the system SHALL call `SearchNewConcerts` for each followed artist in parallel
+- **AND** upon all searches completing, the system SHALL navigate to the Dashboard
+
+#### Scenario: Partial failure
+- **WHEN** `SearchNewConcerts` fails for one or more artists
+- **THEN** the system SHALL proceed with successfully retrieved data
+- **AND** the system SHALL NOT block navigation due to individual artist failures
+
+#### Scenario: Initial artist list retrieval failure
+- **WHEN** the loading sequence starts
+- **AND** the `ListFollowedArtists` RPC fails with a retriable error after retries
+- **THEN** the system SHALL navigate to the Dashboard
+- **AND** the system SHALL NOT display an infinite loading state
+
+#### Scenario: Artist list retrieval canceled by abort signal
+- **WHEN** the loading sequence starts
+- **AND** the `ListFollowedArtists` RPC is in-flight
+- **AND** the global timeout fires and aborts the request via AbortSignal
+- **THEN** the system SHALL immediately propagate the cancellation error without retrying
+- **AND** the system SHALL NOT increment the retry counter
+- **AND** the system SHALL NOT emit retry log messages

--- a/openspec/changes/archive/2026-03-10-fix-abort-error-retry/tasks.md
+++ b/openspec/changes/archive/2026-03-10-fix-abort-error-retry/tasks.md
@@ -1,0 +1,16 @@
+## 1. Verify delay() behavior
+
+- [x] 1.1 Read `delay()` method in `loading-sequence-service.ts` and confirm whether it sets `err.name = 'AbortError'` on the thrown error when the signal aborts
+- [x] 1.2 If `delay()` does not set `err.name = 'AbortError'`, update it to throw an error with `name: 'AbortError'` for consistency with browser conventions
+
+## 2. Add cancellation guard to getFollowedArtistsWithRetry
+
+- [x] 2.1 Add `ConnectError` and `Code` imports from `@connectrpc/connect` to `loading-sequence-service.ts`
+- [x] 2.2 Add cancellation check as the first statement in the catch block (before `attempt++`): re-throw immediately if `err.name === 'AbortError'` or `ConnectError` with `Code.Canceled`
+
+## 3. Testing
+
+- [x] 3.1 Add unit test: verify that `AbortError` is re-thrown immediately without retry
+- [x] 3.2 Add unit test: verify that `ConnectError(Code.Canceled)` is re-thrown immediately without retry
+- [x] 3.3 Add unit test: verify that retriable errors (e.g., `ConnectError(Code.Unavailable)`) still trigger retry with delay
+- [x] 3.4 Run `make check` to verify lint and existing tests pass

--- a/openspec/specs/loading-sequence/spec.md
+++ b/openspec/specs/loading-sequence/spec.md
@@ -74,7 +74,7 @@ The system SHALL enforce a 10-second global timeout on data aggregation to preve
 
 #### Scenario: Timeout fires
 - **WHEN** 10 seconds have elapsed and data aggregation has not completed
-- **THEN** the system SHALL abort all remaining search requests
+- **THEN** the system SHALL abort all remaining in-flight requests (including `ListFollowedArtists` retries and `SearchNewConcerts` calls)
 - **AND** the system SHALL navigate to the Dashboard with only the successfully retrieved data
 - **AND** the system SHALL NOT display an error message
 

--- a/openspec/specs/loading-sequence/spec.md
+++ b/openspec/specs/loading-sequence/spec.md
@@ -55,9 +55,17 @@ The system SHALL only be used for authenticated users who need `loadingService.a
 
 #### Scenario: Initial artist list retrieval failure
 - **WHEN** the loading sequence starts
-- **AND** the `ListFollowedArtists` RPC fails after retries
+- **AND** the `ListFollowedArtists` RPC fails with a retriable error after retries
 - **THEN** the system SHALL navigate to the Dashboard
 - **AND** the system SHALL NOT display an infinite loading state
+
+#### Scenario: Artist list retrieval canceled by abort signal
+- **WHEN** the loading sequence starts
+- **AND** the `ListFollowedArtists` RPC is in-flight
+- **AND** the global timeout fires and aborts the request via AbortSignal
+- **THEN** the system SHALL immediately propagate the cancellation error without retrying
+- **AND** the system SHALL NOT increment the retry counter
+- **AND** the system SHALL NOT emit retry log messages
 
 ---
 


### PR DESCRIPTION
## Summary

Sync OpenSpec artifacts for the `fix-abort-error-retry` change (frontend#31).

- **Spec sync**: Add "Artist list retrieval canceled by abort signal" scenario to `loading-sequence` spec, and refine "Initial artist list retrieval failure" to specify "retriable error" qualifier
- **Archive**: Move completed `fix-abort-error-retry` change to archive

Related implementation PR: liverty-music/frontend#140

close: liverty-music/frontend#31
