### PR TITLE
docs(openspec): add trace context propagation spec and archive

### DIFF
--- a/openspec/changes/archive/2026-03-12-propagate-traceparent-to-consumer/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-12-propagate-traceparent-to-consumer/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-12

--- a/openspec/changes/archive/2026-03-12-propagate-traceparent-to-consumer/design.md
+++ b/openspec/changes/archive/2026-03-12-propagate-traceparent-to-consumer/design.md
@@ -1,0 +1,48 @@
+## Context
+
+The backend uses Watermill for async messaging (NATS JetStream in production, GoChannel locally). The `watermill-opentelemetry` library (`wotel`) is already a dependency and provides both a `Trace()` subscriber middleware and a `PublisherDecorator`.
+
+Current state:
+- **Publisher**: `NewEvent(data)` creates a `message.Message` with CloudEvents metadata but no `context.Context`. The message's internal context defaults to `context.Background()`. The publisher is **not** wrapped with `wotel.NewPublisherDecorator()`, so no trace context is injected into message metadata.
+- **Consumer**: `wotel.Trace()` middleware is registered on the router and starts a span using `msg.Context()`. However, all 4 consumer handlers immediately discard it with `ctx := context.Background()`, losing trace information.
+- **Logging**: `go-logging` v1.2.0 extracts `trace_id` and `span_id` from `context.Context` via `trace.SpanFromContext(ctx)`. When `context.Background()` is passed, `SpanContext.IsValid()` returns false and no trace fields are emitted.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Consumer structured logs include `trace_id` and `span_id` fields
+- Publisher and Consumer share the same trace, enabling end-to-end distributed tracing across the message broker
+- No new dependencies required
+
+**Non-Goals:**
+- Implementing baggage propagation (W3C Baggage)
+- Adding trace context to CloudEvents `ce_` metadata attributes (traceparent is propagated via Watermill metadata, separate from CloudEvents attributes)
+- Changing the global `TextMapPropagator` — `wotel` uses its own internal propagation via message metadata keys
+
+## Decisions
+
+### 1. Use `msg.Context()` in consumer handlers instead of `context.Background()`
+
+The `wotel.Trace()` middleware already calls `msg.SetContext(ctx)` with a span-enriched context before invoking the handler. Handlers just need to read it.
+
+**Alternative considered**: Extract trace context manually from message metadata using `propagation.TraceContext{}`. Rejected because the middleware already does this — manual extraction would duplicate work.
+
+### 2. Add `context.Context` parameter to `NewEvent()`
+
+Change signature from `NewEvent(data any)` to `NewEvent(ctx context.Context, data any)` and call `msg.SetContext(ctx)`. This passes the caller's trace context into the message so that the publisher decorator can extract it.
+
+**Alternative considered**: Set context at the `publishEvent()` call site instead of in `NewEvent()`. Rejected because `NewEvent` is the message factory — context attachment belongs with message creation for consistency.
+
+### 3. Wrap Publisher with `wotel.NewPublisherDecorator()`
+
+The decorator intercepts `Publish()`, extracts trace context from `msg.Context()`, and injects it into message metadata as Watermill metadata keys. The consumer-side `wotel.Trace()` middleware reads these keys back and restores the trace context.
+
+This is necessary because message context does not survive serialization over NATS — only metadata does.
+
+**Alternative considered**: Manually inject/extract traceparent into CloudEvents `ce_traceparent` attribute. Rejected because `wotel` already has a well-tested metadata-based propagation mechanism, and mixing propagation strategies adds complexity.
+
+## Risks / Trade-offs
+
+- **[Risk] Breaking change to `NewEvent()` signature** → All call sites must be updated to pass `ctx`. This is a compile-time breakage, so the compiler catches any missed call sites. Mitigation: update all call sites in the same PR.
+- **[Risk] Publisher decorator adds per-message span overhead** → Each published message gets a producer span. This is expected behavior for distributed tracing and the overhead is negligible. The `AlwaysSample` tracer is already in use.
+- **[Trade-off] GoChannel vs NATS behavior difference** → With GoChannel (local dev), `msg.Context()` is preserved in-process without metadata serialization, so tracing works even without the decorator. With NATS, the decorator is required. The decorator works correctly in both cases, so we apply it unconditionally.

--- a/openspec/changes/archive/2026-03-12-propagate-traceparent-to-consumer/proposal.md
+++ b/openspec/changes/archive/2026-03-12-propagate-traceparent-to-consumer/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+Consumer process structured logs are missing `trace_id` and `span_id` fields, breaking distributed tracing continuity between Publisher and Consumer. This makes it impossible to trace event-driven processing end-to-end in Cloud Trace.
+
+## What Changes
+
+- Fix consumer handlers to use `msg.Context()` instead of `context.Background()`, propagating the trace context injected by the Watermill OTel middleware into logs and downstream processing
+- Pass `context.Context` to `NewEvent()` and call `msg.SetContext(ctx)` so the caller's trace context is attached to the message
+- Wrap the Publisher with `wotel.NewPublisherDecorator()` to inject traceparent into NATS message metadata, ensuring trace continuity across the message broker
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+(none — this is an implementation-level fix, no spec-level behavior changes)
+
+## Impact
+
+- **backend**: `internal/infrastructure/messaging/` — `cloudevents.go`, `publisher.go`, `router.go` (add Publisher decorator)
+- **backend**: `internal/adapter/event/` — all consumer handlers (`concert_consumer.go`, `notification_consumer.go`, `venue_consumer.go`, `artist_consumer.go`)
+- **backend**: `internal/usecase/` — all `NewEvent()` call sites (add `ctx` argument)
+- **dependency**: `github.com/voi-oss/watermill-opentelemetry` (already present, no new dependency needed)

