### PR TITLE
feat!(concert): restructure ListByFollowerResponse with DateLaneGroup

### DIFF
--- a/openspec/changes/nearby-proximity-filter/design.md
+++ b/openspec/changes/nearby-proximity-filter/design.md
@@ -1,0 +1,101 @@
+## Context
+
+The Liverty Music platform notifies users about upcoming concerts for artists they follow. Each user sets a "hype level" per artist (WATCH / HOME / NEARBY / ANYWHERE) that controls notification scope and dashboard rendering. The `HYPE_TYPE_NEARBY` enum value exists in proto but is unimplemented — the backend treats it as ANYWHERE and the frontend hides it.
+
+The dashboard displays concerts in a three-lane highway UI (home / nearby / away) grouped by date. Currently, lane classification is performed entirely in the frontend by comparing `venue.admin_area` against `user.home.level_1` (ISO 3166-2 code equality). This is inaccurate: a concert in Fukuoka is classified as "nearby" for a Tokyo user, even though it is 900km away.
+
+Venues are created during concert discovery with raw scraper data, then asynchronously enriched via MusicBrainz and Google Places to obtain canonical names and external IDs. Neither pipeline currently extracts latitude/longitude, despite both APIs returning coordinates in their responses.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Implement proximity-based NEARBY classification using Haversine distance between user home centroid and venue lat/lng
+- Consolidate home/nearby/away lane classification in the backend as shared domain logic
+- Restructure `ListByFollowerResponse` to return date-grouped, lane-classified concert data
+- Enable `HYPE_TYPE_NEARBY` in the notification filter with real proximity logic
+- Extract and persist venue coordinates from existing enrichment pipeline responses
+
+**Non-Goals:**
+
+- User-configurable proximity radius (fixed at 200km for Phase 1)
+- Real-time GPS-based proximity (uses static home area centroid)
+- PostGIS or spatial database extensions (Haversine computed in application layer)
+- Support for countries other than Japan in Phase 1 (centroid data is Japan-only)
+- Exposing venue lat/lng in the proto Venue entity (backend-internal only for now)
+
+## Decisions
+
+### D1: Haversine distance with venue lat/lng (not admin_area centroid-to-centroid)
+
+Compare the user's home area centroid against the venue's actual latitude/longitude from external place services, rather than comparing centroids of two admin areas.
+
+**Rationale**: Venue-level coordinates are more accurate — a concert hall on the border of two prefectures is classified correctly. Admin-area centroids lose precision for large prefectures (e.g., Hokkaido spans 500km). The enrichment pipeline already calls Google Places and MusicBrainz, which both return coordinates — no additional API calls needed.
+
+**Alternative rejected**: Admin-area centroid-to-centroid comparison. Simpler but less accurate, and fails for venues without admin_area.
+
+### D2: Static Go map for prefecture centroids (not DB table)
+
+Store 47 Japanese prefecture centroid coordinates as a Go `map[string]LatLng` constant in `internal/geo/centroid.go`, keyed by ISO 3166-2 code.
+
+**Rationale**: Phase 1 is Japan-only with a fixed, small dataset. A DB table adds migration, query, and caching complexity for no benefit. Data source: Geospatial Information Authority of Japan (GSI) published prefecture capital coordinates.
+
+**Alternative rejected**: PostgreSQL table with centroid data. Better for multi-country support but premature for Phase 1. Migration path is straightforward when needed.
+
+### D3: Fixed 200km threshold
+
+Use a fixed Haversine distance threshold of 200km for the NEARBY boundary.
+
+**Rationale**: 200km covers reasonable day-trip ranges across Japan — Tokyo captures the entire Kanto region plus Shizuoka/Yamanashi/Nagano (9 prefectures), Osaka captures 13 including Nagoya. For Hokkaido (where no other prefectural capital is within 200km), venue-level coordinates still capture intra-prefecture venues like Asahikawa (130km from Sapporo) and Obihiro (185km).
+
+### D4: Lane classification as backend domain logic
+
+Move the home/nearby/away classification from the frontend `assignLane()` function to a backend domain service (`internal/geo.ClassifyLane`), shared by both the `ListByFollower` RPC handler and `NotifyNewConcerts()`.
+
+**Rationale**: Lane classification is a domain concept, not a presentation concern. The notification filter and dashboard must agree on what "nearby" means. Centralizing in the backend ensures consistency and allows threshold changes without frontend deployment.
+
+**Classification rules**:
+1. `venue.admin_area == user.home.level_1` → HOME
+2. `venue.latitude/longitude` present AND `Haversine(home_centroid, venue_latlng) <= 200km` → NEARBY
+3. Everything else (no coordinates, beyond threshold, no user home) → AWAY
+
+### D5: Restructure ListByFollowerResponse to DateLaneGroup
+
+Replace the flat `repeated Concert concerts` with `repeated DateLaneGroup groups`, where each group contains a date and three lane-specific concert lists.
+
+```protobuf
+message ListByFollowerResponse {
+  repeated DateLaneGroup groups = 1;
+}
+
+message DateLaneGroup {
+  entity.v1.LocalDate date = 1;
+  repeated entity.v1.Concert home = 2;
+  repeated entity.v1.Concert nearby = 3;
+  repeated entity.v1.Concert away = 4;
+}
+```
+
+**Rationale**: The frontend already structures data this way (DateGroup with home/nearby/away arrays). Server-side grouping eliminates redundant processing and the need for the frontend to fetch user home separately. Breaking change is acceptable (no users yet).
+
+### D6: Extract coordinates during enrichment (not discovery)
+
+Venue lat/lng is populated during the enrichment pipeline (MusicBrainz/Google Places resolution), not during initial concert discovery.
+
+**Rationale**: Discovery creates venues with minimal scraper data (name + optional admin_area). The enrichment pipeline already calls external APIs that return coordinates — extracting lat/lng is a minimal addition to the existing data flow. Venues with `enrichment_status = 'pending'` or `'failed'` will have NULL coordinates and fall into the AWAY lane, which is acceptable.
+
+### D7: Venue coordinates are backend-internal (not in proto Venue)
+
+Latitude and longitude are stored in the `venues` DB table and the Go `entity.Venue` struct, but are NOT added to the proto `Venue` message.
+
+**Rationale**: Coordinates are used only for backend proximity calculation. Adding them to proto creates a public API surface that requires versioning discipline. If frontend map features are needed later, a dedicated field can be added then.
+
+## Risks / Trade-offs
+
+- **[Enrichment coverage gap]** Venues with `enrichment_status = 'pending'` or `'failed'` have no lat/lng and always classify as AWAY. This is acceptable because enrichment runs asynchronously after discovery, and failed enrichment indicates the venue couldn't be resolved by any external service. → Mitigation: Monitor enrichment success rate; consider re-running failed venues periodically.
+
+- **[MusicBrainz coordinate availability]** Not all MusicBrainz Place records have coordinates populated. → Mitigation: Fall through to Google Places, which has near-universal coordinate coverage for venue searches.
+
+- **[Breaking RPC change]** `ListByFollowerResponse` restructuring breaks existing frontend. → Mitigation: No users in production; frontend and backend deploy together. Add `buf skip breaking` label to specification PR.
+
+- **[Hokkaido edge case]** 200km from Sapporo covers no other prefectural capital. → Mitigation: Venue-level lat/lng means intra-Hokkaido venues (Asahikawa 130km, Obihiro 185km) are correctly classified as NEARBY. This is the intended behavior.

