### PR TITLE
docs: sync venue-normalization spec and archive enrich-venue

### DIFF
--- a/openspec/changes/archive/2026-03-12-enrich-venue/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-12-enrich-venue/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-12

--- a/openspec/changes/archive/2026-03-12-enrich-venue/design.md
+++ b/openspec/changes/archive/2026-03-12-enrich-venue/design.md
@@ -1,0 +1,72 @@
+## Context
+
+The venue enrichment pipeline runs in the consumer pod as an event handler (`venue.created.v1`) and as a batch step in the concert-discovery CronJob. It queries MusicBrainz first, then falls back to Google Maps. Currently the Google Maps client authenticates via an API key passed as a query parameter, but the key was never provisioned to the consumer pod's environment.
+
+The consumer pod already runs with Workload Identity Federation — the `backend-app` GCP service account is bound to the K8s service account via GKE Workload Identity, and Application Default Credentials (ADC) are available inside the pod. This is used today for Cloud SQL IAM authentication.
+
+Error logging is currently spread across three layers (usecase `enrichOne`, repository `MarkFailed`, event consumer `Handle`), making it difficult to correlate failures in Cloud Logging.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Enable Google Maps Places API access using WIF/OAuth (no API key secret management)
+- Consolidate enrichment error logs to top-level call sites with full diagnostic attributes
+- Keep the enrichment pipeline's existing retry semantics unchanged
+
+**Non-Goals:**
+- Re-enriching the 196 currently-failed venues (separate operational task after deployment)
+- Improving venue name normalization or deduplication logic
+- Migrating from Places API legacy to Places API (New) endpoint format (current Text Search endpoint works with OAuth)
+
+## Decisions
+
+### D1: WIF/OAuth via ADC instead of API key
+
+**Decision:** Use `golang.org/x/oauth2/google` to obtain an OAuth2 token via Application Default Credentials (ADC), and send it as `Authorization: Bearer <token>` with `X-Goog-User-Project` header.
+
+**Alternatives considered:**
+- **API key via Secret Manager + ExternalSecret**: Requires new GCP secret, ExternalSecret resource, and key rotation management. More moving parts.
+- **API key via Pulumi-managed ConfigMap**: Insecure — API key would be visible in plain text in K8s manifests.
+
+**Rationale:** WIF is already operational for Cloud SQL. Reusing the same SA eliminates secret management entirely. OAuth tokens are short-lived (1h) and auto-refreshed by the `oauth2.TokenSource`, removing rotation concerns.
+
+### D2: Places API Text Search endpoint compatibility with OAuth
+
+**Decision:** Continue using the legacy Text Search endpoint (`/maps/api/place/textsearch/json`) with OAuth Bearer token instead of the `key=` query parameter.
+
+**Rationale:** The Places API (New) documentation confirms OAuth support. The legacy endpoint also accepts OAuth tokens — the authentication method is independent of the endpoint version. This avoids a simultaneous endpoint migration.
+
+### D3: Google Maps searcher always registered (no conditional)
+
+**Decision:** Remove the `if cfg.GoogleMapsAPIKey != ""` conditional in DI wiring. The Google Maps searcher is always registered because ADC is always available in GKE pods with Workload Identity.
+
+**Rationale:** Eliminates a silent failure mode where the searcher was simply absent, causing 60% of venues to fail enrichment without any warning log.
+
+### D4: Error logging consolidation — top-level only
+
+**Decision:** Remove log statements from:
+1. `enrichOne()` — searcher transient error warn (L172-175)
+2. `VenueRepository.MarkFailed()` — repo-layer warn (L172-175 in venue_repo.go)
+
+Add/enhance log statements at:
+1. `EnrichPendingVenues()` — per-venue error log with attrs: `venue_id`, `raw_name`, `admin_area`, `error`, `outcome` (failed/transient)
+2. `EnrichOne()` — single error log with same attrs on transient failure
+3. `VenueConsumer.Handle()` — error log when `EnrichOne` returns error, with attrs: `venue_id`, `venue_name`, `error`
+
+**Rationale:** A single structured log per venue per enrichment attempt at the top-level call site provides complete context for filtering in Cloud Logging. Internal layers return errors upward; only the outermost handler logs.
+
+### D5: Merge log enhancement (kept in enrichOne)
+
+**Decision:** Keep the merge Info log inside `enrichOne()` (not at the top level) because the merge result data (canonical_id, duplicate_id) is only available inside the function. Enhance it with additional attrs: `canonical_name`, `raw_name`.
+
+**Rationale:** Merge is a success path, not an error path. The top-level caller sees `nil` error and has no merge-specific data to log. Keeping the log at the merge site is the natural location.
+
+## Risks / Trade-offs
+
+**[Risk] Places API not enabled in GCP project** → Pulumi change enables `places-backend.googleapis.com`. Verified via `pulumi preview` before deploy.
+
+**[Risk] IAM permission propagation delay** → IAM bindings can take up to 60s to propagate. Consumer pod restart after Pulumi deploy ensures fresh ADC token. ArgoCD rollout handles this naturally.
+
+**[Risk] OAuth token refresh under load** → `oauth2.TokenSource` from `google.DefaultTokenSource` handles refresh automatically with caching. The MusicBrainz rate limiter (1 req/s) means Google Maps is called at most once per second per venue — well within token refresh capacity.
+
+**[Trade-off] Legacy Text Search endpoint** → We continue using the legacy endpoint rather than migrating to Places API (New) REST format. This is acceptable because the auth change is orthogonal to the endpoint format, and the legacy endpoint is functional.

