### PR TITLE
refactor!(proto): introduce Coordinates message and Proximity enum

### DIFF
--- a/openspec/changes/archive/2026-03-11-introduce-coordinates-vo/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-11-introduce-coordinates-vo/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-11

--- a/openspec/changes/archive/2026-03-11-introduce-coordinates-vo/design.md
+++ b/openspec/changes/archive/2026-03-11-introduce-coordinates-vo/design.md
@@ -1,0 +1,53 @@
+## Context
+
+Geographic coordinates currently exist as raw `optional double` fields in proto (`centroid_latitude`, `centroid_longitude` on `Home`) and flat struct fields in Go entities (`Latitude *float64`, `Longitude *float64` on `Venue`; `Latitude float64`, `Longitude float64` on `Home`). This is inconsistent with the project convention of wrapping every domain concept in a dedicated type. It also allows structurally invalid states — one coordinate present without the other.
+
+The `refactor-usecase-layer-boundaries` change recently introduced the centroid fields and renamed `Lat`/`Lng` to `Latitude`/`Longitude`, but did not address the missing VO abstraction.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Introduce a shared `Coordinates` VO usable by `Home` (centroid), `Venue` (location), and `VenuePlace` (search result)
+- Eliminate structurally invalid states (lat without lng)
+- Align proto and Go entity representations
+
+**Non-Goals:**
+- Adding `Coordinates` to `venue.proto` — proto venue fields are out of scope; the Venue proto currently has no coordinate fields and adding them is a separate concern
+- Database schema changes — DB columns remain flat (`centroid_latitude`, `centroid_longitude`, `latitude`, `longitude`); Repository layer handles mapping
+- Adding validation constraints to `Coordinates` — raw WGS 84 values including 0.0 are valid
+
+## Decisions
+
+### Decision 1: Single `Coordinates` message in `entity/v1/`
+
+Place `Coordinates` in a new file `entity/v1/coordinates.proto` alongside other entity types.
+
+**Alternative**: Define it inside `user.proto` as a nested message → rejected because `Venue` and other entities also need coordinates.
+
+### Decision 2: `Home.centroid` as `optional Coordinates`
+
+Replace `optional double centroid_latitude = 4` and `optional double centroid_longitude = 5` with `optional Coordinates centroid = 4`. Field number 4 reused; field 5 marked `reserved`.
+
+**Alternative**: Keep flat fields → rejected because it violates the type-safe wrapper convention and allows half-populated state.
+
+### Decision 3: Go entity `*Coordinates` for optional, value `Coordinates` for required
+
+- `Home.Centroid *Coordinates` — nil when centroid cannot be resolved (unsupported country)
+- `Venue.Coordinates *Coordinates` — nil until enrichment populates coordinates
+- `VenuePlace.Coordinates *Coordinates` — nil when external service returns no coordinates
+
+### Decision 4: Infrastructure `LatLng` struct renamed to `Coordinates`
+
+The `infrastructure/geo/centroid.go` already has a `LatLng` struct with `Latitude`/`Longitude` fields. Rename to `Coordinates` to match the entity type name, keeping the infrastructure struct separate (infra returns its own type, repository maps to entity).
+
+**Alternative**: Use `entity.Coordinates` directly in infrastructure → rejected because infrastructure should not import entity layer.
+
+### Decision 5: DB columns unchanged
+
+DB columns stay as `centroid_latitude`/`centroid_longitude` (homes) and `latitude`/`longitude` (venues). Repository layer maps between flat columns and `*entity.Coordinates`. No migration needed.
+
+## Risks / Trade-offs
+
+- **Breaking proto change** → Mitigated: branch is unreleased, `buf skip breaking` label on PR.
+- **Field number reuse in Home** → Field 4 changes type from `double` to `Coordinates` message. Safe because branch is unreleased and no data exists with the old schema.
+- **Increased indirection** → `home.Centroid.Latitude` vs `home.Latitude`. Acceptable trade-off for type safety and consistency.

--- a/openspec/changes/archive/2026-03-11-introduce-coordinates-vo/proposal.md
+++ b/openspec/changes/archive/2026-03-11-introduce-coordinates-vo/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+Geographic coordinates (latitude/longitude) appear as raw `double` fields in proto and flat struct fields in Go entities across `Home` and `Venue`. This violates the project's type-safe wrapper convention — every other domain concept uses a dedicated message/struct. The raw fields also allow structurally invalid states (e.g., latitude present but longitude absent).
+
+## What Changes
+
+- **Proto**: Introduce a `Coordinates` message in `entity/v1/` with `double latitude` and `double longitude` fields. Replace raw `optional double centroid_latitude`/`centroid_longitude` on `Home` with `optional Coordinates centroid`. **BREAKING**
+- **Go Entity**: Introduce `entity.Coordinates` struct. Replace `Home.Latitude`/`Home.Longitude` with `Home.Centroid *Coordinates`. Replace `Venue.Latitude`/`Venue.Longitude` and `VenuePlace.Latitude`/`VenuePlace.Longitude` with `*Coordinates` fields.
+- **Infrastructure**: Update repository mappers to convert between flat DB columns and `*Coordinates`.
+- **Spec docs**: Update `user-home`, `nearby-proximity`, and `venue-normalization` specs to reference `Coordinates` VO.
+
+## Capabilities
+
+### New Capabilities
+
+- `coordinates-vo`: Shared `Coordinates` value object for representing geographic latitude/longitude pairs across the domain model.
+
+### Modified Capabilities
+
+- `user-home`: `Home` proto message and Go entity use `Coordinates` instead of raw fields.
+- `nearby-proximity`: Proximity classification references `Home.Centroid` coordinates via `Coordinates` VO.
+- `venue-normalization`: Venue coordinate storage uses `Coordinates` VO in Go entity.
+
+## Impact
+
+- **Proto** (`entity/v1/user.proto`): Breaking field change on `Home` message — unreleased branch, `buf skip breaking` label required.
+- **Go Entity** (`entity/`): `Home`, `Venue`, `VenuePlace` struct field changes — all consumers must update.
+- **Infrastructure** (`database/rdb/`, `maps/google/`, `infrastructure/geo/`): Repository and mapper code updates for `*Coordinates` conversion.
+- **UseCase** (`usecase/`): `Concert.ProximityTo` and any code accessing `Home.Latitude`/`Longitude` must use `Centroid` field.
+- **Adapter** (`adapter/rpc/mapper/`): Proto-to-entity mapping for `Home.centroid` and `Venue` coordinates.
+- **Tests**: Entity and usecase tests referencing coordinate fields must update.

--- a/openspec/changes/archive/2026-03-11-introduce-coordinates-vo/specs/coordinates-vo/spec.md
+++ b/openspec/changes/archive/2026-03-11-introduce-coordinates-vo/specs/coordinates-vo/spec.md
@@ -1,0 +1,54 @@
+## ADDED Requirements
+
+### Requirement: Coordinates Value Object
+
+The system SHALL provide a `Coordinates` value object representing a WGS 84 geographic point (latitude/longitude pair). This type SHALL be used wherever geographic coordinates appear in the domain model, ensuring coordinates always travel as an atomic pair.
+
+#### Scenario: Proto Coordinates message
+
+- **WHEN** the `Coordinates` proto message is defined in `entity/v1/`
+- **THEN** it SHALL contain a `double latitude` field
+- **AND** a `double longitude` field
+- **AND** no validation constraints (raw WGS 84 values, including 0.0, are valid)
+
+#### Scenario: Go entity Coordinates struct
+
+- **WHEN** the Go `entity.Coordinates` struct is defined
+- **THEN** it SHALL contain `Latitude float64` and `Longitude float64` fields
+- **AND** the struct SHALL be used as `*Coordinates` (pointer) when the coordinates are optional (e.g., unenriched venues, unsupported countries)
+
+#### Scenario: Coordinates used by Home centroid
+
+- **WHEN** the `Home` proto message references centroid coordinates
+- **THEN** it SHALL use `optional Coordinates centroid` instead of separate `optional double` fields
+- **AND** the Go `entity.Home` struct SHALL use `Centroid *Coordinates`
+
+#### Scenario: Coordinates used by Venue location
+
+- **WHEN** the Go `entity.Venue` struct references geographic coordinates
+- **THEN** it SHALL use `Coordinates *Coordinates` instead of separate `*float64` fields
+- **AND** the `entity.VenuePlace` struct SHALL likewise use `Coordinates *Coordinates`
+
+#### Scenario: Coordinates round-trip through venue repository
+
+- **WHEN** `VenueRepository.UpdateEnriched` is called with a venue that has non-nil `Coordinates`
+- **THEN** the coordinates SHALL be persisted as `latitude` and `longitude` columns
+- **AND** a subsequent `VenueRepository.Get` SHALL return the venue with `Coordinates` populated with the same values
+- **WHEN** `VenueRepository.UpdateEnriched` is called with a venue that has nil `Coordinates`
+- **THEN** the `latitude` and `longitude` columns SHALL be set to NULL
+- **AND** a subsequent `VenueRepository.Get` SHALL return the venue with nil `Coordinates`
+
+#### Scenario: Coordinates mapping in concert listing
+
+- **WHEN** `ConcertRepository.ListByFollower` returns concerts with associated venues
+- **AND** the venue has both `latitude` and `longitude` columns populated in the database
+- **THEN** the returned `Venue.Coordinates` SHALL be non-nil with the correct latitude and longitude values
+- **WHEN** either or both coordinate columns are NULL in the database
+- **THEN** the returned `Venue.Coordinates` SHALL be nil
+
+#### Scenario: PlaceSearcher adapters map external coordinates to entity.Coordinates
+
+- **WHEN** a PlaceSearcher adapter (MusicBrainz or Google Maps) receives a response with both latitude and longitude present
+- **THEN** the returned `VenuePlace.Coordinates` SHALL be non-nil with the mapped values
+- **WHEN** a PlaceSearcher adapter receives a response with either or both coordinates absent
+- **THEN** the returned `VenuePlace.Coordinates` SHALL be nil

