### PR TITLE
docs(openspec): add fix-venue-dedup and remove-venue-enrichment changes

### DIFF
--- a/openspec/changes/fix-venue-dedup/.openspec.yaml
+++ b/openspec/changes/fix-venue-dedup/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-13

--- a/openspec/changes/fix-venue-dedup/design.md
+++ b/openspec/changes/fix-venue-dedup/design.md
@@ -1,0 +1,90 @@
+## Context
+
+The concert discovery pipeline scrapes multiple sources per artist. Each source may use a slightly different text representation for the same venue (e.g., "SGCホール有明" vs "SGC HALL ARIAKE"). The current `resolveVenue` uses exact string matching (`WHERE name = $1 OR raw_name = $1`), which creates duplicate venue records for each text variant. These duplicates cascade into duplicate event records because the DB natural key `(venue_id, local_event_date, start_at)` treats different venue IDs as distinct.
+
+The async enrichment pipeline (MusicBrainz → Google Maps fallback) is designed to merge duplicates post-hoc, but this has gaps: enrichment can fail, and timing windows allow duplicates to persist before enrichment completes.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Eliminate venue duplication at creation time by using Google Places API `place_id` as the canonical identifier
+- Prevent event duplication caused by venue text variants by removing venue from the dedup key
+- Clean up existing inconsistent data for a fresh start
+
+**Non-Goals:**
+- Removing the async enrichment pipeline entirely — it remains as a fallback for venues not found by Google Places (small/new venues)
+- Changing the MusicBrainz integration — it continues to work as before for MBID enrichment
+- Handling multi-artist events (festivals where multiple artists share an event) — out of scope
+
+## Decisions
+
+### Decision 1: Synchronous Google Places lookup in `resolveVenue`
+
+**Choice**: Call Google Places API Text Search synchronously during `CreateFromDiscovered` to obtain `place_id` and canonical name before creating/looking up a venue.
+
+**Flow**:
+```
+resolveVenue(listed_venue_name, admin_area)
+  ├─ Check batch cache (newVenues map by place_id) → hit: return existing
+  ├─ Google Places API Text Search(listed_venue_name + admin_area)
+  │   ├─ Found: GetByPlaceID(place_id)
+  │   │   ├─ Exists: return existing venue ID
+  │   │   └─ Not found: Create venue (name=canonical, raw_name=listed, place_id, enriched)
+  │   └─ Not found: fallback to current flow
+  │       ├─ GetByName(listed_venue_name) → return if found
+  │       └─ Create venue (name=raw_name=listed, pending enrichment)
+  └─ API error: fallback to current flow (same as "Not found")
+```
+
+**Alternatives considered**:
+- *Batch all venues then call API*: More complex, marginal benefit since batches are small (5-10 venues)
+- *Keep async-only enrichment, improve matching*: Fuzzy matching is fragile and doesn't solve the root cause
+
+**Rationale**: Google Places `place_id` is a stable, globally unique identifier. Looking it up at creation time eliminates the entire class of text-matching bugs. Cost is negligible at current volume (~$0.032/request, <10 unique venues per batch).
+
+### Decision 2: Remove venue from dedup key, add artist_id
+
+**Choice**: Change the dedup key from `(date|venue|start_at)` to `(date|start_at)` at the application layer, and the DB unique constraint from `(venue_id, local_event_date, start_at)` to `(artist_id, local_event_date, start_at)` on the events table.
+
+**Rationale**: An artist cannot perform at two different venues at the same time on the same day. This is a stronger invariant than venue matching, and it's immune to text variations.
+
+**Application-layer dedup (concert_uc.go)**:
+- `DateVenueKey()` → `DateKey()`: returns `date` only
+- `DedupeKey()`: returns `date|start_at_utc` (no venue)
+- `seen` map key: `date|start_at_utc`
+- `seenDate` map key: `date` (replaces `seenDateVenue`)
+
+**DB constraint**:
+- `artist_id` must be added to the `events` table (currently only on `concerts`)
+- New unique constraint: `UNIQUE NULLS NOT DISTINCT (artist_id, local_event_date, start_at)`
+- The upsert query references this new constraint
+
+**Alternatives considered**:
+- *Keep venue in key, normalize venue text first*: Still fragile — normalization can't handle all variants
+- *Use venue_id after Places API resolution*: Better than text, but adding artist_id is simpler and more robust
+
+### Decision 3: Data cleanup via migration
+
+**Choice**: A DB migration that truncates all concerts, events, and orphaned venues. The next discovery cron run will re-populate with clean, deduplicated data.
+
+**Rationale**: The existing data has known duplicates that cannot be reliably de-duplicated in-place (some venues have `enrichment_status = 'failed'`). Since the discovery pipeline can regenerate all data within one cron cycle, a clean slate is the simplest approach.
+
+**Migration steps**:
+1. `DELETE FROM concerts` (removes FK references to events)
+2. `DELETE FROM events` (removes FK references to venues)
+3. `DELETE FROM venues WHERE NOT EXISTS (SELECT 1 FROM events WHERE events.venue_id = venues.id)` — clean up orphaned venues (should be all of them after step 2)
+4. Add `artist_id` column to events (NOT NULL, FK to artists)
+5. Drop old constraint `uq_events_natural_key`
+6. Add new constraint `UNIQUE NULLS NOT DISTINCT (artist_id, local_event_date, start_at)`
+
+## Risks / Trade-offs
+
+**[Risk] Google Places API unavailability during venue resolution** → Mitigation: Fallback to current text-based flow. Venue will be created with `pending` enrichment status and handled by the async pipeline as before.
+
+**[Risk] Google Places API returns wrong venue for ambiguous names** → Mitigation: Include `admin_area` in the search text to disambiguate. Accept that edge cases may still occur — the async enrichment pipeline remains as a second pass.
+
+**[Risk] Data loss during cleanup migration** → Mitigation: Data is fully recoverable via the next cron run. The migration only deletes concert/event/venue data, not artist or user data. Search logs are preserved so the 24h cooldown applies normally.
+
+**[Risk] `artist_id` on events table denormalization** → Trade-off accepted. The `artist_id` already exists on the `concerts` table (1:1 with events for now). Adding it to `events` enables a stronger unique constraint. The cost is one extra UUID column.
+
+**[Trade-off] Same-day, same-time events for different artists at the same venue** → The new constraint `(artist_id, local_event_date, start_at)` is per-artist, so different artists at the same venue/time are not affected. This is correct behavior.