--- a/openspec/changes/archive/2026-03-12-enrich-venue/proposal.md
+++ b/openspec/changes/archive/2026-03-12-enrich-venue/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+The venue enrichment pipeline is failing to enrich 60% of venues (196/327) because the Google Maps fallback searcher is not operational — the `GOOGLE_MAPS_API_KEY` environment variable was never provisioned to the consumer pod. Additionally, enrichment error logs are scattered across usecase, repository, and consumer layers without sufficient diagnostic attributes, making troubleshooting difficult. The Google Maps client currently uses API key authentication; switching to Workload Identity Federation (WIF) with OAuth eliminates the need for secret management and aligns with the existing GKE IAM setup.
+
+## What Changes
+
+- Replace Google Maps API key authentication with WIF-based OAuth (ADC + Bearer token) in the Google Maps client
+- Remove `GOOGLE_MAPS_API_KEY` config dependency from the consumer application
+- Grant the existing `backend-app` GCP service account permission to call the Places API
+- Enable the Places API (`places-backend.googleapis.com`) in the GCP project via Pulumi
+- Consolidate enrichment error logging: remove scattered logs from `enrichOne()` internals and the `MarkFailed` repository method; emit structured error logs with full diagnostic attributes at the two top-level call sites (`EnrichPendingVenues`, `EnrichOne`) and in the event consumer handler
+- Add merge-specific attributes (canonical_id, duplicate_id, canonical_name, raw_name) to the merge Info log
+
+## Capabilities
+
+### New Capabilities
+
+_(none)_
+
+### Modified Capabilities
+
+- `venue-normalization`: Google Maps authentication method changes from API key to WIF/OAuth. Enrichment error logging consolidation requires updating the failure-logging behavior described in the enrichment scenarios.
+
+## Impact
+
+- **backend**: Google Maps client (`internal/infrastructure/maps/google/client.go`) switches from API key query param to `Authorization: Bearer` header with ADC. DI wiring (`internal/di/consumer.go`) removes the `cfg.GoogleMapsAPIKey` conditional — Google Maps searcher is always registered. Usecase and repo logging refactored.
+- **cloud-provisioning**: Pulumi enables `places-backend.googleapis.com` API. IAM binding grants Places API access to `backend-app` SA. Consumer configmap no longer needs `GOOGLE_MAPS_API_KEY`.
+- **config**: `GOOGLE_MAPS_API_KEY` field removed from `config.ConsumerConfig`.

