### PR TITLE
docs(openspec): add entity-domain-logic spec and archive change

### DIFF
--- a/openspec/changes/archive/2026-03-12-enrich-entity-domain-logic/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-12-enrich-entity-domain-logic/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-11

--- a/openspec/changes/archive/2026-03-12-enrich-entity-domain-logic/design.md
+++ b/openspec/changes/archive/2026-03-12-enrich-entity-domain-logic/design.md
@@ -1,0 +1,75 @@
+## Context
+
+The backend follows Clean Architecture with entity, usecase, adapter, and infrastructure layers. Currently the entity layer (`internal/entity/`) contains mostly pure data structs and interface definitions, with only one business logic method (`Concert.ProximityTo()`). Pure business rules — validation, classification, deduplication, construction — are spread across `internal/usecase/` as private helper functions, making them harder to test and reuse.
+
+The existing `NewArtist` constructor sets the pattern: entity constructors generate UUIDs and set defaults. Several other entities are constructed inline in usecases with ad-hoc UUID generation.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Move all pure business logic (functions that depend only on entity fields) from usecase to entity layer
+- Add constructor functions for entities that need ID generation or default values
+- Add validation methods on domain types
+- Achieve comprehensive test coverage for all entity-layer logic (new and existing)
+
+**Non-Goals:**
+- Moving orchestration logic that requires repositories or external services
+- Changing any public API, proto schema, or database schema
+- Refactoring the usecase layer beyond replacing inlined logic with entity method calls
+- Moving interfaces between layers (entity/ vs usecase/ interface placement is a separate discussion)
+
+## Decisions
+
+### 1. Methods vs package-level functions
+
+**Decision**: Use receiver methods when the logic is intrinsic to a single entity instance. Use package-level functions when operating on slices or across multiple entity types.
+
+| Function | Style | Rationale |
+|----------|-------|-----------|
+| `Home.Validate()` | Method | Validates its own fields |
+| `Hype.ShouldNotify(home, concerts)` | Method on `Hype` | Hype determines the decision |
+| `Hype.IsValid()` | Method | Enum self-validation |
+| `ScrapedConcert.DedupeKey()` | Method | Derives key from own fields |
+| `GroupByDateAndProximity(concerts, home)` | Package function | Operates on a slice, returns `[]*ProximityGroup` |
+| `FilterArtistsByMBID(artists)` | Package function | Slice operation |
+| `GenerateTokenID()` | Package function | No receiver, pure generation |
+| `NewOfficialSite(artistID, url)` | Package function (constructor) | Follows `NewArtist` pattern |
+| `NewVenueFromScraped(name)` | Package function (constructor) | ID + defaults |
+
+**Alternative considered**: Creating type aliases for slices (e.g., `type Concerts []*Concert`) with methods. Rejected — adds indirection without proportional benefit for the current codebase size.
+
+### 2. Error return type for validation
+
+**Decision**: Entity validation methods return `error` (stdlib), not `apperr` types.
+
+**Rationale**: Entity layer should not depend on application error libraries (`apperr`, `codes`). The usecase caller wraps the error with `apperr.New(codes.InvalidArgument, err.Error())` as needed. This keeps the entity layer framework-free.
+
+**Alternative considered**: Return `apperr` directly from entity. Rejected — introduces infrastructure dependency into the domain core.
+
+### 3. `Hype.ShouldNotify` scope
+
+**Decision**: `Hype.ShouldNotify(home *Home, venueAreas map[string]struct{}, concerts []*Concert) bool`
+
+The method receives pre-computed `venueAreas` (a map of venue admin areas from the concert batch) rather than computing it internally. This avoids repeated iteration when checking multiple followers against the same concert batch.
+
+**Rationale**: The usecase already computes `venueAreas` once for the entire follower loop. Passing it in keeps the entity method pure while preserving the optimization.
+
+### 4. Test file organization
+
+**Decision**: One `_test.go` file per entity source file, in the same package (`package entity`).
+
+| Source | Test file |
+|--------|-----------|
+| `concert.go` | `concert_test.go` |
+| `user.go` | `user_test.go` |
+| `follow.go` | `follow_test.go` |
+| `artist.go` | `artist_test.go` |
+| `ticket.go` | `ticket_test.go` |
+
+All tests use table-driven patterns. No mocks needed — these are pure function tests.
+
+## Risks / Trade-offs
+
+- **[Risk] Usecase tests may break** → Usecase tests that call the moved private functions will need updating. Mitigation: the replacement is mechanical (call entity function instead of local one). Usecase tests that test orchestration remain valid.
+- **[Risk] Signature changes during move** → Some functions need slight signature adjustments (e.g., `Hype.ShouldNotify` receives `venueAreas` parameter). Mitigation: compile-time verification ensures correctness.
+- **[Trade-off] Entity package grows** → More code in entity/. Acceptable because it's domain logic that belongs there, and it's offset by reduced usecase complexity.

