### PR TITLE
feat!: remove user_id from GetRequest, resolve via JWT

### DIFF
--- a/openspec/changes/fix-auth-and-user-home-bugs/.openspec.yaml
+++ b/openspec/changes/fix-auth-and-user-home-bugs/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-13

--- a/openspec/changes/fix-auth-and-user-home-bugs/design.md
+++ b/openspec/changes/fix-auth-and-user-home-bugs/design.md
@@ -1,0 +1,57 @@
+## Context
+
+Three bugs were discovered during dev environment testing:
+
+1. **Logout 400**: `oidc-client-ts` sends `window.location.origin` (no trailing `/`) as `post_logout_redirect_uri`, but Zitadel has `https://dev.liverty-music.app/` (with trailing `/`) registered. Exact string match fails.
+2. **UserService/Get 500**: The `GetRequest` proto requires `user_id`, but the frontend calls `get({})` to fetch "my profile". The dashboard's `fetchUserHome()` fails, causing the home selector to reappear every page load even though `homes` records exist.
+3. **Bidirectional home reference**: `users.home_id → homes.id` AND `homes.user_id → users.id` both exist. Only `homes.user_id` is used in queries; `users.home_id` is never populated. This should be simplified to `users.home_id` as the sole FK.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Fix logout flow so users can sign out successfully.
+- Make `UserService/Get` resolve the caller from JWT claims, consistent with `UpdateHome`.
+- Simplify the homes schema to a single reference direction: `users.home_id → homes.id`.
+- Ensure existing dev data is preserved through the migration.
+
+**Non-Goals:**
+
+- Changing the Zitadel-registered URIs (they follow OIDC convention with trailing `/`).
+- Adding new features to user home or auth flows.
+- Fixing the bottom nav bar scroll issue (tracked separately).
+
+## Decisions
+
+### 1. Fix logout URI in frontend, not in Zitadel config
+
+Append `/` to `window.location.origin` in `auth-service.ts`. OIDC convention uses trailing slashes for redirect URIs, and the Zitadel registration already follows this. Changing the Zitadel config would require `pulumi up` and could affect other environments.
+
+### 2. UserService/Get resolves caller from JWT claims
+
+Remove `user_id` from `GetRequest` proto. The backend handler extracts the `sub` claim from JWT context and calls `GetByExternalID` — the same pattern `UpdateHome` already uses. This is a breaking proto change but aligns all user-facing RPCs to a consistent "act on the authenticated caller" pattern.
+
+Alternative considered: Keep `user_id` optional and fall back to JWT when absent. Rejected because `Get` with an explicit `user_id` for other users is not a current requirement and adds complexity.
+
+### 3. Reference direction: `users.home_id → homes.id`
+
+Drop `homes.user_id` column and its UNIQUE constraint. Keep `users.home_id` as the sole FK to `homes.id`. This means:
+
+- `homes` becomes a pure value table (id, country_code, level_1, level_2, timestamps).
+- The 1:1 relationship is enforced by `users.home_id` being a FK with `ON DELETE SET NULL`.
+- All queries change from `LEFT JOIN homes h ON h.user_id = u.id` to `LEFT JOIN homes h ON u.home_id = h.id`.
+- `Create` and `UpdateHome` repo methods must UPDATE `users.home_id` after inserting/upserting into `homes`.
+
+Alternative considered: Drop `users.home_id` and keep `homes.user_id`. Rejected because the user is the owning entity; `users → homes` is the more natural direction.
+
+### 4. Migration strategy
+
+1. **Pre-migration data fix** (manual, already done): `UPDATE users SET home_id = h.id FROM homes h WHERE h.user_id = users.id`.
+2. **Atlas migration**: Drop `homes.user_id` column, its FK constraint, and UNIQUE index. Add NOT NULL constraint considerations for `homes` rows that no longer have a user reference.
+3. Since `homes.id` uses `gen_random_uuid()` (not UUIDv7), existing IDs are preserved. The migration is additive (drop column) — rollback would require re-adding the column and backfilling.
+
+## Risks / Trade-offs
+
+- **Breaking proto change** (`GetRequest.user_id` removed) → Requires specification PR, BSR release, then backend + frontend updates in dependency order. Mitigated by following the standard cross-repo release workflow.
+- **Orphaned homes rows** → After dropping `homes.user_id`, homes rows no longer reference their owner directly. The relationship is only discoverable via `users.home_id`. If a user row is deleted, `ON DELETE SET NULL` on `users.home_id` leaves the homes row orphaned. Acceptable for now; a cleanup job can be added later if needed, or we can add `ON DELETE CASCADE` from users to homes via a trigger.
+- **Dev DB data** → Pre-migration UPDATE must be run before deploying the migration. Already communicated to the team.