--- a/openspec/changes/nearby-proximity-filter/proposal.md
+++ b/openspec/changes/nearby-proximity-filter/proposal.md
@@ -1,32 +1,32 @@
 ## Why
 
-The `rename-passion-to-hype` change introduces `HYPE_TYPE_NEARBY` in the proto enum but leaves it unimplemented — the UI hides it and the backend falls back to ANYWHERE behavior. To complete the 4-tier hype system, the NEARBY tier needs a concrete proximity definition that determines which concerts are "close enough" to notify users about. Unlike HOME (exact ISO 3166-2 match), NEARBY requires physical distance calculation between the user's home area and a concert venue's area, which is a fundamentally different kind of geographic filtering that does not yet exist in the system.
+The `rename-passion-to-hype` change introduces `HYPE_TYPE_NEARBY` in the proto enum but leaves it unimplemented — the UI hides it and the backend falls back to ANYWHERE behavior. To complete the 4-tier hype system, the NEARBY tier needs a concrete proximity definition that determines which concerts are "close enough" to notify users about. Unlike HOME (exact ISO 3166-2 match), NEARBY requires physical distance calculation between the user's home area centroid and a concert venue's actual latitude/longitude, which is a fundamentally different kind of geographic filtering that does not yet exist in the system.
+
+Additionally, the current dashboard lane classification ("home / nearby / away") is performed entirely in the frontend using a naive `admin_area` string comparison — any venue outside the user's home area is classified as "nearby" regardless of actual distance. The home/nearby/away classification is a shared domain concept used by both the dashboard and the notification filter, and should be computed by the backend as the single source of truth.
 
 ## What Changes
 
