### PR TITLE
docs(openspec): archive fix-keda-argocd-replicas-conflict change

### DIFF
--- a/openspec/changes/archive/2026-03-13-fix-keda-argocd-replicas-conflict/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-13-fix-keda-argocd-replicas-conflict/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-13

--- a/openspec/changes/archive/2026-03-13-fix-keda-argocd-replicas-conflict/design.md
+++ b/openspec/changes/archive/2026-03-13-fix-keda-argocd-replicas-conflict/design.md
@@ -1,0 +1,50 @@
+## Context
+
+The `backend` ArgoCD Application manages the `consumer-app` Deployment with `replicas: 1` in the Kustomize base manifest. KEDA ScaledObject targets the same Deployment with `minReplicaCount: 0`, scaling to zero when the NATS JetStream trigger is inactive. ArgoCD's `selfHeal: true` continuously restores `replicas: 1`, creating an infinite reconciliation loop.
+
+Current state:
+- `k8s/namespaces/backend/base/consumer/deployment.yaml`: `spec.replicas: 1`
+- ScaledObject: `minReplicaCount: 0`, `cooldownPeriod: 300`
+- ArgoCD: `automated.selfHeal: true`
+- Observed: Deployment generation 8871+, selfHealAttempts 38+
+
+## Goals / Non-Goals
+
+**Goals:**
+- Eliminate the ArgoCD ↔ KEDA reconciliation loop for `consumer-app`
+- Let KEDA have sole ownership of `replicas` for Deployments managed by ScaledObjects
+
+**Non-Goals:**
+- Changing KEDA scaling parameters (min/max replicas, triggers)
+- Modifying ArgoCD sync policy globally
+
+## Decisions
+
+### 1. Remove `replicas` from Deployment manifest
+
+Remove `spec.replicas` from `consumer/deployment.yaml`. When omitted, Kubernetes defaults to `1` on first creation, and KEDA immediately takes over via HPA. This is the [recommended pattern from KEDA docs](https://keda.sh/docs/2.16/concepts/scaling-deployments/#details).
+
+**Alternative considered**: Set `replicas: 0` in manifest. Rejected because it would cause a brief outage on every ArgoCD sync before KEDA scales up.
+
+### 2. Add `ignoreDifferences` for replicas on backend Application
+
+Add `ignoreDifferences` to the `backend` ArgoCD Application spec as a defense-in-depth measure:
+
+```yaml
+spec:
+  ignoreDifferences:
+  - group: apps
+    kind: Deployment
+    name: consumer-app
+    jsonPointers:
+    - /spec/replicas
+```
+
+This ensures ArgoCD never considers `replicas` drift as OutOfSync, even if someone accidentally re-adds `replicas` to the manifest.
+
+**Where to configure**: In the root-app Application definition in `cloud-provisioning` that generates the `backend` Application, or directly on the Application resource.
+
+## Risks / Trade-offs
+
+- **[Risk] KEDA removed without replicas field** → Kubernetes defaults to `1` replica; KEDA also stores `originalReplicaCount: 1` and restores it on ScaledObject deletion. Low risk.
+- **[Risk] ignoreDifferences too broad** → Scoped to `consumer-app` Deployment only, not all Deployments. Acceptable.

--- a/openspec/changes/archive/2026-03-13-fix-keda-argocd-replicas-conflict/proposal.md
+++ b/openspec/changes/archive/2026-03-13-fix-keda-argocd-replicas-conflict/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+KEDA ScaledObject (`minReplicaCount: 0`) and ArgoCD auto-sync (`selfHeal: true`) are fighting over the `consumer-app` Deployment's `replicas` field. The Deployment manifest hardcodes `replicas: 1`, but KEDA scales it to `0` when idle. ArgoCD detects the drift and syncs it back to `1`, KEDA immediately scales down again — creating an infinite loop (generation: 8871, selfHealAttempts: 38+). Image Updater exacerbates this by updating annotations every minute.
+
+## What Changes
+
+- Remove `replicas` field from `consumer-app` Deployment manifest so KEDA has sole ownership of replica count
+- Add `ignoreDifferences` for `spec.replicas` on the `backend` ArgoCD Application as a safety net
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+(none — this is an infrastructure configuration fix, no spec-level behavior changes)
+
+## Impact
+
+- **cloud-provisioning**: `k8s/namespaces/backend/base/consumer/deployment.yaml` — remove `replicas: 1`
+- **cloud-provisioning**: ArgoCD Application definition for `backend` — add `ignoreDifferences` for Deployment replicas
+- **Risk**: Minimal. KEDA already records `originalReplicaCount: 1` and restores it if the ScaledObject is deleted

--- a/openspec/changes/archive/2026-03-13-fix-keda-argocd-replicas-conflict/specs/infra/spec.md
+++ b/openspec/changes/archive/2026-03-13-fix-keda-argocd-replicas-conflict/specs/infra/spec.md
@@ -1,0 +1,17 @@
+## ADDED Requirements
+
+### Requirement: KEDA-managed Deployments SHALL NOT declare replicas
+
+Deployments targeted by a KEDA ScaledObject SHALL omit `spec.replicas` from their Kustomize base manifest, delegating replica count management entirely to KEDA.
+
+#### Scenario: Consumer Deployment with no replicas field
+- **WHEN** the `consumer-app` Deployment manifest is rendered by Kustomize
+- **THEN** the output SHALL NOT contain `spec.replicas`
+
+### Requirement: ArgoCD SHALL ignore replicas drift for KEDA-managed Deployments
+
+The ArgoCD Application for the `backend` namespace SHALL include `ignoreDifferences` for `spec.replicas` on Deployments managed by KEDA ScaledObjects.
+
+#### Scenario: KEDA scales consumer to zero
+- **WHEN** KEDA scales `consumer-app` to 0 replicas due to no active triggers
+- **THEN** ArgoCD SHALL NOT report the Deployment as OutOfSync

--- a/openspec/changes/archive/2026-03-13-fix-keda-argocd-replicas-conflict/tasks.md
+++ b/openspec/changes/archive/2026-03-13-fix-keda-argocd-replicas-conflict/tasks.md
@@ -1,0 +1,15 @@
+## 1. Fix Deployment Manifest
+
+- [x] 1.1 Remove `replicas: 1` from `k8s/namespaces/backend/base/consumer/deployment.yaml`
+- [x] 1.2 Run `make lint-k8s` to validate the manifest renders correctly without replicas
+
+## 2. Add ignoreDifferences to ArgoCD Application
+
+- [x] 2.1 Add `ignoreDifferences` for `spec.replicas` on `consumer-app` Deployment to the `backend` ArgoCD Application definition
+- [x] 2.2 Run `make lint` to validate all changes
+
+## 3. Deploy and Verify
+
+- [x] 3.1 Create PR to cloud-provisioning
+- [x] 3.2 Merge PR and verify ArgoCD syncs to Synced/Healthy
+- [x] 3.3 Confirm the OutOfSync loop has stopped (generation count stable, no selfHeal attempts)

--- a/openspec/specs/infra/spec.md
+++ b/openspec/specs/infra/spec.md
@@ -1,0 +1,15 @@
+### Requirement: KEDA-managed Deployments SHALL NOT declare replicas
+
+Deployments targeted by a KEDA ScaledObject SHALL omit `spec.replicas` from their Kustomize base manifest, delegating replica count management entirely to KEDA.
+
+#### Scenario: Consumer Deployment with no replicas field
+- **WHEN** the `consumer-app` Deployment manifest is rendered by Kustomize
+- **THEN** the output SHALL NOT contain `spec.replicas`
+
+### Requirement: ArgoCD SHALL ignore replicas drift for KEDA-managed Deployments
+
+The ArgoCD Application for the `backend` namespace SHALL include `ignoreDifferences` for `spec.replicas` on Deployments managed by KEDA ScaledObjects.
+
+#### Scenario: KEDA scales consumer to zero
+- **WHEN** KEDA scales `consumer-app` to 0 replicas due to no active triggers
+- **THEN** ArgoCD SHALL NOT report the Deployment as OutOfSync


### PR DESCRIPTION
## 🔗 Related Issue

Closes liverty-music/cloud-provisioning#148

## 📝 Summary of Changes

Archive the completed `fix-keda-argocd-replicas-conflict` OpenSpec change and add `openspec/specs/infra/spec.md` defining requirements for KEDA-managed Deployment replicas ownership and ArgoCD `ignoreDifferences` configuration.

No proto changes — OpenSpec documentation only.

## ✅ Self-Checklist

- [x] I have linked the related issue.
- [x] I have updated the relevant documentation (e.g., `README.md`) if needed.
- [x] I have run `buf lint` and `buf format` locally and all checks have passed.
- [x] My proto definitions follow the project's style guidelines and validation rules.
- [x] Breaking changes have been justified and documented if applicable.
