### PR TITLE
docs(openspec): sync specs and archive fix-dashboard-lane-classification

### DIFF
--- a/openspec/changes/archive/2026-03-13-fix-dashboard-lane-classification/design.md
+++ b/openspec/changes/archive/2026-03-13-fix-dashboard-lane-classification/design.md
@@ -1,0 +1,59 @@
+## Context
+
+The dashboard timeline classifies concerts into three proximity lanes (Home / Near / Away) based on the user's home area. Two implementation bugs cause all concerts to display in "Away Stage":
+
+1. During onboarding, `loadData()` fires before the user selects a home. After selection, `onHomeSelected()` does not reload data, so the stale all-Away result persists.
+2. After sign-up, `needsRegion` checks `localStorage('guest.home')` which was already cleared by `GuestDataMergeService.clearAll()`. The backend has the user's home (set atomically via `CreateRequest.home`), but the dashboard never queries it.
+
+The `user-home` spec already defines the correct behavior: authenticated users SHALL read home from `UserService.Get`, guests SHALL fall back to localStorage. The `UserHomeSelector.confirmSelection()` method already distinguishes authenticated vs guest for writes (RPC vs localStorage), but `getStoredHome()` only reads localStorage.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Fix lane classification during onboarding so concerts are re-classified after home selection
+- Align `needsRegion` determination with `user-home` spec: authenticated users check backend, guests check localStorage
+- Keep changes minimal and contained to the dashboard and home selector
+
+**Non-Goals:**
+- Changing the backend `ListByFollowerGrouped` classification logic (it works correctly given a home)
+- Modifying the `GuestDataMergeService.clearAll()` behavior (clearing `guest.*` is correct by design)
+- Adding new RPC endpoints or proto changes
+
+## Decisions
+
+### D1: Reload data after home selection during onboarding
+
+**Chosen**: Add `this.loadData()` in `dashboard.ts:onHomeSelected()` after storing the home. During onboarding (guest phase), the backend still receives `home=nil` because the guest home is only in localStorage. However, once data reload is in place, the correct classification will work after sign-up when the backend has the home.
+
+**Consideration**: During the guest onboarding phase, the backend has no home for this user, so a reload would still return all-Away. The real fix requires combining D1 with D2 — after sign-up, the dashboard loads with the backend-known home and correctly classifies lanes. For the initial guest dashboard visit, the lane intro plays over the correctly-classified data only if the backend knows the home, which it doesn't yet during guest phase.
+
+**Revised approach**: The `onHomeSelected()` reload alone doesn't help during guest phase because the backend doesn't know the guest's home. The meaningful fix is ensuring the post-sign-up dashboard visit works correctly (D2). However, adding the reload is still correct for the Settings page scenario where an authenticated user changes their home.
+
+### D2: Use backend User.home for authenticated users' `needsRegion` check
+
+**Chosen**: Modify the dashboard's `loading()` lifecycle to fetch the user's home status from the backend when authenticated, instead of relying on `localStorage('guest.home')`.
+
+**Approach**: The dashboard already calls `dashboardService.loadDashboardEvents()` which calls `concertService.listByFollower()`. The `ListByFollowerGrouped` RPC already uses the backend home for classification. The issue is only the `needsRegion` UI flag.
+
+Two options:
+
+**Option A — Fetch User via UserService.Get**: Call `UserService.Get` in `loading()` to check `user.home`. This adds one RPC call but gives a definitive answer.
+
+**Option B — Infer from loadData result**: After `loadData()` resolves, check if any concerts landed in `home` or `nearby` lanes. If yes, the backend has a home set. If all are in `away`, the home might be missing — but this is ambiguous (all concerts could legitimately be far away).
+
+**Decision**: Option A. An explicit `UserService.Get` check is unambiguous and aligns with the spec requirement. The RPC is lightweight and can be parallelized with `loadDashboardEvents()`.
+
+**Implementation**: In `dashboard.ts:loading()`:
+- If authenticated: fetch `UserService.Get` → check `user.home` → set `needsRegion`
+- If guest: fall back to `UserHomeSelector.getStoredHome()` (current behavior)
+
+### D3: Keep `getStoredHome()` as guest-only utility
+
+**Chosen**: Do not modify `UserHomeSelector.getStoredHome()` to also query the backend. It remains a synchronous localStorage check, used only for guests. The dashboard takes responsibility for choosing the right source based on auth state.
+
+**Rationale**: Making `getStoredHome()` async (to support an RPC call) would change the call sites and add complexity. The dashboard is the only consumer that needs the authenticated path, so localizing the logic there is simpler.
+
+## Risks / Trade-offs
+
+- **[Extra RPC call on dashboard load]** → `UserService.Get` adds one request for authenticated users. Mitigation: parallelize with `loadDashboardEvents()` using `Promise.all`. The call is lightweight (single row lookup).
+- **[Guest onboarding lane intro still shows all-Away]** → During the guest phase, the backend has no home, so lanes cannot be classified. Mitigation: This is inherent to the guest model — lane classification requires a server-side home. The lane intro labels (HOME / NEAR / AWAY) still explain the concept even with empty home/near columns. The correct classification appears after sign-up when the user returns to the dashboard.