-- Define a proximity model for NEARBY: given a user's home area (ISO 3166-2 code) and a concert venue's admin area (ISO 3166-2 code), determine whether the venue is "nearby"
-- Choose a distance strategy — options include:
-  - **Centroid distance**: Calculate distance between geographic centroids of the two admin areas, with a configurable radius threshold
-  - **Adjacency graph**: Precompute a neighbor list for each admin area (e.g., Tokyo is adjacent to Saitama, Chiba, Kanagawa) and define "nearby" as N-hop adjacency
-  - **Region grouping**: Use predefined region groups (Kanto, Kansai, etc.) — simpler but less accurate and conflates UI grouping with business logic
-- Implement the chosen model in the backend notification filter so `HYPE_TYPE_NEARBY` sends notifications for concerts in the user's home area AND nearby areas
+- Add latitude and longitude to venue records, populated during the existing venue enrichment pipeline from MusicBrainz coordinates and Google Places geometry
+- Define a proximity model: compute Haversine distance between the user's home area centroid (from a static Go lookup of 47 Japanese prefecture centroids) and the venue's actual lat/lng, with a fixed 200km threshold
+- Unify the home/nearby/away classification as backend domain logic, used by both the dashboard RPC and the notification filter
+- **BREAKING**: Restructure `ListByFollowerResponse` from a flat concert list to date-grouped lane-classified groups (`DateLaneGroup[]`), each containing home/nearby/away concert lists
+- Implement NEARBY filtering in `NotifyNewConcerts()` using the same proximity logic (replacing the current ANYWHERE fallback)
 - Expose NEARBY as a selectable option in the frontend hype selector (currently hidden)
-- Update the Dashboard Live Highway lane assignment if needed (NEARBY notifications should correspond to Lane 1 + Lane 2 concerts)
 
 ## Capabilities
 
 ### New Capabilities
 
-- `nearby-proximity`: Definition of geographic proximity between ISO 3166-2 admin areas, including the distance/adjacency model, data source, and query interface used by the notification filter
+- `nearby-proximity`: Definition of geographic proximity between a user's home area and a concert venue, including the Haversine distance model, venue lat/lng data source, home centroid lookup, and the classification interface used by both dashboard and notification filter
 
 ### Modified Capabilities
 
-- `hype-notification-filter`: NEARBY tier transitions from ANYWHERE fallback to actual proximity-based filtering using the new proximity model
-- `my-artists`: Hype selector exposes NEARBY (🔥🔥) as a fourth selectable option between HOME and ANYWHERE
+- `live-events`: `ListByFollower` response changes from flat `repeated Concert` to `repeated DateLaneGroup` with server-side date grouping and lane classification; Dashboard Lane Classification moves from frontend to backend
+- `venue-normalization`: Enrichment pipeline extracts and persists venue latitude/longitude from MusicBrainz coordinates and Google Places geometry during enrichment
 
 ## Impact
 
