### PR TITLE
docs(openspec): update task progress and archive stale change

### DIFF
--- a/openspec/changes/archive/2026-03-06-fix-gemini-concert-search-errors/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-06-fix-gemini-concert-search-errors/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-06

--- a/openspec/changes/archive/2026-03-06-fix-gemini-concert-search-errors/design.md
+++ b/openspec/changes/archive/2026-03-06-fix-gemini-concert-search-errors/design.md
@@ -1,0 +1,55 @@
+## Context
+
+The `ConcertSearcher.Search()` method in `internal/infrastructure/gcp/gemini/searcher.go` calls Gemini with Google Search grounding to discover concerts for an artist. Two bugs exist:
+
+1. When Gemini's response exceeds `maxOutputTokens` (8192), `FinishReason` is `MAX_TOKENS` and the JSON is truncated. The code proceeds to `json.Unmarshal` which fails. This affects ~20% of artists per batch (those with extensive tour schedules).
+2. The schema declares `start_time`/`open_time` as `TypeString` but instructs "Return null if unknown." Since `TypeString` cannot represent JSON `null`, Gemini returns the literal string `"null"`, which fails `time.Parse(RFC3339, "null")`.
+
+The caller (`concert_uc.go:executeSearch`) marks the search as failed and the CronJob retries on the next run, so no data is permanently lost — but the retry also hits the same token limit.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Eliminate `unexpected end of JSON input` errors by detecting truncated responses before parsing
+- Reduce truncation frequency by increasing token headroom
+- Eliminate noisy WARN logs from `"null"` string parse failures
+- Add test coverage for both scenarios
+
+**Non-Goals:**
+- Best-effort JSON repair for truncated responses (fragile, risks malformed event data)
+- Streaming responses to avoid token limits (architectural change, overkill for this fix)
+- Changing the Gemini model or switching to structured output mode
+
+## Decisions
+
+### 1. Detect MAX_TOKENS and return error (not attempt repair)
+
+**Decision**: Check `candidate.FinishReason == genai.FinishReasonMaxTokens` after receiving the response and before calling `parseEvents()`. Return an explicit error.
+
+**Alternatives considered**:
+- **Best-effort JSON repair**: Find the last complete JSON object in the truncated response and parse partial results. Rejected because truncation can occur mid-field (e.g., mid-URL or mid-date), producing invalid event data that propagates downstream.
+- **Silent skip (return nil, nil)**: Treat as "no concerts found." Rejected because it silently drops real data and the caller would mark it as `completed`, preventing retry.
+
+**Rationale**: Returning an error causes `markSearchFailed()`, which allows the CronJob to retry. Combined with the increased token limit, retries are unlikely to hit the same issue.
+
+### 2. Increase maxOutputTokens from 8192 to 16384
+
+**Decision**: Double the output token limit. Based on log analysis, the largest successful response used ~2,172 candidate tokens. Truncated responses were cut at ~1,566 tokens (the limit applies to total including tool_use tokens). 16384 provides sufficient headroom.
+
+**Alternatives considered**:
+- **32768 or higher**: Unnecessary — no observed response would require this. Can be revisited if 16384 proves insufficient.
+- **Keep 8192**: The error detection alone doesn't solve the problem; artists would fail on every retry.
+
+### 3. Fix schema description + add "null" guard
+
+**Decision**: Two-pronged fix:
+1. Change schema description from "Return null if unknown" to "Return empty string if unknown"
+2. Add `*ev.StartTime != "null"` guard in parse logic
+
+Both changes are needed because Gemini's output is non-deterministic — even with the updated description, previously-cached or edge-case responses may still produce `"null"`.
+
+## Risks / Trade-offs
+
+- **[Risk] 16384 tokens still insufficient for some artists** → Mitigation: The MAX_TOKENS detection returns a clear error and the search is retried. If this becomes frequent, the limit can be increased further with negligible cost impact (~$0.004/call difference).
+- **[Risk] Schema description change affects Gemini behavior for other fields** → Mitigation: The change is scoped to `start_time` and `open_time` only. `admin_area` already uses "Return empty string if uncertain" and works correctly.
+- **[Trade-off] Error on MAX_TOKENS means zero concerts for that artist on that run** → Acceptable because the CronJob retries, and with 16384 tokens the vast majority of artists will succeed.