--- a/openspec/changes/archive/2026-03-12-enrich-entity-domain-logic/proposal.md
+++ b/openspec/changes/archive/2026-03-12-enrich-entity-domain-logic/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+The recent `introduce-coordinates-vo` refactoring moved `Concert.ProximityTo()` into the entity layer, proving that pure business logic belongs with the data it operates on. However, several other pure business rules remain scattered across the usecase layer — validation, classification, deduplication, and construction logic that depend only on entity fields. This makes them harder to test (requiring usecase-level setup with mocks) and harder to reuse. Moving them to the entity layer improves testability, discoverability, and domain cohesion.
+
+## What Changes
+
+- **Move pure business logic to entity layer**: Relocate validation, classification, grouping, and filtering functions from `usecase/` to `entity/` as methods or package-level functions.
+- **Add entity constructors with ID generation**: Introduce constructor functions (following the existing `NewArtist` pattern) for entities that currently have inline UUID generation scattered across usecases.
+- **Add enum validation methods**: Provide `IsValid()` methods on domain enum types (`Hype`, etc.) to replace ad-hoc `default:` guards.
+- **Add comprehensive unit tests**: Cover all newly added entity functions AND existing entity functions that gained testability from prior refactoring (e.g., `Concert.ProximityTo()`).
+
+## Capabilities
+
+### New Capabilities
+
+- `entity-domain-logic`: Covers the entity-layer enrichment — moved business logic, constructors, validation methods, and their comprehensive test coverage.
+
+### Modified Capabilities
+
+(none — no spec-level behavior changes; this is an internal restructuring)
+
+## Impact
+
+- **`internal/entity/`**: New methods, constructors, and package-level functions added. New `_test.go` files created.
+- **`internal/usecase/`**: Existing private functions replaced with calls to entity-layer equivalents. Reduced code volume and simplified test setup.
+- **No API changes**: No proto, RPC, or database changes. Purely internal refactoring.
+- **No migration needed**: No schema or infrastructure impact.