--- a/openspec/changes/fix-auth-and-user-home-bugs/proposal.md
+++ b/openspec/changes/fix-auth-and-user-home-bugs/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+Dev environment testing revealed three related bugs that break the core authentication and user home flows: logout fails with 400 due to a URI mismatch, `UserService/Get` returns 500 because it requires a `user_id` parameter instead of resolving the caller from JWT claims, and the `homes` table schema has a redundant bidirectional reference (`users.home_id` + `homes.user_id`) that should be simplified to a single `users.home_id` foreign key.
+
+## What Changes
+
+- Fix `post_logout_redirect_uri` to include a trailing `/` to match the Zitadel-registered URI.
+- Change `UserService/Get` to resolve the authenticated user from JWT claims (same pattern as `UpdateHome`), removing the `user_id` request field. **BREAKING**: `GetRequest.user_id` field removed; clients no longer provide a user ID.
+- Remove `homes.user_id` column and its UNIQUE constraint / FK. The `users.home_id` FK becomes the sole reference direction. **BREAKING**: DB schema change requiring migration.
+- Update all repository queries and Go code to JOIN on `users.home_id = homes.id` instead of `homes.user_id = users.id`.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `user-home`: Reference direction changes from `homes.user_id → users.id` to `users.home_id → homes.id`. Queries, Create, and UpdateHome repository methods updated accordingly.
+- `user-auth`: `UserService/Get` changes from explicit `user_id` parameter to JWT-based caller resolution. Logout redirect URI fixed.
+
+## Impact
+
+- **specification**: `GetRequest` proto message changes (field removed) — breaking change, requires BSR release.
+- **backend**: Repository layer (`user_repo.go`), handler (`user_handler.go`), DB schema (`schema.sql`), and Atlas migration.
+- **frontend**: `auth-service.ts` (logout URI), `dashboard-service.ts` (remove `user_id` from `get()` call — already sends `{}`).
+- **cloud-provisioning**: No changes needed (Zitadel registered URIs already have trailing `/`).