--- a/openspec/changes/fix-venue-dedup/proposal.md
+++ b/openspec/changes/fix-venue-dedup/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+Venue records are duplicated when different scraping sources use slightly different text for the same physical venue (e.g., "太宰府天満宮 仮殿" vs "太宰府天満宮", "SGCホール有明" vs "SGC HALL ARIAKE"). Because `resolveVenue` uses exact string matching (`GetByName`), each variant creates a separate venue record. This cascades into duplicate events because the DB natural key `(venue_id, local_event_date, start_at)` cannot detect duplicates across different venue IDs. The async enrichment pipeline is designed to merge these later, but it does not always succeed (enrichment failures, timing gaps).
+
+## What Changes
+
+- **Move venue resolution to Google Places API at creation time**: Instead of creating venues from raw text and enriching later, `resolveVenue` will call the Google Places API first to obtain a canonical `place_id` and name, then look up by `google_place_id` for a reliable existence check.
+- **Remove venue from the concert dedup key**: Change the application-level dedup key from `(date|venue|start_at)` to `(date|start_at)` and the DB natural key from `(venue_id, local_event_date, start_at)` to `(artist_id, local_event_date, start_at)`, since a single artist cannot perform at two venues simultaneously.
+- **Clean up existing duplicate data**: Delete all existing concert/event/venue records and let the discovery pipeline re-populate cleanly.
+
+## Capabilities
+
+### New Capabilities
+
+_(none)_
+
+### Modified Capabilities
+
+- `venue-normalization`: Venue resolution moves from async post-enrichment to synchronous at creation time using Google Places API. The async enrichment pipeline becomes a fallback for venues not found by Google Places.
+- `concert-search`: The dedup natural key changes from `(date|venue|start_at)` to `(date|start_at)` at the application layer, removing venue from the comparison.
+- `concert-service`: The DB unique constraint on events changes from `(venue_id, local_event_date, start_at)` to `(artist_id, local_event_date, start_at)`, and a data cleanup migration removes all existing records for a fresh start.
+
+## Impact
+
+- **backend**: `concert_creation_uc.go` (resolveVenue rewrite), `concert_uc.go` (dedup key change), `venue_repo.go` (new `GetByPlaceID`), `concert_repo.go` (upsert query change), DB migration (constraint change + data cleanup)
+- **Google Places API cost**: ~$0.032/request for Text Search; expected volume is low (5-10 unique venues per scrape batch)
+- **Data**: All existing events, concerts, and orphaned venues will be deleted. The next discovery cron run will re-populate with clean data.

--- a/openspec/changes/fix-venue-dedup/specs/concert-search/spec.md
+++ b/openspec/changes/fix-venue-dedup/specs/concert-search/spec.md
@@ -1,0 +1,88 @@
+## MODIFIED Requirements
+
+### Requirement: Concert Deduplication Natural Key
+
+The `executeSearch` dedup logic SHALL use the natural key `(local_event_date, start_at_utc)` to determine whether a scraped concert already exists in the database. The venue name is excluded from the dedup key because an artist cannot perform at two different venues simultaneously on the same day. The comparison SHALL normalize timezone differences and handle `start_at` nil states according to the rules defined below. The dedup SHALL apply both when comparing scraped concerts against existing DB records and when comparing scraped concerts within the same batch.
+
+#### Scenario: Same instant expressed in different timezones
+
+- **WHEN** a scraped concert has `start_at = 2026-06-01T18:00:00+09:00` (JST)
+- **AND** an existing concert has `start_at = 2026-06-01T09:00:00Z` (UTC)
+- **AND** both have the same `local_event_date`
+- **THEN** the scraped concert SHALL be treated as a duplicate
+- **AND** SHALL NOT be published in the `concert.discovered.v1` event
+
+#### Scenario: Scraped concert has nil start_at, existing has start_at
+
+- **WHEN** a scraped concert has `start_at = nil`
+- **AND** an existing concert has a non-nil `start_at`
+- **AND** both have the same `local_event_date`
+- **THEN** the scraped concert SHALL be treated as a duplicate
+- **AND** SHALL NOT be published
+- **AND** the nil `start_at` SHALL NOT overwrite the existing value (the existing record already has richer information)
+
+#### Scenario: Scraped concert has start_at, existing has nil
+
+- **WHEN** a scraped concert has a non-nil `start_at`
+- **AND** an existing concert has `start_at = nil`
+- **AND** both have the same `local_event_date`
+- **THEN** the scraped concert SHALL be published in the `concert.discovered.v1` event
+- **AND** the downstream UPSERT SHALL update the existing record's `start_at` with the newly discovered value
+
+#### Scenario: Both have non-nil start_at representing different instants
+
+- **WHEN** a scraped concert has a non-nil `start_at`
+- **AND** an existing concert has a non-nil `start_at`
+- **AND** both have the same `local_event_date`
+- **AND** the two `start_at` values represent different instants after UTC normalization (e.g., matinee 13:00 UTC vs evening 18:00 UTC)
+- **THEN** the scraped concert SHALL be treated as a distinct event (separate show)
+- **AND** SHALL be published in the `concert.discovered.v1` event
+
+#### Scenario: Both have nil start_at, same date
+
+- **WHEN** a scraped concert has `start_at = nil`
+- **AND** an existing concert has `start_at = nil`
+- **AND** both have the same `local_event_date`
+- **THEN** the scraped concert SHALL be treated as a duplicate
+- **AND** SHALL NOT be published
+
+#### Scenario: Different date
+
+- **WHEN** a scraped concert has a different `local_event_date` from an existing concert
+- **THEN** the scraped concert SHALL be treated as a distinct event
+- **AND** SHALL be published regardless of `start_at` values
+
+#### Scenario: Within-batch dedup — same instant in different timezones
+
+- **WHEN** two scraped concerts in the same Gemini response have the same `local_event_date`
+- **AND** their `start_at` values represent the same instant after UTC normalization
+- **THEN** only the first concert SHALL be included in the `concert.discovered.v1` event
+- **AND** the second SHALL be discarded as a within-batch duplicate
+
+#### Scenario: Within-batch — genuinely different start_at
+
+- **WHEN** two scraped concerts in the same Gemini response have the same `local_event_date`
+- **AND** their `start_at` values represent different instants after UTC normalization
+- **THEN** both concerts SHALL be included in the `concert.discovered.v1` event (matinee/evening shows)
+
+### Requirement: Dedup Key Comparison for Existing Concerts
+
+The dedup logic SHALL build a lookup set from existing DB concerts using `ListByArtist(upcomingOnly=true)`. When `Event.ListedVenueName` is `nil` (legacy rows inserted before this field was added), the existing concert SHALL still participate in dedup using the `(local_event_date, start_at)` key.
+
+#### Scenario: Existing concert with nil ListedVenueName still participates in dedup
+
+- **WHEN** an existing concert has `ListedVenueName = nil` (legacy data)
+- **THEN** it SHALL still be added to the dedup lookup set using `(local_event_date, start_at_utc)` as the key
+
+#### Scenario: Existing concert with non-nil ListedVenueName is included
+
+- **WHEN** an existing concert has a non-nil `ListedVenueName`
+- **THEN** it SHALL be added to the dedup lookup set using `(local_event_date, start_at_utc)` as the key
+
+## REMOVED Requirements
+
+### Requirement: Resilience to Gemini API Non-Determinism — Scenario: Same date, different venue
+
+**Reason**: The venue name is no longer part of the dedup key. The scenario "Same date, different venue → treated as distinct event" is no longer applicable because dedup is now based on `(date, start_at)` only. Two concerts on the same date with the same start_at are always considered duplicates regardless of venue name.
+
+**Migration**: Events at the same date and start_at that were previously considered distinct due to different venue names will now be deduplicated. The data cleanup migration ensures a clean starting state.