--- a/openspec/changes/archive/2026-03-12-enrich-entity-domain-logic/specs/entity-domain-logic/spec.md
+++ b/openspec/changes/archive/2026-03-12-enrich-entity-domain-logic/specs/entity-domain-logic/spec.md
@@ -1,0 +1,306 @@
+## ADDED Requirements
+
+### Requirement: Home validation
+
+The `Home` entity SHALL provide a `Validate() error` method that enforces structural integrity of geographic home area data. The method SHALL return the first validation error encountered.
+
+Validation rules:
+1. `CountryCode` MUST match ISO 3166-1 alpha-2 format (`^[A-Z]{2}$`).
+2. `Level1` MUST match ISO 3166-2 subdivision format (`^[A-Z]{2}-[A-Z0-9]{1,3}$`).
+3. The first two characters of `Level1` MUST equal `CountryCode`.
+4. When `Level2` is non-nil, its length MUST be between 1 and 20 characters inclusive.
+
+#### Scenario: Valid home with all fields
+
+- **WHEN** Home has CountryCode="JP", Level1="JP-13", Level2=nil
+- **THEN** Validate returns nil
+
+#### Scenario: Valid home with Level2
+
+- **WHEN** Home has CountryCode="JP", Level1="JP-13", Level2="Shibuya"
+- **THEN** Validate returns nil
+
+#### Scenario: Invalid country code format
+
+- **WHEN** Home has CountryCode="j" (lowercase or wrong length)
+- **THEN** Validate returns error mentioning "ISO 3166-1 alpha-2"
+
+#### Scenario: Invalid Level1 format
+
+- **WHEN** Home has Level1="INVALID"
+- **THEN** Validate returns error mentioning "ISO 3166-2"
+
+#### Scenario: Level1 prefix mismatch
+
+- **WHEN** Home has CountryCode="JP" but Level1="US-CA"
+- **THEN** Validate returns error mentioning prefix mismatch
+
+#### Scenario: Level2 empty string
+
+- **WHEN** Home has Level2 pointing to an empty string
+- **THEN** Validate returns error mentioning "1 and 20 characters"
+
+#### Scenario: Level2 too long
+
+- **WHEN** Home has Level2 pointing to a 21-character string
+- **THEN** Validate returns error mentioning "1 and 20 characters"
+
+---
+
+### Requirement: Hype validity check
+
+The `Hype` type SHALL provide an `IsValid() bool` method that returns true only for the four defined values: `watch`, `home`, `nearby`, `away`.
+
+#### Scenario: Known hype values
+
+- **WHEN** Hype is one of HypeWatch, HypeHome, HypeNearby, HypeAway
+- **THEN** IsValid returns true
+
+#### Scenario: Unknown hype value
+
+- **WHEN** Hype is "unknown" or an empty string
+- **THEN** IsValid returns false
+
+---
+
+### Requirement: Hype-based notification eligibility
+
+The `Hype` type SHALL provide a `ShouldNotify(home *Home, venueAreas map[string]struct{}, concerts []*Concert) bool` method that determines whether a follower with this hype level should receive push notifications for a batch of new concerts.
+
+Decision rules (evaluated in order):
+1. `HypeWatch` → false (never notify).
+2. `HypeHome` → true only if `home` is non-nil AND `home.Level1` exists in `venueAreas`.
+3. `HypeNearby` → true only if any concert has `ProximityHome` or `ProximityNearby` relative to `home`.
+4. `HypeAway` → true (always notify).
+5. Any other value → false.
+
+#### Scenario: HypeWatch never notifies
+
+- **WHEN** Hype is HypeWatch with any home and concerts
+- **THEN** ShouldNotify returns false
+
+#### Scenario: HypeHome matches venue area
+
+- **WHEN** Hype is HypeHome, home.Level1="JP-13", venueAreas contains "JP-13"
+- **THEN** ShouldNotify returns true
+
+#### Scenario: HypeHome no match
+
+- **WHEN** Hype is HypeHome, home.Level1="JP-13", venueAreas contains only "JP-27"
+- **THEN** ShouldNotify returns false
+
+#### Scenario: HypeHome with nil home
+
+- **WHEN** Hype is HypeHome, home is nil
+- **THEN** ShouldNotify returns false
+
+#### Scenario: HypeHome with empty Level1
+
+- **WHEN** Hype is HypeHome, home.Level1 is empty string
+- **THEN** ShouldNotify returns false
+
+#### Scenario: HypeNearby with nearby concert
+
+- **WHEN** Hype is HypeNearby, home has centroid, a concert venue is within 200km
+- **THEN** ShouldNotify returns true
+
+#### Scenario: HypeNearby with only distant concerts
+
+- **WHEN** Hype is HypeNearby, all concerts are beyond 200km
+- **THEN** ShouldNotify returns false
+
+#### Scenario: HypeNearby with nil home
+
+- **WHEN** Hype is HypeNearby, home is nil
+- **THEN** ShouldNotify returns false
+
+#### Scenario: HypeAway always notifies
+
+- **WHEN** Hype is HypeAway with any home and concerts
+- **THEN** ShouldNotify returns true
+
+#### Scenario: Unknown hype skips
+
+- **WHEN** Hype is "unknown"
+- **THEN** ShouldNotify returns false
+
+---
+
+### Requirement: Concert proximity grouping
+
+The entity package SHALL provide a `GroupByDateAndProximity(concerts []*Concert, home *Home) []*ProximityGroup` function that classifies concerts into Home/Nearby/Distant buckets grouped by calendar date.
+
+Rules:
+1. Concerts SHALL be grouped by `LocalDate` formatted as "YYYY-MM-DD".
+2. Within each group, each concert SHALL be classified using `Concert.ProximityTo(home)`.
+3. Groups SHALL be returned in the order of first appearance (preserving input date order).
+4. An empty or nil input SHALL return nil.
+
+#### Scenario: Empty input
+
+- **WHEN** concerts slice is empty
+- **THEN** function returns nil
+
+#### Scenario: Single date, mixed proximity
+
+- **WHEN** three concerts on 2026-03-15: one HOME, one NEARBY, one AWAY
+- **THEN** returns one ProximityGroup with correct bucket assignments
+
+#### Scenario: Multiple dates preserve order
+
+- **WHEN** concerts span March 15, March 17, March 16 (in that input order)
+- **THEN** returns three groups in order: March 15, March 17, March 16
+
+#### Scenario: Nil home classifies all as Distant
+
+- **WHEN** home is nil, concerts have venues
+- **THEN** all concerts are placed in the Distant bucket
+
+---
+
+### Requirement: Concert proximity classification
+
+The existing `Concert.ProximityTo(home *Home) Proximity` method SHALL classify a concert's geographic proximity to the user's home area.
+
+Classification rules (evaluated in order):
+1. AWAY — if `home` is nil or `Venue` is nil.
+2. HOME — if venue's `AdminArea` matches `home.Level1`.
+3. NEARBY — if venue has `Coordinates`, home has `Centroid`, and Haversine distance ≤ 200km.
+4. AWAY — everything else.
+
+#### Scenario: Nil home
+
+- **WHEN** home is nil
+- **THEN** returns ProximityAway
+
+#### Scenario: Nil venue
+
+- **WHEN** concert has no venue
+- **THEN** returns ProximityAway
+
+#### Scenario: Admin area match
+
+- **WHEN** venue.AdminArea="JP-13" and home.Level1="JP-13"
+- **THEN** returns ProximityHome
+
+#### Scenario: Admin area mismatch with nearby coordinates
+
+- **WHEN** venue.AdminArea="JP-14" (Kanagawa), home.Level1="JP-13" (Tokyo), venue is 30km from home centroid
+- **THEN** returns ProximityNearby
+
+#### Scenario: Admin area mismatch beyond threshold
+
+- **WHEN** venue is 500km from home centroid, admin areas differ
+- **THEN** returns ProximityAway
+
+#### Scenario: Venue has no coordinates
+
+- **WHEN** venue.Coordinates is nil, admin areas differ
+- **THEN** returns ProximityAway
+
+#### Scenario: Home has no centroid
+
+- **WHEN** home.Centroid is nil, admin areas differ
+- **THEN** returns ProximityAway
+
+#### Scenario: Admin area match takes priority over distance
+
+- **WHEN** venue.AdminArea matches home.Level1, even though distance > 200km
+- **THEN** returns ProximityHome (admin area check runs first)
+
+#### Scenario: Venue admin area is nil
+
+- **WHEN** venue.AdminArea is nil, venue has coordinates within 200km of home
+- **THEN** returns ProximityNearby
+
+---
+
+### Requirement: Scraped concert deduplication key
+
+The `ScrapedConcert` entity SHALL provide a `DedupeKey() string` method that generates a unique deduplication key from its natural key fields.
+
+Key format: `"YYYY-MM-DD|<listed_venue_name>"` when `StartTime` is nil, or `"YYYY-MM-DD|<listed_venue_name>|HH:MM:SSZ"` when `StartTime` is non-nil (UTC formatted).
+
+#### Scenario: Without start time
+
+- **WHEN** ScrapedConcert has LocalDate=2026-03-15, ListedVenueName="Zepp Tokyo", StartTime=nil
+- **THEN** DedupeKey returns "2026-03-15|Zepp Tokyo"
+
+#### Scenario: With start time
+
+- **WHEN** ScrapedConcert has LocalDate=2026-03-15, ListedVenueName="Zepp Tokyo", StartTime=19:00 UTC
+- **THEN** DedupeKey returns "2026-03-15|Zepp Tokyo|19:00:00Z"
+
+#### Scenario: DateVenueKey subset
+
+- **WHEN** ScrapedConcert has a start time
+- **THEN** DedupeKey begins with DateVenueKey value
+
+---
+
+### Requirement: Artist filtering by MBID
+
+The entity package SHALL provide a `FilterArtistsByMBID(artists []*Artist) []*Artist` function that removes artists with empty MBID and deduplicates by MBID keeping the first occurrence.
+
+#### Scenario: Mixed valid and empty MBIDs
+
+- **WHEN** input contains artists with MBIDs ["abc", "", "def", "abc"]
+- **THEN** returns artists with MBIDs ["abc", "def"] in order
+
+#### Scenario: All empty MBIDs
+
+- **WHEN** all artists have empty MBID
+- **THEN** returns empty slice
+
+#### Scenario: No duplicates
+
+- **WHEN** all artists have unique non-empty MBIDs
+- **THEN** returns all artists unchanged
+
+#### Scenario: Empty input
+
+- **WHEN** input is nil or empty
+- **THEN** returns empty slice
+
+---
+
+### Requirement: OfficialSite constructor
+
+The entity package SHALL provide `NewOfficialSite(artistID, url string) *OfficialSite` that creates an OfficialSite with an auto-generated UUIDv7 ID.
+
+#### Scenario: Constructor generates ID
+
+- **WHEN** NewOfficialSite("artist-123", "https://example.com") is called
+- **THEN** returned OfficialSite has non-empty ID, ArtistID="artist-123", URL="https://example.com"
+
+#### Scenario: ID is unique per call
+
+- **WHEN** NewOfficialSite is called twice with the same arguments
+- **THEN** each call returns a different ID
+
+---
+
+### Requirement: Venue constructor from scraped data
+
+The entity package SHALL provide `NewVenueFromScraped(name string) *Venue` that creates a Venue with auto-generated UUIDv7 ID, EnrichmentStatus=pending, and RawName=name.
+
+#### Scenario: Constructor sets defaults
+
+- **WHEN** NewVenueFromScraped("Zepp Tokyo") is called
+- **THEN** returned Venue has non-empty ID, Name="Zepp Tokyo", RawName="Zepp Tokyo", EnrichmentStatus=EnrichmentStatusPending
+
+---
+
+### Requirement: Token ID generation
+
+The entity package SHALL provide `GenerateTokenID() (uint64, error)` that produces an ERC-721 token ID from the high 64 bits of a UUIDv7.
+
+#### Scenario: Generates non-zero token ID
+
+- **WHEN** GenerateTokenID is called
+- **THEN** returns a non-zero uint64 and nil error
+
+#### Scenario: Monotonically increasing
+
+- **WHEN** GenerateTokenID is called twice in sequence
+- **THEN** second value is greater than or equal to first (UUIDv7 timestamp ordering)

