### PR TITLE
docs(openspec): add CSS redesign roadmap changes

### DIFF
--- a/openspec/changes/archive/2026-03-13-fix-highway-layout/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-13-fix-highway-layout/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-13

--- a/openspec/changes/archive/2026-03-13-fix-highway-layout/design.md
+++ b/openspec/changes/archive/2026-03-13-fix-highway-layout/design.md
@@ -1,0 +1,84 @@
+## Context
+
+The `live-highway` component renders a three-lane concert schedule (HOME / NEAR / AWAY). The current DOM places the stage header inside the scroll container alongside date separators — both using `position: sticky`. This structural decision created a cascade of CSS hacks: `z-index: 10` to prevent date separators painting over the header, `inset-block-start: 41px` hardcoded to offset below the header, and `isolation: isolate` to scope the z-index. All three are anti-patterns that the CSS redesign initiative aims to eliminate.
+
+The parent `.highway-layout` uses `display: flex; flex-direction: column`, which is incorrect for a 2D structure-first layout (fixed header row + flexible scroll area) per the web-design-specialist layout engine selection principle.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Eliminate z-index, magic numbers, and isolation hacks through DOM restructuring
+- Apply correct layout engine (Grid for 2D structure-first)
+- Correct the flawed stacking context management rule in the css-linting spec
+- Fix the incorrect reasoning in the css-cleanup design document
+
+**Non-Goals:**
+- Redesigning the visual appearance of the highway component
+- Changing the three-lane grid structure or event card layout
+- Modifying the date grouping logic in TypeScript
+- Adding new CSS features (Container Queries, Scroll-driven Animations, etc.)
+
+## Decisions
+
+### Decision 1: Move stage header outside scroll container
+
+The stage header is a static column label — it never changes based on scroll position. Placing it outside `.highway-scroll` eliminates the sticky sibling stacking conflict entirely.
+
+**Before:**
+```
+.highway-scroll
+  ├── .stage-header (sticky, z-index: 10)
+  └── dateGroups
+      ├── .date-separator (sticky, top: 41px)
+      └── .lane-grid
+```
+
+**After:**
+```
+.highway-layout
+  ├── .stage-header (static)
+  └── .highway-scroll
+      └── dateGroups
+          ├── .date-separator (sticky, top: 0)
+          └── .lane-grid
+```
+
+**Alternative considered:** Keep the header inside the scroll container and use a design token `--stage-header-height` instead of `41px`. Rejected because this only addresses the magic number, not the structural problem (sticky sibling stacking, z-index dependency). The root cause is the DOM structure.
+
+### Decision 2: Convert highway-layout from Flexbox to Grid
+
+`.highway-layout` manages a 2D structure: a fixed-height header row and a flexible scroll area. Per the layout engine selection table:
+
+| Engine | Dimension | Sizing Driver | Applies here? |
+|--------|-----------|---------------|---------------|
+| Flexbox | 1D | Content-first | No — this is 2D |
+| **Grid** | **2D** | **Structure-first** | **Yes — fixed row + flexible row** |
+
+```css
+.highway-layout {
+    display: grid;
+    grid-template-rows: auto 1fr;
+    block-size: 100%;
+}
+```
+
+`auto` sizes the header to its content. `1fr` gives the remaining space to the scroll area. No `flex: 1` or `flex-direction: column` needed.
+
+### Decision 3: Add scrollbar-gutter for column alignment
+
+When `.highway-scroll` has overflow, the scrollbar narrows its content area. The `.stage-header` (now outside the scroll container) occupies the full parent width, causing a subtle column misalignment between header and grid.
+
+`scrollbar-gutter: stable` reserves space for the scrollbar even when content doesn't overflow, keeping column widths consistent.
+
+### Decision 4: Correct the css-cleanup design reasoning and spec rule
+
+The `css-cleanup` change introduced an incorrect rule: "Components SHALL manage stacking via `isolation: isolate` on parent containers instead of arbitrary z-index values." This is based on two wrong premises:
+1. `position: sticky` does not create a stacking context by itself (only with non-auto z-index)
+2. `isolation: isolate` on a parent does not control sibling stacking order — it only scopes children's z-index from leaking outward
+
+The correct principle: eliminate the need for z-index through proper DOM structure (don't make elements that need different stacking be sticky siblings). Remove the incorrect spec rule and fix the design document reasoning.
+
+## Risks / Trade-offs
+
+- [Column alignment with overlay scrollbars] → `scrollbar-gutter: stable` always reserves scrollbar space, which wastes ~15px on platforms that use overlay scrollbars (macOS). Acceptable for this component's narrow lane columns. If problematic later, `scrollbar-gutter: stable both-edges` can balance visually.
+- [Existing unit/E2E tests] → Tests reference DOM structure via class selectors (`.stage-header`, `.highway-scroll`). The class names don't change, only the DOM nesting. Tests querying `.highway-scroll .stage-header` will need updating. Minimal blast radius.

--- a/openspec/changes/archive/2026-03-13-fix-highway-layout/proposal.md
+++ b/openspec/changes/archive/2026-03-13-fix-highway-layout/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+The `live-highway` component has a structural anti-pattern: the stage header (`HOME STAGE / NEAR STAGE / AWAY STAGE`) is placed inside the scroll container as a `position: sticky` sibling of date-separator elements. This forces a `z-index: 10` hack (violating the `property-disallowed-list` stylelint rule), a hardcoded `inset-block-start: 41px` magic number on date separators (violating design token conventions), and an unnecessary `isolation: isolate` on the scroll container. Additionally, the parent layout uses `flex-direction: column` for what is a 2D structure-first layout, violating the web-design-specialist layout engine selection principle.
+
+## What Changes
+
+- Move `.stage-header` out of `.highway-scroll` to be a sibling in `.highway-layout`, eliminating the sticky stacking conflict entirely
+- Convert `.highway-layout` from `display: flex; flex-direction: column` to `display: grid; grid-template-rows: auto 1fr` (2D structure-first layout)
+- Remove `position: sticky` and `inset-block-start: 0` from `.stage-header` (no longer needed outside the scroll container)
+- Change `.date-separator` from `inset-block-start: 41px` to `inset-block-start: 0` (no more magic number)
+- Remove `isolation: isolate` from `.highway-scroll` (no longer needed without z-index conflicts)
+- Add `scrollbar-gutter: stable` to `.highway-scroll` to prevent column misalignment between the header and the scroll content
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `css-linting`: Remove the incorrect stacking context management rule ("Components SHALL manage stacking via `isolation: isolate` on parent containers instead of arbitrary z-index values") added by the `css-cleanup` change. The correct approach is structural — elements that need different stacking should not be sticky siblings in the same scroll container.
+
+## Impact
+
+- `frontend/src/components/live-highway/live-highway.html` — DOM restructure (move stage-header out of scroll container)
+- `frontend/src/components/live-highway/live-highway.css` — Layout engine change (flex → grid), remove sticky/z-index/isolation hacks, fix magic number
+- `specification/openspec/changes/css-cleanup/design.md` — Correct the flawed Decision 1 reasoning about `isolation: isolate`
+- `specification/openspec/changes/css-cleanup/specs/css-linting/spec.md` — Remove incorrect stacking context rule
+- No backend or API changes

--- a/openspec/changes/archive/2026-03-13-fix-highway-layout/specs/css-linting/spec.md
+++ b/openspec/changes/archive/2026-03-13-fix-highway-layout/specs/css-linting/spec.md
@@ -1,0 +1,14 @@
+## MODIFIED Requirements
+
+### Requirement: Stylelint enforces stacking context management
+The linter SHALL disallow `z-index` via the `property-disallowed-list` rule. Components SHALL resolve stacking requirements through proper DOM structure — elements that need different stacking order SHALL NOT be placed as sticky siblings within the same scroll container. The `isolation: isolate` property MAY be used to scope stacking contexts where needed, but it does not substitute for correct DOM structure.
+
+#### Scenario: No stylelint-disable for z-index
+- **WHEN** stylelint runs against all CSS files
+- **THEN** zero `stylelint-disable` comments for the `property-disallowed-list` rule SHALL exist
+- **AND** all stacking requirements SHALL be resolved via proper DOM structure (e.g., moving fixed headers outside scroll containers)
+
+#### Scenario: No magic numbers for sticky offsets
+- **WHEN** a CSS file contains `position: sticky` with a non-zero `inset-block-start` value
+- **THEN** the value SHALL reference a design token custom property
+- **AND** hardcoded pixel values (e.g., `41px`) SHALL NOT be used

--- a/openspec/changes/archive/2026-03-13-fix-highway-layout/tasks.md
+++ b/openspec/changes/archive/2026-03-13-fix-highway-layout/tasks.md
@@ -1,0 +1,31 @@
+## 1. Restructure live-highway DOM
+
+- [x] 1.1 Move `.stage-header` out of `.highway-scroll` to be a direct child of `.highway-layout` (before `.highway-scroll`) in `live-highway.html`
+
+## 2. Update live-highway CSS
+
+- [x] 2.1 Convert `.highway-layout` from `display: flex; flex-direction: column` to `display: grid; grid-template-rows: auto 1fr`
+- [x] 2.2 Remove `position: sticky` and `inset-block-start: 0` from `.stage-header`
+- [x] 2.3 Remove `isolation: isolate` from `.highway-scroll`
+- [x] 2.4 Add `scrollbar-gutter: stable` to `.highway-scroll`
+- [x] 2.5 Change `.date-separator` `inset-block-start` from `41px` to `0`
+
+## 3. Fix global.css prefers-contrast rule
+
+- [x] 3.1 Remove `a` from the `:where(button, a, input, textarea, select)` selector in the `prefers-contrast: more` media query in `global.css`
+
+## 4. Correct css-cleanup design and spec
+
+- [x] 4.1 Rewrite Decision 1 in `openspec/changes/css-cleanup/design.md` to describe DOM restructuring instead of `isolation: isolate`
+- [x] 4.2 Update the stacking context management requirement in `openspec/changes/css-cleanup/specs/css-linting/spec.md` to reference proper DOM structure instead of `isolation: isolate`
+
+## 5. Update css-state-separation tasks
+
+- [x] 5.1 Remove section 6 from `openspec/changes/css-state-separation/tasks.md` and ensure sections 1-4 tasks are fully atomic (both TS/HTML and CSS changes in each task)
+
+## 6. Verification
+
+- [x] 6.1 Run `make check` in frontend — zero stylelint errors, zero biome errors, all unit tests pass
+- [x] 6.2 Grep for `z-index` in frontend CSS — zero occurrences
+- [x] 6.3 Grep for `41px` in frontend CSS — zero occurrences
+- [x] 6.4 Grep for `stylelint-disable` in frontend CSS — zero occurrences

--- a/openspec/changes/css-cleanup/.openspec.yaml
+++ b/openspec/changes/css-cleanup/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-13

--- a/openspec/changes/css-cleanup/design.md
+++ b/openspec/changes/css-cleanup/design.md
@@ -9,7 +9,7 @@ The `improve-css-design` change migrated from TailwindCSS to CUBE CSS architectu
 
 **Goals:**
 - Eliminate all `stylelint-disable` comments by fixing the underlying issues
-- Replace `z-index` with proper stacking context management (`isolation: isolate`)
+- Eliminate `z-index` via DOM restructuring (move sticky header outside scroll container)
 - Remove obsolete Tailwind references from specs and lint config
 - Consolidate duplicate `@keyframes` into `utilities.css`
 - Add `prefers-contrast` / `forced-colors` accessibility support
@@ -21,11 +21,11 @@ The `improve-css-design` change migrated from TailwindCSS to CUBE CSS architectu
 
 ## Decisions
 
-### Decision 1: Replace z-index with `isolation: isolate`
+### Decision 1: Eliminate z-index via DOM restructuring
 
-The `z-index: 10` in `.stage-header` (sticky header) is used to stack above scrolling content. Since `position: sticky` already creates a stacking context, and the header only needs to stack above its siblings within the same parent, `isolation: isolate` on the parent container achieves the same result without an arbitrary z-index value.
+The `z-index: 10` in `.stage-header` existed because it was a `position: sticky` sibling of `.date-separator` elements inside the same scroll container. The correct fix is to move `.stage-header` outside the scroll container entirely — it is a static column label that should not participate in the scroll area's stacking context. This eliminates the z-index, the `isolation: isolate` hack, and the hardcoded `inset-block-start: 41px` magic number on `.date-separator` (see `fix-highway-layout` change for implementation).
 
-**Alternative**: Create a z-index token scale (e.g., `--z-sticky: 10`). Rejected because CUBE CSS philosophy prefers eliminating z-index entirely via proper stacking contexts.
+**Alternative considered**: `isolation: isolate` on the parent. Rejected because `isolation: isolate` only scopes children's z-index from leaking outward — it does not control sibling stacking order within the container. `position: sticky` alone (without a non-auto z-index) does not create a stacking context, so siblings with implicit stacking contexts (e.g., via `backdrop-filter`) will still paint over the header.
 
 ### Decision 2: Remove Tailwind at-rule allowances
 
@@ -37,5 +37,4 @@ Any `@keyframes` definition that appears in both a component CSS file and `utili
 
 ## Risks / Trade-offs
 
-- [Risk] Removing `z-index` from `live-highway.css` could break the sticky header stacking in edge cases → Test with the live-highway component to verify the sticky header renders above scrolling content
 - [Risk] Removing `@theme` from `ignoreAtRules` could break if any CSS file still references it → Grep codebase for `@theme` usage before removing

--- a/openspec/changes/css-cleanup/design.md
+++ b/openspec/changes/css-cleanup/design.md
@@ -1,0 +1,41 @@
+## Context
+
+The `improve-css-design` change migrated from TailwindCSS to CUBE CSS architecture. During that migration, several pragmatic shortcuts were taken:
+- One `stylelint-disable-next-line` comment bypasses the `z-index` ban in `live-highway.css`
+- The `css-linting` spec still contains a "Stylelint compatible with Tailwind CSS v4" requirement that is now dead
+- The `stylelint.config.js` still allows `@theme` in `ignoreAtRules` (Tailwind remnant)
+
+## Goals / Non-Goals
+
+**Goals:**
+- Eliminate all `stylelint-disable` comments by fixing the underlying issues
+- Replace `z-index` with proper stacking context management (`isolation: isolate`)
+- Remove obsolete Tailwind references from specs and lint config
+- Consolidate duplicate `@keyframes` into `utilities.css`
+- Add `prefers-contrast` / `forced-colors` accessibility support
+
+**Non-Goals:**
+- Refactoring TS/CSS state separation (that's `css-state-separation`)
+- Adding Container Queries, View Transitions, or other modern CSS features (that's `css-modern-patterns`)
+- Redesigning visual appearance of components
+
+## Decisions
+
+### Decision 1: Replace z-index with `isolation: isolate`
+
+The `z-index: 10` in `.stage-header` (sticky header) is used to stack above scrolling content. Since `position: sticky` already creates a stacking context, and the header only needs to stack above its siblings within the same parent, `isolation: isolate` on the parent container achieves the same result without an arbitrary z-index value.
+
+**Alternative**: Create a z-index token scale (e.g., `--z-sticky: 10`). Rejected because CUBE CSS philosophy prefers eliminating z-index entirely via proper stacking contexts.
+
+### Decision 2: Remove Tailwind at-rule allowances
+
+Remove `@theme` from `ignoreAtRules` in `stylelint.config.js` and `theme()` from `ignoreFunctions`. These were needed for Tailwind v4 compatibility but serve no purpose now.
+
+### Decision 3: Keyframes consolidation into utilities.css
+
+Any `@keyframes` definition that appears in both a component CSS file and `utilities.css` should exist only in `utilities.css` within `@layer utility`. Component CSS files should reference the animation by name without redefining the keyframes.
+
+## Risks / Trade-offs
+
+- [Risk] Removing `z-index` from `live-highway.css` could break the sticky header stacking in edge cases → Test with the live-highway component to verify the sticky header renders above scrolling content
+- [Risk] Removing `@theme` from `ignoreAtRules` could break if any CSS file still references it → Grep codebase for `@theme` usage before removing

--- a/openspec/changes/css-cleanup/proposal.md
+++ b/openspec/changes/css-cleanup/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+The `improve-css-design` change established the CUBE CSS architecture, but left behind several lint violations bypassed with `stylelint-disable` comments. The `css-linting` spec requires z-index to be rejected, yet a `stylelint-disable-next-line` override remains in `live-highway.css`. Additionally, the `css-linting` spec still references TailwindCSS compatibility requirements that no longer apply after the Tailwind removal.
+
+## What Changes
+
+- Remove the `z-index: 10` usage in `live-highway.css` by replacing it with `isolation: isolate` on the parent element (proper stacking context management)
+- Remove all `stylelint-disable` comments that bypass CUBE CSS or anti-pattern rules
+- Deduplicate `@keyframes` definitions that exist in both `utilities.css` and component CSS files — consolidate into `@layer utility`
+- Remove Tailwind-specific requirements from `css-linting` spec (the `@theme`, `theme()`, and `@apply` at-rule allowances are dead code now)
+- Add `prefers-contrast: more` and `forced-colors: active` media query support for accessibility
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `css-linting`: Remove Tailwind CSS v4 compatibility requirements; they are obsolete after the Tailwind removal in `improve-css-design`
+
+## Impact
+
+- **frontend**: CSS files (`live-highway.css`, `utilities.css`, component CSS with duplicate keyframes), `stylelint.config.js` (remove `@theme`/`theme()` allowances)
+- **specification**: `openspec/specs/css-linting/spec.md` (remove Tailwind compatibility requirement)

--- a/openspec/changes/css-cleanup/specs/css-linting/spec.md
+++ b/openspec/changes/css-cleanup/specs/css-linting/spec.md
@@ -1,0 +1,30 @@
+## REMOVED Requirements
+
+### Requirement: Stylelint compatible with Tailwind CSS v4
+**Reason**: TailwindCSS was removed from the project in `improve-css-design`. The CUBE CSS architecture uses plain `@layer`, `@scope`, and CSS custom properties — no Tailwind directives exist in the codebase.
+**Migration**: Remove `@theme` from `ignoreAtRules` and `theme()` from `ignoreFunctions` in `stylelint.config.js`. No CSS file changes needed as no Tailwind directives remain.
+
+## ADDED Requirements
+
+### Requirement: Stylelint enforces stacking context management
+The linter SHALL disallow `z-index` without escape hatches. Components SHALL manage stacking via `isolation: isolate` on parent containers instead of arbitrary z-index values.
+
+#### Scenario: No stylelint-disable for z-index
+- **WHEN** stylelint runs against all CSS files
+- **THEN** zero `stylelint-disable` comments for the `property-disallowed-list` rule SHALL exist
+- **AND** all stacking requirements SHALL be resolved via `isolation: isolate` or natural stacking contexts
+
+### Requirement: Stylelint enforces accessibility media queries
+The linter SHALL not flag accessibility-related media features as errors.
+
+#### Scenario: prefers-contrast allowed
+- **WHEN** a CSS file contains `@media (prefers-contrast: more)` or `@media (prefers-contrast: less)`
+- **THEN** Stylelint SHALL not report any errors
+
+#### Scenario: forced-colors allowed
+- **WHEN** a CSS file contains `@media (forced-colors: active)`
+- **THEN** Stylelint SHALL not report any errors
+
+#### Scenario: prefers-reduced-motion allowed
+- **WHEN** a CSS file contains `@media (prefers-reduced-motion: reduce)`
+- **THEN** Stylelint SHALL not report any errors

--- a/openspec/changes/css-cleanup/specs/css-linting/spec.md
+++ b/openspec/changes/css-cleanup/specs/css-linting/spec.md
@@ -7,12 +7,12 @@
 ## ADDED Requirements
 
 ### Requirement: Stylelint enforces stacking context management
-The linter SHALL disallow `z-index` without escape hatches. Components SHALL manage stacking via `isolation: isolate` on parent containers instead of arbitrary z-index values.
+The linter SHALL disallow `z-index` via the `property-disallowed-list` rule. Components SHALL resolve stacking requirements through proper DOM structure — elements that need different stacking order SHALL NOT be placed as sticky siblings within the same scroll container.
 
 #### Scenario: No stylelint-disable for z-index
 - **WHEN** stylelint runs against all CSS files
 - **THEN** zero `stylelint-disable` comments for the `property-disallowed-list` rule SHALL exist
-- **AND** all stacking requirements SHALL be resolved via `isolation: isolate` or natural stacking contexts
+- **AND** all stacking requirements SHALL be resolved via proper DOM structure (e.g., moving fixed headers outside scroll containers)
 
 ### Requirement: Stylelint enforces accessibility media queries
 The linter SHALL not flag accessibility-related media features as errors.

--- a/openspec/changes/css-cleanup/tasks.md
+++ b/openspec/changes/css-cleanup/tasks.md
@@ -1,0 +1,37 @@
+## 1. Remove z-index and fix stacking contexts
+
+- [ ] 1.1 Replace `z-index: 10` in `live-highway.css` `.stage-header` with `isolation: isolate` on the parent container
+- [ ] 1.2 Remove the `stylelint-disable-next-line property-disallowed-list` comment in `live-highway.css`
+- [ ] 1.3 Verify sticky header renders above scrolling content without z-index
+
+## 2. Remove Tailwind remnants from lint config
+
+- [ ] 2.1 Remove `@theme` from `ignoreAtRules` in `stylelint.config.js` (if present)
+- [ ] 2.2 Remove `theme()` from `ignoreFunctions` in `stylelint.config.js` (if present)
+- [ ] 2.3 Grep codebase for any remaining `@theme` or `theme()` usage and remove
+
+## 3. Consolidate duplicate @keyframes
+
+- [ ] 3.1 Audit all CSS files for `@keyframes` definitions that duplicate those in `utilities.css`
+- [ ] 3.2 Remove duplicate `@keyframes` from component CSS files, keeping only the `utilities.css` definitions
+- [ ] 3.3 Verify component animations still reference the correct keyframes names
+
+## 4. Add accessibility and form control enhancements
+
+- [ ] 4.1 Add `prefers-contrast: more` styles to components with insufficient contrast in dark theme
+- [ ] 4.2 Add `forced-colors: active` media query to ensure interactive elements remain visible in Windows High Contrast Mode
+- [ ] 4.3 Verify existing `prefers-reduced-motion` styles are comprehensive
+- [ ] 4.4 Add `accent-color: var(--color-brand-primary)` to form controls (checkbox, radio, select) in `global.css`
+- [ ] 4.5 Replace standalone `clip: rect(0, 0, 0, 0)` in `discover-page.css` with `clip-path: inset(50%)` (modern syntax)
+
+## 5. Update specification
+
+- [ ] 5.1 Remove "Stylelint compatible with Tailwind CSS v4" requirement from `css-linting` spec
+- [ ] 5.2 Add stacking context management requirement to `css-linting` spec
+- [ ] 5.3 Add accessibility media query requirement to `css-linting` spec
+
+## 6. Verification
+
+- [ ] 6.1 Run `make check` — zero stylelint errors, zero biome errors
+- [ ] 6.2 Run `make test` — all unit tests pass
+- [ ] 6.3 Confirm zero `stylelint-disable` comments remain in the codebase

--- a/openspec/changes/css-cleanup/tasks.md
+++ b/openspec/changes/css-cleanup/tasks.md
@@ -1,37 +1,37 @@
 ## 1. Remove z-index and fix stacking contexts
 
-- [ ] 1.1 Replace `z-index: 10` in `live-highway.css` `.stage-header` with `isolation: isolate` on the parent container
-- [ ] 1.2 Remove the `stylelint-disable-next-line property-disallowed-list` comment in `live-highway.css`
-- [ ] 1.3 Verify sticky header renders above scrolling content without z-index
+- [x] 1.1 Replace `z-index: 10` in `live-highway.css` `.stage-header` with `isolation: isolate` on the parent container
+- [x] 1.2 Remove the `stylelint-disable-next-line property-disallowed-list` comment in `live-highway.css`
+- [x] 1.3 Verify sticky header renders above scrolling content without z-index
 
 ## 2. Remove Tailwind remnants from lint config
 
-- [ ] 2.1 Remove `@theme` from `ignoreAtRules` in `stylelint.config.js` (if present)
-- [ ] 2.2 Remove `theme()` from `ignoreFunctions` in `stylelint.config.js` (if present)
-- [ ] 2.3 Grep codebase for any remaining `@theme` or `theme()` usage and remove
+- [x] 2.1 Remove `@theme` from `ignoreAtRules` in `stylelint.config.js` (if present)
+- [x] 2.2 Remove `theme()` from `ignoreFunctions` in `stylelint.config.js` (if present)
+- [x] 2.3 Grep codebase for any remaining `@theme` or `theme()` usage and remove
 
 ## 3. Consolidate duplicate @keyframes
 
-- [ ] 3.1 Audit all CSS files for `@keyframes` definitions that duplicate those in `utilities.css`
-- [ ] 3.2 Remove duplicate `@keyframes` from component CSS files, keeping only the `utilities.css` definitions
-- [ ] 3.3 Verify component animations still reference the correct keyframes names
+- [x] 3.1 Audit all CSS files for `@keyframes` definitions that duplicate those in `utilities.css`
+- [x] 3.2 Remove duplicate `@keyframes` from component CSS files, keeping only the `utilities.css` definitions
+- [x] 3.3 Verify component animations still reference the correct keyframes names
 
 ## 4. Add accessibility and form control enhancements
 
-- [ ] 4.1 Add `prefers-contrast: more` styles to components with insufficient contrast in dark theme
-- [ ] 4.2 Add `forced-colors: active` media query to ensure interactive elements remain visible in Windows High Contrast Mode
-- [ ] 4.3 Verify existing `prefers-reduced-motion` styles are comprehensive
-- [ ] 4.4 Add `accent-color: var(--color-brand-primary)` to form controls (checkbox, radio, select) in `global.css`
-- [ ] 4.5 Replace standalone `clip: rect(0, 0, 0, 0)` in `discover-page.css` with `clip-path: inset(50%)` (modern syntax)
+- [x] 4.1 Add `prefers-contrast: more` styles to components with insufficient contrast in dark theme
+- [x] 4.2 Add `forced-colors: active` media query to ensure interactive elements remain visible in Windows High Contrast Mode
+- [x] 4.3 Verify existing `prefers-reduced-motion` styles are comprehensive
+- [x] 4.4 Add `accent-color: var(--color-brand-primary)` to form controls (checkbox, radio, select) in `global.css`
+- [x] 4.5 Replace standalone `clip: rect(0, 0, 0, 0)` in `discover-page.css` with `clip-path: inset(50%)` (modern syntax)
 
 ## 5. Update specification
 
-- [ ] 5.1 Remove "Stylelint compatible with Tailwind CSS v4" requirement from `css-linting` spec
-- [ ] 5.2 Add stacking context management requirement to `css-linting` spec
-- [ ] 5.3 Add accessibility media query requirement to `css-linting` spec
+- [x] 5.1 Remove "Stylelint compatible with Tailwind CSS v4" requirement from `css-linting` spec
+- [x] 5.2 Add stacking context management requirement to `css-linting` spec
+- [x] 5.3 Add accessibility media query requirement to `css-linting` spec
 
 ## 6. Verification
 
-- [ ] 6.1 Run `make check` — zero stylelint errors, zero biome errors
-- [ ] 6.2 Run `make test` — all unit tests pass
-- [ ] 6.3 Confirm zero `stylelint-disable` comments remain in the codebase
+- [x] 6.1 Run `make check` — zero stylelint errors, zero biome errors
+- [x] 6.2 Run `make test` — all unit tests pass
+- [x] 6.3 Confirm zero `stylelint-disable` comments remain in the codebase

--- a/openspec/changes/css-modern-patterns/.openspec.yaml
+++ b/openspec/changes/css-modern-patterns/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-13

--- a/openspec/changes/css-modern-patterns/design.md
+++ b/openspec/changes/css-modern-patterns/design.md
@@ -1,0 +1,68 @@
+## Context
+
+The `modern-css-platform` spec already defines requirements for Container Queries, View Transitions, `:has()`, `@starting-style`, and Anchor Positioning. After `css-state-separation` cleans up TS/CSS responsibility leaks, this change focuses on adopting additional modern CSS patterns that further reduce JavaScript involvement in presentation concerns.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Replace all JS scroll listeners with Scroll-driven Animations (`animation-timeline: scroll()`)
+- Replace `requestAnimationFrame` entry animation deferrals with `@starting-style`
+- Adopt CSS `:has()` for parent-state styling where JS class toggling was previously required
+- Ensure all responsive components use Container Queries (audit for gaps)
+- Expand Anchor Positioning beyond coach-mark to tooltips and dropdowns
+
+**Non-Goals:**
+- Redesigning the visual appearance of components
+- Adding new UI components
+- Changing the component architecture or state management
+- Polyfilling for browsers below 2026 Baseline
+
+## Decisions
+
+### Decision 1: Scroll-driven Animations over JS scroll listeners
+
+Use `animation-timeline: scroll()` and `animation-timeline: view()` for:
+- Progress indicators that track scroll position
+- Parallax effects on scrollable content
+- Sticky header shadow that appears on scroll
+
+JS scroll listeners (`addEventListener('scroll', ...)`) SHALL be removed and replaced with pure CSS. This moves the work to the compositor thread, eliminating jank.
+
+**Alternative**: `IntersectionObserver` for enter-viewport effects. Still valid for non-animation triggers (lazy loading, analytics), but animation-linked effects belong in CSS.
+
+### Decision 2: @starting-style for entry animations
+
+Elements inserted into the DOM (via `if.bind`, `repeat.for`, or popover) SHALL use `@starting-style` to define their initial animation state:
+
+```css
+.toast-item {
+  opacity: 1;
+  transform: translateY(0);
+  transition: opacity 300ms, transform 300ms;
+
+  @starting-style {
+    opacity: 0;
+    transform: translateY(-1rem);
+  }
+}
+```
+
+This replaces the pattern of using `requestAnimationFrame` to add an animation class after DOM insertion.
+
+### Decision 3: CSS :has() for parent-state styling
+
+Parent elements that need to change style based on child state SHALL use `:has()`:
+
+```css
+.nav-tab:has([data-active]) {
+  color: var(--color-text-primary);
+}
+```
+
+This replaces patterns where TS sets a class on the parent when a child's state changes.
+
+## Risks / Trade-offs
+
+- [Risk] Scroll-driven Animations are Baseline 2024 (December) — some older mobile browsers may not support them → Use `@supports (animation-timeline: scroll())` feature query with graceful degradation (static fallback)
+- [Risk] `@starting-style` requires the element to have a `transition` — if transition is removed (e.g., reduced motion), entry animation silently disappears → This is correct behavior; `prefers-reduced-motion` should disable entry animations
+- [Risk] `:has()` has slight performance implications with deeply nested selectors → Limit `:has()` depth to 1-2 levels; avoid `:has(> * > * > .target)` patterns

--- a/openspec/changes/css-modern-patterns/proposal.md
+++ b/openspec/changes/css-modern-patterns/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+After `css-cleanup` (lint hardening) and `css-state-separation` (TS/CSS responsibility split), the codebase is ready to adopt 2026 Web Platform Baseline CSS features that replace remaining JavaScript-based patterns. Container Queries are specified but not fully utilized. Scroll-driven Animations, CSS `:has()` for parent-state styling, and `@starting-style` for entry animations are available but not yet adopted. These features eliminate JavaScript scroll listeners, class-toggling for parent state, and `requestAnimationFrame` deferrals — moving the work to the compositor thread for better performance.
+
+## What Changes
+
+- **Container Queries full adoption**: Audit all components for responsive breakpoints and convert remaining fixed layouts to container-query-driven responsive designs
+- **CSS `:has()` for parent-state styling**: Replace JS-driven parent class toggling with `:has()` selectors (e.g., nav item active state, form validation feedback)
+- **Scroll-driven Animations**: Replace JS scroll listeners with `animation-timeline: scroll()` for scroll-linked effects (parallax, progress indicators)
+- **`@starting-style` for entry animations**: Replace `requestAnimationFrame` deferrals for newly inserted DOM elements with `@starting-style` declarations
+- **Anchor Positioning refinements**: Expand CSS Anchor Positioning usage beyond coach-mark, using `position-area` and `position-try-fallbacks` for tooltips and popovers
+
+## Capabilities
+
+### New Capabilities
+
+(none — all features are already specified in `modern-css-platform`)
+
+### Modified Capabilities
+
+- `modern-css-platform`: Add Scroll-driven Animations requirement; strengthen Container Queries requirement to cover all responsive components
+
+## Impact
+
+- **frontend**: Component CSS files that use JS scroll listeners, `requestAnimationFrame` for entry animations, or JS-driven parent class toggling. Key components: `live-highway`, `dashboard`, `my-artists-page`, `event-detail-sheet`
+- **specification**: Delta spec for `modern-css-platform`

--- a/openspec/changes/css-modern-patterns/specs/modern-css-platform/spec.md
+++ b/openspec/changes/css-modern-patterns/specs/modern-css-platform/spec.md
@@ -1,0 +1,66 @@
+## ADDED Requirements
+
+### Requirement: Scroll-driven Animations for scroll-linked effects
+Scroll-linked visual effects (progress indicators, parallax, shadow-on-scroll) SHALL use CSS Scroll-driven Animations instead of JavaScript scroll event listeners.
+
+#### Scenario: Scroll progress indicator
+- **WHEN** a scrollable container needs a visual progress indicator
+- **THEN** the indicator element SHALL use `animation-timeline: scroll()` with a `@keyframes` rule
+- **AND** no JavaScript `scroll` event listener SHALL be used for this purpose
+
+#### Scenario: Sticky header shadow on scroll
+- **WHEN** a sticky header needs to show a shadow after the user scrolls past a threshold
+- **THEN** the shadow SHALL be driven by `animation-timeline: scroll()` or `animation-timeline: view()`
+- **AND** no JavaScript SHALL toggle a class or data attribute based on `scrollTop`
+
+#### Scenario: Graceful degradation for unsupported browsers
+- **WHEN** a browser does not support `animation-timeline: scroll()`
+- **THEN** the element SHALL display in its default (non-animated) state
+- **AND** `@supports (animation-timeline: scroll())` SHALL gate scroll-driven animation rules
+
+### Requirement: @starting-style for all entry animations
+Elements inserted into the DOM dynamically SHALL use `@starting-style` for entry animations instead of `requestAnimationFrame` or two-step class toggling.
+
+#### Scenario: List item entry animation
+- **WHEN** a new item is added to a `repeat.for` list
+- **THEN** the item SHALL define `@starting-style` with initial values (e.g., `opacity: 0`)
+- **AND** the element's `transition` property SHALL animate from the starting style to the resting state
+- **AND** no `requestAnimationFrame` SHALL be used to defer a class or attribute change
+
+#### Scenario: Popover content entry
+- **WHEN** `showPopover()` is called on a popover element
+- **THEN** the popover's content SHALL use `@starting-style` for entry transition
+- **AND** no JavaScript SHALL delay `showPopover()` with `requestAnimationFrame` for animation purposes
+
+### Requirement: CSS :has() for parent-state styling
+Parent elements SHALL use `:has()` pseudo-class to style themselves based on child or sibling state, instead of JavaScript-driven parent class toggling.
+
+#### Scenario: Navigation parent highlights active child
+- **WHEN** a navigation list contains a child with `[data-active]` or `[aria-current]`
+- **THEN** the parent navigation item SHALL style itself via `:has([data-active])` or `:has([aria-current])` selector
+- **AND** no JavaScript SHALL set a class or attribute on the parent element for this purpose
+
+#### Scenario: Form group highlights on invalid child
+- **WHEN** a form field within a group becomes invalid
+- **THEN** the parent group element SHALL style itself via `:has(:invalid)` or `:has([aria-invalid="true"])`
+- **AND** no JavaScript validation watcher SHALL toggle a parent class
+
+## MODIFIED Requirements
+
+### Requirement: Container Queries for component-level responsive design
+Components that render in variable-width containers SHALL use CSS Container Queries instead of viewport-based media queries for layout adaptation. All responsive components SHALL be audited and converted.
+
+#### Scenario: Event card adapts to lane width
+- **WHEN** an `event-card` renders inside a `live-highway` lane
+- **THEN** the lane element SHALL declare `container-type: inline-size`
+- **AND** the card layout SHALL adapt using `@container` rules based on the lane's available width
+
+#### Scenario: Container query fallback
+- **WHEN** a browser does not support Container Queries
+- **THEN** the component SHALL fall back to a reasonable default layout
+- **AND** the `@supports (container-type: inline-size)` feature query SHALL gate container-specific rules
+
+#### Scenario: All responsive components use Container Queries
+- **WHEN** any component has layout that adapts to available space
+- **THEN** the component SHALL use `@container` queries, not `@media (min-width: ...)` or `@media (max-width: ...)`
+- **AND** stylelint SHALL enforce this via `media-feature-name-disallowed-list`

--- a/openspec/changes/css-modern-patterns/tasks.md
+++ b/openspec/changes/css-modern-patterns/tasks.md
@@ -1,0 +1,44 @@
+## 1. Audit current JS-driven patterns
+
+- [ ] 1.1 Grep for `addEventListener('scroll'` and `scroll` event listeners — identify candidates for Scroll-driven Animations
+- [ ] 1.2 Grep for `requestAnimationFrame` used for entry animation deferrals — identify candidates for `@starting-style`
+- [ ] 1.3 Grep for parent class/attribute toggling driven by child state — identify candidates for CSS `:has()`
+- [ ] 1.4 Grep for `@media (min-width` or `@media (max-width` in component CSS — identify remaining viewport queries to convert
+
+## 2. Scroll-driven Animations
+
+- [ ] 2.1 Replace JS scroll listeners with `animation-timeline: scroll()` for scroll-linked effects
+- [ ] 2.2 Add `@supports (animation-timeline: scroll())` feature queries for graceful degradation
+- [ ] 2.3 Remove corresponding JS scroll event listeners and cleanup functions
+
+## 3. @starting-style for entry animations
+
+- [ ] 3.1 Add `@starting-style` to toast notification entry animation, remove `requestAnimationFrame` deferral if present
+- [ ] 3.2 Add `@starting-style` to popover entry animations, remove `requestAnimationFrame` deferral if present
+- [ ] 3.3 Add `@starting-style` to dynamically inserted list items (repeat.for) that have entry animations
+
+## 4. CSS :has() for parent-state styling
+
+- [ ] 4.1 Refactor navigation active state: use `:has([data-active])` on parent instead of JS parent class toggle
+- [ ] 4.2 Refactor form validation: use `:has(:invalid)` on parent group instead of JS validation watcher
+- [ ] 4.3 Identify and refactor any other parent-child state patterns
+
+## 5. Container Queries full coverage
+
+- [ ] 5.1 Audit all components for responsive layout — ensure every responsive component uses `@container` not `@media`
+- [ ] 5.2 Add `container-type: inline-size` to parent containers that are missing it
+- [ ] 5.3 Convert any remaining viewport-width media queries to container queries
+
+## 6. Anchor Positioning expansion
+
+- [ ] 6.1 Identify tooltip and dropdown components that use JS positioning
+- [ ] 6.2 Replace JS positioning with CSS Anchor Positioning (`position-anchor`, `position-area`, `position-try-fallbacks`)
+- [ ] 6.3 Add `@supports` fallback for browsers without Anchor Positioning support
+
+## 7. Verification
+
+- [ ] 7.1 Run `make check` — zero stylelint errors, zero biome errors
+- [ ] 7.2 Run `make test` — all unit tests pass
+- [ ] 7.3 Grep for remaining JS scroll listeners used for visual effects — zero matches
+- [ ] 7.4 Grep for `requestAnimationFrame` used for entry animation — zero matches
+- [ ] 7.5 Grep for viewport-width `@media` queries in component CSS — zero matches

--- a/openspec/changes/css-state-separation/.openspec.yaml
+++ b/openspec/changes/css-state-separation/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-13

--- a/openspec/changes/css-state-separation/design.md
+++ b/openspec/changes/css-state-separation/design.md
@@ -1,0 +1,63 @@
+## Context
+
+The CUBE CSS exception layer prescribes `data-*` attributes for state-driven styling. The `modern-css-platform` spec already requires `data-state` for animation state and `transitionend` for post-animation cleanup. However, the codebase still has 13+ instances of TS/CSS responsibility leaks identified in the `improve-css-design` audit: 3 inline style bindings, 3 class ternaries, 5 setTimeout-based animation orchestrations, and 2 unnecessary `if.bind` for visual state.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Establish a clear contract: TS sets `data-*` attributes and CSS custom properties; CSS reads them for styling
+- Eliminate all `setTimeout` calls that duplicate CSS animation/transition durations
+- Create Aurelia custom attributes for recurring data-state patterns
+- Ensure animation durations live in CSS only (single source of truth)
+
+**Non-Goals:**
+- Changing the visual design of any component
+- Adding new animations or transitions
+- Refactoring component architecture or state management
+- Adding Container Queries, View Transitions, or Scroll-driven Animations (that's `css-modern-patterns`)
+
+## Decisions
+
+### Decision 1: CSS custom properties for continuous values, data-* for discrete states
+
+Two distinct patterns based on value type:
+- **Continuous values** (offsets, colors, dimensions): Pass via `style="--_prop: ${value}"` — CSS reads via `var(--_prop, fallback)`. Use the `--_` prefix convention (component-local custom property).
+- **Discrete states** (active/inactive, entering/exiting): Pass via `data-state="${value}"` — CSS reads via `[data-state="active"]`.
+
+**Alternative**: Use `data-*` for everything. Rejected because `data-*` attributes are strings and clumsy for pixel values that change every frame (gestures).
+
+### Decision 2: Aurelia custom attribute for state binding
+
+Create a `state-attr` custom attribute that binds a boolean TS property to a `data-state` attribute:
+
+```html
+<div state-attr="active.bind: isActive; variant.bind: currentVariant">
+```
+
+This eliminates repetitive ternary patterns in templates. The custom attribute sets `data-state="active"` and `data-variant="${currentVariant}"` on the host element.
+
+**Alternative**: Keep explicit `data-state="${ternary}"` in templates. Acceptable for one-off cases but DRY violation for the 10+ components that use this pattern.
+
+### Decision 3: animationend/transitionend for animation lifecycle
+
+Replace `setTimeout(() => cleanup(), DURATION_MS)` with:
+```typescript
+element.addEventListener('transitionend', (e) => {
+  if (e.propertyName !== 'opacity') return
+  cleanup()
+}, { once: true })
+```
+
+For `prefers-reduced-motion`, detect via `matchMedia('(prefers-reduced-motion: reduce)')` and run cleanup immediately since no transition fires.
+
+**Alternative**: Keep setTimeout as fallback alongside event listener. Rejected because it creates race conditions. The CSS event is the authoritative signal.
+
+### Decision 4: Remove if.bind where Popover API manages visibility
+
+For `celebration-overlay` and `coach-mark`, remove `if.bind="visible"` and rely on the Popover API's `showPopover()`/`hidePopover()` which manages top-layer visibility natively. CSS handles transitions via `[data-state]`.
+
+## Risks / Trade-offs
+
+- [Risk] Gesture-driven transforms (swipe, drag) update `--_offset` every frame via style binding → This is acceptable; CSS custom properties on `style=` are the standard pattern for frame-by-frame updates. No alternative avoids this.
+- [Risk] `transitionend` may not fire if element is removed before transition completes → Use `{ once: true }` and ensure element remains in DOM during transition (if.bind removal helps here).
+- [Risk] The `state-attr` custom attribute adds a new Aurelia dependency → Keep it simple (< 30 lines), no external deps, tested via unit test.

--- a/openspec/changes/css-state-separation/proposal.md
+++ b/openspec/changes/css-state-separation/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+After establishing the CUBE CSS architecture (`improve-css-design`), significant TS/CSS responsibility leaks remain. TypeScript controls visual state through inline `style=` bindings, class-name ternaries, and `setTimeout` with hardcoded animation durations — all of which should be CSS's responsibility. The CUBE CSS exception layer (`data-*` attributes) and modern CSS features (`animationend`, CSS custom properties) provide the right primitives, but they are underutilized. This creates fragile timing dependencies between TS and CSS, duplicate duration constants, and makes it impossible to restyle components without modifying TypeScript.
+
+## What Changes
+
+- **Inline style= → CSS custom properties**: Replace `style="transform: translateX(${offset}px)"` patterns with `style="--offset: ${offset}px"` and CSS `transform: translateX(var(--offset, 0px))`
+- **Class ternaries → data-* exception attributes**: Replace `class="${flag ? 'active' : ''}"` with `data-state="${flag ? 'active' : 'inactive'}"` and CSS `[data-state="active"] { }`
+- **setTimeout animation → CSS event-driven**: Replace `setTimeout(() => hide(), EXIT_ANIMATION_MS)` with `animationend`/`transitionend` event listeners — single source of truth for durations in CSS only
+- **if.bind for visual state → popover API / hidden**: Remove `if.bind` on elements where the Popover API already manages visibility
+- **Aurelia custom attributes**: Create reusable custom attributes for common data-state patterns (e.g., `state-class`, `css-var`)
+
+## Capabilities
+
+### New Capabilities
+
+- `css-state-management`: Defines how visual state SHALL be communicated between TypeScript and CSS — data-* attributes for discrete states, CSS custom properties for continuous values, CSS events for animation lifecycle
+
+### Modified Capabilities
+
+- `cube-css-architecture`: Strengthen exception layer requirements — class toggling for visual state SHALL be prohibited; data-* attributes SHALL be the only mechanism
+- `modern-css-platform`: Add requirement for CSS custom properties as the bridge between dynamic TS values and CSS — inline style manipulation of layout/visual properties SHALL be prohibited
+
+## Impact
+
+- **frontend**: All component `.ts`, `.html`, and `.css` files that use inline styles, class ternaries, or setTimeout for animation. Major refactors in: `my-artists-page`, `event-detail-sheet`, `celebration-overlay`, `loading-sequence`, `pwa-install-prompt`, `notification-prompt`, `discover-page`, `coach-mark`
+- **specification**: New `css-state-management` spec, delta specs for `cube-css-architecture` and `modern-css-platform`

--- a/openspec/changes/css-state-separation/specs/css-state-management/spec.md
+++ b/openspec/changes/css-state-separation/specs/css-state-management/spec.md
@@ -1,0 +1,87 @@
+# CSS State Management
+
+## Purpose
+
+Defines how visual state SHALL be communicated between TypeScript ViewModels and CSS stylesheets. Establishes two primitives — `data-*` attributes for discrete states and CSS custom properties for continuous values — and prohibits direct style manipulation or class toggling for visual concerns.
+
+## Requirements
+
+### Requirement: Discrete visual state via data-* attributes
+Components that have discrete visual states (active/inactive, entering/exiting, expanded/collapsed) SHALL communicate state to CSS exclusively via `data-*` attributes on the host or target element.
+
+#### Scenario: Component active state
+- **WHEN** a component's visual state changes (e.g., active → inactive)
+- **THEN** the TypeScript ViewModel SHALL set `data-state="active"` or `data-state="inactive"` on the element
+- **AND** CSS SHALL style the element via `[data-state="active"] { }` selectors
+- **AND** no `classList.add()`, `classList.remove()`, or `classList.toggle()` SHALL be used for visual state changes
+
+#### Scenario: Template binding for discrete state
+- **WHEN** an Aurelia template needs to express a discrete visual state
+- **THEN** the template SHALL use `data-state="${expression}"` attribute binding
+- **AND** the template SHALL NOT use `class="${condition ? 'name' : ''}"` ternary patterns for visual state
+
+#### Scenario: Multiple orthogonal states
+- **WHEN** an element has multiple independent state dimensions (e.g., variant AND disabled)
+- **THEN** each dimension SHALL use a separate `data-*` attribute (`data-variant="muted"`, `data-disabled`)
+- **AND** CSS SHALL compose selectors via `[data-variant="muted"][data-disabled] { }`
+
+### Requirement: Continuous dynamic values via CSS custom properties
+Components that need to pass dynamic numeric or color values from TypeScript to CSS SHALL use CSS custom properties via inline `style` binding, not inline style declarations.
+
+#### Scenario: Gesture-driven transform
+- **WHEN** a component tracks a gesture offset (swipe, drag) that updates per-frame
+- **THEN** the template SHALL bind `style="--_offset: ${offset}px"`
+- **AND** CSS SHALL apply `transform: translateX(var(--_offset, 0px))`
+- **AND** the template SHALL NOT use `style="transform: translateX(${offset}px)"`
+
+#### Scenario: Dynamic color
+- **WHEN** a component receives a dynamic color value (e.g., artist theme color)
+- **THEN** the template SHALL bind `style="--_color: ${color}"`
+- **AND** CSS SHALL use `var(--_color)` in gradient, background, or color declarations
+- **AND** the template SHALL NOT inline the full CSS declaration (e.g., `style="background: linear-gradient(...)"`)
+
+#### Scenario: Component-local custom property naming
+- **WHEN** a CSS custom property is scoped to a single component
+- **THEN** the property name SHALL use the `--_` prefix (e.g., `--_offset`, `--_color`)
+- **AND** global design token properties SHALL NOT use the `--_` prefix
+
+### Requirement: Animation lifecycle via CSS events
+Post-animation cleanup (DOM removal, state reset, callback invocation) SHALL use `transitionend` or `animationend` events instead of `setTimeout` with hardcoded durations.
+
+#### Scenario: Exit transition cleanup
+- **WHEN** a component triggers an exit transition by setting `data-state="exiting"`
+- **THEN** the component SHALL listen for `transitionend` (filtering by `propertyName`) to perform cleanup
+- **AND** no `setTimeout` SHALL be used with a duration matching the CSS transition duration
+
+#### Scenario: Reduced motion bypass
+- **WHEN** the user has `prefers-reduced-motion: reduce` enabled
+- **AND** CSS applies `transition: none` or `animation: none`
+- **THEN** the component SHALL detect reduced motion via `matchMedia('(prefers-reduced-motion: reduce)')` and perform cleanup immediately
+- **AND** the component SHALL NOT wait for `transitionend` (which will not fire)
+
+#### Scenario: Animation duration single source of truth
+- **WHEN** an animation or transition duration is defined
+- **THEN** the duration SHALL exist only in CSS (via design token or direct value)
+- **AND** no TypeScript constant (e.g., `EXIT_ANIMATION_MS`, `FADE_DURATION_MS`) SHALL duplicate the CSS duration
+
+### Requirement: No if.bind for visual-only visibility
+Elements whose visibility is managed by the Popover API or CSS transitions SHALL NOT use `if.bind` for show/hide. DOM insertion/removal SHALL be reserved for conditional content, not visual state.
+
+#### Scenario: Popover element stays in DOM
+- **WHEN** a component uses the Popover API (`showPopover()`/`hidePopover()`)
+- **THEN** the popover element SHALL remain in the DOM at all times (no `if.bind`)
+- **AND** the Popover API SHALL manage top-layer visibility natively
+
+#### Scenario: Overlay with exit animation
+- **WHEN** an overlay has a CSS exit transition (e.g., fade out)
+- **THEN** the overlay element SHALL remain in the DOM during the transition
+- **AND** `if.bind` SHALL NOT remove the element before the transition completes
+- **AND** element removal (if needed) SHALL happen in the `transitionend` callback
+
+### Requirement: Aurelia custom attribute for state binding
+A reusable Aurelia custom attribute SHALL provide declarative data-state binding, eliminating repetitive ternary expressions in templates.
+
+#### Scenario: Boolean state binding
+- **WHEN** a component has a boolean property that drives a visual state
+- **THEN** the template MAY use `<div data-active.bind="isActive">` to set or remove the `data-active` attribute
+- **AND** CSS SHALL target `[data-active]` for the active state and `:not([data-active])` for the inactive state

--- a/openspec/changes/css-state-separation/specs/cube-css-architecture/spec.md
+++ b/openspec/changes/css-state-separation/specs/cube-css-architecture/spec.md
@@ -1,0 +1,18 @@
+## MODIFIED Requirements
+
+### Requirement: Exception layer for state deviations via `data-*` attributes
+Component state variations SHALL use `data-*` attributes (not CSS class toggling) to drive styling, as enforced by the `cube/exception-data-attr` rule. Class-name ternary expressions in templates for visual state SHALL be prohibited.
+
+#### Scenario: State-driven styling uses data attributes
+- **WHEN** a component has visual state variations (e.g., active, disabled, loading)
+- **THEN** the variations SHALL be expressed via `data-state`, `data-variant`, or `data-theme` attributes
+- **AND** CSS selectors SHALL target `[data-state="active"]` etc. within `@layer exception` or within `@layer block` using `data-*` attribute selectors
+
+#### Scenario: Stylelint enforces data attribute convention
+- **WHEN** stylelint runs against all CSS files
+- **THEN** the `cube/exception-data-attr` and `cube/data-attr-naming` rules SHALL report zero warnings
+
+#### Scenario: Class ternary patterns prohibited for visual state
+- **WHEN** a template needs to express a visual state change
+- **THEN** the template SHALL NOT use `class="${condition ? 'class-name' : ''}"` patterns
+- **AND** the template SHALL use `data-state="${condition ? 'active' : 'inactive'}"` or equivalent `data-*` binding instead

--- a/openspec/changes/css-state-separation/specs/modern-css-platform/spec.md
+++ b/openspec/changes/css-state-separation/specs/modern-css-platform/spec.md
@@ -1,0 +1,29 @@
+## ADDED Requirements
+
+### Requirement: CSS custom properties as TS-to-CSS bridge
+Dynamic values that originate in TypeScript and affect CSS layout or appearance SHALL be passed via CSS custom properties on the `style` attribute, not via inline CSS declarations.
+
+#### Scenario: Inline style uses custom property
+- **WHEN** a template binds a dynamic value to an element's style
+- **THEN** the binding SHALL set a CSS custom property (e.g., `style="--_offset: ${value}px"`)
+- **AND** the CSS rule SHALL consume the property (e.g., `transform: translateX(var(--_offset, 0px))`)
+- **AND** the template SHALL NOT inline the full CSS declaration (e.g., `style="transform: translateX(${value}px)"`)
+
+#### Scenario: Dynamic gradient color
+- **WHEN** a component receives a dynamic color for use in a gradient
+- **THEN** the template SHALL bind `style="--_color: ${color}"`
+- **AND** CSS SHALL define the gradient structure using `var(--_color)`
+- **AND** the template SHALL NOT construct the full `background: linear-gradient(...)` string inline
+
+### Requirement: No setTimeout for CSS animation timing
+TypeScript SHALL NOT use `setTimeout` with hardcoded durations that mirror CSS transition or animation durations. Animation lifecycle SHALL be driven by CSS events.
+
+#### Scenario: Post-animation cleanup uses transitionend
+- **WHEN** a component needs to perform cleanup after a CSS transition completes
+- **THEN** the component SHALL listen for `transitionend` or `animationend` events
+- **AND** no `setTimeout` SHALL be used with a duration value that matches a CSS duration
+
+#### Scenario: Exit animation with popover
+- **WHEN** a popover element has an exit animation and needs to call `hidePopover()` after completion
+- **THEN** the component SHALL listen for `animationend` on the popover element
+- **AND** `hidePopover()` SHALL be called in the event handler, not in a `setTimeout` callback

--- a/openspec/changes/css-state-separation/tasks.md
+++ b/openspec/changes/css-state-separation/tasks.md
@@ -1,0 +1,46 @@
+## 1. Inline style= → CSS custom properties
+
+- [ ] 1.1 Refactor `my-artists-page.html` swipe transform: replace `style="transform: translateX(${offset}px)"` with `style="--_swipe-offset: ${offset}px"` and CSS `transform: translateX(var(--_swipe-offset, 0px))`
+- [ ] 1.2 Refactor `my-artists-page.html` artist gradient: replace `style="background: linear-gradient(135deg, ${color}40, ${color}10)"` with `style="--_artist-color: ${color}"` and CSS gradient using `var(--_artist-color)`
+- [ ] 1.3 Refactor `event-detail-sheet.html` drag transform: replace `style="transform: ${...}"` with `style="--_drag-offset: ${dragOffset}px"` and CSS `transform: translateY(var(--_drag-offset, 0px))`
+
+## 2. Class ternary → data-* exception attributes
+
+- [ ] 2.1 Refactor `discover-page.html` genre chips visibility: replace `class="genre-chips ${isSearchMode ? 'hidden' : ''}"` with `data-search-mode` attribute + CSS selector
+- [ ] 2.2 Refactor `discover-page.html` search results visibility: replace `class="search-results ${isSearchMode ? '' : 'hidden'}"` with `data-search-mode` attribute + CSS selector
+- [ ] 2.3 Refactor `my-artists-page.html` hype pulse: replace `class="hype-btn ${pulsingArtistId === artist.id ? 'animate-hype-pulse' : ''}"` with `data-pulsing` attribute + CSS selector
+- [ ] 2.4 Refactor `discover-page.html` guidance hiding: replace `class="hud-message ${guidanceHiding ? 'hiding' : ''}"` with `data-guidance-state` attribute + CSS selector
+
+## 3. setTimeout → animationend/transitionend
+
+- [ ] 3.1 Refactor `celebration-overlay.ts`: replace `setTimeout(startFadeOut, displayDuration)` → use CSS animation with built-in delay, listen to `animationend` for cleanup
+- [ ] 3.2 Refactor `pwa-install-prompt.ts` `hideWithAnimation()`: replace `setTimeout(hidePopover, EXIT_ANIMATION_MS)` → listen to `animationend` on popover element
+- [ ] 3.3 Refactor `notification-prompt.ts` `hideWithAnimation()`: same pattern as 3.2
+- [ ] 3.4 Refactor `my-artists-page.ts` hype pulse: replace `setTimeout(() => pulsingArtistId = '', 300)` → listen to `animationend` on the button element
+- [ ] 3.5 Refactor `loading-sequence.ts` phase transitions: extract `FADE_DURATION_MS` to CSS-only, use `transitionend` on the phase message element for sequencing
+- [ ] 3.6 Remove all `EXIT_ANIMATION_MS`, `FADE_DURATION_MS`, and similar TS constants that duplicate CSS durations
+
+## 4. Remove if.bind for visual-only visibility
+
+- [ ] 4.1 Refactor `celebration-overlay.html`: remove `if.bind="visible"`, keep element in DOM, manage visibility via `data-state` + CSS
+- [ ] 4.2 Refactor `coach-mark.html`: remove `if.bind="visible"`, rely on Popover API `showPopover()`/`hidePopover()` for visibility
+
+## 5. Aurelia custom attribute for state binding
+
+- [ ] 5.1 Evaluate whether a `state-attr` custom attribute is warranted based on the number of remaining data-* bindings after steps 1-4
+- [ ] 5.2 If warranted, create `src/custom-attributes/state-attr.ts` with unit tests
+
+## 6. CSS updates for new data-* selectors
+
+- [ ] 6.1 Update `discover-page.css`: add `[data-search-mode]` selectors to replace `.hidden` class rules
+- [ ] 6.2 Update `my-artists-page.css`: add `[data-pulsing]` selector to replace `.animate-hype-pulse` class rule
+- [ ] 6.3 Update `celebration-overlay.css`: adjust selectors for always-in-DOM element with `data-state`
+- [ ] 6.4 Update component CSS files to use `var(--_offset)` patterns instead of expecting inline transforms
+
+## 7. Verification
+
+- [ ] 7.1 Run `make check` — zero stylelint errors, zero biome errors
+- [ ] 7.2 Run `make test` — all unit tests pass
+- [ ] 7.3 Grep for remaining `setTimeout` calls that duplicate CSS durations — zero matches
+- [ ] 7.4 Grep for remaining `class="${.*?}"` ternary patterns for visual state — zero matches
+- [ ] 7.5 Grep for remaining inline `style="transform:` or `style="background:` patterns — zero matches

--- a/openspec/changes/css-state-separation/tasks.md
+++ b/openspec/changes/css-state-separation/tasks.md
@@ -30,17 +30,10 @@
 - [ ] 5.1 Evaluate whether a `state-attr` custom attribute is warranted based on the number of remaining data-* bindings after steps 1-4
 - [ ] 5.2 If warranted, create `src/custom-attributes/state-attr.ts` with unit tests
 
-## 6. CSS updates for new data-* selectors
+## 6. Verification
 
-- [ ] 6.1 Update `discover-page.css`: add `[data-search-mode]` selectors to replace `.hidden` class rules
-- [ ] 6.2 Update `my-artists-page.css`: add `[data-pulsing]` selector to replace `.animate-hype-pulse` class rule
-- [ ] 6.3 Update `celebration-overlay.css`: adjust selectors for always-in-DOM element with `data-state`
-- [ ] 6.4 Update component CSS files to use `var(--_offset)` patterns instead of expecting inline transforms
-
-## 7. Verification
-
-- [ ] 7.1 Run `make check` — zero stylelint errors, zero biome errors
-- [ ] 7.2 Run `make test` — all unit tests pass
-- [ ] 7.3 Grep for remaining `setTimeout` calls that duplicate CSS durations — zero matches
-- [ ] 7.4 Grep for remaining `class="${.*?}"` ternary patterns for visual state — zero matches
-- [ ] 7.5 Grep for remaining inline `style="transform:` or `style="background:` patterns — zero matches
+- [ ] 6.1 Run `make check` — zero stylelint errors, zero biome errors
+- [ ] 6.2 Run `make test` — all unit tests pass
+- [ ] 6.3 Grep for remaining `setTimeout` calls that duplicate CSS durations — zero matches
+- [ ] 6.4 Grep for remaining `class="${.*?}"` ternary patterns for visual state — zero matches
+- [ ] 6.5 Grep for remaining inline `style="transform:` or `style="background:` patterns — zero matches

--- a/openspec/specs/css-linting/spec.md
+++ b/openspec/specs/css-linting/spec.md
@@ -90,20 +90,44 @@ The linter SHALL enforce a consistent property declaration order grouped by func
 - **THEN** properties SHALL be ordered in the following group sequence: Interaction, Positioning, Layout, Box Model, Typography, Appearance, Transition/Animation
 - **AND** `stylelint --fix` SHALL automatically reorder properties
 
-### Requirement: Stylelint compatible with Tailwind CSS v4
-The linter SHALL not flag valid Tailwind v4 directives or modern CSS at-rules as errors.
+### Requirement: Stylelint compatible with modern CSS at-rules
+The linter SHALL not flag valid modern CSS at-rules as errors.
 
-#### Scenario: Tailwind at-rules accepted
-- **WHEN** a CSS file contains `@theme`, `@layer`, or `@apply` directives
+#### Scenario: Standard CSS at-rules accepted
+- **WHEN** a CSS file contains `@layer`, `@scope`, or `@property` at-rules
 - **THEN** Stylelint SHALL not report unknown at-rule errors
 
 #### Scenario: Modern CSS at-rules accepted
 - **WHEN** a CSS file contains `@container`, `@starting-style`, or `@property` at-rules
 - **THEN** Stylelint SHALL not report unknown at-rule errors
 
-#### Scenario: Tailwind theme function accepted
-- **WHEN** a CSS file uses the `theme()` function
-- **THEN** Stylelint SHALL not report unknown function errors
+### Requirement: Stylelint enforces stacking context management
+The linter SHALL disallow `z-index` via the `property-disallowed-list` rule. Components SHALL resolve stacking requirements through proper DOM structure — elements that need different stacking order SHALL NOT be placed as sticky siblings within the same scroll container. The `isolation: isolate` property MAY be used to scope stacking contexts where needed, but it does not substitute for correct DOM structure.
+
+#### Scenario: No stylelint-disable for z-index
+- **WHEN** stylelint runs against all CSS files
+- **THEN** zero `stylelint-disable` comments for the `property-disallowed-list` rule SHALL exist
+- **AND** all stacking requirements SHALL be resolved via proper DOM structure (e.g., moving fixed headers outside scroll containers)
+
+#### Scenario: No magic numbers for sticky offsets
+- **WHEN** a CSS file contains `position: sticky` with a non-zero `inset-block-start` value
+- **THEN** the value SHALL reference a design token custom property
+- **AND** hardcoded pixel values (e.g., `41px`) SHALL NOT be used
+
+### Requirement: Stylelint enforces accessibility media queries
+The linter SHALL not flag accessibility-related media features as errors.
+
+#### Scenario: prefers-contrast allowed
+- **WHEN** a CSS file contains `@media (prefers-contrast: more)` or `@media (prefers-contrast: less)`
+- **THEN** Stylelint SHALL not report any errors
+
+#### Scenario: forced-colors allowed
+- **WHEN** a CSS file contains `@media (forced-colors: active)`
+- **THEN** Stylelint SHALL not report any errors
+
+#### Scenario: prefers-reduced-motion allowed
+- **WHEN** a CSS file contains `@media (prefers-reduced-motion: reduce)`
+- **THEN** Stylelint SHALL not report any errors
 
 ### Requirement: Stylelint integrated into CI pipeline
 The linter SHALL run as part of the standard CI lint check.


### PR DESCRIPTION
## Summary

- Add three staged OpenSpec changes for CSS redesign: `css-cleanup`, `css-state-separation`, `css-modern-patterns`
- Each change includes proposal, design, specs (delta), and tasks artifacts
- Update `css-linting` spec: remove Tailwind v4 requirement, add stacking context management and accessibility media query requirements
- Add new specs: `css-state-management`, `modern-css-platform`
- Mark all 20 `css-cleanup` tasks as complete

## Test plan

- [ ] Verify OpenSpec CLI can parse all new change artifacts (`openspec status --change css-cleanup`)
- [ ] Confirm delta specs are valid and reference existing capability specs correctly
- [ ] Review task lists for completeness and correct ordering

Refs: #215