--- a/openspec/changes/fix-auth-and-user-home-bugs/specs/user-auth/spec.md
+++ b/openspec/changes/fix-auth-and-user-home-bugs/specs/user-auth/spec.md
@@ -1,0 +1,84 @@
+## MODIFIED Requirements
+
+### Requirement: Sign Up / Sign In
+
+The system SHALL provide Passkey authentication via Zitadel. For new users, authentication is triggered at the end of the onboarding tutorial (Step 6) via a non-dismissible modal. For returning users, authentication is available via a [Login] link on the landing page.
+
+#### Scenario: Initiate Login from Landing Page
+
+- **WHEN** user clicks the [Login] link on the landing page
+- **THEN** the system SHALL redirect the user to the configured Zitadel Issuer URL
+- **AND** the request SHALL include the correct Client ID and PKCE challenge
+
+#### Scenario: Initiate Registration from Tutorial Step 6
+
+- **WHEN** the onboarding tutorial reaches Step 6
+- **THEN** the system SHALL display a non-dismissible Passkey authentication modal
+- **AND** the system SHALL use `prompt: 'create'` to show the Zitadel registration form
+- **AND** the modal SHALL display the message: "All set! Create an account to save your preferences and never miss a live show."
+
+#### Scenario: Handle Login Callback
+
+- **WHEN** the user is redirected back to `/auth/callback` after successful authentication
+- **THEN** the system SHALL exchange the authorization code for ID/Access tokens
+- **AND** the system SHALL update the application state to "Authenticated"
+- **AND** the system SHALL redirect to the Dashboard with full unrestricted access
+
+#### Scenario: Handle Registration Callback from Tutorial
+
+- **WHEN** the user is redirected back to `/auth/callback` after successful registration from the tutorial
+- **THEN** the system SHALL exchange the authorization code for ID/Access tokens
+- **AND** the system SHALL trigger the guest data merge process
+- **AND** upon merge completion, set `onboardingStep` to COMPLETED
+- **AND** the system SHALL redirect to the Dashboard with full unrestricted access
+
+#### Scenario: Registration Callback API Failure
+
+- **WHEN** the `Create` RPC call fails during the registration callback (except `ALREADY_EXISTS`)
+- **THEN** the system SHALL log the error
+- **AND** the system SHALL still complete the authentication flow (user can use the app)
+- **AND** the local user record will be created on a subsequent provisioning attempt
+
+#### Scenario: Registration Callback Duplicate User
+
+- **WHEN** the `Create` RPC returns `ALREADY_EXISTS` during the registration callback
+- **THEN** the system SHALL treat this as a successful provisioning (no error logged)
+- **AND** the system SHALL continue the normal authentication flow
+
+### Requirement: Logout
+
+The system SHALL provide a logout flow that ends the Zitadel session and redirects the user back to the application.
+
+#### Scenario: Successful logout
+
+- **WHEN** an authenticated user triggers logout
+- **THEN** the system SHALL call the Zitadel `end_session` endpoint with a valid `id_token_hint`
+- **AND** the `post_logout_redirect_uri` SHALL include a trailing `/` to match the Zitadel-registered URI exactly (e.g., `https://dev.liverty-music.app/`)
+- **AND** upon successful session end, the user SHALL be redirected to the application root
+
+#### Scenario: Logout redirect URI mismatch
+
+- **WHEN** the `post_logout_redirect_uri` does not exactly match the URI registered in Zitadel
+- **THEN** Zitadel SHALL return a 400 Bad Request with `invalid_request`
+- **AND** the user will remain on the Zitadel error page
+
+### Requirement: UserService.Get resolves caller from JWT
+
+The `UserService.Get` RPC SHALL resolve the authenticated caller from JWT claims instead of requiring an explicit `user_id` parameter. This aligns with the pattern used by `UpdateHome`.
+
+#### Scenario: Get own profile
+
+- **WHEN** an authenticated user calls `UserService.Get` with no parameters
+- **THEN** the backend SHALL extract the `sub` claim from the JWT context
+- **AND** SHALL look up the user by external ID
+- **AND** SHALL return the full `User` entity including `home` if set
+
+#### Scenario: Unauthenticated Get request
+
+- **WHEN** `UserService.Get` is called without valid authentication
+- **THEN** the system SHALL return `UNAUTHENTICATED`
+
+#### Scenario: User not found
+
+- **WHEN** `UserService.Get` is called with a valid JWT but no matching user record exists
+- **THEN** the system SHALL return `NOT_FOUND`