-- **backend**: New proximity data source (static lookup table or geospatial query), updated notification filter logic in `NotifyNewConcerts()`, possible new DB table or config for area proximity data
-- **frontend**: Hype selector updated to show 4 options instead of 3
-- **specification**: No proto changes needed (NEARBY already defined in HypeType enum)
-- **data**: Requires geographic centroid or adjacency data for all 47 Japanese prefectures (Phase 1); extensible to other countries via ISO 3166-2
+- **specification**: `ListByFollowerResponse` restructured (breaking change); `Venue` entity gains optional `latitude`/`longitude` fields
+- **backend**: New proximity classifier in `internal/geo`; venue entity and DB schema gain lat/lng; enrichment pipeline updated to extract coordinates; `ListByFollower` usecase performs date+lane grouping; `NotifyNewConcerts` uses proximity for NEARBY filtering
+- **frontend**: Dashboard service simplified — removes `assignLane()` and `fetchUserHome()`, consumes pre-classified `DateLaneGroup[]` directly; hype selector shows 4 options
+- **data**: Requires centroid coordinates for 47 Japanese prefectures (static Go map, sourced from Geospatial Information Authority of Japan)

--- a/openspec/changes/nearby-proximity-filter/proposal.md
+++ b/openspec/changes/nearby-proximity-filter/proposal.md
@@ -26,7 +26,7 @@ Additionally, the current dashboard lane classification ("home / nearby / away")
 
 ## Impact
 
-- **specification**: `ListByFollowerResponse` restructured (breaking change); `Venue` entity gains optional `latitude`/`longitude` fields
+- **specification**: `ListByFollowerResponse` restructured (breaking change); venue coordinates are backend-internal (DB + Go struct only, not exposed in proto)
 - **backend**: New proximity classifier in `internal/geo`; venue entity and DB schema gain lat/lng; enrichment pipeline updated to extract coordinates; `ListByFollower` usecase performs date+lane grouping; `NotifyNewConcerts` uses proximity for NEARBY filtering
 - **frontend**: Dashboard service simplified — removes `assignLane()` and `fetchUserHome()`, consumes pre-classified `DateLaneGroup[]` directly; hype selector shows 4 options
 - **data**: Requires centroid coordinates for 47 Japanese prefectures (static Go map, sourced from Geospatial Information Authority of Japan)

--- a/openspec/changes/nearby-proximity-filter/specs/live-events/spec.md
+++ b/openspec/changes/nearby-proximity-filter/specs/live-events/spec.md
@@ -1,0 +1,44 @@
+## MODIFIED Requirements
+
+### Requirement: Live Schedule Access
+
+The system MUST provide access to the collected schedule of concerts.
+
+#### Scenario: List Concerts
+
+- **WHEN** `ListConcerts` is called for a valid artist ID
+- **THEN** the system MUST return a chronologically sorted list of future concerts for that artist.
+
+#### Scenario: List Concerts by Follower
+
+- **WHEN** `ListByFollower` is called by an authenticated user
+- **THEN** the system MUST return concerts for all artists followed by that user, grouped by date and classified into home/nearby/away lanes
+- **AND** each group SHALL contain a calendar date and three concert lists (home, nearby, away)
+- **AND** groups SHALL be ordered by date ascending
+- **AND** lane classification SHALL be performed by the backend using the proximity classification model
+- **AND** the result SHALL be retrieved in a single RPC call
+
+### Requirement: Dashboard Lane Classification
+
+The backend SHALL classify live events into three lanes based on the proximity classification model, replacing the previous frontend-only classification.
+
+#### Scenario: Home lane assignment
+
+- **WHEN** a concert's venue `admin_area` matches the user's `home.level_1`
+- **THEN** the concert SHALL be placed in the `home` list of its date group
+
+#### Scenario: Nearby lane assignment
+
+- **WHEN** a concert's venue has coordinates within 200km of the user's home centroid
+- **AND** the venue `admin_area` does not match the user's `home.level_1`
+- **THEN** the concert SHALL be placed in the `nearby` list of its date group
+
+#### Scenario: Away lane assignment
+
+- **WHEN** a concert's venue is beyond 200km, has no coordinates, or the user has no home set
+- **THEN** the concert SHALL be placed in the `away` list of its date group
+
+#### Scenario: User has no home set
+
+- **WHEN** the user has not set a home area
+- **THEN** all concerts SHALL be placed in the `away` list of their respective date groups