--- a/openspec/changes/archive/2026-03-11-introduce-coordinates-vo/specs/nearby-proximity/spec.md
+++ b/openspec/changes/archive/2026-03-11-introduce-coordinates-vo/specs/nearby-proximity/spec.md
@@ -1,10 +1,4 @@
-# nearby-proximity Specification
-
-## Purpose
-
-The `nearby-proximity` capability defines the geographic proximity classification model used to categorize concert venues relative to a user's home area. It provides the Haversine-based distance calculation, home area centroid lookup, and venue coordinate storage required by the dashboard lane classification system.
-
-## Requirements
+## MODIFIED Requirements
 
 ### Requirement: Proximity Classification Model
 
@@ -83,27 +77,3 @@ The infrastructure centroid resolution logic SHALL be independently testable and
 - **WHEN** `ResolveCentroid` is called with an unsupported ISO 3166-2 code (e.g., `US-NY`)
 - **THEN** it SHALL return `ok = false`
 - **AND** the caller SHALL treat the coordinates as absent
-
-### Requirement: Haversine Distance Calculation
-
-The system SHALL compute great-circle distance between two geographic points using the Haversine formula.
-
-#### Scenario: Distance calculation accuracy
-
-- **WHEN** the system calculates distance between Tokyo centroid (35.6895, 139.6917) and a venue at Saitama Super Arena (35.8950, 139.6314)
-- **THEN** the result SHALL be approximately 23km (within 1km tolerance)
-
-### Requirement: Venue Coordinate Storage
-
-The system SHALL store latitude and longitude for venue records in the database, populated during the venue enrichment pipeline.
-
-#### Scenario: Coordinates populated after enrichment
-
-- **WHEN** a venue is successfully enriched via MusicBrainz or Google Places
-- **AND** the external service response includes coordinates
-- **THEN** the venue record SHALL be updated with latitude and longitude values
-
-#### Scenario: Coordinates absent for unenriched venues
-
-- **WHEN** a venue has `enrichment_status` of `pending` or `failed`
-- **THEN** the venue's latitude and longitude SHALL be NULL

--- a/openspec/changes/archive/2026-03-11-introduce-coordinates-vo/specs/user-home/spec.md
+++ b/openspec/changes/archive/2026-03-11-introduce-coordinates-vo/specs/user-home/spec.md
@@ -1,0 +1,54 @@
+## MODIFIED Requirements
+
+### Requirement: User Home Area Data Model
+
+The system SHALL support a structured `home` field on the User entity representing the user's home area — the geographic area where the user regularly attends live events without considering it a "trip" (遠征). The value is a structured geographic location expressed through a hierarchy of internationally standardized codes, with centroid coordinates for proximity calculations.
+
+#### Scenario: Home message in Proto definition
+
+- **WHEN** the `Home` proto message is defined
+- **THEN** it SHALL contain a `string country_code` field validated as ISO 3166-1 alpha-2 (exactly two uppercase Latin letters, e.g., `JP`, `US`)
+- **AND** a `string level_1` field validated as ISO 3166-2 format (4–6 characters, e.g., `JP-13`, `US-NY`)
+- **AND** an `optional string level_2` field for finer-grained subdivision (1–20 characters when present)
+- **AND** an `optional Coordinates centroid` field for the geographic centroid of the home area
+
+#### Scenario: Home field in database
+
+- **WHEN** the `homes` table is defined
+- **THEN** it SHALL include a primary key `id TEXT`
+- **AND** a required `country_code TEXT` column storing an ISO 3166-1 alpha-2 code
+- **AND** a required `level_1 TEXT` column storing an ISO 3166-2 subdivision code
+- **AND** a nullable `level_2 TEXT` column storing a country-specific finer area code
+- **AND** a nullable `centroid_latitude DOUBLE PRECISION` column for the centroid latitude
+- **AND** a nullable `centroid_longitude DOUBLE PRECISION` column for the centroid longitude
+
+#### Scenario: Home field in Go entity
+
+- **WHEN** the Go `entity.Home` struct is defined
+- **THEN** it SHALL include `ID string`, `CountryCode string`, `Level1 string`, `Level2 *string`, and `Centroid *Coordinates` fields
+- **AND** the `entity.User` struct SHALL include a `Home *Home` field
+- **AND** a nil `Home` SHALL mean the user has not set their home area
+
+#### Scenario: Centroid populated at write time
+
+- **WHEN** `UserRepository.Create` or `UserRepository.UpdateHome` is called with a `Home` value
+- **THEN** the repository implementation SHALL resolve the `Level1` ISO 3166-2 code to centroid coordinates
+- **AND** store the resolved centroid as `centroid_latitude` and `centroid_longitude` alongside the other home fields
+- **AND** the centroid resolution logic SHALL be an infrastructure implementation detail (not visible to usecase/entity layers)
+
+#### Scenario: Centroid round-trip through user repository
+
+- **WHEN** a user is created or their home is updated with a supported country code (e.g., `JP-13`)
+- **AND** the centroid is successfully resolved
+- **THEN** a subsequent `UserRepository.Get`, `GetByExternalID`, or `GetByEmail` SHALL return the user with `Home.Centroid` populated with the resolved latitude and longitude
+- **WHEN** a user's home is set with an unsupported country code
+- **THEN** a subsequent retrieval SHALL return the user with `Home.Centroid` as nil
+
+#### Scenario: Code system contract for level_2
+
+- **WHEN** `level_2` is populated
+- **THEN** its code system SHALL be determined by `country_code`:
+  - `JP` → future use (not yet defined; Phase 1 always omits level_2)
+  - `US` → FIPS county code (e.g., `06037` for Los Angeles County)
+  - `DE` → AGS code (e.g., `09162` for Munich)
+- **AND** additional country mappings SHALL be documented in the `Home` proto message comment as they are introduced

--- a/openspec/changes/archive/2026-03-11-introduce-coordinates-vo/specs/venue-normalization/spec.md
+++ b/openspec/changes/archive/2026-03-11-introduce-coordinates-vo/specs/venue-normalization/spec.md
@@ -1,0 +1,52 @@
+## MODIFIED Requirements
+
+### Requirement: Venue Enrichment Pipeline
+
+The system SHALL provide an async enrichment pipeline that resolves raw venue names to canonical external identifiers (MusicBrainz MBID or Google Maps place_id) and updates venue records with canonical names and geographic coordinates.
+
+#### Scenario: Successful enrichment via MusicBrainz
+
+- **WHEN** the enrichment job processes a venue with `enrichment_status = 'pending'`
+- **AND** MusicBrainz place search returns a match
+- **THEN** the venue record SHALL be updated with the MusicBrainz MBID
+- **AND** `venues.raw_name` SHALL be set to the current `venues.name` (if `raw_name` is NULL) to preserve the original scraper-provided name
+- **AND** `venues.name` SHALL be overwritten with the canonical name from MusicBrainz
+- **AND** `enrichment_status` SHALL be set to `'enriched'`
+- **AND** the venue's `Coordinates` SHALL be set to the value returned by the PlaceSearcher (non-nil when the response includes coordinates, nil otherwise)
+
+#### Scenario: Successful enrichment via Google Maps fallback
+
+- **WHEN** the enrichment job processes a venue with `enrichment_status = 'pending'`
+- **AND** MusicBrainz place search returns no match
+- **AND** Google Maps Text Search returns a match
+- **THEN** the venue record SHALL be updated with the Google Maps place_id
+- **AND** `venues.raw_name` SHALL be set to the current `venues.name` (if `raw_name` is NULL) to preserve the original scraper-provided name
+- **AND** `venues.name` SHALL be overwritten with the canonical name from Google Maps
+- **AND** `enrichment_status` SHALL be set to `'enriched'`
+- **AND** the venue's `Coordinates` SHALL be updated from the Google Maps geometry response
+
+#### Scenario: Both sources miss
+
+- **WHEN** the enrichment job processes a venue with `enrichment_status = 'pending'`
+- **AND** MusicBrainz returns no match
+- **AND** Google Maps returns no match
+- **THEN** `enrichment_status` SHALL be set to `'failed'`
+- **AND** `venues.name` SHALL remain unchanged
+- **AND** the venue's `Coordinates` SHALL remain nil
+- **AND** the venue SHALL NOT be retried in subsequent job runs
+
+#### Scenario: Ambiguous results (multiple matches)
+
+- **WHEN** the enrichment job processes a venue with `enrichment_status = 'pending'`
+- **AND** MusicBrainz or Google Maps returns more than one candidate match
+- **THEN** the venue SHALL NOT be updated with any external identifier
+- **AND** `venues.name` SHALL remain unchanged
+- **AND** `enrichment_status` SHALL be set to `'failed'`
+- **AND** the ambiguity SHALL be logged for future manual review
+
+#### Scenario: admin_area used as search hint
+
+- **WHEN** the enrichment job queries MusicBrainz or Google Maps for a venue
+- **AND** the venue has a non-NULL `admin_area` (ISO 3166-2 code)
+- **THEN** the system SHALL convert the ISO 3166-2 code to a locale-appropriate text name before including it in the search query
+- **AND** the text name SHALL be in the language most likely to yield accurate results for the target service (e.g., Japanese for MusicBrainz JP venues, English for Google Maps)