--- a/openspec/changes/archive/2026-03-12-enrich-entity-domain-logic/tasks.md
+++ b/openspec/changes/archive/2026-03-12-enrich-entity-domain-logic/tasks.md
@@ -1,0 +1,44 @@
+## 1. Entity validation & enum methods
+
+- [x] 1.1 Add `Home.Validate() error` method to `entity/user.go` with ISO 3166 regex validation; move `countryCodeRe` and `iso31662Re` from `usecase/user_uc.go`
+- [x] 1.2 Add `Hype.IsValid() bool` method to `entity/follow.go`
+- [x] 1.3 Write `entity/user_test.go` — table-driven tests for `Home.Validate()` covering all 7 scenarios from spec
+- [x] 1.4 Write `entity/follow_test.go` — table-driven tests for `Hype.IsValid()` covering known and unknown values
+
+## 2. Notification eligibility logic
+
+- [x] 2.1 Add `Hype.ShouldNotify(home *Home, venueAreas map[string]struct{}, concerts []*Concert) bool` method to `entity/follow.go`
+- [x] 2.2 Write tests for `Hype.ShouldNotify()` in `entity/follow_test.go` covering all 10 scenarios from spec (HypeWatch, HypeHome match/no-match/nil-home/empty-Level1, HypeNearby nearby/distant/nil-home, HypeAway, unknown)
+- [x] 2.3 Update `usecase/push_notification_uc.go` to call `f.Hype.ShouldNotify()` instead of inline switch; remove `hasNearbyConcert()` private function
+
+## 3. Concert grouping & deduplication
+
+- [x] 3.1 Add `GroupByDateAndProximity(concerts []*Concert, home *Home) []*ProximityGroup` to `entity/concert.go`; move from `usecase/concert_uc.go`
+- [x] 3.2 Add `ScrapedConcert.DedupeKey() string` and `ScrapedConcert.DateVenueKey() string` methods to `entity/concert.go`; remove `concertKey()` and `dateVenueKey()` from `usecase/concert_uc.go`
+- [x] 3.3 Write `entity/concert_test.go` — table-driven tests for `Concert.ProximityTo()` covering all 9 scenarios from spec (nil home, nil venue, admin match, nearby, distant, no venue coords, no home centroid, admin priority, nil admin area)
+- [x] 3.4 Write tests for `GroupByDateAndProximity()` in `entity/concert_test.go` covering all 4 scenarios (empty, single date mixed, multiple dates order, nil home)
+- [x] 3.5 Write tests for `ScrapedConcert.DedupeKey()` and `DateVenueKey()` in `entity/concert_test.go` covering all 3 scenarios
+- [x] 3.6 Update `usecase/concert_uc.go` to call entity-level `GroupByDateAndProximity()`, `DedupeKey()`, and `DateVenueKey()`; remove private functions
+
+## 4. Artist filtering
+
+- [x] 4.1 Add `FilterArtistsByMBID(artists []*Artist) []*Artist` to `entity/artist.go`; move from `usecase/artist_uc.go`
+- [x] 4.2 Write `entity/artist_test.go` — table-driven tests for `FilterArtistsByMBID()` covering all 4 scenarios (mixed, all empty, no duplicates, empty input)
+- [x] 4.3 Update `usecase/artist_uc.go` to call `entity.FilterArtistsByMBID()` instead of private `filterAndDedupByMBID()`
+
+## 5. Entity constructors
+
+- [x] 5.1 Add `NewOfficialSite(artistID, url string) *OfficialSite` constructor to `entity/artist.go`
+- [x] 5.2 Add `NewVenueFromScraped(name string) *Venue` constructor to `entity/venue.go`
+- [x] 5.3 Add `GenerateTokenID() (uint64, error)` to `entity/ticket.go`; move from `usecase/ticket_uc.go`
+- [x] 5.4 Write tests for `NewOfficialSite()` in `entity/artist_test.go` (ID generation, unique IDs, field mapping)
+- [x] 5.5 Write tests for `NewVenueFromScraped()` in `entity/venue_test.go` (ID generation, defaults)
+- [x] 5.6 Write tests for `GenerateTokenID()` in `entity/ticket_test.go` (non-zero, monotonic ordering)
+- [x] 5.7 Update `usecase/follow_uc.go` to use `entity.NewOfficialSite()` instead of inline construction
+- [x] 5.8 Update `usecase/ticket_uc.go` to use `entity.GenerateTokenID()` instead of private `generateTokenID()`
+
+## 6. Usecase cleanup & integration
+
+- [x] 6.1 Update `usecase/user_uc.go` to call `home.Validate()` instead of private `validateHome()`; remove `validateHome()`, `countryCodeRe`, `iso31662Re`
+- [x] 6.2 Run `make check` to verify all lint and tests pass
+- [x] 6.3 Run `mockery` if any interface signatures changed

