### PR TITLE
docs: add align-secret-manager-naming change artifacts

### DIFF
--- a/openspec/changes/align-secret-manager-naming/.openspec.yaml
+++ b/openspec/changes/align-secret-manager-naming/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-12

--- a/openspec/changes/align-secret-manager-naming/design.md
+++ b/openspec/changes/align-secret-manager-naming/design.md
@@ -1,0 +1,81 @@
+## Context
+
+Blockchain-related secrets are named inconsistently across all layers. The feature has never worked in dev because Secret Manager entries were never created — ExternalSecret has been in `SecretSyncedError` since 2026-02-21, causing ArgoCD to report the backend Application as Degraded.
+
+Current naming chaos:
+
+| Layer | Deployer Key | RPC URL | Bundler |
+|-------|-------------|---------|---------|
+| Go `envconfig` tag | `TICKET_SBT_DEPLOYER_KEY` | `BASE_SEPOLIA_RPC_URL` | `BUNDLER_API_KEY` |
+| ExternalSecret `remoteRef.key` | `ticket-sbt-deployer-key` | `base-sepolia-rpc-url` | `bundler-api-key` |
+| Pulumi SM name | `blockchain-deployer-private-key` | `blockchain-rpc-url` | `bundler-api-key` |
+| ESC path | `smartContract.deployerEoa.privateKey` | (missing) | `smartContract.bundlerApiKey` |
+| Pulumi interface | `gcp.ticketSbtDeployerKey` | `gcp.baseSepoliaRpcUrl` | `gcp.bundlerApiKey` |
+| Secret Manager (actual) | does not exist | does not exist | does not exist |
+
+Six layers, five different naming conventions.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Unify all layers under a single `blockchain`-prefixed naming convention
+- Rename Go envconfig tags (feature is not running, safe to change)
+- Extract blockchain config from `GcpConfig` into a dedicated `BlockchainConfig` interface in Pulumi
+- Move ESC secrets from `smartContract.*` to `blockchain.*`
+- Create the secrets in GCP Secret Manager (dev environment)
+- Resolve ExternalSecret `SecretSyncedError` and ArgoCD `Degraded` status
+- Update documentation (`TICKET_SYSTEM_SETUP.md`)
+
+**Non-Goals:**
+- Deploying the TicketSBT contract (requires separate setup)
+- Enabling ticket minting in production (dev only)
+- Multi-chain support (YAGNI — single-chain design is sufficient)
+
+## Decisions
+
+### 1. `blockchain` is the naming domain across all layers
+
+The Go struct is `BlockchainConfig`. All layers derive names from this domain:
+
+| Layer | Deployer Key | RPC URL | Bundler |
+|-------|-------------|---------|---------|
+| Go envconfig | `BLOCKCHAIN_DEPLOYER_PRIVATE_KEY` | `BLOCKCHAIN_RPC_URL` | `BLOCKCHAIN_BUNDLER_API_KEY` |
+| ESC path | `blockchain.deployerPrivateKey` | `blockchain.rpcUrl` | `blockchain.bundlerApiKey` |
+| Pulumi interface | `BlockchainConfig.deployerPrivateKey` | `BlockchainConfig.rpcUrl` | `BlockchainConfig.bundlerApiKey` |
+| SM name | `blockchain-deployer-private-key` | `blockchain-rpc-url` | `blockchain-bundler-api-key` |
+| ExternalSecret secretKey | `BLOCKCHAIN_DEPLOYER_PRIVATE_KEY` | `BLOCKCHAIN_RPC_URL` | `BLOCKCHAIN_BUNDLER_API_KEY` |
+| ExternalSecret remoteRef.key | `blockchain-deployer-private-key` | `blockchain-rpc-url` | `blockchain-bundler-api-key` |
+
+**Rationale**: Chain-specific names (`BASE_SEPOLIA_*`) break on mainnet migration. Contract-specific names (`TICKET_SBT_*`) break when the same deployer EOA is reused for other contracts. `BLOCKCHAIN_*` is the right abstraction level — stable across chain and contract changes.
+
+### 2. Extract `BlockchainConfig` from `GcpConfig` in Pulumi
+
+Blockchain secrets are not GCP-specific. Create a separate `BlockchainConfig` interface and move the fields out of `GcpConfig`:
+
+```typescript
+export interface BlockchainConfig {
+  deployerPrivateKey?: string
+  rpcUrl?: string
+  bundlerApiKey?: string
+}
+```
+
+Read from Pulumi config under the `blockchain` namespace instead of `gcp`.
+
+### 3. Migrate ESC from `smartContract.*` to `blockchain.*`
+
+Move existing values:
+- `smartContract.deployerEoa.privateKey` → `blockchain.deployerPrivateKey`
+- `smartContract.bundlerApiKey` → `blockchain.bundlerApiKey`
+- Add missing: `blockchain.rpcUrl`
+- Remove old `smartContract.*` keys after migration
+
+### 4. RPC URL derivation
+
+The Alchemy API key from `smartContract.bundlerApiKey` (`qTGHFFio_i56ngeXDUMMO`) is likely the same key used for the RPC URL: `https://base-sepolia.g.alchemy.com/v2/<API_KEY>`. Confirm with user before setting.
+
+## Risks / Trade-offs
+
+- **[Risk] Go envconfig rename breaks local `.env` files** → Acceptable. Feature never worked; no one has working `.env` entries for these fields.
+- **[Risk] ESC migration leaves orphaned `smartContract.*` keys** → Clean up in the same change. Remove after verifying new keys work.
+- **[Risk] `TICKET_SBT_ADDRESS` still missing** → Even with all three secrets, ticket minting requires the deployed contract address. Out of scope — the DI code gracefully logs a warning when absent.

