### PR TITLE
docs(openspec): add onboarding UX bug fixes and concert data gate changes

### DIFF
--- a/openspec/changes/fix-onboarding-ux-bugs/.openspec.yaml
+++ b/openspec/changes/fix-onboarding-ux-bugs/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-11

--- a/openspec/changes/fix-onboarding-ux-bugs/design.md
+++ b/openspec/changes/fix-onboarding-ux-bugs/design.md
@@ -1,0 +1,214 @@
+## Context
+
+The onboarding flow (PR #146) guides unauthenticated users through artist discovery → dashboard → my-artists → signup. The implementation has several interrelated bugs stemming from three root causes:
+
+1. **AuthHook gap**: Routes without `tutorialStep` data fall through to the "not authenticated" branch, triggering an inappropriate toast during onboarding.
+2. **Spotlight rendering bug**: The coach mark overlay's own `background` paints over the child spotlight element's `box-shadow` hole, making the cutout invisible.
+3. **Progress semantics mismatch**: The progress bar tracks concert search completion (`completedSearchCount / followedCount`) while the guidance message tracks follow progress toward a 3-artist target.
+
+The frontend already uses CSS Anchor Positioning (Baseline 2025) for tooltip placement. The DNA orb canvas uses Canvas 2D with Matter.js physics and an existing particle system in `OrbRenderer`.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Fix all 6 identified UX bugs so the onboarding tutorial is completable end-to-end
+- Replace the broken spotlight with a working implementation that supports border-radius
+- Add visual feedback to the DNA orb when artists are followed (color injection + swirl)
+- Add regression tests for the fixed behaviors
+
+**Non-Goals:**
+- Redesigning the overall onboarding flow or step sequence
+- Adding new onboarding steps
+- Changing the backend or proto definitions
+- Performance optimization of the Canvas rendering pipeline
+
+## Decisions
+
+### D1: Spotlight — CSS Anchor Positioning Hybrid (box-shadow + transparent click-blockers)
+
+**Chosen**: A `.visual-spotlight` element positioned with `anchor()` functions uses `box-shadow: 0 0 0 100vmax` to create the dark overlay with a transparent cutout. Four invisible `.click-blocker` divs (top/right/bottom/left) also positioned with `anchor()` block clicks outside the target. The spotlight element uses `border-radius: var(--spotlight-radius)` for shape control.
+
+**Alternatives considered**:
+- **SVG mask on overlay**: Baseline 2015 support, perfect border-radius via `rx`/`ry`. But requires JS `getBoundingClientRect()` to update SVG rect attributes and `-webkit-mask` prefix. Since the project already depends on CSS Anchor Positioning (used in existing coach-mark tooltip), the browser support advantage is moot.
+- **Current approach (child box-shadow inside overlay div)**: Fundamentally broken — parent `background` paints over child's shadow hole. Not fixable without removing the parent background, which defeats the purpose.
+- **4-mask only (no visual spotlight)**: Works for click blocking but produces rectangular-only cutouts with no border-radius support.
+
+**Rationale**: The hybrid approach eliminates all JS coordinate calculations (`getBoundingClientRect`, `updateSpotlightPosition`), delegates positioning entirely to the CSS engine, supports arbitrary border-radius via CSS variable, and integrates with View Transitions API for smooth spotlight movement across all target changes — both same-page (lane introduction sequence) and cross-route (Discovery → Dashboard → My Artists). The visual/logic layer separation is clean and testable.
+
+**Implementation pattern** (CSS):
+
+```css
+/* View Transition for smooth spotlight movement */
+::view-transition-group(spotlight) {
+  animation-duration: 0.4s;
+  animation-timing-function: cubic-bezier(0.25, 1, 0.5, 1);
+}
+
+.coach-mark-overlay {
+  /* Popover UA reset */
+  margin: 0; border: none; padding: 0;
+  width: 100vw; height: 100vh;
+  background: transparent;
+  pointer-events: none;
+  &::backdrop { display: none; }
+}
+
+.visual-spotlight {
+  position: fixed;
+  top: anchor(--coach-target top);
+  right: anchor(--coach-target right);
+  bottom: anchor(--coach-target bottom);
+  left: anchor(--coach-target left);
+  margin: -8px;
+  border-radius: var(--spotlight-radius, 12px);
+  box-shadow: 0 0 0 100vmax color-mix(in oklch, oklch(0% 0 0) 70%, transparent);
+  pointer-events: none;
+  view-transition-name: spotlight;
+}
+
+.click-blocker {
+  position: fixed;
+  background-color: transparent;
+  pointer-events: auto;
+}
+.mask-top    { inset: 0 0 auto 0; bottom: anchor(--coach-target top); }
+.mask-bottom { inset: auto 0 0 0; top: anchor(--coach-target bottom); }
+.mask-left   { top: anchor(--coach-target top); bottom: anchor(--coach-target bottom); left: 0; right: anchor(--coach-target left); }
+.mask-right  { top: anchor(--coach-target top); bottom: anchor(--coach-target bottom); right: 0; left: anchor(--coach-target right); }
+```
+
+**Implementation pattern** (JS — anchor-name reassignment wrapped in View Transition):
+
+```typescript
+// Target change: wrap in View Transition for smooth spotlight slide
+document.startViewTransition(() => {
+  this.currentTarget?.style.removeProperty('anchor-name');
+  newTarget.style.anchorName = '--coach-target';
+  this.currentTarget = newTarget;
+});
+```
+
+### D2: DNA Orb Color Injection — Bubble Hue Pass-Through
+
+**Chosen**: When the absorption animation delivers a bubble to the orb center, pass the bubble's existing hue (already computed from `artistHue(name)` for canvas rendering) to `OrbRenderer.injectColor(hue)`. This method replaces 5-8 existing particles with new particles at the given hue and triggers a swirl animation (3x rotation speed, ~1000ms decay).
+
+**Rationale**: The bubble already has a deterministic hue computed for rendering. Passing it through the absorption callback avoids re-importing `color-generator.ts` and keeps the data flow unidirectional: bubble → absorption → orb. Over successive follows, the orb accumulates diverse hues, visually representing the user's "Music DNA."
+
+### D3: AuthHook — Onboarding-Aware Fallback
+
+**Chosen**: Insert a new Priority 2.5 check between the current tutorial step check and the "not authenticated" fallback:
+
+```
+Priority 2: tutorialStep defined + isOnboarding → allow if step reached
+Priority 2.5 (NEW): tutorialStep undefined + isOnboarding → redirect to current step route (no toast)
+Priority 3: Not authenticated → toast + redirect to LP
+```
+
+**Rationale**: Minimal change. One `if` branch addition. No toast, no user confusion. The redirect takes the user back to wherever they should be in the tutorial.
+
+### D4: Home Nav Click — Step Advancement via Coach Mark
+
+**Chosen**: The existing coach mark targets `[data-nav-dashboard]`. Fix the spotlight (D1) so users can see and tap it. The existing `onCoachMarkTap()` already advances the step and navigates. Additionally, handle the case where a user clicks the nav button directly (bypassing the coach mark overlay) by checking onboarding state in the nav-bar component and advancing the step if the follow threshold is met.
+
+### D5: Progress Bar Removal
+
+**Chosen**: Remove the `search-progress-bar` HTML, CSS, and the `searchProgress` / `completedSearchCount` / `concertSearchStatus` tracking from `DiscoverPage`. The coach mark appearance (triggered when `followedCount >= 3 && completedSearchCount >= followedCount`) remains as the progression signal, but the visual progress indicator is replaced by the DNA orb color evolution.
+
+Note: `completedSearchCount` is still needed for the `showDashboardCoachMark` computed property. Only the progress bar UI and `searchProgress` getter are removed.
+
+### D7: Continuous Spotlight — App-Shell Level Coach Mark
+
+**Chosen**: Move the `<coach-mark>` component from individual route page templates (discover-page, dashboard, my-artists-page) to a single instance in the app shell (`my-app.html`). The onboarding service drives the target selector, message, spotlight radius, and active state. The popover opens once at Step 1 (Dashboard icon) and stays open through Step 5 (Passion Level), with only the target changing via anchor-name reassignment + View Transitions. The popover closes at Step 6 (SignUp modal).
+
+**Alternatives considered**:
+- **Per-page coach mark instances (current)**: Each route template creates/destroys its own `<coach-mark>`. This causes the spotlight to blink off and on between steps, breaking the guided flow feel. Also duplicates state management across 3 pages.
+
+**Rationale**: A single app-shell instance naturally supports continuous spotlight across route navigations. View Transitions animate the spotlight slide because the same DOM element persists. The onboarding service already tracks `currentStep` — it simply publishes the target config, and the coach mark reacts. Individual pages become simpler (no coach mark bindings). Cleanup is centralized: one `hidePopover()` call at Step 6.
+
+### D8: Tooltip Arrow — Inline SVG with Drawing Animation
+
+**Chosen**: Add inline SVG arrows to the coach mark tooltip. The arrow is a `<svg>` element with a curved `<path>` for the line and a separate `<path>` for the arrowhead. Direction (up/down) is selected via Aurelia `switch.bind` on the tooltip's resolved `position-area`. The drawing animation uses CSS `stroke-dasharray` / `stroke-dashoffset` (600ms ease-out), and the arrowhead fades in after a 300ms delay.
+
+**Alternatives considered**:
+- **External image assets**: Requires HTTP requests, doesn't adapt to theme/color changes, resolution-dependent. Not acceptable for 2026 baseline.
+- **CSS-only triangle (`border` trick)**: No curved path, no animation, looks generic.
+- **Canvas-drawn arrow**: Overkill, not DOM-inspectable, breaks accessibility.
+
+**Rationale**: Inline SVG with `currentColor` inherits the tooltip's color via CSS cascade — zero theme coupling. The `stroke-dasharray` animation creates an organic "hand-drawn" feel that makes the coach mark feel personal rather than generic UI chrome. Aurelia's `switch.bind` selects the correct arrow direction at compile time with no runtime overhead.
+
+**Implementation pattern** (HTML):
+
+```html
+<div class="coach-arrow" switch.bind="arrowDirection">
+  <svg case="up" viewBox="0 0 100 100" fill="none" stroke="currentColor">
+    <path class="arrow-line" d="M10,90 Q50,90 90,20" />
+    <path class="arrow-head" d="M70,20 L90,20 L90,40" />
+  </svg>
+  <svg case="down" viewBox="0 0 100 100" fill="none" stroke="currentColor">
+    <path class="arrow-line" d="M10,10 Q50,10 90,80" />
+    <path class="arrow-head" d="M70,80 L90,80 L90,60" />
+  </svg>
+</div>
+```
+
+**Implementation pattern** (CSS):
+
+```css
+.coach-arrow svg {
+  width: 80px; height: 80px;
+  stroke-width: 4px; stroke-linecap: round; stroke-linejoin: round;
+  filter: drop-shadow(0 4px 6px color-mix(in oklch, oklch(0% 0 0) 50%, transparent));
+  transform: rotate(-5deg);
+}
+.arrow-line {
+  stroke-dasharray: 150; stroke-dashoffset: 150;
+  animation: draw-line 0.6s cubic-bezier(0.25, 1, 0.5, 1) forwards;
+}
+.arrow-head {
+  opacity: 0;
+  animation: fade-in-head 0.3s ease-out 0.5s forwards;
+}
+@keyframes draw-line { to { stroke-dashoffset: 0; } }
+@keyframes fade-in-head { to { opacity: 1; } }
+@media (prefers-reduced-motion: reduce) {
+  .arrow-line { animation: none; stroke-dashoffset: 0; }
+  .arrow-head { animation: none; opacity: 1; }
+}
+```
+
+### D9: Tooltip Handwritten Font
+
+**Chosen**: Use a handwritten-style Google Font (e.g., `Caveat`, `Klee One`, or `Zen Kurenaido` for Japanese text) for the coach mark tooltip message text. The font is loaded via `@import` or `<link>` from Google Fonts and applied to the tooltip message element via `font-family`.
+
+**Rationale**: The handwritten font reinforces the personal, friendly tone of the onboarding guidance — consistent with the hand-drawn SVG arrow (D8) and the organic DNA orb animation (D2). It visually distinguishes coach mark messages from standard UI text, making them feel like personal notes rather than system prompts. Japanese-compatible handwritten fonts (`Klee One`, `Zen Kurenaido`) ensure the Japanese tooltip messages render with the intended aesthetic.
+
+**Implementation pattern** (CSS):
+
+```css
+/* Google Fonts import (in global stylesheet or component) */
+@import url('https://fonts.googleapis.com/css2?family=Klee+One&display=swap');
+
+.coach-tooltip-message {
+  font-family: 'Klee One', cursive;
+  font-size: 18px;
+  line-height: 1.6;
+}
+```
+
+### D6: Toast Popover UA Style Reset
+
+**Chosen**: Add explicit popover reset styles to the toast container: `background: transparent; border: none; padding: 0; margin: 0;`. This neutralizes the browser's default popover UA stylesheet which adds white background and border.
+
+## Implementation References
+
+The following research documents contain full implementation examples (Aurelia 2 components, CSS, and JS) that informed the design decisions above. Read these before implementing D1, D7, and D8:
+
+- `docs/research/spotlight-anchor-positioning.md` — CSS Anchor Positioning hybrid spotlight: box-shadow visual layer, transparent click-blockers, Popover API, View Transitions API (D1, D7)
+- `docs/research/coach-mark-svg-arrow.md` — Inline SVG directional arrow with `stroke-dasharray` drawing animation, Aurelia `switch.bind` for direction, `currentColor` theming (D8)
+
+## Risks / Trade-offs
+
+- **[Transparent click-blocker corner gap]** → The 4 rectangular blockers leave tiny triangular gaps at rounded corners where clicks can pass through. Mitigation: The gaps are ~3px at 12px border-radius — negligible for finger taps on mobile. Acceptable trade-off for pure-CSS positioning.
+- **[anchor() in inset properties]** → While CSS Anchor Positioning is Baseline 2025, using `anchor()` within `inset` shorthand may have edge cases in early implementations. Mitigation: Use longhand properties (`top`, `right`, `bottom`, `left`) if shorthand causes issues. Test on iOS Safari 18+ and Chrome Android.
+- **[Orb particle count growth]** → Injecting 5-8 particles per follow could exceed `maxParticles` (60) after many follows. Mitigation: `injectColor()` replaces existing particles rather than adding new ones, keeping the count constant.
+- **[Concert search still runs in background]** → Removing the progress bar doesn't remove the background concert search. The search still runs and is needed for `showDashboardCoachMark`. Only the visual indicator is removed.

--- a/openspec/changes/fix-onboarding-ux-bugs/proposal.md
+++ b/openspec/changes/fix-onboarding-ux-bugs/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+The onboarding flow shipped in PR #146 has multiple UX bugs that break the tutorial experience: the "Login required" toast fires incorrectly during onboarding, the spotlight overlay doesn't visually highlight the target element, the progress bar contradicts the guidance message, and the Home nav button silently fails to navigate. These issues make the onboarding confusing and unusable — users cannot complete the tutorial as designed.
+
+## What Changes
+
+- **Fix auth redirect during onboarding**: When an onboarding user taps a route without `tutorialStep` (Tickets, Settings), redirect silently to the current step's route instead of showing a "Login required" toast.
+- **Fix spotlight visibility**: Replace the broken box-shadow-on-child approach with a CSS Anchor Positioning hybrid (visual spotlight via `box-shadow` on an anchor-positioned element + transparent click-blockers). This makes the spotlight cutout actually visible with border-radius support.
+- **Remove progress bar, add DNA orb color injection**: Remove the concert-search progress bar (which contradicts the guidance message). Instead, when a bubble is absorbed into the orb, inject that bubble's hue into the orb's particle system with a swirl animation — making the orb visually richer as more artists are followed.
+- **Fix Home nav during onboarding**: Spotlight the Home icon as the coach mark target. When tapped, advance the onboarding step to DASHBOARD and navigate. Also handle direct nav-bar clicks during onboarding by advancing the step if the user has met the follow threshold.
+- **Fix toast popover white background leak**: Reset UA default styles on the toast popover container to prevent white background bleeding at corners.
+- **Add tests**: Add unit and integration tests covering the fixed behaviors to prevent regression.
+
+## Capabilities
+
+### New Capabilities
+
+- `onboarding-spotlight`: Coach mark spotlight implementation using CSS Anchor Positioning hybrid (visual box-shadow layer + transparent click-blockers), replacing the broken overlay+child box-shadow approach.
+- `dna-orb-color-injection`: DNA orb particle color injection — absorbing a followed artist's bubble injects its hue into the orb's particle system with a swirl animation.
+
+### Modified Capabilities
+
+- `frontend-onboarding-flow`: Auth redirect behavior during onboarding changes (no toast for non-tutorial routes), progress bar removed, Home nav spotlight added.
+- `frontend-route-guard`: AuthHook gains an onboarding-aware fallback that redirects without toast when tutorialStep is undefined but user is in onboarding.
+- `onboarding-tutorial`: Tutorial step progression updated — Home nav click advances step to DASHBOARD when follow threshold is met.
+
+## Impact
+
+- **Frontend components**: `coach-mark/`, `toast-notification/`, `dna-orb/orb-renderer.ts`, `dna-orb/dna-orb-canvas.ts`, `bottom-nav-bar/`
+- **Frontend hooks**: `auth-hook.ts` (redirect logic change)
+- **Frontend routes**: `discover-page.ts` (progress bar removal, orb integration), `discover-page.html`, `discover-page.css`
+- **Tests**: New test files for auth-hook onboarding scenarios, coach-mark spotlight visibility, orb color injection, discover-page guidance consistency
+- **No backend or proto changes required**

--- a/openspec/changes/fix-onboarding-ux-bugs/specs/dna-orb-color-injection/spec.md
+++ b/openspec/changes/fix-onboarding-ux-bugs/specs/dna-orb-color-injection/spec.md
@@ -1,0 +1,88 @@
+## ADDED Requirements
+
+### Requirement: Bubble Hue Injection into Orb Particles
+
+When an artist bubble is absorbed into the DNA orb, the orb's particle system SHALL incorporate the bubble's hue, visually reflecting the followed artist's color identity.
+
+#### Scenario: Follow triggers color injection
+
+- **WHEN** an artist bubble completes its absorption animation into the orb center
+- **THEN** the `OrbRenderer` SHALL replace 5-8 existing particles with new particles at the absorbed bubble's hue
+- **AND** the replacement SHALL keep the total particle count constant (no net growth)
+- **AND** the new particles SHALL have randomized angle, radius, speed, size, and opacity within normal ranges
+
+#### Scenario: Accumulated follows produce diverse orb colors
+
+- **WHEN** a user has followed 3 artists with hues 142 (green), 287 (purple), and 35 (orange)
+- **THEN** the orb SHALL contain particles in all three hue families mixed with the base hue range (220-280)
+- **AND** the visual effect SHALL be a multi-colored particle swirl representing the user's "Music DNA"
+
+#### Scenario: Hue comes from bubble's existing rendering color
+
+- **WHEN** the absorption animation fires for a bubble
+- **THEN** the hue passed to `OrbRenderer.injectColor()` SHALL be the same hue used to render that bubble on the canvas
+- **AND** the system SHALL NOT re-compute the hue from the artist name
+
+### Requirement: Swirl Animation on Follow
+
+The orb SHALL play a swirl animation when a new artist color is injected, making the color mixing visually dynamic.
+
+#### Scenario: Swirl triggers on color injection
+
+- **WHEN** `OrbRenderer.injectColor(hue)` is called
+- **THEN** the orb's particle rotation speed SHALL increase to 3x normal speed
+- **AND** the speed boost SHALL decay smoothly back to 1x over approximately 1000ms
+- **AND** the glow intensity SHALL temporarily increase by 0.4 (additive with pulse)
+
+#### Scenario: Swirl during reduced motion preference
+
+- **WHEN** the user has `prefers-reduced-motion: reduce` enabled
+- **THEN** the color injection SHALL still occur (particles change hue)
+- **BUT** the rotation speed boost SHALL be suppressed (remain at 1x)
+- **AND** the glow intensity boost SHALL be suppressed
+
+#### Scenario: Multiple rapid follows
+
+- **WHEN** a user follows two artists in quick succession (within 1 second)
+- **THEN** each follow SHALL inject its own color independently
+- **AND** the swirl animations SHALL compound (speed boost restarts from 3x on each injection)
+- **AND** the particle count SHALL remain constant
+
+## Test Cases
+
+### Unit Tests (Vitest — orb-renderer.spec.ts)
+
+#### TC-ORB-01: injectColor preserves particle count
+
+- **Given** an OrbRenderer initialized with `maxParticles = 60`
+- **When** `injectColor(142)` is called
+- **Then** `particles.length` SHALL remain 60
+- **And** at least 5 particles SHALL have hue within ±10 of 142
+
+#### TC-ORB-02: swirlIntensity set to 1.0 after injectColor
+
+- **Given** an OrbRenderer with `swirlIntensity = 0`
+- **When** `injectColor(200)` is called
+- **Then** `swirlIntensity` SHALL be `1.0`
+
+#### TC-ORB-03: swirlIntensity decays to 0 after sufficient updates
+
+- **Given** an OrbRenderer after `injectColor(100)` (`swirlIntensity = 1.0`)
+- **When** `update(100)` is called 12 times (1200ms total, >1000ms decay window)
+- **Then** `swirlIntensity` SHALL be `0`
+
+#### TC-ORB-04: Multiple rapid injectColor calls inject each hue
+
+- **Given** an OrbRenderer
+- **When** `injectColor(100)` then `update(200)` then `injectColor(300)` are called
+- **Then** `swirlIntensity` SHALL restart to `1.0` on the second call
+- **And** particles SHALL contain hues near both 100 and 300
+
+### Unit Tests (Vitest — dna-orb-canvas.spec.ts)
+
+#### TC-ORB-05: Absorption completion threads hue to OrbRenderer
+
+- **Given** a DnaOrbCanvas handling an artist interaction
+- **When** `startAbsorption()` is called
+- **Then** it SHALL receive the artist's hue and an `onComplete` callback
+- **And** when the absorption completes, `orbRenderer.injectColor(hue)` SHALL be called

--- a/openspec/changes/fix-onboarding-ux-bugs/specs/frontend-onboarding-flow/spec.md
+++ b/openspec/changes/fix-onboarding-ux-bugs/specs/frontend-onboarding-flow/spec.md
@@ -1,0 +1,81 @@
+## MODIFIED Requirements
+
+### Requirement: Interactive Artist Discovery (Bubble Network UI)
+
+The system SHALL provide an engaging, gamified interface for users to discover and follow artists using Last.fm API data. During the tutorial, followed artists are stored locally (not via backend RPC). Additionally, the system SHALL trigger a background concert search for each followed artist to pre-populate concert data for the Dashboard. The DNA orb SHALL visually evolve as artists are followed, incorporating each artist's color into its particle system.
+
+#### Scenario: Initial artist bubble display
+
+- **WHEN** a user reaches the Artist Discovery step (Step 1)
+- **THEN** the system SHALL call Last.fm's `geo.getTopArtists` API with `country=japan`
+- **AND** the system SHALL display approximately 30 top artists as floating circular bubbles with physics-based animation
+
+#### Scenario: Guest user follows artist via bubble tap
+
+- **WHEN** a guest user (in tutorial) taps an artist bubble
+- **THEN** the system SHALL trigger the absorption animation
+- **AND** the system SHALL store the artist in `liverty:guest:followedArtists` in LocalStorage
+- **AND** the system SHALL NOT call any backend RPC for the follow operation itself
+- **AND** the system SHALL call `ConcertService/SearchNewConcerts` fire-and-forget in the background
+- **AND** errors from `SearchNewConcerts` SHALL be logged to console and NOT affect the follow operation or UI
+- **AND** upon absorption completion, the bubble's hue SHALL be injected into the orb's particle system with a swirl animation
+
+#### Scenario: Discover to Dashboard transition
+
+- **WHEN** a user is at Step 1 (Artist Discovery)
+- **AND** the user has followed >= 3 artists
+- **AND** concert search results have been received for all followed artists (or timed out)
+- **THEN** the system SHALL activate a coach mark spotlight on the Dashboard icon in the bottom navigation bar
+- **AND** the system SHALL display the coach mark message: "タイムテーブルを見てみよう！"
+- **AND** when the user taps the Dashboard icon through the spotlight, the system SHALL advance `onboardingStep` to 3 (DASHBOARD)
+- **AND** the system SHALL navigate to `/dashboard`
+
+#### Scenario: Concert data availability at Dashboard
+
+- **WHEN** the user arrives at the Dashboard after completing Artist Discovery
+- **THEN** concert data MAY already be available from the fire-and-forget `SearchNewConcerts` calls triggered during artist follows in Discovery
+- **AND** the Dashboard SHALL display its own loading skeleton / promise states for any data still pending
+- **AND** the system SHALL NOT rely on a loading screen to mask data fetching
+
+## REMOVED Requirements
+
+### Requirement: Progress bar reaches target
+
+**Reason**: The progress bar tracked concert search completion which contradicted the guidance message tracking follow count. Replaced by DNA orb color evolution as visual feedback for follow progress.
+
+**Migration**: Remove `search-progress-bar` HTML/CSS from discover-page template. Remove `searchProgress` getter from DiscoverPage. The `completedSearchCount` tracking remains for the `showDashboardCoachMark` condition.
+
+### Requirement: Step 1 - Progress bar display
+
+**Reason**: Same as above. The progress bar is removed and replaced by DNA orb visual feedback.
+
+**Migration**: Remove the progress bar UI. The concert search tracking logic remains internally for gating the coach mark appearance.
+
+## Test Cases
+
+### Unit Tests (Vitest — discover-page.spec.ts)
+
+#### TC-OF-01: Progress bar elements are absent from template
+
+- **Given** the discover-page component is rendered
+- **Then** no `.search-progress-bar` or `.search-progress-fill` elements SHALL exist in the DOM
+
+#### TC-OF-02: searchProgress getter is removed
+
+- **Given** the DiscoverPage class
+- **Then** no `searchProgress` property or getter SHALL exist
+- **And** `completedSearchCount` SHALL still be available (used by `showDashboardCoachMark`)
+
+#### TC-OF-03: showDashboardCoachMark gates on follow count and search completion
+
+- **Given** `onboardingStep = 1`
+- **When** `followedArtists.length >= 3` AND `completedSearchCount >= followedArtists.length`
+- **Then** `showDashboardCoachMark` SHALL be `true`
+
+### Unit Tests (Vitest — toast-notification.spec.ts)
+
+#### TC-OF-04: Toast popover container has transparent background
+
+- **Given** the toast-notification component uses `popover="manual"`
+- **Then** the popover container SHALL have CSS class `toast-popover`
+- **And** the CSS rule `[popover].toast-popover` SHALL set `background: transparent`, `border: none`, `padding: 0`, `margin: 0`

--- a/openspec/changes/fix-onboarding-ux-bugs/specs/frontend-route-guard/spec.md
+++ b/openspec/changes/fix-onboarding-ux-bugs/specs/frontend-route-guard/spec.md
@@ -1,0 +1,75 @@
+## MODIFIED Requirements
+
+### Requirement: Global Auth Hook
+
+The system SHALL provide a global authentication lifecycle hook that checks the user's authentication state and onboarding step before allowing navigation. The hook SHALL follow a priority-based decision tree: authentication status first, then onboarding step, with an onboarding-aware fallback for routes without tutorial step metadata.
+
+#### Scenario: Authenticated user navigates to any route
+
+- **WHEN** a user has `isAuthenticated = true`
+- **THEN** the system SHALL allow the route component to load regardless of `onboardingStep` value
+- **AND** no tutorial UI restrictions SHALL be applied
+
+#### Scenario: Unauthenticated user with onboardingStep in tutorial range navigates to a tutorial-gated route
+
+- **WHEN** a user has `isAuthenticated = false`
+- **AND** `onboardingStep` is between 1 and 6
+- **AND** the target route has `data.tutorialStep` defined
+- **THEN** the system SHALL allow navigation if `onboardingStep >= tutorialStep`
+- **AND** the system SHALL redirect to the current step's route if `onboardingStep < tutorialStep`
+
+#### Scenario: Unauthenticated user in onboarding navigates to a route without tutorialStep
+
+- **WHEN** a user has `isAuthenticated = false`
+- **AND** `onboardingStep` is between 1 and 6
+- **AND** the target route does NOT have `data.tutorialStep` defined
+- **AND** the target route does NOT have `data.auth = false`
+- **THEN** the system SHALL redirect to the route corresponding to the current onboarding step
+- **AND** the system SHALL NOT display a "Login required" toast
+- **AND** the system SHALL NOT display any error notification
+
+#### Scenario: Unauthenticated user with onboardingStep = COMPLETED
+
+- **WHEN** a user has `isAuthenticated = false`
+- **AND** `onboardingStep` is COMPLETED (7)
+- **THEN** the system SHALL redirect the user to the landing page
+- **AND** the landing page SHALL display only the [Login] CTA
+
+#### Scenario: Unauthenticated user with no onboardingStep
+
+- **WHEN** a user has `isAuthenticated = false`
+- **AND** `onboardingStep` is unset or 0
+- **THEN** the system SHALL redirect the user to the landing page
+- **AND** the system SHALL display a "Login required" toast notification
+- **AND** the landing page SHALL display [Get Started] and [Login]
+
+## Test Cases
+
+### Unit Tests (Vitest)
+
+#### TC-RG-01: Onboarding user navigating to route without tutorialStep redirects silently
+
+- **Given** `isAuthenticated = false`, `onboardingStep = 1`
+- **When** navigating to a route without `data.tutorialStep` (e.g., Tickets)
+- **Then** AuthHook SHALL return a redirect to the current step's route
+- **And** no "Login required" toast SHALL be published to EventAggregator
+
+#### TC-RG-02: Onboarding user navigating to future step redirects to current step
+
+- **Given** `isAuthenticated = false`, `onboardingStep = 1`
+- **When** navigating to a route with `data.tutorialStep = 3`
+- **Then** AuthHook SHALL redirect to the Step 1 route (discover)
+- **And** no toast SHALL be published
+
+#### TC-RG-03: Non-onboarding unauthenticated user sees "Login required" toast
+
+- **Given** `isAuthenticated = false`, `onboardingStep = 0` (or unset)
+- **When** navigating to a protected route
+- **Then** AuthHook SHALL redirect to the landing page
+- **And** a "Login required" toast SHALL be published to EventAggregator
+
+#### TC-RG-04: Authenticated user passes through without restriction
+
+- **Given** `isAuthenticated = true`
+- **When** navigating to any route
+- **Then** AuthHook SHALL allow navigation (return `true`)

--- a/openspec/changes/fix-onboarding-ux-bugs/specs/onboarding-spotlight/spec.md
+++ b/openspec/changes/fix-onboarding-ux-bugs/specs/onboarding-spotlight/spec.md
@@ -1,0 +1,258 @@
+## ADDED Requirements
+
+### Requirement: Spotlight Visual Layer via Box-Shadow
+
+The coach mark spotlight SHALL use a CSS Anchor Positioning hybrid approach. A `.visual-spotlight` element SHALL be positioned over the target using `anchor()` functions in `inset` properties, with `box-shadow: 0 0 0 100vmax` to create the dark overlay and a transparent cutout. The element SHALL use `border-radius: var(--spotlight-radius)` for shape control and `pointer-events: none` to allow click-through.
+
+#### Scenario: Spotlight renders with rounded cutout over target
+
+- **WHEN** a coach mark is activated with a target selector
+- **THEN** the system SHALL position a `.visual-spotlight` element using CSS `anchor()` functions referencing the target's anchor name
+- **AND** the spotlight SHALL create a dark overlay (70% opacity) across the entire viewport via `box-shadow: 0 0 0 100vmax`
+- **AND** the spotlight cutout SHALL match the target's border-radius via `var(--spotlight-radius)`
+- **AND** the spotlight element SHALL have `pointer-events: none`
+
+#### Scenario: Spotlight shape adapts per step
+
+- **WHEN** the coach mark targets a circular element (e.g., nav icon)
+- **THEN** `--spotlight-radius` SHALL be set to `50%`
+- **WHEN** the coach mark targets a rectangular element (e.g., concert card)
+- **THEN** `--spotlight-radius` SHALL be set to `12px`
+
+#### Scenario: Spotlight cutout has padding around target
+
+- **WHEN** the spotlight is positioned over a target element
+- **THEN** the spotlight cutout SHALL extend 8px beyond the target's bounding box on all sides (via `margin: -8px`)
+
+### Requirement: Click-Blocker Layer via Transparent Anchor-Positioned Divs
+
+The coach mark SHALL use four transparent click-blocker divs (top, right, bottom, left) positioned with CSS `anchor()` functions to block interactions outside the target element.
+
+#### Scenario: Clicks outside spotlight are blocked
+
+- **WHEN** the coach mark overlay is active
+- **AND** the user taps an area covered by a click-blocker div
+- **THEN** the tap SHALL be intercepted by the blocker (`pointer-events: auto`)
+- **AND** the tap SHALL NOT reach the underlying page content
+
+#### Scenario: Clicks inside spotlight reach the target
+
+- **WHEN** the coach mark overlay is active
+- **AND** the user taps inside the spotlight cutout area
+- **THEN** the tap SHALL pass through to the actual target element
+- **AND** the target element SHALL receive the click event natively
+
+#### Scenario: Click-blockers cover the entire viewport except target bounds
+
+- **WHEN** the coach mark overlay is active
+- **THEN** `.mask-top` SHALL cover from viewport top to `anchor(target top)`
+- **AND** `.mask-bottom` SHALL cover from `anchor(target bottom)` to viewport bottom
+- **AND** `.mask-left` SHALL cover from viewport left to `anchor(target left)`, between target top and bottom
+- **AND** `.mask-right` SHALL cover from `anchor(target right)` to viewport right, between target top and bottom
+
+### Requirement: Spotlight Uses Popover Top Layer
+
+The coach mark overlay container SHALL use `popover="manual"` to render on the browser's top layer, eliminating z-index stacking context issues.
+
+#### Scenario: Spotlight renders above all page content
+
+- **WHEN** the coach mark is activated
+- **THEN** the overlay container SHALL call `showPopover()` to enter the top layer
+- **AND** the spotlight and click-blockers SHALL render above all other content regardless of z-index
+
+#### Scenario: Popover UA styles are neutralized
+
+- **WHEN** the popover is displayed
+- **THEN** the container SHALL have `background: transparent`, `border: none`, `padding: 0`, `margin: 0`
+- **AND** `::backdrop` SHALL be set to `display: none`
+
+### Requirement: Continuous Spotlight Persistence
+
+The spotlight SHALL remain continuously active from the moment it first appears (Step 1, Dashboard icon) until the sign-up modal is displayed (Step 6). The popover SHALL NOT be closed and reopened between steps; instead, the target SHALL be updated via anchor-name reassignment while the overlay remains open. This provides uninterrupted visual guidance throughout the entire onboarding tutorial.
+
+#### Scenario: Spotlight activates at Step 1 and persists through Step 5
+
+- **WHEN** the coach mark first activates at Step 1 (Dashboard icon in discover page)
+- **THEN** the overlay popover SHALL call `showPopover()` once
+- **AND** the popover SHALL remain open through all subsequent steps (Step 3 lane intro, Step 3 card, Step 4 My Artists tab, Step 5 Passion Level)
+- **AND** the target SHALL change by reassigning `anchor-name` to the new target element
+- **AND** the tooltip message SHALL update to match the current step
+
+#### Scenario: Spotlight deactivates at Step 6
+
+- **WHEN** `onboardingStep` advances to 6 (SignUp)
+- **THEN** the overlay popover SHALL call `hidePopover()`
+- **AND** the current target's `anchor-name` SHALL be removed
+- **AND** the scroll lock on `<au-viewport>` SHALL be released
+- **AND** no orphaned click-blockers or anchor-names SHALL remain in the DOM
+
+#### Scenario: App-shell level placement
+
+- **WHEN** the onboarding spotlight is active
+- **THEN** the `<coach-mark>` component SHALL be rendered in the app shell (`my-app.html`), not in individual route page templates
+- **AND** the onboarding service SHALL drive the target selector, message, spotlight radius, and active state
+- **AND** individual route pages SHALL NOT contain their own `<coach-mark>` instances for onboarding steps
+
+### Requirement: Smooth Spotlight Movement via View Transitions API
+
+The spotlight SHALL animate smoothly when moving between targets, both within the same page (e.g., lane introduction sequence) and across route navigations (e.g., Discovery → Dashboard → My Artists). The `.visual-spotlight` element SHALL use `view-transition-name: spotlight` to enable browser-native cross-fade/slide animation.
+
+#### Scenario: Same-page target change (lane introduction)
+
+- **WHEN** the spotlight target changes within the same page (e.g., HOME STAGE → NEAR STAGE → AWAY STAGE → concert card)
+- **THEN** the system SHALL wrap the anchor-name reassignment in `document.startViewTransition()`
+- **AND** the spotlight SHALL slide smoothly from the old target position to the new target position
+- **AND** the animation duration SHALL be approximately 400ms with an ease-out curve
+
+#### Scenario: Cross-route target change
+
+- **WHEN** a route navigation occurs while the spotlight is active (e.g., Discovery Dashboard icon → Dashboard lane header, or Dashboard My Artists tab → My Artists Passion Level)
+- **THEN** the system SHALL use `document.startViewTransition()` to wrap the navigation
+- **AND** the spotlight SHALL animate from its previous position to the new target on the destination page
+- **AND** the tooltip text SHALL update to the new step's message
+- **AND** the popover SHALL NOT be closed during the transition
+
+#### Scenario: Reduced motion preference
+
+- **WHEN** the user has `prefers-reduced-motion: reduce` enabled
+- **THEN** the View Transition animation SHALL be suppressed (instant position change)
+- **AND** the spotlight SHALL still appear at the correct target position
+
+### Requirement: Tooltip Anchor Positioning
+
+The coach mark tooltip SHALL be positioned using CSS Anchor Positioning relative to the target element.
+
+#### Scenario: Tooltip appears below target
+
+- **WHEN** the coach mark is active
+- **THEN** the tooltip SHALL use `position-anchor` referencing the target's anchor name
+- **AND** the tooltip SHALL use `position-area: block-end` as the default placement
+- **AND** the tooltip SHALL use `position-try-fallbacks: flip-block, flip-inline` for overflow handling
+
+### Requirement: Inline SVG Directional Arrow
+
+The tooltip SHALL include a hand-drawn style directional arrow rendered as inline SVG. No external image assets (`<img>`, `.png`, `.svg` files) SHALL be used. The arrow SHALL visually connect the tooltip to the spotlight target.
+
+#### Scenario: Arrow direction adapts to tooltip placement
+
+- **WHEN** the tooltip is positioned below the target (`position-area: block-end`)
+- **THEN** the arrow SVG SHALL render an upward-pointing curved path connecting from the tooltip toward the target
+- **WHEN** the tooltip is positioned above the target (via `position-try-fallbacks: flip-block`)
+- **THEN** the arrow SVG SHALL render a downward-pointing curved path
+- **AND** the arrow direction SHALL be selected using Aurelia `switch.bind` on the resolved `position-area`
+
+#### Scenario: Arrow drawing animation on appearance
+
+- **WHEN** the tooltip first appears or the target changes
+- **THEN** the arrow path SHALL animate with a drawing effect using `stroke-dasharray` / `stroke-dashoffset` over approximately 600ms
+- **AND** the arrowhead SHALL fade in after the line drawing completes (300ms delay)
+
+#### Scenario: Arrow inherits theme color
+
+- **WHEN** the tooltip is rendered
+- **THEN** the SVG SHALL use `stroke="currentColor"` to inherit the tooltip's text color
+- **AND** the arrow SHALL automatically adapt to theme changes without separate assets
+
+#### Scenario: Arrow with reduced motion preference
+
+- **WHEN** the user has `prefers-reduced-motion: reduce` enabled
+- **THEN** the drawing animation SHALL be disabled (arrow appears immediately)
+- **AND** the arrow SHALL still be visible in its final drawn state
+
+### Requirement: Handwritten Font for Tooltip Text
+
+The coach mark tooltip message text SHALL use a handwritten-style font to reinforce the personal, friendly tone of the onboarding guidance. The font SHALL support Japanese characters since all tooltip messages are in Japanese.
+
+#### Scenario: Tooltip message renders in handwritten font
+
+- **WHEN** the coach mark tooltip is displayed
+- **THEN** the tooltip message text SHALL use a Japanese-compatible handwritten font (e.g., `Klee One`, `Zen Kurenaido`)
+- **AND** the font SHALL be loaded from Google Fonts
+- **AND** the font SHALL be applied only to the tooltip message element, not to action buttons or other UI elements
+
+#### Scenario: Handwritten font fallback
+
+- **WHEN** the handwritten font fails to load (e.g., offline, network error)
+- **THEN** the tooltip message SHALL fall back to `cursive` generic font family
+- **AND** the tooltip SHALL remain readable and functional
+
+#### Scenario: Handwritten font with reduced motion preference
+
+- **WHEN** the user has `prefers-reduced-motion: reduce` enabled
+- **THEN** the handwritten font SHALL still be applied (it is a visual style, not an animation)
+
+## Test Cases
+
+### Unit Tests (Vitest — coach-mark.spec.ts)
+
+#### TC-SP-01: Target element receives anchor-name when highlighted
+
+- **Given** a coach mark component is created
+- **When** `activateSpotlight(selector, message, onTap)` is called with a valid target selector
+- **Then** the target element's `anchorName` style SHALL be set to `--coach-target`
+
+#### TC-SP-02: Popover opens only once (continuous persistence)
+
+- **Given** the coach mark is not yet visible
+- **When** `activateSpotlight()` is called for the first time
+- **Then** `showPopover()` SHALL be called once on the overlay element
+- **When** `activateSpotlight()` is called again with a different target
+- **Then** `showPopover()` SHALL NOT be called again
+
+#### TC-SP-03: Target change does not close popover
+
+- **Given** the coach mark is active with target A
+- **When** `activateSpotlight()` is called with target B
+- **Then** `hidePopover()` SHALL NOT be called
+- **And** target A's `anchorName` SHALL be cleared
+- **And** target B's `anchorName` SHALL be set to `--coach-target`
+
+#### TC-SP-04: Deactivate cleans up all state
+
+- **Given** the coach mark is active
+- **When** `deactivateSpotlight()` is called
+- **Then** `hidePopover()` SHALL be called on the overlay element
+- **And** the current target's `anchorName` SHALL be cleared
+- **And** scroll lock on `<au-viewport>` SHALL be released (`overflow` reset)
+
+#### TC-SP-05: Arrow direction resolves to 'up' or 'down'
+
+- **Given** the coach mark is active
+- **When** the tooltip position is `block-end` (below target)
+- **Then** `arrowDirection` SHALL be `'up'`
+- **When** the tooltip position is `block-start` (above target)
+- **Then** `arrowDirection` SHALL be `'down'`
+
+#### TC-SP-06: Blocker click invokes onTap callback
+
+- **Given** the coach mark is active with an `onTap` callback
+- **When** the user clicks a `.click-blocker` element
+- **Then** the `onTap` callback SHALL be invoked
+
+#### TC-SP-07: spotlightRadius defaults to '12px'
+
+- **Given** the coach mark is activated without specifying spotlightRadius
+- **Then** the `--spotlight-radius` CSS custom property SHALL default to `'12px'`
+
+#### TC-SP-08: Target retry with exponential backoff
+
+- **Given** the target element does not exist in the DOM
+- **When** `activateSpotlight()` is called
+- **Then** the system SHALL retry finding the target (using fake timers to advance)
+- **And** the system SHALL find and highlight the target once it appears
+
+#### TC-SP-09: Target interceptor intercepts clicks
+
+- **Given** the coach mark is active with a target
+- **When** the user clicks the `.target-interceptor` overlay
+- **Then** `preventDefault()` and `stopPropagation()` SHALL be called on the event
+- **And** the `onTap` callback SHALL be invoked
+
+### E2E Tests (Playwright — manual verification)
+
+#### TC-SP-E2E-01: Full onboarding spotlight continuity
+
+- Verify spotlight opens at Step 1 and persists through Step 5 without blinking
+- Verify View Transition slide animation between targets
+- Verify tooltip text updates at each step
+- Verify cleanup at Step 6: no anchor-name, no scroll lock, popover hidden

--- a/openspec/changes/fix-onboarding-ux-bugs/specs/onboarding-tutorial/spec.md
+++ b/openspec/changes/fix-onboarding-ux-bugs/specs/onboarding-tutorial/spec.md
@@ -1,0 +1,263 @@
+## MODIFIED Requirements
+
+### Requirement: Coach Mark Overlay System
+
+The system SHALL provide a reusable coach mark overlay component that highlights a target element using a CSS Anchor Positioning hybrid approach: a visual spotlight layer (box-shadow with border-radius) for the dark overlay cutout and transparent click-blocker divs for interaction control. The component SHALL render on the browser's top layer via the Popover API.
+
+#### Scenario: Spotlight renders for active step
+
+- **WHEN** a tutorial step requires a coach mark
+- **THEN** the system SHALL display a `.visual-spotlight` element with `box-shadow: 0 0 0 100vmax` creating a 70% opacity dark overlay
+- **AND** the spotlight cutout SHALL match the target's shape via `border-radius: var(--spotlight-radius)`
+- **AND** the spotlight SHALL have a `2px solid` ring in the brand accent color
+- **AND** the ring SHALL animate with a pulse effect (scale 1 -> 1.05 -> 1, 1.5s infinite)
+- **AND** the system SHALL display a tooltip with the step's instructional text
+- **AND** the tooltip message text SHALL use a handwritten font (`Klee One`, fallback: `cursive`)
+- **AND** the tooltip SHALL use `font-size: 18px`, `padding: 16px`, white text on a transparent background with a subtle `drop-shadow` for legibility over the dark overlay
+- **AND** the tooltip arrow SHALL be positioned relative to the text based on direction: above the text when pointing up (tooltip below target), below the text when pointing down (tooltip above target)
+
+#### Scenario: Only highlighted element is interactive
+
+- **WHEN** the coach mark overlay is active
+- **THEN** four transparent click-blocker divs (top, right, bottom, left) SHALL be positioned using CSS `anchor()` functions to cover the viewport outside the target bounds
+- **AND** the click-blockers SHALL have `pointer-events: auto` to block taps
+- **AND** the spotlight cutout area SHALL have `pointer-events: none` allowing taps to pass through to the target
+- **AND** the target element SHALL receive click events natively without JS coordinate forwarding
+
+#### Scenario: Scroll lock during coach mark
+
+- **WHEN** the coach mark overlay is active
+- **THEN** the system SHALL disable scrolling on the `<au-viewport>` scroll container by adding `overflow: hidden`
+- **AND** scrolling SHALL be restored when the coach mark is deactivated
+
+#### Scenario: Coach mark target not found
+
+- **WHEN** the target element for a coach mark is not present in the DOM
+- **THEN** the system SHALL retry finding the element with exponential backoff (up to 5 seconds)
+- **AND** if still not found, the system SHALL log an error and hide the coach mark
+
+#### Scenario: Reduced motion preference
+
+- **WHEN** the user has `prefers-reduced-motion: reduce` enabled
+- **THEN** the spotlight pulse animation SHALL be disabled
+- **AND** the static ring border SHALL remain visible
+
+### Requirement: Linear Step Progression
+
+The system SHALL enforce a strict linear progression through tutorial steps. Users SHALL NOT be able to skip steps or navigate freely during the tutorial. Direct navigation via the bottom nav bar SHALL advance the step when the prerequisite conditions are met.
+
+#### Scenario: Step 0 - Landing Page entry
+
+- **WHEN** a user is at Step 0 (LP)
+- **AND** the user taps the [Get Started] CTA
+- **THEN** the system SHALL advance `onboardingStep` to 1
+- **AND** navigate to the Artist Discovery screen
+
+#### Scenario: Step 1 - Artist Discovery completion with concert data gate
+
+- **WHEN** a user is at Step 1 (Artist Discovery / Bubble UI)
+- **AND** the user has followed 3 or more artists via bubble taps
+- **AND** concert search results have been received for all followed artists (or timed out after 15 seconds per artist)
+- **THEN** the system SHALL activate the continuous spotlight on the Dashboard icon in the bottom navigation bar (target: `[data-nav-dashboard]`)
+- **AND** the spotlight SHALL remain continuously active from this point through Step 5 (see `onboarding-spotlight` capability, Continuous Spotlight Persistence)
+- **AND** the coach mark SHALL display the message: "タイムテーブルを見てみよう！"
+- **AND** when the user taps the Dashboard icon through the spotlight, the system SHALL advance `onboardingStep` to 3 (DASHBOARD), skipping Step 2 (LOADING)
+- **AND** the system SHALL navigate to the Dashboard (`/dashboard`)
+- **AND** the spotlight SHALL slide smoothly to the next target on the Dashboard via View Transitions API
+
+#### Scenario: Step 1 - Direct Home nav tap when coach mark is active
+
+- **WHEN** a user is at Step 1
+- **AND** the coach mark spotlight on the Dashboard icon is active
+- **AND** the user taps the Home/Dashboard icon in the bottom nav bar (bypassing the coach mark overlay)
+- **THEN** the system SHALL advance `onboardingStep` to 3 (DASHBOARD)
+- **AND** the system SHALL navigate to `/dashboard`
+
+#### Scenario: Step 2 - Loading sequence (deprecated for onboarding)
+
+- **WHEN** a user is at Step 2 (LOADING)
+- **THEN** this step is no longer entered during the onboarding flow
+- **AND** the `OnboardingStep.LOADING` enum value (2) SHALL be retained for backward compatibility with existing localStorage state
+- **AND** if a user has `onboardingStep=2` in localStorage from a prior session, the route guard SHALL redirect them to the Dashboard (`/dashboard`)
+
+#### Scenario: Step 1 - Spotlight deactivation before navigation
+
+- **WHEN** a user is at Step 1
+- **AND** the user taps the Dashboard coach mark
+- **THEN** the system SHALL deactivate the spotlight (`deactivateSpotlight()`) before navigating to `/dashboard`
+- **AND** this ensures the popover top layer is cleared so that Dashboard overlays (celebration, region selector) are not blocked by click-blockers
+
+#### Scenario: Step 3 - Dashboard reveal with celebration and lane introduction
+
+- **WHEN** a user is at Step 3 (Dashboard)
+- **THEN** the system SHALL display the celebration overlay only once per onboarding session, persisted via `localStorage` key `onboarding.celebrationShown`
+- **AND** on page reload, if `celebrationShown` is already set, the celebration SHALL NOT replay
+- **AND** after celebration (or immediately if already shown), the system SHALL display the region selection BottomSheet overlay (if home area not yet set)
+- **AND** after region selection, the system SHALL run the lane introduction sequence (see `dashboard-lane-introduction` capability)
+- **AND** during lane introduction, the continuous spotlight SHALL slide between lane headers (HOME STAGE → NEAR STAGE → AWAY STAGE) via View Transitions API
+- **AND** after lane introduction, the system SHALL disable scrolling
+- **AND** the spotlight SHALL slide to the first concert card
+- **AND** the system SHALL display a coach mark tooltip: "タップして詳細を見てみよう！"
+
+#### Scenario: Step 3 - Concert card tap
+
+- **WHEN** a user is at Step 3
+- **AND** the user taps the spotlighted concert card
+- **THEN** the system SHALL advance `onboardingStep` to 4
+- **AND** open the concert detail sheet (popover)
+- **AND** the spotlight SHALL slide to the [My Artists] tab in the bottom navigation bar
+
+#### Scenario: Step 4 - Detail sheet with My Artists tab guidance
+
+- **WHEN** a user is at Step 4 (Detail sheet open)
+- **THEN** the system SHALL NOT allow the detail sheet to be dismissed (no swipe-down, no backdrop tap)
+- **AND** the spotlight SHALL already be highlighting the [My Artists] tab (slid from concert card)
+- **AND** the system SHALL display a coach mark tooltip: "アーティスト一覧も見てみよう！"
+
+#### Scenario: Step 4 - My Artists tab tap
+
+- **WHEN** a user is at Step 4
+- **AND** the user taps the highlighted [My Artists] tab
+- **THEN** the system SHALL advance `onboardingStep` to 5
+- **AND** navigate to the My Artists screen
+- **AND** the spotlight SHALL slide to the Passion Level toggle of the first artist via View Transitions API
+
+#### Scenario: Step 5 - Passion Level guidance
+
+- **WHEN** a user is at Step 5 (My Artists)
+- **THEN** the spotlight SHALL already be highlighting the Passion Level toggle (slid from My Artists tab)
+- **AND** the system SHALL display a coach mark tooltip: "好きなレベルを設定してみよう！"
+
+#### Scenario: Step 5 - Passion Level changed
+
+See "Requirement: Step 5 Passion Level Explanation Timing" for the updated behaviour of this scenario.
+
+#### Scenario: Step 5 to Step 6 - Spotlight deactivation
+
+- **WHEN** `onboardingStep` advances to 6 (SignUp)
+- **THEN** the continuous spotlight SHALL fade out and deactivate (`hidePopover()`)
+- **AND** the current target's `anchor-name` SHALL be removed
+- **AND** the scroll lock on `<au-viewport>` SHALL be released
+
+#### Scenario: Step 6 - SignUp modal display
+
+- **WHEN** a user is at Step 6
+- **THEN** the system SHALL display the Passkey authentication modal
+- **AND** the modal SHALL NOT be dismissible (no close button, no backdrop tap, no escape key)
+- **AND** the modal message SHALL read: "All set! Create an account to save your preferences and never miss a live show."
+- **AND** no spotlight, click-blockers, or orphaned anchor-names SHALL be present in the DOM
+
+#### Scenario: Step 6 - Passkey authentication success
+
+- **WHEN** a user is at Step 6
+- **AND** the user completes Passkey authentication successfully
+- **THEN** the system SHALL trigger the guest data merge process
+- **AND** upon merge completion, set `onboardingStep` to 7 (COMPLETED)
+- **AND** remove all tutorial UI restrictions (coach marks, spotlight, interaction locks)
+- **AND** navigate to the Dashboard with full unrestricted access
+
+#### Scenario: Step 6 - Page reload
+
+- **WHEN** a user reloads the page with `onboardingStep = 6`
+- **THEN** the system SHALL re-display the non-dismissible SignUp modal immediately
+
+## Test Cases
+
+### Unit Tests (Vitest — discover-page.spec.ts)
+
+#### TC-TUT-01: Coach mark tap at Step 1 advances to DASHBOARD and navigates
+
+- **Given** `onboardingStep = 1`, `showDashboardCoachMark = true`
+- **When** the coach mark `onTap` callback is invoked
+- **Then** `onboardingService.setStep(DASHBOARD)` SHALL be called
+- **And** `router.load('/dashboard')` SHALL be called
+
+#### TC-TUT-02: showDashboardCoachMark is false with fewer than 3 follows
+
+- **Given** `onboardingStep = 1`, fewer than 3 artists followed
+- **Then** `showDashboardCoachMark` SHALL be `false`
+- **And** `activateSpotlight()` SHALL NOT be called
+
+### Unit Tests (Vitest — my-artists-page.spec.ts)
+
+#### TC-TUT-03: Step 5 activates spotlight on hype button after artists load
+
+- **Given** `onboardingStep = 5`, artists list has at least 1 artist
+- **When** the page loads
+- **Then** `onboardingService.activateSpotlight('[data-hype-button]', ...)` SHALL be called
+
+#### TC-TUT-04: Step 5 deactivates spotlight before showing hype explanation
+
+- **Given** `onboardingStep = 5`, spotlight is active
+- **When** user selects a passion level
+- **Then** `onboardingService.deactivateSpotlight()` SHALL be called before the explanation dialog opens
+
+### Unit Tests (Vitest — discover-page.spec.ts) — Bug Fix Coverage
+
+#### TC-TUT-05: Coach mark tap deactivates spotlight before navigating
+
+- **Given** `onboardingStep = 1`, coach mark is active
+- **When** `onCoachMarkTap()` is called
+- **Then** `onboardingService.deactivateSpotlight()` SHALL be called before `router.load('/dashboard')`
+- **And** `onboardingService.setStep(DASHBOARD)` SHALL be called
+
+### Unit Tests (Vitest — auth-hook.spec.ts) — Bug Fix Coverage
+
+#### TC-TUT-06: Direct nav tap advances step when spotlight is active
+
+- **Given** `onboardingStep = 1`, spotlight is active on Dashboard icon
+- **When** the user taps the Dashboard icon in the bottom nav bar (bypassing the coach mark overlay)
+- **Then** the auth hook SHALL allow navigation (`canLoad` returns `true`)
+- **And** `onboardingService.deactivateSpotlight()` SHALL be called
+- **And** `onboardingService.setStep(DASHBOARD)` SHALL be called
+- **And** NO "Login required" toast SHALL be published
+
+#### TC-TUT-07: Nav tap blocked when spotlight is NOT active
+
+- **Given** `onboardingStep = 1`, spotlight is NOT active
+- **When** the user taps the Dashboard icon (tutorialStep = 3)
+- **Then** the auth hook SHALL redirect to the current step's route
+- **And** navigation to Dashboard SHALL be denied
+
+### Unit Tests (Vitest — dashboard.spec.ts) — Bug Fix Coverage
+
+#### TC-TUT-08: celebrationShown persists across page reloads
+
+- **Given** `onboardingStep = 3`, Dashboard has been loaded once (celebration shown)
+- **When** the page is reloaded (new Dashboard instance)
+- **Then** `showCelebration` SHALL be `false` (read from localStorage)
+- **And** the Dashboard SHALL be interactive without the celebration overlay blocking interaction
+
+#### TC-TUT-09: Dashboard loads without error when celebrationShown is set
+
+- **Given** `localStorage` has `onboarding.celebrationShown = '1'`
+- **When** Dashboard `loading()` is called at Step 3
+- **Then** `showCelebration` SHALL be `false`
+- **And** the celebration overlay SHALL NOT render
+
+### E2E Tests (Playwright — manual verification)
+
+#### TC-TUT-E2E-01: Full step progression (Step 0 → Step 6)
+
+- Step 0: Tap [Get Started] → navigate to Discover
+- Step 1: Follow 3+ artists → coach mark appears on Home icon → tap → navigate to Dashboard
+- Step 3: Lane intro sequence → concert card coach mark → tap card → detail sheet
+- Step 4: My Artists tab coach mark → tap → navigate to My Artists
+- Step 5: Passion Level coach mark → set level → explanation popup
+- Step 6: Sign-up modal appears, non-dismissible
+
+#### TC-TUT-E2E-02: No "Login required" toast during onboarding nav
+
+- During onboarding, tap Tickets or Settings nav → verify silent redirect, no toast displayed
+
+#### TC-TUT-E2E-03: Page reload at Step 3 does not replay celebration
+
+- Navigate through onboarding to Step 3 → celebration plays once → reload page → Dashboard loads without celebration, user can interact normally
+
+#### TC-TUT-E2E-04: Coach mark tooltip has no background color
+
+- At any step with a coach mark → verify the tooltip has a transparent background with only white text and drop-shadow, no colored background box
+
+#### TC-TUT-E2E-05: Spotlight visible on all coach mark steps
+
+- At Step 1 (Dashboard icon), Step 3 (concert card), Step 4 (My Artists tab), Step 5 (hype button) → verify the dark overlay with spotlight cutout is visible around the target element

--- a/openspec/changes/fix-onboarding-ux-bugs/tasks.md
+++ b/openspec/changes/fix-onboarding-ux-bugs/tasks.md
@@ -1,0 +1,79 @@
+## 1. AuthHook Fix — Onboarding-Aware Fallback
+
+- [x] 1.1 Add Priority 2.5 branch in `auth-hook.ts`: when `tutorialStep` is undefined AND `isOnboarding` is true, redirect to current step's route without toast
+- [x] 1.2 Add unit test: onboarding user navigating to route without `tutorialStep` (e.g., Tickets) SHALL redirect silently (no toast published to EventAggregator)
+- [x] 1.3 Add unit test: onboarding user navigating to route with `tutorialStep` > `currentStep` SHALL redirect to current step's route
+- [x] 1.4 Add unit test: non-onboarding unauthenticated user navigating to protected route SHALL still show "Login required" toast
+
+## 2. Coach Mark Spotlight — CSS Anchor Positioning Hybrid + Continuous Persistence
+
+- [x] 2.1 Add inline SVG-free markup to `coach-mark.html`: replace `.coach-mark-spotlight` div with `.visual-spotlight` element + 4 `.click-blocker` divs (top/right/bottom/left)
+- [x] 2.2 Rewrite `coach-mark.css`: remove overlay `background`, add `.visual-spotlight` with `anchor()` inset + `box-shadow: 0 0 0 100vmax` + `border-radius: var(--spotlight-radius)`, add `.click-blocker` styles with transparent bg + `pointer-events: auto` + `anchor()` positioning
+- [x] 2.3 Add popover UA style reset to `.coach-mark-overlay`: `background: transparent; border: none; padding: 0; margin: 0;` and `::backdrop { display: none; }`
+- [x] 2.4 Simplify `coach-mark.ts`: remove `updateSpotlightPosition()` method and `getBoundingClientRect()` calls. Keep `findAndHighlight()` for anchor-name assignment and retry logic. Remove `spotlightEl` ref (no longer needed).
+- [x] 2.5 Add `--spotlight-radius` CSS custom property support: set on the spotlight element based on a new `@bindable spotlightRadius` property (default: `'12px'`)
+- [x] 2.6 Update `onOverlayClick()`: since click-blockers handle blocking and clicks pass through natively to the target, simplify to only call `onTap()` callback (remove coordinate calculation logic)
+- [x] 2.7 Add `view-transition-name: spotlight` to `.visual-spotlight` in CSS, add `::view-transition-group(spotlight)` animation rule (400ms ease-out)
+- [x] 2.8 Wrap anchor-name reassignment in `highlight()` with `document.startViewTransition()` for smooth spotlight slide on target change (same-page and cross-route)
+- [x] 2.9 Add `prefers-reduced-motion` media query to suppress View Transition animation
+- [x] 2.10 Move `<coach-mark>` from individual route templates (discover-page.html, dashboard.html, my-artists-page.html) to a single instance in `my-app.html`
+- [x] 2.11 Add onboarding spotlight config to onboarding service: expose `spotlightTarget`, `spotlightMessage`, `spotlightRadius`, `spotlightActive` properties driven by `currentStep`
+- [x] 2.12 Bind app-shell `<coach-mark>` to onboarding service properties: `target-selector.bind`, `message.bind`, `spotlight-radius.bind`, `active.bind`
+- [x] 2.13 Remove per-page coach mark bindings and onTap handlers from discover-page.ts, dashboard.ts, my-artists-page.ts — delegate to onboarding service `onSpotlightTap()` callback
+- [x] 2.14 Ensure popover stays open across route navigations: `highlight()` reassigns anchor-name without calling `hidePopover()`/`showPopover()` when already open
+- [x] 2.15 Add `deactivate()` method: called at Step 6, calls `hidePopover()`, removes anchor-name, releases scroll lock
+- [x] 2.16 Add inline SVG arrow to `coach-mark.html`: use `switch.bind` on `arrowDirection` to render up/down curved `<path>` elements with `stroke="currentColor"`
+- [x] 2.17 Add arrow CSS: `stroke-dasharray`/`stroke-dashoffset` drawing animation (600ms), arrowhead fade-in (300ms delay), `prefers-reduced-motion` override
+- [x] 2.18 Add `arrowDirection` computed property to `coach-mark.ts`: determine 'up' or 'down' based on tooltip's resolved position relative to target
+- [x] 2.19 Add handwritten font: import `Klee One` from Google Fonts, apply `font-family: 'Klee One', cursive` to `.coach-tooltip-message` in `coach-mark.css`
+- [x] 2.20 Add unit test: when coach mark is active, `.visual-spotlight` element exists with `box-shadow` style applied
+- [x] 2.21 Add unit test: when coach mark is active, 4 `.click-blocker` elements exist with `pointer-events: auto`
+- [x] 2.22 Add unit test: target element receives `anchor-name: --coach-target` when highlighted
+- [x] 2.23 Add unit test: changing target via `highlight(newTarget)` does not call `hidePopover()` (popover stays open)
+- [x] 2.24 Add unit test: `deactivate()` calls `hidePopover()` and cleans up anchor-name and scroll lock
+- [x] 2.25 Add unit test: SVG arrow element exists in tooltip when coach mark is active
+- [x] 2.26 Add unit test: tooltip message element uses handwritten font family (`Klee One`)
+
+## 3. Toast Popover White Background Fix
+
+- [x] 3.1 Add popover UA style reset to toast container in `toast-notification.html` or via CSS: `background: transparent; border: none; padding: 0; margin: 0;`
+- [x] 3.2 Add visual regression test: toast popover container has transparent background when displayed
+
+## 4. Progress Bar Removal
+
+- [x] 4.1 Remove `.search-progress-bar` and `.search-progress-fill` elements from `discover-page.html`
+- [x] 4.2 Remove `.search-progress-bar` and `.search-progress-fill` CSS rules from `discover-page.css`
+- [x] 4.3 Remove `searchProgress` getter from `discover-page.ts` (keep `completedSearchCount` and `concertSearchStatus` — still needed for `showDashboardCoachMark`)
+- [x] 4.4 Update existing discover-page tests: remove any assertions about progress bar, verify `showDashboardCoachMark` still works correctly
+
+## 5. DNA Orb Color Injection + Swirl Animation
+
+- [x] 5.1 Add `injectColor(hue: number)` method to `OrbRenderer`: replace 5-8 existing particles with new particles at the given hue, trigger swirl state
+- [x] 5.2 Add swirl state to `OrbRenderer.update()`: track `swirlIntensity` (decays from 1.0 to 0 over ~1000ms), multiply particle rotation speed by `1 + swirlIntensity * 2` during swirl
+- [x] 5.3 Add glow boost during swirl in `OrbRenderer.render()`: add `swirlIntensity * 0.4` to effective intensity
+- [x] 5.4 Thread bubble hue through absorption: in `dna-orb-canvas.ts`, pass the absorbed bubble's hue from the absorption animator completion callback to `orbRenderer.injectColor(hue)`
+- [x] 5.5 Add `prefers-reduced-motion` check: skip rotation speed boost when reduced motion is preferred
+- [x] 5.6 Add unit test: `OrbRenderer.injectColor(142)` results in particles containing hue 142 while total count remains at `maxParticles`
+- [x] 5.7 Add unit test: `swirlIntensity` starts at 1.0 after `injectColor()` and decays to 0 after sufficient `update()` calls
+- [x] 5.8 Add unit test: multiple rapid `injectColor()` calls each inject their hue and restart swirl
+
+## 6. Home Nav Step Advancement
+
+- [x] 6.1 In `bottom-nav-bar.ts` or `discover-page.ts`: when onboarding user taps Home/Dashboard nav AND `showDashboardCoachMark` is true, advance step to DASHBOARD and navigate to `/dashboard`
+- [x] 6.2 Set `--spotlight-radius: 50%` for the Dashboard nav icon coach mark target (circular icon)
+- [x] 6.3 Add unit test: tapping Home nav during onboarding when coach mark is active advances `onboardingStep` to 3 and triggers navigation to `/dashboard`
+- [x] 6.4 Add unit test: tapping Home nav during onboarding when coach mark is NOT active (fewer than 3 follows) does NOT advance step
+
+## 7. Integration Verification
+
+- [ ] 7.1 Manual E2E test: full onboarding flow verifying continuous spotlight from Step 1 through Step 6
+    - Step 0→1: Tap [Get Started] → navigate to Discover (no spotlight yet)
+    - Step 1: Follow 3 artists → verify orb color changes on each absorption → spotlight activates on Home icon (`--spotlight-radius: 50%`) → tooltip "タイムテーブルを見てみよう！" in handwritten font → tap Home icon → **spotlight slides** to Dashboard
+    - Step 3 (lane intro): Spotlight slides HOME STAGE → NEAR STAGE → AWAY STAGE → first concert card (verify smooth View Transition animation between each) → tooltip "タップして詳細を見てみよう！" → tap card → detail sheet opens → **spotlight slides** to My Artists tab
+    - Step 4: Verify spotlight already on [My Artists] tab (no blink) → detail sheet not dismissible → tooltip "アーティスト一覧も見てみよう！" → tap My Artists → **spotlight slides** to Passion Level toggle
+    - Step 5: Verify spotlight already on Passion Level toggle (no blink) → tooltip "好きなレベルを設定してみよう！" → change passion level → explanation popup after 800ms
+    - Step 6: Spotlight fades out → sign-up modal appears (non-dismissible) → verify cleanup: no `anchor-name` on any element, no scroll lock on `au-viewport`, no orphaned click-blockers, popover hidden
+    - **Key verification**: The popover was opened ONCE at Step 1 and never closed until Step 6
+- [ ] 7.2 Manual test: during onboarding, tap Tickets/Settings nav items → verify silent redirect, no toast
+- [ ] 7.3 Manual test: verify toast notifications display without white corner gap
+- [x] 7.4 Run `make check` in frontend repo — all lint and tests pass

--- a/openspec/changes/onboarding-concert-data-gate/.openspec.yaml
+++ b/openspec/changes/onboarding-concert-data-gate/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-12

--- a/openspec/changes/onboarding-concert-data-gate/design.md
+++ b/openspec/changes/onboarding-concert-data-gate/design.md
@@ -1,0 +1,54 @@
+## Context
+
+The onboarding flow progresses: Discovery (Step 1) → Dashboard (Step 3) → My Artists (Step 5) → Signup (Step 6). The transition from Step 1 to Step 3 is gated by `showDashboardCoachMark`, which currently requires only that `SearchNewConcerts` RPC calls have completed (or timed out). It does not verify that `ConcertService/List` will return any data.
+
+When the Dashboard loads with zero concert groups, the live-highway component renders its empty state (`if.bind="!loading && isEmpty"`), so the lane header elements (`[data-stage-home]`, etc.) and concert card elements (`[data-live-card]`) are absent from the DOM. The coach mark's `findAndHighlight()` retries for 5 seconds, then only sets `visible = false` without closing the popover or releasing the scroll lock, leaving the UI inoperable.
+
+Three layers need fixing: (1) the Discovery gate, (2) the Dashboard fallback, (3) the coach mark cleanup.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Prevent the Dashboard coach mark from activating when no concerts exist for the followed artists
+- Provide user feedback when concert searches complete with no results
+- Gracefully handle the edge case where the user reaches the Dashboard during onboarding with zero data (defense-in-depth)
+- Ensure the coach mark component never leaves orphaned overlays
+
+**Non-Goals:**
+- Changing the backend `ConcertService/List` or `SearchNewConcerts` APIs
+- Adding retry logic for concert searches (already has 15s timeout per artist)
+- Modifying the non-onboarding Dashboard behavior
+
+## Decisions
+
+### Decision 1: Pre-check via `ConcertService/List` on Discovery page
+
+**Chosen**: After all `SearchNewConcerts` calls complete, call `ConcertService/List` to verify at least 1 date group exists before activating the Dashboard coach mark.
+
+**Why**: This is the earliest point to detect the empty-data scenario. The existing `completedSearchCount` tracking already knows when all searches are done — adding a List call at that point is minimal overhead.
+
+**Alternative considered**: Check individual `SearchNewConcerts` responses for result counts. Rejected because `SearchNewConcerts` is a fire-and-forget background job — it doesn't return concert counts in its response.
+
+### Decision 2: Guidance message for zero-concert state
+
+**Chosen**: When all concert searches complete but `ConcertService/List` returns empty, update the guidance HUD message to prompt the user to follow more artists ("No upcoming events found. Try following more artists!"). Do not show the Dashboard coach mark.
+
+**Why**: The user needs feedback to understand why the coach mark hasn't appeared. Without guidance, they would be stuck on the Discovery page with no clear next action.
+
+### Decision 3: Dashboard fallback — skip lane intro to My Artists
+
+**Chosen**: If `startLaneIntro()` runs with `dateGroups.length === 0`, skip the entire lane intro and advance directly to Step 4 (My Artists tab spotlight).
+
+**Why**: Defense-in-depth. The user could reach the Dashboard via direct nav tap (bypassing the coach mark gate). Rather than showing a broken lane intro, gracefully skip to the next meaningful step.
+
+### Decision 4: Coach mark `deactivate()` on retry exhaustion
+
+**Chosen**: Replace `this.visible = false` with `this.deactivate()` in `findAndHighlight()` when retries are exhausted.
+
+**Why**: `deactivate()` properly closes the popover, releases the scroll lock, clears the anchor-name, and stops retry timers. The partial cleanup was the direct cause of the stuck overlay.
+
+## Risks / Trade-offs
+
+- **[Risk] `ConcertService/List` adds a network call to Discovery** → Mitigation: This call is only made once after all searches complete. The Dashboard will make the same call anyway, so the data is useful regardless.
+- **[Risk] User could be stuck on Discovery if no artists have concerts** → Mitigation: The guidance message tells them to follow more artists. The underlying data issue (no concerts for followed artists) is expected for niche/new artists.
+- **[Trade-off] Dashboard fallback skips the lane intro entirely** → Accepted: An empty Dashboard has no lanes to introduce. The lane intro can be experienced on subsequent visits once concerts are available.

--- a/openspec/changes/onboarding-concert-data-gate/proposal.md
+++ b/openspec/changes/onboarding-concert-data-gate/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+The onboarding flow transitions users from Artist Discovery (Step 1) to Dashboard (Step 3) after concert searches complete, but does not verify that concerts were actually found. When `ConcertService/List` returns zero groups, the Dashboard renders an empty state, and the lane introduction sequence fails because its target elements (`[data-stage-home]`, `[data-live-card]`) do not exist in the DOM. This leaves the coach mark overlay stuck with click-blockers active, making the UI completely inoperable.
+
+The root cause is a missing data gate: the spec requires "concert search results have been received" but not "concerts have been discovered." The search can complete successfully with zero results.
+
+## What Changes
+
+- Add a concert data verification gate to the Discovery page coach mark condition: require `ConcertService/List` to return at least 1 date group before activating the Dashboard coach mark
+- Add a user-facing message when searches complete but no concerts are found, prompting the user to follow more artists
+- Add a Dashboard-side fallback: if the user reaches the Dashboard during onboarding with zero concert data (e.g., via direct nav tap), skip the lane intro and advance to Step 4 (My Artists tab spotlight) gracefully
+- Add a coach mark component safety net: when `findAndHighlight()` exhausts retries, fully deactivate (close popover, release scroll lock, clear anchor-name) instead of only hiding the element
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `onboarding-tutorial`: Step 1 completion condition changes from "search completed" to "search completed AND concerts found". Add Step 3 empty-data fallback scenario.
+- `dashboard-lane-introduction`: Add graceful skip behavior when no concert data is available.
+- `onboarding-spotlight`: Coach mark `findAndHighlight()` retry exhaustion must fully deactivate instead of partial hide.
+
+## Impact
+
+- **Frontend**: `discover-page.ts` (coach mark gate), `dashboard.ts` (lane intro skip), `coach-mark.ts` (retry exhaustion cleanup)
+- **E2E Tests**: New test scenario for empty concert data on Dashboard
+- **Unit Tests**: New tests for Discovery gate condition and Dashboard empty-data fallback
+- **No backend changes**: The `ConcertService/List` API already returns empty groups correctly; this is purely a frontend flow control issue

--- a/openspec/changes/onboarding-concert-data-gate/specs/dashboard-lane-introduction/spec.md
+++ b/openspec/changes/onboarding-concert-data-gate/specs/dashboard-lane-introduction/spec.md
@@ -1,0 +1,71 @@
+## MODIFIED Requirements
+
+### Requirement: Sequential Lane Header Spotlight
+
+The system SHALL introduce each dashboard lane by sequentially spotlighting the STAGE headers with explanatory coach marks before spotlighting the first concert card.
+
+#### Scenario: Lane introduction begins after region selection
+
+- **WHEN** the celebration overlay has faded
+- **AND** the region selection (if needed) has completed
+- **AND** `ConcertService/List` has returned 1 or more date groups
+- **THEN** the system SHALL begin the lane introduction sequence
+- **AND** scrolling SHALL be disabled during the entire sequence
+
+#### Scenario: Lane introduction skipped when no concert data
+
+- **WHEN** the celebration overlay has faded
+- **AND** the region selection (if needed) has completed
+- **AND** `ConcertService/List` has returned 0 date groups
+- **THEN** the system SHALL NOT begin the lane introduction sequence
+- **AND** the system SHALL log a warning: "No concert data available, skipping lane intro"
+- **AND** the system SHALL skip directly to Step 4 behavior (My Artists tab spotlight)
+
+#### Scenario: HOME STAGE header spotlight
+
+- **WHEN** the lane introduction sequence begins
+- **THEN** the system SHALL spotlight the HOME STAGE header element
+- **AND** the coach mark SHALL display: "地元のライブ情報！"
+- **AND** the spotlight SHALL remain for 2 seconds or until the user taps
+
+#### Scenario: NEAR STAGE header spotlight
+
+- **WHEN** the HOME STAGE spotlight completes (2s timeout or user tap)
+- **THEN** the system SHALL spotlight the NEAR STAGE header element
+- **AND** the coach mark SHALL display: "近くのエリアのライブも！"
+- **AND** the spotlight SHALL remain for 2 seconds or until the user taps
+
+#### Scenario: AWAY STAGE header spotlight
+
+- **WHEN** the NEAR STAGE spotlight completes (2s timeout or user tap)
+- **THEN** the system SHALL spotlight the AWAY STAGE header element
+- **AND** the coach mark SHALL display: "全国のライブ情報もチェック！"
+- **AND** the spotlight SHALL remain for 2 seconds or until the user taps
+
+#### Scenario: Transition to first card spotlight
+
+- **WHEN** the AWAY STAGE spotlight completes
+- **THEN** the system SHALL proceed to the existing Step 3 card spotlight behavior
+- **AND** scrolling SHALL remain disabled until the card is tapped
+
+### Requirement: Lane Introduction State Management
+
+The lane introduction sequence SHALL be managed locally within the dashboard component, not persisted in the onboarding service.
+
+#### Scenario: Lane intro state is ephemeral
+
+- **WHEN** the dashboard component manages the lane introduction
+- **THEN** the intro state SHALL be a local variable (e.g., `laneIntroPhase: 'home' | 'near' | 'away' | 'card' | 'done'`)
+- **AND** the state SHALL NOT be written to `liverty:onboardingStep` in LocalStorage
+
+#### Scenario: Page reload during lane introduction
+
+- **WHEN** the user reloads the page during the lane introduction sequence
+- **THEN** the system SHALL restart the lane introduction from the beginning (HOME STAGE)
+- **AND** the celebration overlay SHALL NOT replay (it uses a separate one-time flag)
+
+#### Scenario: Data loading awaited before lane intro decision
+
+- **WHEN** `startLaneIntro()` is called
+- **THEN** the system SHALL await the `dataPromise` (ConcertService/List response) before deciding whether to run or skip the lane intro
+- **AND** if the data fetch fails, the system SHALL proceed with whatever data is available (possibly empty, triggering the skip path)

--- a/openspec/changes/onboarding-concert-data-gate/specs/onboarding-tutorial/spec.md
+++ b/openspec/changes/onboarding-concert-data-gate/specs/onboarding-tutorial/spec.md
@@ -1,0 +1,225 @@
+## MODIFIED Requirements
+
+### Requirement: Linear Step Progression
+
+The system SHALL enforce a strict linear progression through tutorial steps. Users SHALL NOT be able to skip steps or navigate freely during the tutorial.
+
+#### Scenario: Step 0 - Landing Page entry
+
+- **WHEN** a user is at Step 0 (LP)
+- **AND** the user taps the [Get Started] CTA
+- **THEN** the system SHALL advance `onboardingStep` to 1
+- **AND** navigate to the Artist Discovery screen
+
+#### Scenario: Step 1 - Artist Discovery completion with concert data gate
+
+- **WHEN** a user is at Step 1 (Artist Discovery / Bubble UI)
+- **AND** the user has followed 3 or more artists via bubble taps
+- **AND** concert search results have been received for all followed artists (or timed out after 15 seconds per artist)
+- **AND** `ConcertService/List` returns at least 1 date group for the followed artists
+- **THEN** the system SHALL activate a coach mark spotlight on the Dashboard icon in the bottom navigation bar (target: `[data-nav-dashboard]`)
+- **AND** the coach mark SHALL display the message: "タイムテーブルを見てみよう！"
+- **AND** when the user taps the Dashboard icon, the system SHALL advance `onboardingStep` to 3 (DASHBOARD), skipping Step 2 (LOADING)
+- **AND** the system SHALL navigate to the Dashboard (`/dashboard`)
+
+#### Scenario: Step 1 - Concert searches complete with no results
+
+- **WHEN** a user is at Step 1 (Artist Discovery / Bubble UI)
+- **AND** the user has followed 3 or more artists
+- **AND** concert search results have been received for all followed artists (or timed out)
+- **AND** `ConcertService/List` returns 0 date groups
+- **THEN** the system SHALL NOT activate the Dashboard coach mark
+- **AND** the system SHALL update the guidance HUD message to: "No upcoming events found yet — try following more artists!"
+- **AND** the system SHALL re-evaluate the concert data gate each time a new artist is followed and their concert search completes
+
+#### Scenario: Step 1 - Progress bar display
+
+- **WHEN** a user is at Step 1
+- **THEN** the system SHALL display a progress bar showing concert search completion status
+- **AND** the progress bar SHALL fill continuously based on the ratio of completed concert searches to total followed artists
+- **AND** the progress bar target SHALL require 3 or more artists with completed (or timed-out) concert searches
+- **AND** the user MAY continue following more artists after reaching 3
+
+#### Scenario: Step 2 - Loading sequence (deprecated for onboarding)
+
+- **WHEN** a user is at Step 2 (LOADING)
+- **THEN** this step is no longer entered during the onboarding flow
+- **AND** the `OnboardingStep.LOADING` enum value (2) SHALL be retained for backward compatibility with existing localStorage state
+- **AND** if a user has `onboardingStep=2` in localStorage from a prior session, the route guard SHALL redirect them to the Dashboard (`/dashboard`)
+
+#### Scenario: Step 3 - Dashboard reveal with celebration and lane introduction
+
+- **WHEN** a user is at Step 3 (Dashboard)
+- **THEN** the system SHALL display the celebration overlay (see `onboarding-celebration` capability)
+- **AND** after celebration, the system SHALL display the region selection BottomSheet overlay (if home area not yet set)
+- **AND** after region selection, the system SHALL run the lane introduction sequence (see `dashboard-lane-introduction` capability)
+- **AND** after lane introduction, the system SHALL disable scrolling
+- **AND** the system SHALL apply a spotlight overlay highlighting only the first concert card
+- **AND** the system SHALL display a coach mark tooltip: "タップして詳細を見てみよう！"
+
+#### Scenario: Step 3 - Dashboard with no concert data (fallback)
+
+- **WHEN** a user is at Step 3 (Dashboard)
+- **AND** `ConcertService/List` returns 0 date groups (e.g., user reached Dashboard via direct nav tap bypassing the concert data gate)
+- **THEN** the system SHALL skip the lane introduction sequence entirely
+- **AND** the system SHALL advance `onboardingStep` to 4 (DETAIL)
+- **AND** the system SHALL activate the spotlight on the [My Artists] tab in the bottom navigation bar
+- **AND** the system SHALL display a coach mark tooltip: "アーティスト一覧も見てみよう！"
+
+#### Scenario: Step 3 - Concert card tap
+
+- **WHEN** a user is at Step 3
+- **AND** the user taps the spotlighted concert card
+- **THEN** the system SHALL advance `onboardingStep` to 4
+- **AND** open the concert detail sheet (popover)
+
+#### Scenario: Step 4 - Detail sheet with My Artists tab guidance
+
+- **WHEN** a user is at Step 4 (Detail sheet open)
+- **THEN** the system SHALL NOT allow the detail sheet to be dismissed (no swipe-down, no backdrop tap)
+- **AND** the system SHALL highlight the [My Artists] tab in the bottom navigation bar
+- **AND** the system SHALL display a coach mark tooltip: "アーティスト一覧も見てみよう！"
+
+#### Scenario: Step 4 - My Artists tab tap
+
+- **WHEN** a user is at Step 4
+- **AND** the user taps the highlighted [My Artists] tab
+- **THEN** the system SHALL advance `onboardingStep` to 5
+- **AND** navigate to the My Artists screen
+
+#### Scenario: Step 5 - Passion Level guidance
+
+- **WHEN** a user is at Step 5 (My Artists)
+- **THEN** the system SHALL highlight the Passion Level toggle of the first artist in the list
+- **AND** the system SHALL display a coach mark tooltip: "好きなレベルを設定してみよう！"
+
+#### Scenario: Step 5 - Passion Level changed
+
+See "Requirement: Step 5 Passion Level Explanation Timing" below for the updated behaviour of this scenario.
+
+#### Scenario: Step 6 - SignUp modal display
+
+- **WHEN** a user is at Step 6
+- **THEN** the system SHALL display the Passkey authentication modal
+- **AND** the modal SHALL NOT be dismissible (no close button, no backdrop tap, no escape key)
+- **AND** the modal message SHALL read: "All set! Create an account to save your preferences and never miss a live show."
+
+#### Scenario: Step 6 - Passkey authentication success
+
+- **WHEN** a user is at Step 6
+- **AND** the user completes Passkey authentication successfully
+- **THEN** the system SHALL trigger the guest data merge process
+- **AND** upon merge completion, set `onboardingStep` to 7 (COMPLETED)
+- **AND** remove all tutorial UI restrictions (coach marks, spotlight, interaction locks)
+- **AND** navigate to the Dashboard with full unrestricted access
+
+#### Scenario: Step 6 - Page reload
+
+- **WHEN** a user reloads the page with `onboardingStep = 6`
+- **THEN** the system SHALL re-display the non-dismissible SignUp modal immediately
+
+### Requirement: Coach Mark Overlay System
+
+The system SHALL provide a reusable coach mark overlay component that highlights a target element with a high-contrast spotlight effect, pulse animation, and large instructional tooltip.
+
+#### Scenario: Spotlight renders for active step
+
+- **WHEN** a tutorial step requires a coach mark
+- **THEN** the system SHALL dim the entire screen with a semi-transparent overlay at `oklch(0% 0 0deg / 75%)`
+- **AND** the system SHALL cut out a highlight area around the target element
+- **AND** the highlight area SHALL have a `2px solid` ring in the brand accent color
+- **AND** the ring SHALL animate with a pulse effect (scale 1→1.05→1, 1.5s infinite)
+- **AND** the system SHALL display a tooltip with the step's instructional text
+- **AND** the tooltip SHALL use `font-size: 16px`, `padding: 16px`, brand accent background color, white text, and `border-radius: 12px`
+
+#### Scenario: Only highlighted element is interactive
+
+- **WHEN** the coach mark overlay is active
+- **THEN** only the highlighted target element SHALL accept user interaction (tap/click)
+- **AND** all other elements SHALL be blocked by the overlay
+
+#### Scenario: Scroll lock during coach mark
+
+- **WHEN** the coach mark overlay is active
+- **THEN** the system SHALL disable scrolling on the `<au-viewport>` scroll container by adding `overflow: hidden`
+- **AND** scrolling SHALL be restored when the coach mark is deactivated
+
+#### Scenario: Coach mark target not found
+
+- **WHEN** the target element for a coach mark is not present in the DOM
+- **THEN** the system SHALL retry finding the element with exponential backoff (up to 5 seconds)
+- **AND** if still not found, the system SHALL fully deactivate the coach mark overlay: close the popover, release scroll lock, clear anchor-name assignments, and log an error
+- **AND** no click-blockers, spotlight elements, or scroll locks SHALL remain in the DOM after deactivation
+
+#### Scenario: Reduced motion preference
+
+- **WHEN** the user has `prefers-reduced-motion: reduce` enabled
+- **THEN** the spotlight pulse animation SHALL be disabled
+- **AND** the static ring border SHALL remain visible
+
+## Test Cases
+
+### Unit Tests (Vitest — discover-page.spec.ts)
+
+#### TC-GATE-01: Dashboard coach mark requires concert data
+
+- **Given** `onboardingStep = 1`, 3+ artists followed, all concert searches completed
+- **And** `ConcertService/List` returns 0 date groups
+- **When** `showDashboardCoachMark` is evaluated
+- **Then** it SHALL be `false`
+- **And** `activateSpotlight()` SHALL NOT be called
+
+#### TC-GATE-02: Dashboard coach mark activates when concerts exist
+
+- **Given** `onboardingStep = 1`, 3+ artists followed, all concert searches completed
+- **And** `ConcertService/List` returns 1+ date groups
+- **When** `showDashboardCoachMark` is evaluated
+- **Then** it SHALL be `true`
+- **And** `activateSpotlight('[data-nav-dashboard]', ...)` SHALL be called
+
+#### TC-GATE-03: Guidance message updates when no concerts found
+
+- **Given** `onboardingStep = 1`, 3+ artists followed, all concert searches completed
+- **And** `ConcertService/List` returns 0 date groups
+- **Then** the guidance message SHALL indicate no upcoming events and prompt to follow more artists
+
+### Unit Tests (Vitest — dashboard.spec.ts)
+
+#### TC-GATE-04: Lane intro skipped when dateGroups is empty
+
+- **Given** `onboardingStep = 3`, `dateGroups = []`
+- **When** `startLaneIntro()` is called (via `onCelebrationComplete()` or `onHomeSelected()`)
+- **Then** `laneIntroPhase` SHALL be `'done'`
+- **And** `onboardingService.setStep(4)` SHALL be called (DETAIL)
+- **And** `onboardingService.activateSpotlight('[data-nav-my-artists]', ...)` SHALL be called
+
+### Unit Tests (Vitest — coach-mark.spec.ts)
+
+#### TC-GATE-05: Coach mark fully deactivates when target not found after retries
+
+- **Given** the coach mark is active with a selector that matches no DOM element
+- **When** 5 seconds of retry have elapsed
+- **Then** the popover SHALL be hidden (`hidePopover()`)
+- **And** scroll lock SHALL be released (overflow restored on `au-viewport`)
+- **And** `anchor-name` SHALL be cleared from any previous target
+- **And** no click-blockers SHALL remain visible
+
+### E2E Tests (Playwright)
+
+#### TC-GATE-E2E-01: Dashboard with no concerts skips lane intro without stuck overlay
+
+- **Given** `onboardingStep = 3`, `celebrationShown = 1`, `guest.home` is set
+- **And** `ConcertService/List` mock returns `{ dateGroups: [] }`
+- **When** the Dashboard page loads
+- **Then** no click-blockers SHALL be present in the DOM
+- **And** no spotlight overlay SHALL be visible
+- **And** `onboardingStep` SHALL advance to `4`
+
+#### TC-GATE-E2E-02: Discovery does not show coach mark when no concerts found
+
+- **Given** `onboardingStep = 1`, 3+ artists followed (via localStorage seed)
+- **And** `SearchNewConcerts` mock returns success
+- **And** `ConcertService/List` mock returns `{ dateGroups: [] }`
+- **When** all concert searches complete
+- **Then** no Dashboard coach mark SHALL appear
+- **And** the guidance HUD SHALL display a "no upcoming events" message

--- a/openspec/changes/onboarding-concert-data-gate/tasks.md
+++ b/openspec/changes/onboarding-concert-data-gate/tasks.md
@@ -1,0 +1,35 @@
+## 1. Discovery Page — Concert Data Gate
+
+- [x] 1.1 Add `ConcertService/List` call after all concert searches complete in `discover-page.ts`: when `completedSearchCount >= followedCount`, call `ConcertService/List` and store the result count in a new `concertGroupCount` field
+- [x] 1.2 Update `showDashboardCoachMark` getter to additionally require `concertGroupCount > 0`
+- [x] 1.3 Add i18n keys for the zero-concert guidance message ("No upcoming events found yet — try following more artists!") in `en/translation.json` and `ja/translation.json`
+- [x] 1.4 Update `guidanceMessage` getter to return the zero-concert message when `completedSearchCount >= followedCount && concertGroupCount === 0`
+- [x] 1.5 Re-evaluate the concert data gate when a new artist is followed and their search completes (existing `markSearchDone` → re-call `ConcertService/List`)
+
+## 2. Dashboard — Empty Data Fallback
+
+- [x] 2.1 Make `startLaneIntro()` async and await `dataPromise` before checking `dateGroups.length` (already implemented — verify)
+- [x] 2.2 When `dateGroups.length === 0`, skip lane intro entirely: set `laneIntroPhase = 'done'`, call `skipToMyArtists()` which sets Step 4 and activates My Artists tab spotlight (already implemented — verify)
+- [x] 2.3 Add card-phase guard in `advanceLaneIntro()`: if advancing to 'card' with `dateGroups.length === 0`, skip to done and call `skipToMyArtists()` (already implemented — verify)
+
+## 3. Coach Mark — Retry Exhaustion Cleanup
+
+- [x] 3.1 In `coach-mark.ts` `findAndHighlight()`, replace `this.visible = false` with `this.deactivate()` when retries are exhausted after 5 seconds (already implemented — verify)
+
+## 4. Unit Tests
+
+- [x] 4.1 Add test TC-GATE-01: `showDashboardCoachMark` is false when `concertGroupCount === 0` despite 3+ follows and all searches complete
+- [x] 4.2 Add test TC-GATE-02: `showDashboardCoachMark` is true when `concertGroupCount > 0` with 3+ follows and all searches complete
+- [x] 4.3 Add test TC-GATE-03: Guidance message shows "no upcoming events" when searches complete with no concerts
+- [x] 4.4 Verify test TC-GATE-04 exists: Lane intro skipped when dateGroups is empty (already implemented — verify)
+- [x] 4.5 Verify test TC-GATE-05 exists: Coach mark fully deactivates on retry exhaustion (already implemented — verify)
+
+## 5. E2E Tests
+
+- [x] 5.1 Add E2E test TC-GATE-E2E-01: Dashboard with empty concert data skips lane intro without stuck overlay (already implemented — verify)
+- [x] 5.2 Add E2E test TC-GATE-E2E-02: Discovery page does not show Dashboard coach mark when `ConcertService/List` returns empty groups
+
+## 6. Lint & Verification
+
+- [x] 6.1 Run `make check` (lint + unit tests) and fix any failures
+- [x] 6.2 Run E2E tests against dev server and fix any failures (12/13 pass; 1 pre-existing failure in continuous flow test unrelated to this change)


### PR DESCRIPTION
Add OpenSpec change artifacts for two onboarding-related changes:

- **fix-onboarding-ux-bugs**: Bug fixes discovered during E2E testing (celebration overlay bind-phase, coach mark scroll, toast cleanup)
- **onboarding-concert-data-gate**: Concert data dependency gate ensuring dashboard loads real data before coach marks activate

close: #201