--- a/openspec/changes/archive/2026-03-11-introduce-coordinates-vo/tasks.md
+++ b/openspec/changes/archive/2026-03-11-introduce-coordinates-vo/tasks.md
@@ -1,0 +1,50 @@
+## 1. Proto Schema (specification repo)
+
+- [x] 1.1 Create `entity/v1/coordinates.proto` with `Coordinates` message (`double latitude`, `double longitude`)
+- [x] 1.2 Replace `optional double centroid_latitude` (field 4) and `optional double centroid_longitude` (field 5) on `Home` with `optional Coordinates centroid = 4`, reserve field 5
+- [x] 1.3 Update `Home` message comments to reference `Coordinates centroid`
+- [x] 1.4 Run `buf lint` and `buf format -w`, verify breaking changes are expected
+
+## 2. Go Entity Layer (backend repo)
+
+- [x] 2.1 Create `entity.Coordinates` struct with `Latitude float64` and `Longitude float64`
+- [x] 2.2 Replace `Home.Latitude float64` and `Home.Longitude float64` with `Centroid *Coordinates`
+- [x] 2.3 Replace `Venue.Latitude *float64` and `Venue.Longitude *float64` with `Coordinates *Coordinates`
+- [x] 2.4 Replace `VenuePlace.Latitude *float64` and `VenuePlace.Longitude *float64` with `Coordinates *Coordinates`
+- [x] 2.5 Update `Concert.ProximityTo` to use `home.Centroid` and `venue.Coordinates`
+- [x] 2.6 Update `Concert.ProximityTo` unit tests
+
+## 3. Infrastructure Layer (backend repo)
+
+- [x] 3.1 Rename `infrastructure/geo.LatLng` struct to `Coordinates`
+- [x] 3.2 Update `user_repo.go` to map between DB columns and `*entity.Coordinates` for Home centroid
+- [x] 3.3 Update `venue_repo.go` to map between DB columns and `*entity.Coordinates` for Venue coordinates
+- [x] 3.4 Update `concert_repo.go` to map between DB columns and `*entity.Coordinates` for Venue coordinates
+- [x] 3.5 Update MusicBrainz `place_searcher.go` to return `*entity.Coordinates` in `VenuePlace`
+- [x] 3.6 Update Google Maps `place_searcher.go` to return `*entity.Coordinates` in `VenuePlace`
+
+## 4. UseCase Layer (backend repo)
+
+- [x] 4.1 Update `venue_enrichment_uc.go` to use `Venue.Coordinates` and `VenuePlace.Coordinates`
+
+## 5. Adapter Layer (backend repo)
+
+- [x] 5.1 Update RPC mapper for `Home.centroid` proto-to-entity conversion
+
+## 6. Tests and Verification (backend repo)
+
+- [x] 6.1 Update infrastructure tests (`client_test.go`, `venue_repo` tests) for `*Coordinates`
+- [x] 6.2 Update usecase tests referencing venue/home coordinate fields
+- [x] 6.3 Run `go build ./...` to verify compilation
+- [x] 6.4 Run `go test ./...` to verify all tests pass
+
+## 7. New Coordinates Test Coverage (backend repo)
+
+- [x] 7.1 Add `geo/centroid_test.go`: test `ResolveCentroid` for known JP code (returns coords, ok=true) and unsupported code (ok=false)
+- [x] 7.2 Add `venue_repo_test.go` test: `UpdateEnriched` with non-nil Coordinates → `Get` returns same coords; with nil Coordinates → `Get` returns nil coords
+- [x] 7.3 Add `user_repo_test.go` test: Create/UpdateHome with supported JP code → `Get` returns non-nil `Home.Centroid`; unsupported code → nil `Centroid`
+- [x] 7.4 Add `concert_repo_test.go` assertion: `ListByFollower` result includes `Venue.Coordinates` when DB has lat/lng, nil when DB has NULLs
+- [x] 7.5 Add `maps/google/place_searcher_test.go`: test `SearchPlace` returns non-nil Coordinates when response has lat/lng, nil when absent
+- [x] 7.6 Add `music/musicbrainz/place_searcher_test.go`: test `SearchPlace` returns non-nil Coordinates when response has lat/lng, nil when absent
+- [x] 7.7 Add `venue_enrichment_uc_test.go` assertion: verify `UpdateEnriched` is called with correct `Coordinates` value from PlaceSearcher response
+- [x] 7.8 Run `go test ./...` to verify all new tests pass

--- a/openspec/changes/refactor-usecase-layer-boundaries/.openspec.yaml
+++ b/openspec/changes/refactor-usecase-layer-boundaries/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-11

--- a/openspec/changes/refactor-usecase-layer-boundaries/design.md
+++ b/openspec/changes/refactor-usecase-layer-boundaries/design.md
@@ -1,0 +1,144 @@
+## Context
+
+The backend follows Clean Architecture with four layers: Entity, UseCase, Adapter, Infrastructure. Over time, several usecase files have accumulated direct imports from `internal/infrastructure/` and `internal/geo/`, violating the dependency rule (inner layers must not depend on outer layers). The most impactful violation is `push_notification_uc.go` calling `webpush.SendNotification` directly, making notification delivery untestable.
+
+A misplaced `internal/geo` package contains both business rules (lane classification) and infrastructure concerns (hardcoded centroid data, display name tables). The classification logic itself is a domain concept that belongs on the `Concert` entity, while the data tables belong in infrastructure.
+
+This change is cross-repo: proto schema changes in specification must be released before backend can consume the new generated types.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Eliminate all `internal/infrastructure/*` and `internal/geo` imports from usecase layer
+- Make every usecase method testable with mocks alone (no real HTTP, no real webpush)
+- Establish `Proximity` as the canonical domain concept replacing UI-oriented "Lane"
+- Move `Home` centroid resolution to write-time, eliminating runtime data lookups in business logic
+
+**Non-Goals:**
+- HypeType ANYWHERE → AWAY rename (separate change)
+- Adding non-Japanese centroid data (Phase 2)
+- Changing the event-driven architecture (Watermill `message.Publisher` stays as-is)
+- Refactoring `message.Publisher` — it is already an abstract interface
+
+## Decisions
+
+### 1. `Proximity` as proto enum + `Concert.ProximityTo()` as entity receiver
+
+**Decision**: Define `Proximity` enum in `entity/v1/proximity.proto`. Implement classification as `func (c *Concert) ProximityTo(home *Home) Proximity` in Go entity layer.
+
+**Why**: The classification is a domain concept (how close is this concert to the user?). Making it a `Concert` receiver encapsulates nil-guard logic for both `home` and `venue`, and reads naturally: `c.ProximityTo(user.Home)`.
+
+**Alternative considered**: Package-level function `ClassifyProximity(home, venue)` — rejected because it forces nil checks at every call site.
+
+### 2. Centroid on `Home` entity (write-time resolution)
+
+**Decision**: Add `centroid_latitude DOUBLE PRECISION` and `centroid_longitude DOUBLE PRECISION` to the `homes` table. Populate at write time in `UserRepository.Create` / `UpdateHome`. The `Home` entity gains `Latitude float64` and `Longitude float64` fields.
+
+**Why**: This eliminates the need for a `GeoDataProvider` interface at read time. `Concert.ProximityTo()` becomes a pure function over entity fields — no interface injection, no data lookups.
+
+**Centroid resolution strategy**: The repository layer uses an internal centroid table (same data as current `geo.prefectureCentroids`) to resolve `level_1` → `(latitude, longitude)` during write. This is an infrastructure implementation detail invisible to usecase/entity layers.
+
+**Backfill**: A DB migration backfills existing `homes` rows using the same centroid lookup.
+
+### 3. `ProximityGroup` replaces `DateLaneGroup`
+
+**Decision**: Rename `DateLaneGroup` to `ProximityGroup` in `concert_service.proto`. Rename field `away` to `distant`.
+
+**Why**: "Lane" is a UI presentation concept. "Proximity" is the domain concept. The field rename `away` → `distant` aligns with the `PROXIMITY_AWAY` enum value while being semantically accurate for the "beyond threshold" case.
+
+**Breaking change handling**: This is a breaking proto change. The specification PR will use the `buf skip breaking` label.
+
+### 4. `PushNotificationSender` interface
+
+**Decision**: Define in entity layer:
+
+```go
+type PushNotificationSender interface {
+    Send(ctx context.Context, payload []byte, sub *PushSubscription) error
+}
+```
+
+Infrastructure implements this using `webpush-go` with VAPID credentials and `http.Client`. The sender returns `apperr` errors: `apperr.ErrNotFound` for 410 Gone (subscription expired), `codes.Internal` for delivery failures. This keeps HTTP status code semantics in infrastructure while the usecase handles domain-level error classification (e.g., delete stale subscription on NotFound).
+
+**Why**: The usecase currently holds `vapidPublicKey`, `vapidPrivate`, `vapidContact`, and `*http.Client` — all infrastructure concerns. Extracting a sender interface moves all of this to infrastructure while keeping the business logic (410 Gone cleanup, per-subscription error handling) in usecase where it belongs.
+
+### 5. Event data types to entity layer
+
+**Decision**: Move `messaging.ConcertDiscoveredData`, `messaging.ScrapedConcertData`, `messaging.ConcertCreatedData`, `messaging.VenueCreatedData`, and `messaging.ArtistCreatedData` from `infrastructure/messaging` to `entity/` as pure data structs.
+
+Move event subject constants (`SubjectConcertDiscovered`, etc.) alongside them.
+
+Keep `messaging.NewEvent()` factory in infrastructure (it creates Watermill `message.Message`).
+
+**Why**: `ConcertCreationUseCase.CreateFromDiscovered(ctx, data messaging.ConcertDiscoveredData)` has an infrastructure type in its public interface. The data structs are just DTOs with no infrastructure dependency — they belong in entity.
+
+### 6. `MerkleTreeBuilder` interface
+
+**Decision**: Define in entity layer:
+
+```go
+type MerkleTreeBuilder interface {
+    IdentityCommitment(userID []byte) ([]byte, error)
+    Build(eventID string, leaves [][]byte) (nodes []MerkleNode, root []byte, err error)
+}
+```
+
+`entry_uc.go` calls this interface instead of `merkle.IdentityCommitment()` and `merkle.NewBuilder()`.
+
+**Why**: Poseidon hash implementation is an infrastructure concern. The usecase should only know "compute commitment" and "build tree", not which hash function is used.
+
+### 7. `AdminAreaResolver` interface
+
+**Decision**: Define in entity layer:
+
+```go
+type AdminAreaResolver interface {
+    DisplayName(code, lang string) string
+}
+```
+
+`venue_enrichment_uc.go` uses this instead of `geo.DisplayName()`.
+
+`NormalizeAdminArea` stays in infrastructure — it's only called from `infrastructure/gcp/gemini/searcher.go`.
+
+### 8. `Cache` interface for artist usecase
+
+**Decision**: Define in entity layer or usecase layer:
+
+```go
+type Cache interface {
+    Get(key string) any
+    Set(key string, value any)
+}
+```
+
+Replace `*cache.MemoryCache` concrete type in `artistUseCase` struct.
+
+### 9. `Haversine` to `pkg/geo`
+
+**Decision**: Move `Haversine` function to `pkg/geo/haversine.go`. It's a pure math function with no external dependencies — `pkg/` is the correct home for cross-layer utilities.
+
+### 10. Dissolve `internal/geo`
+
+**Decision**: After all functions are relocated, delete the `internal/geo` package entirely.
+
+Destination for each function:
+| Function | Destination |
+|---|---|
+| `ClassifyLane` | entity `Concert.ProximityTo()` |
+| `Lane` type + constants | entity `Proximity` type |
+| `NearbyThresholdKm` | entity constant |
+| `Haversine` | `pkg/geo` |
+| `PrefectureCentroid` | infrastructure (internal to repo, used at write-time) |
+| `DisplayName` | infrastructure (behind `AdminAreaResolver` interface) |
+| `NormalizeAdminArea` | infrastructure (already only used there) |
+
+## Risks / Trade-offs
+
+**[Risk] Backfill migration for centroid columns** → Centroid data is static and well-known (47 Japanese prefectures). Migration uses a VALUES list to UPDATE existing rows. Reversible with a simple `ALTER TABLE DROP COLUMN`.
+
+**[Risk] Breaking proto change (DateLaneGroup → ProximityGroup)** → Frontend and backend must be updated together after BSR gen. Use `buf skip breaking` label on specification PR. Frontend impact is limited to type imports and field names in the concert list view.
+
+**[Risk] Many interfaces extracted at once** → Each interface is small (1-3 methods) and has a single implementation. The risk of over-abstraction is low because every extraction is motivated by a concrete testability problem. Each can be implemented and tested independently.
+
+**[Trade-off] Event data types in entity layer** → These DTOs are not "core business entities" in the purest sense, but they appear in usecase public interfaces. Placing them in entity is pragmatic — the alternative (a separate `usecase/dto` package) adds a layer without clear benefit.