--- a/openspec/changes/align-secret-manager-naming/proposal.md
+++ b/openspec/changes/align-secret-manager-naming/proposal.md
@@ -1,0 +1,34 @@
+## Why
+
+Blockchain-related secret names are inconsistent across six layers (Go envconfig, ExternalSecret, Pulumi SM names, ESC paths, Pulumi TypeScript interface, GCP Secret Manager). The naming chaos — mixing `TICKET_SBT_*`, `blockchain-*`, `BASE_SEPOLIA_*`, `smartContract.*`, and `gcp.*` — caused ExternalSecret to reference non-existent Secret Manager keys. The backend ArgoCD Application has been Degraded since 2026-02-21 and the ticket minting feature has never worked in dev.
+
+## What Changes
+
+- Unify all layers under `BLOCKCHAIN_*` / `blockchain.*` / `blockchain-*` naming convention
+- Rename Go `envconfig` struct tags (feature is currently non-functional, safe to change)
+- Extract `BlockchainConfig` from `GcpConfig` in Pulumi TypeScript
+- Migrate ESC secrets from `smartContract.*` to `blockchain.*`
+- Update ExternalSecret manifest to match new naming
+- Create secrets in GCP Secret Manager via `pulumi up`
+- Update `TICKET_SYSTEM_SETUP.md` documentation
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+(none — infrastructure configuration fix across all layers)
+
+## Impact
+
+- **backend**: `pkg/config/config.go` envconfig tags renamed
+- **cloud-provisioning**: `src/gcp/components/project.ts` new `BlockchainConfig` interface
+- **cloud-provisioning**: `src/gcp/index.ts` config reading and SM names
+- **cloud-provisioning**: `k8s/namespaces/backend/base/server/external-secret.yaml` key names
+- **cloud-provisioning**: `docs/TICKET_SYSTEM_SETUP.md` documentation
+- **Pulumi ESC**: `liverty-music/dev` environment secret paths migrated
+- **GCP Secret Manager**: 3 new secrets created
+- **Kubernetes**: ExternalSecret syncs successfully, ArgoCD Degraded resolves

--- a/openspec/changes/align-secret-manager-naming/specs/no-spec-changes.md
+++ b/openspec/changes/align-secret-manager-naming/specs/no-spec-changes.md
@@ -1,0 +1,3 @@
+# No Spec Changes
+
+This change is an infrastructure configuration fix. No capability-level requirements are added or modified.