--- a/openspec/specs/entity-domain-logic/spec.md
+++ b/openspec/specs/entity-domain-logic/spec.md
@@ -69,7 +69,7 @@ The `Hype` type SHALL provide a `ShouldNotify(home *Home, venueAreas map[string]
 
 Decision rules (evaluated in order):
 1. `HypeWatch` → false (never notify).
-2. `HypeHome` → true only if `home` is non-nil AND `home.Level1` exists in `venueAreas`.
+2. `HypeHome` → true only if `home` is non-nil AND `home.Level1` is non-empty AND `home.Level1` exists in `venueAreas`.
 3. `HypeNearby` → true only if any concert has `ProximityHome` or `ProximityNearby` relative to `home`.
 4. `HypeAway` → true (always notify).
 5. Any other value → false.
@@ -282,7 +282,7 @@ The entity package SHALL provide `NewOfficialSite(artistID, url string) *Officia
 
 ### Requirement: Venue constructor from scraped data
 
-The entity package SHALL provide `NewVenueFromScraped(name string) *Venue` that creates a Venue with auto-generated UUIDv7 ID, EnrichmentStatus=pending, and RawName=name.
+The entity package SHALL provide `NewVenueFromScraped(name string) *Venue` that creates a Venue with auto-generated UUIDv7 ID, Name=name, EnrichmentStatus=pending, and RawName=name.
 
 #### Scenario: Constructor sets defaults
 