--- a/openspec/changes/refactor-usecase-layer-boundaries/proposal.md
+++ b/openspec/changes/refactor-usecase-layer-boundaries/proposal.md
@@ -1,0 +1,40 @@
+## Why
+
+The backend usecase layer has accumulated direct dependencies on infrastructure packages (`webpush-go`, `infrastructure/messaging`, `infrastructure/merkle`) and a misplaced concrete implementation package (`internal/geo`). This makes pure business logic untestable in isolation and violates Clean Architecture's dependency rule. The most critical case is `push_notification_uc.go`, where `webpush.SendNotification` is called directly — making the notification delivery path completely untestable.
+
+## What Changes
+
+- **Define `Proximity` enum in proto** as the canonical domain concept for the geographic relationship between a user's home and a concert venue, replacing the UI-oriented "Lane" terminology.
+- **BREAKING**: Rename `DateLaneGroup` to `ProximityGroup` in `concert_service.proto`, and rename its `away` field to `distant`.
+- **Add centroid fields to `Home`** (proto message and DB schema) so that proximity classification becomes a pure entity function with no infrastructure dependency.
+- **Move `ClassifyLane` logic to `Concert.ProximityTo(home)` receiver method** on the entity layer, replacing all `geo.ClassifyLane` calls in usecase.
+- **Dissolve `internal/geo` package**: move `Haversine` to `pkg/geo`, move data tables (centroids, display names, normalization) to infrastructure, remove the package.
+- **Extract `PushNotificationSender` interface** in entity layer, move `webpush` library usage to infrastructure, making `NotifyNewConcerts` fully testable.
+- **Move `messaging` event types to entity layer** where they appear in usecase public interfaces (specifically `ConcertDiscoveredData` in `ConcertCreationUseCase`).
+- **Extract `MerkleTreeBuilder` interface** in entity layer, move `infrastructure/merkle` direct calls out of `entry_uc.go`.
+- **Replace `*cache.MemoryCache` concrete type** in `artistUseCase` with a `Cache` interface.
+- **Move `AdminAreaResolver` behind an interface** for `DisplayName` used by `venue_enrichment_uc`.
+
+## Capabilities
+
+### New Capabilities
+
+- `proximity-model`: Defines the `Proximity` enum in proto, `ProximityGroup` message, and the `Concert.ProximityTo()` entity method — the domain model for geographic closeness classification.
+
+### Modified Capabilities
+
+- `nearby-proximity`: Requirements change from "system SHALL maintain a centroid lookup" to "Home entity SHALL carry centroid coordinates populated at write time". `ClassifyLane` moves from a standalone function to a `Concert` receiver method.
+- `user-home`: Home data model gains centroid fields (`centroid_latitude`, `centroid_longitude`) in both proto and DB schema. Centroid resolution happens at write time in the repository layer.
+- `concert-service`: `DateLaneGroup` renamed to `ProximityGroup` with field rename `away` → `distant`. Response uses `Proximity` enum terminology.
+
+## Impact
+
+- **specification**: New `Proximity` enum, `Home` message change, `ProximityGroup` rename (breaking proto change).
+- **backend/entity**: New `Proximity` type, `Concert.ProximityTo()` method, `Home` struct gains `Latitude`/`Longitude`, new interfaces (`PushNotificationSender`, `MerkleTreeBuilder`, `AdminAreaResolver`, `Cache`).
+- **backend/usecase**: Remove all `infrastructure/*` and `internal/geo` imports. `ConcertCreationUseCase.CreateFromDiscovered` signature changes to use entity-layer types.
+- **backend/infrastructure**: New implementations for extracted interfaces. Centroid resolution at `UpdateHome`/`Create` time. `webpush` adapter. `internal/geo` dissolved.
+- **backend/pkg/geo**: New package with `Haversine` function.
+- **backend/adapter**: Mapper updates for `ProximityGroup` rename.
+- **frontend**: Adapt to `ProximityGroup` rename and `Proximity` enum (generated types change).
+- **DB migration**: Add `centroid_latitude`/`centroid_longitude` columns to `homes` table, backfill existing rows.
+- **backend/tests**: Add usecase tests exercising extracted interfaces (sender error paths, builder error paths, repository error propagation).