--- a/openspec/changes/fix-venue-dedup/specs/concert-service/spec.md
+++ b/openspec/changes/fix-venue-dedup/specs/concert-service/spec.md
@@ -1,0 +1,126 @@
+## MODIFIED Requirements
+
+### Requirement: Event Natural Key Constraint
+
+The `events` table SHALL have a composite UNIQUE constraint on the natural key `(artist_id, local_event_date, start_at)` to prevent duplicate event rows at the database level. The `artist_id` column SHALL be added to the `events` table to enable per-artist deduplication independent of venue.
+
+#### Scenario: Duplicate event insert is rejected
+
+- **WHEN** a concert is inserted with the same `(artist_id, local_event_date, start_at)` as an existing event
+- **THEN** the database SHALL reject the insert via the UNIQUE constraint
+- **AND** the application SHALL handle this gracefully via UPSERT (not error)
+
+#### Scenario: NULL-safe equality for start_at in constraint
+
+- **WHEN** two events have the same `artist_id` and `local_event_date`
+- **AND** both have `start_at = NULL`
+- **THEN** the UNIQUE constraint SHALL treat them as duplicates
+- **AND** the constraint SHALL use a `UNIQUE NULLS NOT DISTINCT` clause
+
+#### Scenario: Same artist and date with different start_at
+
+- **WHEN** two events have the same `artist_id` and `local_event_date`
+- **AND** different non-NULL `start_at` values
+- **THEN** the UNIQUE constraint SHALL allow both rows (matinee/evening shows)
+
+#### Scenario: Different artists at same venue, date, and time
+
+- **WHEN** two events have different `artist_id` values
+- **AND** the same `venue_id`, `local_event_date`, and `start_at`
+- **THEN** the UNIQUE constraint SHALL allow both rows (festival/multi-artist events)
+
+### Requirement: Concert UPSERT on Natural Key
+
+The `ConcertRepository.Create` bulk insert SHALL use `ON CONFLICT` on the natural key `(artist_id, local_event_date, start_at)` to perform an UPSERT. The `artist_id` SHALL be included in the events insert as it is now part of the natural key. When a conflict is detected, the existing record's `open_at` SHALL be updated if the new value provides previously unknown information.
+
+#### Scenario: Insert new event (no conflict)
+
+- **WHEN** `Create` is called with a concert whose natural key does not exist
+- **THEN** the event SHALL be inserted normally
+
+#### Scenario: Different start_at inserts new row (not UPSERT)
+
+- **WHEN** `Create` is called with a concert at the same `(artist_id, local_event_date)` as an existing event
+- **AND** the `start_at` values differ
+- **THEN** the natural keys are distinct and no conflict occurs
+- **AND** the new concert SHALL be inserted as a separate event row
+
+#### Scenario: Conflict with richer open_at — update existing
+
+- **WHEN** `Create` is called with a concert whose natural key matches an existing event
+- **AND** the existing event has `open_at = NULL`
+- **AND** the new concert has a non-NULL `open_at`
+- **THEN** the existing event's `open_at` SHALL be updated to the new value via `COALESCE(EXCLUDED.open_at, events.open_at)`
+
+#### Scenario: Conflict does not overwrite existing non-NULL open_at with NULL
+
+- **WHEN** `Create` is called with a concert whose natural key matches an existing event
+- **AND** the existing event already has a non-NULL `open_at`
+- **AND** the new concert has `open_at = NULL`
+- **THEN** the existing event's `open_at` SHALL NOT be overwritten
+
+#### Scenario: Concerts row skipped for UPSERTed events with different UUID
+
+- **WHEN** `Create` is called with a concert whose event UUID differs from the existing event at the same natural key
+- **THEN** the events UPSERT SHALL update the existing row (keeping the original UUID)
+- **AND** the input UUID SHALL NOT exist in the `events` table
+- **AND** the `concerts` INSERT SHALL skip this row via `WHERE EXISTS`
+
+### Requirement: Concert Persistence
+
+The system SHALL automatically persist any new concerts discovered via the search mechanism. The `ConcertRepository.Create` method SHALL accept a variadic number of concerts for bulk insert support. The bulk insert SHALL use the PostgreSQL `unnest` pattern instead of manual placeholder construction.
+
+#### Scenario: Persist New Concerts
+
+- **WHEN** `SearchNewConcerts` is called and finds concerts not currently in the database
+- **THEN** the new concerts are saved to the persisted storage via a single bulk insert call
+- **AND** returned in the response with valid IDs
+
+#### Scenario: Persist Venues
+
+- **WHEN** a discovered concert has a venue that does not exist in the database
+- **THEN** a new venue is created dynamically, resolved via Google Places API when available
+- **AND** if Google Places API returns a result, the venue SHALL be created with `google_place_id`, canonical name, coordinates, and `enrichment_status = 'enriched'`
+- **AND** if Google Places API is unavailable or returns no result, the venue SHALL be created based on the listed venue name with `enrichment_status = 'pending'`
+- **AND** the new concert is associated with this venue
+
+#### Scenario: Bulk insert uses unnest
+
+- **WHEN** `Create` is called with multiple concerts
+- **THEN** the repository SHALL use `unnest` arrays for both `events` and `concerts` table inserts
+- **AND** the events insert SHALL include `artist_id` as part of the unnest arrays
+- **AND** the implementation SHALL NOT use manual `fmt.Sprintf` placeholder construction
+
+#### Scenario: Single concert creation
+
+- **WHEN** `Create` is called with a single concert argument
+- **THEN** it SHALL behave identically to bulk insert with a single element
+
+### Requirement: Duplicate Data Cleanup Migration
+
+A one-time database migration SHALL delete all existing concert, event, and venue records to ensure a clean state before applying the new natural key constraint.
+
+#### Scenario: All concerts, events, and venues are deleted
+
+- **WHEN** the migration runs
+- **THEN** all rows in the `concerts` table SHALL be deleted
+- **AND** all rows in the `events` table SHALL be deleted
+- **AND** all rows in the `venues` table SHALL be deleted
+
+#### Scenario: artist_id column added to events
+
+- **WHEN** the migration runs
+- **THEN** an `artist_id` column of type `UUID NOT NULL` SHALL be added to the `events` table
+- **AND** a foreign key constraint referencing `artists(id)` SHALL be added
+
+#### Scenario: New unique constraint applied after cleanup
+
+- **WHEN** the migration runs
+- **THEN** the old constraint `uq_events_natural_key` on `(venue_id, local_event_date, start_at)` SHALL be dropped
+- **AND** a new constraint `UNIQUE NULLS NOT DISTINCT (artist_id, local_event_date, start_at)` SHALL be added
+
+#### Scenario: Migration is idempotent
+
+- **WHEN** the migration is run on a database with no data
+- **THEN** the DELETE statements SHALL complete without error
+- **AND** the constraint changes SHALL succeed