--- a/openspec/changes/nearby-proximity-filter/specs/nearby-proximity/spec.md
+++ b/openspec/changes/nearby-proximity-filter/specs/nearby-proximity/spec.md
@@ -20,6 +20,7 @@ The system SHALL classify the geographic relationship between a user's home area
 #### Scenario: AWAY classification for distant venues
 
 - **WHEN** the venue has latitude and longitude coordinates
+- **AND** the venue's `admin_area` does **not** match the user's `home.level_1`
 - **AND** the Haversine distance between the home centroid and the venue coordinates exceeds 200km
 - **THEN** the venue SHALL be classified as AWAY
 

--- a/openspec/changes/nearby-proximity-filter/specs/nearby-proximity/spec.md
+++ b/openspec/changes/nearby-proximity-filter/specs/nearby-proximity/spec.md
@@ -1,0 +1,73 @@
+## ADDED Requirements
+
+### Requirement: Proximity Classification Model
+
+The system SHALL classify the geographic relationship between a user's home area and a concert venue into one of three lanes: HOME, NEARBY, or AWAY.
+
+#### Scenario: HOME classification by admin_area match
+
+- **WHEN** the venue's `admin_area` matches the user's `home.level_1` (ISO 3166-2 code equality)
+- **THEN** the venue SHALL be classified as HOME
+
+#### Scenario: NEARBY classification by Haversine distance
+
+- **WHEN** the venue's `admin_area` does not match the user's `home.level_1`
+- **AND** the venue has latitude and longitude coordinates
+- **AND** the user's home area has a known centroid
+- **AND** the Haversine distance between the home centroid and the venue coordinates is less than or equal to 200km
+- **THEN** the venue SHALL be classified as NEARBY
+
+#### Scenario: AWAY classification for distant venues
+
+- **WHEN** the venue has latitude and longitude coordinates
+- **AND** the Haversine distance between the home centroid and the venue coordinates exceeds 200km
+- **THEN** the venue SHALL be classified as AWAY
+
+#### Scenario: AWAY classification for venues without coordinates
+
+- **WHEN** the venue does not have latitude or longitude coordinates
+- **AND** the venue's `admin_area` does not match the user's `home.level_1`
+- **THEN** the venue SHALL be classified as AWAY
+
+#### Scenario: AWAY classification when user has no home
+
+- **WHEN** the user has not set a home area
+- **THEN** all venues SHALL be classified as AWAY
+
+### Requirement: Home Area Centroid Lookup
+
+The system SHALL maintain a lookup of geographic centroid coordinates for each supported ISO 3166-2 subdivision, used as the reference point for proximity calculations.
+
+#### Scenario: Japanese prefecture centroid lookup
+
+- **WHEN** a proximity calculation is performed for a user with a Japanese home area (e.g., `JP-13`)
+- **THEN** the system SHALL resolve the ISO 3166-2 code to a latitude/longitude centroid for distance calculation
+
+#### Scenario: Unsupported country code
+
+- **WHEN** a proximity calculation is performed for a user with a home area in an unsupported country
+- **THEN** the system SHALL treat all venues as AWAY (no proximity data available)
+
+### Requirement: Haversine Distance Calculation
+
+The system SHALL compute great-circle distance between two geographic points using the Haversine formula.
+
+#### Scenario: Distance calculation accuracy
+
+- **WHEN** the system calculates distance between Tokyo centroid (35.6895, 139.6917) and a venue at Saitama Super Arena (35.8950, 139.6314)
+- **THEN** the result SHALL be approximately 23km (within 1km tolerance)
+
+### Requirement: Venue Coordinate Storage
+
+The system SHALL store latitude and longitude for venue records in the database, populated during the venue enrichment pipeline.
+
+#### Scenario: Coordinates populated after enrichment
+
+- **WHEN** a venue is successfully enriched via MusicBrainz or Google Places
+- **AND** the external service response includes coordinates
+- **THEN** the venue record SHALL be updated with latitude and longitude values
+
+#### Scenario: Coordinates absent for unenriched venues
+
+- **WHEN** a venue has `enrichment_status` of `pending` or `failed`
+- **THEN** the venue's latitude and longitude SHALL be NULL

