### PR TITLE
refactor!(entity): rename HYPE_TYPE_ANYWHERE to HYPE_TYPE_AWAY

### DIFF
--- a/openspec/changes/archive/2026-03-11-rename-hype-anywhere-to-away/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-11-rename-hype-anywhere-to-away/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-11

--- a/openspec/changes/archive/2026-03-11-rename-hype-anywhere-to-away/design.md
+++ b/openspec/changes/archive/2026-03-11-rename-hype-anywhere-to-away/design.md
@@ -1,0 +1,66 @@
+## Context
+
+The hype tier system uses four values: `watch`, `home`, `nearby`, `anywhere`. The "Anywhere" tier was introduced in the `rename-passion-to-hype` change as a replacement for `must_go`. The term "Away" better communicates the user's willingness to travel away from home and creates a cleaner tier progression: Watch → Home → Nearby → Away.
+
+This rename touches all layers: proto enum, Go constants, database stored values, frontend enum references, and i18n labels. The wire format (proto enum number 4) is unchanged.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Rename `HYPE_TYPE_ANYWHERE` → `HYPE_TYPE_AWAY` in proto
+- Rename `HypeAnywhere` → `HypeAway` and `"anywhere"` → `"away"` in Go
+- Migrate database stored values from `'anywhere'` to `'away'`
+- Update frontend enum references and i18n keys
+- Update spec documents to use "Away" terminology
+
+**Non-Goals:**
+- Changing tier semantics or notification behavior
+- Modifying the proto enum numeric value (stays at 4)
+- Updating archive files (historical records remain as-is)
+
+## Decisions
+
+### 1. Database migration strategy: single UPDATE + constraint swap
+
+A new migration renames stored values in-place:
+
+```sql
+UPDATE followed_artists SET hype = 'away' WHERE hype = 'anywhere';
+ALTER TABLE followed_artists ALTER COLUMN hype SET DEFAULT 'away';
+-- Drop old CHECK, add new with 'away'
+```
+
+**Alternative**: Add `'away'` as an accepted value alongside `'anywhere'`, deprecate later.
+**Rationale**: Clean cut is simpler. The rename is atomic within a transaction. No dual-value ambiguity.
+
+### 2. Proto enum: rename value name, keep number
+
+```proto
+HYPE_TYPE_AWAY = 4;  // was HYPE_TYPE_ANYWHERE
+```
+
+Wire compatibility is preserved (number 4 unchanged). This is a breaking change in generated code names only.
+
+**Alternative**: Add `HYPE_TYPE_AWAY = 5` as a new value and deprecate `HYPE_TYPE_ANYWHERE`.
+**Rationale**: Adding a new numeric value creates mapping complexity and a permanent deprecated enum value. Since this ships as a coordinated release (specification → backend → frontend), a clean rename is preferable.
+
+### 3. Cross-repo deployment order
+
+Same pattern as the parent `refactor-follow-entity` change:
+
+```
+1. specification PR → merge → Release → BSR gen
+2. backend PR (includes DB migration + code rename)
+3. frontend PR (enum reference + i18n updates)
+```
+
+The backend migration must run before the new code deploys. Atlas Kubernetes Operator handles this via sync wave ordering.
+
+### 4. i18n key rename: `hype.anywhere` → `hype.away`
+
+Both the key and any labels/descriptions referencing "Anywhere" are updated. The Japanese label `遠征OK` remains unchanged since it already conveys the "Away" meaning.
+
+## Risks / Trade-offs
+
+- **Breaking proto change** → Coordinated release across 3 repos. Mitigated by the established release process (specification first, then downstream).
+- **Data migration on live table** → Single UPDATE statement on `followed_artists`. Low risk: the table is small and the update is indexed. Rollback: reverse migration (`'away'` → `'anywhere'`).

--- a/openspec/changes/archive/2026-03-11-rename-hype-anywhere-to-away/proposal.md
+++ b/openspec/changes/archive/2026-03-11-rename-hype-anywhere-to-away/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+The hype tier "Anywhere" is being renamed to "Away" for consistency and clarity. "Away" better conveys willingness to travel away from home, pairs naturally with the tier progression (Watch → Home → Nearby → Away), and aligns with the existing Japanese label `遠征OK`. This is a terminology rename across proto, backend, frontend, and specs.
+
+## What Changes
+
+- **BREAKING**: Rename proto enum value `HYPE_TYPE_ANYWHERE` to `HYPE_TYPE_AWAY` in `entity/v1/follow.proto`
+- Rename Go constant `HypeAnywhere` to `HypeAway` with value `"away"` in `entity/follow.go`
+- Update all backend references (mapper, usecase, tests) from `HypeAnywhere`/`"anywhere"` to `HypeAway`/`"away"`
+- Add database migration: update existing `'anywhere'` values to `'away'`, change DEFAULT and CHECK constraint
+- Update desired-state schema (`schema.sql`) to reflect `'away'`
+- Update frontend `HypeType.ANYWHERE` references to `HypeType.AWAY`
+- Update i18n keys from `hype.anywhere` to `hype.away` in EN and JA translation files
+- Update spec documents to use "Away" terminology
+
+## Capabilities
+
+### New Capabilities
+
+_(None — this is a terminology rename)_
+
+### Modified Capabilities
+
+- `passion-level`: Rename the highest hype tier from "Anywhere" to "Away" in tier definitions and default behavior
+
+## Impact
+
+- **Proto (specification)**: Breaking enum value rename in `entity/v1/follow.proto`; wire value (4) unchanged
+- **Backend**: 5 Go files + schema.sql updated; 1 new migration file
+- **Frontend**: 1 TypeScript file + 2 i18n JSON files updated
+- **Database**: Migration required to rename stored values, DEFAULT, and CHECK constraint
+- **Archive files**: Left untouched (historical records)