--- a/openspec/changes/refactor-usecase-layer-boundaries/specs/concert-service/spec.md
+++ b/openspec/changes/refactor-usecase-layer-boundaries/specs/concert-service/spec.md
@@ -1,0 +1,39 @@
+## RENAMED Requirements
+
+### Requirement: DateLaneGroup → ProximityGroup
+
+- **FROM**: `DateLaneGroup` message in `concert_service.proto`
+- **TO**: `ProximityGroup` message in `concert_service.proto`
+
+## MODIFIED Requirements
+
+### Requirement: List Concerts by Follower
+
+The system SHALL provide an RPC to retrieve all concerts for artists followed by the authenticated user, grouped by date and classified by proximity.
+
+#### Scenario: Authenticated user with followed artists
+
+- **WHEN** `ListByFollower` is called by an authenticated user who follows one or more artists
+- **THEN** it SHALL return concerts grouped by date using `ProximityGroup` messages
+- **AND** each `ProximityGroup` SHALL contain concerts classified into `home`, `nearby`, and `distant` fields based on `Concert.ProximityTo(user.Home)`
+- **AND** each concert SHALL include a resolved `Venue` object with `name` and `admin_area` if available
+- **AND** each concert SHALL include `listed_venue_name` with the raw scraped venue name
+- **AND** groups SHALL be ordered by date ascending
+
+#### Scenario: Authenticated user with no followed artists
+
+- **WHEN** `ListByFollower` is called by an authenticated user who follows no artists
+- **THEN** it SHALL return an empty list without error
+
+#### Scenario: Unauthenticated caller
+
+- **WHEN** `ListByFollower` is called without valid authentication
+- **THEN** it SHALL return an `UNAUTHENTICATED` error
+
+#### Scenario: ProximityGroup field structure
+
+- **WHEN** a `ProximityGroup` message is defined in proto
+- **THEN** it SHALL contain a required `date` field of type `entity.v1.LocalDate`
+- **AND** a `repeated entity.v1.Concert home` field for home-proximity concerts
+- **AND** a `repeated entity.v1.Concert nearby` field for nearby-proximity concerts
+- **AND** a `repeated entity.v1.Concert distant` field for away-proximity concerts

--- a/openspec/changes/refactor-usecase-layer-boundaries/specs/nearby-proximity/spec.md
+++ b/openspec/changes/refactor-usecase-layer-boundaries/specs/nearby-proximity/spec.md
@@ -1,0 +1,73 @@
+## MODIFIED Requirements
+
+### Requirement: Proximity Classification Model
+
+The system SHALL classify the geographic relationship between a user's home area and a concert venue into one of three proximity levels: HOME, NEARBY, or AWAY. Classification SHALL be performed by the `Concert.ProximityTo(home)` entity method using centroid coordinates stored on the `Home` entity.
+
+#### Scenario: HOME classification by admin_area match
+
+- **WHEN** the venue's `admin_area` matches the user's `home.Level1` (ISO 3166-2 code equality)
+- **THEN** the venue SHALL be classified as HOME
+
+#### Scenario: NEARBY classification by Haversine distance
+
+- **WHEN** the venue's `admin_area` does not match the user's `home.Level1`
+- **AND** the venue has latitude and longitude coordinates
+- **AND** the Haversine distance between the home centroid (`home.Latitude`, `home.Longitude`) and the venue coordinates is less than or equal to 200km
+- **THEN** the venue SHALL be classified as NEARBY
+
+#### Scenario: AWAY classification for distant venues
+
+- **WHEN** the venue has latitude and longitude coordinates
+- **AND** the venue's `admin_area` does **not** match the user's `home.Level1`
+- **AND** the Haversine distance between the home centroid and the venue coordinates exceeds 200km
+- **THEN** the venue SHALL be classified as AWAY
+
+#### Scenario: AWAY classification for venues without coordinates
+
+- **WHEN** the venue does not have latitude or longitude coordinates
+- **AND** the venue's `admin_area` does not match the user's `home.Level1`
+- **THEN** the venue SHALL be classified as AWAY
+
+#### Scenario: AWAY classification when user has no home
+
+- **WHEN** the user has not set a home area (home is nil)
+- **THEN** all venues SHALL be classified as AWAY
+
+### Requirement: Home Area Centroid Lookup
+
+The system SHALL resolve geographic centroid coordinates for the user's home area at write time (when `UpdateHome` or `Create` is called) and store them on the `homes` table. The centroid lookup is an infrastructure implementation detail — the entity and usecase layers access centroids via `Home.Latitude` and `Home.Longitude` fields.
+
+#### Scenario: Centroid resolved at home write time
+
+- **WHEN** a user sets or updates their home area via `UpdateHome` or `Create`
+- **THEN** the repository layer SHALL resolve the `level_1` ISO 3166-2 code to centroid coordinates
+- **AND** store the centroid as `centroid_latitude` and `centroid_longitude` on the `homes` table row
+
+#### Scenario: Japanese prefecture centroid resolution
+
+- **WHEN** a home area is set with a Japanese ISO 3166-2 code (e.g., `JP-13`)
+- **THEN** the repository SHALL resolve it to the prefecture's approximate geographic centroid
+
+#### Scenario: Unsupported country code centroid
+
+- **WHEN** a home area is set with an unsupported country's ISO 3166-2 code
+- **THEN** the centroid columns SHALL be set to NULL
+- **AND** `Concert.ProximityTo()` SHALL treat missing centroids as AWAY (no NEARBY classification possible)
+
+#### Scenario: Existing rows backfilled
+
+- **WHEN** the centroid columns migration is applied
+- **THEN** all existing `homes` rows with Japanese ISO 3166-2 codes SHALL be backfilled with centroid coordinates
+
+## REMOVED Requirements
+
+### Requirement: Haversine Distance Calculation
+
+**Reason**: Moved to the `proximity-model` capability as `pkg/geo.Haversine`. The function is unchanged; only its organizational location changes.
+**Migration**: Import from `pkg/geo` instead of `internal/geo`.
+
+### Requirement: Venue Coordinate Storage
+
+**Reason**: Venue coordinate storage is not specific to the proximity capability — it is part of the venue enrichment pipeline. This requirement was incorrectly scoped here.
+**Migration**: No behavioral change. Venue coordinates continue to be populated by the venue enrichment pipeline.

--- a/openspec/changes/refactor-usecase-layer-boundaries/specs/proximity-model/spec.md
+++ b/openspec/changes/refactor-usecase-layer-boundaries/specs/proximity-model/spec.md
@@ -1,0 +1,68 @@
+## ADDED Requirements
+
+### Requirement: Proximity Enum in Proto
+
+The system SHALL define a `Proximity` enum in `entity/v1/proximity.proto` representing the geographic closeness between a user's home area and a concert venue. This enum is the canonical domain concept for proximity classification, symmetric with `HypeType`.
+
+#### Scenario: Proximity enum definition
+
+- **WHEN** the `Proximity` enum is defined in proto
+- **THEN** it SHALL contain the values `PROXIMITY_UNSPECIFIED` (0), `PROXIMITY_HOME` (1), `PROXIMITY_NEARBY` (2), and `PROXIMITY_AWAY` (3)
+- **AND** each value SHALL have a documentation comment explaining its meaning
+
+#### Scenario: Symmetry with HypeType
+
+- **WHEN** a user's `HypeType` is `HOME`
+- **THEN** the corresponding proximity classification for notification filtering SHALL be `PROXIMITY_HOME`
+- **AND** `HypeType.NEARBY` corresponds to `PROXIMITY_NEARBY`
+- **AND** `HypeType.AWAY` corresponds to `PROXIMITY_AWAY`
+
+### Requirement: Concert.ProximityTo Entity Method
+
+The Go entity layer SHALL provide a `ProximityTo` receiver method on `Concert` that classifies the geographic relationship between the concert's venue and a user's home. This method SHALL be a pure function over entity fields with no infrastructure dependencies.
+
+#### Scenario: HOME classification by admin_area match
+
+- **WHEN** `Concert.ProximityTo(home)` is called
+- **AND** the concert's venue `admin_area` matches `home.Level1`
+- **THEN** the method SHALL return `ProximityHome`
+
+#### Scenario: NEARBY classification by Haversine distance
+
+- **WHEN** `Concert.ProximityTo(home)` is called
+- **AND** the venue's `admin_area` does not match `home.Level1`
+- **AND** the venue has latitude and longitude coordinates
+- **AND** the Haversine distance between `(home.Latitude, home.Longitude)` and the venue coordinates is less than or equal to 200km
+- **THEN** the method SHALL return `ProximityNearby`
+
+#### Scenario: AWAY classification for distant venues
+
+- **WHEN** `Concert.ProximityTo(home)` is called
+- **AND** the Haversine distance exceeds 200km
+- **THEN** the method SHALL return `ProximityAway`
+
+#### Scenario: AWAY classification when venue has no coordinates
+
+- **WHEN** `Concert.ProximityTo(home)` is called
+- **AND** the venue's latitude or longitude is nil
+- **THEN** the method SHALL return `ProximityAway`
+
+#### Scenario: AWAY classification when home is nil
+
+- **WHEN** `Concert.ProximityTo(nil)` is called
+- **THEN** the method SHALL return `ProximityAway`
+
+#### Scenario: AWAY classification when venue is nil
+
+- **WHEN** `Concert.ProximityTo(home)` is called
+- **AND** the concert's venue is nil
+- **THEN** the method SHALL return `ProximityAway`
+
+### Requirement: Haversine in pkg/geo
+
+The system SHALL provide a `Haversine` function in `pkg/geo` for computing great-circle distance between two WGS 84 coordinates. This is a pure math utility with no external dependencies, usable by any layer.
+
+#### Scenario: Distance calculation
+
+- **WHEN** `geo.Haversine` is called with Tokyo centroid (35.6895, 139.6917) and Saitama Super Arena (35.8950, 139.6314)
+- **THEN** the result SHALL be approximately 23km (within 1km tolerance)