--- a/openspec/changes/archive/2026-03-12-enrich-venue/specs/venue-normalization/spec.md
+++ b/openspec/changes/archive/2026-03-12-enrich-venue/specs/venue-normalization/spec.md
@@ -1,0 +1,94 @@
+## ADDED Requirements
+
+### Requirement: Google Maps Authentication via Workload Identity
+
+The Google Maps Places API client SHALL authenticate using OAuth 2.0 tokens obtained via Application Default Credentials (ADC) instead of an API key.
+
+#### Scenario: OAuth token obtained via ADC in GKE
+
+- **WHEN** the consumer pod starts in a GKE cluster with Workload Identity enabled
+- **THEN** the Google Maps client SHALL obtain an OAuth 2.0 access token using `google.DefaultTokenSource` with scope `https://www.googleapis.com/auth/cloud-platform`
+- **AND** the client SHALL include the token in the `Authorization: Bearer <token>` header on every Places API request
+- **AND** the client SHALL include the `X-Goog-User-Project` header with the GCP project ID
+
+#### Scenario: Google Maps searcher always registered
+
+- **WHEN** the consumer application initializes the venue enrichment pipeline
+- **THEN** the Google Maps searcher SHALL always be registered as a fallback searcher
+- **AND** registration SHALL NOT be conditional on the presence of an API key environment variable
+
+### Requirement: Enrichment Error Logging Consolidation
+
+The venue enrichment pipeline SHALL emit structured error logs exclusively at the top-level call site with sufficient diagnostic attributes for troubleshooting.
+
+#### Scenario: Error log emitted at top level for batch enrichment
+
+- **WHEN** `EnrichPendingVenues` processes a venue and enrichment fails
+- **THEN** a single structured log entry SHALL be emitted at the `EnrichPendingVenues` level
+- **AND** the log entry SHALL include attributes: `venue_id`, `raw_name`, `error`, and `outcome` (one of `failed` or `transient`)
+- **AND** no duplicate error log SHALL be emitted from `enrichOne` internals or the repository layer for the same failure
+
+#### Scenario: Error log emitted at top level for event-driven enrichment
+
+- **WHEN** `VenueConsumer.Handle` processes a `venue.created.v1` event and `EnrichOne` returns an error
+- **THEN** a structured error log SHALL be emitted at the consumer handler level
+- **AND** the log entry SHALL include attributes: `venue_id`, `venue_name`, and `error`
+
+#### Scenario: Merge log includes diagnostic attributes
+
+- **WHEN** a duplicate venue is detected and merged during enrichment
+- **THEN** the merge Info log SHALL include attributes: `canonical_id`, `duplicate_id`, `canonical_name`, and `raw_name`
+
+## MODIFIED Requirements
+
+### Requirement: Venue Enrichment Pipeline
+
+The system SHALL provide an async enrichment pipeline that resolves raw venue names to canonical external identifiers (MusicBrainz MBID or Google Maps place_id) and updates venue records with canonical names and geographic coordinates.
+
+#### Scenario: Successful enrichment via MusicBrainz
+
+- **WHEN** the enrichment job processes a venue with `enrichment_status = 'pending'`
+- **AND** MusicBrainz place search returns a match
+- **THEN** the venue record SHALL be updated with the MusicBrainz MBID
+- **AND** `venues.raw_name` SHALL be set to the current `venues.name` (if `raw_name` is NULL) to preserve the original scraper-provided name
+- **AND** `venues.name` SHALL be overwritten with the canonical name from MusicBrainz
+- **AND** `enrichment_status` SHALL be set to `'enriched'`
+- **AND** the venue's `Coordinates` SHALL be set to the value returned by the PlaceSearcher (non-nil when the response includes coordinates, nil otherwise)
+
+#### Scenario: Successful enrichment via Google Maps fallback
+
+- **WHEN** the enrichment job processes a venue with `enrichment_status = 'pending'`
+- **AND** MusicBrainz place search returns no match
+- **AND** Google Maps Text Search returns a match
+- **THEN** the Google Maps client SHALL authenticate via OAuth Bearer token (not API key)
+- **AND** the venue record SHALL be updated with the Google Maps place_id
+- **AND** `venues.raw_name` SHALL be set to the current `venues.name` (if `raw_name` is NULL) to preserve the original scraper-provided name
+- **AND** `venues.name` SHALL be overwritten with the canonical name from Google Maps
+- **AND** `enrichment_status` SHALL be set to `'enriched'`
+- **AND** the venue's `Coordinates` SHALL be updated from the Google Maps geometry response
+
+#### Scenario: Both sources miss
+
+- **WHEN** the enrichment job processes a venue with `enrichment_status = 'pending'`
+- **AND** MusicBrainz returns no match
+- **AND** Google Maps returns no match
+- **THEN** `enrichment_status` SHALL be set to `'failed'`
+- **AND** `venues.name` SHALL remain unchanged
+- **AND** the venue's `Coordinates` SHALL remain nil
+- **AND** the venue SHALL NOT be retried in subsequent job runs
+
+#### Scenario: Ambiguous results (multiple matches)
+
+- **WHEN** the enrichment job processes a venue with `enrichment_status = 'pending'`
+- **AND** MusicBrainz or Google Maps returns more than one candidate match
+- **THEN** the venue SHALL NOT be updated with any external identifier
+- **AND** `venues.name` SHALL remain unchanged
+- **AND** `enrichment_status` SHALL be set to `'failed'`
+- **AND** the ambiguity SHALL be logged for future manual review
+
+#### Scenario: admin_area used as search hint
+
+- **WHEN** the enrichment job queries MusicBrainz or Google Maps for a venue
+- **AND** the venue has a non-NULL `admin_area` (ISO 3166-2 code)
+- **THEN** the system SHALL convert the ISO 3166-2 code to a locale-appropriate text name before including it in the search query
+- **AND** the text name SHALL be in the language most likely to yield accurate results for the target service (e.g., Japanese for MusicBrainz JP venues, English for Google Maps)