--- a/openspec/changes/archive/2026-03-11-rename-hype-anywhere-to-away/specs/passion-level/spec.md
+++ b/openspec/changes/archive/2026-03-11-rename-hype-anywhere-to-away/specs/passion-level/spec.md
@@ -1,0 +1,20 @@
+## MODIFIED Requirements
+
+### Requirement: Passion Level Tiers
+
+The system SHALL support four hype tiers for each followed artist:
+
+| Tier | Value | Meaning |
+|------|-------|---------|
+| Watch | `watch` | Dashboard view only, no push notifications |
+| Home | `home` | Push notifications for home area concerts only |
+| Nearby | `nearby` | Reserved for Phase 2 (physical proximity); not user-selectable |
+| Away | `away` | Push notifications for all concerts nationwide (default on follow) |
+
+The term "passion level" is renamed to "hype" throughout code, proto, and specs.
+
+#### Scenario: Default hype on follow
+
+- **GIVEN** a user follows a new artist
+- **WHEN** the follow relationship is created
+- **THEN** the hype SHALL default to Away

--- a/openspec/changes/archive/2026-03-11-rename-hype-anywhere-to-away/tasks.md
+++ b/openspec/changes/archive/2026-03-11-rename-hype-anywhere-to-away/tasks.md
@@ -1,0 +1,28 @@
+## 1. Specification (Proto + Specs)
+
+- [x] 1.1 Rename `HYPE_TYPE_ANYWHERE` to `HYPE_TYPE_AWAY` in `proto/liverty_music/entity/v1/follow.proto` (keep numeric value 4)
+- [x] 1.2 Update comment in `follow.proto` enum header from "ANYWHERE" to "AWAY"
+- [x] 1.3 Update `openspec/specs/passion-level/spec.md` tier table: "Anywhere" → "Away", `anywhere` → `away`
+
+## 2. Backend — Entity + Mapper
+
+- [x] 2.1 Rename `HypeAnywhere` to `HypeAway` with value `"away"` in `internal/entity/follow.go`
+- [x] 2.2 Update comment on the constant from "HypeAnywhere" to "HypeAway"
+- [x] 2.3 Update mapper in `internal/adapter/rpc/mapper/follow.go`: `HypeAnywhere`/`HYPE_TYPE_ANYWHERE` → `HypeAway`/`HYPE_TYPE_AWAY`
+
+## 3. Backend — UseCase + Tests
+
+- [x] 3.1 Update `internal/usecase/push_notification_uc.go`: rename `entity.HypeAnywhere` references and comments
+- [x] 3.2 Update `internal/usecase/push_notification_uc_test.go`: rename all `entity.HypeAnywhere` test data
+- [x] 3.3 Update `internal/usecase/follow_uc_test.go`: rename all `entity.HypeAnywhere` test data
+
+## 4. Backend — Database Schema + Migration
+
+- [x] 4.1 Update desired-state schema `internal/infrastructure/database/rdb/schema/schema.sql`: DEFAULT `'away'`, CHECK constraint with `'away'`, column comment
+- [x] 4.2 Create new migration file: `UPDATE followed_artists SET hype = 'away' WHERE hype = 'anywhere'`, alter DEFAULT, drop/recreate CHECK constraint, update column comment
+
+## 5. Frontend
+
+- [x] 5.1 Update `src/routes/my-artists/my-artists-page.ts`: `HypeType.ANYWHERE` → `HypeType.AWAY`, i18n key `hype.anywhere` → `hype.away`
+- [x] 5.2 Update `src/locales/en/translation.json`: rename `anywhere` keys to `away`, update label to "Away"
+- [x] 5.3 Update `src/locales/ja/translation.json`: rename `anywhere` keys to `away`

--- a/proto/liverty_music/entity/v1/follow.proto
+++ b/proto/liverty_music/entity/v1/follow.proto
@@ -9,7 +9,7 @@ option go_package = "github.com/liverty-music/specification/gen/go/liverty_music
 
 // HypeType represents the user's enthusiasm tier for a followed artist.
 // It controls push notification scope and dashboard rendering behavior.
-// Values are ordered by ascending enthusiasm: WATCH (lowest) to ANYWHERE (highest).
+// Values are ordered by ascending enthusiasm: WATCH (lowest) to AWAY (highest).
 enum HypeType {
   // Default value; must not be used in API requests.
   HYPE_TYPE_UNSPECIFIED = 0;
@@ -23,7 +23,7 @@ enum HypeType {
   HYPE_TYPE_NEARBY = 3;
   // Push notifications for all concerts nationwide. This is the default tier
   // assigned when a user first follows an artist. Die-hard fan level.
-  HYPE_TYPE_ANYWHERE = 4;
+  HYPE_TYPE_AWAY = 4;
 }
 
 // FollowedArtist represents an artist together with the fan's personal follow


### PR DESCRIPTION
## Related Issue

Closes #187

## Summary of Changes

- Rename `HYPE_TYPE_ANYWHERE` to `HYPE_TYPE_AWAY` in `follow.proto` enum (wire value 4 unchanged)
- Update enum header comment from "ANYWHERE" to "AWAY"
- Archive the OpenSpec change artifacts for this rename

The term "Away" better communicates that a fan is willing to travel for concerts, aligning with the home/away sports terminology already used by the other tiers.

## Self-Checklist

- [x] I have linked the related issue.
- [x] I have updated the relevant documentation if needed.
- [x] I have run `buf lint` and `buf format` locally and all checks have passed.
- [x] My proto definitions follow the project style guidelines and validation rules.
- [x] Breaking changes have been justified and documented if applicable.