--- a/openspec/changes/refactor-usecase-layer-boundaries/specs/user-home/spec.md
+++ b/openspec/changes/refactor-usecase-layer-boundaries/specs/user-home/spec.md
@@ -1,0 +1,47 @@
+## MODIFIED Requirements
+
+### Requirement: User Home Area Data Model
+
+The system SHALL support a structured `home` field on the User entity representing the user's home area — the geographic area where the user regularly attends live events without considering it a "trip" (遠征). The value is a structured geographic location expressed through a hierarchy of internationally standardized codes, with centroid coordinates for proximity calculations.
+
+#### Scenario: Home message in Proto definition
+
+- **WHEN** the `Home` proto message is defined
+- **THEN** it SHALL contain a `string country_code` field validated as ISO 3166-1 alpha-2 (exactly two uppercase Latin letters, e.g., `JP`, `US`)
+- **AND** a `string level_1` field validated as ISO 3166-2 format (4–6 characters, e.g., `JP-13`, `US-NY`)
+- **AND** an `optional string level_2` field for finer-grained subdivision (1–20 characters when present)
+- **AND** an `optional double centroid_latitude` field for the centroid latitude
+- **AND** an `optional double centroid_longitude` field for the centroid longitude
+
+#### Scenario: Home field in database
+
+- **WHEN** the `homes` table is defined
+- **THEN** it SHALL include a primary key `id TEXT`
+- **AND** a required `country_code TEXT` column storing an ISO 3166-1 alpha-2 code
+- **AND** a required `level_1 TEXT` column storing an ISO 3166-2 subdivision code
+- **AND** a nullable `level_2 TEXT` column storing a country-specific finer area code
+- **AND** a nullable `centroid_latitude DOUBLE PRECISION` column for the centroid latitude
+- **AND** a nullable `centroid_longitude DOUBLE PRECISION` column for the centroid longitude
+
+#### Scenario: Home field in Go entity
+
+- **WHEN** the Go `entity.Home` struct is defined
+- **THEN** it SHALL include `ID string`, `CountryCode string`, `Level1 string`, `Level2 *string`, `Latitude float64`, and `Longitude float64` fields
+- **AND** the `entity.User` struct SHALL include a `Home *Home` field
+- **AND** a nil `Home` SHALL mean the user has not set their home area
+
+#### Scenario: Centroid populated at write time
+
+- **WHEN** `UserRepository.Create` or `UserRepository.UpdateHome` is called with a `Home` value
+- **THEN** the repository implementation SHALL resolve the `Level1` ISO 3166-2 code to centroid coordinates
+- **AND** store the resolved `centroid_latitude` and `centroid_longitude` alongside the other home fields
+- **AND** the centroid resolution logic SHALL be an infrastructure implementation detail (not visible to usecase/entity layers)
+
+#### Scenario: Code system contract for level_2
+
+- **WHEN** `level_2` is populated
+- **THEN** its code system SHALL be determined by `country_code`:
+  - `JP` → future use (not yet defined; Phase 1 always omits level_2)
+  - `US` → FIPS county code (e.g., `06037` for Los Angeles County)
+  - `DE` → AGS code (e.g., `09162` for Munich)
+- **AND** additional country mappings SHALL be documented in the `Home` proto message comment as they are introduced

--- a/openspec/changes/refactor-usecase-layer-boundaries/tasks.md
+++ b/openspec/changes/refactor-usecase-layer-boundaries/tasks.md
@@ -1,0 +1,80 @@
+## 1. Proto Schema (specification repo)
+
+- [x] 1.1 Create `entity/v1/proximity.proto` with `Proximity` enum (UNSPECIFIED, HOME, NEARBY, AWAY)
+- [x] 1.2 Add `optional double centroid_latitude` and `optional double centroid_longitude` fields to `Home` message in `user.proto`
+- [x] 1.3 Rename `DateLaneGroup` to `ProximityGroup` in `concert_service.proto`, rename field `away` to `distant`
+- [x] 1.4 Run `buf lint` and `buf format -w`, verify breaking changes are expected
+
+## 2. Database Migration (backend repo)
+
+- [x] 2.1 Add `centroid_latitude DOUBLE PRECISION` and `centroid_longitude DOUBLE PRECISION` columns to `homes` table in desired-state schema
+- [x] 2.2 Generate Atlas migration with backfill for existing Japanese prefecture rows
+- [x] 2.3 Validate migration locally with `atlas migrate apply --env local`
+
+## 3. Entity Layer — Proximity Model (backend repo)
+
+- [x] 3.1 Create `entity/proximity.go`: `Proximity` type, constants (`ProximityHome`, `ProximityNearby`, `ProximityAway`), `NearbyThresholdKm` constant
+- [x] 3.2 Add `Latitude float64` and `Longitude float64` fields to `entity.Home` struct
+- [x] 3.3 Create `pkg/geo/haversine.go` with `Haversine` function (move from `internal/geo`)
+- [x] 3.4 Implement `Concert.ProximityTo(home *Home) Proximity` receiver method on entity
+- [x] 3.5 Write unit tests for `Concert.ProximityTo` covering all scenarios (HOME, NEARBY, AWAY, nil home, nil venue, missing coordinates)
+
+## 4. Entity Layer — Interface Extraction (backend repo)
+
+- [x] 4.1 Define `PushNotificationSender` interface in entity layer
+- [x] 4.2 Define `MerkleTreeBuilder` interface in entity layer
+- [x] 4.3 Define `AdminAreaResolver` interface in entity layer
+- [x] 4.4 Define `Cache` interface (in entity or usecase layer)
+- [x] 4.5 Move event data types (`ConcertDiscoveredData`, `ScrapedConcertData`, `ConcertCreatedData`, `VenueCreatedData`, `ArtistCreatedData`) and subject constants from `infrastructure/messaging` to entity layer
+
+## 5. Infrastructure — Interface Implementations (backend repo)
+
+- [x] 5.1 Implement `PushNotificationSender` using `webpush-go` (move VAPID config and `http.Client` here)
+- [x] 5.2 Implement `MerkleTreeBuilder` wrapping existing `infrastructure/merkle` package
+- [x] 5.3 Implement `AdminAreaResolver` using the display name table from `internal/geo`
+- [x] 5.4 Update `UserRepository.Create` and `UpdateHome` to resolve and persist centroid at write time
+- [x] 5.5 Move centroid data table and `NormalizeAdminArea` to infrastructure
+
+## 6. UseCase Layer Refactor (backend repo)
+
+- [x] 6.1 Refactor `push_notification_uc.go`: inject `PushNotificationSender`, remove `webpush`/`net/http`/VAPID fields
+- [x] 6.2 Refactor `concert_uc.go`: replace `groupByDateAndLane` with `entity.GroupByDateAndProximity` or direct `Concert.ProximityTo` calls, remove `geo` import
+- [x] 6.3 Refactor `push_notification_uc.go`: replace `hasNearbyConcert` with `Concert.ProximityTo`, remove `geo` import
+- [x] 6.4 Refactor `venue_enrichment_uc.go`: inject `AdminAreaResolver`, remove `geo` import
+- [x] 6.5 Refactor `entry_uc.go`: inject `MerkleTreeBuilder`, remove `infrastructure/merkle` import
+- [x] 6.6 Refactor `artist_uc.go`: inject `Cache` interface, remove `pkg/cache` concrete type import
+- [x] 6.7 Refactor `artist_uc.go`, `concert_uc.go`, `concert_creation_uc.go`: use entity-layer event types, remove `infrastructure/messaging` import (keep `messaging.NewEvent` call only where `message.Publisher.Publish` is used)
+- [x] 6.8 Update `ConcertCreationUseCase.CreateFromDiscovered` signature to use entity-layer type
+
+## 7. DI Wiring (backend repo)
+
+- [x] 7.1 Update Wire providers to inject new interfaces (`PushNotificationSender`, `MerkleTreeBuilder`, `AdminAreaResolver`, `Cache`)
+- [x] 7.2 Run `wire` to regenerate DI code
+
+## 8. Adapter Layer (backend repo)
+
+- [x] 8.1 Update RPC mapper for `ProximityGroup` (was `DateLaneGroup`)
+- [x] 8.2 Update concert handler for renamed response type
+
+## 9. Cleanup (backend repo)
+
+- [x] 9.1 Delete `internal/geo` package entirely
+- [x] 9.2 Run `mockery` to regenerate mocks for new interfaces
+- [x] 9.3 Update tests for refactored usecases (especially `NotifyNewConcerts` — now testable with mock sender)
+- [x] 9.4 Run `make check` to verify lint + tests pass
+
+## 10. UseCase Tests — Extracted Interface Coverage (backend repo)
+
+- [x] 10.1 `push_notification_uc_test.go`: Sender returns `apperr.ErrNotFound` (410 Gone) → verify `DeleteByEndpoint` is called to clean up stale subscription
+- [x] 10.2 `push_notification_uc_test.go`: `DeleteByEndpoint` fails after 410 Gone → verify error is logged but processing continues
+- [x] 10.3 `push_notification_uc_test.go`: Sender returns transient error (Internal) → verify error is logged and remaining subscriptions are still processed
+- [x] 10.4 `push_notification_uc_test.go`: Multiple subscriptions with mixed results (success, 410 Gone, transient error) → verify each is handled correctly
+- [x] 10.5 `entry_uc_test.go`: `MerkleTreeBuilder.IdentityCommitment` returns error → verify error is wrapped and returned
+- [x] 10.6 `entry_uc_test.go`: `MerkleTreeBuilder.Build` returns error → verify error is wrapped and returned
+- [x] 10.7 `venue_enrichment_uc_test.go`: `UpdateEnriched` repository error → verify error propagation
+- [x] 10.8 `venue_enrichment_uc_test.go`: `MergeVenues` repository error during duplicate merge → verify error propagation
+
+## 11. Frontend (frontend repo)
+
+- [ ] 11.1 Update generated types import (`DateLaneGroup` → `ProximityGroup`, field `away` → `distant`) — **blocked on spec release to BSR**
+- [ ] 11.2 Update dashboard concert grouping to use new type/field names — **blocked on spec release to BSR**

