### PR TITLE
refactor!: extract Follow domain into independent FollowService

### DIFF
--- a/buf.yaml
+++ b/buf.yaml
@@ -15,4 +15,5 @@ breaking:
   use:
     - FILE
   ignore:
+    - proto/liverty_music/entity/v1/artist.proto
     - proto/liverty_music/rpc/artist/v1/artist_service.proto

--- a/proto/liverty_music/entity/v1/artist.proto
+++ b/proto/liverty_music/entity/v1/artist.proto
@@ -59,26 +59,3 @@ message OfficialSiteUrl {
   // The URI value of the official site.
   string value = 1 [(buf.validate.field).string.uri = true];
 }
-
-// HypeType represents the user's enthusiasm tier for a followed artist.
-// It controls push notification scope and dashboard rendering behavior.
-// Values are ordered by ascending enthusiasm: WATCH (lowest) to ANYWHERE (highest).
-enum HypeType {
-  // Default value; must not be used in API requests.
-  HYPE_TYPE_UNSPECIFIED = 0;
-
-  // Dashboard view only. No push notifications are sent for this artist.
-  HYPE_TYPE_WATCH = 1;
-
-  // Push notifications only for concerts in the user's home area
-  // (ISO 3166-2 subdivision match). This is a moderate engagement tier.
-  HYPE_TYPE_HOME = 2;
-
-  // Push notifications for concerts within physical proximity of the user's
-  // home area. Reserved for Phase 2; not exposed in the UI selector.
-  HYPE_TYPE_NEARBY = 3;
-
-  // Push notifications for all concerts nationwide. This is the default tier
-  // assigned when a user first follows an artist. Die-hard fan level.
-  HYPE_TYPE_ANYWHERE = 4;
-}

--- a/proto/liverty_music/entity/v1/follow.proto
+++ b/proto/liverty_music/entity/v1/follow.proto
@@ -1,0 +1,41 @@
+syntax = "proto3";
+
+package liverty_music.entity.v1;
+
+import "buf/validate/validate.proto";
+import "liverty_music/entity/v1/artist.proto";
+
+option go_package = "github.com/liverty-music/specification/gen/go/liverty_music/entity/v1;entityv1";
+
+// HypeType represents the user's enthusiasm tier for a followed artist.
+// It controls push notification scope and dashboard rendering behavior.
+// Values are ordered by ascending enthusiasm: WATCH (lowest) to ANYWHERE (highest).
+enum HypeType {
+  // Default value; must not be used in API requests.
+  HYPE_TYPE_UNSPECIFIED = 0;
+  // Dashboard view only. No push notifications are sent for this artist.
+  HYPE_TYPE_WATCH = 1;
+  // Push notifications only for concerts in the user's home area
+  // (ISO 3166-2 subdivision match). This is a moderate engagement tier.
+  HYPE_TYPE_HOME = 2;
+  // Push notifications for concerts within physical proximity of the user's
+  // home area. Reserved for Phase 2; not exposed in the UI selector.
+  HYPE_TYPE_NEARBY = 3;
+  // Push notifications for all concerts nationwide. This is the default tier
+  // assigned when a user first follows an artist. Die-hard fan level.
+  HYPE_TYPE_ANYWHERE = 4;
+}
+
+// FollowedArtist represents an artist together with the fan's personal follow
+// settings for that artist. It captures both who the artist is and how
+// enthusiastically the fan wants to be kept informed about their concerts.
+message FollowedArtist {
+  // The artist that the fan is following.
+  Artist artist = 1 [(buf.validate.field).required = true];
+  // The fan's hype level for this artist, which determines the scope of
+  // concert push notifications they receive.
+  HypeType hype = 2 [
+    (buf.validate.field).required = true,
+    (buf.validate.field).enum.defined_only = true
+  ];
+}

--- a/proto/liverty_music/rpc/artist/v1/artist_service.proto
+++ b/proto/liverty_music/rpc/artist/v1/artist_service.proto
@@ -1,9 +1,9 @@
 syntax = "proto3";
 
-// Package liverty_music.rpc.v1 provides gRPC service definitions for artist management.
+// Package liverty_music.rpc.artist.v1 provides gRPC service definitions for artist management.
 //
 // This package includes the ArtistService which handles artist discovery,
-// lifecycle management, and user relationship tracking (following).
+// lifecycle management, and integration with external recommendation engines.
 package liverty_music.rpc.artist.v1;
 
 import "buf/validate/validate.proto";
