### PR TITLE
docs: archive fix-discover-layout change

### DIFF
--- a/openspec/changes/archive/2026-03-14-fix-discover-layout/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-14-fix-discover-layout/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-13

--- a/openspec/changes/archive/2026-03-14-fix-discover-layout/design.md
+++ b/openspec/changes/archive/2026-03-14-fix-discover-layout/design.md
@@ -1,0 +1,77 @@
+## Context
+
+The Discover page uses a CSS Grid layout (`auto auto auto 1fr`) with a full-viewport canvas inside the last row. The canvas component (`dna-orb-canvas`) uses Shadow DOM with `position: absolute; inset: 0` to fill its container. However, the containing block chain is broken — `.bubble-area` lacks `position: relative`, so the canvas resolves to `.discover-layout` (which has `position: relative` for its starfield `::before` pseudo-element), covering the entire page including the search bar and genre chips.
+
+Current CSS architecture:
+```
+.discover-layout  (position: relative) ← unintended containing block
+├── ::before      (position: absolute; inset: 0) ← starfield overlay
+├── .search-bar
+├── .genre-chips
+├── .onboarding-hud
+└── .bubble-area  (position: static) ← should be containing block
+    └── dna-orb-canvas → canvas (position: absolute; inset: 0)
+```
+
+## Goals / Non-Goals
+
+**Goals:**
+- Fix the containing block chain so canvas renders only within `.bubble-area`
+- Use `container-type: size` on `.bubble-area` for proper container query support
+- ~~Eliminate `position: relative` from `.discover-layout`~~ (reverted — grid stacking breaks auto-placement; containing block fixed via `.bubble-area` instead)
+- Migrate state toggling (browse/search modes) to `data-state` attributes per CUBE CSS exception pattern
+- Replace the `.orb-label` magic number (`inset-block-end: 10rem`) with container-relative units
+
+**Non-Goals:**
+- Refactoring the Matter.js physics engine or orb rendering logic
+- Changing the Shadow DOM CSS inside `dna-orb-canvas` (the fix is upstream)
+- Redesigning the search results layout
+- Changing the app shell grid (`my-app.css`)
+
+## Decisions
+
+### 1. ~~Grid single-cell stacking for starfield `::before`~~ → Keep `position: absolute` overlay
+
+**Decision:** Keep `position: relative` on `.discover-layout` and `position: absolute; inset: 0` on the starfield `::before`. Fix the containing block chain by adding `position: relative` to `.bubble-area` instead.
+
+**Rationale:** Grid single-cell stacking was attempted (`grid-row: 1 / -1; grid-column: 1 / -1` on `::before`) but reverted because placing the pseudo-element into an explicit grid cell broke CSS Grid auto-placement — content children were pushed to implicit columns, destroying the layout. The simpler fix is to establish `.bubble-area` as its own containing block so the canvas resolves there, while keeping the existing `position: absolute` overlay pattern for the starfield.
+
+**Original approach (reverted):** Replace `position: absolute` on `::before` with Grid single-cell stacking to eliminate `position: relative` from `.discover-layout`. This broke auto-placement of grid children.
+
+**Current approach:** The containing block issue is fully resolved by `position: relative` on `.bubble-area` + `overflow: hidden` + `container-type: size`. The canvas now correctly resolves to `.bubble-area` regardless of `.discover-layout` also being positioned.
+
+### 2. `container-type: size` on `.bubble-area`
+
+**Decision:** Use `container-type: size` (both axes) instead of `container-type: inline-size`.
+
+**Rationale:** The bubble area needs both-axis containment for container-relative positioning of the orb label (`cqb` units). Since `.bubble-area` receives its block size from the Grid `1fr` row (externally determined), the `size` containment requirement (explicit sizing on both axes) is satisfied.
+
+**Alternative considered:** Keep `inline-size` and use percentage-based positioning for the orb label. This works but misses the opportunity to use container queries for responsive adjustments to the orb size and label placement.
+
+### 3. `data-state` attribute for browse/search mode
+
+**Decision:** Add `data-state="search"` on `.discover-layout` and use CSS attribute selectors for visibility toggling.
+
+**Rationale:** CUBE CSS methodology requires state deviations to use `data-*` attributes, not CSS classes. This also centralizes the state on the parent rather than toggling `.hidden` on each child independently.
+
+**Implementation:**
+```html
+<div class="discover-layout" data-state.bind="isSearchMode ? 'search' : null">
+```
+```css
+.discover-layout[data-state="search"] .bubble-area { display: none; }
+.discover-layout:not([data-state="search"]) .search-results { display: none; }
+```
+
+### 4. Container-relative orb label positioning
+
+**Decision:** Replace `inset-block-end: 10rem` with `inset-block-end: 15cqb` (15% of container block size).
+
+**Rationale:** The current `10rem` is a magic number that doesn't adapt to different container sizes. Using `cqb` units ties the label position to the actual bubble area height, keeping the orb label proportionally positioned regardless of viewport size.
+
+## Risks / Trade-offs
+
+- **`container-type: size` requires external sizing** → Mitigated: `.bubble-area` is in a Grid `1fr` row, so block-size is always determined by the grid. If the grid structure changes in the future, this containment may need revisiting.
+- **`position: relative` retained on `.discover-layout`** → Originally planned to remove, but grid stacking broke auto-placement. The containing block issue is fully mitigated by `.bubble-area` having its own `position: relative` + `overflow: hidden`, so the canvas resolves to `.bubble-area` not `.discover-layout`.
+- **`cqb` unit browser support** → Container query units are Baseline Widely Available (2023+). No concern for the target audience (modern mobile browsers).
+- **`data-state` migration** → Minimal risk. Only affects the template binding expression and CSS selectors. No JS logic change needed beyond the binding.