--- a/openspec/changes/fix-venue-dedup/specs/venue-normalization/spec.md
+++ b/openspec/changes/fix-venue-dedup/specs/venue-normalization/spec.md
@@ -1,0 +1,98 @@
+## MODIFIED Requirements
+
+### Requirement: Venue Enrichment Pipeline
+
+The system SHALL provide an async enrichment pipeline that resolves raw venue names to canonical external identifiers (MusicBrainz MBID or Google Maps place_id) and updates venue records with canonical names and geographic coordinates. This pipeline now serves as a **fallback** for venues that were not resolved at creation time via the synchronous Google Places lookup.
+
+#### Scenario: Successful enrichment via MusicBrainz
+
+- **WHEN** the enrichment job processes a venue with `enrichment_status = 'pending'`
+- **AND** MusicBrainz place search returns a match
+- **THEN** the venue record SHALL be updated with the MusicBrainz MBID
+- **AND** `venues.raw_name` SHALL be set to the current `venues.name` (if `raw_name` is NULL) to preserve the original scraper-provided name
+- **AND** `venues.name` SHALL be overwritten with the canonical name from MusicBrainz
+- **AND** `enrichment_status` SHALL be set to `'enriched'`
+- **AND** the venue's `Coordinates` SHALL be set to the value returned by the PlaceSearcher (non-nil when the response includes coordinates, nil otherwise)
+
+#### Scenario: Successful enrichment via Google Maps fallback
+
+- **WHEN** the enrichment job processes a venue with `enrichment_status = 'pending'`
+- **AND** MusicBrainz place search returns no match
+- **AND** Google Maps Text Search returns a match
+- **THEN** the Google Maps client SHALL authenticate via OAuth Bearer token (not API key)
+- **AND** the venue record SHALL be updated with the Google Maps place_id
+- **AND** `venues.raw_name` SHALL be set to the current `venues.name` (if `raw_name` is NULL) to preserve the original scraper-provided name
+- **AND** `venues.name` SHALL be overwritten with the canonical name from Google Maps
+- **AND** `enrichment_status` SHALL be set to `'enriched'`
+- **AND** the venue's `Coordinates` SHALL be updated from the Google Maps geometry response
+
+#### Scenario: Both sources miss
+
+- **WHEN** the enrichment job processes a venue with `enrichment_status = 'pending'`
+- **AND** MusicBrainz returns no match
+- **AND** Google Maps returns no match
+- **THEN** `enrichment_status` SHALL be set to `'failed'`
+- **AND** `venues.name` SHALL remain unchanged
+- **AND** the venue's `Coordinates` SHALL remain nil
+- **AND** the venue SHALL NOT be retried in subsequent job runs
+
+#### Scenario: Ambiguous results (multiple matches)
+
+- **WHEN** the enrichment job processes a venue with `enrichment_status = 'pending'`
+- **AND** MusicBrainz or Google Maps returns more than one candidate match
+- **THEN** the venue SHALL NOT be updated with any external identifier
+- **AND** `venues.name` SHALL remain unchanged
+- **AND** `enrichment_status` SHALL be set to `'failed'`
+- **AND** the ambiguity SHALL be logged for future manual review
+
+#### Scenario: admin_area used as search hint
+
+- **WHEN** the enrichment job queries MusicBrainz or Google Maps for a venue
+- **AND** the venue has a non-NULL `admin_area` (ISO 3166-2 code)
+- **THEN** the system SHALL convert the ISO 3166-2 code to a locale-appropriate text name before including it in the search query
+- **AND** the text name SHALL be in the language most likely to yield accurate results for the target service (e.g., Japanese for MusicBrainz JP venues, English for Google Maps)
+
+#### Scenario: Venue already enriched at creation time is skipped
+
+- **WHEN** the enrichment job runs
+- **AND** a venue was resolved via Google Places API at creation time (has `google_place_id` set and `enrichment_status = 'enriched'`)
+- **THEN** the venue SHALL be skipped by the enrichment pipeline
+
+### Requirement: Venue Deduplication During Discovery
+
+The concert discovery phase SHALL resolve venues using the Google Places API at creation time, falling back to `raw_name` lookup when the API is unavailable or returns no results.
+
+#### Scenario: Venue resolved via Google Places API at creation time
+
+- **WHEN** the concert creation step attempts to resolve a venue for a scraped concert
+- **THEN** the system SHALL first call the Google Places API Text Search with the `listed_venue_name` and `admin_area`
+- **AND** if a result is found, the system SHALL look up the venue by `google_place_id`
+- **AND** if a venue record with that `google_place_id` exists, the existing venue SHALL be used
+- **AND** if no venue record with that `google_place_id` exists, a new venue SHALL be created with the canonical name, `google_place_id`, coordinates, and `enrichment_status = 'enriched'`
+
+#### Scenario: Google Places API returns no result
+
+- **WHEN** the Google Places API Text Search returns no results for a venue name
+- **THEN** the system SHALL fall back to the existing `GetByName` lookup
+- **AND** if no venue is found by name, a new venue SHALL be created with `enrichment_status = 'pending'`
+
+#### Scenario: Google Places API is unavailable
+
+- **WHEN** the Google Places API returns a transient error (timeout, 5xx, rate limit)
+- **THEN** the system SHALL fall back to the existing `GetByName` lookup
+- **AND** SHALL NOT fail the entire concert creation batch
+
+#### Scenario: Batch-local cache uses place_id as key
+
+- **WHEN** multiple concerts in the same batch refer to the same physical venue with different text variants
+- **AND** Google Places API resolves them to the same `place_id`
+- **THEN** only one venue record SHALL be created
+- **AND** subsequent concerts in the batch SHALL reuse the cached venue ID
+
+#### Scenario: Enriched venue found by raw_name
+
+- **WHEN** the concert discovery step attempts to find a venue by its scraped name
+- **AND** Google Places API is not used or returns no result
+- **AND** no venue record matches on `venues.name`
+- **AND** a venue record matches on `venues.raw_name`
+- **THEN** the existing venue record SHALL be used (no new record created)