--- a/openspec/changes/nearby-proximity-filter/specs/venue-normalization/spec.md
+++ b/openspec/changes/nearby-proximity-filter/specs/venue-normalization/spec.md
@@ -1,0 +1,52 @@
+## MODIFIED Requirements
+
+### Requirement: Venue Enrichment Pipeline
+
+The system SHALL provide an async enrichment pipeline that resolves raw venue names to canonical external identifiers (MusicBrainz MBID or Google Maps place_id) and updates venue records with canonical names and geographic coordinates.
+
+#### Scenario: Successful enrichment via MusicBrainz
+
+- **WHEN** the enrichment job processes a venue with `enrichment_status = 'pending'`
+- **AND** MusicBrainz place search returns a match
+- **THEN** the venue record SHALL be updated with the MusicBrainz MBID
+- **AND** `venues.raw_name` SHALL be set to the current `venues.name` (if `raw_name` is NULL) to preserve the original scraper-provided name
+- **AND** `venues.name` SHALL be overwritten with the canonical name from MusicBrainz
+- **AND** `enrichment_status` SHALL be set to `'enriched'`
+- **AND** if the MusicBrainz response includes coordinates, `venues.latitude` and `venues.longitude` SHALL be updated
+
+#### Scenario: Successful enrichment via Google Maps fallback
+
+- **WHEN** the enrichment job processes a venue with `enrichment_status = 'pending'`
+- **AND** MusicBrainz place search returns no match
+- **AND** Google Maps Text Search returns a match
+- **THEN** the venue record SHALL be updated with the Google Maps place_id
+- **AND** `venues.raw_name` SHALL be set to the current `venues.name` (if `raw_name` is NULL) to preserve the original scraper-provided name
+- **AND** `venues.name` SHALL be overwritten with the canonical name from Google Maps
+- **AND** `enrichment_status` SHALL be set to `'enriched'`
+- **AND** `venues.latitude` and `venues.longitude` SHALL be updated from the Google Maps geometry response
+
+#### Scenario: Both sources miss
+
+- **WHEN** the enrichment job processes a venue with `enrichment_status = 'pending'`
+- **AND** MusicBrainz returns no match
+- **AND** Google Maps returns no match
+- **THEN** `enrichment_status` SHALL be set to `'failed'`
+- **AND** `venues.name` SHALL remain unchanged
+- **AND** `venues.latitude` and `venues.longitude` SHALL remain NULL
+- **AND** the venue SHALL NOT be retried in subsequent job runs
+
+#### Scenario: Ambiguous results (multiple matches)
+
+- **WHEN** the enrichment job processes a venue with `enrichment_status = 'pending'`
+- **AND** MusicBrainz or Google Maps returns more than one candidate match
+- **THEN** the venue SHALL NOT be updated with any external identifier
+- **AND** `venues.name` SHALL remain unchanged
+- **AND** `enrichment_status` SHALL be set to `'failed'`
+- **AND** the ambiguity SHALL be logged for future manual review
+
+#### Scenario: admin_area used as search hint
+
+- **WHEN** the enrichment job queries MusicBrainz or Google Maps for a venue
+- **AND** the venue has a non-NULL `admin_area` (ISO 3166-2 code)
+- **THEN** the system SHALL convert the ISO 3166-2 code to a locale-appropriate text name before including it in the search query
+- **AND** the text name SHALL be in the language most likely to yield accurate results for the target service (e.g., Japanese for MusicBrainz JP venues, English for Google Maps)