--- a/openspec/specs/coordinates-vo/spec.md
+++ b/openspec/specs/coordinates-vo/spec.md
@@ -1,0 +1,60 @@
+# coordinates-vo Specification
+
+## Purpose
+
+The `coordinates-vo` capability defines the `Coordinates` value object — an atomic WGS 84 latitude/longitude pair used throughout the domain model wherever geographic coordinates appear.
+
+## Requirements
+
+### Requirement: Coordinates Value Object
+
+The system SHALL provide a `Coordinates` value object representing a WGS 84 geographic point (latitude/longitude pair). This type SHALL be used wherever geographic coordinates appear in the domain model, ensuring coordinates always travel as an atomic pair.
+
+#### Scenario: Proto Coordinates message
+
+- **WHEN** the `Coordinates` proto message is defined in `entity/v1/`
+- **THEN** it SHALL contain a `double latitude` field
+- **AND** a `double longitude` field
+- **AND** no validation constraints (raw WGS 84 values, including 0.0, are valid)
+
+#### Scenario: Go entity Coordinates struct
+
+- **WHEN** the Go `entity.Coordinates` struct is defined
+- **THEN** it SHALL contain `Latitude float64` and `Longitude float64` fields
+- **AND** the struct SHALL be used as `*Coordinates` (pointer) when the coordinates are optional (e.g., unenriched venues, unsupported countries)
+
+#### Scenario: Coordinates used by Home centroid
+
+- **WHEN** the `Home` proto message references centroid coordinates
+- **THEN** it SHALL use `optional Coordinates centroid` instead of separate `optional double` fields
+- **AND** the Go `entity.Home` struct SHALL use `Centroid *Coordinates`
+
+#### Scenario: Coordinates used by Venue location
+
+- **WHEN** the Go `entity.Venue` struct references geographic coordinates
+- **THEN** it SHALL use `Coordinates *Coordinates` instead of separate `*float64` fields
+- **AND** the `entity.VenuePlace` struct SHALL likewise use `Coordinates *Coordinates`
+
+#### Scenario: Coordinates round-trip through venue repository
+
+- **WHEN** `VenueRepository.UpdateEnriched` is called with a venue that has non-nil `Coordinates`
+- **THEN** the coordinates SHALL be persisted as `latitude` and `longitude` columns
+- **AND** a subsequent `VenueRepository.Get` SHALL return the venue with `Coordinates` populated with the same values
+- **WHEN** `VenueRepository.UpdateEnriched` is called with a venue that has nil `Coordinates`
+- **THEN** the `latitude` and `longitude` columns SHALL be set to NULL
+- **AND** a subsequent `VenueRepository.Get` SHALL return the venue with nil `Coordinates`
+
+#### Scenario: Coordinates mapping in concert listing
+
+- **WHEN** `ConcertRepository.ListByFollower` returns concerts with associated venues
+- **AND** the venue has both `latitude` and `longitude` columns populated in the database
+- **THEN** the returned `Venue.Coordinates` SHALL be non-nil with the correct latitude and longitude values
+- **WHEN** either or both coordinate columns are NULL in the database
+- **THEN** the returned `Venue.Coordinates` SHALL be nil
+
+#### Scenario: PlaceSearcher adapters map external coordinates to entity.Coordinates
+
+- **WHEN** a PlaceSearcher adapter (MusicBrainz or Google Maps) receives a response with both latitude and longitude present
+- **THEN** the returned `VenuePlace.Coordinates` SHALL be non-nil with the mapped values
+- **WHEN** a PlaceSearcher adapter receives a response with either or both coordinates absent
+- **THEN** the returned `VenuePlace.Coordinates` SHALL be nil

--- a/openspec/specs/user-home/spec.md
+++ b/openspec/specs/user-home/spec.md
@@ -1,6 +1,6 @@
 ### Requirement: User Home Area Data Model
 
-The system SHALL support a structured `home` field on the User entity representing the user's home area — the geographic area where the user regularly attends live events without considering it a "trip" (遠征). The value is a structured geographic location expressed through a hierarchy of internationally standardized codes.
+The system SHALL support a structured `home` field on the User entity representing the user's home area — the geographic area where the user regularly attends live events without considering it a "trip" (遠征). The value is a structured geographic location expressed through a hierarchy of internationally standardized codes, with centroid coordinates for proximity calculations.
 
 #### Scenario: Home message in Proto definition
 
@@ -8,6 +8,7 @@ The system SHALL support a structured `home` field on the User entity representi
 - **THEN** it SHALL contain a `string country_code` field validated as ISO 3166-1 alpha-2 (exactly two uppercase Latin letters, e.g., `JP`, `US`)
 - **AND** a `string level_1` field validated as ISO 3166-2 format (4–6 characters, e.g., `JP-13`, `US-NY`)
 - **AND** an `optional string level_2` field for finer-grained subdivision (1–20 characters when present)
+- **AND** an `optional Coordinates centroid` field for the geographic centroid of the home area
 
 #### Scenario: Home field on User message
 
@@ -22,14 +23,31 @@ The system SHALL support a structured `home` field on the User entity representi
 - **AND** a required `country_code TEXT` column storing an ISO 3166-1 alpha-2 code
 - **AND** a required `level_1 TEXT` column storing an ISO 3166-2 subdivision code
 - **AND** a nullable `level_2 TEXT` column storing a country-specific finer area code
+- **AND** a nullable `centroid_latitude DOUBLE PRECISION` column for the centroid latitude
+- **AND** a nullable `centroid_longitude DOUBLE PRECISION` column for the centroid longitude
 - **AND** the `users` table SHALL reference `homes.id` via a nullable `home_id TEXT` foreign key
 
 #### Scenario: Home field in Go entity
 
 - **WHEN** the Go `entity.Home` struct is defined
-- **THEN** it SHALL include `ID string`, `CountryCode string`, `Level1 string`, and `Level2 *string` fields
+- **THEN** it SHALL include `ID string`, `CountryCode string`, `Level1 string`, `Level2 *string`, and `Centroid *Coordinates` fields
 - **AND** the `entity.User` struct SHALL include a `Home *Home` field
 - **AND** a nil `Home` SHALL mean the user has not set their home area
+
+#### Scenario: Centroid populated at write time
+
+- **WHEN** `UserRepository.Create` or `UserRepository.UpdateHome` is called with a `Home` value
+- **THEN** the repository implementation SHALL resolve the `Level1` ISO 3166-2 code to centroid coordinates
+- **AND** store the resolved centroid as `centroid_latitude` and `centroid_longitude` alongside the other home fields
+- **AND** the centroid resolution logic SHALL be an infrastructure implementation detail (not visible to usecase/entity layers)
+
+#### Scenario: Centroid round-trip through user repository
+
+- **WHEN** a user is created or their home is updated with a supported country code (e.g., `JP-13`)
+- **AND** the centroid is successfully resolved
+- **THEN** a subsequent `UserRepository.Get`, `GetByExternalID`, or `GetByEmail` SHALL return the user with `Home.Centroid` populated with the resolved latitude and longitude
+- **WHEN** a user's home is set with an unsupported country code
+- **THEN** a subsequent retrieval SHALL return the user with `Home.Centroid` as nil
 
 #### Scenario: Code system contract for level_2
 

--- a/openspec/specs/venue-normalization/spec.md
+++ b/openspec/specs/venue-normalization/spec.md
@@ -18,7 +18,7 @@ The system SHALL provide an async enrichment pipeline that resolves raw venue na
 - **AND** `venues.raw_name` SHALL be set to the current `venues.name` (if `raw_name` is NULL) to preserve the original scraper-provided name
 - **AND** `venues.name` SHALL be overwritten with the canonical name from MusicBrainz
 - **AND** `enrichment_status` SHALL be set to `'enriched'`
-- **AND** if the MusicBrainz response includes coordinates, `venues.latitude` and `venues.longitude` SHALL be updated
+- **AND** the venue's `Coordinates` SHALL be set to the value returned by the PlaceSearcher (non-nil when the response includes coordinates, nil otherwise)
 
 #### Scenario: Successful enrichment via Google Maps fallback
 
@@ -29,7 +29,7 @@ The system SHALL provide an async enrichment pipeline that resolves raw venue na
 - **AND** `venues.raw_name` SHALL be set to the current `venues.name` (if `raw_name` is NULL) to preserve the original scraper-provided name
 - **AND** `venues.name` SHALL be overwritten with the canonical name from Google Maps
 - **AND** `enrichment_status` SHALL be set to `'enriched'`
-- **AND** `venues.latitude` and `venues.longitude` SHALL be updated from the Google Maps geometry response
+- **AND** the venue's `Coordinates` SHALL be updated from the Google Maps geometry response
 
 #### Scenario: Both sources miss
 
@@ -38,7 +38,7 @@ The system SHALL provide an async enrichment pipeline that resolves raw venue na
 - **AND** Google Maps returns no match
 - **THEN** `enrichment_status` SHALL be set to `'failed'`
 - **AND** `venues.name` SHALL remain unchanged