--- a/openspec/changes/fix-venue-dedup/tasks.md
+++ b/openspec/changes/fix-venue-dedup/tasks.md
@@ -1,0 +1,45 @@
+## 1. Database Migration
+
+- [x] 1.1 Create migration: DELETE all rows from `concerts`, `events`, `venues` tables
+- [x] 1.2 Create migration: Add `artist_id UUID NOT NULL` column to `events` table with FK to `artists(id)`
+- [x] 1.3 Create migration: Drop old constraint `uq_events_natural_key` on `(venue_id, local_event_date, start_at)`
+- [x] 1.4 Create migration: Add new constraint `UNIQUE NULLS NOT DISTINCT (artist_id, local_event_date, start_at)` on `events`
+- [x] 1.5 Update `schema.sql` desired state to reflect new `events` table structure
+- [x] 1.6 Run `atlas migrate validate --env local` and verify migration integrity
+
+## 2. Venue Repository — `GetByPlaceID`
+
+- [x] 2.1 Add `GetByPlaceID(ctx, placeID string) (*Venue, error)` to `VenueRepository` interface in `entity/venue.go`
+- [x] 2.2 Implement `GetByPlaceID` in `rdb/venue_repo.go` (`WHERE google_place_id = $1`)
+- [x] 2.3 Add integration test for `GetByPlaceID`
+
+## 3. Venue Resolution — Synchronous Google Places Lookup
+
+- [x] 3.1 Add `PlaceSearcher` dependency to `ConcertCreationUseCase` (reuse existing `venue.PlaceSearcher` interface)
+- [x] 3.2 Add `VenueRepository` (with `GetByPlaceID`) dependency to `ConcertCreationUseCase`
+- [x] 3.3 Rewrite `resolveVenue` to call Google Places API first, then lookup by `place_id`, falling back to `GetByName` on failure/not-found
+- [x] 3.4 Update batch-local cache key from venue name to `place_id` (with fallback to name for non-Places-resolved venues)
+- [x] 3.5 When creating a venue from Places API result, set `google_place_id`, canonical name, coordinates, and `enrichment_status = 'enriched'`
+- [x] 3.6 Update DI wiring in `internal/di/` to inject `PlaceSearcher` into `ConcertCreationUseCase`
+
+## 4. Concert Dedup Key Change
+
+- [x] 4.1 Rename `DateVenueKey()` to `DateKey()` in `entity/concert.go` — return `date` only (no venue)
+- [x] 4.2 Update `DedupeKey()` in `entity/concert.go` — return `date|start_at_utc` (no venue)
+- [x] 4.3 Update `executeSearch` dedup logic in `concert_uc.go` to use new key functions (remove venue from `seen`/`seenDate` maps)
+- [x] 4.4 Remove the `ListedVenueName == nil` skip in existing concert dedup — all concerts now participate
+- [x] 4.5 Update unit tests for `DateKey()` and `DedupeKey()`
+- [x] 4.6 Update unit tests for `executeSearch` dedup logic
+
+## 5. Concert Repository — UPSERT with artist_id
+
+- [x] 5.1 Update `upsertEventsQuery` to include `artist_id` in INSERT columns and `unnest` arrays
+- [x] 5.2 Update `ON CONFLICT` clause to reference new constraint `(artist_id, local_event_date, start_at)`
+- [x] 5.3 Update `ConcertRepository.Create` to pass `artist_id` for each event in the unnest arrays
+- [x] 5.4 Update `listConcertsByArtistQuery` and related queries to include `events.artist_id` if needed
+- [x] 5.5 Update integration tests for concert repository
+
+## 6. Verification
+
+- [x] 6.1 Run `make check` in backend (lint + tests)
+- [x] 6.2 Run `atlas migrate diff --env local` to verify schema.sql matches migrations