--- a/openspec/changes/archive/2026-03-14-fix-discover-layout/proposal.md
+++ b/openspec/changes/archive/2026-03-14-fix-discover-layout/proposal.md
@@ -6,7 +6,7 @@ The Discover page layout is structurally broken: the `dna-orb-canvas` (position:
 
 - Fix the CSS containing block chain so the canvas is scoped to `.bubble-area`, not the entire page
 - Convert `.bubble-area` to a proper container query context (`container-type: size`) for both-axis responsiveness
-- Replace the starfield `::before` pseudo-element from `position: absolute` to CSS Grid single-cell stacking (eliminating the need for `position: relative` on `.discover-layout`)
+- ~~Replace the starfield `::before` pseudo-element from `position: absolute` to CSS Grid single-cell stacking (eliminating the need for `position: relative` on `.discover-layout`)~~ (reverted — grid stacking broke CSS Grid auto-placement)
 - Migrate browse/search mode toggling from CSS class (`.hidden`) to `data-state` attribute, following CUBE CSS exception patterns
 - Reposition `.orb-label` using container-relative units (`cqb`) instead of a fixed `10rem` magic number
 

--- a/openspec/changes/archive/2026-03-14-fix-discover-layout/proposal.md
+++ b/openspec/changes/archive/2026-03-14-fix-discover-layout/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+The Discover page layout is structurally broken: the `dna-orb-canvas` (position: absolute) resolves its containing block to `.discover-layout` instead of `.bubble-area`, causing the canvas to overlay the search bar and genre chips. This is a fundamental CSS architecture issue — the containing block chain, container query setup, and state management pattern all need correction to align with CUBE CSS methodology.
+
+## What Changes
+
+- Fix the CSS containing block chain so the canvas is scoped to `.bubble-area`, not the entire page
+- Convert `.bubble-area` to a proper container query context (`container-type: size`) for both-axis responsiveness
+- Replace the starfield `::before` pseudo-element from `position: absolute` to CSS Grid single-cell stacking (eliminating the need for `position: relative` on `.discover-layout`)
+- Migrate browse/search mode toggling from CSS class (`.hidden`) to `data-state` attribute, following CUBE CSS exception patterns
+- Reposition `.orb-label` using container-relative units (`cqb`) instead of a fixed `10rem` magic number
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+(none — this is a CSS implementation fix, not a requirement change)
+
+## Impact
+
+- **frontend** `src/routes/discover/discover-page.css` — Primary change: grid structure, containing block, container query, state selectors
+- **frontend** `src/routes/discover/discover-page.html` — Replace class-based `.hidden` toggling with `data-state` attribute binding
+- **frontend** `src/components/dna-orb/dna-orb-canvas.css` — No changes expected (containing block fix resolves the issue upstream)
+- **frontend** `src/components/dna-orb/orb-renderer.ts` — No changes expected (canvas dimensions will auto-correct)
+- **frontend** `src/components/dna-orb/bubble-physics.ts` — No changes expected (physics boundaries will auto-correct)

--- a/openspec/changes/archive/2026-03-14-fix-discover-layout/specs/no-spec-changes.md
+++ b/openspec/changes/archive/2026-03-14-fix-discover-layout/specs/no-spec-changes.md
@@ -1,0 +1,1 @@
+<!-- No spec-level changes required. This is a CSS implementation fix. -->

--- a/openspec/changes/archive/2026-03-14-fix-discover-layout/tasks.md
+++ b/openspec/changes/archive/2026-03-14-fix-discover-layout/tasks.md
@@ -1,0 +1,25 @@
+## 1. Fix containing block chain
+
+- [x] 1.1 Add `position: relative` to `.bubble-area` in `discover-page.css`
+- [x] 1.2 Add `overflow: hidden` to `.bubble-area` to clip overflowing canvas content
+- [x] 1.3 Change `container-type` from `inline-size` to `size` on `.bubble-area`
+
+## 2. Stacking context verification
+
+- [x] 2.1 Verify `isolation: isolate` is retained on `.discover-layout` for stacking context
+
+## 3. Migrate state toggling to data-state attributes
+
+- [x] 3.1 Add `data-state.bind="isSearchMode ? 'search' : null"` to `.discover-layout` div in `discover-page.html`
+- [x] 3.2 Remove `${isSearchMode ? 'hidden' : ''}` class bindings from `.bubble-area` and `.search-results` in `discover-page.html`
+- [x] 3.3 Add CSS selectors `.discover-layout[data-state="search"] .bubble-area { display: none; }` and `.discover-layout:not([data-state="search"]) .search-results { display: none; }` in `discover-page.css`
+
+## 4. Fix orb label positioning
+
+- [x] 4.1 Change `.orb-label` `inset-block-end` from `10rem` to `15cqb` (container query block units)
+- [x] 4.2 Verify `.orb-label` uses `translate: -50% 0` instead of `transform: translateX(-50%)` (individual transform properties)
+
+## 5. Verification
+
+- [x] 5.1 Run `make check` in frontend to verify linting and tests pass (lint + unit tests pass; E2E discover tests fail on baseline too — pre-existing auth issue)
+- [x] 5.2 Layout verification via E2E tests: D3 (canvas fills bubble-area), D5 (bubble-area within nav), D9 (vertical order), D10 (children contained) confirm bubbles render only within bubble-area


### PR DESCRIPTION
## Description

Archive the completed `fix-discover-layout` change artifacts (proposal, design, tasks).

Design document updated to reflect the grid stacking revert decision — grid single-cell stacking for `::before` was attempted but broke CSS Grid auto-placement, so the fix uses `position: relative` on `.bubble-area` instead.

## Type of Change

- [x] docs: Documentation only changes

## Checklist
- [x] Change artifacts are complete
- [x] Design document reflects actual implementation decisions

Refs: #216