### PR TITLE
docs(openspec): add http-retry-middleware spec

### DIFF
--- a/openspec/changes/archive/2026-03-12-add-http-retry-middleware/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-12-add-http-retry-middleware/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-12

--- a/openspec/changes/archive/2026-03-12-add-http-retry-middleware/design.md
+++ b/openspec/changes/archive/2026-03-12-add-http-retry-middleware/design.md
@@ -1,0 +1,107 @@
+## Context
+
+External API clients handle transient errors inconsistently:
+
+| Client | Throttle | Retry on Rate Limit | Retry on Transient |
+|--------|----------|--------------------|--------------------|
+| Last.fm | 200ms (in-memory) | No | No |
+| MusicBrainz | 1s (in-memory) | No | No |
+| Google Maps | None | No | No |
+| Gemini | N/A (SDK) | Yes (hand-rolled) | Yes (hand-rolled) |
+| Blockchain | N/A (RPC) | N/A | Yes (hand-rolled) |
+
+In-memory throttling breaks when multiple K8s pods or concurrent consumers/jobs overlap. When rate limits are hit, there is no retry — the error propagates immediately. Gemini and Blockchain have duplicated inline retry loops.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Provide a reusable HTTP retry mechanism via `http.RoundTripper` wrapper in `pkg/httpx`
+- Retry on transient HTTP errors (429, 503, 504) with exponential backoff and jitter
+- Respect `Retry-After` headers from upstream APIs
+- Unify Gemini's hand-rolled retry to use `cenkalti/backoff/v5`
+- Maintain the existing throttle → request flow with correct ordering
+
+**Non-Goals:**
+- Circuit breaker pattern (not needed at current scale)
+- Per-client rate limit quotas or distributed throttling (future work)
+- Modifying the Blockchain RPC retry (not HTTP-based, different protocol)
+- Adding retry to WebPush sender (fire-and-forget by design)
+- Changing error codes returned to callers (existing `api.FromHTTP` mapping stays)
+
+## Decisions
+
+### 1. Library: `cenkalti/backoff/v5`
+
+Already an indirect dependency in `go.mod`. Promotes to direct usage.
+
+**Why not alternatives:**
+- `hashicorp/go-retryablehttp` — HTTP-only; cannot reuse for Gemini SDK. Would add a second retry path.
+- `sethvargo/go-retry` — No `Retry-After` support. Lower adoption (708 stars vs 4,000+).
+- `failsafe-go` — Over-engineered for current needs (circuit breaker, hedging). Larger dependency.
+- Custom implementation — Duplicates what `cenkalti/backoff` already provides well.
+
+### 2. Package placement: `pkg/httpx`
+
+New package `pkg/httpx` containing a `RetryTransport` that implements `http.RoundTripper`.
+
+**Why `pkg/httpx`:**
+- `pkg/` is for reusable, domain-agnostic utilities (same as `pkg/throttle`, `pkg/api`)
+- `httpx` follows Go convention for stdlib extensions (`sqlx`, `netx`)
+- Keeps `pkg/api` focused on error conversion only
+
+**Why not `internal/infrastructure/`:**
+- Retry is not an adapter/driver; it's a transport-layer concern
+- Multiple infrastructure clients share it — it belongs in the shared utility layer
+
+### 3. Retry scope: transient HTTP status codes only
+
+Retryable status codes: **429** (Too Many Requests), **503** (Service Unavailable), **504** (Gateway Timeout).
+
+Non-retryable: all 4xx (except 429), 501, connection errors without response.
+
+`Retry-After` header is parsed when present (both absolute date and delta-seconds formats) and used as the minimum backoff for that attempt.
+
+### 4. Throttle-retry ordering: retry outside throttle (Pattern A)
+
+```
+retry loop (with backoff) {
+    throttle.Do {
+        httpClient.Do(req)   ← plain Transport, no RetryTransport
+    }
+}
+```
+
+**Why not RoundTripper-based retry for throttled clients:**
+- If retry lives inside `RoundTripper`, the backoff wait blocks the throttle slot
+- Other callers waiting in the throttle queue are starved during backoff
+- Pattern A releases the throttle slot immediately on failure, backs off externally, then re-enters the queue
+
+**Implementation:** For Last.fm and MusicBrainz, introduce a `retryDo` helper in each client's `get` method that wraps the existing `throttler.Do` call with `backoff.Retry`. The `RetryTransport` is used only by clients without a throttler (Google Maps).
+
+### 5. Gemini: replace inline retry with `backoff.Retry`
+
+Gemini uses the `genai` SDK (not raw HTTP), so `RetryTransport` cannot be used. Instead, wrap the `GenerateContent` call with `backoff.Retry()` using the existing `isRetryable()` predicate.
+
+This replaces the hand-rolled `for attempt := range maxAttempts` loop while preserving identical behavior: max 3 attempts, exponential backoff, context cancellation.
+
+### 6. Configuration defaults
+
+| Parameter | Default | Rationale |
+|-----------|---------|-----------|
+| Max retries | 3 | Matches existing Gemini/Blockchain patterns |
+| Initial interval | 1s | Conservative; avoids hammering rate-limited APIs |
+| Max interval | 10s | Cap for exponential growth |
+| Multiplier | 2.0 | Standard exponential doubling |
+| Jitter | Full (randomized) | Prevents thundering herd across pods |
+
+Configurable via functional options on `RetryTransport` and passed through DI.
+
+## Risks / Trade-offs
+
+**[Risk] Retry amplifies load during outage** → Mitigated by max retry cap (3), exponential backoff with jitter, and `Retry-After` header respect. At scale, circuit breaker would be the next step.
+
+**[Risk] Throttle + retry interaction complexity** → Two distinct patterns (RoundTripper for non-throttled, explicit retry loop for throttled) may confuse future developers. → Mitigated by clear doc comments explaining the pattern choice and a code comment at each usage site.
+
+**[Risk] Request body replay for POST requests** → Google Maps uses POST. `http.Request.Body` is consumed on first read. → `RetryTransport` must buffer or use `GetBody` to replay the body. `http.NewRequest` sets `GetBody` automatically for `bytes.Reader` and `strings.Reader`, which covers our usage.
+
+**[Trade-off] Not unifying Blockchain retry** → Blockchain uses `go-ethereum` RPC client, not HTTP. Forcing it through the same pattern would add complexity without benefit. Its existing retry loop is adequate.