--- a/openspec/changes/remove-venue-enrichment/.openspec.yaml
+++ b/openspec/changes/remove-venue-enrichment/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-13

--- a/openspec/changes/remove-venue-enrichment/design.md
+++ b/openspec/changes/remove-venue-enrichment/design.md
@@ -1,0 +1,70 @@
+## Context
+
+The `fix-venue-dedup` change moved venue resolution to be synchronous at concert creation time via Google Places API. This made the async enrichment pipeline (`venue.created.v1` → `VenueConsumer` → `VenueEnrichmentUseCase`) redundant — it now only processes venues that Places API already failed to find, and almost always fails again.
+
+Current venue creation has two paths:
+1. Places API success → venue created with `enrichment_status = 'enriched'`, coordinates, canonical name
+2. Places API NotFound → venue created with `enrichment_status = 'pending'`, no coordinates → enrichment retries → fails → `enrichment_status = 'failed'`
+
+Path 2 produces unusable data. This design eliminates it.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Eliminate path 2: skip concerts whose venues can't be resolved, log full scraped data for manual recovery
+- Remove the entire enrichment pipeline (UC, consumer, event, repository methods)
+- Remove venue schema fields that only existed for enrichment: `enrichment_status`, `raw_name`, `mbid`
+- Make `placeSearcher` a required dependency (remove nil-guard)
+- Remove `GetByName` fallback from venue resolution
+
+**Non-Goals:**
+- Removing the `musicbrainz` package — it's still used by `ArtistNameResolutionUseCase`
+- Removing `AdminAreaResolver` from the codebase — check if it's used elsewhere; remove only if venue enrichment was its sole consumer
+- Changing the Google Places API integration itself
+- Handling manual venue data entry (future work if needed)
+
+## Decisions
+
+### 1. Skip concert instead of creating unusable venue
+
+**Decision**: When Places API returns NotFound, emit a structured Warn log with all `ScrapedConcert` fields and skip the concert. Do not create a venue or concert record.
+
+**Alternatives considered**:
+- Create venue with NULL coordinates (current behavior) — produces unusable data that degrades proximity calculations and map display
+- Queue for manual review in a database table — adds complexity; structured logs can be queried in Cloud Logging and are sufficient for the current scale
+
+**Rationale**: At current scale, manual review of venue resolution failures can be handled via Cloud Logging queries. A dedicated review queue can be added later if volume warrants it.
+
+### 2. Return semantics for `resolveVenue`
+
+**Decision**: `resolveVenue` returns `(venueID string, venue *Venue, skip bool, err error)`. When Places API returns NotFound, return `skip = true` with nil error. The caller skips the concert without aborting the batch.
+
+**Alternative**: Return a sentinel error — but this conflates "skip this concert" with "something went wrong", making the caller's control flow less clear.
+
+### 3. Remove `GetByName` fallback entirely
+
+**Decision**: After Places API, do not fall back to name-based DB lookup. The only lookup path is: Places API → `GetByPlaceID` → create new venue.
+
+**Rationale**: `GetByName` was the pre-Places-API dedup mechanism. With `google_place_id` as the canonical identifier, name-based lookup is unreliable (different scrapers use different name variants). Keeping it creates a false sense of safety.
+
+### 4. Make `placeSearcher` required
+
+**Decision**: Remove the `placeSearcher != nil` guard. Panic at startup if not provided.
+
+**Impact on local dev**: Local development must either configure a real Places API key or provide a stub implementation. This is acceptable since the Gemini-based searcher is already used in dev.
+
+### 5. Schema migration: drop columns
+
+**Decision**: Single migration that drops `enrichment_status`, `raw_name`, `mbid`, the `venue_enrichment_status` enum, and the `idx_venues_mbid` unique index.
+
+**Ordering**: This migration runs after the `fix-venue-dedup` data cleanup migration (which DELETEs all venues), so there are no data concerns.
+
+## Risks / Trade-offs
+
+**[Risk] Permanent data loss for unresolvable venues** → Mitigated by structured logging with full `ScrapedConcert` fields. Logs are retained in Cloud Logging for 30 days. If a pattern of failures emerges, a manual review process or Places API query adjustment can be implemented.
+
+**[Risk] Places API outage causes all concerts to be skipped** → The Gemini searcher already has retry with backoff for transient errors (429, 503, 504). True outages would cause the entire batch to fail (non-retryable error propagated up), not silent skipping. Only definitive NotFound results cause skipping.
+
+**[Trade-off] No MusicBrainz venue lookup** → MusicBrainz venue data was a secondary source that rarely provided data Google Places didn't. The MBID field was never exposed via API. Acceptable loss.
+
+**[Trade-off] No `raw_name` preservation** → With synchronous Places API resolution, `Name` is always the canonical name from Places API. The scraped name is logged in the skip log and stored in `events.listed_venue_name`. No need for a separate `raw_name` column.