--- a/openspec/changes/nearby-proximity-filter/tasks.md
+++ b/openspec/changes/nearby-proximity-filter/tasks.md
@@ -1,0 +1,56 @@
+## 1. Proto Schema Changes (specification repo)
+
+- [x] 1.1 Add `DateLaneGroup` message to `concert_service.proto` with `date`, `home`, `nearby`, `away` fields
+- [x] 1.2 Restructure `ListByFollowerResponse` to use `repeated DateLaneGroup groups` (replacing `repeated Concert concerts`)
+- [x] 1.3 Run `buf lint` and `buf format -w` to validate proto changes
+
+## 2. Venue Coordinates (backend repo)
+
+- [x] 2.1 Add `latitude` and `longitude` columns (`DOUBLE PRECISION`, nullable) to `venues` table in `schema.sql`
+- [ ] 2.2 Generate Atlas migration with `atlas migrate diff --env local add_venue_coordinates`
+- [x] 2.3 Add `Latitude *float64` and `Longitude *float64` fields to `entity.Venue` struct
+- [x] 2.4 Update `VenueEnrichmentRepository.UpdateEnriched` to persist latitude/longitude
+- [ ] 2.5 Update venue repository queries (`ListByFollower` JOIN) to include latitude/longitude
+
+## 3. Enrichment Pipeline Coordinate Extraction (backend repo)
+
+- [x] 3.1 Extend MusicBrainz `placeSearchResponse` struct to parse `coordinates.latitude` and `coordinates.longitude`
+- [x] 3.2 Add `Latitude` and `Longitude` fields to MusicBrainz `Place` struct
+- [x] 3.3 Extend Google Places `textSearchResponse` struct to parse `geometry.location.lat` and `geometry.location.lng`
+- [x] 3.4 Add `Latitude` and `Longitude` fields to Google Places `Place` struct
+- [x] 3.5 Add `Latitude` and `Longitude` fields to `entity.VenuePlace`
+- [x] 3.6 Update `PlaceSearcher` adapters (MusicBrainz and Google) to pass coordinates through to `VenuePlace`
+- [x] 3.7 Update `venueEnrichmentUseCase.enrichOne` to set coordinates on the enriched venue entity
+- [ ] 3.8 Write unit tests for coordinate extraction from both MusicBrainz and Google Places responses
+
+## 4. Proximity Classifier (backend repo)
+
+- [x] 4.1 Create `internal/geo/centroid.go` with `PrefectureCentroid` map (47 JP prefectures, sourced from GSI)
+- [x] 4.2 Create `internal/geo/haversine.go` with `Haversine(lat1, lng1, lat2, lng2) float64` function
+- [x] 4.3 Create `internal/geo/lane.go` with `ClassifyLane(homeLevel1 string, venueLat, venueLng *float64, venueAdminArea *string) Lane` function
+- [x] 4.4 Define `Lane` type (`HOME`, `NEARBY`, `AWAY`) in `internal/geo/lane.go`
+- [x] 4.5 Write unit tests for Haversine calculation (known distances: Tokyo-Saitama, Tokyo-Osaka)
+- [x] 4.6 Write unit tests for ClassifyLane (HOME match, NEARBY within threshold, AWAY beyond threshold, missing coordinates, missing home)
+
+## 5. ListByFollower Restructure (backend repo)
+
+- [x] 5.1 Update `ConcertRepository.ListByFollower` query to JOIN venue lat/lng and return venue coordinates
+- [x] 5.2 Create `ConcertUseCase.ListByFollowerGrouped` method that fetches user home, classifies concerts into lanes, and groups by date
+- [ ] 5.3 Update `ConcertHandler.ListByFollower` to call the grouped usecase method and map to `DateLaneGroup` proto response (blocked: BSR gen)
+- [ ] 5.4 Update RPC handler mapper to convert domain lane groups to proto `DateLaneGroup` messages (blocked: BSR gen)
+- [x] 5.5 Write unit tests for the grouped usecase method
+
+## 6. Notification Filter Update (backend repo)
+
+- [x] 6.1 Update `NotifyNewConcerts()` NEARBY case to use `geo.ClassifyLane` instead of ANYWHERE fallback
+- [x] 6.2 Add `ListFollowersWithHype` to return user home area alongside hype level (if not already included)
+- [x] 6.3 Write unit tests for NEARBY notification filtering (within 200km: notify, beyond 200km: skip)
+
+## 7. Frontend Adaptation (frontend repo)
+
+- [ ] 7.1 Update `concert-service.ts` to parse new `DateLaneGroup[]` response structure
+- [ ] 7.2 Simplify `dashboard-service.ts`: remove `assignLane()`, `fetchUserHome()`, and manual grouping logic
+- [ ] 7.3 Map server `DateLaneGroup` directly to `DateGroup` type used by `live-highway` component
+- [ ] 7.4 Update hype selector to show 4 options (WATCH / HOME / NEARBY / ANYWHERE) instead of 3
+- [ ] 7.5 Remove `HYPE_TYPE_NEARBY` rejection in `SetHype` RPC validation (specification + backend)
+- [ ] 7.6 Update frontend unit tests for dashboard service and hype selector

