### PR TITLE
docs: improve onboarding hype UX specs

### DIFF
--- a/openspec/changes/archive/2026-03-13-improve-onboarding-hype-ux/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-13-improve-onboarding-hype-ux/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-13

--- a/openspec/changes/archive/2026-03-13-improve-onboarding-hype-ux/design.md
+++ b/openspec/changes/archive/2026-03-13-improve-onboarding-hype-ux/design.md
@@ -1,0 +1,138 @@
+## Context
+
+The current onboarding Step 5 uses a bottom sheet selector for passion levels, requiring 2 taps to change. The coachmark text ("好きなレベルを設定してみよう！") fails to communicate what hype does. Step 6 forces a non-dismissible signup modal. Users reach Step 5 after: Landing → Discovery → Dashboard → Concert Detail → My Artists. By this point, onboarding fatigue is high — the UX must be fast and self-explanatory.
+
+The frontend is Aurelia 2 with CUBE CSS methodology. Onboarding state is managed via `liverty:onboardingStep` in localStorage. Guest follows are stored in localStorage and synced to backend after signup.
+
+## Goals / Non-Goals
+
+**Goals:**
+- 1-tap hype changes directly in the artist list (no bottom sheet)
+- Communicate hype-notification linkage at the moment of highest user motivation
+- Provide signup opt-out ("あとで") while maintaining persistent signup CTAs
+- Eliminate localStorage hype state for unauthenticated users (avoid sync bugs)
+- Complete onboarding in fewer mandatory steps
+
+**Non-Goals:**
+- Changing the hype proto schema (HYPE_TYPE values remain unchanged)
+- Modifying notification delivery logic
+- Redesigning the Grid (Festival) view (list view only)
+- Implementing the NEARBY tier in backend notification filtering (remains Phase 2)
+
+## Decisions
+
+### Decision 1: Inline dot slider instead of bottom sheet
+
+**Choice**: 4-stop discrete slider on each artist row, aligned with sticky header columns.
+
+**Why**: Bottom sheet requires 2 taps, interrupts scanning flow, and provides no spatial context for what levels mean. An inline slider enables 1-tap changes and the sticky header provides persistent context.
+
+**Alternative considered**: Segmented control per row — rejected because segments with emoji labels (👀🔥🔥🔥🔥🔥🔥🔥🔥🔥) consume too much horizontal space and look cluttered.
+
+**Implementation**:
+- Sticky header: `position: sticky; top: 0` with `backdrop-filter: blur(8px)` on `surface-raised` background
+- Header uses CSS Grid with 4 equal columns aligned to slider stop positions
+- Each artist row: `display: flex` with artist name (`flex-shrink: 1; overflow: hidden; text-overflow: ellipsis`) and slider (`flex-grow: 1`)
+- Slider: 4 dot stops connected by a 2px track line; active dot is 14px with artist-color glow matching hype tier CSS effects from `passion-level` spec
+- Tap target: each dot has a 44×44px transparent hit area (minimum touch target per WCAG)
+- Slider change emits a custom event; for authenticated users, calls `SetHype` RPC with optimistic update
+
+### Decision 2: Block hype changes for unauthenticated users
+
+**Choice**: Slider tap triggers the notification dialog instead of changing hype. The slider does not move.
+
+**Why**: Allowing hype changes before signup would require persisting hype values in localStorage per artist per follow, then syncing them to backend after signup. The current guest data merge already handles follow list sync — adding hype sync increases complexity and bug surface (race conditions, partial sync, stale state).
+
+**Alternative considered**: Allow changes with localStorage persistence — rejected due to sync complexity. The follow sync (ListFollowed → diff → bulk SetHype) would need to handle: (a) artists unfollowed before signup, (b) hype values changed multiple times, (c) concurrent follow/unfollow during sync.
+
+**Implementation**:
+- `HypeSlider` component checks `AuthService.isAuthenticated` on tap
+- If unauthenticated: dispatch `hype-signup-prompt` event (caught by parent page)
+- If authenticated: update hype optimistically and fire RPC
+- All sliders show at WATCH position for unauthenticated users (this is the truth — they have no hype set)
+
+### Decision 3: Coachmark targets sticky header, not individual artist
+
+**Choice**: Spotlight the entire sticky header legend row.
+
+**Why**: The header contains the visual language (emoji + labels) that gives meaning to the slider stops. Spotlighting it teaches users to read the legend, which persists during scroll. Spotlighting an individual artist's slider doesn't explain what the stops mean.
+
+**Implementation**:
+- Coach mark target: `[data-hype-header]` attribute on the sticky header element
+- Coach mark message: "絶対に見逃したくないアーティストの熱量を上げておこう"
+- Dismiss: tap anywhere on overlay (standard coach mark behavior)
+- After dismiss: `onboardingStep` advances to 7 (COMPLETED) — onboarding is done
+- No more Step 6 (forced signup modal is removed)
+
+### Decision 4: Single-page notification dialog on first unauthenticated slider tap
+
+**Choice**: One dialog explaining hype tiers → notification scope, with signup CTA and "あとで" option.
+
+**Why**: 3-page slide carousel was considered but rejected — users are at Step 5 with high onboarding fatigue. A single page with clear mapping (hype tier → notification scope) is sufficient. The dialog triggers at peak motivation (user just tried to change something).
+
+**Dialog content**:
+```
+🔔 ライブ通知について
+
+👀 通知なし
+🔥 地元のライブを通知
+🔥🔥 近くのライブも通知
+🔥🔥🔥 全国のライブを通知
+
+通知を受け取るにはアカウント登録が必要です
+
+[ アカウント作成 ]    ← primary button
+[ あとで ]            ← ghost button
+```
+
+**Trigger condition**: First slider tap while unauthenticated AND `onboardingStep >= 5` (onboarding completed or in progress). The "shown" state is tracked in the existing `onboardingStep` progression — once the user reaches Step 7, the dialog has been shown or is no longer relevant for onboarding.
+
+**"アカウント作成" flow**: Initiates Zitadel OIDC Passkey flow (same as current Step 6).
+**"あとで" flow**: Closes dialog, does not change slider, shows inline banner.
+
+### Decision 5: Persistent inline signup banner
+
+**Choice**: A compact banner at the bottom of the artist list (scroll content, not sticky) and at the bottom of the dashboard lane area.
+
+**Why**: After dismissing the dialog, users need a non-intrusive path back to signup. Inline placement (not sticky) avoids obscuring content. Two locations (My Artists + Dashboard) ensure the CTA is visible on the two most-visited pages.
+
+**Implementation**:
+- Shared `signup-prompt-banner` component used in both pages
+- Conditionally rendered: `!authService.isAuthenticated`
+- My Artists: placed after the last artist row in the scroll container
+- Dashboard: placed after the lane grid in the scroll container
+- Copy: "🔔 通知を有効にするには [アカウント作成]"
+- On signup completion: component's `isAuthenticated` binding triggers removal
+
+### Decision 6: Default hype changes from HOME to WATCH
+
+**Choice**: New follows default to WATCH (HYPE_TYPE_WATCH).
+
+**Why**: Starting at WATCH means users experience "raising" hype — a positive action. Starting at HOME means users would need to "lower" it, which feels like removing something. WATCH also means zero notifications by default, which is a safer UX for users who haven't explicitly opted in.
+
+**Backend change**: `FollowArtist` handler sets default hype to `HYPE_TYPE_WATCH` instead of `HYPE_TYPE_HOME`. This is a behavior change, not a schema change.
+
+**Migration**: Existing users' hype values are unchanged. Only new follows after deployment get the new default.
+
+### Decision 7: Emotion-based tier labels
+
+**Choice**: Japanese UI labels use emotion-based phrasing; internal proto values unchanged.
+
+| Proto Value | Current UI Label | New UI Label (ja) | New UI Label (en) |
+|-------------|------------------|--------------------|---------------------|
+| WATCH | Watch / 👀 | チェック | Just checking |
+| HOME | Home / 🔥 | 地元 | Local shows |
+| NEARBY | NearBy / 🔥🔥 | 近くも | Nearby too |
+| AWAY | Away / 🔥🔥🔥 | どこでも！ | Anywhere! |
+
+**Why**: "Watch/Home/NearBy/Away" are proximity concepts that make sense to developers but not to users asking "how much do I care about this artist?" Emotion-based labels map to user intent.
+
+## Risks / Trade-offs
+
+**[Risk] Users skip signup entirely** → Mitigation: Inline banner provides persistent, non-intrusive CTA on both primary pages. The hype slider being locked at WATCH creates functional motivation to sign up (they can see the slider but can't use it). Future: consider time-delayed re-prompt after N sessions.
+
+**[Risk] Coachmark on header doesn't draw attention to sliders** → Mitigation: The coachmark copy mentions "熱量を上げておこう" which creates curiosity to try the sliders. The header spotlight with emoji labels is visually distinct. If conversion is low, can add a secondary coachmark on the first artist's slider.
+
+**[Risk] Default WATCH breaks existing user expectations** → Mitigation: Only affects NEW follows after deployment. Existing follows retain their current hype. The "raise to enable" pattern is standard in notification UX (iOS, Android both default to off).
+
+**[Risk] Disabled sliders frustrate unauthenticated users** → Mitigation: Sliders are visually at WATCH (not greyed out/disabled). They respond to tap with the notification dialog, which explains why and provides a clear path. This is a "gate" not a "wall" — the path forward is obvious.

--- a/openspec/changes/archive/2026-03-13-improve-onboarding-hype-ux/proposal.md
+++ b/openspec/changes/archive/2026-03-13-improve-onboarding-hype-ux/proposal.md
@@ -1,0 +1,39 @@
+## Why
+
+The current onboarding Step 5 (My Artists) uses a 2-tap passion level selector (tap icon → bottom sheet → select) with a coachmark that says "好きなレベルを設定してみよう！" — neither the UI nor the text communicates what hype levels actually do. Users don't understand the connection between hype and notification scope, and the friction of a bottom sheet discourages exploration. Additionally, the current flow forces a non-dismissible signup modal (Step 6) with no opt-out, losing users who aren't ready to commit.
+
+## What Changes
+
+- **Replace bottom sheet selector with inline dot slider**: Each artist row gets a 4-stop slider (WATCH/HOME/NEARBY/AWAY) enabling 1-tap hype changes directly in the list view
+- **Add sticky header with hype level legend**: Visual column headers (👀/🔥/🔥🔥/🔥🔥🔥 with labels) that remain visible during scroll, aligning with slider stop positions
+- **Change default hype from HOME to WATCH**: New follows start at WATCH (👀) so users experience "raising" hype (positive) rather than "lowering" it
+- **Redesign Step 5 coachmark**: Spotlight the sticky header legend instead of an individual artist's hype icon, with motivation-focused copy ("絶対に見逃したくないアーティストの熱量を上げておこう")
+- **Replace Step 5→6 explanation dialog with notification-focused dialog**: On first slider change, show a single-page dialog explaining hype-notification linkage and presenting signup CTA with "あとで" opt-out
+- **Block hype changes for unauthenticated users**: Slider tap triggers the notification dialog; the slider does not move until after signup (no localStorage hype state to sync)
+- **Add inline signup banner to My Artists and Dashboard**: After dismissing the dialog with "あとで", show a persistent inline banner prompting account creation; banner disappears after signup
+- **Replace non-dismissible Step 6 signup modal**: The signup prompt is now integrated into the hype dialog and inline banner; the forced modal is removed
+- **Update hype tier labels**: Use emotion-based labels (チェック/地元/近くも/どこでも！) instead of functional labels (Watch/Home/NearBy/Away)
+- **Apply hype-level CSS effects to slider active dot**: The selected dot mirrors the dashboard card glow for that tier, making the slider itself a preview
+
+## Capabilities
+
+### New Capabilities
+
+- `hype-inline-slider`: Inline 4-stop dot slider for setting hype level per artist in the My Artists list view, with sticky header legend and artist-color glow on active dot
+- `signup-prompt-banner`: Persistent inline banner on My Artists and Dashboard pages prompting unauthenticated users to create an account, dismissed on signup completion
+
+### Modified Capabilities
+
+- `my-artists`: Replace bottom sheet passion selector with inline dot slider UI; artist row layout changes from name + icon to name + slider on same row
+- `onboarding-tutorial`: Step 5 coachmark targets header legend instead of individual artist icon; Step 5 slider interaction triggers notification dialog instead of passion explanation; Step 6 non-dismissible signup modal replaced by dialog CTA and inline banner flow
+- `passion-level`: Default hype changes from HOME to WATCH; add emotion-based tier labels for UI display; hype changes blocked for unauthenticated users (no localStorage hype persistence)
+- `frontend-onboarding-flow`: Remove forced signup modal at Step 6; onboarding completes at Step 5 coachmark dismissal; signup is prompted via hype dialog and inline banner
+
+## Impact
+
+- **Frontend (My Artists page)**: Complete redesign of artist list row layout and hype interaction pattern
+- **Frontend (Dashboard)**: Add inline signup banner component
+- **Frontend (Onboarding service)**: Step 5/6 logic rewrite; Step 6 modal removal; new dialog and banner components
+- **Backend (Follow service)**: Default hype value changes from HOME to WATCH for new follows
+- **Proto (follow.proto)**: No schema changes needed (WATCH already exists as HYPE_TYPE_WATCH)
+- **Specification**: Multiple capability specs updated

--- a/openspec/changes/archive/2026-03-13-improve-onboarding-hype-ux/specs/frontend-onboarding-flow/spec.md
+++ b/openspec/changes/archive/2026-03-13-improve-onboarding-hype-ux/specs/frontend-onboarding-flow/spec.md
@@ -1,0 +1,40 @@
+## MODIFIED Requirements
+
+### Requirement: Landing Page with Authentication
+
+The system SHALL provide a landing page that communicates the service value proposition and provides entry points for both new users (tutorial) and returning users (direct login). Authentication is no longer required at the landing page; new users enter a guest tutorial flow. The tutorial completes at Step 5 (My Artists) with signup prompted via notification dialog and inline banners.
+
+#### Scenario: First-time user visits landing page
+
+- **WHEN** a user accesses the application for the first time
+- **THEN** the system SHALL display a hero message communicating the core value ("大好きなあのバンドのライブ、もう二度と見逃さない。")
+- **AND** the system SHALL display a sub-message ("あなたの推しアーティストを登録するだけで、全国のライブ日程を自動収集。")
+- **AND** the system SHALL provide a primary [Get Started] CTA button that enters the tutorial flow without authentication
+- **AND** the system SHALL provide a secondary [Login] text link for returning users
+- **AND** the system SHALL NOT provide "Sign Up" or "Sign In" buttons that trigger immediate authentication
+
+#### Scenario: User taps Get Started
+
+- **WHEN** a user taps the [Get Started] button
+- **THEN** the system SHALL set `onboardingStep` to 1 in LocalStorage
+- **AND** the system SHALL navigate to the Artist Discovery page (`/onboarding/discover`)
+- **AND** the system SHALL NOT require authentication
+
+#### Scenario: User taps Login
+
+- **WHEN** a user taps the [Login] link
+- **THEN** the system SHALL initiate the Zitadel OIDC flow for Passkey authentication
+- **AND** upon successful authentication, the system SHALL redirect to the Dashboard with full unrestricted access
+
+#### Scenario: User provisioning fails during login callback
+
+- **WHEN** the OIDC callback processing fails
+- **THEN** the system SHALL display an error message on the callback page
+- **AND** the system SHALL provide a "Return to Home" link
+
+## REMOVED Requirements
+
+### Requirement: Step 6 - SignUp modal display (from frontend-onboarding-flow perspective)
+
+**Reason**: The forced signup modal at Step 6 is removed. Onboarding completes at Step 5 (coachmark dismissal). Signup is prompted via optional notification dialog and persistent inline banners on My Artists and Dashboard pages.
+**Migration**: Remove Step 6 modal rendering from the onboarding flow. If `onboardingStep=6` is found in localStorage, advance to 7 (COMPLETED). Signup CTA is now in the notification dialog and `signup-prompt-banner` component.

--- a/openspec/changes/archive/2026-03-13-improve-onboarding-hype-ux/specs/hype-inline-slider/spec.md
+++ b/openspec/changes/archive/2026-03-13-improve-onboarding-hype-ux/specs/hype-inline-slider/spec.md
@@ -1,0 +1,74 @@
+# Capability: Hype Inline Slider
+
+## Purpose
+
+Provide a 1-tap inline slider for setting hype level per artist in the My Artists list view, with a sticky header legend and artist-color glow on the active dot.
+
+## ADDED Requirements
+
+### Requirement: Sticky Header Legend
+
+The My Artists list view SHALL display a sticky header row showing hype tier icons and emotion-based labels, aligned with slider stop positions.
+
+#### Scenario: Header renders with 4 columns
+
+- **WHEN** the My Artists page renders in list view
+- **THEN** the system SHALL display a sticky header row below the page title
+- **AND** the header SHALL contain 4 equally-spaced columns: 👀 チェック, 🔥 地元, 🔥🔥 近くも, 🔥🔥🔥 どこでも！
+- **AND** the header SHALL use `position: sticky; top: 0` with `backdrop-filter: blur(8px)` on the surface-raised background
+- **AND** each column SHALL vertically align with the corresponding dot stop on artist row sliders
+
+#### Scenario: Header remains visible during scroll
+
+- **WHEN** the user scrolls the artist list
+- **THEN** the sticky header SHALL remain visible at the top of the scroll container
+- **AND** the header SHALL have a `[data-hype-header]` attribute for coach mark targeting
+
+### Requirement: Inline Dot Slider
+
+Each artist row in the My Artists list view SHALL include a 4-stop discrete dot slider for hype level selection, enabling 1-tap changes without opening a bottom sheet.
+
+#### Scenario: Slider renders on each artist row
+
+- **WHEN** an artist row renders in list view
+- **THEN** the row SHALL display the artist name (left-aligned, truncated with ellipsis) and the dot slider (right-aligned) on the same row
+- **AND** the slider SHALL display 4 dot stops connected by a 2px track line
+- **AND** the active dot SHALL be 14px diameter; inactive dots SHALL be 8px diameter
+- **AND** each dot SHALL have a minimum 44×44px transparent tap target area
+
+#### Scenario: Active dot reflects hype tier CSS effects
+
+- **WHEN** the slider renders with a specific hype level selected
+- **THEN** the active dot SHALL apply the same CSS glow effects as defined in the passion-level card styling spec:
+  - WATCH: `1px solid white/10` border, no glow
+  - HOME: artist-color border at 40% opacity, `box-shadow: 0 0 8px` at 30% opacity
+  - NEARBY: artist-color `2px solid` border, `box-shadow: 0 0 16px` at 50% opacity, gentle pulse animation
+  - AWAY: animated gradient border, layered glow (`0 0 24px` at 60% + `0 0 48px` at 20%), strong pulse animation
+- **AND** the artist color SHALL be derived from the existing deterministic color generator
+
+#### Scenario: Reduced motion preference
+
+- **WHEN** the user has `prefers-reduced-motion: reduce` enabled
+- **THEN** all pulse and gradient rotation animations on active dots SHALL be disabled
+- **AND** static border and glow styles SHALL remain visible
+
+#### Scenario: Authenticated user taps a dot
+
+- **WHEN** an authenticated user taps an inactive dot on a slider
+- **THEN** the active dot SHALL animate to the tapped position (200ms ease-out transition)
+- **AND** the system SHALL optimistically update the UI
+- **AND** the system SHALL call `SetHype` RPC with the new hype level
+- **AND** if the RPC fails, the slider SHALL revert to the previous position
+
+#### Scenario: Unauthenticated user taps a dot
+
+- **WHEN** an unauthenticated user taps any dot on a slider
+- **THEN** the slider SHALL NOT move
+- **AND** the system SHALL dispatch a `hype-signup-prompt` custom event
+- **AND** the My Artists page SHALL handle this event by displaying the notification dialog (see `onboarding-tutorial` spec)
+
+#### Scenario: Slider dot positions align with header columns
+
+- **WHEN** the page renders
+- **THEN** the 4 slider dot stops SHALL be positioned to vertically align with the 4 header legend columns
+- **AND** alignment SHALL be maintained across viewport widths (CSS Grid shared column template)

--- a/openspec/changes/archive/2026-03-13-improve-onboarding-hype-ux/specs/my-artists/spec.md
+++ b/openspec/changes/archive/2026-03-13-improve-onboarding-hype-ux/specs/my-artists/spec.md
@@ -1,0 +1,30 @@
+## MODIFIED Requirements
+
+### Requirement: Artist List Row
+
+Each artist row in the My Artists list view SHALL display the artist's name and an inline hype dot slider on the same row.
+
+#### Scenario: Artist row layout
+
+- **WHEN** an artist row is rendered in list view
+- **THEN** the row SHALL display the artist name (left) and inline dot slider (right) on the same horizontal line
+- **AND** the artist name SHALL truncate with ellipsis if it exceeds available space
+- **AND** the row SHALL have a minimum height of 44px
+
+#### Scenario: Hype slider replaces passion icon
+
+- **WHEN** the My Artists list view renders
+- **THEN** the system SHALL display the inline dot slider (from `hype-inline-slider` capability) instead of the passion level icon
+- **AND** the bottom sheet selector SHALL NOT be used for hype changes in list view
+
+## REMOVED Requirements
+
+### Requirement: Tapping passion icon opens selector
+
+**Reason**: Replaced by inline dot slider that enables 1-tap hype changes directly in the list row. The bottom sheet selector required 2 taps and interrupted the scanning flow.
+**Migration**: Remove bottom sheet component usage from My Artists list view. Hype changes are handled by the inline dot slider component. The bottom sheet MAY be retained for Grid (Festival) view's long-press context menu.
+
+### Requirement: Selecting a passion level
+
+**Reason**: The bottom sheet selection flow is replaced by inline dot slider interaction. Optimistic update and RPC call behavior moves to the slider component.
+**Migration**: Optimistic update and SetHype RPC logic moves to the `hype-inline-slider` component's authenticated tap handler.

--- a/openspec/changes/archive/2026-03-13-improve-onboarding-hype-ux/specs/onboarding-tutorial/spec.md
+++ b/openspec/changes/archive/2026-03-13-improve-onboarding-hype-ux/specs/onboarding-tutorial/spec.md
@@ -1,0 +1,82 @@
+## MODIFIED Requirements
+
+### Requirement: Linear Step Progression
+
+The system SHALL enforce a strict linear progression through tutorial steps. Users SHALL NOT be able to skip steps or navigate freely during the tutorial. Step 5 is the final interactive step; Step 6 (forced signup modal) is removed.
+
+#### Scenario: Step 5 - Hype Header Coachmark
+
+- **WHEN** a user is at Step 5 (My Artists)
+- **THEN** the system SHALL display the sticky hype header legend with `[data-hype-header]` attribute
+- **AND** the system SHALL spotlight the sticky header using the coach mark overlay
+- **AND** the coach mark message SHALL read: "絶対に見逃したくないアーティストの熱量を上げておこう"
+
+#### Scenario: Step 5 - Coachmark dismissal completes onboarding
+
+- **WHEN** a user is at Step 5
+- **AND** the user taps the coach mark overlay to dismiss it
+- **THEN** the system SHALL advance `onboardingStep` to 7 (COMPLETED)
+- **AND** the system SHALL remove all tutorial UI restrictions (coach marks, spotlight, interaction locks)
+- **AND** the user SHALL have full unrestricted access to the My Artists page
+
+#### Scenario: Step 5 - Unauthenticated slider tap triggers notification dialog
+
+- **WHEN** a user is at Step 5 or has completed onboarding (Step >= 7)
+- **AND** the user is unauthenticated
+- **AND** the user taps a hype slider dot
+- **THEN** the system SHALL display the notification dialog (single page)
+- **AND** the dialog SHALL display hype tier → notification scope mapping:
+  - 👀 通知なし
+  - 🔥 地元のライブを通知
+  - 🔥🔥 近くのライブも通知
+  - 🔥🔥🔥 全国のライブを通知
+- **AND** the dialog SHALL display: "通知を受け取るにはアカウント登録が必要です"
+- **AND** the dialog SHALL present two buttons: [アカウント作成] (primary) and [あとで] (ghost)
+
+#### Scenario: Notification dialog - アカウント作成
+
+- **WHEN** the user taps [アカウント作成] in the notification dialog
+- **THEN** the system SHALL initiate the Zitadel OIDC Passkey authentication flow
+- **AND** upon successful authentication, the system SHALL trigger the guest data merge process
+- **AND** after merge, hype sliders SHALL become interactive
+
+#### Scenario: Notification dialog - あとで
+
+- **WHEN** the user taps [あとで] in the notification dialog
+- **THEN** the dialog SHALL close
+- **AND** the hype slider SHALL remain at the current position (WATCH for all artists)
+- **AND** the inline signup banner SHALL become visible on My Artists and Dashboard pages
+
+#### Scenario: Notification dialog shown once per session
+
+- **WHEN** the user has dismissed the notification dialog with "あとで"
+- **AND** the user taps another slider dot in the same session
+- **THEN** the notification dialog SHALL NOT be shown again
+- **AND** the slider SHALL NOT move (still unauthenticated)
+
+## REMOVED Requirements
+
+### Requirement: Step 5 Passion Level Explanation Timing
+
+**Reason**: Replaced by the notification dialog triggered on unauthenticated slider tap. The previous flow (change passion level → 800ms delay → explanation dialog → advance to Step 6) is removed. Onboarding now completes at Step 5 coachmark dismissal.
+**Migration**: Remove the passion explanation dialog component. Remove the 800ms delay timer. Step 5 → Step 6 transition is removed; Step 5 coachmark dismissal advances directly to Step 7 (COMPLETED).
+
+### Requirement: Step 6 - SignUp modal display
+
+**Reason**: The non-dismissible signup modal is replaced by the optional notification dialog (triggered by slider tap) and persistent inline signup banners. Users are no longer forced to sign up to complete onboarding.
+**Migration**: Remove the Step 6 signup modal component. Remove the non-dismissible dialog logic. Signup prompts are handled by the notification dialog and `signup-prompt-banner` component. The `OnboardingStep` enum value 6 SHALL be retained for backward compatibility — if a user has `onboardingStep=6` in localStorage from a prior session, the route guard SHALL advance them to Step 7 (COMPLETED).
+
+### Requirement: Step 6 - Passkey authentication success
+
+**Reason**: Authentication success handling moves from Step 6 modal to the notification dialog's [アカウント作成] flow. Guest data merge is triggered from the notification dialog instead.
+**Migration**: Move guest data merge trigger to the notification dialog's authentication success callback. The merge logic itself is unchanged.
+
+### Requirement: Step 6 - Page reload
+
+**Reason**: Step 6 no longer exists as a distinct step.
+**Migration**: If `onboardingStep=6` is found in localStorage on page load, advance to Step 7 (COMPLETED).
+
+### Requirement: Sign-up Modal Entrance Animation
+
+**Reason**: The sign-up modal (Step 6) is removed entirely.
+**Migration**: Remove sign-up modal entrance animation CSS. The notification dialog uses standard dialog entrance animation.

--- a/openspec/changes/archive/2026-03-13-improve-onboarding-hype-ux/specs/passion-level/spec.md
+++ b/openspec/changes/archive/2026-03-13-improve-onboarding-hype-ux/specs/passion-level/spec.md
@@ -1,0 +1,40 @@
+## MODIFIED Requirements
+
+### Requirement: Passion Level Tiers
+
+The system SHALL support four hype level tiers for each followed artist, with emotion-based UI labels:
+
+| Tier | Proto Value | Emoji | UI Label (ja) | UI Label (en) | Notification Scope |
+|------|-------------|-------|----------------|----------------|-------------------|
+| Watch | HYPE_TYPE_WATCH | 👀 | チェック | Just checking | None |
+| Home | HYPE_TYPE_HOME | 🔥 | 地元 | Local shows | Home area only |
+| Nearby | HYPE_TYPE_NEARBY | 🔥🔥 | 近くも | Nearby too | Within 200km (Phase 2) |
+| Away | HYPE_TYPE_AWAY | 🔥🔥🔥 | どこでも！ | Anywhere! | All concerts |
+
+#### Scenario: Default hype level on follow
+
+- **WHEN** a user follows a new artist
+- **AND** the follow relationship is created
+- **THEN** the hype level SHALL default to Watch (HYPE_TYPE_WATCH)
+
+#### Scenario: UI labels use emotion-based phrasing
+
+- **WHEN** hype level labels are displayed in the UI (slider header, dialogs, settings)
+- **THEN** the system SHALL use emotion-based labels (チェック/地元/近くも/どこでも！) instead of proximity-based labels (Watch/Home/NearBy/Away)
+
+### Requirement: Hype Changes Require Authentication
+
+The system SHALL prevent unauthenticated users from changing hype levels. Hype state SHALL NOT be persisted in localStorage.
+
+#### Scenario: Unauthenticated user attempts hype change
+
+- **WHEN** an unauthenticated user attempts to change a hype level (via slider tap or any UI control)
+- **THEN** the system SHALL NOT update the hype level
+- **AND** the system SHALL trigger a signup prompt flow
+- **AND** no hype value SHALL be written to localStorage
+
+#### Scenario: Authenticated user changes hype
+
+- **WHEN** an authenticated user changes a hype level
+- **THEN** the system SHALL call `SetHype` RPC and persist the change on the backend
+- **AND** the UI SHALL update optimistically

--- a/openspec/changes/archive/2026-03-13-improve-onboarding-hype-ux/specs/signup-prompt-banner/spec.md
+++ b/openspec/changes/archive/2026-03-13-improve-onboarding-hype-ux/specs/signup-prompt-banner/spec.md
@@ -1,0 +1,62 @@
+# Capability: Signup Prompt Banner
+
+## Purpose
+
+Provide a persistent inline banner on My Artists and Dashboard pages prompting unauthenticated users to create an account, dismissed automatically on signup completion.
+
+## ADDED Requirements
+
+### Requirement: Inline Signup Banner on My Artists
+
+The My Artists page SHALL display a persistent inline banner at the end of the artist list prompting unauthenticated users to sign up.
+
+#### Scenario: Banner appears for unauthenticated users
+
+- **WHEN** an unauthenticated user views the My Artists page
+- **AND** the user has dismissed the notification dialog with "あとで" (or has completed onboarding without signup)
+- **THEN** the system SHALL display an inline banner after the last artist row
+- **AND** the banner SHALL display: "🔔 通知を有効にするには [アカウント作成]"
+- **AND** the [アカウント作成] button SHALL initiate the Zitadel OIDC Passkey flow
+
+#### Scenario: Banner not shown for authenticated users
+
+- **WHEN** an authenticated user views the My Artists page
+- **THEN** the signup banner SHALL NOT be rendered
+
+#### Scenario: Banner disappears after signup
+
+- **WHEN** the user completes signup (isAuthenticated becomes true)
+- **THEN** the signup banner SHALL be removed from the DOM
+
+### Requirement: Inline Signup Banner on Dashboard
+
+The Dashboard page SHALL display a persistent inline banner prompting unauthenticated users to sign up.
+
+#### Scenario: Banner appears on dashboard for unauthenticated users
+
+- **WHEN** an unauthenticated user views the Dashboard
+- **AND** the user has completed onboarding (onboardingStep >= 7) or has dismissed the notification dialog
+- **THEN** the system SHALL display an inline banner after the lane grid content
+- **AND** the banner SHALL display: "🔔 ライブ通知を受け取ろう [アカウント作成]"
+- **AND** the [アカウント作成] button SHALL initiate the Zitadel OIDC Passkey flow
+
+#### Scenario: Banner not shown during onboarding steps 1-4
+
+- **WHEN** the user is at onboarding steps 1 through 4
+- **THEN** the dashboard signup banner SHALL NOT be rendered
+
+#### Scenario: Banner not shown for authenticated users on dashboard
+
+- **WHEN** an authenticated user views the Dashboard
+- **THEN** the signup banner SHALL NOT be rendered
+
+### Requirement: Shared Banner Component
+
+The signup prompt banner SHALL be implemented as a shared component reusable across pages.
+
+#### Scenario: Component renders consistently
+
+- **WHEN** the signup-prompt-banner component is used on different pages
+- **THEN** the visual style SHALL be consistent (same padding, typography, button style)
+- **AND** the component SHALL accept a `message` attribute for page-specific copy
+- **AND** the component SHALL be part of the scroll content (not sticky/fixed)

--- a/openspec/changes/archive/2026-03-13-improve-onboarding-hype-ux/tasks.md
+++ b/openspec/changes/archive/2026-03-13-improve-onboarding-hype-ux/tasks.md
@@ -1,0 +1,55 @@
+## 1. Backend: Default Hype Change
+
+- [x] 1.1 Change default hype from HOME to WATCH in FollowArtist handler
+- [x] 1.2 Update unit tests for FollowArtist to assert WATCH default
+
+## 2. Frontend: Hype Inline Slider Component
+
+- [x] 2.1 Create `hype-inline-slider` component with 4-stop dot slider (track, dots, active dot with artist-color glow)
+- [x] 2.2 Implement hype-tier CSS effects on active dot (WATCH/HOME/NEARBY/AWAY glow matching passion-level card styles)
+- [x] 2.3 Add 44×44px tap target areas and 200ms slide transition animation
+- [x] 2.4 Add `prefers-reduced-motion` support (disable pulse/gradient animations)
+- [x] 2.5 Wire authenticated tap handler: optimistic update + SetHype RPC + rollback on failure
+- [x] 2.6 Wire unauthenticated tap handler: dispatch `hype-signup-prompt` event, block slider movement
+
+## 3. Frontend: My Artists Page Redesign
+
+- [x] 3.1 Add sticky header with hype legend (👀🔥🔥🔥🔥🔥🔥🔥 + emotion labels), `position: sticky`, `backdrop-filter: blur`, `[data-hype-header]` attribute
+- [x] 3.2 Refactor artist list row: single-line layout with name (flex-shrink, ellipsis) + inline slider (flex-grow)
+- [x] 3.3 Align slider dot positions with header legend columns via shared CSS Grid template
+- [x] 3.4 Remove bottom sheet passion level selector from list view
+- [x] 3.5 Update emotion-based tier labels in HYPE_META (チェック/地元/近くも/どこでも！)
+
+## 4. Frontend: Notification Dialog
+
+- [x] 4.1 Create notification dialog component (single-page: hype tier → notification scope mapping + signup CTA + "あとで" button)
+- [x] 4.2 Handle `hype-signup-prompt` event on My Artists page to show notification dialog
+- [x] 4.3 Implement "アカウント作成" button: initiate Zitadel OIDC Passkey flow, trigger guest data merge on success
+- [x] 4.4 Implement "あとで" button: close dialog, show inline signup banner
+- [x] 4.5 Add once-per-session guard (dialog not shown again after "あとで" dismissal)
+
+## 5. Frontend: Signup Prompt Banner
+
+- [x] 5.1 Create shared `signup-prompt-banner` component with configurable message and signup CTA
+- [x] 5.2 Add banner to My Artists page (after last artist row, within scroll content)
+- [x] 5.3 Add banner to Dashboard page (after lane grid, within scroll content)
+- [x] 5.4 Add conditional rendering: show only when unauthenticated and onboarding completed or dialog dismissed
+- [x] 5.5 Auto-remove banner when isAuthenticated becomes true
+
+## 6. Frontend: Onboarding Flow Updates
+
+- [x] 6.1 Update Step 5 coachmark: target `[data-hype-header]`, message "絶対に見逃したくないアーティストの熱量を上げておこう"
+- [x] 6.2 Change Step 5 coachmark dismissal to advance directly to Step 7 (COMPLETED)
+- [x] 6.3 Remove Step 6 signup modal component and its entrance animation CSS
+- [x] 6.4 Remove passion explanation dialog and 800ms delay timer
+- [x] 6.5 Add backward compatibility: if onboardingStep=6 found in localStorage, advance to 7
+- [x] 6.6 Remove Step 5 → Step 6 transition logic from OnboardingService
+
+## 7. Testing
+
+- [x] 7.1 Unit test: hype-inline-slider authenticated tap (optimistic update + RPC)
+- [x] 7.2 Unit test: hype-inline-slider unauthenticated tap (event dispatch, no slider movement)
+- [x] 7.3 Unit test: notification dialog once-per-session guard
+- [x] 7.4 Unit test: signup-prompt-banner conditional rendering
+- [x] 7.5 Unit test: onboarding Step 5 → Step 7 progression (skip Step 6)
+- [x] 7.6 Unit test: backward compat for onboardingStep=6 in localStorage

--- a/openspec/specs/frontend-onboarding-flow/spec.md
+++ b/openspec/specs/frontend-onboarding-flow/spec.md
@@ -1,8 +1,8 @@
-## MODIFIED Requirements
+## Requirements
 
 ### Requirement: Landing Page with Authentication
 
-The system SHALL provide a landing page that communicates the service value proposition and provides entry points for both new users (tutorial) and returning users (direct login). Authentication is no longer required at the landing page; new users enter a guest tutorial flow.
+The system SHALL provide a landing page that communicates the service value proposition and provides entry points for both new users (tutorial) and returning users (direct login). Authentication is no longer required at the landing page; new users enter a guest tutorial flow. The tutorial completes at Step 5 (My Artists) with signup prompted via notification dialog and inline banners.
 
 #### Scenario: First-time user visits landing page
 
@@ -108,3 +108,8 @@ The system SHALL provide an engaging, gamified interface for users to discover a
 - **THEN** concert data MAY already be available from the fire-and-forget `SearchNewConcerts` calls triggered during artist follows in Discovery
 - **AND** the Dashboard SHALL display its own loading skeleton / promise states for any data still pending
 - **AND** the system SHALL NOT rely on a loading screen to mask data fetching
+
+### Requirement: Step 6 - SignUp modal display (REMOVED)
+
+**Reason**: The forced signup modal at Step 6 is removed. Onboarding completes at Step 5 (coachmark dismissal). Signup is prompted via optional notification dialog and persistent inline banners on My Artists and Dashboard pages.
+**Migration**: Remove Step 6 modal rendering from the onboarding flow. If `onboardingStep=6` is found in localStorage, advance to 7 (COMPLETED). Signup CTA is now in the notification dialog and `signup-prompt-banner` component.

--- a/openspec/specs/hype-inline-slider/spec.md
+++ b/openspec/specs/hype-inline-slider/spec.md
@@ -1,0 +1,74 @@
+# Capability: Hype Inline Slider
+
+## Purpose
+
+Provide a 1-tap inline slider for setting hype level per artist in the My Artists list view, with a sticky header legend and artist-color glow on the active dot.
+
+## Requirements
+
+### Requirement: Sticky Header Legend
+
+The My Artists list view SHALL display a sticky header row showing hype tier icons and emotion-based labels, aligned with slider stop positions.
+
+#### Scenario: Header renders with 4 columns
+
+- **WHEN** the My Artists page renders in list view
+- **THEN** the system SHALL display a sticky header row below the page title
+- **AND** the header SHALL contain 4 equally-spaced columns: 👀 チェック, 🔥 地元, 🔥🔥 近くも, 🔥🔥🔥 どこでも！
+- **AND** the header SHALL use `position: sticky; top: 0` with `backdrop-filter: blur(8px)` on the surface-raised background
+- **AND** each column SHALL vertically align with the corresponding dot stop on artist row sliders
+
+#### Scenario: Header remains visible during scroll
+
+- **WHEN** the user scrolls the artist list
+- **THEN** the sticky header SHALL remain visible at the top of the scroll container
+- **AND** the header SHALL have a `[data-hype-header]` attribute for coach mark targeting
+
+### Requirement: Inline Dot Slider
+
+Each artist row in the My Artists list view SHALL include a 4-stop discrete dot slider for hype level selection, enabling 1-tap changes without opening a bottom sheet.
+
+#### Scenario: Slider renders on each artist row
+
+- **WHEN** an artist row renders in list view
+- **THEN** the row SHALL display the artist name (left-aligned, truncated with ellipsis) and the dot slider (right-aligned) on the same row
+- **AND** the slider SHALL display 4 dot stops connected by a 2px track line
+- **AND** the active dot SHALL be 14px diameter; inactive dots SHALL be 8px diameter
+- **AND** each dot SHALL have a minimum 44×44px transparent tap target area
+
+#### Scenario: Active dot reflects hype tier CSS effects
+
+- **WHEN** the slider renders with a specific hype level selected
+- **THEN** the active dot SHALL apply the same CSS glow effects as defined in the passion-level card styling spec:
+  - WATCH: `1px solid white/10` border, no glow
+  - HOME: artist-color border at 40% opacity, `box-shadow: 0 0 8px` at 30% opacity
+  - NEARBY: artist-color `2px solid` border, `box-shadow: 0 0 16px` at 50% opacity, gentle pulse animation
+  - AWAY: animated gradient border, layered glow (`0 0 24px` at 60% + `0 0 48px` at 20%), strong pulse animation
+- **AND** the artist color SHALL be derived from the existing deterministic color generator
+
+#### Scenario: Reduced motion preference
+
+- **WHEN** the user has `prefers-reduced-motion: reduce` enabled
+- **THEN** all pulse and gradient rotation animations on active dots SHALL be disabled
+- **AND** static border and glow styles SHALL remain visible
+
+#### Scenario: Authenticated user taps a dot
+
+- **WHEN** an authenticated user taps an inactive dot on a slider
+- **THEN** the active dot SHALL animate to the tapped position (200ms ease-out transition)
+- **AND** the system SHALL optimistically update the UI
+- **AND** the system SHALL call `SetHype` RPC with the new hype level
+- **AND** if the RPC fails, the slider SHALL revert to the previous position
+
+#### Scenario: Unauthenticated user taps a dot
+
+- **WHEN** an unauthenticated user taps any dot on a slider
+- **THEN** the slider SHALL NOT move
+- **AND** the system SHALL dispatch a `hype-signup-prompt` custom event
+- **AND** the My Artists page SHALL handle this event by displaying the notification dialog (see `onboarding-tutorial` spec)
+
+#### Scenario: Slider dot positions align with header columns
+
+- **WHEN** the page renders
+- **THEN** the 4 slider dot stops SHALL be positioned to vertically align with the 4 header legend columns
+- **AND** alignment SHALL be maintained across viewport widths (CSS Grid shared column template)

--- a/openspec/specs/my-artists/spec.md
+++ b/openspec/specs/my-artists/spec.md
@@ -8,26 +8,30 @@ Display and manage the user's followed artists, providing list and grid views wi
 
 ### Requirement: Artist List Row
 
-Each artist row in the My Artists list view SHALL display the artist's name, color accent, and passion level indicator.
+Each artist row in the My Artists list view SHALL display the artist's name and an inline hype dot slider on the same row.
 
-#### Scenario: Passion level indicator displayed
+#### Scenario: Artist row layout
 
-- **GIVEN** the My Artists list view
-- **WHEN** an artist row is rendered
-- **THEN** a passion level icon SHALL appear next to the artist name
+- **WHEN** an artist row is rendered in list view
+- **THEN** the row SHALL display the artist name (left) and inline dot slider (right) on the same horizontal line
+- **AND** the artist name SHALL truncate with ellipsis if it exceeds available space
+- **AND** the row SHALL have a minimum height of 44px
 
-#### Scenario: Tapping passion icon opens selector
+#### Scenario: Hype slider replaces passion icon
 
-- **GIVEN** an artist row with a passion level icon
-- **WHEN** the user taps the icon
-- **THEN** a bottom sheet SHALL appear with all three passion level options
+- **WHEN** the My Artists list view renders
+- **THEN** the system SHALL display the inline dot slider (from `hype-inline-slider` capability) instead of the passion level icon
+- **AND** the bottom sheet selector SHALL NOT be used for hype changes in list view
 
-#### Scenario: Selecting a passion level
+### Requirement: Tapping passion icon opens selector (REMOVED)
 
-- **GIVEN** the passion level bottom sheet is open
-- **WHEN** the user selects a level
-- **THEN** the UI SHALL update optimistically and call SetPassionLevel RPC
-- **AND** if the RPC fails, the UI SHALL roll back to the previous level
+**Reason**: Replaced by inline dot slider that enables 1-tap hype changes directly in the list row. The bottom sheet selector required 2 taps and interrupted the scanning flow.
+**Migration**: Remove bottom sheet component usage from My Artists list view. Hype changes are handled by the inline dot slider component. The bottom sheet MAY be retained for Grid (Festival) view's long-press context menu.
+
+### Requirement: Selecting a passion level (REMOVED)
+
+**Reason**: The bottom sheet selection flow is replaced by inline dot slider interaction. Optimistic update and RPC call behavior moves to the slider component.
+**Migration**: Optimistic update and SetHype RPC logic moves to the `hype-inline-slider` component's authenticated tap handler.
 
 ### Requirement: View Toggle (List / Grid)
 

--- a/openspec/specs/my-artists/spec.md
+++ b/openspec/specs/my-artists/spec.md
@@ -47,16 +47,16 @@ The My Artists page SHALL offer a view toggle between List view (default) and Gr
 
 The Grid view SHALL display followed artists as poster-style tiles in a responsive grid layout.
 
-#### Scenario: Must Go tiles are larger
+#### Scenario: Away tiles are larger
 
 - **GIVEN** the Grid view is active
-- **WHEN** an artist has passion level Must Go
+- **WHEN** an artist has hype level Away (HYPE_TYPE_AWAY)
 - **THEN** their tile SHALL span 2 columns and 2 rows
 
-#### Scenario: Non-Must-Go tiles are standard size
+#### Scenario: Non-Away tiles are standard size
 
 - **GIVEN** the Grid view is active
-- **WHEN** an artist has passion level Local Only or Keep an Eye
+- **WHEN** an artist has hype level Watch, Home, or Nearby
 - **THEN** their tile SHALL span 1 column and 1 row
 
 #### Scenario: Long-press opens context menu

--- a/openspec/specs/onboarding-tutorial/spec.md
+++ b/openspec/specs/onboarding-tutorial/spec.md
@@ -6,7 +6,7 @@ Defines the linear onboarding tutorial flow that guides new users through artist
 ## Requirements
 ### Requirement: Onboarding Step State Management
 
-The system SHALL maintain an `onboardingStep` numeric value in LocalStorage under the key `liverty:onboardingStep` to track the user's progress through the linear tutorial. Valid values are 0-6 (in-progress) and 7 (COMPLETED).
+The system SHALL maintain an `onboardingStep` numeric value in LocalStorage under the key `liverty:onboardingStep` to track the user's progress through the linear tutorial. Valid values are 0-5 (in-progress), 6 (legacy: immediately migrated to 7), and 7 (COMPLETED).
 
 #### Scenario: Initial state for new visitor
 
@@ -223,20 +223,20 @@ The system SHALL treat `isAuthenticated = true` as an unconditional override of 
 
 ---
 
-### Requirement: No Permission Prompts During Onboarding Steps 1-6
+### Requirement: No Permission Prompts During Onboarding Steps 1-5
 
-The system SHALL suppress all permission prompts (PWA install banner, push notification opt-in) while the user is progressing through onboarding Steps 1-6. Permission prompts are deferred until after Step 7 (COMPLETED).
+The system SHALL suppress all permission prompts (PWA install banner, push notification opt-in) while the user is progressing through onboarding Steps 1-5. Permission prompts are deferred until after Step 7 (COMPLETED).
 
 #### Scenario: PWA install suppressed during tutorial
 
-- **WHEN** the user is at any onboarding step between 1 and 6
+- **WHEN** the user is at any onboarding step between 1 and 5
 - **AND** the browser fires the `beforeinstallprompt` event
 - **THEN** the system SHALL capture the event for later use
 - **BUT** the system SHALL NOT display the PWA install banner
 
 #### Scenario: Notification prompt suppressed during tutorial
 
-- **WHEN** the user is at any onboarding step between 1 and 6
+- **WHEN** the user is at any onboarding step between 1 and 5
 - **THEN** the system SHALL NOT render or evaluate the notification prompt component
 
 #### Scenario: Prompts become eligible after completion

--- a/openspec/specs/onboarding-tutorial/spec.md
+++ b/openspec/specs/onboarding-tutorial/spec.md
@@ -28,7 +28,7 @@ The system SHALL maintain an `onboardingStep` numeric value in LocalStorage unde
 
 ### Requirement: Linear Step Progression
 
-The system SHALL enforce a strict linear progression through tutorial steps. Users SHALL NOT be able to skip steps or navigate freely during the tutorial.
+The system SHALL enforce a strict linear progression through tutorial steps. Users SHALL NOT be able to skip steps or navigate freely during the tutorial. Step 5 is the final interactive step; Step 6 (forced signup modal) is removed.
 
 #### Scenario: Step 0 - Landing Page entry
 
@@ -94,36 +94,70 @@ The system SHALL enforce a strict linear progression through tutorial steps. Use
 - **THEN** the system SHALL advance `onboardingStep` to 5
 - **AND** navigate to the My Artists screen
 
-#### Scenario: Step 5 - Passion Level guidance
+#### Scenario: Step 5 - Hype Header Coachmark
 
 - **WHEN** a user is at Step 5 (My Artists)
-- **THEN** the system SHALL highlight the Passion Level toggle of the first artist in the list
-- **AND** the system SHALL display a coach mark tooltip: "好きなレベルを設定してみよう！"
+- **THEN** the system SHALL display the sticky hype header legend with `[data-hype-header]` attribute
+- **AND** the system SHALL spotlight the sticky header using the coach mark overlay
+- **AND** the coach mark message SHALL read: "絶対に見逃したくないアーティストの熱量を上げておこう"
 
-#### Scenario: Step 5 - Passion Level changed
+#### Scenario: Step 5 - Coachmark dismissal completes onboarding
 
-See "Requirement: Step 5 Passion Level Explanation Timing" below for the updated behaviour of this scenario.
+- **WHEN** a user is at Step 5
+- **AND** the user taps the coach mark overlay to dismiss it
+- **THEN** the system SHALL advance `onboardingStep` to 7 (COMPLETED)
+- **AND** the system SHALL remove all tutorial UI restrictions (coach marks, spotlight, interaction locks)
+- **AND** the user SHALL have full unrestricted access to the My Artists page
 
-#### Scenario: Step 6 - SignUp modal display
+#### Scenario: Step 5 - Unauthenticated slider tap triggers notification dialog
 
-- **WHEN** a user is at Step 6
-- **THEN** the system SHALL display the Passkey authentication modal
-- **AND** the modal SHALL NOT be dismissible (no close button, no backdrop tap, no escape key)
-- **AND** the modal message SHALL read: "All set! Create an account to save your preferences and never miss a live show."
+- **WHEN** a user is at Step 5 or has completed onboarding (Step >= 7)
+- **AND** the user is unauthenticated
+- **AND** the user taps a hype slider dot
+- **THEN** the system SHALL display the notification dialog (single page)
+- **AND** the dialog SHALL display hype tier → notification scope mapping:
+  - 👀 通知なし
+  - 🔥 地元のライブを通知
+  - 🔥🔥 近くのライブも通知
+  - 🔥🔥🔥 全国のライブを通知
+- **AND** the dialog SHALL display: "通知を受け取るにはアカウント登録が必要です"
+- **AND** the dialog SHALL present two buttons: [アカウント作成] (primary) and [あとで] (ghost)
 
-#### Scenario: Step 6 - Passkey authentication success
+#### Scenario: Notification dialog - アカウント作成
 
-- **WHEN** a user is at Step 6
-- **AND** the user completes Passkey authentication successfully
-- **THEN** the system SHALL trigger the guest data merge process
-- **AND** upon merge completion, set `onboardingStep` to 7 (COMPLETED)
-- **AND** remove all tutorial UI restrictions (coach marks, spotlight, interaction locks)
-- **AND** navigate to the Dashboard with full unrestricted access
+- **WHEN** the user taps [アカウント作成] in the notification dialog
+- **THEN** the system SHALL initiate the Zitadel OIDC Passkey authentication flow
+- **AND** upon successful authentication, the system SHALL trigger the guest data merge process
+- **AND** after merge, hype sliders SHALL become interactive
 
-#### Scenario: Step 6 - Page reload
+#### Scenario: Notification dialog - あとで
 
-- **WHEN** a user reloads the page with `onboardingStep = 6`
-- **THEN** the system SHALL re-display the non-dismissible SignUp modal immediately
+- **WHEN** the user taps [あとで] in the notification dialog
+- **THEN** the dialog SHALL close
+- **AND** the hype slider SHALL remain at the current position (WATCH for all artists)
+- **AND** the inline signup banner SHALL become visible on My Artists and Dashboard pages
+
+#### Scenario: Notification dialog shown once per session
+
+- **WHEN** the user has dismissed the notification dialog with "あとで"
+- **AND** the user taps another slider dot in the same session
+- **THEN** the notification dialog SHALL NOT be shown again
+- **AND** the slider SHALL NOT move (still unauthenticated)
+
+#### Scenario: Step 6 - SignUp modal display (REMOVED)
+
+**Reason**: The non-dismissible signup modal is replaced by the optional notification dialog (triggered by slider tap) and persistent inline signup banners. Users are no longer forced to sign up to complete onboarding.
+**Migration**: Remove the Step 6 signup modal component. Remove the non-dismissible dialog logic. Signup prompts are handled by the notification dialog and `signup-prompt-banner` component. The `OnboardingStep` enum value 6 SHALL be retained for backward compatibility — if a user has `onboardingStep=6` in localStorage from a prior session, the route guard SHALL advance them to Step 7 (COMPLETED).
+
+#### Scenario: Step 6 - Passkey authentication success (REMOVED)
+
+**Reason**: Authentication success handling moves from Step 6 modal to the notification dialog's [アカウント作成] flow. Guest data merge is triggered from the notification dialog instead.
+**Migration**: Move guest data merge trigger to the notification dialog's authentication success callback. The merge logic itself is unchanged.
+
+#### Scenario: Step 6 - Page reload (REMOVED)
+
+**Reason**: Step 6 no longer exists as a distinct step.
+**Migration**: If `onboardingStep=6` is found in localStorage on page load, advance to Step 7 (COMPLETED).
 
 ### Requirement: Coach Mark Overlay System
 
@@ -207,40 +241,21 @@ The system SHALL suppress all permission prompts (PWA install banner, push notif
 
 #### Scenario: Prompts become eligible after completion
 
-- **WHEN** the user completes Step 6 and transitions to Step 7 (COMPLETED)
+- **WHEN** the user completes Step 5 and transitions to Step 7 (COMPLETED)
 - **THEN** permission prompts SHALL become eligible according to the prompt-timing capability rules
 - **AND** the onboarding tutorial SHALL NOT block prompt display after this point
 
 ---
 
-### Requirement: Step 5 Passion Level Explanation Timing
+### Requirement: Step 5 Passion Level Explanation Timing (REMOVED)
 
-The Step 5 passion explanation SHALL provide immediate visual feedback on tap and appear after a shorter delay, replacing the current 3-second silent wait.
-
-#### Scenario: Step 5 - Passion Level changed (MODIFIED)
-
-- **WHEN** a user is at Step 5
-- **AND** the user changes the Passion Level of the highlighted artist
-- **THEN** the passion button SHALL immediately show a brief highlight/pulse animation (scale 1 -> 1.1 -> 1, ~300ms) as visual confirmation that the selection registered
-- **AND** the system SHALL display the passion explanation after an 800ms delay (not 3000ms)
-- **AND** the system SHALL advance `onboardingStep` to 6
+**Reason**: Replaced by the notification dialog triggered on unauthenticated slider tap. The previous flow (change passion level → 800ms delay → explanation dialog → advance to Step 6) is removed. Onboarding now completes at Step 5 coachmark dismissal.
+**Migration**: Remove the passion explanation dialog component. Remove the 800ms delay timer. Step 5 → Step 6 transition is removed; Step 5 coachmark dismissal advances directly to Step 7 (COMPLETED).
 
 ---
 
-### Requirement: Sign-up Modal Entrance Animation
+### Requirement: Sign-up Modal Entrance Animation (REMOVED)
 
-The sign-up modal (Step 6) SHALL animate on entrance to match the visual polish of the onboarding flow.
-
-#### Scenario: Sign-up modal entrance
-
-- **WHEN** the sign-up modal becomes visible (Step 6 activation or page reload at Step 6)
-- **THEN** the modal content panel SHALL animate in with a scale + fade effect (scale 0.95 -> 1, opacity 0 -> 1)
-- **AND** the animation duration SHALL be 400ms with cubic-bezier spring easing
-- **AND** a subtle radial gradient glow SHALL appear behind the modal content using the brand-primary color at low opacity
-
-#### Scenario: Reduced motion preference
-
-- **WHEN** the user has `prefers-reduced-motion: reduce` enabled
-- **THEN** the sign-up modal entrance animation SHALL be skipped
-- **AND** the modal SHALL appear instantly, with both the entrance animation and the `::before` radial gradient glow suppressed (`display: none`; the glow is a static pseudo-element not covered by `animation: none`)
+**Reason**: The sign-up modal (Step 6) is removed entirely.
+**Migration**: Remove sign-up modal entrance animation CSS. The notification dialog uses standard dialog entrance animation.
 

--- a/openspec/specs/passion-level/spec.md
+++ b/openspec/specs/passion-level/spec.md
@@ -45,62 +45,62 @@ The system SHALL prevent unauthenticated users from changing hype levels. Hype s
 - **THEN** the system SHALL call `SetHype` RPC and persist the change on the backend
 - **AND** the UI SHALL update optimistically
 
-### Requirement: Passion Level Persistence
+### Requirement: Hype Level Persistence
 
-The system SHALL persist each user's passion level per followed artist in the backend database, enabling cross-device synchronization.
+The system SHALL persist each user's hype level per followed artist in the backend database, enabling cross-device synchronization.
 
-#### Scenario: Passion level survives session restart
+#### Scenario: Hype level survives session restart
 
-- **GIVEN** a user sets an artist to Must Go
+- **GIVEN** a user sets an artist to Away (どこでも！)
 - **WHEN** the user closes and reopens the app
-- **THEN** the artist SHALL still display as Must Go
+- **THEN** the artist SHALL still display as Away (どこでも！)
 
-### Requirement: SetPassionLevel API
+### Requirement: SetHype API
 
-The system SHALL provide a SetPassionLevel RPC endpoint that accepts an artist ID and a passion level, updating the user's preference for that artist.
+The system SHALL provide a SetHype RPC endpoint that accepts an artist ID and a hype level, updating the user's preference for that artist.
 
 #### Scenario: Successful update
 
 - **GIVEN** an authenticated user who follows an artist
-- **WHEN** the user calls SetPassionLevel with a valid artist ID and passion level
-- **THEN** the system SHALL update the passion level and return success
+- **WHEN** the user calls SetHype with a valid artist ID and hype level
+- **THEN** the system SHALL update the hype level and return success
 
 #### Scenario: Unauthenticated request
 
 - **GIVEN** an unauthenticated request
-- **WHEN** the user calls SetPassionLevel
+- **WHEN** the user calls SetHype
 - **THEN** the system SHALL return an Unauthenticated error
 
 #### Scenario: Invalid artist ID
 
 - **GIVEN** an authenticated user
-- **WHEN** the user calls SetPassionLevel without an artist ID
+- **WHEN** the user calls SetHype without an artist ID
 - **THEN** the system SHALL return an InvalidArgument error
 
-### Requirement: PassionLevel in ListFollowed Response
+### Requirement: HypeLevel in ListFollowed Response
 
-The system SHALL include the user's passion level for each artist in the ListFollowed response, using a FollowedArtist wrapper that contains both the artist entity and the passion level.
+The system SHALL include the user's hype level for each artist in the ListFollowed response, using a FollowedArtist wrapper that contains both the artist entity and the hype level.
 
-#### Scenario: ListFollowed returns passion levels
+#### Scenario: ListFollowed returns hype levels
 
-- **GIVEN** a user follows three artists with different passion levels
+- **GIVEN** a user follows three artists with different hype levels
 - **WHEN** the user calls ListFollowed
-- **THEN** each artist in the response SHALL include its corresponding passion level
+- **THEN** each artist in the response SHALL include its corresponding hype level
 
 ### Requirement: Hype Visual Indicators on Dashboard Cards
 
 The system SHALL visually indicate hype (passion) levels on dashboard event cards using border gradient, glow effects, and neon text-shadow, without consuming additional card space.
 
-#### Scenario: WATCH (Keep an Eye) card styling
+#### Scenario: WATCH card styling
 
-- **WHEN** an event card is rendered for an artist with Keep an Eye hype level
+- **WHEN** an event card is rendered for an artist with Watch hype level
 - **THEN** the card SHALL have a `1px solid` border at `white/10` opacity
 - **AND** the card SHALL NOT have glow or text-shadow effects
 - **AND** no emoji badge SHALL be displayed
 
-#### Scenario: HOME (Local Only) card styling
+#### Scenario: HOME card styling
 
-- **WHEN** an event card is rendered for an artist with Local Only hype level
+- **WHEN** an event card is rendered for an artist with Home hype level
 - **THEN** the card SHALL have a `1px solid` border using the artist's color at 40% opacity
 - **AND** the card SHALL have a subtle `box-shadow: 0 0 8px` glow using the artist's color at 30% opacity
 - **AND** the artist name SHALL have a subtle `text-shadow: 0 0 4px` using the artist's color at 30% opacity
@@ -115,9 +115,9 @@ The system SHALL visually indicate hype (passion) levels on dashboard event card
 - **AND** the glow SHALL animate with a gentle pulse (2-second cycle)
 - **AND** no emoji badge SHALL be displayed
 
-#### Scenario: AWAY (Must Go) card styling
+#### Scenario: AWAY card styling
 
-- **WHEN** an event card is rendered for an artist with Must Go (Away) hype level
+- **WHEN** an event card is rendered for an artist with Away hype level
 - **THEN** the card SHALL have a `2px` animated gradient border (conic-gradient rotation)
 - **AND** the card SHALL have a layered glow: `box-shadow: 0 0 24px` at 60% opacity and `0 0 48px` at 20% opacity
 - **AND** the artist name SHALL have a strong neon `text-shadow: 0 0 12px` and `0 0 24px` at 40% opacity

--- a/openspec/specs/passion-level/spec.md
+++ b/openspec/specs/passion-level/spec.md
@@ -8,19 +8,42 @@ Allow users to express different levels of enthusiasm for followed artists, infl
 
 ### Requirement: Passion Level Tiers
 
-The system SHALL support three passion level tiers for each followed artist:
+The system SHALL support four hype level tiers for each followed artist, with emotion-based UI labels:
 
-| Tier | Icon | Meaning |
-|------|------|---------|
-| Must Go | fire fire | User will travel anywhere for this artist |
-| Local Only | fire | Default tier; events shown normally |
-| Keep an Eye | eyes | Display on Dashboard but exclude from push notifications |
+| Tier | Proto Value | Emoji | UI Label (ja) | UI Label (en) | Notification Scope |
+|------|-------------|-------|----------------|----------------|-------------------|
+| Watch | HYPE_TYPE_WATCH | 👀 | チェック | Just checking | None |
+| Home | HYPE_TYPE_HOME | 🔥 | 地元 | Local shows | Home area only |
+| Nearby | HYPE_TYPE_NEARBY | 🔥🔥 | 近くも | Nearby too | Within 200km (Phase 2) |
+| Away | HYPE_TYPE_AWAY | 🔥🔥🔥 | どこでも！ | Anywhere! | All concerts |
 
-#### Scenario: Default passion level on follow
+#### Scenario: Default hype level on follow
 
-- **GIVEN** a user follows a new artist
-- **WHEN** the follow relationship is created
-- **THEN** the passion level SHALL default to Local Only
+- **WHEN** a user follows a new artist
+- **AND** the follow relationship is created
+- **THEN** the hype level SHALL default to Watch (HYPE_TYPE_WATCH)
+
+#### Scenario: UI labels use emotion-based phrasing
+
+- **WHEN** hype level labels are displayed in the UI (slider header, dialogs, settings)
+- **THEN** the system SHALL use emotion-based labels (チェック/地元/近くも/どこでも！) instead of proximity-based labels (Watch/Home/NearBy/Away)
+
+### Requirement: Hype Changes Require Authentication
+
+The system SHALL prevent unauthenticated users from changing hype levels. Hype state SHALL NOT be persisted in localStorage.
+
+#### Scenario: Unauthenticated user attempts hype change
+
+- **WHEN** an unauthenticated user attempts to change a hype level (via slider tap or any UI control)
+- **THEN** the system SHALL NOT update the hype level
+- **AND** the system SHALL trigger a signup prompt flow
+- **AND** no hype value SHALL be written to localStorage
+
+#### Scenario: Authenticated user changes hype
+
+- **WHEN** an authenticated user changes a hype level
+- **THEN** the system SHALL call `SetHype` RPC and persist the change on the backend
+- **AND** the UI SHALL update optimistically
 
 ### Requirement: Passion Level Persistence
 

--- a/openspec/specs/signup-prompt-banner/spec.md
+++ b/openspec/specs/signup-prompt-banner/spec.md
@@ -1,0 +1,62 @@
+# Capability: Signup Prompt Banner
+
+## Purpose
+
+Provide a persistent inline banner on My Artists and Dashboard pages prompting unauthenticated users to create an account, dismissed automatically on signup completion.
+
+## Requirements
+
+### Requirement: Inline Signup Banner on My Artists
+
+The My Artists page SHALL display a persistent inline banner at the end of the artist list prompting unauthenticated users to sign up.
+
+#### Scenario: Banner appears for unauthenticated users
+
+- **WHEN** an unauthenticated user views the My Artists page
+- **AND** the user has dismissed the notification dialog with "あとで" (or has completed onboarding without signup)
+- **THEN** the system SHALL display an inline banner after the last artist row
+- **AND** the banner SHALL display: "🔔 通知を有効にするには [アカウント作成]"
+- **AND** the [アカウント作成] button SHALL initiate the Zitadel OIDC Passkey flow
+
+#### Scenario: Banner not shown for authenticated users
+
+- **WHEN** an authenticated user views the My Artists page
+- **THEN** the signup banner SHALL NOT be rendered
+
+#### Scenario: Banner disappears after signup
+
+- **WHEN** the user completes signup (isAuthenticated becomes true)
+- **THEN** the signup banner SHALL be removed from the DOM
+
+### Requirement: Inline Signup Banner on Dashboard
+
+The Dashboard page SHALL display a persistent inline banner prompting unauthenticated users to sign up.
+
+#### Scenario: Banner appears on dashboard for unauthenticated users
+
+- **WHEN** an unauthenticated user views the Dashboard
+- **AND** the user has completed onboarding (onboardingStep >= 7) or has dismissed the notification dialog
+- **THEN** the system SHALL display an inline banner after the lane grid content
+- **AND** the banner SHALL display: "🔔 ライブ通知を受け取ろう [アカウント作成]"
+- **AND** the [アカウント作成] button SHALL initiate the Zitadel OIDC Passkey flow
+
+#### Scenario: Banner not shown during onboarding steps 1-4
+
+- **WHEN** the user is at onboarding steps 1 through 4
+- **THEN** the dashboard signup banner SHALL NOT be rendered
+
+#### Scenario: Banner not shown for authenticated users on dashboard
+
+- **WHEN** an authenticated user views the Dashboard
+- **THEN** the signup banner SHALL NOT be rendered
+
+### Requirement: Shared Banner Component
+
+The signup prompt banner SHALL be implemented as a shared component reusable across pages.
+
+#### Scenario: Component renders consistently
+
+- **WHEN** the signup-prompt-banner component is used on different pages
+- **THEN** the visual style SHALL be consistent (same padding, typography, button style)
+- **AND** the component SHALL accept a `message` attribute for page-specific copy
+- **AND** the component SHALL be part of the scroll content (not sticky/fixed)


### PR DESCRIPTION
## 🔗 Related Issue

Closes #216

## 📝 Summary of Changes

Archive the `improve-onboarding-hype-ux` OpenSpec change and sync updated capability specs to main.

**New specs:**
- `hype-inline-slider` — 4-stop inline dot slider for hype level in My Artists
- `signup-prompt-banner` — persistent inline banner prompting signup for guests

**Updated specs:**
- `my-artists` — inline slider replaces bottom sheet selector
- `passion-level` — 4 emotion-based tiers, default Watch, auth required
- `onboarding-tutorial` — Step 5 hype coachmark, Step 6 removed
- `frontend-onboarding-flow` — removed forced signup modal

## ✅ Self-Checklist

- [x] I have linked the related issue.
- [x] I have updated the relevant documentation (e.g., `README.md`) if needed.
- [x] I have run `buf lint` and `buf format` locally and all checks have passed.
- [x] My proto definitions follow the project's style guidelines and validation rules.
- [x] Breaking changes have been justified and documented if applicable.