--- a/openspec/changes/remove-venue-enrichment/proposal.md
+++ b/openspec/changes/remove-venue-enrichment/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+The async venue enrichment pipeline (MusicBrainz + Google Maps fallback) is redundant now that `fix-venue-dedup` resolves venues synchronously via Google Places API at concert creation time. When Places API returns NotFound, the enrichment pipeline retries the same search with the same query and almost always fails again, leaving behind unusable venue records (no coordinates, no canonical name, `enrichment_status = 'failed'`). These records provide no value to users and add complexity to the codebase.
+
+By skipping concerts whose venues can't be resolved via Places API and logging the full scraped data for manual review, we eliminate the enrichment pipeline entirely and simplify the venue data model.
+
+## What Changes
+
+- **BREAKING**: `resolveVenue` no longer falls back to name-based lookup or creates pending venues. If Google Places API returns NotFound, the concert is skipped with a structured error log containing all `ScrapedConcert` fields for manual data recovery.
+- **BREAKING**: `placeSearcher` becomes a required dependency (no more nil-guard for local dev). Local development must configure a Places API key or use a stub.
+- Remove the entire venue enrichment pipeline: `VenueEnrichmentUseCase`, `VenueConsumer`, `venue.created.v1` event, `VenueEnrichmentRepository` interface, and all related repository methods (`ListPending`, `MarkFailed`, `UpdateEnriched`, `MergeVenues`).
+- Remove `VenueNamedSearcher`, `AdminAreaResolver` dependency from consumer DI.
+- Remove `venue_enrichment_status` enum, `enrichment_status` column, `raw_name` column, and `mbid` column (+ unique index) from the `venues` table.
+- Remove `GetByName` from `VenueRepository` interface (no longer used after fallback removal).
+- Remove `VenueCreatedData` and `SubjectVenueCreated` from event definitions.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `venue-normalization`: The entire async enrichment pipeline, enrichment status tracking, duplicate merge, and raw_name-based dedup are removed. Venue resolution becomes synchronous-only via Google Places API at concert creation time. Unresolvable venues cause concert records to be skipped rather than created with incomplete data.
+
+## Impact
+
+- **Backend**: `usecase/venue_enrichment_uc.go`, `adapter/event/venue_consumer.go`, related tests, DI wiring, repository methods, and entity fields are deleted. `concert_creation_uc.go` is simplified. Schema migration drops columns/enum.
+- **Database**: Migration to drop `enrichment_status`, `raw_name`, `mbid` columns and `venue_enrichment_status` enum. Existing data already cleaned by `fix-venue-dedup` migration.
+- **Infrastructure**: MusicBrainz client remains (used by artist name resolution) but is no longer wired into venue enrichment. Google Maps venue searcher in consumer DI is removed (Places API is used in concert creation instead).
+- **Observability**: New structured error log for skipped concerts replaces enrichment failure logs.

--- a/openspec/changes/remove-venue-enrichment/specs/venue-normalization/spec.md
+++ b/openspec/changes/remove-venue-enrichment/specs/venue-normalization/spec.md
@@ -1,0 +1,100 @@
+## ADDED Requirements
+
+### Requirement: Skip Unresolvable Venues
+
+The concert creation pipeline SHALL skip concerts whose venues cannot be resolved via Google Places API, rather than creating venue records with incomplete data.
+
+#### Scenario: Places API returns NotFound
+
+- **WHEN** `resolveVenue` calls Google Places API for a scraped venue name
+- **AND** the API returns NotFound
+- **THEN** the concert SHALL NOT be persisted to the database
+- **AND** the system SHALL emit a structured Warn log containing all fields of the `ScrapedConcert` (title, local_date, start_time, open_time, listed_venue_name, admin_area, source_url)
+- **AND** processing SHALL continue with the next concert in the batch
+
+#### Scenario: Places API returns a non-retryable error
+
+- **WHEN** `resolveVenue` calls Google Places API for a scraped venue name
+- **AND** the API returns an error that is not NotFound (e.g., InvalidArgument)
+- **THEN** the concert SHALL NOT be persisted to the database
+- **AND** the system SHALL emit a structured Warn log with the error and all `ScrapedConcert` fields
+- **AND** processing SHALL continue with the next concert in the batch
+
+### Requirement: PlaceSearcher Is Required
+
+The `ConcertCreationUseCase` SHALL require a non-nil `VenuePlaceSearcher` at construction time.
+
+#### Scenario: Nil placeSearcher at startup
+
+- **WHEN** `NewConcertCreationUseCase` is called with a nil `placeSearcher`
+- **THEN** the function SHALL panic with a descriptive message
+
+## REMOVED Requirements
+
+### Requirement: Venue Enrichment Pipeline
+
+**Reason**: Venue resolution is now synchronous via Google Places API at concert creation time. The async enrichment pipeline (MusicBrainz → Google Maps fallback) is redundant and produces unusable data when both sources fail.
+
+**Migration**: Venues are resolved at creation time. Unresolvable venues cause concerts to be skipped with structured logging for manual review.
+
+### Requirement: Google Maps Authentication via Workload Identity
+
+**Reason**: The Google Maps venue searcher used by the enrichment pipeline is removed. Google Places API authentication for concert creation is handled by the existing Gemini-based searcher infrastructure.
+
+**Migration**: No action required. The Gemini searcher's authentication remains unchanged.
+
+### Requirement: Enrichment Error Logging Consolidation
+
+**Reason**: The enrichment pipeline that generated these logs is removed.
+
+**Migration**: Replaced by skip-concert Warn logs in the concert creation pipeline.
+
+### Requirement: Venue Duplicate Merge
+
+**Reason**: Venue deduplication is now handled at creation time via `google_place_id` lookup (`GetByPlaceID`). The post-hoc merge during enrichment is no longer needed.
+
+**Migration**: `GetByPlaceID` in the concert creation flow prevents duplicates from being created in the first place.
+
+### Requirement: Venue Enrichment Status Tracking
+
+**Reason**: All venues are now created in an enriched state (with Google Places canonical name and coordinates) or not created at all. The `enrichment_status` lifecycle is eliminated.
+
+**Migration**: The `enrichment_status` column, `venue_enrichment_status` enum, `raw_name` column, and `mbid` column are dropped from the `venues` table.
+
+### Requirement: Enrichment Job Execution
+
+**Reason**: The enrichment job is removed along with the enrichment pipeline.
+
+**Migration**: No action required. The concert-discovery CronJob no longer has a venue enrichment post-step.
+
+### Requirement: Venue Deduplication During Discovery
+
+**Reason**: `raw_name`-based fallback lookup is removed. Venue deduplication is now based on `google_place_id` via `GetByPlaceID`, which is more reliable than name matching.
+
+**Migration**: Venue lookup uses `GetByPlaceID` instead of `GetByName`/`raw_name` fallback.
+
+## MODIFIED Requirements
+
+### Requirement: Venue Resolution During Concert Creation
+
+The concert creation pipeline SHALL resolve venues synchronously via Google Places API. The `placeSearcher` dependency is required (not optional). Name-based fallback (`GetByName`) is removed.
+
+#### Scenario: Successful venue resolution via Places API
+
+- **WHEN** the concert creation pipeline processes a scraped concert
+- **AND** Google Places API returns a match
+- **THEN** the system SHALL look up an existing venue by `google_place_id` via `GetByPlaceID`
+- **AND** if no existing venue is found, the system SHALL create a new venue with canonical name, coordinates, and `google_place_id` from the Places API result
+
+#### Scenario: Venue already exists by place_id
+
+- **WHEN** the concert creation pipeline processes a scraped concert
+- **AND** Google Places API returns a match
+- **AND** a venue with the same `google_place_id` already exists in the database
+- **THEN** the existing venue SHALL be reused (no new venue created)
+
+#### Scenario: Venue found in batch-local cache
+
+- **WHEN** the concert creation pipeline processes a scraped concert
+- **AND** the venue's `google_place_id` matches a venue already resolved in the current batch
+- **THEN** the cached venue SHALL be reused without additional database or API calls