--- a/openspec/changes/archive/2026-03-06-fix-gemini-concert-search-errors/proposal.md
+++ b/openspec/changes/archive/2026-03-06-fix-gemini-concert-search-errors/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+The Gemini-based concert search is failing silently for a significant portion of artists in production. Two distinct bugs cause data loss: (1) responses exceeding `maxOutputTokens` are truncated mid-JSON, causing 100% parse failure for affected artists (~20% of batch), and (2) Gemini returns the literal string `"null"` for unknown start times, triggering noisy WARN logs. Both were identified from dev environment logs on 2026-03-06. Ref: liverty-music/backend#151, liverty-music/backend#152.
+
+## What Changes
+
+- Increase `maxOutputTokens` from 8192 to 16384 to reduce the frequency of truncated responses
+- Detect `FinishReason: MAX_TOKENS` before attempting JSON parse and return an explicit error instead of crashing on malformed JSON
+- Update Gemini schema descriptions for `start_time` and `open_time` from "Return null if unknown" to "Return empty string if unknown" to align with `TypeString`
+- Add guard for the literal string `"null"` in start_time/open_time parse logic so it is treated as unknown (nil) without a WARN log
+
+## Capabilities
+
+### New Capabilities
+
+None. This is a bug fix in the existing infrastructure layer.
+
+### Modified Capabilities
+
+None. The `concert-search` capability requirements are unchanged; only the implementation is fixed.
+
+## Impact
+
+- **Code**: `internal/infrastructure/gcp/gemini/searcher.go` (main fix), `searcher_test.go` (new test cases)
+- **APIs**: No API changes. No proto changes.
+- **Cost**: Marginal increase in Gemini API cost for previously-truncated responses (~$0.02/batch increase, negligible)
+- **Reliability**: Concert discovery success rate expected to improve from ~80% to ~95%+ per batch

--- a/openspec/changes/archive/2026-03-06-fix-gemini-concert-search-errors/specs/no-changes.md
+++ b/openspec/changes/archive/2026-03-06-fix-gemini-concert-search-errors/specs/no-changes.md
@@ -1,0 +1,4 @@
+No capability-level specification changes required.
+
+This is a pure implementation bug fix in the Gemini concert searcher infrastructure layer.
+The `concert-search` capability requirements remain unchanged.

--- a/openspec/changes/archive/2026-03-06-fix-gemini-concert-search-errors/tasks.md
+++ b/openspec/changes/archive/2026-03-06-fix-gemini-concert-search-errors/tasks.md
@@ -1,0 +1,17 @@
+## 1. MAX_TOKENS Handling (#151)
+
+- [x] 1.1 Increase `maxOutputTokens` from 8192 to 16384 in `searcher.go`
+- [x] 1.2 Add `FinishReason == MAX_TOKENS` check after candidate extraction in `Search()`, return explicit error before calling `parseEvents()`
+- [x] 1.3 Add test case for MAX_TOKENS finish reason in `searcher_test.go` (mock response with `finishReason: "MAX_TOKENS"` and truncated JSON body)
+
+## 2. Literal "null" String Handling (#152)
+
+- [x] 2.1 Update schema description for `start_time` from "Return null if unknown" to "Return empty string if unknown" in `searcher.go`
+- [x] 2.2 Update schema description for `open_time` with the same change
+- [x] 2.3 Add `"null"` guard to `start_time` parse logic in `parseEvents()` (treat `"null"` as unknown, no WARN log)
+- [x] 2.4 Add `"null"` guard to `open_time` parse logic in `parseEvents()`
+- [x] 2.5 Add test case for `start_time: "null"` string in `searcher_test.go` (expect `StartTime: nil`, no error)
+
+## 3. Verification
+
+- [x] 3.1 Run `make check` to verify lint and tests pass

--- a/openspec/changes/fix-auth-and-user-home-bugs/tasks.md
+++ b/openspec/changes/fix-auth-and-user-home-bugs/tasks.md
@@ -31,7 +31,7 @@
 
 ## 6. Cross-Repo Release
 
-- [ ] 6.1 Create specification PR, merge, and create GitHub Release (triggers BSR publish)
+- [x] 6.1 Create specification PR (#214), merge, and create GitHub Release (triggers BSR publish)
 - [ ] 6.2 After BSR gen completes, update backend `go.sum` with new proto types
-- [ ] 6.3 Create backend PR with migration + code changes
-- [ ] 6.4 Create frontend PR with auth fixes
+- [x] 6.3 Create backend PR (#201, draft) with migration + code changes
+- [x] 6.4 Create frontend PR (#163) with auth fixes


### PR DESCRIPTION
## 🔗 Related Issue

Refs #214

## 📝 Summary of Changes

- Mark completed cross-repo release tasks (6.1, 6.3, 6.4) in `fix-auth-and-user-home-bugs` change
- Archive stale `fix-gemini-concert-search-errors` change from 2026-03-06

No proto changes — OpenSpec documentation housekeeping only.

## ✅ Self-Checklist

- [x] I have linked the related issue.
- [x] I have updated the relevant documentation (e.g., `README.md`) if needed.
- [x] I have run `buf lint` and `buf format` locally and all checks have passed.
- [x] My proto definitions follow the project's style guidelines and validation rules.
- [x] Breaking changes have been justified and documented if applicable.