--- a/openspec/changes/archive/2026-03-13-fix-dashboard-lane-classification/proposal.md
+++ b/openspec/changes/archive/2026-03-13-fix-dashboard-lane-classification/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+The dashboard timeline displays all concerts in the "Away Stage" lane regardless of the user's home area. Two implementation bugs cause this:
+
+1. **Onboarding data reload gap**: `dashboard.ts:onHomeSelected()` stores the selected home in localStorage and starts the lane intro, but does not re-invoke `loadData()`. The initial load ran before the user selected a home (Home=nil → backend classifies all concerts as Away), and this stale result remains on screen.
+2. **Authenticated user home source mismatch**: `needsRegion` is determined solely by `localStorage.getItem('guest.home')` via `UserHomeSelector.getStoredHome()`. After sign-up, `GuestDataMergeService.clearAll()` removes all `guest.*` keys — including `guest.home` — so `needsRegion` evaluates to `true` even though the backend already has the user's home. This violates the `user-home` spec requirement: "Dashboard reads home from User entity" (authenticated users SHALL read home from `UserService.Get`, not localStorage).
+
+## What Changes
+
+- **Fix 1 — Reload data after home selection**: In `dashboard.ts:onHomeSelected()`, call `loadData()` after storing the home so the backend re-classifies concerts with the newly selected home context.
+- **Fix 2 — Use backend home for authenticated users**: Change the `needsRegion` determination so authenticated users check the `User.home` field from `UserService.Get` instead of localStorage. `getStoredHome()` remains as the guest-only fallback.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `user-home`: Implementation aligns with existing spec requirement "Dashboard reads home from User entity" and "Guest fallback to localStorage".
+- `frontend-onboarding-flow`: Home selection during onboarding triggers dashboard data reload.
+
+### New Capabilities
+
+None.
+
+## Impact
+
+- **Frontend**: `dashboard.ts`, potentially `user-home-selector.ts` or a new dashboard-level home resolution helper
+- **Backend**: No changes — `UserService.Get` already returns `User.home`
+- **Proto**: No changes