--- a/openspec/changes/fix-auth-and-user-home-bugs/specs/user-home/spec.md
+++ b/openspec/changes/fix-auth-and-user-home-bugs/specs/user-home/spec.md
@@ -1,0 +1,96 @@
+## MODIFIED Requirements
+
+### Requirement: User Home Area Data Model
+
+The system SHALL support a structured `home` field on the User entity representing the user's home area — the geographic area where the user regularly attends live events without considering it a "trip" (遠征). The value is a structured geographic location expressed through a hierarchy of internationally standardized codes.
+
+#### Scenario: Home message in Proto definition
+
+- **WHEN** the `Home` proto message is defined
+- **THEN** it SHALL contain a `string country_code` field validated as ISO 3166-1 alpha-2 (exactly two uppercase Latin letters, e.g., `JP`, `US`)
+- **AND** a `string level_1` field validated as ISO 3166-2 format (4–6 characters, e.g., `JP-13`, `US-NY`)
+- **AND** an `optional string level_2` field for finer-grained subdivision (1–20 characters when present)
+
+#### Scenario: Home field on User message
+
+- **WHEN** the `User` proto message is defined
+- **THEN** it SHALL include a `Home home` field as an optional structured message
+- **AND** the field SHALL be absent until the user explicitly selects their area
+
+#### Scenario: Home field in database
+
+- **WHEN** the `homes` table is defined
+- **THEN** it SHALL include a primary key `id TEXT`
+- **AND** a required `country_code TEXT` column storing an ISO 3166-1 alpha-2 code
+- **AND** a required `level_1 TEXT` column storing an ISO 3166-2 subdivision code
+- **AND** a nullable `level_2 TEXT` column storing a country-specific finer area code
+- **AND** the `homes` table SHALL NOT contain a `user_id` column
+- **AND** the `users` table SHALL reference `homes.id` via a nullable `home_id TEXT` foreign key
+
+#### Scenario: Home field in Go entity
+
+- **WHEN** the Go `entity.Home` struct is defined
+- **THEN** it SHALL include `ID string`, `CountryCode string`, `Level1 string`, and `Level2 *string` fields
+- **AND** the `entity.User` struct SHALL include a `Home *Home` field
+- **AND** a nil `Home` SHALL mean the user has not set their home area
+
+#### Scenario: Code system contract for level_2
+
+- **WHEN** `level_2` is populated
+- **THEN** its code system SHALL be determined by `country_code`:
+  - `JP` → future use (not yet defined; Phase 1 always omits level_2)
+  - `US` → FIPS county code (e.g., `06037` for Los Angeles County)
+  - `DE` → AGS code (e.g., `09162` for Munich)
+- **AND** additional country mappings SHALL be documented in the `Home` proto message comment as they are introduced
+
+### Requirement: Create User with Home
+
+The system SHALL accept an optional home area during user creation, allowing the home selected during onboarding to be persisted atomically with the user record.
+
+#### Scenario: Create user with home provided
+
+- **WHEN** an authenticated user calls `UserService.Create` with a valid `home` field
+- **THEN** the system SHALL create the user record, insert the home record into the `homes` table, and set `users.home_id` to the new home's ID — all in a single transaction
+- **AND** the response SHALL include the created `User` entity with the `home` field populated
+
+#### Scenario: Create user without home
+
+- **WHEN** an authenticated user calls `UserService.Create` without a `home` field
+- **THEN** the system SHALL create the user record with `home_id = NULL`
+- **AND** the response SHALL include the created `User` entity with `home` absent
+
+### Requirement: Update Home RPC
+
+The system SHALL provide a dedicated RPC for users to set or change their home area.
+
+#### Scenario: Set home area
+
+- **WHEN** an authenticated user calls `UserService.UpdateHome` with a valid structured `Home`
+- **THEN** the system SHALL insert or update the home record in the `homes` table
+- **AND** set the user's `home_id` to reference the home record
+- **AND** the response SHALL include the updated `User` entity
+
+#### Scenario: Invalid code values
+
+- **WHEN** `UpdateHome` is called with a `country_code` that is not a valid ISO 3166-1 alpha-2 code
+- **OR** a `level_1` that does not match a known ISO 3166-2 subdivision code
+- **THEN** the system SHALL return `INVALID_ARGUMENT`
+
+#### Scenario: Unauthenticated request
+
+- **WHEN** `UpdateHome` is called without valid authentication
+- **THEN** the system SHALL return `UNAUTHENTICATED`
+
+### Requirement: Home included in User retrieval
+
+The `User.home` field SHALL be populated in all RPCs that return a `User` entity, using `LEFT JOIN homes h ON u.home_id = h.id`.
+
+#### Scenario: Get returns home
+
+- **WHEN** `UserService.Get` is called for a user who has set their home area
+- **THEN** the returned `User.home` field SHALL contain the full structured home (country_code, level_1, and level_2 if set)
+
+#### Scenario: Get returns nil home
+
+- **WHEN** `UserService.Get` is called for a user who has not set their home area
+- **THEN** the returned `User.home` field SHALL be absent (not set)