-- **AND** `venues.latitude` and `venues.longitude` SHALL remain NULL
+- **AND** the venue's `Coordinates` SHALL remain nil
 - **AND** the venue SHALL NOT be retried in subsequent job runs
 
 #### Scenario: Ambiguous results (multiple matches)

--- a/proto/liverty_music/entity/v1/coordinates.proto
+++ b/proto/liverty_music/entity/v1/coordinates.proto
@@ -1,0 +1,14 @@
+syntax = "proto3";
+
+package liverty_music.entity.v1;
+
+// Coordinates represents a WGS 84 geographic point as a latitude/longitude pair.
+// Used wherever the domain model requires a geographic location — for example,
+// the centroid of a user's home area or the position of a concert venue.
+message Coordinates {
+  // The WGS 84 latitude in decimal degrees (range: -90 to +90).
+  double latitude = 1;
+
+  // The WGS 84 longitude in decimal degrees (range: -180 to +180).
+  double longitude = 2;
+}

--- a/proto/liverty_music/entity/v1/proximity.proto
+++ b/proto/liverty_music/entity/v1/proximity.proto
@@ -1,0 +1,26 @@
+syntax = "proto3";
+
+package liverty_music.entity.v1;
+
+option go_package = "github.com/liverty-music/specification/gen/go/liverty_music/entity/v1;entityv1";
+
+// Proximity represents the geographic closeness between a user's home area
+// and a concert venue. It is a computed value derived from the user's Home
+// and the venue's coordinates or administrative area.
+//
+// This enum mirrors the scoping tiers in HypeType:
+//   - HypeType defines what the user *wants* to hear about.
+//   - Proximity defines what a concert *actually is* relative to the user.
+enum Proximity {
+  // Default value; must not be used in API requests.
+  PROXIMITY_UNSPECIFIED = 0;
+  // The venue is within the user's home administrative area
+  // (ISO 3166-2 subdivision match with home.level_1).
+  PROXIMITY_HOME = 1;
+  // The venue is within 200km of the user's home area centroid
+  // but outside the home administrative area.
+  PROXIMITY_NEARBY = 2;
+  // The venue is beyond 200km from the user's home area centroid,
+  // has unknown location, or the user has no home set.
+  PROXIMITY_AWAY = 3;
+}

--- a/proto/liverty_music/entity/v1/user.proto
+++ b/proto/liverty_music/entity/v1/user.proto
@@ -119,4 +119,5 @@ message Home {
   optional Coordinates centroid = 4;
 
   reserved 5;
+  reserved "centroid_latitude", "centroid_longitude";
 }

--- a/proto/liverty_music/entity/v1/user.proto
+++ b/proto/liverty_music/entity/v1/user.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package liverty_music.entity.v1;
 
 import "buf/validate/validate.proto";
+import "liverty_music/entity/v1/coordinates.proto";
 
 // UserId is a globally unique identifier for a platform user.
 message UserId {
@@ -43,8 +44,8 @@ message User {
 
   // The user's home area — the geographic region where the user regularly attends
   // live events without considering it a trip (遠征).
-  // Used as the baseline for dashboard lane assignment: events in the home area
-  // appear in the "Home" lane, nearby areas in "Nearby", and everything else in "Away".
+  // Used as the baseline for proximity classification: events in the home area
+  // are classified as HOME, nearby areas as NEARBY, and everything else as AWAY.
   // Absent until the user explicitly selects their area during onboarding or in settings.
   Home home = 6;
 }
@@ -54,14 +55,18 @@ message User {
 //
 // A user's home area is the geographic region where they regularly attend
 // live events without considering it a trip (遠征). This concept anchors the
-// dashboard lane classification system:
-//   - "Home" lane:   the event's venue falls within the user's home area.
-//   - "Nearby" lane: the event has a known area, but it differs from the user's home.
-//   - "Away" lane:   the event has no known area, or the user has no home set.
+// proximity classification system (see Proximity enum):
+//   - HOME:   the event's venue falls within the user's home area.
+//   - NEARBY: the event is within 200km of the user's home centroid.
+//   - AWAY:   the event is beyond 200km, has no known area, or the user has no home set.
 //
-// Lane assignment granularity:
-//   - When level_2 is set, lane comparison uses level_2 (finer granularity).
-//   - When level_2 is absent, lane comparison uses level_1 (coarser granularity).
+// Proximity assignment granularity:
+//   - When level_2 is set, admin_area comparison uses level_2 (finer granularity).
+//   - When level_2 is absent, admin_area comparison uses level_1 (coarser granularity).
+//
+// The centroid (a Coordinates value) is resolved automatically at write time
+// from the level_1 (or level_2) code. It serves as the reference point for
+// NEARBY distance calculations.
 //
 // Code system contract:
 //   - level_1 is always an ISO 3166-2 subdivision code, worldwide, without exception.
@@ -105,4 +110,13 @@ message Home {
     (buf.validate.field).string.min_len = 1,
     (buf.validate.field).string.max_len = 20
   ];
+
+  // The approximate geographic centroid of this home area.
+  // Populated automatically at write time by resolving the level_1 (or level_2)
+  // code to its centroid coordinates. Used as the reference point for proximity
+  // calculations (e.g., Concert.ProximityTo). Absent when the centroid cannot
+  // be resolved (unsupported country).
+  optional Coordinates centroid = 4;
+
+  reserved 5;
 }

--- a/proto/liverty_music/rpc/concert/v1/concert_service.proto
+++ b/proto/liverty_music/rpc/concert/v1/concert_service.proto
@@ -60,20 +60,20 @@ message ListResponse {
 message ListByFollowerRequest {}
 
 // ListByFollowerResponse contains concerts for all artists followed by the caller,
-// grouped by date and classified into geographic proximity lanes.
+// grouped by date and classified by geographic proximity.
 message ListByFollowerResponse {
   reserved 1;
   reserved "concerts";
 
   // Concert groups ordered by date ascending. Each group contains concerts
-  // for a single date, classified into home/nearby/away lanes based on the
-  // geographic relationship between the user's home area and each venue.
-  repeated DateLaneGroup groups = 2;
+  // for a single date, classified into home/nearby/distant buckets based on
+  // the geographic proximity between the user's home area and each venue.
+  repeated ProximityGroup groups = 2;
 }
 
-// DateLaneGroup contains concerts for a single calendar date, classified into
-// three geographic proximity lanes relative to the authenticated user's home area.
-message DateLaneGroup {
+// ProximityGroup contains concerts for a single calendar date, classified into
+// three geographic proximity buckets relative to the authenticated user's home area.
+message ProximityGroup {
   // The calendar date for this group.
   entity.v1.LocalDate date = 1 [(buf.validate.field).required = true];
 
@@ -84,7 +84,7 @@ message DateLaneGroup {
   repeated entity.v1.Concert nearby = 3;
 
   // Concerts at venues beyond 200km, with unknown location, or when the user has no home set.
-  repeated entity.v1.Concert away = 4;
+  repeated entity.v1.Concert distant = 4;
 }
 
 // SearchNewConcertsRequest specifies the artist for whom to search for new concerts.

--- a/proto/liverty_music/rpc/concert/v1/concert_service.proto
+++ b/proto/liverty_music/rpc/concert/v1/concert_service.proto
@@ -74,6 +74,8 @@ message ListByFollowerResponse {
 // ProximityGroup contains concerts for a single calendar date, classified into
 // three geographic proximity buckets relative to the authenticated user's home area.
 message ProximityGroup {
+  reserved "away";
+
   // The calendar date for this group.
   entity.v1.LocalDate date = 1 [(buf.validate.field).required = true];
 


### PR DESCRIPTION
## 🔗 Related Issue

Closes #191

## 📝 Summary of Changes

Introduce `Coordinates` proto message and `Proximity` enum to support the backend's Coordinates VO and usecase layer boundary refactoring.

**Proto changes:**
- New `Coordinates` message (`entity/v1/coordinates.proto`) — WGS 84 lat/lng pair
- New `Proximity` enum (`entity/v1/proximity.proto`) — HOME, NEARBY, AWAY classification
- `Home` message: replace `optional double centroid_latitude/centroid_longitude` with `optional Coordinates centroid`, reserve field 5
- `ListByFollowerResponse`: rename `DateLaneGroup` to `ProximityGroup`, use `Proximity` enum

**OpenSpec changes:**
- New `coordinates-vo` capability spec
- Updated `user-home`, `nearby-proximity`, `venue-normalization` main specs with Coordinates VO references
- Archived `introduce-coordinates-vo` change
- Added `refactor-usecase-layer-boundaries` change artifacts

**Breaking changes (intentional):** `DateLaneGroup` deleted, `Home` field 4 type changed. Unreleased branch — `buf skip breaking` label required.

## 📋 Commit Log

- `373e84a` feat!(proto): add Coordinates message and Proximity enum
- `1f8fb1b` docs(openspec): sync specs and archive changes

## ✅ Self-Checklist

- [x] I have linked the related issue.
- [x] I have added or updated tests to cover my changes.
- [ ] I have updated the relevant documentation (e.g., `README.md`, `CLAUDE.md`).
- [x] I have run `buf lint` and `buf format` locally and all checks have passed.
- [x] My code follows the architecture and style guidelines of the project.