--- a/openspec/changes/remove-venue-enrichment/tasks.md
+++ b/openspec/changes/remove-venue-enrichment/tasks.md
@@ -1,0 +1,52 @@
+## 1. Simplify resolveVenue — Skip Unresolvable Concerts
+
+- [ ] 1.1 Change `resolveVenue` return signature to `(venueID, *Venue, skip bool, err)` — return `skip=true` when Places API returns NotFound or non-retryable error
+- [ ] 1.2 Add structured Warn log on skip with all `ScrapedConcert` fields (title, local_date, start_time, open_time, listed_venue_name, admin_area, source_url)
+- [ ] 1.3 Remove `GetByName` fallback from `resolveVenue`
+- [ ] 1.4 Remove `createVenuePending()` method
+- [ ] 1.5 Remove `venue.created.v1` publish loop from `CreateFromDiscovered`
+- [ ] 1.6 Update `CreateFromDiscovered` to skip concerts where `resolveVenue` returns `skip=true`
+- [ ] 1.7 Make `placeSearcher` required: panic in `NewConcertCreationUseCase` if nil
+- [ ] 1.8 Update unit tests for `concert_creation_uc_test.go`
+
+## 2. Remove Venue Enrichment Pipeline
+
+- [ ] 2.1 Delete `usecase/venue_enrichment_uc.go` and `venue_enrichment_uc_test.go`
+- [ ] 2.2 Delete `adapter/event/venue_consumer.go` and `venue_consumer_test.go`
+- [ ] 2.3 Remove `VenueEnrichmentUseCase` interface
+- [ ] 2.4 Remove `VenueNamedSearcher` type
+- [ ] 2.5 Remove `VenueCreatedData` and `SubjectVenueCreated` from `entity/event_data.go`
+
+## 3. Remove Enrichment Repository Methods
+
+- [ ] 3.1 Remove `VenueEnrichmentRepository` interface from `entity/venue.go`
+- [ ] 3.2 Remove `ListPending`, `MarkFailed`, `UpdateEnriched`, `MergeVenues` from `rdb/venue_repo.go`
+- [ ] 3.3 Remove `GetByName` from `VenueRepository` interface and `rdb/venue_repo.go`
+- [ ] 3.4 Update `rdb/venue_repo_test.go` — remove tests for deleted methods
+- [ ] 3.5 Remove `AdminAreaResolver` interface and implementation if only used by enrichment
+
+## 4. Clean Up Entity and Schema
+
+- [ ] 4.1 Remove `EnrichmentStatus` constants and field from `entity/venue.go`
+- [ ] 4.2 Remove `RawName` field from `entity/venue.go`
+- [ ] 4.3 Remove `MBID` field from `entity/venue.go`
+- [ ] 4.4 Update `rdb/venue_repo.go` Create method — remove `enrichment_status`, `raw_name`, `mbid` from INSERT
+- [ ] 4.5 Update all venue-related test helpers and raw SQL INSERTs to remove dropped columns
+- [ ] 4.6 Update `entity/venue_test.go` — remove tests for deleted fields
+
+## 5. Database Migration
+
+- [ ] 5.1 Update `schema.sql` — drop `enrichment_status`, `raw_name`, `mbid` columns, `venue_enrichment_status` enum, `idx_venues_mbid` index
+- [ ] 5.2 Create migration: drop columns and enum from `venues` table
+- [ ] 5.3 Run `atlas migrate validate --env local`
+
+## 6. DI Wiring
+
+- [ ] 6.1 Remove venue enrichment wiring from `di/consumer.go` (MusicBrainz venue searcher, Google Maps venue searcher, `VenueEnrichmentUseCase`, `VenueConsumer`, router handler)
+- [ ] 6.2 Remove `placeSearcher` nil-guard from DI — ensure it's always provided
+- [ ] 6.3 Run `mockery` to regenerate mocks
+
+## 7. Verification
+
+- [ ] 7.1 Run `make check` (lint + tests)
+- [ ] 7.2 Run `atlas migrate diff --env local` to verify schema.sql matches migrations


### PR DESCRIPTION
## 🔗 Related Issue

Closes #221

## 📝 Summary of Changes

Add two OpenSpec change artifacts for the venue deduplication overhaul:

**fix-venue-dedup** (complete — 28/28 tasks):
- Proposal, design, delta specs, and implementation tasks
- Fixes venue dedup by using Google Places API `place_id` as canonical identifier
- Changes event natural key from `(venue_id, date, start_at)` to `(artist_id, date, start_at)`
- Delta specs for `concert-search`, `concert-service`, `venue-normalization`

**remove-venue-enrichment** (proposed — 0/24 tasks):
- Proposal, design, delta spec, and implementation tasks
- Removes the async enrichment pipeline (now redundant after synchronous Places API resolution)
- Skips concerts with unresolvable venues, logs full scraped data for manual review
- Delta spec for `venue-normalization` (7 requirements removed, 2 added, 1 modified)

No proto changes — documentation only.

## ✅ Self-Checklist

- [x] I have linked the related issue.
- [x] I have updated the relevant documentation (e.g., `README.md`) if needed.
- [x] I have run `buf lint` and `buf format` locally and all checks have passed.
- [x] My proto definitions follow the project's style guidelines and validation rules.
- [x] Breaking changes have been justified and documented if applicable.