@@ -47,35 +47,6 @@ service ArtistService {
   // Possible errors:
   // - NOT_FOUND: The specified official site identifier does not exist.
   rpc DeleteOfficialSite(DeleteOfficialSiteRequest) returns (DeleteOfficialSiteResponse);
-
-  // Follow establishes a follow relationship between the current user and an artist.
-  // This personalization allows the system to notify users about concerts.
-  //
-  // Possible errors:
-  // - NOT_FOUND: The specified artist ID does not exist.
-  // - INTERNAL: An error occurred while persisting the relationship.
-  rpc Follow(FollowRequest) returns (FollowResponse);
-
-  // Unfollow removes an existing follow relationship.
-  //
-  // Possible errors:
-  // - NOT_FOUND: The user was not following the specified artist.
-  rpc Unfollow(UnfollowRequest) returns (UnfollowResponse);
-
-  // ListFollowed retrieves the list of artists currently followed by the authenticated user.
-  // Each entry includes the user's hype preference for the artist.
-  //
-  // Possible errors:
-  // - UNAUTHENTICATED: The user identity could not be verified.
-  rpc ListFollowed(ListFollowedRequest) returns (ListFollowedResponse);
-
-  // SetHype updates the user's enthusiasm tier for a followed artist.
-  // The hype level controls push notification scope and dashboard rendering.
-  //
-  // Possible errors:
-  // - NOT_FOUND: The user is not following the specified artist.
-  // - INVALID_ARGUMENT: The hype value is invalid or unspecified.
-  rpc SetHype(SetHypeRequest) returns (SetHypeResponse);
 
   // ListSimilar retrieves artists similar to a specified artist using recommendation engines.
   //
@@ -146,67 +117,6 @@ message DeleteOfficialSiteRequest {
 
 // DeleteOfficialSiteResponse is returned upon successful site removal.
 message DeleteOfficialSiteResponse {}
-
-// FollowRequest specifies the artist the current user wishes to follow.
-message FollowRequest {
-  // Required. The unique identifier of the artist to follow.
-  entity.v1.ArtistId artist_id = 1 [(buf.validate.field).required = true];
-}
-
-// FollowResponse is returned upon successfully establishing the follow relationship.
-message FollowResponse {}
-
-// UnfollowRequest specifies the artist the current user wishes to unfollow.
-message UnfollowRequest {
-  // Required. The unique identifier of the artist to unfollow.
-  entity.v1.ArtistId artist_id = 1 [(buf.validate.field).required = true];
-}
-
-// UnfollowResponse is returned upon successfully removing the follow relationship.
-message UnfollowResponse {}
-
-// ListFollowedRequest is the request for listing the current user's followed artists.
-message ListFollowedRequest {}
-
-// ListFollowedResponse contains the collection of artists followed by the user,
-// enriched with per-user hype metadata.
-message ListFollowedResponse {
-  // The collection of followed artists with their hype preferences.
-  repeated FollowedArtist artists = 1;
-}
-
-// FollowedArtist represents an artist with user-specific follow metadata.
-// This is an RPC-layer message (not an entity) because hype is
-// per-user context, not an intrinsic property of the Artist entity.
-message FollowedArtist {
-  // The artist entity.
-  entity.v1.Artist artist = 1 [(buf.validate.field).required = true];
-
-  // The user's hype level for this artist.
-  entity.v1.HypeType hype = 2 [
-    (buf.validate.field).required = true,
-    (buf.validate.field).enum.defined_only = true
-  ];
-}
-
-// SetHypeRequest provides the artist ID and the new hype level to set.
-message SetHypeRequest {
-  // Required. The unique identifier of the artist.
-  entity.v1.ArtistId artist_id = 1 [(buf.validate.field).required = true];
-
-  // Required. The new hype tier.
-  // HYPE_TYPE_NEARBY (3) is rejected — not user-selectable in Phase 1.
-  entity.v1.HypeType hype = 2 [
-    (buf.validate.field).required = true,
-    (buf.validate.field).enum = {
-      defined_only: true
-      not_in: [3]
-    }
-  ];
-}
-
-// SetHypeResponse is returned upon a successful hype level update.
-message SetHypeResponse {}
 
 // ListSimilarRequest specifies the seed artist for discovery.
 message ListSimilarRequest {

--- a/proto/liverty_music/rpc/follow/v1/follow_service.proto
+++ b/proto/liverty_music/rpc/follow/v1/follow_service.proto
@@ -1,0 +1,90 @@
+syntax = "proto3";
+
+// Package liverty_music.rpc.follow.v1 provides the FollowService for managing
+// user-artist follow relationships and hype preferences.
+package liverty_music.rpc.follow.v1;
+
+import "buf/validate/validate.proto";
+import "liverty_music/entity/v1/artist.proto";
+import "liverty_music/entity/v1/follow.proto";
+
+// FollowService manages the relationship between fans and the artists they follow.
+// It handles follow/unfollow actions, hype level preferences, and listing
+// followed artists for the authenticated user.
+service FollowService {
+  // Follow establishes a follow relationship between the current user and an artist.
+  // This personalization allows the system to notify users about concerts.
+  //
+  // Possible errors:
+  // - NOT_FOUND: The specified artist ID does not exist.
+  // - INTERNAL: An error occurred while persisting the relationship.
+  rpc Follow(FollowRequest) returns (FollowResponse);
+
+  // Unfollow removes an existing follow relationship.
+  //
+  // Possible errors:
+  // - NOT_FOUND: The user was not following the specified artist.
+  rpc Unfollow(UnfollowRequest) returns (UnfollowResponse);
+
+  // ListFollowed retrieves the list of artists currently followed by the authenticated user.
+  // Each entry includes the user's hype preference for the artist.
+  //
+  // Possible errors:
+  // - UNAUTHENTICATED: The user identity could not be verified.
+  rpc ListFollowed(ListFollowedRequest) returns (ListFollowedResponse);
+
+  // SetHype updates the user's enthusiasm tier for a followed artist.
+  // The hype level controls push notification scope and dashboard rendering.
+  //
+  // Possible errors:
+  // - NOT_FOUND: The user is not following the specified artist.
+  // - INVALID_ARGUMENT: The hype value is invalid or unspecified.
+  rpc SetHype(SetHypeRequest) returns (SetHypeResponse);
+}
+
+// FollowRequest specifies the artist the current user wishes to follow.
+message FollowRequest {
+  // Required. The unique identifier of the artist to follow.
+  entity.v1.ArtistId artist_id = 1 [(buf.validate.field).required = true];
+}
+
+// FollowResponse is returned upon successfully establishing the follow relationship.
+message FollowResponse {}
+
+// UnfollowRequest specifies the artist the current user wishes to unfollow.
+message UnfollowRequest {
+  // Required. The unique identifier of the artist to unfollow.
+  entity.v1.ArtistId artist_id = 1 [(buf.validate.field).required = true];
+}
+
+// UnfollowResponse is returned upon successfully removing the follow relationship.
+message UnfollowResponse {}
+
+// ListFollowedRequest is the request for listing the current user's followed artists.
+message ListFollowedRequest {}
+
+// ListFollowedResponse contains the collection of artists followed by the user,
+// enriched with per-user hype metadata.
+message ListFollowedResponse {
+  // The collection of followed artists with their hype preferences.
+  repeated entity.v1.FollowedArtist artists = 1;
+}
+
+// SetHypeRequest provides the artist ID and the new hype level to set.
+message SetHypeRequest {
+  // Required. The unique identifier of the artist.
+  entity.v1.ArtistId artist_id = 1 [(buf.validate.field).required = true];
+
+  // Required. The new hype tier.
+  // HYPE_TYPE_NEARBY (3) is rejected — not user-selectable in Phase 1.
+  entity.v1.HypeType hype = 2 [
+    (buf.validate.field).required = true,
+    (buf.validate.field).enum = {
+      defined_only: true
+      not_in: [3]
+    }
+  ];
+}
+
+// SetHypeResponse is returned upon a successful hype level update.
+message SetHypeResponse {}


### PR DESCRIPTION
## Summary

Extract Follow-related proto definitions from the Artist domain into an independent Follow entity and service.

- **New** `entity/v1/follow.proto` — `HypeType` enum + `FollowedArtist` message (moved from `artist.proto`)
- **New** `rpc/follow/v1/follow_service.proto` — `FollowService` with `Follow`, `Unfollow`, `ListFollowed`, `SetHype` RPCs
- **Modified** `entity/v1/artist.proto` — `HypeType` removed
- **Modified** `rpc/artist/v1/artist_service.proto` — Follow RPCs and messages removed
- **Modified** `buf.yaml` — added `artist.proto` to breaking ignore list

## Motivation

Follow and Hype are user-personalization concerns, not intrinsic properties of the Artist entity. Separating them enables independent evolution of both domains.

## Breaking changes

- `HypeType` enum moved from `entity/v1/artist.proto` to `entity/v1/follow.proto`
- `FollowedArtist` message moved from `rpc/artist/v1/artist_service.proto` to `entity/v1/follow.proto`
- Follow/Unfollow/ListFollowed/SetHype RPCs moved from `ArtistService` to `FollowService`

Closes #185