### PR TITLE
docs: sync CUBE CSS architecture and design token specs

### DIFF
--- a/openspec/changes/archive/2026-03-13-improve-css-design/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-13-improve-css-design/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-13

--- a/openspec/changes/archive/2026-03-13-improve-css-design/design.md
+++ b/openspec/changes/archive/2026-03-13-improve-css-design/design.md
@@ -1,0 +1,158 @@
+## Context
+
+The frontend currently uses TailwindCSS v4 for design tokens (`@theme`), CSS reset (Preflight), and utility class generation. 22 of 26 HTML templates embed Tailwind utility classes directly. Component CSS files (14 total, 202 stylelint warnings) have no `@layer` structure. PR #156 introduced a custom stylelint plugin enforcing CUBE CSS methodology rules — all as warnings to allow gradual migration.
+
+The goal is to replace Tailwind entirely with CUBE CSS architecture: a cascade-driven, `@layer`-ordered system where Global styles do the heavy lifting, Composition primitives control layout, and Block-scoped CSS handles component-specific overrides.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Establish `@layer` ordering (reset, tokens, global, composition, utility, block, exception) as the cascade foundation
+- Replace Tailwind `@theme` with plain CSS custom properties in `tokens.css`
+- Replace Tailwind Preflight with a custom reset
+- Decompose `my-app.css` (243 lines) into CUBE-layered files under `src/styles/`
+- Migrate all 14 component CSS files to `@layer block { @scope() { ... } }`
+- Remove all Tailwind utility classes from 22 HTML templates
+- Achieve 0 stylelint warnings (currently 202)
+- Remove `tailwindcss` and `@tailwindcss/vite` from dependencies
+
+**Non-Goals:**
+
+- Redesigning the visual appearance — token values and visual output remain identical
+- Adding new features or pages during migration
+- Introducing a CSS preprocessor (Sass, PostCSS plugins) — pure CSS only
+- Creating a comprehensive utility class library — CUBE philosophy favors Global + Composition over utilities
+
+## Decisions
+
+### Decision 1: File structure — `src/styles/` with `main.css` as entry point
+
+```
+src/
+  styles/
+    main.css           ← CSS entry point: @layer declarations + @import ordering
+    tokens.css         ← Design tokens as CSS custom properties
+    reset.css          ← Browser reset (replaces Tailwind Preflight)
+    global.css         ← CUBE Global: base element styles, fluid typography
+    compositions.css   ← CUBE Composition: layout primitives (.cluster, .stack, etc.)
+    utilities.css      ← CUBE Utility: single-purpose classes + animation keyframes
+
+  my-app.css           ← @layer block { @scope(my-app) { app shell layout } }
+  components/
+    <name>/<name>.css  ← @layer block { @scope(<element>) { ... } }
+  routes/
+    <name>/<name>.css  ← @layer block { @scope(<element>) { ... } }
+```
+
+`main.ts` imports `./styles/main.css`. Component CSS files remain colocated with their Aurelia components.
+
+**Why not a single file?** CUBE CSS layers have distinct responsibilities. Separate files make it clear which layer a style belongs to and prevent accidental cross-layer leakage.
+
+**Why `main.css` not `my-app.css` as entry point?** `my-app.css` is Aurelia's convention for the `my-app` component's colocated CSS. Using it as the global entry point conflates "app shell component styles" with "entire application's CSS architecture." `main.css` pairs with `main.ts` (the bootstrap file) and clearly means "the CSS entry point."
+
+### Decision 2: `@layer` ordering — CUBE layers declared in `main.css`
+
+```css
+/* src/styles/main.css */
+@layer reset, tokens, global, composition, utility, block, exception;
+
+@import './reset.css' layer(reset);
+@import './tokens.css' layer(tokens);
+@import './global.css' layer(global);
+@import './compositions.css' layer(composition);
+@import './utilities.css' layer(utility);
+```
+
+`tokens` is a dedicated layer between reset and global. Tokens define values (`:root` custom properties); global applies them to elements. Separating these concerns makes it clear that `tokens.css` should only contain custom property definitions, not style rules.
+
+Block and exception layers are populated by component CSS files via `@layer block { ... }` declarations in each file.
+
+**Why this order?** Follows CUBE CSS cascade philosophy: reset (lowest) → tokens (design values) → global (element defaults) → composition (layout) → utility (overrides) → block (component-specific) → exception (state deviations). Each layer can override the previous.
+
+### Decision 3: Tailwind removal — phased approach with co-existence
+
+Tailwind cannot be removed in one PR without breaking 22 HTML files. The migration uses a phased approach:
+
+1. **PR 1 (Foundation)**: Create `src/styles/` infrastructure, import alongside existing Tailwind. Both systems co-exist.
+2. **PR 2-N (Component migration)**: One component per PR — migrate its CSS to `@layer block { @scope }` and rewrite its HTML to remove Tailwind classes. Absorb Tailwind utilities into Global/Composition/Block CSS.
+3. **PR Last (Cleanup)**: Remove `@import "tailwindcss"`, `@tailwindcss/vite` plugin, and npm packages.
+
+**Why not all at once?** A single PR touching 36+ files (14 CSS + 22 HTML) is unreviewable and high-risk for visual regressions. Component-by-component migration keeps PRs small and allows visual verification per component.
+
+### Decision 4: Spacing philosophy — parent controls gap, children use fluid padding
+
+Replace Tailwind's per-element spacing utilities (`px-4 py-3 mb-2 gap-2`) with CUBE CSS spacing principles:
+
+- **Parent controls inter-child spacing** via `gap` (grid/flex) or the `.flow` composition (lobotomized owl `> * + *`).
+- **Children never set external margin** — margin is the parent's responsibility.
+- **Internal padding uses `clamp()`** for fluid, container-responsive sizing.
+- **Spacing scale** defined as CSS custom properties in `tokens.css`.
+
+### Decision 5: Reset strategy — custom reset, not a library
+
+Write a minimal reset in `reset.css` using `:where()` for zero specificity:
+
+```css
+@layer reset {
+  :where(*, *::before, *::after) { box-sizing: border-box; margin: 0; padding: 0; }
+  :where(html) { -webkit-text-size-adjust: none; text-size-adjust: none; }
+  :where(img, picture, video, canvas, svg) { display: block; max-inline-size: 100%; }
+  :where(input, button, textarea, select) { font: inherit; }
+  :where(body) { min-block-size: 100dvh; }
+}
+```
+
+**Why `:where()`?** Zero specificity means any subsequent layer (global, utility, block) can override without specificity battles. This is a CUBE CSS best practice.
+
+**Why not `modern-normalize`?** It adds opinions we don't need and doesn't use `:where()` for zero specificity. A minimal custom reset aligned with our specific needs is more maintainable.
+
+### Decision 6: Global layer — "do as much as you can here"
+
+Following Andy Bell's principle, `global.css` handles:
+
+- Base typography: `body` font, fluid type scale with `clamp()`, `h1`-`h6` defaults
+- Base element styles: `a`, `button`, `input`, `svg` — styled without classes
+- Dark theme defaults: `body` background, text color from tokens
+- View transition styles: `::view-transition-old/new(root)`
+
+The goal is that **bare HTML elements look correct without any classes**. Block CSS only handles deviations from these defaults.
+
+### Decision 7: Composition primitives — start minimal, extract as needed
+
+Initial compositions based on current Tailwind usage patterns:
+
+| Composition | Replaces | Purpose |
+|-------------|----------|---------|
+| `.flow` | `space-y-*` / manual `mb-*` | Vertical rhythm via lobotomized owl (`> * + *`) |
+| `.stack` | `flex flex-col gap-*` | Vertical stacking with flexbox gap |
+| `.cluster` | `flex items-center gap-*` | Horizontal inline grouping with wrapping |
+| `.center` | `flex items-center justify-center` | Centering content |
+| `.wrapper` | `max-w-md w-full px-4` | Max-width content wrapper with inline padding |
+| `.grid-auto` | `grid grid-cols-* gap-*` | Auto-fit responsive grid |
+
+Additional compositions will be extracted during component migration as patterns emerge. Do not pre-create compositions that aren't needed yet.
+
+### Decision 8: HTML class notation — CUBE grouping convention
+
+```html
+<div class="[ card ] [ stack ] [ text-muted ]">
+```
+
+- `[ block ]` — component-specific class (matched by `@scope`)
+- `[ composition ]` — layout primitive
+- `[ utility ]` — single-purpose override
+
+Brackets are optional sugar for readability; CSS treats them as part of the class list (they're ignored). This convention makes it easy to see which layer each class belongs to.
+
+## Risks / Trade-offs
+
+**[Visual regression during migration]** → Each component PR must be visually verified in the dev server. Consider adding Playwright visual regression snapshots for critical components.
+
+**[Tailwind + CUBE co-existence during migration]** → Both systems' `@layer` declarations will be active simultaneously. Tailwind's layers (`base`, `components`, `utilities`) and CUBE's layers will co-exist. This is safe because they use different layer names and the explicit `@layer` declaration in `main.css` establishes the CUBE order. Tailwind's generated classes remain functional until removed from HTML.
+
+**[Larger initial effort for Global layer]** → Writing `global.css` properly (fluid typography, base element styles) takes more upfront work than Tailwind's Preflight. But this is a one-time investment that reduces per-component work significantly — if Global is good, Block CSS is minimal.
+
+**[Loss of Tailwind's utility generation]** → No auto-generated utility classes. Hand-written compositions and utilities must be maintained. Trade-off: fewer utilities, but each one is intentional and documented. CUBE philosophy favors fewer classes overall.
+
+**[Stale Tailwind classes during migration]** → Between PR 1 and PR Last, some HTML files will still use Tailwind classes. Stylelint warnings will decrease incrementally, not all at once. Track progress via `npm run lint:css` warning count.

--- a/openspec/changes/archive/2026-03-13-improve-css-design/proposal.md
+++ b/openspec/changes/archive/2026-03-13-improve-css-design/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+The frontend CSS is currently a mix of Tailwind utility classes in HTML templates (22 of 26 files) and component-colocated CSS files with no `@layer` structure. This conflicts with CUBE CSS methodology — which emphasizes cascade-driven, semantic styling — and makes the codebase harder to reason about. PR #156 introduced a stylelint plugin enforcing CUBE CSS rules, producing 202 warnings across 14 CSS files. Now is the time to resolve those warnings and fully migrate to CUBE CSS while removing the Tailwind dependency entirely.
+
+## What Changes
+
+- **Remove TailwindCSS dependency** — delete `@import "tailwindcss"`, `@tailwindcss/vite` plugin, and npm packages. Replace Tailwind's preflight with a custom reset, `@theme` tokens with plain CSS custom properties, and utility classes with CUBE composition/utility/block CSS.
+- **Establish CUBE CSS `@layer` architecture** — create `src/styles/main.css` as the CSS entry point with explicit `@layer` ordering: `reset, tokens, global, composition, utility, block, exception`.
+- **Decompose `my-app.css`** — split the monolithic 243-line file into `tokens.css`, `reset.css`, `global.css`, `compositions.css`, `utilities.css` under `src/styles/`, plus a residual `my-app.css` as a block-layer component CSS.
+- **Migrate component CSS to `@layer block { @scope }`** — wrap each component's colocated CSS in `@layer block { @scope(<component-selector>) { ... } }`.
+- **Rewrite HTML templates** — remove all Tailwind utility classes from 22 HTML files; replace with CUBE composition classes, utility classes, or absorb into block-scoped CSS.
+
+## Capabilities
+
+### New Capabilities
+
+- `cube-css-architecture`: Defines the CUBE CSS layer structure (`src/styles/`), file organization, `@layer` ordering, and the relationship between global styles and component-colocated block CSS.
+
+### Modified Capabilities
+
+- `design-system`: Design tokens move from Tailwind `@theme` to plain CSS custom properties in `tokens.css`. Token names and values are preserved; only the delivery mechanism changes.
+- `modern-css-platform`: Adds `@layer`, `@scope`, and explicit cascade ordering as foundational CSS patterns. Removes Tailwind as a dependency.
+
+## Impact
+
+- **Frontend repo only** — no backend or specification changes.
+- **All 14 CSS files** — restructured into CUBE layers.
+- **22 HTML template files** — Tailwind classes removed and replaced.
+- **Build config** — `vite.config.ts` loses `@tailwindcss/vite` plugin.
+- **Dependencies** — `tailwindcss` and `@tailwindcss/vite` removed from `package.json`.
+- **Stylelint** — existing 202 warnings should reduce to 0 after migration.
+- **Visual regression risk** — high during migration; each component PR should be visually verified.

--- a/openspec/changes/archive/2026-03-13-improve-css-design/specs/cube-css-architecture/spec.md
+++ b/openspec/changes/archive/2026-03-13-improve-css-design/specs/cube-css-architecture/spec.md
@@ -1,0 +1,198 @@
+## ADDED Requirements
+
+### Requirement: CUBE CSS layer ordering via `@layer`
+The application SHALL declare a global CSS layer order that enforces the CUBE CSS cascade hierarchy. All styles MUST reside within an explicit `@layer` block.
+
+#### Scenario: Layer order declared in main.css
+- **WHEN** `src/styles/main.css` is loaded
+- **THEN** the file SHALL declare `@layer reset, tokens, global, composition, utility, block, exception;` as the first statement
+- **AND** each subsequent `@import` SHALL specify which layer it belongs to via `layer()` syntax
+
+#### Scenario: No styles outside @layer
+- **WHEN** stylelint runs against any CSS file in the project
+- **THEN** the `cube/require-layer` rule SHALL report zero warnings
+- **AND** every style rule, `@keyframes`, and `@media` block SHALL be nested inside an `@layer` block
+
+---
+
+### Requirement: CSS entry point at `src/styles/main.css`
+The application SHALL use `src/styles/main.css` as the single CSS entry point, imported from `main.ts`.
+
+#### Scenario: main.ts imports main.css
+- **WHEN** the application bootstraps via `main.ts`
+- **THEN** `main.ts` SHALL contain `import './styles/main.css'`
+- **AND** `main.css` SHALL import all global style files (tokens, reset, global, compositions, utilities) in layer order
+
+#### Scenario: main.css imports in correct order
+- **WHEN** `main.css` is parsed by the browser
+- **THEN** the imports SHALL follow this order:
+  1. `reset.css` in `layer(reset)`
+  2. `tokens.css` in `layer(tokens)`
+  3. `global.css` in `layer(global)`
+  4. `compositions.css` in `layer(composition)`
+  5. `utilities.css` in `layer(utility)`
+
+---
+
+### Requirement: Design tokens in `tokens.css` as plain CSS custom properties
+The application SHALL define all design tokens as CSS custom properties in `src/styles/tokens.css`, without dependency on any CSS framework's token system.
+
+#### Scenario: Token file contains all design tokens
+- **WHEN** `tokens.css` is loaded
+- **THEN** it SHALL define custom properties for colors (`--color-brand-*`, `--color-surface-*`, `--color-text-*`), typography (`--font-display`, `--font-body`), spacing scale (`--space-3xs` through `--space-3xl`), radii (`--radius-*`), shadows (`--shadow-*`), container breakpoints (`--container-*`), and transition tokens (`--transition-*`)
+
+#### Scenario: Token values use OKLCH color model
+- **WHEN** color tokens are defined
+- **THEN** all color values SHALL use `oklch()` notation
+- **AND** no `rgb()`, `hsl()`, or hex notation SHALL appear
+
+---
+
+### Requirement: Browser reset in `reset.css` using `:where()` for zero specificity
+The application SHALL use a custom CSS reset that normalizes browser defaults with zero specificity so that any subsequent layer can override without specificity conflicts.
+
+#### Scenario: Reset uses :where() wrapper
+- **WHEN** `reset.css` is loaded inside `@layer reset`
+- **THEN** all selectors SHALL be wrapped in `:where()` pseudo-class
+- **AND** the reset SHALL include: `box-sizing: border-box` on all elements, `margin: 0` on all elements, `display: block; max-inline-size: 100%` on media elements, `font: inherit` on form elements, and `min-block-size: 100dvh` on `body`
+
+#### Scenario: Reset has zero specificity
+- **WHEN** any rule in a higher layer (global, block, etc.) targets the same element
+- **THEN** the higher-layer rule SHALL win without needing increased specificity
+- **AND** no `!important` SHALL be required to override reset styles
+
+---
+
+### Requirement: Global layer for base element styling
+The `global.css` file SHALL define default styles for bare HTML elements following the CUBE CSS principle of "do as much as you can in the global CSS."
+
+#### Scenario: Bare elements are visually correct without classes
+- **WHEN** an HTML page contains bare `body`, `h1`-`h6`, `p`, `a`, `button`, `input`, `svg` elements with no class attributes
+- **THEN** each element SHALL have appropriate default styling from `@layer global`
+- **AND** `body` SHALL have the dark theme background (`--color-surface-base`) and primary text color (`--color-text-primary`)
+- **AND** `h1`-`h6` SHALL use the display font (`--font-display`) with a fluid type scale via `clamp()`
+- **AND** `a` elements SHALL have a visible, accessible default style
+- **AND** `button` elements SHALL have a base interactive style (cursor, padding, border-radius from tokens)
+
+#### Scenario: View transitions defined in global layer
+- **WHEN** a route change occurs
+- **THEN** `::view-transition-old(root)` and `::view-transition-new(root)` styles SHALL be defined in `@layer global`
+- **AND** transition values SHALL reference design tokens (`--transition-route-duration`, `--transition-route-easing`)
+
+---
+
+### Requirement: Composition layer for layout primitives
+The `compositions.css` file SHALL provide reusable layout classes that control spatial relationships between child elements.
+
+#### Scenario: Flow composition (vertical rhythm)
+- **WHEN** elements need vertical rhythm with consistent spacing between siblings
+- **THEN** the `.flow` class SHALL provide vertical spacing via `> * + * { margin-block-start: var(--flow-space, 1em) }`
+- **AND** the spacing SHALL be customizable via `--flow-space` custom property on any descendant
+
+#### Scenario: Stack composition
+- **WHEN** elements need vertical stacking with consistent spacing via flexbox
+- **THEN** the `.stack` class SHALL provide `display: flex; flex-direction: column; gap: var(--space-m)`
+- **AND** the gap SHALL be customizable via `--stack-gap` custom property
+
+#### Scenario: Cluster composition
+- **WHEN** elements need horizontal inline grouping with wrapping
+- **THEN** the `.cluster` class SHALL provide `display: flex; flex-wrap: wrap; align-items: center; gap: var(--space-s)`
+- **AND** the gap SHALL be customizable via `--cluster-gap` custom property
+
+#### Scenario: Center composition
+- **WHEN** content needs centering within its container
+- **THEN** the `.center` class SHALL provide centering with `margin-inline: auto` and a configurable `max-inline-size`
+
+#### Scenario: Wrapper composition
+- **WHEN** content needs a max-width constraint with horizontal padding
+- **THEN** the `.wrapper` class SHALL provide `max-inline-size: var(--wrapper-max, 65ch); padding-inline: var(--gutter, var(--space-m)); margin-inline: auto`
+
+#### Scenario: Compositions contain no visual properties
+- **WHEN** stylelint runs against `compositions.css`
+- **THEN** the `cube/no-visual-in-composition` rule SHALL report zero warnings
+- **AND** no `color`, `background`, `border`, `shadow`, `font-*`, or `text-*` properties SHALL appear in composition classes
+
+---
+
+### Requirement: Utility layer for single-purpose overrides
+The `utilities.css` file SHALL provide single-purpose utility classes that each control exactly one CSS property or concern.
+
+#### Scenario: Animation keyframes and utility classes
+- **WHEN** a component needs a shared animation
+- **THEN** `@keyframes` definitions (fade-in, fade-out, fade-slide-up, modal-enter, hype-pulse, bounce-in) SHALL be defined in `@layer utility`
+- **AND** corresponding `.animate-*` utility classes SHALL apply the animation with a single `animation` shorthand
+
+#### Scenario: Reduced motion override
+- **WHEN** the user has `prefers-reduced-motion: reduce` enabled
+- **THEN** a utility-layer `@media` rule SHALL disable all animations on `.animate-*` classes and view transitions
+
+#### Scenario: Utilities limited to single property
+- **WHEN** stylelint runs against `utilities.css`
+- **THEN** the `cube/utility-single-property` rule SHALL report zero warnings
+
+---
+
+### Requirement: Block layer for component-scoped styles
+Each component's colocated CSS file SHALL wrap its styles in `@layer block { @scope(<element-selector>) { ... } }`.
+
+#### Scenario: Component CSS uses @scope
+- **WHEN** a component CSS file (e.g., `event-card.css`) is loaded
+- **THEN** all styles SHALL be inside `@layer block { @scope(event-card) { ... } }`
+- **AND** styles SHALL not leak to elements outside the component's scope
+
+#### Scenario: Block files limited to ~80 lines
+- **WHEN** stylelint runs against a component CSS file
+- **THEN** the `cube/block-max-lines` rule SHALL report zero warnings for each `@scope` block
+- **AND** if a block exceeds the limit, styles SHALL be refactored — extracting shared patterns to composition or utility layers
+
+#### Scenario: One block per file
+- **WHEN** stylelint runs against a component CSS file
+- **THEN** the `cube/one-block-per-file` rule SHALL report zero warnings
+- **AND** each `.css` file SHALL contain at most one `@scope` block
+
+---
+
+### Requirement: Exception layer for state deviations via `data-*` attributes
+Component state variations SHALL use `data-*` attributes (not CSS class toggling) to drive styling, as enforced by the `cube/exception-data-attr` rule.
+
+#### Scenario: State-driven styling uses data attributes
+- **WHEN** a component has visual state variations (e.g., active, disabled, loading)
+- **THEN** the variations SHALL be expressed via `data-state`, `data-variant`, or `data-theme` attributes
+- **AND** CSS selectors SHALL target `[data-state="active"]` etc. within `@layer exception` or within `@layer block` using `data-*` attribute selectors
+
+#### Scenario: Stylelint enforces data attribute convention
+- **WHEN** stylelint runs against all CSS files
+- **THEN** the `cube/exception-data-attr` and `cube/data-attr-naming` rules SHALL report zero warnings
+
+---
+
+### Requirement: Spacing controlled by parent, not child
+Layout spacing SHALL follow the CUBE CSS principle where parent elements control inter-child spacing via `gap`, and children SHALL NOT set external margins.
+
+#### Scenario: No child margin for spacing
+- **WHEN** a layout needs spacing between sibling elements
+- **THEN** the parent SHALL use `gap` (grid or flex) or the `.stack` / `.cluster` composition
+- **AND** child elements SHALL NOT use `margin-block-start`, `margin-block-end`, or equivalent properties for inter-sibling spacing
+
+#### Scenario: Internal padding uses fluid values
+- **WHEN** a component needs internal spacing
+- **THEN** `padding` SHALL use `clamp()` or CSS custom properties from the spacing scale
+- **AND** fixed pixel values for padding SHALL be avoided in favor of fluid, token-based values
+
+---
+
+### Requirement: No TailwindCSS dependency
+The application SHALL not depend on TailwindCSS for any styling functionality.
+
+#### Scenario: No Tailwind in build pipeline
+- **WHEN** the application builds via Vite
+- **THEN** `vite.config.ts` SHALL NOT import or register `@tailwindcss/vite`
+- **AND** no CSS file SHALL contain `@import "tailwindcss"`
+
+#### Scenario: No Tailwind packages in dependencies
+- **WHEN** `package.json` is inspected
+- **THEN** neither `tailwindcss` nor `@tailwindcss/vite` SHALL appear in `dependencies` or `devDependencies`
+
+#### Scenario: No Tailwind utility classes in HTML
+- **WHEN** any HTML template file is inspected
+- **THEN** no Tailwind-generated utility class names (e.g., `flex`, `px-4`, `text-white`, `bg-surface-base`, `hover:bg-white/5`) SHALL appear in `class` attributes

--- a/openspec/changes/archive/2026-03-13-improve-css-design/specs/design-system/spec.md
+++ b/openspec/changes/archive/2026-03-13-improve-css-design/specs/design-system/spec.md
@@ -1,0 +1,62 @@
+## MODIFIED Requirements
+
+### Requirement: Design Token Definition
+The system SHALL define a centralized set of design tokens using plain CSS custom properties in `src/styles/tokens.css` to ensure visual consistency across all screens.
+
+#### Scenario: Color tokens defined
+- **WHEN** the design system is initialized
+- **THEN** the system SHALL define the following color token groups via CSS custom properties in `tokens.css`:
+  - `--color-brand-primary`: oklch(58.5% 0.233 277deg)
+  - `--color-brand-secondary`: oklch(54.1% 0.281 293deg)
+  - `--color-brand-accent`: oklch(78.9% 0.154 211deg)
+  - `--color-surface-base`: oklch(14.5% 0.014 286deg)
+  - `--color-surface-raised`: oklch(17.8% 0.014 286deg)
+  - `--color-surface-overlay`: oklch(21% 0.014 286deg)
+  - `--color-text-primary`: oklch(98.5% 0 0deg)
+  - `--color-text-secondary`: oklch(78.8% 0.013 286deg)
+  - `--color-text-muted`: oklch(55.6% 0.014 286deg)
+- **AND** all components SHALL reference these tokens instead of hardcoded color values
+- **AND** tokens SHALL be defined on `:root` using standard CSS custom property syntax, not Tailwind's `@theme` directive
+
+#### Scenario: Typography tokens defined
+- **WHEN** the design system is initialized
+- **THEN** the system SHALL define font family tokens:
+  - `--font-display`: "Outfit", system-ui, sans-serif for hero copy, card headlines, section titles
+  - `--font-body`: system-ui, -apple-system, sans-serif for paragraphs, labels, metadata
+- **AND** the system SHALL define a type scale with sizes for mega (4xl or larger), heading (2xl-3xl), body (base-lg), caption (xs-sm)
+
+#### Scenario: Shape tokens defined
+- **WHEN** the design system is initialized
+- **THEN** the system SHALL define radius tokens: `--radius-card` (1rem), `--radius-button` (0.75rem), `--radius-sheet` (1.5rem)
+- **AND** the system SHALL define shadow tokens: `--shadow-card-glow`, `--shadow-sheet`, `--shadow-button`
+
+#### Scenario: Spacing scale tokens defined
+- **WHEN** the design system is initialized
+- **THEN** the system SHALL define a fluid spacing scale using `clamp()` with tokens from `--space-3xs` through `--space-3xl`
+- **AND** composition primitives and block styles SHALL reference these spacing tokens instead of fixed pixel values
+
+#### Scenario: Container query breakpoint tokens defined
+- **WHEN** the design system is initialized
+- **THEN** the system SHALL define container query breakpoint tokens for component-level responsive design:
+  - `--container-sm`: 320px
+  - `--container-md`: 480px
+  - `--container-lg`: 640px
+- **AND** components using Container Queries SHALL reference these tokens for consistent breakpoints
+
+#### Scenario: View transition tokens defined
+- **WHEN** the design system is initialized
+- **THEN** the system SHALL define view transition duration and easing tokens:
+  - `--transition-route-duration`: 200ms
+  - `--transition-route-easing`: ease-out
+- **AND** route transitions SHALL reference these tokens instead of hardcoded values
+
+---
+
+### Requirement: Container Query infrastructure
+The design system SHALL provide base styles for declaring container contexts.
+
+#### Scenario: Container type with named container
+- **WHEN** a component needs to use Container Queries for responsive child layout
+- **THEN** the component's wrapper element SHALL declare `container-type: inline-size` with a corresponding `container-name`
+- **AND** child elements SHALL use `@container <name>` rules referencing the design system breakpoint tokens
+- **AND** the `cube/require-container-name` stylelint rule SHALL report zero warnings

--- a/openspec/changes/archive/2026-03-13-improve-css-design/specs/modern-css-platform/spec.md
+++ b/openspec/changes/archive/2026-03-13-improve-css-design/specs/modern-css-platform/spec.md
@@ -1,0 +1,67 @@
+## ADDED Requirements
+
+### Requirement: CSS `@layer` for cascade management
+All CSS styles SHALL be organized into explicit `@layer` blocks following the CUBE CSS methodology. The cascade order SHALL be enforced by a single `@layer` declaration in the CSS entry point.
+
+#### Scenario: Layer declaration establishes cascade
+- **WHEN** `src/styles/main.css` is parsed
+- **THEN** the `@layer` declaration SHALL establish the order: `reset, tokens, global, composition, utility, block, exception`
+- **AND** all CSS files SHALL place their rules inside the appropriate layer
+- **AND** the `cube/require-layer` stylelint rule SHALL report zero warnings across all files
+
+#### Scenario: Layer order prevents specificity wars
+- **WHEN** a block-layer rule and a utility-layer rule target the same element
+- **THEN** the block-layer rule SHALL win due to its later position in the cascade order
+- **AND** no `!important` SHALL be needed to resolve layer conflicts
+
+---
+
+### Requirement: CSS `@scope` for component isolation
+Component-specific styles in the block layer SHALL use `@scope()` to prevent style leakage beyond component boundaries.
+
+#### Scenario: Component CSS scoped to custom element
+- **WHEN** a component CSS file defines styles (e.g., `event-card.css`)
+- **THEN** all rules SHALL be inside `@layer block { @scope(event-card) { ... } }`
+- **AND** selectors within the scope SHALL only match descendants of the `<event-card>` element
+- **AND** the `cube/block-require-scope` stylelint rule SHALL report zero warnings
+
+#### Scenario: Scope limit prevents deep leaking
+- **WHEN** a scoped component contains nested components
+- **THEN** the parent scope's styles SHALL NOT affect elements inside child component boundaries
+- **AND** `@scope(<parent>) to (<child>)` syntax MAY be used when explicit scope limits are needed
+
+---
+
+### Requirement: No viewport media queries for component responsiveness
+Components SHALL use CSS Container Queries for responsive layout, not viewport-based media queries. Viewport media queries SHALL only be used for truly viewport-dependent concerns (e.g., `prefers-reduced-motion`, `prefers-color-scheme`).
+
+#### Scenario: Component layout uses container queries
+- **WHEN** a component needs to adapt its layout to available space
+- **THEN** the component SHALL use `@container` rules, not `@media (min-width: ...)` or `@media (max-width: ...)`
+- **AND** the stylelint configuration SHALL warn on viewport-width media queries in component CSS
+
+## MODIFIED Requirements
+
+### Requirement: OKLCH color enforcement
+All color definitions in CSS SHALL use the `oklch()` function. Legacy color functions and hex notation SHALL be rejected by Stylelint.
+
+#### Scenario: OKLCH used for solid colors
+- **WHEN** a CSS property requires a color value (e.g., `color`, `background-color`, `border-color`)
+- **THEN** the value SHALL use `oklch()` notation
+- **AND** Stylelint SHALL reject `rgb()`, `rgba()`, `hsl()`, `hsla()`, and hex colors
+
+#### Scenario: OKLCH used for transparency
+- **WHEN** a color requires an alpha/transparency component
+- **THEN** the value SHALL use `oklch(L C H / alpha)` syntax
+- **AND** legacy `rgba(R G B / alpha)` SHALL be rejected
+
+#### Scenario: Color derivation uses color-mix()
+- **WHEN** a color needs to be derived from a base token (e.g., hover state, transparency variant)
+- **THEN** the value SHALL use `color-mix(in oklch, ...)` instead of defining a separate token
+- **AND** the `cube/prefer-color-mix` stylelint rule SHALL report zero warnings
+
+## REMOVED Requirements
+
+### Requirement: Tailwind theme colors exempt
+**Reason**: TailwindCSS is being removed from the project. The `theme()` function and Tailwind-generated CSS custom properties will no longer exist.
+**Migration**: All color values are now plain CSS custom properties in `tokens.css`, referenced via `var(--color-*)`. The OKLCH enforcement applies universally — no exemptions needed.

--- a/openspec/changes/archive/2026-03-13-improve-css-design/tasks.md
+++ b/openspec/changes/archive/2026-03-13-improve-css-design/tasks.md
@@ -1,0 +1,68 @@
+## 1. Foundation — styles/ infrastructure (PR 1)
+
+- [x] 1.1 Create `src/styles/tokens.css` — extract `@theme` block from `my-app.css` into plain CSS custom properties on `:root` (colors, typography, radii, shadows, container breakpoints, transition tokens, spacing scale)
+- [x] 1.2 Create `src/styles/reset.css` — write custom CSS reset using `:where()` selectors inside `@layer reset`
+- [x] 1.3 Create `src/styles/global.css` — write base element styles inside `@layer global` (body, h1-h6 fluid typography, a, button, input, svg defaults, view transition styles, dark theme defaults)
+- [x] 1.4 Create `src/styles/compositions.css` — define initial composition primitives inside `@layer composition` (.stack, .cluster, .center, .wrapper, .grid-auto)
+- [x] 1.5 Create `src/styles/utilities.css` — move `@keyframes` and `.animate-*` classes from `my-app.css` inside `@layer utility`, add `prefers-reduced-motion` override
+- [x] 1.6 Create `src/styles/main.css` — `@layer` order declaration + `@import` statements in correct order
+- [x] 1.7 Update `main.ts` to `import './styles/main.css'`
+- [x] 1.8 Verify Tailwind and CUBE CSS co-exist — `npm run build` succeeds, no visual regressions on dev server
+
+## 2. App shell migration (PR 2)
+
+- [x] 2.1 Rewrite `my-app.css` — wrap app shell layout (my-app, main, au-viewport, live-highway, overlay collapse) in `@layer block { @scope(my-app) { ... } }`
+- [x] 2.2 Move `.event-card-responsive` container query rules from `my-app.css` to `event-card.css`
+- [x] 2.3 Remove `@import "tailwindcss"` and `@theme` block from `my-app.css`
+- [x] 2.4 Verify `npm run build` succeeds and app shell layout is intact
+
+## 3. Small component migration (PR 3)
+
+- [x] 3.1 Migrate `dna-orb-canvas.css` — wrap in `@layer block { @scope(dna-orb-canvas) {} }`
+- [x] 3.2 Migrate `dna-orb-canvas.html` — remove any Tailwind classes
+- [x] 3.3 Migrate `error-banner.css` — wrap in `@layer block { @scope(error-banner) {} }`
+- [x] 3.4 Migrate `error-banner.html` — replace Tailwind classes with block CSS + compositions
+- [x] 3.5 Migrate `tickets-page.css` — wrap in `@layer block { @scope(tickets-page) {} }`
+- [x] 3.6 Migrate `tickets-page.html` — replace Tailwind classes with block CSS + compositions
+
+## 4. Medium component migration (PR 4)
+
+- [x] 4.1 Migrate `toast-notification.css` + `.html` — block-scope CSS, remove Tailwind from HTML
+- [x] 4.2 Migrate `signup-modal.css` + `.html` — block-scope CSS, remove Tailwind from HTML
+- [x] 4.3 Migrate `event-detail-sheet.css` + `.html` — block-scope CSS, remove Tailwind from HTML
+- [x] 4.4 Migrate `user-home-selector.css` + `.html` — block-scope CSS, remove Tailwind from HTML
+- [x] 4.5 Migrate `my-artists-page.css` + `.html` — block-scope CSS, remove Tailwind from HTML
+
+## 5. Large component migration (PR 5-6)
+
+- [x] 5.1 Migrate `event-card.css` + `.html` — block-scope CSS, absorb `.event-card-responsive` rules, remove Tailwind from HTML
+- [x] 5.2 Migrate `coach-mark.css` + `.html` — block-scope CSS, fix `container-name` warning, fix `vw` → `vi` warning, fix property order warning
+- [x] 5.3 Migrate `loading-sequence.css` + `.html` — block-scope CSS, fix `container-name` warnings, remove Tailwind from HTML
+- [x] 5.4 Migrate `celebration-overlay.css` + `.html` — block-scope CSS, remove Tailwind from HTML
+- [x] 5.5 Migrate `discover-page.css` + `.html` — block-scope CSS, fix `container-name` warnings, remove Tailwind from HTML (largest file: 416 lines, may need extraction to compositions)
+
+## 6. Remaining HTML template migration (PR 7)
+
+- [x] 6.1 Migrate `welcome-page.html` — replace Tailwind classes (heavy animation + gradient usage)
+- [x] 6.2 Migrate `bottom-nav-bar.html` — replace Tailwind classes
+- [x] 6.3 Migrate `auth-status.html` — replace Tailwind classes
+- [x] 6.4 Migrate `auth-callback.html` — replace Tailwind classes
+- [x] 6.5 Migrate `dashboard.html` — replace Tailwind classes
+- [x] 6.6 Migrate `not-found-page.html` — replace Tailwind classes
+- [x] 6.7 Migrate `settings-page.html` — replace Tailwind classes
+- [x] 6.8 Migrate `notification-prompt.html` — replace Tailwind classes
+- [x] 6.9 Migrate `pwa-install-prompt.html` — replace Tailwind classes
+- [x] 6.10 Migrate `inline-error.html` — replace Tailwind classes
+- [x] 6.11 Migrate `about-page.html` — replace Tailwind classes
+- [x] 6.12 Migrate `live-highway.html` — replace Tailwind classes
+
+## 7. Tailwind removal and cleanup (PR 8)
+
+- [x] 7.1 Remove `@tailwindcss/vite` from `vite.config.ts`
+- [x] 7.2 Remove `tailwindcss` and `@tailwindcss/vite` from `package.json`
+- [x] 7.3 Run `npm install` to clean lockfile
+- [x] 7.4 Update `AGENTS.md` — change stack table from TailwindCSS to CUBE CSS
+- [x] 7.5 Update stylelint rules from warnings to errors (promote `cube/*` rules)
+- [x] 7.6 Verify `npm run lint:css` reports 0 warnings and 0 errors
+- [x] 7.7 Verify `npm run build` succeeds
+- [x] 7.8 Full visual regression check on dev server across all routes

--- a/openspec/specs/cube-css-architecture/spec.md
+++ b/openspec/specs/cube-css-architecture/spec.md
@@ -1,0 +1,204 @@
+# CUBE CSS Architecture
+
+## Purpose
+
+Defines the CSS architecture for the Liverty Music frontend using the CUBE CSS methodology (Composition, Utility, Block, Exception). Establishes layer ordering, file structure, component scoping, and styling conventions that replace TailwindCSS with plain CSS custom properties, `@layer`, and `@scope`.
+
+## Requirements
+
+### Requirement: CUBE CSS layer ordering via `@layer`
+The application SHALL declare a global CSS layer order that enforces the CUBE CSS cascade hierarchy. All styles MUST reside within an explicit `@layer` block.
+
+#### Scenario: Layer order declared in main.css
+- **WHEN** `src/styles/main.css` is loaded
+- **THEN** the file SHALL declare `@layer reset, tokens, global, composition, utility, block, exception;` as the first statement
+- **AND** each subsequent `@import` SHALL specify which layer it belongs to via `layer()` syntax
+
+#### Scenario: No styles outside @layer
+- **WHEN** stylelint runs against any CSS file in the project
+- **THEN** the `cube/require-layer` rule SHALL report zero warnings
+- **AND** every style rule, `@keyframes`, and `@media` block SHALL be nested inside an `@layer` block
+
+---
+
+### Requirement: CSS entry point at `src/styles/main.css`
+The application SHALL use `src/styles/main.css` as the single CSS entry point, imported from `main.ts`.
+
+#### Scenario: main.ts imports main.css
+- **WHEN** the application bootstraps via `main.ts`
+- **THEN** `main.ts` SHALL contain `import './styles/main.css'`
+- **AND** `main.css` SHALL import all global style files (tokens, reset, global, compositions, utilities) in layer order
+
+#### Scenario: main.css imports in correct order
+- **WHEN** `main.css` is parsed by the browser
+- **THEN** the imports SHALL follow this order:
+  1. `reset.css` in `layer(reset)`
+  2. `tokens.css` in `layer(tokens)`
+  3. `global.css` in `layer(global)`
+  4. `compositions.css` in `layer(composition)`
+  5. `utilities.css` in `layer(utility)`
+
+---
+
+### Requirement: Design tokens in `tokens.css` as plain CSS custom properties
+The application SHALL define all design tokens as CSS custom properties in `src/styles/tokens.css`, without dependency on any CSS framework's token system.
+
+#### Scenario: Token file contains all design tokens
+- **WHEN** `tokens.css` is loaded
+- **THEN** it SHALL define custom properties for colors (`--color-brand-*`, `--color-surface-*`, `--color-text-*`), typography (`--font-display`, `--font-body`), spacing scale (`--space-3xs` through `--space-3xl`), radii (`--radius-*`), shadows (`--shadow-*`), container breakpoints (`--container-*`), and transition tokens (`--transition-*`)
+
+#### Scenario: Token values use OKLCH color model
+- **WHEN** color tokens are defined
+- **THEN** all color values SHALL use `oklch()` notation
+- **AND** no `rgb()`, `hsl()`, or hex notation SHALL appear
+
+---
+
+### Requirement: Browser reset in `reset.css` using `:where()` for zero specificity
+The application SHALL use a custom CSS reset that normalizes browser defaults with zero specificity so that any subsequent layer can override without specificity conflicts.
+
+#### Scenario: Reset uses :where() wrapper
+- **WHEN** `reset.css` is loaded inside `@layer reset`
+- **THEN** all selectors SHALL be wrapped in `:where()` pseudo-class
+- **AND** the reset SHALL include: `box-sizing: border-box` on all elements, `margin: 0` on all elements, `display: block; max-inline-size: 100%` on media elements, `font: inherit` on form elements, and `min-block-size: 100dvh` on `body`
+
+#### Scenario: Reset has zero specificity
+- **WHEN** any rule in a higher layer (global, block, etc.) targets the same element
+- **THEN** the higher-layer rule SHALL win without needing increased specificity
+- **AND** no `!important` SHALL be required to override reset styles
+
+---
+
+### Requirement: Global layer for base element styling
+The `global.css` file SHALL define default styles for bare HTML elements following the CUBE CSS principle of "do as much as you can in the global CSS."
+
+#### Scenario: Bare elements are visually correct without classes
+- **WHEN** an HTML page contains bare `body`, `h1`-`h6`, `p`, `a`, `button`, `input`, `svg` elements with no class attributes
+- **THEN** each element SHALL have appropriate default styling from `@layer global`
+- **AND** `body` SHALL have the dark theme background (`--color-surface-base`) and primary text color (`--color-text-primary`)
+- **AND** `h1`-`h6` SHALL use the display font (`--font-display`) with a fluid type scale via `clamp()`
+- **AND** `a` elements SHALL have a visible, accessible default style
+- **AND** `button` elements SHALL have a base interactive style (cursor, padding, border-radius from tokens)
+
+#### Scenario: View transitions defined in global layer
+- **WHEN** a route change occurs
+- **THEN** `::view-transition-old(root)` and `::view-transition-new(root)` styles SHALL be defined in `@layer global`
+- **AND** transition values SHALL reference design tokens (`--transition-route-duration`, `--transition-route-easing`)
+
+---
+
+### Requirement: Composition layer for layout primitives
+The `compositions.css` file SHALL provide reusable layout classes that control spatial relationships between child elements.
+
+#### Scenario: Flow composition (vertical rhythm)
+- **WHEN** elements need vertical rhythm with consistent spacing between siblings
+- **THEN** the `.flow` class SHALL provide vertical spacing via `> * + * { margin-block-start: var(--flow-space, 1em) }`
+- **AND** the spacing SHALL be customizable via `--flow-space` custom property on any descendant
+
+#### Scenario: Stack composition
+- **WHEN** elements need vertical stacking with consistent spacing via flexbox
+- **THEN** the `.stack` class SHALL provide `display: flex; flex-direction: column; gap: var(--space-m)`
+- **AND** the gap SHALL be customizable via `--stack-gap` custom property
+
+#### Scenario: Cluster composition
+- **WHEN** elements need horizontal inline grouping with wrapping
+- **THEN** the `.cluster` class SHALL provide `display: flex; flex-wrap: wrap; align-items: center; gap: var(--space-s)`
+- **AND** the gap SHALL be customizable via `--cluster-gap` custom property
+
+#### Scenario: Center composition
+- **WHEN** content needs centering within its container
+- **THEN** the `.center` class SHALL provide centering with `margin-inline: auto` and a configurable `max-inline-size`
+
+#### Scenario: Wrapper composition
+- **WHEN** content needs a max-width constraint with horizontal padding
+- **THEN** the `.wrapper` class SHALL provide `max-inline-size: var(--wrapper-max, 65ch); padding-inline: var(--gutter, var(--space-m)); margin-inline: auto`
+
+#### Scenario: Compositions contain no visual properties
+- **WHEN** stylelint runs against `compositions.css`
+- **THEN** the `cube/no-visual-in-composition` rule SHALL report zero warnings
+- **AND** no `color`, `background`, `border`, `shadow`, `font-*`, or `text-*` properties SHALL appear in composition classes
+
+---
+
+### Requirement: Utility layer for single-purpose overrides
+The `utilities.css` file SHALL provide single-purpose utility classes that each control exactly one CSS property or concern.
+
+#### Scenario: Animation keyframes and utility classes
+- **WHEN** a component needs a shared animation
+- **THEN** `@keyframes` definitions (fade-in, fade-out, fade-slide-up, modal-enter, hype-pulse, bounce-in) SHALL be defined in `@layer utility`
+- **AND** corresponding `.animate-*` utility classes SHALL apply the animation with a single `animation` shorthand
+
+#### Scenario: Reduced motion override
+- **WHEN** the user has `prefers-reduced-motion: reduce` enabled
+- **THEN** a utility-layer `@media` rule SHALL disable all animations on `.animate-*` classes and view transitions
+
+#### Scenario: Utilities limited to single property
+- **WHEN** stylelint runs against `utilities.css`
+- **THEN** the `cube/utility-single-property` rule SHALL report zero warnings
+
+---
+
+### Requirement: Block layer for component-scoped styles
+Each component's colocated CSS file SHALL wrap its styles in `@layer block { @scope(<element-selector>) { ... } }`.
+
+#### Scenario: Component CSS uses @scope
+- **WHEN** a component CSS file (e.g., `event-card.css`) is loaded
+- **THEN** all styles SHALL be inside `@layer block { @scope(event-card) { ... } }`
+- **AND** styles SHALL not leak to elements outside the component's scope
+
+#### Scenario: Block files limited to ~80 lines
+- **WHEN** stylelint runs against a component CSS file
+- **THEN** the `cube/block-max-lines` rule SHALL report zero warnings for each `@scope` block
+- **AND** if a block exceeds the limit, styles SHALL be refactored -- extracting shared patterns to composition or utility layers
+
+#### Scenario: One block per file
+- **WHEN** stylelint runs against a component CSS file
+- **THEN** the `cube/one-block-per-file` rule SHALL report zero warnings
+- **AND** each `.css` file SHALL contain at most one `@scope` block
+
+---
+
+### Requirement: Exception layer for state deviations via `data-*` attributes
+Component state variations SHALL use `data-*` attributes (not CSS class toggling) to drive styling, as enforced by the `cube/exception-data-attr` rule.
+
+#### Scenario: State-driven styling uses data attributes
+- **WHEN** a component has visual state variations (e.g., active, disabled, loading)
+- **THEN** the variations SHALL be expressed via `data-state`, `data-variant`, or `data-theme` attributes
+- **AND** CSS selectors SHALL target `[data-state="active"]` etc. within `@layer exception` or within `@layer block` using `data-*` attribute selectors
+
+#### Scenario: Stylelint enforces data attribute convention
+- **WHEN** stylelint runs against all CSS files
+- **THEN** the `cube/exception-data-attr` and `cube/data-attr-naming` rules SHALL report zero warnings
+
+---
+
+### Requirement: Spacing controlled by parent, not child
+Layout spacing SHALL follow the CUBE CSS principle where parent elements control inter-child spacing via `gap`, and children SHALL NOT set external margins.
+
+#### Scenario: No child margin for spacing
+- **WHEN** a layout needs spacing between sibling elements
+- **THEN** the parent SHALL use `gap` (grid or flex) or the `.stack` / `.cluster` composition
+- **AND** child elements SHALL NOT use `margin-block-start`, `margin-block-end`, or equivalent properties for inter-sibling spacing
+
+#### Scenario: Internal padding uses fluid values
+- **WHEN** a component needs internal spacing
+- **THEN** `padding` SHALL use `clamp()` or CSS custom properties from the spacing scale
+- **AND** fixed pixel values for padding SHALL be avoided in favor of fluid, token-based values
+
+---
+
+### Requirement: No TailwindCSS dependency
+The application SHALL not depend on TailwindCSS for any styling functionality.
+
+#### Scenario: No Tailwind in build pipeline
+- **WHEN** the application builds via Vite
+- **THEN** `vite.config.ts` SHALL NOT import or register `@tailwindcss/vite`
+- **AND** no CSS file SHALL contain `@import "tailwindcss"`
+
+#### Scenario: No Tailwind packages in dependencies
+- **WHEN** `package.json` is inspected
+- **THEN** neither `tailwindcss` nor `@tailwindcss/vite` SHALL appear in `dependencies` or `devDependencies`
+
+#### Scenario: No Tailwind utility classes in HTML
+- **WHEN** any HTML template file is inspected
+- **THEN** no Tailwind-generated utility class names (e.g., `flex`, `px-4`, `text-white`, `bg-surface-base`, `hover:bg-white/5`) SHALL appear in `class` attributes

--- a/openspec/specs/cube-css-architecture/spec.md
+++ b/openspec/specs/cube-css-architecture/spec.md
@@ -97,12 +97,12 @@ The `compositions.css` file SHALL provide reusable layout classes that control s
 
 #### Scenario: Stack composition
 - **WHEN** elements need vertical stacking with consistent spacing via flexbox
-- **THEN** the `.stack` class SHALL provide `display: flex; flex-direction: column; gap: var(--space-m)`
+- **THEN** the `.stack` class SHALL provide `display: flex; flex-direction: column; gap: var(--stack-gap, var(--space-m))`
 - **AND** the gap SHALL be customizable via `--stack-gap` custom property
 
 #### Scenario: Cluster composition
 - **WHEN** elements need horizontal inline grouping with wrapping
-- **THEN** the `.cluster` class SHALL provide `display: flex; flex-wrap: wrap; align-items: center; gap: var(--space-s)`
+- **THEN** the `.cluster` class SHALL provide `display: flex; flex-wrap: wrap; align-items: center; gap: var(--cluster-gap, var(--space-s))`
 - **AND** the gap SHALL be customizable via `--cluster-gap` custom property
 
 #### Scenario: Center composition
@@ -120,7 +120,7 @@ The `compositions.css` file SHALL provide reusable layout classes that control s
 
 ---
 
-### Requirement: Utility layer for single-purpose overrides
+### Requirement: Utility layer for single-purpose helpers
 The `utilities.css` file SHALL provide single-purpose utility classes that each control exactly one CSS property or concern.
 
 #### Scenario: Animation keyframes and utility classes

--- a/openspec/specs/design-system/spec.md
+++ b/openspec/specs/design-system/spec.md
@@ -2,38 +2,44 @@
 
 ## Purpose
 
-Defines the centralized design token system and visual foundation for the Liverty Music application, ensuring consistency across all screens through Tailwind CSS v4 design tokens, a dark-first theme, and optimized display font loading.
+Defines the centralized design token system and visual foundation for the Liverty Music application, ensuring consistency across all screens through plain CSS custom properties in `tokens.css`, a dark-first theme, and optimized display font loading.
 
 ## Requirements
 
 ### Requirement: Design Token Definition
-The system SHALL define a centralized set of design tokens using Tailwind CSS v4's `@theme` directive to ensure visual consistency across all screens.
+The system SHALL define a centralized set of design tokens using plain CSS custom properties in `src/styles/tokens.css` to ensure visual consistency across all screens.
 
 #### Scenario: Color tokens defined
 - **WHEN** the design system is initialized
-- **THEN** the system SHALL define the following color token groups via CSS custom properties:
-  - `--color-brand-primary`: indigo-500
-  - `--color-brand-secondary`: violet-500
-  - `--color-brand-accent`: cyan-400
-  - `--color-surface-background`: gray-950
-  - `--color-surface-layer-1`: gray-900
-  - `--color-surface-layer-2`: gray-800
-  - `--color-text-primary`: white
-  - `--color-text-secondary`: gray-300
-  - `--color-text-muted`: gray-500
+- **THEN** the system SHALL define the following color token groups via CSS custom properties in `tokens.css`:
+  - `--color-brand-primary`: oklch(58.5% 0.233 277deg)
+  - `--color-brand-secondary`: oklch(54.1% 0.281 293deg)
+  - `--color-brand-accent`: oklch(78.9% 0.154 211deg)
+  - `--color-surface-base`: oklch(14.5% 0.014 286deg)
+  - `--color-surface-raised`: oklch(17.8% 0.014 286deg)
+  - `--color-surface-overlay`: oklch(21% 0.014 286deg)
+  - `--color-text-primary`: oklch(98.5% 0 0deg)
+  - `--color-text-secondary`: oklch(78.8% 0.013 286deg)
+  - `--color-text-muted`: oklch(55.6% 0.014 286deg)
 - **AND** all components SHALL reference these tokens instead of hardcoded color values
+- **AND** tokens SHALL be defined on `:root` using standard CSS custom property syntax, not Tailwind's `@theme` directive
 
 #### Scenario: Typography tokens defined
 - **WHEN** the design system is initialized
 - **THEN** the system SHALL define font family tokens:
-  - `--font-display`: display/heading font (e.g., Outfit) for hero copy, card headlines, section titles
-  - `--font-body`: body text font (system-ui, sans-serif) for paragraphs, labels, metadata
+  - `--font-display`: "Outfit", system-ui, sans-serif for hero copy, card headlines, section titles
+  - `--font-body`: system-ui, -apple-system, sans-serif for paragraphs, labels, metadata
 - **AND** the system SHALL define a type scale with sizes for mega (4xl or larger), heading (2xl-3xl), body (base-lg), caption (xs-sm)
 
 #### Scenario: Shape tokens defined
 - **WHEN** the design system is initialized
 - **THEN** the system SHALL define radius tokens: `--radius-card` (1rem), `--radius-button` (0.75rem), `--radius-sheet` (1.5rem)
 - **AND** the system SHALL define shadow tokens: `--shadow-card-glow`, `--shadow-sheet`, `--shadow-button`
+
+#### Scenario: Spacing scale tokens defined
+- **WHEN** the design system is initialized
+- **THEN** the system SHALL define a fluid spacing scale using `clamp()` with tokens from `--space-3xs` through `--space-3xl`
+- **AND** composition primitives and block styles SHALL reference these spacing tokens instead of fixed pixel values
 
 #### Scenario: Container query breakpoint tokens defined
 - **WHEN** the design system is initialized
@@ -97,7 +103,8 @@ The design system SHALL provide View Transition styles as the primary route anim
 ### Requirement: Container Query infrastructure
 The design system SHALL provide base styles for declaring container contexts.
 
-#### Scenario: Container type utility
+#### Scenario: Container type with named container
 - **WHEN** a component needs to use Container Queries for responsive child layout
-- **THEN** the component's wrapper element SHALL declare `container-type: inline-size`
-- **AND** child elements SHALL use `@container` rules referencing the design system breakpoint tokens
+- **THEN** the component's wrapper element SHALL declare `container-type: inline-size` with a corresponding `container-name`
+- **AND** child elements SHALL use `@container <name>` rules referencing the design system breakpoint tokens
+- **AND** the `cube/require-container-name` stylelint rule SHALL report zero warnings

--- a/openspec/specs/modern-css-platform/spec.md
+++ b/openspec/specs/modern-css-platform/spec.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-Defines the modern CSS platform standards for the Liverty Music frontend, leveraging 2026 Web Platform Baseline features including Container Queries, View Transitions API, `:has()` selectors, CSS Logical Properties, Anchored Container Queries, `@starting-style`, `transitionend`-based cleanup, `overscroll-behavior`, and `scrollIntoView` + `scrollend` patterns for responsive, performant, and internationalization-ready styling.
+Defines the modern CSS platform standards for the Liverty Music frontend, leveraging 2026 Web Platform Baseline features including Container Queries, View Transitions API, `:has()` selectors, CSS Logical Properties, `@layer` cascade management, `@scope` component isolation, Anchored Container Queries, `@starting-style`, `transitionend`-based cleanup, `overscroll-behavior`, and `scrollIntoView` + `scrollend` patterns for responsive, performant, and internationalization-ready styling.
 
 ## Requirements
 
@@ -62,6 +62,42 @@ Layout, spacing, and positioning properties SHALL use CSS Logical Properties for
 - **THEN** all existing physical directional properties SHALL have been migrated to logical equivalents
 - **AND** `stylelint --fix` or manual migration SHALL have resolved all violations
 
+### Requirement: CSS `@layer` for cascade management
+All CSS styles SHALL be organized into explicit `@layer` blocks following the CUBE CSS methodology. The cascade order SHALL be enforced by a single `@layer` declaration in the CSS entry point.
+
+#### Scenario: Layer declaration establishes cascade
+- **WHEN** `src/styles/main.css` is parsed
+- **THEN** the `@layer` declaration SHALL establish the order: `reset, tokens, global, composition, utility, block, exception`
+- **AND** all CSS files SHALL place their rules inside the appropriate layer
+- **AND** the `cube/require-layer` stylelint rule SHALL report zero warnings across all files
+
+#### Scenario: Layer order prevents specificity wars
+- **WHEN** a block-layer rule and a utility-layer rule target the same element
+- **THEN** the block-layer rule SHALL win due to its later position in the cascade order
+- **AND** no `!important` SHALL be needed to resolve layer conflicts
+
+### Requirement: CSS `@scope` for component isolation
+Component-specific styles in the block layer SHALL use `@scope()` to prevent style leakage beyond component boundaries.
+
+#### Scenario: Component CSS scoped to custom element
+- **WHEN** a component CSS file defines styles (e.g., `event-card.css`)
+- **THEN** all rules SHALL be inside `@layer block { @scope(event-card) { ... } }`
+- **AND** selectors within the scope SHALL only match descendants of the `<event-card>` element
+- **AND** the `cube/block-require-scope` stylelint rule SHALL report zero warnings
+
+#### Scenario: Scope limit prevents deep leaking
+- **WHEN** a scoped component contains nested components
+- **THEN** the parent scope's styles SHALL NOT affect elements inside child component boundaries
+- **AND** `@scope(<parent>) to (<child>)` syntax MAY be used when explicit scope limits are needed
+
+### Requirement: No viewport media queries for component responsiveness
+Components SHALL use CSS Container Queries for responsive layout, not viewport-based media queries. Viewport media queries SHALL only be used for truly viewport-dependent concerns (e.g., `prefers-reduced-motion`, `prefers-color-scheme`).
+
+#### Scenario: Component layout uses container queries
+- **WHEN** a component needs to adapt its layout to available space
+- **THEN** the component SHALL use `@container` rules, not `@media (min-width: ...)` or `@media (max-width: ...)`
+- **AND** the stylelint configuration SHALL warn on viewport-width media queries in component CSS
+
 ### Requirement: OKLCH color enforcement
 All color definitions in CSS SHALL use the `oklch()` function. Legacy color functions and hex notation SHALL be rejected by Stylelint.
 
@@ -75,9 +111,10 @@ All color definitions in CSS SHALL use the `oklch()` function. Legacy color func
 - **THEN** the value SHALL use `oklch(L C H / alpha)` syntax
 - **AND** legacy `rgba(R G B / alpha)` SHALL be rejected
 
-#### Scenario: Tailwind theme colors exempt
-- **WHEN** a color value is provided via Tailwind `theme()` function or CSS custom properties (e.g., `var(--color-brand-primary)`)
-- **THEN** the value SHALL not be subject to color function linting
+#### Scenario: Color derivation uses color-mix()
+- **WHEN** a color needs to be derived from a base token (e.g., hover state, transparency variant)
+- **THEN** the value SHALL use `color-mix(in oklch, ...)` instead of defining a separate token
+- **AND** the `cube/prefer-color-mix` stylelint rule SHALL report zero warnings
 
 ### Requirement: Anchored Container Query for position-dependent child styling
 Components that use CSS Anchor Positioning with fallback positions SHALL use `container-type: anchored` and `@container anchored(fallback: ...)` to style descendant elements based on which fallback was applied, instead of JavaScript-based position detection.


### PR DESCRIPTION
## Related Issue

Closes #211

## Summary of Changes

Sync main capability specs to reflect the completed TailwindCSS → CUBE CSS migration:

- **New spec: `cube-css-architecture`** — Defines the complete CUBE CSS layer ordering (reset, tokens, global, composition, utility, block, exception), `@scope` component isolation, design tokens as plain CSS custom properties, composition primitives, and exception layer via `data-*` attributes
- **Updated: `design-system`** — Token format changed from Tailwind `@theme` to plain CSS custom properties with OKLCH values; added spacing scale tokens and container infrastructure requirement with `container-name` enforcement
- **Updated: `modern-css-platform`** — Added `@layer` and `@scope` requirements, removed "Tailwind theme colors exempt" scenario, added `color-mix(in oklch, ...)` enforcement and no-viewport-media-queries for components
- **Archived: `improve-css-design`** — All 48/48 tasks complete

Companion to liverty-music/frontend#158

## Self-Checklist

- [x] I have linked the related issue.
- [x] I have updated the relevant documentation if needed.
- [x] No proto changes — buf lint/format/breaking not applicable.
- [x] No breaking changes.