### PR TITLE
docs(openspec): archive fix-places-api-permission change

### DIFF
--- a/openspec/changes/archive/2026-03-12-fix-places-api-permission/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-12-fix-places-api-permission/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-12

--- a/openspec/changes/archive/2026-03-12-fix-places-api-permission/design.md
+++ b/openspec/changes/archive/2026-03-12-fix-places-api-permission/design.md
@@ -1,0 +1,40 @@
+## Context
+
+The backend consumer calls Google Places API (New) using OAuth Bearer tokens via GCP Application Default Credentials (Workload Identity). The `X-Goog-User-Project` header is set for billing attribution. GCP requires the calling service account to have `serviceusage.services.use` permission on the billing project when this header is present. The backend-app SA currently lacks this permission.
+
+Current backend-app SA roles (in `kubernetes.ts`):
+- `roles/logging.logWriter`
+- `roles/monitoring.metricWriter`
+- `roles/cloudtrace.agent`
+- `roles/cloudsql.instanceUser`
+- `roles/aiplatform.user`
+
+## Goals / Non-Goals
+
+**Goals:**
+- Grant the backend-app SA the minimum IAM permission needed to call Places API (New) via OAuth.
+
+**Non-Goals:**
+- Changing the authentication method (e.g., switching to API key auth).
+- Adding Places API-specific roles (none exist; Places API authorization is controlled by API enablement + service usage permission).
+- Modifying backend application code.
+
+## Decisions
+
+### Use `roles/serviceusage.serviceUsageConsumer`
+
+**Rationale:** This is the narrowest predefined role that includes `serviceusage.services.use`. It grants permission to use APIs enabled on the project, without granting ability to enable/disable APIs or manage quotas.
+
+**Alternatives considered:**
+- `roles/editor`: Includes the permission but is far too broad (violates least privilege).
+- Custom IAM role: Unnecessary overhead for a single well-scoped predefined role.
+- Remove `X-Goog-User-Project` header: Would break billing attribution and is required by Places API (New) for OAuth calls.
+
+### Apply at project level (same as existing roles)
+
+**Rationale:** The existing backend-app SA roles are all bound at the project level. This role follows the same pattern and is appropriate since the SA only operates within one project.
+
+## Risks / Trade-offs
+
+- **[Broader than Places API]** `serviceusage.services.use` allows calling any enabled API on the project, not just Places API. → Acceptable: the SA already has `cloud-platform` scope, and API access is further gated by API-specific IAM roles where applicable (e.g., Cloud SQL, AI Platform). Places API has no API-specific IAM role.
+- **[No rollback needed]** Adding an IAM binding is non-destructive. If reverted, venue enrichment returns to the current broken state. No data loss risk.

--- a/openspec/changes/archive/2026-03-12-fix-places-api-permission/proposal.md
+++ b/openspec/changes/archive/2026-03-12-fix-places-api-permission/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+The backend-app service account lacks the `serviceusage.services.use` permission required for OAuth-authenticated calls to Google Places API (New). When the consumer sends requests with `Authorization: Bearer` + `X-Goog-User-Project`, GCP checks that the caller has permission to use APIs on the billing project. Without `roles/serviceusage.serviceUsageConsumer`, all Places API calls return `403 permission_denied`, blocking venue enrichment.
+
+## What Changes
+
+- Add `roles/serviceusage.serviceUsageConsumer` to the backend-app service account's project-level IAM bindings in Pulumi (cloud-provisioning).
+- This grants `serviceusage.services.use`, the minimum permission needed for OAuth + `X-Goog-User-Project` API calls.
+
+## Capabilities
+
+### New Capabilities
+
+None. This is an infrastructure/IAM fix, not a new capability.
+
+### Modified Capabilities
+
+None. The venue enrichment capability's requirements are unchanged; this fixes a missing permission that prevents the existing implementation from working.
+
+## Impact
+
+- **cloud-provisioning**: `src/gcp/components/kubernetes.ts` — one IAM role addition to backend-app SA bindings.
+- **backend**: No code changes. The existing Places API client will work once the IAM role is applied.
+- **Deployment**: Requires `pulumi up` on the dev stack to apply the IAM binding. Effect is immediate after apply.

--- a/openspec/changes/archive/2026-03-12-fix-places-api-permission/specs/infrastructure-iam/spec.md
+++ b/openspec/changes/archive/2026-03-12-fix-places-api-permission/specs/infrastructure-iam/spec.md
@@ -1,0 +1,12 @@
+## ADDED Requirements
+
+### Requirement: Backend SA has service usage permission
+The backend-app service account SHALL have the `roles/serviceusage.serviceUsageConsumer` IAM role bound at the project level, granting `serviceusage.services.use` permission required for OAuth-authenticated API calls with `X-Goog-User-Project` billing attribution.
+
+#### Scenario: Places API call succeeds with OAuth token
+- **WHEN** the consumer sends a POST request to `places.googleapis.com` with a Bearer token and `X-Goog-User-Project` header
+- **THEN** GCP authorizes the request and the Places API returns search results (not 403)
+
+#### Scenario: IAM role is scoped to project level
+- **WHEN** the backend-app SA IAM bindings are inspected
+- **THEN** `roles/serviceusage.serviceUsageConsumer` is present alongside existing roles (logWriter, metricWriter, etc.)

--- a/openspec/changes/archive/2026-03-12-fix-places-api-permission/tasks.md
+++ b/openspec/changes/archive/2026-03-12-fix-places-api-permission/tasks.md
@@ -1,0 +1,10 @@
+## 1. IAM Role Addition
+
+- [x] 1.1 Add `roles/serviceusage.serviceUsageConsumer` to backend-app SA role bindings in `cloud-provisioning/src/gcp/components/kubernetes.ts`
+- [x] 1.2 Run `make check` in cloud-provisioning to verify lint and type checks pass
+
+## 2. Deployment
+
+- [x] 2.1 Run `pulumi preview` on dev stack to verify the IAM binding diff
+- [x] 2.2 Run `pulumi up` on dev stack after user approval
+- [x] 2.3 Verify Places API calls succeed by checking consumer logs for successful venue enrichment (no more 403)


### PR DESCRIPTION
## Related Issue

Related: liverty-music/cloud-provisioning#146

## Summary of Changes

Archive the completed `fix-places-api-permission` OpenSpec change after successfully resolving the Places API (New) 403 `permission_denied` error.

The fix was applied in `cloud-provisioning` (PR #147) by adding `roles/serviceusage.serviceUsageConsumer` to the backend-app service account. Venue enrichment via Places API (New) is now working correctly in dev.

## Self-Checklist

- [x] I have linked the related issue.
- [x] I have updated the relevant documentation (e.g., `README.md`) if needed.
- [x] I have run `buf lint` and `buf format` locally and all checks have passed.
- [x] My proto definitions follow the project's style guidelines and validation rules.
- [x] Breaking changes have been justified and documented if applicable.