--- a/openspec/changes/archive/2026-03-12-propagate-traceparent-to-consumer/specs/event-management/spec.md
+++ b/openspec/changes/archive/2026-03-12-propagate-traceparent-to-consumer/specs/event-management/spec.md
@@ -1,0 +1,15 @@
+## ADDED Requirements
+
+### Requirement: Trace context propagation across message broker
+
+The system SHALL propagate W3C Trace Context (traceparent) from the publisher process to the consumer process via message metadata. Consumer-side structured logs SHALL include `trace_id` and `span_id` fields extracted from the propagated trace context.
+
+#### Scenario: Consumer log includes trace fields from publisher trace
+
+- **WHEN** a publisher emits an event while processing a traced request
+- **THEN** the consumer handler's structured logs MUST contain `trace_id` and `span_id` fields matching the publisher's trace
+
+#### Scenario: Consumer handler operates within propagated span
+
+- **WHEN** the consumer receives a message with trace context in its metadata
+- **THEN** all downstream operations (database queries, nested event publishing) MUST be children of the propagated trace

--- a/openspec/changes/archive/2026-03-12-propagate-traceparent-to-consumer/tasks.md
+++ b/openspec/changes/archive/2026-03-12-propagate-traceparent-to-consumer/tasks.md
@@ -1,0 +1,22 @@
+## 1. Publisher-side trace context injection
+
+- [x] 1.1 Add `context.Context` parameter to `NewEvent()` in `internal/infrastructure/messaging/cloudevents.go` and call `msg.SetContext(ctx)`
+- [x] 1.2 Update `NewEvent()` call site in `internal/usecase/concert_uc.go` to pass `ctx`
+- [x] 1.3 Update `NewEvent()` call site in `internal/usecase/concert_creation_uc.go` to pass `ctx`
+- [x] 1.4 Update `NewEvent()` call site in `internal/usecase/artist_uc.go` to pass `ctx`
+
+## 2. Publisher decorator for metadata propagation
+
+- [x] 2.1 Wrap the publisher with `wotel.NewPublisherDecorator()` in `internal/infrastructure/messaging/publisher.go`
+
+## 3. Consumer-side trace context usage
+
+- [x] 3.1 Replace `ctx := context.Background()` with `ctx := msg.Context()` in `internal/adapter/event/concert_consumer.go`
+- [x] 3.2 Replace `ctx := context.Background()` with `ctx := msg.Context()` in `internal/adapter/event/artist_consumer.go`
+- [x] 3.3 Replace `ctx := context.Background()` with `ctx := msg.Context()` in `internal/adapter/event/venue_consumer.go`
+- [x] 3.4 Replace `ctx := context.Background()` with `ctx := msg.Context()` in `internal/adapter/event/notification_consumer.go`
+
+## 4. Verification
+
+- [x] 4.1 Run `make check` to verify compilation and tests pass
+- [x] 4.2 Verify consumer logs include `trace_id` and `span_id` fields (local test with GoChannel)

--- a/openspec/specs/event-management/spec.md
+++ b/openspec/specs/event-management/spec.md
@@ -23,3 +23,17 @@ The system SHALL support extending the base `Event` entity with domain-specific 
 - **WHEN** a `Concert` is created
 - **THEN** an associated `Event` record is strictly required
 - **AND** the `Concert` record shares the same unique identifier (or references it as a foreign key with uniqueness constraint)
+
+### Requirement: Trace context propagation across message broker
+
+The system SHALL propagate W3C Trace Context (traceparent) from the publisher process to the consumer process via message metadata. Consumer-side structured logs SHALL include `trace_id` and `span_id` fields extracted from the propagated trace context.
+
+#### Scenario: Consumer log includes trace fields from publisher trace
+
+- **WHEN** a publisher emits an event while processing a traced request
+- **THEN** the consumer handler's structured logs MUST contain `trace_id` and `span_id` fields matching the publisher's trace
+
+#### Scenario: Consumer handler operates within propagated span
+
+- **WHEN** the consumer receives a message with trace context in its metadata
+- **THEN** all downstream operations (database queries, nested event publishing) MUST be children of the propagated trace


### PR DESCRIPTION
## 🔗 Related Issue

Refs: liverty-music/backend#198

## 📝 Summary of Changes

- Add "Trace context propagation across message broker" requirement to `openspec/specs/event-management/spec.md` with 2 scenarios
- Archive the completed `propagate-traceparent-to-consumer` change (proposal, design, delta specs, tasks)

## 📋 Commit Log

- f4c3b8f docs(openspec): add trace context propagation spec and archive

## ✅ Self-Checklist

- [x] I have linked the related issue.
- [x] My changes follow the project conventions.
