### PR TITLE
fix!(concert): revert ProximityGroup field distant back to away

### DIFF
--- a/openspec/changes/refactor-usecase-layer-boundaries/design.md
+++ b/openspec/changes/refactor-usecase-layer-boundaries/design.md
@@ -42,9 +42,9 @@ This change is cross-repo: proto schema changes in specification must be release
 
 ### 3. `ProximityGroup` replaces `DateLaneGroup`
 
-**Decision**: Rename `DateLaneGroup` to `ProximityGroup` in `concert_service.proto`. Rename field `away` to `distant`.
+**Decision**: Rename `DateLaneGroup` to `ProximityGroup` in `concert_service.proto`. Keep field name `away` (consistent with `PROXIMITY_AWAY` enum value).
 
-**Why**: "Lane" is a UI presentation concept. "Proximity" is the domain concept. The field rename `away` → `distant` aligns with the `PROXIMITY_AWAY` enum value while being semantically accurate for the "beyond threshold" case.
+**Why**: "Lane" is a UI presentation concept. "Proximity" is the domain concept. The field name `away` is retained because it matches the `PROXIMITY_AWAY` enum value — consistency between enum and field names is more important than avoiding reuse of the old message's field name.
 
 **Breaking change handling**: This is a breaking proto change. The specification PR will use the `buf skip breaking` label.
 

--- a/openspec/changes/refactor-usecase-layer-boundaries/tasks.md
+++ b/openspec/changes/refactor-usecase-layer-boundaries/tasks.md
@@ -2,7 +2,7 @@
 
 - [x] 1.1 Create `entity/v1/proximity.proto` with `Proximity` enum (UNSPECIFIED, HOME, NEARBY, AWAY)
 - [x] 1.2 Add `optional double centroid_latitude` and `optional double centroid_longitude` fields to `Home` message in `user.proto`
-- [x] 1.3 Rename `DateLaneGroup` to `ProximityGroup` in `concert_service.proto`, rename field `away` to `distant`
+- [x] 1.3 Rename `DateLaneGroup` to `ProximityGroup` in `concert_service.proto` (keep field name `away` — consistent with `PROXIMITY_AWAY` enum)
 - [x] 1.4 Run `buf lint` and `buf format -w`, verify breaking changes are expected
 
 ## 2. Database Migration (backend repo)
@@ -76,5 +76,7 @@
 
 ## 11. Frontend (frontend repo)
 
-- [ ] 11.1 Update generated types import (`DateLaneGroup` → `ProximityGroup`, field `away` → `distant`) — **blocked on spec release to BSR**
-- [ ] 11.2 Update dashboard concert grouping to use new type/field names — **blocked on spec release to BSR**
+- [x] 11.1 Update BSR packages to v0.23.0 (v1-compatible): `@buf/liverty-music_schema.bufbuild_es@1.10.0-20260312065554-983c096e26c3.1`
+- [ ] 11.2 Update `DateLaneGroup` → `ProximityGroup` imports (field name `away` unchanged)
+- [ ] 11.3 Update dashboard concert grouping to use new type/field names
+- [ ] 11.4 Run `make check` to verify lint + tests pass

--- a/proto/liverty_music/rpc/concert/v1/concert_service.proto
+++ b/proto/liverty_music/rpc/concert/v1/concert_service.proto
@@ -66,7 +66,7 @@ message ListByFollowerResponse {
   reserved "concerts";
 
   // Concert groups ordered by date ascending. Each group contains concerts
-  // for a single date, classified into home/nearby/distant buckets based on
+  // for a single date, classified into home/nearby/away buckets based on
   // the geographic proximity between the user's home area and each venue.
   repeated ProximityGroup groups = 2;
 }
@@ -74,7 +74,7 @@ message ListByFollowerResponse {
 // ProximityGroup contains concerts for a single calendar date, classified into
 // three geographic proximity buckets relative to the authenticated user's home area.
 message ProximityGroup {
-  reserved "away";
+  reserved "distant";
 
   // The calendar date for this group.
   entity.v1.LocalDate date = 1 [(buf.validate.field).required = true];
@@ -86,7 +86,7 @@ message ProximityGroup {
   repeated entity.v1.Concert nearby = 3;
 
   // Concerts at venues beyond 200km, with unknown location, or when the user has no home set.
-  repeated entity.v1.Concert distant = 4;
+  repeated entity.v1.Concert away = 4;
 }
 
 // SearchNewConcertsRequest specifies the artist for whom to search for new concerts.


### PR DESCRIPTION
## Related Issue

Refs: #191

## Summary of Changes

Revert `ProximityGroup` field name from `distant` back to `away` for consistency with the `PROXIMITY_AWAY` enum value.

The original refactor renamed `DateLaneGroup.away` → `ProximityGroup.distant`, but this created an inconsistency: the enum value is `PROXIMITY_AWAY` while the field was `distant`. Field names should match their corresponding enum values.

- Proto: `ProximityGroup.distant` → `ProximityGroup.away` (field number 4 unchanged)
- Reserved name updated: `"away"` → `"distant"`
- Design and tasks artifacts updated accordingly

BREAKING CHANGE: `ProximityGroup` field 4 renamed from `distant` to `away`.

## Self-Checklist

- [x] I have linked the related issue.
- [x] I have updated the relevant documentation (e.g., `README.md`) if needed.
- [x] I have run `buf lint` and `buf format` locally and all checks have passed.
- [x] My proto definitions follow the project's style guidelines and validation rules.
- [x] Breaking changes have been justified and documented if applicable.