--- a/openspec/changes/archive/2026-03-12-add-http-retry-middleware/proposal.md
+++ b/openspec/changes/archive/2026-03-12-add-http-retry-middleware/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+External API clients (Last.fm, MusicBrainz, Google Maps, Gemini) handle rate limit errors inconsistently. Last.fm and MusicBrainz rely solely on in-memory throttling, which breaks when multiple K8s pods or concurrent jobs overlap — hitting rate limits with no retry. Gemini and Blockchain have hand-rolled retry loops with duplicated backoff logic. There is no shared retry infrastructure.
+
+## What Changes
+
+- Add a new `pkg/httpx` package providing an `http.RoundTripper` wrapper with configurable exponential backoff retry (using `cenkalti/backoff/v5`, already in go.mod)
+- The RoundTripper retries on transient HTTP status codes (429, 503, 504) and respects `Retry-After` headers
+- Wire retry-enabled `http.Client` instances into Last.fm, MusicBrainz, and Google Maps clients via DI
+- Replace Gemini's hand-rolled retry loop with `cenkalti/backoff/v5` `Retry()` (SDK client, not HTTP-based — cannot use RoundTripper)
+- Adopt "throttle outside, retry inside" pattern: throttle gates the request attempt, retry with backoff happens outside the throttle slot so backoff wait doesn't block other callers
+
+## Capabilities
+
+### New Capabilities
+
+_None — this is an infrastructure-level improvement with no user-facing capability change._
+
+### Modified Capabilities
+
+_None — no spec-level behavior changes. Error codes returned to callers remain the same (`ResourceExhausted`, `Unavailable`, etc.)._
+
+## Impact
+
+- **backend/pkg/httpx/**: New package (retry RoundTripper)
+- **backend/pkg/throttle/**: No changes needed
+- **backend/internal/infrastructure/music/lastfm/**: Receives retry-enabled `http.Client`; retry loop moves outside throttle
+- **backend/internal/infrastructure/music/musicbrainz/**: Same as Last.fm
+- **backend/internal/infrastructure/maps/google/**: Receives retry-enabled `http.Client` (currently has no retry at all)
+- **backend/internal/infrastructure/gcp/gemini/**: Replace inline retry with `backoff.Retry()`
+- **backend/internal/di/**: Wire retry-configured `http.Client` for external API clients
+- **Dependencies**: `cenkalti/backoff/v5` promoted from indirect to direct (already in go.mod)

--- a/openspec/changes/archive/2026-03-12-add-http-retry-middleware/proposal.md
+++ b/openspec/changes/archive/2026-03-12-add-http-retry-middleware/proposal.md
@@ -8,7 +8,7 @@ External API clients (Last.fm, MusicBrainz, Google Maps, Gemini) handle rate lim
 - The RoundTripper retries on transient HTTP status codes (429, 503, 504) and respects `Retry-After` headers
 - Wire retry-enabled `http.Client` instances into Last.fm, MusicBrainz, and Google Maps clients via DI
 - Replace Gemini's hand-rolled retry loop with `cenkalti/backoff/v5` `Retry()` (SDK client, not HTTP-based — cannot use RoundTripper)
-- Adopt "throttle outside, retry inside" pattern: throttle gates the request attempt, retry with backoff happens outside the throttle slot so backoff wait doesn't block other callers
+- Adopt "retry outside throttle" pattern (Pattern A): retry with backoff wraps the throttle call so backoff wait doesn't block other callers' throttle slots
 
 ## Capabilities
 

--- a/openspec/changes/archive/2026-03-12-add-http-retry-middleware/specs/http-retry/spec.md
+++ b/openspec/changes/archive/2026-03-12-add-http-retry-middleware/specs/http-retry/spec.md
@@ -1,0 +1,49 @@
+## ADDED Requirements
+
+### Requirement: HTTP retry on transient errors
+The system SHALL automatically retry HTTP requests that fail with transient status codes (429 Too Many Requests, 503 Service Unavailable, 504 Gateway Timeout) using exponential backoff with jitter.
+
+#### Scenario: Retry on 429 rate limit
+- **WHEN** an external HTTP API returns 429 Too Many Requests
+- **THEN** the system SHALL wait with exponential backoff and retry the request up to 3 times
+
+#### Scenario: Retry on 503 service unavailable
+- **WHEN** an external HTTP API returns 503 Service Unavailable
+- **THEN** the system SHALL wait with exponential backoff and retry the request up to 3 times
+
+#### Scenario: Retry on 504 gateway timeout
+- **WHEN** an external HTTP API returns 504 Gateway Timeout
+- **THEN** the system SHALL wait with exponential backoff and retry the request up to 3 times
+
+#### Scenario: No retry on client errors
+- **WHEN** an external HTTP API returns a 4xx status code other than 429
+- **THEN** the system SHALL NOT retry and SHALL return the error immediately
+
+#### Scenario: All retries exhausted
+- **WHEN** all retry attempts are exhausted
+- **THEN** the system SHALL return the last error to the caller
+
+### Requirement: Retry-After header respect
+The system SHALL parse and respect the `Retry-After` HTTP header when present in a response, using the specified delay as the minimum backoff for that retry attempt.
+
+#### Scenario: Retry-After with delta-seconds
+- **WHEN** a 429 response includes a `Retry-After: 5` header
+- **THEN** the system SHALL wait at least 5 seconds before retrying
+
+#### Scenario: Retry-After with HTTP-date
+- **WHEN** a 429 response includes a `Retry-After` header with an HTTP-date value
+- **THEN** the system SHALL wait until the specified time before retrying
+
+### Requirement: Context cancellation during retry
+The system SHALL respect context cancellation during retry backoff waits, stopping the retry loop immediately when the context is canceled or its deadline is exceeded.
+
+#### Scenario: Context canceled during backoff
+- **WHEN** the context is canceled while waiting for a retry backoff
+- **THEN** the system SHALL stop retrying and return the context error
+
+### Requirement: Request body replay for retried POST requests
+The system SHALL correctly replay the request body for POST/PUT requests across retry attempts.
+
+#### Scenario: POST request retried after 503
+- **WHEN** a POST request to an external API receives 503 and is retried
+- **THEN** the retried request SHALL contain the same body as the original request

--- a/openspec/changes/archive/2026-03-12-add-http-retry-middleware/specs/http-retry/spec.md
+++ b/openspec/changes/archive/2026-03-12-add-http-retry-middleware/specs/http-retry/spec.md
@@ -42,7 +42,7 @@ The system SHALL respect context cancellation during retry backoff waits, stoppi
 - **THEN** the system SHALL stop retrying and return the context error
 
 ### Requirement: Request body replay for retried POST requests
-The system SHALL correctly replay the request body for POST/PUT requests across retry attempts.
+The system SHALL correctly replay the request body for POST requests across retry attempts.
 
 #### Scenario: POST request retried after 503
 - **WHEN** a POST request to an external API receives 503 and is retried

--- a/openspec/changes/archive/2026-03-12-add-http-retry-middleware/tasks.md
+++ b/openspec/changes/archive/2026-03-12-add-http-retry-middleware/tasks.md
@@ -1,0 +1,29 @@
+## 1. Core: `pkg/httpx` RetryTransport
+
+- [x] 1.1 Create `pkg/httpx/retry.go` with `RetryTransport` implementing `http.RoundTripper` — exponential backoff via `cenkalti/backoff/v5`, retries on 429/503/504, parses `Retry-After` header (delta-seconds and HTTP-date), replays request body via `GetBody`
+- [x] 1.2 Add functional options: `WithMaxRetries`, `WithInitialInterval`, `WithMaxInterval`
+- [x] 1.3 Create `pkg/httpx/retry_test.go` — unit tests using `httptest.Server`: retry on 429/503/504, no retry on 400/401/404, Retry-After respect, context cancellation during backoff, POST body replay, all retries exhausted
+
+## 2. Integrate: Google Maps client
+
+- [x] 2.1 Wire `RetryTransport`-enabled `http.Client` into `google.NewClient` via DI (`internal/di/provider.go`)
+- [x] 2.2 Verify existing Google Maps tests pass with the new transport
+
+## 3. Integrate: Last.fm client (throttle + retry)
+
+- [x] 3.1 Add retry loop around `throttler.Do` in `lastfm.client.get()` using `backoff.Retry` — retry wraps the throttle call so backoff waits don't block the throttle slot
+- [x] 3.2 Add/update tests for Last.fm client verifying retry on 429 after throttle
+
+## 4. Integrate: MusicBrainz client (throttle + retry)
+
+- [x] 4.1 Add retry loop around `throttler.Do` in each MusicBrainz method using `backoff.Retry` — same pattern as Last.fm
+- [x] 4.2 Add/update tests for MusicBrainz client verifying retry on 503 after throttle
+
+## 5. Refactor: Gemini retry with `cenkalti/backoff`
+
+- [x] 5.1 Replace hand-rolled `for attempt := range maxAttempts` loop in `gemini.searcher.Search()` with `backoff.Retry()`, using existing `isRetryable()` as the permanent-error predicate
+- [x] 5.2 Update `gemini/retry_test.go` to work with the new backoff-based implementation — same test scenarios, same behavioral assertions
+
+## 6. Promote dependency
+
+- [x] 6.1 Run `go mod tidy` to promote `cenkalti/backoff/v5` from indirect to direct in `go.mod`

--- a/openspec/specs/http-retry/spec.md
+++ b/openspec/specs/http-retry/spec.md
@@ -1,0 +1,49 @@
+## ADDED Requirements
+
+### Requirement: HTTP retry on transient errors
+The system SHALL automatically retry HTTP requests that fail with transient status codes (429 Too Many Requests, 503 Service Unavailable, 504 Gateway Timeout) using exponential backoff with jitter.
+
+#### Scenario: Retry on 429 rate limit
+- **WHEN** an external HTTP API returns 429 Too Many Requests
+- **THEN** the system SHALL wait with exponential backoff and retry the request up to 3 times
+
+#### Scenario: Retry on 503 service unavailable
+- **WHEN** an external HTTP API returns 503 Service Unavailable
+- **THEN** the system SHALL wait with exponential backoff and retry the request up to 3 times
+
+#### Scenario: Retry on 504 gateway timeout
+- **WHEN** an external HTTP API returns 504 Gateway Timeout
+- **THEN** the system SHALL wait with exponential backoff and retry the request up to 3 times
+
+#### Scenario: No retry on client errors
+- **WHEN** an external HTTP API returns a 4xx status code other than 429
+- **THEN** the system SHALL NOT retry and SHALL return the error immediately
+
+#### Scenario: All retries exhausted
+- **WHEN** all retry attempts are exhausted
+- **THEN** the system SHALL return the last error to the caller
+
+### Requirement: Retry-After header respect
+The system SHALL parse and respect the `Retry-After` HTTP header when present in a response, using the specified delay as the minimum backoff for that retry attempt.
+
+#### Scenario: Retry-After with delta-seconds
+- **WHEN** a 429 response includes a `Retry-After: 5` header
+- **THEN** the system SHALL wait at least 5 seconds before retrying
+
+#### Scenario: Retry-After with HTTP-date
+- **WHEN** a 429 response includes a `Retry-After` header with an HTTP-date value
+- **THEN** the system SHALL wait until the specified time before retrying
+
+### Requirement: Context cancellation during retry
+The system SHALL respect context cancellation during retry backoff waits, stopping the retry loop immediately when the context is canceled or its deadline is exceeded.
+
+#### Scenario: Context canceled during backoff
+- **WHEN** the context is canceled while waiting for a retry backoff
+- **THEN** the system SHALL stop retrying and return the context error
+
+### Requirement: Request body replay for retried POST requests
+The system SHALL correctly replay the request body for POST/PUT requests across retry attempts.
+
+#### Scenario: POST request retried after 503
+- **WHEN** a POST request to an external API receives 503 and is retried
+- **THEN** the retried request SHALL contain the same body as the original request

--- a/openspec/specs/http-retry/spec.md
+++ b/openspec/specs/http-retry/spec.md
@@ -42,7 +42,7 @@ The system SHALL respect context cancellation during retry backoff waits, stoppi
 - **THEN** the system SHALL stop retrying and return the context error
 
 ### Requirement: Request body replay for retried POST requests
-The system SHALL correctly replay the request body for POST/PUT requests across retry attempts.
+The system SHALL correctly replay the request body for POST requests across retry attempts.
 
 #### Scenario: POST request retried after 503
 - **WHEN** a POST request to an external API receives 503 and is retried


### PR DESCRIPTION
## 🔗 Related Issue

Closes liverty-music/backend#140

## 📝 Summary of Changes

Add OpenSpec artifacts for the HTTP retry middleware capability:

- **Capability spec** (`openspec/specs/http-retry/spec.md`): Defines retryable HTTP status codes (429, 503, 504), exponential backoff with jitter, Retry-After header parsing (delta-seconds and HTTP-date), context cancellation, and POST body replay requirements.
- **Archived change** (`openspec/changes/archive/2026-03-12-add-http-retry-middleware/`): Complete proposal, design, and task artifacts documenting the library selection (cenkalti/backoff/v5), Pattern A (retry outside throttle), and implementation plan.

## 📋 Commit Log

- `5b41989` docs(openspec): add http-retry-middleware spec and archive

## ✅ Self-Checklist

- [x] I have linked the related issue.
- [x] Spec artifacts follow OpenSpec conventions.
- [x] Change has been archived with all tasks complete.