--- a/openspec/changes/archive/2026-03-13-fix-dashboard-lane-classification/specs/frontend-onboarding-flow/spec.md
+++ b/openspec/changes/archive/2026-03-13-fix-dashboard-lane-classification/specs/frontend-onboarding-flow/spec.md
@@ -1,0 +1,37 @@
+## MODIFIED Requirements
+
+### Requirement: Just-in-Time Region Configuration
+
+The system SHALL collect the user's home area during the Dashboard reveal step of the tutorial (Step 3), presenting the home area selector as a BottomSheet overlay before displaying personalized content. The selector SHALL use the same 2-step region-to-prefecture flow used throughout the application.
+
+#### Scenario: Home area setup overlay on Dashboard reveal (Step 3)
+
+- **WHEN** the user arrives at the Dashboard during the tutorial (Step 3)
+- **AND** the user has not yet configured their home area
+- **THEN** the system SHALL display the Dashboard with a blurred background
+- **AND** the system SHALL present the `user-home-selector` BottomSheet overlay as a native `<dialog>` element via `showModal()`, promoted to the browser's Top Layer (no z-index stacking)
+- **AND** the selector SHALL display Step 1 with quick-select major city buttons (Tokyo, Osaka, Nagoya, Fukuoka, Sapporo, Sendai) and region buttons (Hokkaido, Tohoku, Kanto, Chubu, Kinki, Chugoku, Shikoku, Kyushu)
+- **AND** the BottomSheet SHALL use the design system's dark surface palette and sheet radius token
+
+#### Scenario: Quick-select city in onboarding
+
+- **WHEN** the user taps a quick-select city button in Step 1
+- **THEN** the system SHALL immediately confirm the selection with the city's prefecture code (e.g., Tokyo -> JP-13)
+- **AND** the system SHALL NOT display Step 2
+
+#### Scenario: Region-to-prefecture selection in onboarding
+
+- **WHEN** the user taps a region button in Step 1
+- **THEN** the system SHALL transition to Step 2 showing prefectures within the selected region
+- **AND** Step 2 SHALL include a back button to return to Step 1
+- **WHEN** the user taps a prefecture in Step 2
+- **THEN** the system SHALL confirm the selection with the prefecture's ISO 3166-2 code
+
+#### Scenario: Magic moment after home area selection
+
+- **WHEN** the user selects their home area (via quick-select or region-to-prefecture)
+- **THEN** the system SHALL store the selected code in localStorage under `guest.home`
+- **AND** the system SHALL immediately close the BottomSheet
+- **AND** the system SHALL unblur the Dashboard background with a smooth transition animation
+- **AND** the system SHALL reload concert data from the backend so lane classification reflects the selected home area
+- **AND** the system SHALL dynamically populate the Live Highway UI with the reloaded, home-area-classified events

--- a/openspec/changes/archive/2026-03-13-fix-dashboard-lane-classification/specs/user-home/spec.md
+++ b/openspec/changes/archive/2026-03-13-fix-dashboard-lane-classification/specs/user-home/spec.md
@@ -1,0 +1,37 @@
+## MODIFIED Requirements
+
+### Requirement: Frontend home area persistence via RPC
+
+The frontend SHALL store the user's home area server-side via RPC, replacing localStorage-based persistence for authenticated users.
+
+#### Scenario: Onboarding home area selection persisted at account creation
+
+- **WHEN** a guest user has selected their home area during onboarding
+- **AND** the user subsequently creates an account
+- **THEN** the frontend SHALL include the selected home in the `UserService.Create` request
+- **AND** SHALL NOT make a separate `UpdateHome` call for the initial home
+
+#### Scenario: Settings home area change triggers UpdateHome RPC
+
+- **WHEN** an authenticated user changes their home area via the `user-home-selector`
+- **THEN** the frontend SHALL call `UserService.UpdateHome` with the new structured home
+- **AND** SHALL NOT write to localStorage for the home area
+
+#### Scenario: Dashboard reads home from User entity
+
+- **WHEN** the dashboard loads for an authenticated user
+- **THEN** the dashboard SHALL call `UserService.Get` to obtain the user's home status
+- **AND** the `needsRegion` flag SHALL be determined by the presence of `user.home` in the response
+- **AND** the dashboard SHALL NOT read from localStorage to determine `needsRegion`
+
+#### Scenario: Guest fallback to localStorage
+
+- **WHEN** a guest (unauthenticated) user selects their home area
+- **THEN** the frontend SHALL store the selection in localStorage under `guest.home`
+- **AND** the dashboard SHALL read from localStorage for the `needsRegion` determination
+
+#### Scenario: Dashboard reloads data after authenticated home change
+
+- **WHEN** an authenticated user changes their home area via the `user-home-selector` on the dashboard
+- **THEN** the dashboard SHALL reload concert data via `loadDashboardEvents()` after the home update completes
+- **AND** the reloaded data SHALL reflect the new lane classification based on the updated home