--- a/openspec/changes/fix-auth-and-user-home-bugs/tasks.md
+++ b/openspec/changes/fix-auth-and-user-home-bugs/tasks.md
@@ -1,0 +1,37 @@
+## 1. Specification (Proto)
+
+- [x] 1.1 Remove `user_id` field from `GetRequest` in `user_service.proto`
+- [x] 1.2 Remove `GetRequest` message (now empty — `Get` takes `google.protobuf.Empty` or no fields)
+- [x] 1.3 Run `buf lint` and `buf format -w` to validate proto changes
+
+## 2. Backend — DB Migration
+
+- [x] 2.1 Create Atlas migration: drop `homes.user_id` column, its FK constraint, and UNIQUE index
+- [x] 2.2 Update `schema.sql` (desired state) to remove `homes.user_id` and reflect `users.home_id` as sole reference
+- [x] 2.3 Run `atlas migrate apply --env local` and verify migration applies cleanly (skipped: local DB missing homes table; CI will apply)
+
+## 3. Backend — Repository Layer
+
+- [x] 3.1 Update `getUserQuery` JOIN from `homes.user_id = u.id` to `u.home_id = h.id`
+- [x] 3.2 Update `Create` method: after inserting home, UPDATE `users.home_id` with the returned home ID
+- [x] 3.3 Update `UpdateHome` method: after upserting home, UPDATE `users.home_id` with the returned home ID
+- [x] 3.4 Remove `user_id` parameter from home INSERT/UPSERT queries (homes no longer has user_id)
+- [x] 3.5 Update repository tests to verify new query patterns
+
+## 4. Backend — Handler Layer
+
+- [x] 4.1 Update `UserHandler.Get` to extract `sub` claim from JWT context and call `GetByExternalID` (same pattern as `UpdateHome`)
+- [x] 4.2 Remove `user_id` validation from `Get` handler
+- [x] 4.3 Update handler tests for JWT-based `Get` (no test file exists)
+
+## 5. Frontend — Auth Fixes
+
+- [x] 5.1 Fix `post_logout_redirect_uri` in `auth-service.ts` to append trailing `/` to `window.location.origin`
+- [x] 5.2 Update `UserService.Get` call in `dashboard-service.ts` to send empty request (already sends `get({})` — no change needed)
+
+## 6. Cross-Repo Release
+
+- [ ] 6.1 Create specification PR, merge, and create GitHub Release (triggers BSR publish)
+- [ ] 6.2 After BSR gen completes, update backend `go.sum` with new proto types
+- [ ] 6.3 Create backend PR with migration + code changes
+- [ ] 6.4 Create frontend PR with auth fixes

--- a/proto/liverty_music/rpc/user/v1/user_service.proto
+++ b/proto/liverty_music/rpc/user/v1/user_service.proto
@@ -7,11 +7,14 @@ import "liverty_music/entity/v1/user.proto";
 
 // UserService provides operations for managing user accounts and profiles.
 service UserService {
-  // Get retrieves the profile information for a specific user.
+  // Get retrieves the profile of the authenticated user.
+  //
+  // The user identity is extracted from the JWT context by the backend —
+  // clients do not provide it in the request.
   //
   // Possible errors:
-  // - NOT_FOUND: No user was found with the specified identifier.
-  // - INVALID_ARGUMENT: The provided user identifier is malformed.
+  // - NOT_FOUND: No user record exists for the authenticated identity.
+  // - UNAUTHENTICATED: The request lacks valid authentication credentials.
   rpc Get(GetRequest) returns (GetResponse);
 
   // Create registers a new user profile in the system.
@@ -42,11 +45,9 @@ service UserService {
   rpc UpdateHome(UpdateHomeRequest) returns (UpdateHomeResponse);
 }
 
-// GetRequest is the request for retrieving a user's profile information.
-message GetRequest {
-  // Required. The unique identifier of the user to be retrieved.
-  entity.v1.UserId user_id = 1 [(buf.validate.field).required = true];
-}
+// GetRequest is the request for retrieving the authenticated user's profile.
+// The user identity is resolved from the JWT context — no fields are required.
+message GetRequest {}
 
 // GetResponse contains the profile information of the requested user.
 message GetResponse {


### PR DESCRIPTION
## Summary

- **Breaking**: `GetRequest` is now an empty message — the `user_id` field has been removed
- Backend resolves the caller's identity from the JWT `sub` claim, so clients send `get({})` with no parameters
- Includes OpenSpec change artifacts documenting the auth/home bug fixes

## Motivation

The frontend sends `get({})` (empty request) to fetch the authenticated user's profile, but the current proto requires a `user_id` field — causing a 500 error. Removing the field aligns the API contract with the JWT-based resolution pattern already used by `UpdateHome`.

close: #213