--- a/openspec/changes/archive/2026-03-12-enrich-venue/tasks.md
+++ b/openspec/changes/archive/2026-03-12-enrich-venue/tasks.md
@@ -1,0 +1,26 @@
+## 1. Cloud Provisioning — Enable Places API and IAM
+
+- [x] 1.1 Enable `places-backend.googleapis.com` API in the GCP project via Pulumi
+- [x] 1.2 Grant `backend-app` service account IAM permission for Places API access
+
+## 2. Backend — Google Maps Client OAuth Migration
+
+- [x] 2.1 Add `golang.org/x/oauth2` and `golang.org/x/oauth2/google` dependencies
+- [x] 2.2 Refactor `google.Client` to accept an `oauth2.TokenSource` instead of API key; send `Authorization: Bearer` header and `X-Goog-User-Project` header on requests
+- [x] 2.3 Update `google.Client` tests to use the new OAuth-based constructor
+- [x] 2.4 Remove `GoogleMapsAPIKey` field from `config.ConsumerConfig`
+- [x] 2.5 Update DI wiring (`di/consumer.go`): always register Google Maps searcher using ADC token source; remove `cfg.GoogleMapsAPIKey` conditional
+
+## 3. Backend — Enrichment Error Logging Consolidation
+
+- [x] 3.1 Remove transient error warn log from `enrichOne()` internals (searcher loop)
+- [x] 3.2 Remove warn log from `VenueRepository.MarkFailed()`
+- [x] 3.3 Enhance `EnrichPendingVenues()` error logging: add attrs `venue_id`, `raw_name`, `error`, `outcome`
+- [x] 3.4 Enhance `EnrichOne()`: add error log with attrs `venue_id`, `raw_name`, `error` on transient failure
+- [x] 3.5 Add error log to `VenueConsumer.Handle()` with attrs `venue_id`, `venue_name`, `error`
+- [x] 3.6 Enhance merge Info log in `enrichOne()`: add attrs `canonical_name`, `raw_name`
+
+## 4. Verification
+
+- [x] 4.1 Run backend unit tests (`make test`)
+- [x] 4.2 Run cloud-provisioning lint (`make lint`)

--- a/openspec/specs/venue-normalization/spec.md
+++ b/openspec/specs/venue-normalization/spec.md
@@ -25,7 +25,8 @@ The system SHALL provide an async enrichment pipeline that resolves raw venue na
 - **WHEN** the enrichment job processes a venue with `enrichment_status = 'pending'`
 - **AND** MusicBrainz place search returns no match
 - **AND** Google Maps Text Search returns a match
-- **THEN** the venue record SHALL be updated with the Google Maps place_id
+- **THEN** the Google Maps client SHALL authenticate via OAuth Bearer token (not API key)
+- **AND** the venue record SHALL be updated with the Google Maps place_id
 - **AND** `venues.raw_name` SHALL be set to the current `venues.name` (if `raw_name` is NULL) to preserve the original scraper-provided name
 - **AND** `venues.name` SHALL be overwritten with the canonical name from Google Maps
 - **AND** `enrichment_status` SHALL be set to `'enriched'`