--- a/openspec/specs/entity-domain-logic/spec.md
+++ b/openspec/specs/entity-domain-logic/spec.md
@@ -1,0 +1,306 @@
+## ADDED Requirements
+
+### Requirement: Home validation
+
+The `Home` entity SHALL provide a `Validate() error` method that enforces structural integrity of geographic home area data. The method SHALL return the first validation error encountered.
+
+Validation rules:
+1. `CountryCode` MUST match ISO 3166-1 alpha-2 format (`^[A-Z]{2}$`).
+2. `Level1` MUST match ISO 3166-2 subdivision format (`^[A-Z]{2}-[A-Z0-9]{1,3}$`).
+3. The first two characters of `Level1` MUST equal `CountryCode`.
+4. When `Level2` is non-nil, its length MUST be between 1 and 20 characters inclusive.
+
+#### Scenario: Valid home with all fields
+
+- **WHEN** Home has CountryCode="JP", Level1="JP-13", Level2=nil
+- **THEN** Validate returns nil
+
+#### Scenario: Valid home with Level2
+
+- **WHEN** Home has CountryCode="JP", Level1="JP-13", Level2="Shibuya"
+- **THEN** Validate returns nil
+
+#### Scenario: Invalid country code format
+
+- **WHEN** Home has CountryCode="j" (lowercase or wrong length)
+- **THEN** Validate returns error mentioning "ISO 3166-1 alpha-2"
+
+#### Scenario: Invalid Level1 format
+
+- **WHEN** Home has Level1="INVALID"
+- **THEN** Validate returns error mentioning "ISO 3166-2"
+
+#### Scenario: Level1 prefix mismatch
+
+- **WHEN** Home has CountryCode="JP" but Level1="US-CA"
+- **THEN** Validate returns error mentioning prefix mismatch
+
+#### Scenario: Level2 empty string
+
+- **WHEN** Home has Level2 pointing to an empty string
+- **THEN** Validate returns error mentioning "1 and 20 characters"
+
+#### Scenario: Level2 too long
+
+- **WHEN** Home has Level2 pointing to a 21-character string
+- **THEN** Validate returns error mentioning "1 and 20 characters"
+
+---
+
+### Requirement: Hype validity check
+
+The `Hype` type SHALL provide an `IsValid() bool` method that returns true only for the four defined values: `watch`, `home`, `nearby`, `away`.
+
+#### Scenario: Known hype values
+
+- **WHEN** Hype is one of HypeWatch, HypeHome, HypeNearby, HypeAway
+- **THEN** IsValid returns true
+
+#### Scenario: Unknown hype value
+
+- **WHEN** Hype is "unknown" or an empty string
+- **THEN** IsValid returns false
+
+---
+
+### Requirement: Hype-based notification eligibility
+
+The `Hype` type SHALL provide a `ShouldNotify(home *Home, venueAreas map[string]struct{}, concerts []*Concert) bool` method that determines whether a follower with this hype level should receive push notifications for a batch of new concerts.
+
+Decision rules (evaluated in order):
+1. `HypeWatch` → false (never notify).
+2. `HypeHome` → true only if `home` is non-nil AND `home.Level1` exists in `venueAreas`.
+3. `HypeNearby` → true only if any concert has `ProximityHome` or `ProximityNearby` relative to `home`.
+4. `HypeAway` → true (always notify).
+5. Any other value → false.
+
+#### Scenario: HypeWatch never notifies
+
+- **WHEN** Hype is HypeWatch with any home and concerts
+- **THEN** ShouldNotify returns false
+
+#### Scenario: HypeHome matches venue area
+
+- **WHEN** Hype is HypeHome, home.Level1="JP-13", venueAreas contains "JP-13"
+- **THEN** ShouldNotify returns true
+
+#### Scenario: HypeHome no match
+
+- **WHEN** Hype is HypeHome, home.Level1="JP-13", venueAreas contains only "JP-27"
+- **THEN** ShouldNotify returns false
+
+#### Scenario: HypeHome with nil home
+
+- **WHEN** Hype is HypeHome, home is nil
+- **THEN** ShouldNotify returns false
+
+#### Scenario: HypeHome with empty Level1
+
+- **WHEN** Hype is HypeHome, home.Level1 is empty string
+- **THEN** ShouldNotify returns false
+
+#### Scenario: HypeNearby with nearby concert
+
+- **WHEN** Hype is HypeNearby, home has centroid, a concert venue is within 200km
+- **THEN** ShouldNotify returns true
+
+#### Scenario: HypeNearby with only distant concerts
+
+- **WHEN** Hype is HypeNearby, all concerts are beyond 200km
+- **THEN** ShouldNotify returns false
+
+#### Scenario: HypeNearby with nil home
+
+- **WHEN** Hype is HypeNearby, home is nil
+- **THEN** ShouldNotify returns false
+
+#### Scenario: HypeAway always notifies
+
+- **WHEN** Hype is HypeAway with any home and concerts
+- **THEN** ShouldNotify returns true
+
+#### Scenario: Unknown hype skips
+
+- **WHEN** Hype is "unknown"
+- **THEN** ShouldNotify returns false
+
+---
+
+### Requirement: Concert proximity grouping
+
+The entity package SHALL provide a `GroupByDateAndProximity(concerts []*Concert, home *Home) []*ProximityGroup` function that classifies concerts into Home/Nearby/Distant buckets grouped by calendar date.
+
+Rules:
+1. Concerts SHALL be grouped by `LocalDate` formatted as "YYYY-MM-DD".
+2. Within each group, each concert SHALL be classified using `Concert.ProximityTo(home)`.
+3. Groups SHALL be returned in the order of first appearance (preserving input date order).
+4. An empty or nil input SHALL return nil.
+
+#### Scenario: Empty input
+
+- **WHEN** concerts slice is empty
+- **THEN** function returns nil
+
+#### Scenario: Single date, mixed proximity
+
+- **WHEN** three concerts on 2026-03-15: one HOME, one NEARBY, one AWAY
+- **THEN** returns one ProximityGroup with correct bucket assignments
+
+#### Scenario: Multiple dates preserve order
+
+- **WHEN** concerts span March 15, March 17, March 16 (in that input order)
+- **THEN** returns three groups in order: March 15, March 17, March 16
+
+#### Scenario: Nil home classifies all as Distant
+
+- **WHEN** home is nil, concerts have venues
+- **THEN** all concerts are placed in the Distant bucket
+
+---
+
+### Requirement: Concert proximity classification
+
+The existing `Concert.ProximityTo(home *Home) Proximity` method SHALL classify a concert's geographic proximity to the user's home area.
+
+Classification rules (evaluated in order):
+1. AWAY — if `home` is nil or `Venue` is nil.
+2. HOME — if venue's `AdminArea` matches `home.Level1`.
+3. NEARBY — if venue has `Coordinates`, home has `Centroid`, and Haversine distance ≤ 200km.
+4. AWAY — everything else.
+
+#### Scenario: Nil home
+
+- **WHEN** home is nil
+- **THEN** returns ProximityAway
+
+#### Scenario: Nil venue
+
+- **WHEN** concert has no venue
+- **THEN** returns ProximityAway
+
+#### Scenario: Admin area match
+
+- **WHEN** venue.AdminArea="JP-13" and home.Level1="JP-13"
+- **THEN** returns ProximityHome
+
+#### Scenario: Admin area mismatch with nearby coordinates
+
+- **WHEN** venue.AdminArea="JP-14" (Kanagawa), home.Level1="JP-13" (Tokyo), venue is 30km from home centroid
+- **THEN** returns ProximityNearby
+
+#### Scenario: Admin area mismatch beyond threshold
+
+- **WHEN** venue is 500km from home centroid, admin areas differ
+- **THEN** returns ProximityAway
+
+#### Scenario: Venue has no coordinates
+
+- **WHEN** venue.Coordinates is nil, admin areas differ
+- **THEN** returns ProximityAway
+
+#### Scenario: Home has no centroid
+
+- **WHEN** home.Centroid is nil, admin areas differ
+- **THEN** returns ProximityAway
+
+#### Scenario: Admin area match takes priority over distance
+
+- **WHEN** venue.AdminArea matches home.Level1, even though distance > 200km
+- **THEN** returns ProximityHome (admin area check runs first)
+
+#### Scenario: Venue admin area is nil
+
+- **WHEN** venue.AdminArea is nil, venue has coordinates within 200km of home
+- **THEN** returns ProximityNearby
+
+---
+
+### Requirement: Scraped concert deduplication key
+
+The `ScrapedConcert` entity SHALL provide a `DedupeKey() string` method that generates a unique deduplication key from its natural key fields.
+
+Key format: `"YYYY-MM-DD|<listed_venue_name>"` when `StartTime` is nil, or `"YYYY-MM-DD|<listed_venue_name>|HH:MM:SSZ"` when `StartTime` is non-nil (UTC formatted).
+
+#### Scenario: Without start time
+
+- **WHEN** ScrapedConcert has LocalDate=2026-03-15, ListedVenueName="Zepp Tokyo", StartTime=nil
+- **THEN** DedupeKey returns "2026-03-15|Zepp Tokyo"
+
+#### Scenario: With start time
+
+- **WHEN** ScrapedConcert has LocalDate=2026-03-15, ListedVenueName="Zepp Tokyo", StartTime=19:00 UTC
+- **THEN** DedupeKey returns "2026-03-15|Zepp Tokyo|19:00:00Z"
+
+#### Scenario: DateVenueKey subset
+
+- **WHEN** ScrapedConcert has a start time
+- **THEN** DedupeKey begins with DateVenueKey value
+
+---
+
+### Requirement: Artist filtering by MBID
+
+The entity package SHALL provide a `FilterArtistsByMBID(artists []*Artist) []*Artist` function that removes artists with empty MBID and deduplicates by MBID keeping the first occurrence.
+
+#### Scenario: Mixed valid and empty MBIDs
+
+- **WHEN** input contains artists with MBIDs ["abc", "", "def", "abc"]
+- **THEN** returns artists with MBIDs ["abc", "def"] in order
+
+#### Scenario: All empty MBIDs
+
+- **WHEN** all artists have empty MBID
+- **THEN** returns empty slice
+
+#### Scenario: No duplicates
+
+- **WHEN** all artists have unique non-empty MBIDs
+- **THEN** returns all artists unchanged
+
+#### Scenario: Empty input
+
+- **WHEN** input is nil or empty
+- **THEN** returns empty slice
+
+---
+
+### Requirement: OfficialSite constructor
+
+The entity package SHALL provide `NewOfficialSite(artistID, url string) *OfficialSite` that creates an OfficialSite with an auto-generated UUIDv7 ID.
+
+#### Scenario: Constructor generates ID
+
+- **WHEN** NewOfficialSite("artist-123", "https://example.com") is called
+- **THEN** returned OfficialSite has non-empty ID, ArtistID="artist-123", URL="https://example.com"
+
+#### Scenario: ID is unique per call
+
+- **WHEN** NewOfficialSite is called twice with the same arguments
+- **THEN** each call returns a different ID
+
+---
+
+### Requirement: Venue constructor from scraped data
+
+The entity package SHALL provide `NewVenueFromScraped(name string) *Venue` that creates a Venue with auto-generated UUIDv7 ID, EnrichmentStatus=pending, and RawName=name.
+
+#### Scenario: Constructor sets defaults
+
+- **WHEN** NewVenueFromScraped("Zepp Tokyo") is called
+- **THEN** returned Venue has non-empty ID, Name="Zepp Tokyo", RawName="Zepp Tokyo", EnrichmentStatus=EnrichmentStatusPending
+
+---
+
+### Requirement: Token ID generation
+
+The entity package SHALL provide `GenerateTokenID() (uint64, error)` that produces an ERC-721 token ID from the high 64 bits of a UUIDv7.
+
+#### Scenario: Generates non-zero token ID
+
+- **WHEN** GenerateTokenID is called
+- **THEN** returns a non-zero uint64 and nil error
+
+#### Scenario: Monotonically increasing
+
+- **WHEN** GenerateTokenID is called twice in sequence
+- **THEN** second value is greater than or equal to first (UUIDv7 timestamp ordering)


### PR DESCRIPTION
## Summary

- Add **entity-domain-logic** capability spec to `openspec/specs/` (10 requirements, 47 scenarios)
- Archive the completed `enrich-entity-domain-logic` change (27/27 tasks done)

The spec documents pure domain logic that was moved from usecase to entity layer in the backend, covering:
- Home validation (ISO 3166)
- Hype notification eligibility
- Concert proximity grouping and classification
- Scraped concert deduplication keys
- Artist MBID filtering
- Entity constructors (OfficialSite, Venue, TokenID)

## Self-Checklist

- [x] No proto changes — docs only
- [x] All OpenSpec artifacts complete (proposal, design, spec, tasks)