--- a/proto/liverty_music/rpc/concert/v1/concert_service.proto
+++ b/proto/liverty_music/rpc/concert/v1/concert_service.proto
@@ -5,6 +5,7 @@ package liverty_music.rpc.concert.v1;
 import "buf/validate/validate.proto";
 import "liverty_music/entity/v1/artist.proto";
 import "liverty_music/entity/v1/concert.proto";
+import "liverty_music/entity/v1/entity.proto";
 
 // ConcertService provides operations for managing the catalog of musical concerts.
 // It acts as the primary data source for upcoming live music events.
@@ -58,10 +59,32 @@ message ListResponse {
 // is determined from the authentication context.
 message ListByFollowerRequest {}
 
-// ListByFollowerResponse contains the concerts for all artists followed by the caller.
+// ListByFollowerResponse contains concerts for all artists followed by the caller,
+// grouped by date and classified into geographic proximity lanes.
 message ListByFollowerResponse {
-  // The collection of concert events, ordered by date ascending.
-  repeated entity.v1.Concert concerts = 1;
+  reserved 1;
+  reserved "concerts";
+
+  // Concert groups ordered by date ascending. Each group contains concerts
+  // for a single date, classified into home/nearby/away lanes based on the
+  // geographic relationship between the user's home area and each venue.
+  repeated DateLaneGroup groups = 2;
+}
+
+// DateLaneGroup contains concerts for a single calendar date, classified into
+// three geographic proximity lanes relative to the authenticated user's home area.
+message DateLaneGroup {
+  // The calendar date for this group.
+  entity.v1.LocalDate date = 1;
+
+  // Concerts at venues within the user's home area (admin_area matches home.level_1).
+  repeated entity.v1.Concert home = 2;
+
+  // Concerts at venues within 200km of the user's home area centroid.
+  repeated entity.v1.Concert nearby = 3;
+
+  // Concerts at venues beyond 200km, with unknown location, or when the user has no home set.
+  repeated entity.v1.Concert away = 4;
 }
 
 // SearchNewConcertsRequest specifies the artist for whom to search for new concerts.

--- a/proto/liverty_music/rpc/concert/v1/concert_service.proto
+++ b/proto/liverty_music/rpc/concert/v1/concert_service.proto
@@ -75,7 +75,7 @@ message ListByFollowerResponse {
 // three geographic proximity lanes relative to the authenticated user's home area.
 message DateLaneGroup {
   // The calendar date for this group.
-  entity.v1.LocalDate date = 1;
+  entity.v1.LocalDate date = 1 [(buf.validate.field).required = true];
 
   // Concerts at venues within the user's home area (admin_area matches home.level_1).
   repeated entity.v1.Concert home = 2;


### PR DESCRIPTION
## Summary

- **BREAKING**: Replace flat `repeated Concert concerts` in `ListByFollowerResponse` with `repeated DateLaneGroup groups`
- Add `DateLaneGroup` message with `date`, `home`, `nearby`, `away` fields for proximity-based lane classification
- Add OpenSpec change artifacts (design, specs, tasks) for the nearby-proximity-filter feature

## Motivation

The NEARBY hype tier requires server-side geographic proximity filtering. The current flat concert list doesn't convey lane classification to the frontend. `DateLaneGroup` groups concerts by calendar date and classifies them into home/nearby/away lanes using Haversine distance from the user's home area centroid.

## Test plan

- [ ] `buf lint` passes (CI)
- [ ] `buf breaking` reports expected breaking change
- [ ] BSR gen publishes updated types after Release

Closes #182