@@ -56,6 +57,45 @@ The system SHALL provide an async enrichment pipeline that resolves raw venue na
 - **AND** the venue has a non-NULL `admin_area` (ISO 3166-2 code)
 - **THEN** the system SHALL convert the ISO 3166-2 code to a locale-appropriate text name before including it in the search query
 - **AND** the text name SHALL be in the language most likely to yield accurate results for the target service (e.g., Japanese for MusicBrainz JP venues, English for Google Maps)
+
+### Requirement: Google Maps Authentication via Workload Identity
+
+The Google Maps Places API client SHALL authenticate using OAuth 2.0 tokens obtained via Application Default Credentials (ADC) instead of an API key.
+
+#### Scenario: OAuth token obtained via ADC in GKE
+
+- **WHEN** the consumer pod starts in a GKE cluster with Workload Identity enabled
+- **THEN** the Google Maps client SHALL obtain an OAuth 2.0 access token using `google.DefaultTokenSource` with scope `https://www.googleapis.com/auth/cloud-platform`
+- **AND** the client SHALL include the token in the `Authorization: Bearer <token>` header on every Places API request
+- **AND** the client SHALL include the `X-Goog-User-Project` header with the GCP project ID
+
+#### Scenario: Google Maps searcher always registered
+
+- **WHEN** the consumer application initializes the venue enrichment pipeline
+- **THEN** the Google Maps searcher SHALL always be registered as a fallback searcher
+- **AND** registration SHALL NOT be conditional on the presence of an API key environment variable
+
+### Requirement: Enrichment Error Logging Consolidation
+
+The venue enrichment pipeline SHALL emit structured error logs exclusively at the top-level call site with sufficient diagnostic attributes for troubleshooting.
+
+#### Scenario: Error log emitted at top level for batch enrichment
+
+- **WHEN** `EnrichPendingVenues` processes a venue and enrichment fails
+- **THEN** a single structured log entry SHALL be emitted at the `EnrichPendingVenues` level
+- **AND** the log entry SHALL include attributes: `venue_id`, `raw_name`, `error`, and `outcome` (one of `failed` or `transient`)
+- **AND** no duplicate error log SHALL be emitted from `enrichOne` internals or the repository layer for the same failure
+
+#### Scenario: Error log emitted at top level for event-driven enrichment
+
+- **WHEN** `VenueConsumer.Handle` processes a `venue.created.v1` event and `EnrichOne` returns an error
+- **THEN** a structured error log SHALL be emitted at the consumer handler level
+- **AND** the log entry SHALL include attributes: `venue_id`, `venue_name`, and `error`
+
+#### Scenario: Merge log includes diagnostic attributes
+
+- **WHEN** a duplicate venue is detected and merged during enrichment
+- **THEN** the merge Info log SHALL include attributes: `canonical_id`, `duplicate_id`, `canonical_name`, and `raw_name`
 
 ### Requirement: Venue Duplicate Merge
 


### PR DESCRIPTION
## 🔗 Related Issue

Closes #195

## 📝 Summary of Changes

Sync the venue-normalization main spec with the `enrich-venue` change artifacts and archive the change.

### Spec Updates
- Add requirement: "Google Maps Authentication via Workload Identity" (2 scenarios)
- Add requirement: "Enrichment Error Logging Consolidation" (3 scenarios)
- Modify "Venue Enrichment Pipeline" Google Maps fallback scenario to specify OAuth Bearer token auth

### Archive
- Archive `enrich-venue` change to `openspec/changes/archive/2026-03-12-enrich-venue/`

## 📋 Commit Log

- `a68998e` docs(openspec): sync venue-normalization spec and archive enrich-venue

## ✅ Self-Checklist

- [x] I have linked the related issue.
- [x] I have updated the relevant documentation.
- [x] My code follows the architecture and style guidelines of the project.

## 📸 Related PRs

- Backend: liverty-music/backend (companion PR)
- Cloud provisioning: liverty-music/cloud-provisioning (companion PR)