--- a/openspec/changes/archive/2026-03-13-fix-dashboard-lane-classification/tasks.md
+++ b/openspec/changes/archive/2026-03-13-fix-dashboard-lane-classification/tasks.md
@@ -1,0 +1,19 @@
+## 1. Fix needsRegion for Authenticated Users (Bug 2)
+
+- [x] 1.1 In `dashboard.ts:loading()`, add auth-aware `needsRegion` check: if authenticated, call `UserService.Get` (parallelized with `loadDashboardEvents()`) and set `needsRegion` based on `user.home` presence; if guest, fall back to `UserHomeSelector.getStoredHome()`
+- [x] 1.2 Add unit test: authenticated user with `user.home` set → `needsRegion` is `false`, home selector not shown
+- [x] 1.3 Add unit test: authenticated user without `user.home` → `needsRegion` is `true`, home selector shown
+- [x] 1.4 Add unit test: guest user with `guest.home` in localStorage → `needsRegion` is `false`
+- [x] 1.5 Add unit test: guest user without `guest.home` → `needsRegion` is `true`
+
+## 2. Reload Data After Home Selection (Bug 1)
+
+- [x] 2.1 In `dashboard.ts:onHomeSelected()`, call `loadData()` after home is stored (for both onboarding and non-onboarding paths)
+- [x] 2.2 Add unit test: `onHomeSelected()` triggers `loadDashboardEvents()` call
+- [x] 2.3 Add unit test: after `onHomeSelected()`, `dateGroups` reflects reloaded data
+
+## 3. Verification
+
+- [x] 3.1 Run `make check` in frontend repo — all lint and tests pass
+- [x] 3.2 E2E test: onboarding flow — select home area → verify blur removed and data reloaded (`dashboard-lane-classification.spec.ts`)
+- [x] 3.3 E2E test: returning user with stored home → verify no home selector shown (`dashboard-lane-classification.spec.ts`)

--- a/openspec/specs/frontend-onboarding-flow/spec.md
+++ b/openspec/specs/frontend-onboarding-flow/spec.md
@@ -65,7 +65,8 @@ The system SHALL collect the user's home area during the Dashboard reveal step o
 - **THEN** the system SHALL store the selected code in localStorage under `guest.home`
 - **AND** the system SHALL immediately close the BottomSheet
 - **AND** the system SHALL unblur the Dashboard background with a smooth transition animation
-- **AND** the system SHALL dynamically populate the Live Highway UI with home-area-relevant events
+- **AND** the system SHALL reload concert data from the backend so lane classification reflects the selected home area
+- **AND** the system SHALL dynamically populate the Live Highway UI with the reloaded, home-area-classified events
 
 ### Requirement: Interactive Artist Discovery (Bubble Network UI)
 

--- a/openspec/specs/user-home/spec.md
+++ b/openspec/specs/user-home/spec.md
@@ -122,14 +122,21 @@ The frontend SHALL store the user's home area server-side via RPC, replacing loc
 #### Scenario: Dashboard reads home from User entity
 
 - **WHEN** the dashboard loads for an authenticated user
-- **THEN** the lane assignment logic SHALL read the user's home area from the `User` entity obtained via `UserService.Get`
-- **AND** SHALL NOT read from localStorage
+- **THEN** the dashboard SHALL call `UserService.Get` to obtain the user's home status
+- **AND** the `needsRegion` flag SHALL be determined by the presence of `user.home` in the response
+- **AND** the dashboard SHALL NOT read from localStorage to determine `needsRegion`
 
 #### Scenario: Guest fallback to localStorage
 
 - **WHEN** a guest (unauthenticated) user selects their home area
 - **THEN** the frontend SHALL store the selection in localStorage under `guest.home`
-- **AND** the dashboard SHALL read from localStorage for lane assignment
+- **AND** the dashboard SHALL read from localStorage for the `needsRegion` determination
+
+#### Scenario: Dashboard reloads data after authenticated home change
+
+- **WHEN** an authenticated user changes their home area via the `user-home-selector` on the dashboard
+- **THEN** the dashboard SHALL reload concert data via `loadDashboardEvents()` after the home update completes
+- **AND** the reloaded data SHALL reflect the new lane classification based on the updated home
 
 ### Requirement: Unified Home Area Selector Component
 


### PR DESCRIPTION
## Summary
- Sync delta specs from fix-dashboard-lane-classification change to main specs
- Archive completed change artifacts

### Spec changes
- **user-home**: Updated 'Dashboard reads home from User entity' scenario to specify needsRegion flag via UserService.Get; added 'Dashboard reloads data after authenticated home change' scenario
- **frontend-onboarding-flow**: Updated 'Magic moment' scenario to include concert data reload after home selection

## Test plan
- [ ] Verify spec formatting renders correctly
- [ ] No proto changes — buf checks should pass