--- a/openspec/changes/align-secret-manager-naming/tasks.md
+++ b/openspec/changes/align-secret-manager-naming/tasks.md
@@ -1,0 +1,38 @@
+## 1. Go Backend — Rename envconfig tags
+
+- [x] 1.1 Rename `TICKET_SBT_DEPLOYER_KEY` → `BLOCKCHAIN_DEPLOYER_PRIVATE_KEY` in `BlockchainConfig` struct (`pkg/config/config.go`)
+- [x] 1.2 Rename `BASE_SEPOLIA_RPC_URL` → `BLOCKCHAIN_RPC_URL` in `BlockchainConfig` struct
+- [x] 1.3 ~~Rename `BUNDLER_API_KEY` → `BLOCKCHAIN_BUNDLER_API_KEY` in `BlockchainConfig` struct~~ (skipped: field not in Go code yet, future ERC-4337 feature)
+- [x] 1.4 ~~Update Go doc comments on renamed fields~~ (no changes needed: comments describe semantics, not env var names)
+- [x] 1.5 Run `make check` in backend
+
+## 2. Cloud Provisioning — Pulumi TypeScript
+
+- [x] 2.1 Create `BlockchainConfig` interface in `src/gcp/components/project.ts`, move blockchain fields out of `GcpConfig`
+- [x] 2.2 Update `src/gcp/index.ts` to read config from `blockchain` namespace and use new SM names (`blockchain-deployer-private-key`, `blockchain-rpc-url`, `blockchain-bundler-api-key`)
+- [x] 2.3 Run `make check` in cloud-provisioning
+
+## 3. Cloud Provisioning — K8s ExternalSecret
+
+- [x] 3.1 Update `k8s/namespaces/backend/base/server/external-secret.yaml`: rename `secretKey` and `remoteRef.key` to `BLOCKCHAIN_*` / `blockchain-*` naming
+- [x] 3.2 Run `kubectl kustomize` dry-run to verify manifest renders correctly
+
+## 4. Pulumi ESC — Migrate secrets
+
+- [x] 4.1 Set `pulumiConfig.blockchain.deployerPrivateKey` in `liverty-music/dev` ESC (value from existing `smartContract.deployerEoa.privateKey`)
+- [x] 4.2 Set `pulumiConfig.blockchain.rpcUrl` in `liverty-music/dev` ESC (Alchemy Base Sepolia endpoint)
+- [x] 4.3 Set `pulumiConfig.blockchain.bundlerApiKey` in `liverty-music/dev` ESC (value from existing `smartContract.bundlerApiKey`)
+- [ ] 4.4 Remove old `smartContract.*` keys from ESC (manual: `esc env rm liverty-music/dev pulumiConfig.smartContract`)
+
+## 5. Documentation
+
+- [x] 5.1 Update `cloud-provisioning/docs/TICKET_SYSTEM_SETUP.md` to reflect new naming across all references
+
+## 6. Deploy & Verify
+
+- [x] 6.1 Run `pulumi preview` to verify Secret Manager resources will be created with correct names
+- [x] 6.2 Get user approval and run `pulumi up`
+- [x] 6.3 Confirm secrets exist in Secret Manager: `gcloud secrets list --project=liverty-music-dev`
+- [ ] 6.4 Confirm ExternalSecret `server-backend-secrets` status is `Ready: True` (pending: ArgoCD sync after code merge)
+- [ ] 6.5 Confirm ArgoCD `backend` Application health transitions from `Degraded` (pending: ArgoCD sync after code merge)
+- [ ] 6.6 Check server pod logs for blockchain config initialization (pending: ArgoCD sync after code merge)


### PR DESCRIPTION
## Related Issue
Refs: liverty-music/cloud-provisioning#140

## Summary

Add OpenSpec change artifacts for the `align-secret-manager-naming` initiative that unifies blockchain secret naming across all infrastructure layers.

### Artifacts
- `proposal.md`: Problem statement and scope
- `design.md`: Naming convention decisions and layer mapping
- `tasks.md`: Implementation checklist (18/21 complete)

### Related PRs
- liverty-music/cloud-provisioning#143
- liverty-music/backend#194