### PR TITLE
docs(openspec): archive changes and fix spec inconsistencies

### DIFF
--- a/openspec/changes/archive/2026-03-13-fix-sticky-layout/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-13-fix-sticky-layout/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-13

--- a/openspec/changes/archive/2026-03-13-fix-sticky-layout/design.md
+++ b/openspec/changes/archive/2026-03-13-fix-sticky-layout/design.md
@@ -1,0 +1,49 @@
+## Context
+
+`my-app` uses a two-row CSS Grid (`1fr` / `min-content`) with `block-size: 100dvh`. The `<main>` element has `display: contents`, so `au-viewport` becomes a direct grid participant. However, five overlay custom elements sit between `<main>` and `<bottom-nav-bar>` in DOM order. Although four of them have `block-size: 0`, they still occupy implicit grid rows, displacing `bottom-nav-bar` from row 2 to row 7. Additionally, `coach-mark` was never included in the collapse list.
+
+Current DOM order inside `my-app`:
+1. `au-viewport` (via `main { display: contents }`)
+2. `pwa-install-prompt` — implicit row
+3. `notification-prompt` — implicit row
+4. `toast-notification` — implicit row
+5. `error-banner` — implicit row
+6. `coach-mark` — implicit row (no collapse styling at all)
+7. `bottom-nav-bar` — should be row 2, actually row 7
+
+## Goals / Non-Goals
+
+**Goals:**
+- `bottom-nav-bar` occupies the explicit `min-content` grid row and stays pinned at viewport bottom.
+- `live-highway`'s scroll container is properly height-constrained so `position: sticky` works on the stage header and date separators.
+- Overlay elements are completely removed from grid flow.
+
+**Non-Goals:**
+- Changing the HTML structure or DOM order.
+- Modifying overlay component internals — they already use top-layer APIs correctly.
+- Addressing any other layout issues beyond the sticky/fixed positioning bug.
+
+## Decisions
+
+### Use `position: fixed` + `inset: 0` instead of `block-size: 0` collapse
+
+**Choice**: Replace the current `overflow: hidden; display: block; block-size: 0` pattern with `position: fixed; inset: 0`.
+
+**Why**: `position: fixed` removes elements from normal flow entirely — they no longer participate in grid row creation. The current `block-size: 0` approach keeps them in flow (they're still grid items with 0-height implicit rows), which is the root cause. Since these elements use popover/dialog top-layer APIs, their visual rendering is independent of their flow position.
+
+**Alternative considered**: Using `position: absolute` — also removes from flow but requires a positioned ancestor. `fixed` is simpler and more predictable for elements that render in the top layer anyway.
+
+**Alternative considered**: Explicit `grid-row` placement on `au-viewport` and `bottom-nav-bar` — works around the symptom but leaves unnecessary implicit rows in the grid. Less clean.
+
+### Add `coach-mark` to the overlay exclusion list
+
+It was omitted from the original list. It uses the popover API just like the other overlays and should receive identical treatment.
+
+## Risks / Trade-offs
+
+- **[Low] Overlay pointer events**: `position: fixed; inset: 0` creates a full-viewport box. Must keep `pointer-events: none` (or equivalent) so it doesn't intercept clicks. Current `overflow: hidden; block-size: 0` already prevents interaction, but we need to verify this is maintained. → Mitigation: The elements render via top-layer popover/dialog which handles its own pointer events; the fixed-positioned box just needs to not block.
+- **[Low] Aurelia ref binding**: The existing comment notes `display: contents` breaks Aurelia ref bindings. `position: fixed` preserves the box, so this remains safe.
+
+### Implementation note
+
+The final implementation retains both `position: fixed` and `overflow: hidden; block-size: 0` as a defensive measure. While `position: fixed` alone is sufficient for flow removal, the `block-size: 0` provides a fallback for any edge case where the fixed positioning might not apply.

--- a/openspec/changes/archive/2026-03-13-fix-sticky-layout/proposal.md
+++ b/openspec/changes/archive/2026-03-13-fix-sticky-layout/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+Overlay custom elements (`pwa-install-prompt`, `notification-prompt`, `toast-notification`, `error-banner`, `coach-mark`) participate in the `my-app` CSS Grid as implicit row items, pushing `bottom-nav-bar` out of its intended `min-content` row. This breaks two things: (1) the bottom nav disappears off-viewport and only appears when scrolling to the very end, and (2) the `live-highway` scroll container loses its height constraint so the stage header's `position: sticky` has no effect.
+
+## What Changes
+
+- Remove overlay elements from normal grid flow so they no longer create implicit grid rows.
+- Ensure `my-app`'s two-row grid (`1fr` + `min-content`) contains exactly `au-viewport` and `bottom-nav-bar`.
+- Stage header sticky positioning will work correctly once the scroll container is properly height-constrained.
+- No HTML changes required — CSS-only fix.
+
+## Capabilities
+
+### New Capabilities
+
+_(none — this is a bug fix, not a new capability)_
+
+### Modified Capabilities
+
+_(no spec-level behavior changes — the layout was always intended to work this way)_
+
+## Impact
+
+- **File**: `src/my-app.css` — overlay element styles change from `block-size: 0` collapse to `position: fixed` flow removal.
+- **Affected components**: `bottom-nav-bar` (will stay pinned at viewport bottom), `live-highway` stage header (sticky will function), `coach-mark` (needs to be added to the overlay exclusion list).
+- **Risk**: Low — overlay elements already use top-layer APIs (popover/dialog), so removing them from flow has no visual side effects.

--- a/openspec/changes/archive/2026-03-13-fix-sticky-layout/specs/shell-layout/spec.md
+++ b/openspec/changes/archive/2026-03-13-fix-sticky-layout/specs/shell-layout/spec.md
@@ -1,0 +1,16 @@
+## ADDED Requirements
+
+### Requirement: Overlay elements excluded from grid flow
+All overlay custom elements (`pwa-install-prompt`, `notification-prompt`, `toast-notification`, `error-banner`, `coach-mark`) SHALL be removed from normal document flow so they do not create implicit CSS Grid rows in the `my-app` shell layout.
+
+#### Scenario: Bottom nav stays at viewport bottom
+- **WHEN** the dashboard page has enough events to require scrolling
+- **THEN** `bottom-nav-bar` SHALL remain visible and pinned at the bottom of the viewport at all times
+
+#### Scenario: Stage header sticks on scroll
+- **WHEN** the user scrolls the live-highway event list downward
+- **THEN** the stage header (HOME STAGE / NEAR STAGE / AWAY STAGE) SHALL remain fixed at the top of the scroll container and not scroll away
+
+#### Scenario: Overlay elements remain functional
+- **WHEN** an overlay element activates (e.g., toast notification, coach-mark spotlight)
+- **THEN** the overlay SHALL render correctly via the browser top-layer API, unaffected by the flow removal

--- a/openspec/changes/archive/2026-03-13-fix-sticky-layout/tasks.md
+++ b/openspec/changes/archive/2026-03-13-fix-sticky-layout/tasks.md
@@ -1,0 +1,10 @@
+## 1. Fix overlay element flow
+
+- [x] 1.1 In `src/my-app.css`, change the overlay element rule (`pwa-install-prompt, notification-prompt, toast-notification, error-banner`) from `overflow: hidden; display: block; block-size: 0` to `position: fixed` with flow-removal properties, and add `coach-mark` to the selector list
+- [x] 1.2 Ensure overlay elements don't intercept pointer events (add `pointer-events: none` if not already handled by top-layer)
+
+## 2. Verify
+
+- [x] 2.1 Run `make check` to confirm lint + tests pass
+- [x] 2.2 Visual verification in DevTools mobile view: bottom-nav-bar stays pinned at viewport bottom
+- [x] 2.3 Visual verification in DevTools mobile view: stage header remains sticky when scrolling the event list

--- a/openspec/changes/archive/2026-03-13-stylelint-plugin-cube-css/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-13-stylelint-plugin-cube-css/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-12

--- a/openspec/changes/archive/2026-03-13-stylelint-plugin-cube-css/design.md
+++ b/openspec/changes/archive/2026-03-13-stylelint-plugin-cube-css/design.md
@@ -1,0 +1,118 @@
+## Context
+
+The frontend uses stylelint 16.x with ESM (`"type": "module"`). The existing config at `stylelint.config.js` already uses external plugins (`stylelint-use-logical`) and shared configs (`stylelint-config-standard`, `stylelint-config-clean-order`). The CUBE CSS methodology is documented in skill files (`~/.claude/skills/cube-css/`) but has no automated enforcement for structural rules like layer ordering, scope isolation, or design token usage.
+
+All 14 rules need awareness of which `@layer` a declaration lives in — this "layer context" is the defining technical challenge.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Enforce all CUBE CSS methodology rules as stylelint errors
+- Layer-aware rule evaluation (rules behave differently based on which `@layer` code is in)
+- Zero external runtime dependencies (pure stylelint plugin using PostCSS AST)
+- All rules individually configurable and disableable
+- Comprehensive test coverage for each rule
+
+**Non-Goals:**
+- HTML-side enforcement (e.g., `class="[ block ] [ composition ]"` bracket grouping) — requires an HTML linter, not stylelint
+- Auto-fix capabilities for structural rules (require-layer, layer-order) — too risky to auto-rewrite
+- Publishing to npm as a public package (may happen later, but not in scope)
+
+## Decisions
+
+### 1. Package location: `frontend/stylelint-plugin-cube-css/` as a local directory
+
+The plugin lives as a local directory within the frontend repo, referenced via `plugins: ['./stylelint-plugin-cube-css/index.js']` in `stylelint.config.js`.
+
+**Alternatives considered:**
+- **npm workspace package** — Over-engineering for a single-consumer plugin. The frontend repo is not a monorepo with workspaces.
+- **Separate repo** — Adds cross-repo coordination overhead for something used only here. Can extract later if OSS demand arises.
+- **Inline in `src/`** — `src/` is application code; linting tools belong at the project root level.
+
+### 2. Layer context resolution: Walk the PostCSS AST ancestor chain
+
+Each rule that needs layer awareness traverses the parent nodes of a declaration/rule to find the enclosing `@layer` AtRule. This is extracted into a shared utility `getLayerContext(node)` that returns the layer name (or `null` for unlayered code).
+
+```
+AtRule(@layer block)
+  └─ AtRule(@scope .card)
+       └─ Rule(:scope)
+            └─ Declaration(padding: var(--space-m))
+                 ↑ getLayerContext() → "block"
+```
+
+**Alternatives considered:**
+- **Pre-pass to build a layer map** — More complex, harder to maintain, marginal performance benefit given typical file sizes.
+- **File-path based detection** (e.g., `compositions/` → composition layer) — Brittle, doesn't work with bundled CSS or non-standard structures.
+
+### 3. Plugin architecture: Single entry point, one file per rule
+
+```
+stylelint-plugin-cube-css/
+  index.js                    # Plugin registration (exports all rules)
+  lib/
+    utils/
+      get-layer-context.js    # Shared: walk ancestors to find @layer
+      is-var-function.js      # Shared: check if a value contains var()
+      visual-properties.js    # Shared: set of visual treatment properties
+    rules/
+      require-layer.js
+      layer-order.js
+      exception-data-attr.js
+      no-visual-in-composition.js
+      utility-single-property.js
+      block-require-scope.js
+      require-token-variables.js
+      block-max-lines.js
+      one-block-per-file.js
+      prefer-where-in-reset.js
+      data-attr-naming.js
+      prefer-vi-over-vw.js
+      require-container-name.js
+      prefer-color-mix.js
+  test/
+    rules/
+      require-layer.test.js
+      ...                     # One test file per rule
+```
+
+Each rule file exports a standard stylelint rule object using `stylelint.createPlugin()`. Rules follow the naming convention `cube/<rule-name>`.
+
+### 4. `require-token-variables` — calc() must contain at least one `var()`
+
+When a property value uses `calc()`, the rule checks that at least one `var()` reference exists within the calc expression. Pure literal `calc()` expressions (e.g., `calc(16px + 4px)`) are rejected because they bypass the token system.
+
+**Allowed structural values** that bypass the rule entirely: `0`, `auto`, `none`, `inherit`, `initial`, `unset`, `revert`, `currentColor`, `transparent`, fractions (`1fr`, `2fr`), and percentages used structurally (`100%`, `50%`).
+
+**Ignored layers**: `reset` and `global` (where tokens are defined).
+
+### 5. `block-require-scope` — `@scope` required in block layer
+
+Within `@layer block`, all style rules must be wrapped in `@scope(<selector>)`. Direct rules without `@scope` are flagged. This enforces component isolation at the CSS level and eliminates the need for BEM prefixes.
+
+### 6. Visual property set for `no-visual-in-composition`
+
+The following properties are classified as "visual treatment" and disallowed in the composition layer:
+
+- Color: `color`, `background`, `background-color`, `background-image`, `border-color`, `outline-color`
+- Typography: `font-style`, `font-weight`, `text-decoration`, `text-transform`, `letter-spacing`
+- Decorative: `box-shadow`, `text-shadow`, `border-radius`, `opacity`, `filter`, `backdrop-filter`
+- Transitions: `transition`, `animation`
+
+Allowed in composition: `display`, `flex-*`, `grid-*`, `gap`, `align-*`, `justify-*`, `margin-*`, `padding-*`, `inline-size`, `block-size`, `min-*`, `max-*`, `overflow`, `position`.
+
+This set is configurable via rule options.
+
+### 7. Testing: Vitest with stylelint's `lint()` API
+
+Tests use `vitest` (already in the project) and invoke `stylelint.lint({ code, config })` directly to test each rule in isolation. No CSS files on disk needed — all test cases are inline strings.
+
+## Risks / Trade-offs
+
+**[R1] `@scope` browser support is "Baseline Newly Available"** → The project targets modern browsers only. The Aurelia 2 + Vite stack already assumes modern browser support. `@scope` is available in Chrome 118+, Edge 118+, Safari 17.4+, Firefox 128+.
+
+**[R2] Existing CSS files will need migration** → Adding all 14 rules at once will produce many lint errors on existing files. Mitigation: configure new rules as `"warning"` initially, then promote to `"error"` after migration is complete.
+
+**[R3] Layer context detection assumes `@layer` is always an ancestor AtRule** → CSS files that use `@import "file.css" layer(block)` won't have an `@layer` AtRule in the parsed AST of the imported file. Mitigation: document that each CSS file must include its own `@layer` wrapper (which aligns with the methodology's file organization pattern).
+
+**[R4] Performance with 14 rules traversing the AST** → Each rule walks the tree independently. For typical component CSS files (< 200 lines), this is negligible. If performance becomes an issue, rules can be consolidated into a single AST walk later.

--- a/openspec/changes/archive/2026-03-13-stylelint-plugin-cube-css/proposal.md
+++ b/openspec/changes/archive/2026-03-13-stylelint-plugin-cube-css/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+The CUBE CSS methodology defines strict rules for how CSS should be organized across layers (Composition, Utility, Block, Exception), but these rules are currently enforced only by developer discipline and AI skill files. The existing `css-linting` spec covers modern CSS features (OKLCH, logical properties, container queries) but has no enforcement for CUBE CSS structural rules — such as requiring `@layer`, enforcing layer order, restricting what properties appear in which layer, or requiring `@scope` in blocks. A custom stylelint plugin closes this gap by making CUBE CSS methodology violations a lint error.
+
+## What Changes
+
+- Create a new `stylelint-plugin-cube-css` package in the frontend workspace containing 14 custom stylelint rules
+- Integrate the plugin into the existing `stylelint.config.js` configuration
+- Rules enforce all three tiers of CUBE CSS methodology:
+  - **Tier 1 — Core methodology**: `@layer` usage, layer ordering, exception patterns, composition purity, utility scope, block scoping with `@scope`, and design token enforcement via `var()`
+  - **Tier 2 — Structural enforcement**: block size limits, one-block-per-file, `:where()` in reset/global, and `data-*` attribute naming conventions
+  - **Tier 3 — Modern CSS best practices**: `vi` over `vw`, `container-name` requirement, `color-mix()` preference
+
+## Capabilities
+
+### New Capabilities
+- `cube-css-lint-plugin`: The stylelint plugin package itself — rule implementations, test suite, and plugin registration
+- `cube-css-layer-enforcement`: Rules that enforce `@layer` structure (`require-layer`, `layer-order`)
+- `cube-css-layer-constraints`: Rules that constrain what is allowed within each layer (`no-visual-in-composition`, `utility-single-property`, `block-require-scope`, `exception-data-attr`, `data-attr-naming`)
+- `cube-css-token-enforcement`: The `require-token-variables` rule — enforces `var()` for design tokens in consumption layers, with `calc()` awareness
+- `cube-css-structural-rules`: Rules enforcing file/block structure (`block-max-lines`, `one-block-per-file`, `prefer-where-in-reset`)
+- `cube-css-modern-css-rules`: Rules enforcing modern CSS best practices (`prefer-vi-over-vw`, `require-container-name`, `prefer-color-mix`)
+
+### Modified Capabilities
+- `css-linting`: The existing stylelint configuration will be updated to register and configure the new plugin rules
+
+## Impact
+
+- **frontend/**: New package added (likely `packages/stylelint-plugin-cube-css/` or inline within `src/`)
+- **frontend/stylelint.config.js**: Updated to include the plugin and configure all 14 rules
+- **CI pipeline**: No changes needed — `make lint` already runs stylelint
+- **Existing CSS files**: May need updates to comply with new rules (e.g., adding `@layer` wrappers, `@scope` in blocks, replacing magic values with `var()`)
+- **Dependencies**: `stylelint` peer dependency (already installed)

--- a/openspec/changes/archive/2026-03-13-stylelint-plugin-cube-css/specs/css-linting/spec.md
+++ b/openspec/changes/archive/2026-03-13-stylelint-plugin-cube-css/specs/css-linting/spec.md
@@ -1,0 +1,21 @@
+## MODIFIED Requirements
+
+### Requirement: Stylelint compatible with Tailwind CSS v4
+The linter SHALL not flag valid Tailwind v4 directives, modern CSS at-rules, or CUBE CSS plugin rules as errors.
+
+#### Scenario: Tailwind at-rules accepted
+- **WHEN** a CSS file contains `@theme`, `@layer`, or `@apply` directives
+- **THEN** Stylelint SHALL not report unknown at-rule errors
+
+#### Scenario: Modern CSS at-rules accepted
+- **WHEN** a CSS file contains `@container`, `@starting-style`, `@property`, or `@scope` at-rules
+- **THEN** Stylelint SHALL not report unknown at-rule errors
+
+#### Scenario: Tailwind theme function accepted
+- **WHEN** a CSS file uses the `theme()` function
+- **THEN** Stylelint SHALL not report unknown function errors
+
+#### Scenario: CUBE CSS plugin rules configured
+- **WHEN** `stylelint.config.js` is loaded
+- **THEN** the `stylelint-plugin-cube-css` plugin SHALL be registered
+- **AND** all 14 `cube/*` rules SHALL be configured

--- a/openspec/changes/archive/2026-03-13-stylelint-plugin-cube-css/specs/cube-css-layer-constraints/spec.md
+++ b/openspec/changes/archive/2026-03-13-stylelint-plugin-cube-css/specs/cube-css-layer-constraints/spec.md
@@ -1,0 +1,113 @@
+## ADDED Requirements
+
+### Requirement: `cube/exception-data-attr` requires `data-*` selectors in exception layer
+Selectors inside `@layer exception` SHALL contain at least one `[data-*]` attribute selector. CSS-class-only exceptions are prohibited.
+
+#### Scenario: Attribute selector accepted
+- **WHEN** `@layer exception` contains `.card[data-state="reversed"] { ... }`
+- **THEN** the rule SHALL not report an error
+
+#### Scenario: Pure class selector rejected
+- **WHEN** `@layer exception` contains `.card--reversed { ... }` (no `data-*` attribute)
+- **THEN** the rule SHALL report an error: "Exception layer selectors must use [data-*] attribute selectors"
+
+#### Scenario: Multiple data attributes accepted
+- **WHEN** `@layer exception` contains `.card[data-state="loading"][data-variant="compact"] { ... }`
+- **THEN** the rule SHALL not report an error
+
+#### Scenario: Non-exception layers ignored
+- **WHEN** `@layer block` contains `.card { ... }` (no `data-*` attribute)
+- **THEN** the rule SHALL not report an error (rule only applies to exception layer)
+
+### Requirement: `cube/no-visual-in-composition` prohibits visual properties in composition layer
+The composition layer SHALL only contain structural/layout properties. Visual treatment properties SHALL be rejected.
+
+#### Scenario: Layout properties accepted
+- **WHEN** `@layer composition` contains `.cluster { display: flex; flex-wrap: wrap; gap: var(--cluster-gap, var(--space-s)); }`
+- **THEN** the rule SHALL not report an error
+
+#### Scenario: Color property rejected
+- **WHEN** `@layer composition` contains `.flow { color: var(--color-text); }`
+- **THEN** the rule SHALL report an error: "Visual property 'color' is not allowed in the composition layer"
+
+#### Scenario: Background rejected
+- **WHEN** `@layer composition` contains `.wrapper { background: var(--color-surface); }`
+- **THEN** the rule SHALL report an error
+
+#### Scenario: Box-shadow rejected
+- **WHEN** `@layer composition` contains `.sidebar { box-shadow: 0 2px 4px oklch(0% 0 0 / 10%); }`
+- **THEN** the rule SHALL report an error
+
+#### Scenario: Border-radius rejected
+- **WHEN** `@layer composition` contains `.grid { border-radius: var(--radius-m); }`
+- **THEN** the rule SHALL report an error
+
+#### Scenario: Custom visual property set via options
+- **WHEN** the rule is configured with `additionalVisualProperties: ["cursor"]`
+- **THEN** `cursor` SHALL also be rejected in the composition layer
+
+### Requirement: `cube/utility-single-property` limits properties per utility selector
+Each selector in `@layer utility` SHALL contain at most the configured number of properties (default: 2).
+
+#### Scenario: Single property accepted
+- **WHEN** `@layer utility` contains `.mt-s { margin-block-start: var(--space-s); }`
+- **THEN** the rule SHALL not report an error
+
+#### Scenario: Two tightly related properties accepted
+- **WHEN** `@layer utility` contains `.visually-hidden { clip: rect(0 0 0 0); clip-path: inset(50%); }`
+- **THEN** the rule SHALL not report an error (within default limit of 2)
+
+#### Scenario: Too many properties rejected
+- **WHEN** `@layer utility` contains `.badge { color: var(--color-primary); font-size: var(--step-0); padding: var(--space-xs); }`
+- **THEN** the rule SHALL report an error: "Utility selectors must have at most 2 properties, found 3"
+
+#### Scenario: Custom max configured
+- **WHEN** the rule is configured with `[true, { max: 3 }]`
+- **THEN** selectors with 3 or fewer properties SHALL be accepted
+
+#### Scenario: visually-hidden pattern accepted with higher limit
+- **WHEN** the rule is configured with `[true, { max: 6 }]`
+- **AND** `@layer utility` contains `.visually-hidden` with 6 properties
+- **THEN** the rule SHALL not report an error
+
+### Requirement: `cube/block-require-scope` requires `@scope` in block layer
+All style rules inside `@layer block` SHALL be wrapped in `@scope(<selector>)`.
+
+#### Scenario: Scoped block accepted
+- **WHEN** `@layer block` contains `@scope (.card) { :scope { padding: var(--space-m); } }`
+- **THEN** the rule SHALL not report an error
+
+#### Scenario: Unscoped block rejected
+- **WHEN** `@layer block` contains `.card { padding: var(--space-m); }` (not inside `@scope`)
+- **THEN** the rule SHALL report an error: "Block layer rules must be wrapped in @scope()"
+
+#### Scenario: Nested rules inside scope accepted
+- **WHEN** `@layer block` contains `@scope (.card) { :scope { ... } .title { ... } .content { ... } }`
+- **THEN** the rule SHALL not report an error
+
+#### Scenario: Non-block layers ignored
+- **WHEN** `@layer composition` contains `.flow > * + * { ... }` (not inside `@scope`)
+- **THEN** the rule SHALL not report an error (rule only applies to block layer)
+
+### Requirement: `cube/data-attr-naming` restricts data attribute names in exception layer
+Exception layer selectors SHALL only use `data-state`, `data-variant`, or `data-theme` attribute names.
+
+#### Scenario: `data-state` accepted
+- **WHEN** `@layer exception` contains `.card[data-state="loading"] { ... }`
+- **THEN** the rule SHALL not report an error
+
+#### Scenario: `data-variant` accepted
+- **WHEN** `@layer exception` contains `.card[data-variant="compact"] { ... }`
+- **THEN** the rule SHALL not report an error
+
+#### Scenario: `data-theme` accepted
+- **WHEN** `@layer exception` contains `[data-theme="dark"] { ... }`
+- **THEN** the rule SHALL not report an error
+
+#### Scenario: Non-standard data attribute rejected
+- **WHEN** `@layer exception` contains `.card[data-reversed] { ... }`
+- **THEN** the rule SHALL report an error: "Exception data attributes must use 'data-state', 'data-variant', or 'data-theme'. Found 'data-reversed'"
+
+#### Scenario: Custom allowed attributes via options
+- **WHEN** the rule is configured with `[true, { additionalAttributes: ["data-density"] }]`
+- **THEN** `data-density` SHALL also be accepted

--- a/openspec/changes/archive/2026-03-13-stylelint-plugin-cube-css/specs/cube-css-layer-enforcement/spec.md
+++ b/openspec/changes/archive/2026-03-13-stylelint-plugin-cube-css/specs/cube-css-layer-enforcement/spec.md
@@ -1,0 +1,51 @@
+## ADDED Requirements
+
+### Requirement: `cube/require-layer` rejects CSS rules outside `@layer` blocks
+All CSS rules SHALL be inside an `@layer` block. Unlayered styles override all layers and break the CUBE CSS cascade.
+
+#### Scenario: Rule inside `@layer` accepted
+- **WHEN** a CSS file contains `.card { padding: var(--space-m); }` inside `@layer block { ... }`
+- **THEN** the rule SHALL not report an error
+
+#### Scenario: Rule outside `@layer` rejected
+- **WHEN** a CSS file contains `.card { padding: var(--space-m); }` at the top level (not inside any `@layer`)
+- **THEN** the rule SHALL report an error: "All CSS rules must be inside an @layer block"
+
+#### Scenario: `@layer` declaration statement accepted
+- **WHEN** a CSS file contains `@layer reset, global, composition, utility, block, exception;` (a layer order declaration with no body)
+- **THEN** the rule SHALL not report an error (declarations are not rules)
+
+#### Scenario: `@property` at top level accepted
+- **WHEN** a CSS file contains `@property --hue { syntax: "<number>"; inherits: true; initial-value: 260; }` outside `@layer`
+- **THEN** the rule SHALL not report an error (`@property` cannot be inside `@layer`)
+
+#### Scenario: `@keyframes` outside `@layer` rejected
+- **WHEN** a CSS file contains `@keyframes fade-in { ... }` at the top level
+- **THEN** the rule SHALL report an error
+
+### Requirement: `cube/layer-order` enforces correct `@layer` declaration order
+The `@layer` declaration statement SHALL list layers in the order: `reset, global, composition, utility, block, exception`. Subsets are allowed but order must be preserved.
+
+#### Scenario: Correct full order accepted
+- **WHEN** a CSS file contains `@layer reset, global, composition, utility, block, exception;`
+- **THEN** the rule SHALL not report an error
+
+#### Scenario: Correct partial order accepted
+- **WHEN** a CSS file contains `@layer composition, utility, block;` (subset in correct relative order)
+- **THEN** the rule SHALL not report an error
+
+#### Scenario: Wrong order rejected
+- **WHEN** a CSS file contains `@layer block, utility, composition;`
+- **THEN** the rule SHALL report an error: "Layer order must follow: reset, global, composition, utility, block, exception"
+
+#### Scenario: Unknown layer name rejected
+- **WHEN** a CSS file contains `@layer reset, global, components;` (where `components` is not a valid CUBE CSS layer name)
+- **THEN** the rule SHALL report an error: "Unknown layer name 'components'. Expected one of: reset, global, composition, utility, block, exception"
+
+#### Scenario: Multiple `@layer` block declarations maintain order
+- **WHEN** a CSS file contains `@layer composition { ... }` followed by `@layer block { ... }`
+- **THEN** the rule SHALL not report an error (composition before block is correct order)
+
+#### Scenario: Out-of-order `@layer` block declarations rejected
+- **WHEN** a CSS file contains `@layer block { ... }` followed by `@layer composition { ... }`
+- **THEN** the rule SHALL report an error

--- a/openspec/changes/archive/2026-03-13-stylelint-plugin-cube-css/specs/cube-css-lint-plugin/spec.md
+++ b/openspec/changes/archive/2026-03-13-stylelint-plugin-cube-css/specs/cube-css-lint-plugin/spec.md
@@ -1,0 +1,37 @@
+## ADDED Requirements
+
+### Requirement: Plugin registers all rules under the `cube/` namespace
+The plugin SHALL export all rules prefixed with `cube/` so they can be configured individually in `stylelint.config.js`.
+
+#### Scenario: All 14 rules are registered
+- **WHEN** the plugin is loaded by stylelint
+- **THEN** the following rules SHALL be available: `cube/require-layer`, `cube/layer-order`, `cube/exception-data-attr`, `cube/no-visual-in-composition`, `cube/utility-single-property`, `cube/block-require-scope`, `cube/require-token-variables`, `cube/block-max-lines`, `cube/one-block-per-file`, `cube/prefer-where-in-reset`, `cube/data-attr-naming`, `cube/prefer-vi-over-vw`, `cube/require-container-name`, `cube/prefer-color-mix`
+
+#### Scenario: Unknown rule name rejected
+- **WHEN** a user configures `cube/nonexistent-rule` in their stylelint config
+- **THEN** stylelint SHALL report an invalid configuration error
+
+### Requirement: Plugin is a local ESM package
+The plugin SHALL be implemented as a local ESM directory at `frontend/stylelint-plugin-cube-css/` and referenced via a relative path in the stylelint config.
+
+#### Scenario: Plugin loaded via relative path
+- **WHEN** `stylelint.config.js` includes `plugins: ['./stylelint-plugin-cube-css/index.js']`
+- **THEN** stylelint SHALL load and register all plugin rules without errors
+
+### Requirement: Each rule has comprehensive test coverage
+Every rule SHALL have a dedicated test file with passing and failing test cases using vitest and stylelint's `lint()` API.
+
+#### Scenario: Test suite passes
+- **WHEN** `npx vitest run stylelint-plugin-cube-css/` is executed
+- **THEN** all tests SHALL pass with zero failures
+
+### Requirement: Shared layer context utility
+The plugin SHALL provide a shared `getLayerContext(node)` utility that returns the name of the enclosing `@layer` for any PostCSS node.
+
+#### Scenario: Nested node returns correct layer
+- **WHEN** a declaration is nested inside `@layer block { @scope (.card) { :scope { ... } } }`
+- **THEN** `getLayerContext()` SHALL return `"block"`
+
+#### Scenario: Unlayered node returns null
+- **WHEN** a declaration is not inside any `@layer` block
+- **THEN** `getLayerContext()` SHALL return `null`

--- a/openspec/changes/archive/2026-03-13-stylelint-plugin-cube-css/specs/cube-css-modern-css-rules/spec.md
+++ b/openspec/changes/archive/2026-03-13-stylelint-plugin-cube-css/specs/cube-css-modern-css-rules/spec.md
@@ -1,0 +1,58 @@
+## ADDED Requirements
+
+### Requirement: `cube/prefer-vi-over-vw` recommends `vi` unit over `vw`
+CSS values SHALL use the `vi` (viewport inline) unit instead of `vw` (viewport width) for logical consistency with writing-mode awareness.
+
+#### Scenario: `vi` unit accepted
+- **WHEN** a CSS file contains `font-size: clamp(1rem, 0.34vi + 0.91rem, 1.19rem);`
+- **THEN** the rule SHALL not report an error
+
+#### Scenario: `vw` unit rejected
+- **WHEN** a CSS file contains `font-size: clamp(1rem, 0.34vw + 0.91rem, 1.19rem);`
+- **THEN** the rule SHALL report an error: "Use 'vi' instead of 'vw' for logical viewport units"
+
+#### Scenario: `vh` not affected
+- **WHEN** a CSS file contains `block-size: 100vh;`
+- **THEN** the rule SHALL not report an error (only `vw` → `vi` is enforced; `vh` → `vb` is a separate concern)
+
+#### Scenario: `svw` and `lvw` also rejected
+- **WHEN** a CSS file contains `inline-size: 100svw;` or `inline-size: 100lvw;`
+- **THEN** the rule SHALL report an error recommending `svi` or `lvi` respectively
+
+### Requirement: `cube/require-container-name` enforces naming containers
+Elements that declare `container-type` SHALL also declare `container-name`.
+
+#### Scenario: Both properties present accepted
+- **WHEN** a CSS rule contains `container-type: inline-size; container-name: card;`
+- **THEN** the rule SHALL not report an error
+
+#### Scenario: `container` shorthand with name accepted
+- **WHEN** a CSS rule contains `container: card / inline-size;`
+- **THEN** the rule SHALL not report an error
+
+#### Scenario: `container-type` without `container-name` rejected
+- **WHEN** a CSS rule contains `container-type: inline-size;` but no `container-name` declaration
+- **THEN** the rule SHALL report an error: "Elements with container-type must also declare container-name"
+
+#### Scenario: `container-type: normal` ignored
+- **WHEN** a CSS rule contains `container-type: normal;` (the default/reset value)
+- **THEN** the rule SHALL not report an error
+
+### Requirement: `cube/prefer-color-mix` recommends `color-mix()` for derived colors
+When a custom property value in `@layer global` derives a color from another token (e.g., lighter/darker variants), `color-mix()` or relative color syntax SHALL be preferred over manual `oklch()` with hardcoded values.
+
+#### Scenario: `color-mix()` accepted
+- **WHEN** `@layer global` contains `--color-primary-hover: color-mix(in oklch, var(--color-primary) 80%, white);`
+- **THEN** the rule SHALL not report an error
+
+#### Scenario: Relative color syntax accepted
+- **WHEN** `@layer global` contains `--color-primary-light: oklch(from var(--color-primary) calc(l + 0.2) c h);`
+- **THEN** the rule SHALL not report an error
+
+#### Scenario: Base color definition accepted
+- **WHEN** `@layer global` contains `--color-primary: oklch(55% 0.25 260);`
+- **THEN** the rule SHALL not report an error (this is a base definition, not a derivation)
+
+#### Scenario: Derived color without `color-mix()` or relative syntax warned
+- **WHEN** `@layer global` contains `--color-primary-light: oklch(75% 0.15 260);` and a `--color-primary` also exists
+- **THEN** the rule SHALL report a warning: "Consider using color-mix() or relative color syntax to derive color variants from base tokens"

--- a/openspec/changes/archive/2026-03-13-stylelint-plugin-cube-css/specs/cube-css-structural-rules/spec.md
+++ b/openspec/changes/archive/2026-03-13-stylelint-plugin-cube-css/specs/cube-css-structural-rules/spec.md
@@ -1,0 +1,62 @@
+## ADDED Requirements
+
+### Requirement: `cube/block-max-lines` limits block size
+Each `@scope` block inside `@layer block` SHALL contain at most the configured number of lines (default: 80).
+
+#### Scenario: Small block accepted
+- **WHEN** `@layer block` contains a `@scope (.card) { ... }` block with 40 lines
+- **THEN** the rule SHALL not report an error
+
+#### Scenario: Oversized block rejected
+- **WHEN** `@layer block` contains a `@scope (.card) { ... }` block with 95 lines
+- **THEN** the rule SHALL report an error: "Block exceeds 80 lines (found 95). Push work to higher layers."
+
+#### Scenario: Custom max configured
+- **WHEN** the rule is configured with `[true, { max: 120 }]`
+- **THEN** blocks up to 120 lines SHALL be accepted
+
+#### Scenario: Non-block layers ignored
+- **WHEN** `@layer global` contains a rule set spanning 200 lines
+- **THEN** the rule SHALL not report an error
+
+### Requirement: `cube/one-block-per-file` enforces single block per file
+Files containing `@layer block` SHALL have at most one `@scope` directive.
+
+#### Scenario: Single scope accepted
+- **WHEN** a CSS file contains `@layer block { @scope (.card) { ... } }`
+- **THEN** the rule SHALL not report an error
+
+#### Scenario: Multiple scopes rejected
+- **WHEN** a CSS file contains `@layer block { @scope (.card) { ... } @scope (.button) { ... } }`
+- **THEN** the rule SHALL report an error: "Block layer must contain only one @scope. Found 2. Use separate files."
+
+#### Scenario: Files without block layer ignored
+- **WHEN** a CSS file contains only `@layer composition { ... }`
+- **THEN** the rule SHALL not report an error
+
+### Requirement: `cube/prefer-where-in-reset` recommends `:where()` in reset and global layers
+Selectors in `@layer reset` and `@layer global` SHOULD use `:where()` wrapping for zero-specificity defaults.
+
+#### Scenario: `:where()` selector accepted
+- **WHEN** `@layer global` contains `:where(h1, h2, h3) { line-height: 1.2; }`
+- **THEN** the rule SHALL not report an error
+
+#### Scenario: Element selector without `:where()` warned
+- **WHEN** `@layer global` contains `h1, h2, h3 { line-height: 1.2; }`
+- **THEN** the rule SHALL report a warning: "Consider wrapping in :where() for zero-specificity defaults"
+
+#### Scenario: `:root` selector accepted without `:where()`
+- **WHEN** `@layer global` contains `:root { --color-primary: oklch(55% 0.25 260); }`
+- **THEN** the rule SHALL not report an error (`:root` for custom properties is a standard pattern)
+
+#### Scenario: `body` selector accepted without `:where()`
+- **WHEN** `@layer global` contains `body { font-family: var(--font-base); }`
+- **THEN** the rule SHALL not report an error (`body` is a common global singleton)
+
+#### Scenario: Universal selector in reset accepted
+- **WHEN** `@layer reset` contains `:where(*, *::before, *::after) { box-sizing: border-box; }`
+- **THEN** the rule SHALL not report an error
+
+#### Scenario: Non-reset/global layers ignored
+- **WHEN** `@layer block` contains `.card { ... }` without `:where()`
+- **THEN** the rule SHALL not report an error

--- a/openspec/changes/archive/2026-03-13-stylelint-plugin-cube-css/specs/cube-css-token-enforcement/spec.md
+++ b/openspec/changes/archive/2026-03-13-stylelint-plugin-cube-css/specs/cube-css-token-enforcement/spec.md
@@ -1,0 +1,100 @@
+## ADDED Requirements
+
+### Requirement: `cube/require-token-variables` enforces `var()` for design token properties
+Configured properties in consumption layers (composition, utility, block, exception) SHALL use `var()` references instead of raw literal values.
+
+#### Scenario: `var()` value accepted
+- **WHEN** `@layer block` contains `.card { padding: var(--space-m); }`
+- **THEN** the rule SHALL not report an error
+
+#### Scenario: Raw literal rejected
+- **WHEN** `@layer block` contains `.card { padding: 16px; }`
+- **THEN** the rule SHALL report an error: "Property 'padding' must use a design token via var(). Found raw value '16px'"
+
+#### Scenario: Raw color rejected
+- **WHEN** `@layer block` contains `.card { color: oklch(55% 0.25 260); }`
+- **THEN** the rule SHALL report an error
+
+#### Scenario: Raw font-size rejected
+- **WHEN** `@layer utility` contains `.text-lg { font-size: 1.2rem; }`
+- **THEN** the rule SHALL report an error
+
+### Requirement: `calc()` expressions must contain at least one `var()`
+When a token-enforced property uses `calc()`, the expression SHALL contain at least one `var()` reference.
+
+#### Scenario: calc with var() accepted
+- **WHEN** `@layer block` contains `.card { padding: calc(var(--space-m) - 1px); }`
+- **THEN** the rule SHALL not report an error
+
+#### Scenario: calc with division by literal accepted
+- **WHEN** `@layer block` contains `.card { gap: calc(var(--space-s) / 2); }`
+- **THEN** the rule SHALL not report an error
+
+#### Scenario: Pure literal calc rejected
+- **WHEN** `@layer block` contains `.card { padding: calc(16px + 4px); }`
+- **THEN** the rule SHALL report an error: "calc() must reference at least one design token via var()"
+
+#### Scenario: Nested calc with var() accepted
+- **WHEN** `@layer block` contains `.card { inline-size: calc(100% - var(--space-m) * 2); }`
+- **THEN** the rule SHALL not report an error
+
+### Requirement: Structural values bypass token enforcement
+Values that are inherently structural (not design tokens) SHALL be allowed without `var()`.
+
+#### Scenario: Zero accepted
+- **WHEN** `@layer block` contains `.card { padding: 0; }`
+- **THEN** the rule SHALL not report an error
+
+#### Scenario: `auto` accepted
+- **WHEN** `@layer block` contains `.card { margin-inline: auto; }`
+- **THEN** the rule SHALL not report an error
+
+#### Scenario: `none` accepted
+- **WHEN** `@layer block` contains `.card { background: none; }`
+- **THEN** the rule SHALL not report an error
+
+#### Scenario: CSS-wide keywords accepted
+- **WHEN** a property value is `inherit`, `initial`, `unset`, or `revert`
+- **THEN** the rule SHALL not report an error
+
+#### Scenario: `currentColor` accepted
+- **WHEN** `@layer block` contains `.icon { color: currentColor; }`
+- **THEN** the rule SHALL not report an error
+
+#### Scenario: `transparent` accepted
+- **WHEN** `@layer block` contains `.card { background: transparent; }`
+- **THEN** the rule SHALL not report an error
+
+#### Scenario: Grid fractions accepted
+- **WHEN** `@layer block` contains `.layout { grid-template-columns: 1fr 2fr; }`
+- **THEN** the rule SHALL not report an error
+
+### Requirement: Token definition layers are excluded
+The `reset` and `global` layers SHALL be excluded from token enforcement because they are where tokens are defined.
+
+#### Scenario: Raw value in global layer accepted
+- **WHEN** `@layer global` contains `:root { --space-m: 1rem; }`
+- **THEN** the rule SHALL not report an error
+
+#### Scenario: Raw value in reset layer accepted
+- **WHEN** `@layer reset` contains `* { box-sizing: border-box; margin: 0; }`
+- **THEN** the rule SHALL not report an error
+
+### Requirement: Duration and easing properties are token-enforced
+Properties `transition-duration` and `animation-duration` SHALL require `var()` references.
+
+#### Scenario: Duration token accepted
+- **WHEN** `@layer block` contains `.card { transition-duration: var(--duration-fast); }`
+- **THEN** the rule SHALL not report an error
+
+#### Scenario: Raw duration rejected
+- **WHEN** `@layer block` contains `.card { transition-duration: 150ms; }`
+- **THEN** the rule SHALL report an error
+
+### Requirement: Configurable property list
+The list of properties that require `var()` SHALL be configurable via rule options.
+
+#### Scenario: Custom properties list
+- **WHEN** the rule is configured with `[true, { properties: ["padding", "color"] }]`
+- **THEN** only `padding` and `color` SHALL be enforced
+- **AND** other properties like `gap` or `font-size` SHALL be allowed with raw values

--- a/openspec/changes/archive/2026-03-13-stylelint-plugin-cube-css/tasks.md
+++ b/openspec/changes/archive/2026-03-13-stylelint-plugin-cube-css/tasks.md
@@ -1,0 +1,38 @@
+## 1. Plugin Scaffold
+
+- [x] 1.1 Create `frontend/stylelint-plugin-cube-css/` directory structure (`index.js`, `lib/utils/`, `lib/rules/`, `test/rules/`)
+- [x] 1.2 Create `index.js` entry point that registers all 14 rules under the `cube/` namespace
+- [x] 1.3 Create shared utility `lib/utils/get-layer-context.js` (walk PostCSS ancestors to find enclosing `@layer`)
+- [x] 1.4 Create shared utility `lib/utils/is-var-function.js` (check if a value contains `var()`)
+- [x] 1.5 Create shared utility `lib/utils/visual-properties.js` (set of visual treatment property names)
+
+## 2. Tier 1 — Core Methodology Rules
+
+- [x] 2.1 Implement `cube/require-layer` rule and tests
+- [x] 2.2 Implement `cube/layer-order` rule and tests
+- [x] 2.3 Implement `cube/exception-data-attr` rule and tests
+- [x] 2.4 Implement `cube/no-visual-in-composition` rule and tests
+- [x] 2.5 Implement `cube/utility-single-property` rule and tests
+- [x] 2.6 Implement `cube/block-require-scope` rule and tests
+- [x] 2.7 Implement `cube/require-token-variables` rule and tests (including calc() awareness, structural value allowlist, duration properties)
+
+## 3. Tier 2 — Structural Rules
+
+- [x] 3.1 Implement `cube/block-max-lines` rule and tests
+- [x] 3.2 Implement `cube/one-block-per-file` rule and tests
+- [x] 3.3 Implement `cube/prefer-where-in-reset` rule and tests
+- [x] 3.4 Implement `cube/data-attr-naming` rule and tests
+
+## 4. Tier 3 — Modern CSS Rules
+
+- [x] 4.1 Implement `cube/prefer-vi-over-vw` rule and tests
+- [x] 4.2 Implement `cube/require-container-name` rule and tests
+- [x] 4.3 Implement `cube/prefer-color-mix` rule and tests
+
+## 5. Integration
+
+- [x] 5.1 Update `frontend/stylelint.config.js` to register plugin and configure all 14 rules
+- [x] 5.2 Add `@scope` to `at-rule-no-unknown` ignore list in stylelint config
+- [x] 5.3 Run `npm run lint:css` against existing CSS files and document violations
+- [x] 5.4 Fix or suppress existing CSS violations to pass lint
+- [x] 5.5 Run full `make check` to verify CI pipeline passes

--- a/openspec/changes/hydrate-user-profile-on-startup/.openspec.yaml
+++ b/openspec/changes/hydrate-user-profile-on-startup/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-13

--- a/openspec/changes/hydrate-user-profile-on-startup/design.md
+++ b/openspec/changes/hydrate-user-profile-on-startup/design.md
@@ -1,0 +1,70 @@
+## Context
+
+After OIDC authentication, the frontend has access to the identity token (email, preferred_username) via `oidc-client-ts`, but never fetches the backend User entity (which contains business data like `home`). Each page independently decides how to obtain user data:
+
+- **Dashboard**: Calls `UserService.Get` in `loading()` but only checks `resp.user?.home` for a boolean `needsRegion` flag — the full entity is discarded.
+- **Settings**: Reads `localStorage('guest.home')` via `UserHomeSelector.getStoredHome()` — never contacts the backend.
+- **UserHomeSelector**: On authenticated update, calls `updateHome()` RPC but does not write to localStorage. On next Settings visit, localStorage is stale → "Not set".
+
+The project uses **Service-Based State** (singleton DI services, no external state library) as documented in CLAUDE.md.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Provide a single, centralized source of truth for the authenticated user's backend profile in the frontend.
+- Ensure the profile is available before any route renders on page load, reload, and after auth callback.
+- Fix the "My Home Area: Not set" bug on Settings for authenticated users.
+- Maintain the existing guest flow (localStorage-based) unchanged.
+
+**Non-Goals:**
+- Introducing an external state management library (e.g., Redux, MobX).
+- Adding real-time sync or WebSocket-based profile updates.
+- Caching the profile in localStorage or sessionStorage (memory-only is sufficient).
+- Modifying the backend `UserService.Get` RPC or protobuf definitions.
+
+## Decisions
+
+### 1. Extend `UserService` with state, not `AuthService`
+
+**Decision**: Add `current: User | undefined` to the existing `UserService` singleton.
+
+**Alternatives considered**:
+- **AuthService**: Already holds OIDC `User` (identity token). Adding backend `User` (business entity) mixes authentication concerns with domain data. SRP violation.
+- **New `UserProfileService`**: Clean separation but creates redundancy with `UserService` which already owns the RPC client and `updateHome()`.
+
+**Rationale**: `UserService` already owns the RPC client and mutation methods. Adding cached state here maximizes cohesion — the service that fetches and mutates user data also holds the current snapshot.
+
+### 2. Use `AppTask.activating()` for eager load at startup
+
+**Decision**: Register an `AppTask.activating()` hook that awaits `authService.ready` then calls `userService.ensureLoaded()`.
+
+**Alternatives considered**:
+- **Lazy load only (`ensureLoaded()` in each page's `loading()`)**: Requires every page to remember to call it. The current bug is literally a "forgot to call" bug — lazy-only recreates the same failure mode.
+- **Root component `binding()`**: Works but couples app-shell to user service concerns. AppTask is the Aurelia 2 idiomatic equivalent of Angular's `APP_INITIALIZER`.
+- **AuthService constructor triggers load**: Creates circular dependency (`AuthService → UserService → AuthService` via transport).
+
+**Rationale**: AppTask.activating() runs before root component activation and route navigation. It's the Aurelia 2 recommended pattern for async service initialization. Combined with auth-callback load, it covers all entry paths.
+
+### 3. Idempotent `ensureLoaded()` method
+
+**Decision**: `ensureLoaded()` checks `this._current is not undefined` before making an RPC call. Returns immediately if already loaded.
+
+**Rationale**: This method is called from both AppTask (page load/reload) and auth-callback (sign-in/sign-up). Making it idempotent avoids duplicate RPCs when both paths run in the same session.
+
+### 4. Write-through on mutation
+
+**Decision**: `updateHome()` updates `this._current.home` in memory after a successful RPC response.
+
+**Rationale**: The RPC response includes the updated `User` entity. Using the response to update `current` ensures consistency without an extra `get()` call. This is the write-through cache invalidation pattern.
+
+### 5. Clear on sign-out
+
+**Decision**: Add a `clear()` method that sets `_current = undefined`, called during sign-out flow.
+
+**Rationale**: Prevents stale profile data from being visible if a different user signs in on the same browser session.
+
+## Risks / Trade-offs
+
+- **Startup latency**: AppTask adds one `UserService.Get` RPC call (~50ms) before routes render. → Acceptable for data correctness. The call is skipped entirely for unauthenticated/guest users.
+- **Stale data during session**: Profile is loaded once and updated only on local mutations. If another device changes the home area, this session won't see it until reload. → Acceptable given the current single-device usage model. No worse than localStorage.
+- **Auth-callback race**: If `provisionUser()` calls `create` and the user is brand new, `ensureLoaded()` immediately after should return the just-created user with home. → The `create` RPC is synchronous; by the time `ensureLoaded()` runs, the user exists in the backend.

--- a/openspec/changes/hydrate-user-profile-on-startup/proposal.md
+++ b/openspec/changes/hydrate-user-profile-on-startup/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+After account creation or sign-in, the frontend never fetches the backend User entity at startup. Each page independently decides how to obtain user data — Dashboard calls `UserService.Get` but discards the result after a boolean check, while Settings reads only from `localStorage('guest.home')`. This means authenticated users see "Not set" for My Home Area on the Settings page despite having a home registered in the backend. The root cause is the absence of a centralized user profile hydration step after authentication.
+
+## What Changes
+
+- Add a `current: User | undefined` state field to `UserService` (singleton) to hold the authenticated user's backend profile.
+- Add an `ensureLoaded()` method that fetches via `UserService.Get` RPC if `current` is undefined and the user is authenticated (lazy, idempotent).
+- Register an `AppTask.activating()` hook in `main.ts` that awaits `authService.ready` and then calls `userService.ensureLoaded()` — ensuring the profile is available before any route renders on page load / reload.
+- Call `userService.ensureLoaded()` in `auth-callback.ts` after `provisionUser()` — covering the sign-in and sign-up paths where `AppTask` has already fired.
+- Update `UserService.updateHome()` to also update `current` in-memory after a successful RPC, eliminating localStorage as the source of truth for authenticated users.
+- Update `SettingsPage.loading()` and `Dashboard.loading()` to read home from `userService.current?.home` instead of localStorage, with a guest fallback.
+- Clear `userService.current` on sign-out.
+
+## Capabilities
+
+### New Capabilities
+
+- `user-profile-hydration`: Centralized loading and caching of the authenticated user's backend profile in the frontend, triggered at app startup and after auth callback.
+
+### Modified Capabilities
+
+- `user-home`: The frontend home area persistence spec requires a new scenario — Settings and Dashboard SHALL read home from the hydrated User entity, not localStorage, for authenticated users.
+- `settings`: The Settings page requirement for My Home Area display must source from the backend User entity via `UserService` state rather than localStorage.
+
+## Impact
+
+- **Frontend only** — no backend or protobuf changes required. `UserService.Get` RPC already exists and returns `User.home`.
+- **Files affected**: `services/user-service.ts`, `main.ts`, `routes/auth-callback.ts`, `routes/settings/settings-page.ts`, `routes/dashboard.ts`.
+- **Risk**: Low. The `ensureLoaded()` pattern is idempotent and adds a single RPC call on startup (~50ms). Guest flow is unchanged (localStorage fallback).

--- a/openspec/changes/hydrate-user-profile-on-startup/specs/settings/spec.md
+++ b/openspec/changes/hydrate-user-profile-on-startup/specs/settings/spec.md
@@ -1,0 +1,38 @@
+## MODIFIED Requirements
+
+### Requirement: My Home Area Preference
+The system SHALL allow users to change their home area preference (prefecture) which determines the Live Highway Dashboard's geographical context.
+
+#### Scenario: Opening home area selector
+- **WHEN** a user taps the "My Home Area" row in Settings
+- **THEN** the system SHALL display the `user-home-selector` component as a native `<dialog>` element via `showModal()`
+- **AND** the dialog SHALL be promoted to the browser's Top Layer, rendering above all page content including the bottom navigation bar
+- **AND** the dialog SHALL NOT use z-index utilities for stacking
+- **AND** Step 1 SHALL show quick-select major city buttons (Tokyo, Osaka, Nagoya, Fukuoka, Sapporo, Sendai) and region buttons (Hokkaido, Tohoku, Kanto, Chubu, Kinki, Chugoku, Shikoku, Kyushu)
+- **AND** WHEN a user taps a region, Step 2 SHALL show prefectures within the selected region
+
+#### Scenario: Dialog backdrop and dismiss
+- **WHEN** the home area selector dialog is open
+- **THEN** the `::backdrop` pseudo-element SHALL display a dark translucent overlay with blur effect
+- **AND** tapping the backdrop area SHALL close the dialog
+- **AND** pressing the ESC key SHALL close the dialog
+
+#### Scenario: Dialog open/close animation
+- **WHEN** the home area selector dialog opens
+- **THEN** the dialog panel SHALL slide up from the bottom of the viewport with a fade-in (300ms ease-out)
+- **AND** WHEN the dialog closes
+- **THEN** the panel SHALL slide down with a fade-out (300ms ease-out)
+- **AND** users with `prefers-reduced-motion: reduce` SHALL see instant open/close without animation
+
+#### Scenario: Changing home area
+- **WHEN** a user selects a prefecture in Step 2 or a quick-select city in Step 1
+- **THEN** the system SHALL update the user's home area preference
+- **AND** the dialog SHALL close
+- **AND** the Settings row SHALL reflect the new home area
+- **AND** the Dashboard SHALL use the new home area for Live Highway lane calculations on next load
+
+#### Scenario: My Home Area displays from backend User entity
+- **WHEN** the Settings page loads for an authenticated user
+- **THEN** the My Home Area row SHALL display the home area from `UserService.current.home`
+- **AND** SHALL NOT read from localStorage for home area display
+- **AND** if `UserService.current.home` is absent, the row SHALL display the localized "Not set" text

--- a/openspec/changes/hydrate-user-profile-on-startup/specs/user-home/spec.md
+++ b/openspec/changes/hydrate-user-profile-on-startup/specs/user-home/spec.md
@@ -1,0 +1,37 @@
+## MODIFIED Requirements
+
+### Requirement: Frontend home area persistence via RPC
+
+The frontend SHALL store the user's home area server-side via RPC, replacing localStorage-based persistence for authenticated users.
+
+#### Scenario: Onboarding home area selection persisted at account creation
+
+- **WHEN** a guest user has selected their home area during onboarding
+- **AND** the user subsequently creates an account
+- **THEN** the frontend SHALL include the selected home in the `UserService.Create` request
+- **AND** SHALL NOT make a separate `UpdateHome` call for the initial home
+
+#### Scenario: Settings home area change triggers UpdateHome RPC
+
+- **WHEN** an authenticated user changes their home area via the `user-home-selector`
+- **THEN** the frontend SHALL call `UserService.updateHome()` with the new structured home
+- **AND** SHALL NOT write to localStorage for the home area
+
+#### Scenario: Dashboard reads home from hydrated User entity
+
+- **WHEN** the dashboard loads for an authenticated user
+- **THEN** the lane assignment logic SHALL read the user's home area from `UserService.current.home` (the hydrated in-memory User entity)
+- **AND** SHALL NOT call `UserService.Get` independently
+- **AND** SHALL NOT read from localStorage
+
+#### Scenario: Settings reads home from hydrated User entity
+
+- **WHEN** the settings page loads for an authenticated user
+- **THEN** the My Home Area display SHALL read from `UserService.current.home` (the hydrated in-memory User entity)
+- **AND** SHALL NOT read from localStorage
+
+#### Scenario: Guest fallback to localStorage
+
+- **WHEN** a guest (unauthenticated) user selects their home area
+- **THEN** the frontend SHALL store the selection in localStorage under `guest.home`
+- **AND** the dashboard and settings SHALL read from localStorage for home area display

--- a/openspec/changes/hydrate-user-profile-on-startup/specs/user-profile-hydration/spec.md
+++ b/openspec/changes/hydrate-user-profile-on-startup/specs/user-profile-hydration/spec.md
@@ -1,0 +1,91 @@
+## ADDED Requirements
+
+### Requirement: User profile hydration at app startup
+
+The frontend SHALL load the authenticated user's backend profile into a centralized in-memory store during application startup, making the User entity available to all routes without per-page fetching.
+
+#### Scenario: Authenticated page load or reload
+
+- **WHEN** the Aurelia application starts (page load or browser reload)
+- **AND** the OIDC token is present and valid (`authService.isAuthenticated === true`)
+- **THEN** the system SHALL call `UserService.Get` RPC before any route renders
+- **AND** the system SHALL store the returned `User` entity in `UserService.current`
+
+#### Scenario: Unauthenticated or guest startup
+
+- **WHEN** the Aurelia application starts
+- **AND** the user is not authenticated
+- **THEN** the system SHALL NOT call `UserService.Get`
+- **AND** `UserService.current` SHALL remain `undefined`
+
+### Requirement: User profile hydration after auth callback
+
+The frontend SHALL load the authenticated user's backend profile immediately after a successful sign-in or sign-up, before navigating to the destination route.
+
+#### Scenario: Sign-in via auth callback
+
+- **WHEN** an existing user completes OIDC sign-in
+- **AND** the auth callback has successfully processed the token
+- **AND** `provisionUser()` has completed
+- **THEN** the system SHALL call `UserService.ensureLoaded()`
+- **AND** the system SHALL store the returned `User` entity in `UserService.current`
+- **AND** navigation to the destination route SHALL occur only after `ensureLoaded()` resolves
+
+#### Scenario: Sign-up via auth callback
+
+- **WHEN** a new user completes OIDC sign-up during onboarding
+- **AND** the auth callback has processed the token and provisioned the user
+- **THEN** the system SHALL call `UserService.ensureLoaded()`
+- **AND** the returned `User` entity SHALL include the home area submitted during `provisionUser()`
+
+### Requirement: Idempotent profile loading
+
+The `ensureLoaded()` method SHALL be idempotent — multiple calls SHALL NOT result in redundant RPC requests.
+
+#### Scenario: Profile already loaded
+
+- **WHEN** `UserService.ensureLoaded()` is called
+- **AND** `UserService.current` is already populated (not undefined)
+- **THEN** the system SHALL return the existing `current` value immediately
+- **AND** the system SHALL NOT make a `UserService.Get` RPC call
+
+#### Scenario: Profile not yet loaded
+
+- **WHEN** `UserService.ensureLoaded()` is called
+- **AND** `UserService.current` is undefined
+- **AND** `authService.isAuthenticated` is true
+- **THEN** the system SHALL call `UserService.Get` RPC
+- **AND** SHALL store the result in `UserService.current`
+
+### Requirement: Graceful degradation on hydration failure
+
+The startup hydration SHALL NOT prevent the application from loading if the backend is unreachable or returns an error. The system SHALL log the failure and continue with `UserService.current` remaining `undefined`.
+
+#### Scenario: Backend unreachable during startup hydration
+
+- **WHEN** `UserService.ensureLoaded()` is called during `AppTask.activating()`
+- **AND** the RPC call fails (network error, timeout, or server error)
+- **THEN** the system SHALL catch the error
+- **AND** the system SHALL log a warning with the error details
+- **AND** `UserService.current` SHALL remain `undefined`
+- **AND** the application SHALL continue to render normally
+
+### Requirement: Write-through on user mutation
+
+When the user's profile is mutated via an RPC, the in-memory `current` state SHALL be updated with the response, without requiring a separate `Get` call.
+
+#### Scenario: Home area updated
+
+- **WHEN** an authenticated user calls `UserService.updateHome()` successfully
+- **THEN** the system SHALL update `UserService.current` with the `User` entity returned in the RPC response
+- **AND** subsequent reads of `UserService.current.home` SHALL reflect the new home area
+
+### Requirement: Profile cleared on sign-out
+
+The system SHALL clear the in-memory user profile when the user signs out, preventing stale data from being accessible to a subsequent session.
+
+#### Scenario: User signs out
+
+- **WHEN** the user initiates sign-out
+- **THEN** the system SHALL set `UserService.current` to `undefined`
+- **AND** the system SHALL perform this cleanup before the OIDC sign-out redirect

--- a/openspec/changes/hydrate-user-profile-on-startup/tasks.md
+++ b/openspec/changes/hydrate-user-profile-on-startup/tasks.md
@@ -1,0 +1,32 @@
+## 1. UserService state extension
+
+- [x] 1.1 Add `_current: User | undefined` private field and `current` public getter to `UserServiceClient`
+- [x] 1.2 Add `ensureLoaded(): Promise<User | undefined>` method — if `_current` is not undefined, return it; if not authenticated, return undefined; otherwise call `get({})` RPC and store result in `_current`
+- [x] 1.3 Add `clear()` method that sets `_current = undefined`
+- [x] 1.4 Update `updateHome()` to set `_current` from the RPC response (`resp.user`)
+
+## 2. App startup hydration
+
+- [x] 2.1 Register `AppTask.activating()` in `main.ts` that awaits `authService.ready`, then calls `userService.ensureLoaded()` if authenticated
+
+## 3. Auth callback integration
+
+- [x] 3.1 Add `await userService.ensureLoaded()` in `auth-callback.ts` after `provisionUser()` for both sign-in and sign-up paths
+
+## 4. Consumer updates
+
+- [x] 4.1 Update `SettingsPage.loading()` to read home from `userService.current?.home` with guest localStorage fallback
+- [x] 4.2 Update `Dashboard.loading()` to read `needsRegion` from `userService.current?.home` instead of calling `get({})` directly, with guest localStorage fallback
+- [x] 4.3 Remove the standalone `UserService.Get` call in `Dashboard.loading()` (replaced by centralized hydration)
+
+## 5. Sign-out cleanup
+
+- [x] 5.1 Call `userService.clear()` in `SettingsPage.signOut()` before `authService.signOut()`
+
+## 6. Verification
+
+- [x] 6.1 Run `make check` and fix any lint or type errors
+- [x] 6.2 Manually verify: sign up flow → Settings shows correct home area
+- [x] 6.3 Manually verify: sign in flow → Settings shows correct home area
+- [x] 6.4 Manually verify: page reload → Settings still shows correct home area
+- [x] 6.5 Manually verify: guest flow → home area still works via localStorage

--- a/openspec/specs/css-linting/spec.md
+++ b/openspec/specs/css-linting/spec.md
@@ -91,14 +91,14 @@ The linter SHALL enforce a consistent property declaration order grouped by func
 - **AND** `stylelint --fix` SHALL automatically reorder properties
 
 ### Requirement: Stylelint compatible with modern CSS at-rules
-The linter SHALL not flag valid modern CSS at-rules as errors.
+The linter SHALL not flag valid modern CSS at-rules or CUBE CSS plugin rules as errors.
 
 #### Scenario: Standard CSS at-rules accepted
 - **WHEN** a CSS file contains `@layer`, `@scope`, or `@property` at-rules
 - **THEN** Stylelint SHALL not report unknown at-rule errors
 
 #### Scenario: Modern CSS at-rules accepted
-- **WHEN** a CSS file contains `@container`, `@starting-style`, or `@property` at-rules
+- **WHEN** a CSS file contains `@container`, `@starting-style`, `@property`, or `@scope` at-rules
 - **THEN** Stylelint SHALL not report unknown at-rule errors
 
 ### Requirement: Stylelint enforces stacking context management
@@ -128,6 +128,11 @@ The linter SHALL not flag accessibility-related media features as errors.
 #### Scenario: prefers-reduced-motion allowed
 - **WHEN** a CSS file contains `@media (prefers-reduced-motion: reduce)`
 - **THEN** Stylelint SHALL not report any errors
+
+#### Scenario: CUBE CSS plugin rules configured
+- **WHEN** `stylelint.config.js` is loaded
+- **THEN** the `stylelint-plugin-cube-css` plugin SHALL be registered
+- **AND** all 14 `cube/*` rules SHALL be configured
 
 ### Requirement: Stylelint integrated into CI pipeline
 The linter SHALL run as part of the standard CI lint check.

--- a/openspec/specs/cube-css-layer-constraints/spec.md
+++ b/openspec/specs/cube-css-layer-constraints/spec.md
@@ -1,0 +1,119 @@
+# cube-css-layer-constraints Specification
+
+## Purpose
+
+Enforces per-layer content restrictions in the CUBE CSS methodology: exception layer selectors must use `data-*` attributes, composition layer must not contain visual properties, utility selectors are limited in property count, and block layer rules must be wrapped in `@scope`.
+
+## ADDED Requirements
+
+### Requirement: `cube/exception-data-attr` requires `data-*` selectors in exception layer
+Selectors inside `@layer exception` SHALL contain at least one `[data-*]` attribute selector. CSS-class-only exceptions are prohibited.
+
+#### Scenario: Attribute selector accepted
+- **WHEN** `@layer exception` contains `.card[data-state="reversed"] { ... }`
+- **THEN** the rule SHALL not report an error
+
+#### Scenario: Pure class selector rejected
+- **WHEN** `@layer exception` contains `.card--reversed { ... }` (no `data-*` attribute)
+- **THEN** the rule SHALL report an error: "Exception layer selectors must use [data-*] attribute selectors"
+
+#### Scenario: Multiple data attributes accepted
+- **WHEN** `@layer exception` contains `.card[data-state="loading"][data-variant="compact"] { ... }`
+- **THEN** the rule SHALL not report an error
+
+#### Scenario: Non-exception layers ignored
+- **WHEN** `@layer block` contains `.card { ... }` (no `data-*` attribute)
+- **THEN** the rule SHALL not report an error (rule only applies to exception layer)
+
+### Requirement: `cube/no-visual-in-composition` prohibits visual properties in composition layer
+The composition layer SHALL only contain structural/layout properties. Visual treatment properties SHALL be rejected.
+
+#### Scenario: Layout properties accepted
+- **WHEN** `@layer composition` contains `.cluster { display: flex; flex-wrap: wrap; gap: var(--cluster-gap, var(--space-s)); }`
+- **THEN** the rule SHALL not report an error
+
+#### Scenario: Color property rejected
+- **WHEN** `@layer composition` contains `.flow { color: var(--color-text); }`
+- **THEN** the rule SHALL report an error: "Unexpected visual property \"color\" in composition layer. Composition should only contain structural/layout properties."
+
+#### Scenario: Background rejected
+- **WHEN** `@layer composition` contains `.wrapper { background: var(--color-surface); }`
+- **THEN** the rule SHALL report an error
+
+#### Scenario: Box-shadow rejected
+- **WHEN** `@layer composition` contains `.sidebar { box-shadow: 0 2px 4px oklch(0% 0 0 / 10%); }`
+- **THEN** the rule SHALL report an error
+
+#### Scenario: Border-radius rejected
+- **WHEN** `@layer composition` contains `.grid { border-radius: var(--radius-m); }`
+- **THEN** the rule SHALL report an error
+
+#### Scenario: Custom visual property set via options
+- **WHEN** the rule is configured with `additionalVisualProperties: ["cursor"]`
+- **THEN** `cursor` SHALL also be rejected in the composition layer
+
+### Requirement: `cube/utility-single-property` limits properties per utility selector
+Each selector in `@layer utility` SHALL contain at most the configured number of properties (default: 2).
+
+#### Scenario: Single property accepted
+- **WHEN** `@layer utility` contains `.mt-s { margin-block-start: var(--space-s); }`
+- **THEN** the rule SHALL not report an error
+
+#### Scenario: Two tightly related properties accepted
+- **WHEN** `@layer utility` contains `.visually-hidden { clip: rect(0 0 0 0); clip-path: inset(50%); }`
+- **THEN** the rule SHALL not report an error (within default limit of 2)
+
+#### Scenario: Too many properties rejected
+- **WHEN** `@layer utility` contains `.badge { color: var(--color-primary); font-size: var(--step-0); padding: var(--space-xs); }`
+- **THEN** the rule SHALL report an error: "Utility selectors must have at most 2 properties, found 3"
+
+#### Scenario: Custom max configured
+- **WHEN** the rule is configured with `[true, { max: 3 }]`
+- **THEN** selectors with 3 or fewer properties SHALL be accepted
+
+#### Scenario: visually-hidden pattern accepted with higher limit
+- **WHEN** the rule is configured with `[true, { max: 6 }]`
+- **AND** `@layer utility` contains `.visually-hidden` with 6 properties
+- **THEN** the rule SHALL not report an error
+
+### Requirement: `cube/block-require-scope` requires `@scope` in block layer
+All style rules inside `@layer block` SHALL be wrapped in `@scope(<selector>)`.
+
+#### Scenario: Scoped block accepted
+- **WHEN** `@layer block` contains `@scope (.card) { :scope { padding: var(--space-m); } }`
+- **THEN** the rule SHALL not report an error
+
+#### Scenario: Unscoped block rejected
+- **WHEN** `@layer block` contains `.card { padding: var(--space-m); }` (not inside `@scope`)
+- **THEN** the rule SHALL report an error: "Block layer rules must be wrapped in @scope()"
+
+#### Scenario: Nested rules inside scope accepted
+- **WHEN** `@layer block` contains `@scope (.card) { :scope { ... } .title { ... } .content { ... } }`
+- **THEN** the rule SHALL not report an error
+
+#### Scenario: Non-block layers ignored
+- **WHEN** `@layer composition` contains `.flow > * + * { ... }` (not inside `@scope`)
+- **THEN** the rule SHALL not report an error (rule only applies to block layer)
+
+### Requirement: `cube/data-attr-naming` restricts data attribute names in exception layer
+Exception layer selectors SHALL only use `data-state`, `data-variant`, or `data-theme` attribute names.
+
+#### Scenario: `data-state` accepted
+- **WHEN** `@layer exception` contains `.card[data-state="loading"] { ... }`
+- **THEN** the rule SHALL not report an error
+
+#### Scenario: `data-variant` accepted
+- **WHEN** `@layer exception` contains `.card[data-variant="compact"] { ... }`
+- **THEN** the rule SHALL not report an error
+
+#### Scenario: `data-theme` accepted
+- **WHEN** `@layer exception` contains `[data-theme="dark"] { ... }`
+- **THEN** the rule SHALL not report an error
+
+#### Scenario: Non-standard data attribute rejected
+- **WHEN** `@layer exception` contains `.card[data-reversed] { ... }`
+- **THEN** the rule SHALL report an error: "Exception data attributes must use 'data-state', 'data-variant', or 'data-theme'. Found 'data-reversed'"
+
+#### Scenario: Custom allowed attributes via options
+- **WHEN** the rule is configured with `[true, { additionalAttributes: ["data-density"] }]`
+- **THEN** `data-density` SHALL also be accepted

--- a/openspec/specs/cube-css-layer-enforcement/spec.md
+++ b/openspec/specs/cube-css-layer-enforcement/spec.md
@@ -1,0 +1,57 @@
+# cube-css-layer-enforcement Specification
+
+## Purpose
+
+Enforces that all CSS rules live inside `@layer` blocks and that layer declarations follow the canonical CUBE CSS order (`reset, tokens, global, composition, utility, block, exception`). Prevents cascade conflicts caused by unlayered styles.
+
+## ADDED Requirements
+
+### Requirement: `cube/require-layer` rejects CSS rules outside `@layer` blocks
+All CSS rules SHALL be inside an `@layer` block. Unlayered styles override all layers and break the CUBE CSS cascade.
+
+#### Scenario: Rule inside `@layer` accepted
+- **WHEN** a CSS file contains `.card { padding: var(--space-m); }` inside `@layer block { ... }`
+- **THEN** the rule SHALL not report an error
+
+#### Scenario: Rule outside `@layer` rejected
+- **WHEN** a CSS file contains `.card { padding: var(--space-m); }` at the top level (not inside any `@layer`)
+- **THEN** the rule SHALL report an error: "All CSS rules must be inside an @layer block"
+
+#### Scenario: `@layer` declaration statement accepted
+- **WHEN** a CSS file contains `@layer reset, tokens, global, composition, utility, block, exception;` (a layer order declaration with no body)
+- **THEN** the rule SHALL not report an error (declarations are not rules)
+
+#### Scenario: `@property` at top level accepted
+- **WHEN** a CSS file contains `@property --hue { syntax: "<number>"; inherits: true; initial-value: 260; }` outside `@layer`
+- **THEN** the rule SHALL not report an error (`@property` cannot be inside `@layer`)
+
+#### Scenario: `@keyframes` outside `@layer` rejected
+- **WHEN** a CSS file contains `@keyframes fade-in { ... }` at the top level
+- **THEN** the rule SHALL report an error
+
+### Requirement: `cube/layer-order` enforces correct `@layer` declaration order
+The `@layer` declaration statement SHALL list layers in the order: `reset, tokens, global, composition, utility, block, exception`. Subsets are allowed but order must be preserved.
+
+#### Scenario: Correct full order accepted
+- **WHEN** a CSS file contains `@layer reset, tokens, global, composition, utility, block, exception;`
+- **THEN** the rule SHALL not report an error
+
+#### Scenario: Correct partial order accepted
+- **WHEN** a CSS file contains `@layer composition, utility, block;` (subset in correct relative order)
+- **THEN** the rule SHALL not report an error
+
+#### Scenario: Wrong order rejected
+- **WHEN** a CSS file contains `@layer block, utility, composition;`
+- **THEN** the rule SHALL report an error: "Layer order must follow: reset, tokens, global, composition, utility, block, exception"
+
+#### Scenario: Unknown layer name rejected
+- **WHEN** a CSS file contains `@layer reset, global, components;` (where `components` is not a valid CUBE CSS layer name)
+- **THEN** the rule SHALL report an error: "Unknown layer name 'components'. Expected one of: reset, tokens, global, composition, utility, block, exception"
+
+#### Scenario: Multiple `@layer` block declarations maintain order
+- **WHEN** a CSS file contains `@layer composition { ... }` followed by `@layer block { ... }`
+- **THEN** the rule SHALL not report an error (composition before block is correct order)
+
+#### Scenario: Out-of-order `@layer` block declarations rejected
+- **WHEN** a CSS file contains `@layer block { ... }` followed by `@layer composition { ... }`
+- **THEN** the rule SHALL report an error

--- a/openspec/specs/cube-css-lint-plugin/spec.md
+++ b/openspec/specs/cube-css-lint-plugin/spec.md
@@ -1,0 +1,43 @@
+# cube-css-lint-plugin Specification
+
+## Purpose
+
+Defines the Stylelint plugin architecture for CUBE CSS enforcement: plugin registration under the `cube/` namespace, local ESM package structure, shared utilities (`getLayerContext`), and test coverage requirements.
+
+## ADDED Requirements
+
+### Requirement: Plugin registers all rules under the `cube/` namespace
+The plugin SHALL export all rules prefixed with `cube/` so they can be configured individually in `stylelint.config.js`.
+
+#### Scenario: All 14 rules are registered
+- **WHEN** the plugin is loaded by stylelint
+- **THEN** the following rules SHALL be available: `cube/require-layer`, `cube/layer-order`, `cube/exception-data-attr`, `cube/no-visual-in-composition`, `cube/utility-single-property`, `cube/block-require-scope`, `cube/require-token-variables`, `cube/block-max-lines`, `cube/one-block-per-file`, `cube/prefer-where-in-reset`, `cube/data-attr-naming`, `cube/prefer-vi-over-vw`, `cube/require-container-name`, `cube/prefer-color-mix`
+
+#### Scenario: Unknown rule name rejected
+- **WHEN** a user configures `cube/nonexistent-rule` in their stylelint config
+- **THEN** stylelint SHALL report an invalid configuration error
+
+### Requirement: Plugin is a local ESM package
+The plugin SHALL be implemented as a local ESM directory at `frontend/stylelint-plugin-cube-css/` and referenced via a relative path in the stylelint config.
+
+#### Scenario: Plugin loaded via relative path
+- **WHEN** `stylelint.config.js` includes `plugins: ['./stylelint-plugin-cube-css/index.js']`
+- **THEN** stylelint SHALL load and register all plugin rules without errors
+
+### Requirement: Each rule has comprehensive test coverage
+Every rule SHALL have a dedicated test file with passing and failing test cases using vitest and stylelint's `lint()` API.
+
+#### Scenario: Test suite passes
+- **WHEN** `npx vitest run stylelint-plugin-cube-css/` is executed
+- **THEN** all tests SHALL pass with zero failures
+
+### Requirement: Shared layer context utility
+The plugin SHALL provide a shared `getLayerContext(node)` utility that returns the name of the enclosing `@layer` for any PostCSS node.
+
+#### Scenario: Nested node returns correct layer
+- **WHEN** a declaration is nested inside `@layer block { @scope (.card) { :scope { ... } } }`
+- **THEN** `getLayerContext()` SHALL return `"block"`
+
+#### Scenario: Unlayered node returns null
+- **WHEN** a declaration is not inside any `@layer` block
+- **THEN** `getLayerContext()` SHALL return `null`

--- a/openspec/specs/cube-css-modern-css-rules/spec.md
+++ b/openspec/specs/cube-css-modern-css-rules/spec.md
@@ -1,0 +1,64 @@
+# cube-css-modern-css-rules Specification
+
+## Purpose
+
+Enforces modern CSS best practices within the CUBE CSS methodology: logical viewport units (`vi` over `vw`), named containers (`container-name` required with `container-type`), and `color-mix()`/relative color syntax for derived color tokens.
+
+## ADDED Requirements
+
+### Requirement: `cube/prefer-vi-over-vw` recommends `vi` unit over `vw`
+CSS values SHALL use the `vi` (viewport inline) unit instead of `vw` (viewport width) for logical consistency with writing-mode awareness.
+
+#### Scenario: `vi` unit accepted
+- **WHEN** a CSS file contains `font-size: clamp(1rem, 0.34vi + 0.91rem, 1.19rem);`
+- **THEN** the rule SHALL not report an error
+
+#### Scenario: `vw` unit rejected
+- **WHEN** a CSS file contains `font-size: clamp(1rem, 0.34vw + 0.91rem, 1.19rem);`
+- **THEN** the rule SHALL report an error: "Use 'vi' instead of 'vw' for logical viewport units"
+
+#### Scenario: `vh` not affected
+- **WHEN** a CSS file contains `block-size: 100vh;`
+- **THEN** the rule SHALL not report an error (only `vw` → `vi` is enforced; `vh` → `vb` is a separate concern)
+
+#### Scenario: `svw` and `lvw` also rejected
+- **WHEN** a CSS file contains `inline-size: 100svw;` or `inline-size: 100lvw;`
+- **THEN** the rule SHALL report an error recommending `svi` or `lvi` respectively
+
+### Requirement: `cube/require-container-name` enforces naming containers
+Elements that declare `container-type` SHALL also declare `container-name`.
+
+#### Scenario: Both properties present accepted
+- **WHEN** a CSS rule contains `container-type: inline-size; container-name: card;`
+- **THEN** the rule SHALL not report an error
+
+#### Scenario: `container` shorthand with name accepted
+- **WHEN** a CSS rule contains `container: card / inline-size;`
+- **THEN** the rule SHALL not report an error
+
+#### Scenario: `container-type` without `container-name` rejected
+- **WHEN** a CSS rule contains `container-type: inline-size;` but no `container-name` declaration
+- **THEN** the rule SHALL report an error: "Elements with container-type must also declare container-name"
+
+#### Scenario: `container-type: normal` ignored
+- **WHEN** a CSS rule contains `container-type: normal;` (the default/reset value)
+- **THEN** the rule SHALL not report an error
+
+### Requirement: `cube/prefer-color-mix` recommends `color-mix()` for derived colors
+When a custom property value in `@layer global` derives a color from another token (e.g., lighter/darker variants), `color-mix()` or relative color syntax SHALL be preferred over manual `oklch()` with hardcoded values.
+
+#### Scenario: `color-mix()` accepted
+- **WHEN** `@layer global` contains `--color-primary-hover: color-mix(in oklch, var(--color-primary) 80%, white);`
+- **THEN** the rule SHALL not report an error
+
+#### Scenario: Relative color syntax accepted
+- **WHEN** `@layer global` contains `--color-primary-light: oklch(from var(--color-primary) calc(l + 0.2) c h);`
+- **THEN** the rule SHALL not report an error
+
+#### Scenario: Base color definition accepted
+- **WHEN** `@layer global` contains `--color-primary: oklch(55% 0.25 260);`
+- **THEN** the rule SHALL not report an error (this is a base definition, not a derivation)
+
+#### Scenario: Derived color without `color-mix()` or relative syntax warned
+- **WHEN** `@layer global` contains `--color-primary-light: oklch(75% 0.15 260);` and a `--color-primary` also exists
+- **THEN** the rule SHALL report a warning: "Consider using color-mix() or relative color syntax to derive color variants from base tokens"

--- a/openspec/specs/cube-css-structural-rules/spec.md
+++ b/openspec/specs/cube-css-structural-rules/spec.md
@@ -1,0 +1,68 @@
+# cube-css-structural-rules Specification
+
+## Purpose
+
+Enforces structural limits on CUBE CSS block layer: maximum lines per `@scope` block, one block component per file, and `:where()` wrapping in reset/global layers for zero-specificity defaults.
+
+## ADDED Requirements
+
+### Requirement: `cube/block-max-lines` limits block size
+Each `@scope` block inside `@layer block` SHALL contain at most the configured number of lines (default: 80).
+
+#### Scenario: Small block accepted
+- **WHEN** `@layer block` contains a `@scope (.card) { ... }` block with 40 lines
+- **THEN** the rule SHALL not report an error
+
+#### Scenario: Oversized block rejected
+- **WHEN** `@layer block` contains a `@scope (.card) { ... }` block with 95 lines
+- **THEN** the rule SHALL report an error: "@scope block is 95 lines, exceeding the maximum of 80 lines. Split into smaller blocks."
+
+#### Scenario: Custom max configured
+- **WHEN** the rule is configured with `[true, { max: 120 }]`
+- **THEN** blocks up to 120 lines SHALL be accepted
+
+#### Scenario: Non-block layers ignored
+- **WHEN** `@layer global` contains a rule set spanning 200 lines
+- **THEN** the rule SHALL not report an error
+
+### Requirement: `cube/one-block-per-file` enforces single block per file
+Files containing `@layer block` SHALL have at most one `@scope` directive.
+
+#### Scenario: Single scope accepted
+- **WHEN** a CSS file contains `@layer block { @scope (.card) { ... } }`
+- **THEN** the rule SHALL not report an error
+
+#### Scenario: Multiple scopes rejected
+- **WHEN** a CSS file contains `@layer block { @scope (.card) { ... } @scope (.button) { ... } }`
+- **THEN** the rule SHALL report an error: "Block layer must contain only one @scope. Found 2. Use separate files."
+
+#### Scenario: Files without block layer ignored
+- **WHEN** a CSS file contains only `@layer composition { ... }`
+- **THEN** the rule SHALL not report an error
+
+### Requirement: `cube/prefer-where-in-reset` recommends `:where()` in reset and global layers
+Selectors in `@layer reset` and `@layer global` SHOULD use `:where()` wrapping for zero-specificity defaults.
+
+#### Scenario: `:where()` selector accepted
+- **WHEN** `@layer global` contains `:where(h1, h2, h3) { line-height: 1.2; }`
+- **THEN** the rule SHALL not report an error
+
+#### Scenario: Element selector without `:where()` warned
+- **WHEN** `@layer global` contains `h1, h2, h3 { line-height: 1.2; }`
+- **THEN** the rule SHALL report a warning: "Consider wrapping in :where() for zero-specificity defaults"
+
+#### Scenario: `:root` selector accepted without `:where()`
+- **WHEN** `@layer global` contains `:root { --color-primary: oklch(55% 0.25 260); }`
+- **THEN** the rule SHALL not report an error (`:root` for custom properties is a standard pattern)
+
+#### Scenario: `body` selector accepted without `:where()`
+- **WHEN** `@layer global` contains `body { font-family: var(--font-base); }`
+- **THEN** the rule SHALL not report an error (`body` is a common global singleton)
+
+#### Scenario: Universal selector in reset accepted
+- **WHEN** `@layer reset` contains `:where(*, *::before, *::after) { box-sizing: border-box; }`
+- **THEN** the rule SHALL not report an error
+
+#### Scenario: Non-reset/global layers ignored
+- **WHEN** `@layer block` contains `.card { ... }` without `:where()`
+- **THEN** the rule SHALL not report an error

--- a/openspec/specs/cube-css-token-enforcement/spec.md
+++ b/openspec/specs/cube-css-token-enforcement/spec.md
@@ -1,0 +1,106 @@
+# cube-css-token-enforcement Specification
+
+## Purpose
+
+Enforces design token usage via `var()` references for spacing, color, typography, and animation properties in consumption layers (composition, utility, block, exception). Token definition layers (reset, tokens, global) are excluded.
+
+## ADDED Requirements
+
+### Requirement: `cube/require-token-variables` enforces `var()` for design token properties
+Configured properties in consumption layers (composition, utility, block, exception) SHALL use `var()` references instead of raw literal values.
+
+#### Scenario: `var()` value accepted
+- **WHEN** `@layer block` contains `.card { padding: var(--space-m); }`
+- **THEN** the rule SHALL not report an error
+
+#### Scenario: Raw literal rejected
+- **WHEN** `@layer block` contains `.card { padding: 16px; }`
+- **THEN** the rule SHALL report an error: "Property 'padding' must use a design token via var()."
+
+#### Scenario: Raw color rejected
+- **WHEN** `@layer block` contains `.card { color: oklch(55% 0.25 260); }`
+- **THEN** the rule SHALL report an error
+
+#### Scenario: Raw font-size rejected
+- **WHEN** `@layer utility` contains `.text-lg { font-size: 1.2rem; }`
+- **THEN** the rule SHALL report an error
+
+### Requirement: `calc()` expressions must contain at least one `var()`
+When a token-enforced property uses `calc()`, the expression SHALL contain at least one `var()` reference.
+
+#### Scenario: calc with var() accepted
+- **WHEN** `@layer block` contains `.card { padding: calc(var(--space-m) - 1px); }`
+- **THEN** the rule SHALL not report an error
+
+#### Scenario: calc with division by literal accepted
+- **WHEN** `@layer block` contains `.card { gap: calc(var(--space-s) / 2); }`
+- **THEN** the rule SHALL not report an error
+
+#### Scenario: Pure literal calc rejected
+- **WHEN** `@layer block` contains `.card { padding: calc(16px + 4px); }`
+- **THEN** the rule SHALL report an error: "Property 'padding': calc() must reference at least one design token via var()."
+
+#### Scenario: Nested calc with var() accepted
+- **WHEN** `@layer block` contains `.card { inline-size: calc(100% - var(--space-m) * 2); }`
+- **THEN** the rule SHALL not report an error
+
+### Requirement: Structural values bypass token enforcement
+Values that are inherently structural (not design tokens) SHALL be allowed without `var()`.
+
+#### Scenario: Zero accepted
+- **WHEN** `@layer block` contains `.card { padding: 0; }`
+- **THEN** the rule SHALL not report an error
+
+#### Scenario: `auto` accepted
+- **WHEN** `@layer block` contains `.card { margin-inline: auto; }`
+- **THEN** the rule SHALL not report an error
+
+#### Scenario: `none` accepted
+- **WHEN** `@layer block` contains `.card { background: none; }`
+- **THEN** the rule SHALL not report an error
+
+#### Scenario: CSS-wide keywords accepted
+- **WHEN** a property value is `inherit`, `initial`, `unset`, or `revert`
+- **THEN** the rule SHALL not report an error
+
+#### Scenario: `currentColor` accepted
+- **WHEN** `@layer block` contains `.icon { color: currentColor; }`
+- **THEN** the rule SHALL not report an error
+
+#### Scenario: `transparent` accepted
+- **WHEN** `@layer block` contains `.card { background: transparent; }`
+- **THEN** the rule SHALL not report an error
+
+#### Scenario: Grid fractions accepted
+- **WHEN** `@layer block` contains `.layout { grid-template-columns: 1fr 2fr; }`
+- **THEN** the rule SHALL not report an error
+
+### Requirement: Token definition layers are excluded
+The `reset`, `tokens`, and `global` layers SHALL be excluded from token enforcement because they are where tokens are defined.
+
+#### Scenario: Raw value in global layer accepted
+- **WHEN** `@layer global` contains `:root { --space-m: 1rem; }`
+- **THEN** the rule SHALL not report an error
+
+#### Scenario: Raw value in reset layer accepted
+- **WHEN** `@layer reset` contains `* { box-sizing: border-box; margin: 0; }`
+- **THEN** the rule SHALL not report an error
+
+### Requirement: Duration and easing properties are token-enforced
+Properties `transition-duration` and `animation-duration` SHALL require `var()` references.
+
+#### Scenario: Duration token accepted
+- **WHEN** `@layer block` contains `.card { transition-duration: var(--duration-fast); }`
+- **THEN** the rule SHALL not report an error
+
+#### Scenario: Raw duration rejected
+- **WHEN** `@layer block` contains `.card { transition-duration: 150ms; }`
+- **THEN** the rule SHALL report an error
+
+### Requirement: Configurable property list
+The list of properties that require `var()` SHALL be configurable via rule options.
+
+#### Scenario: Custom properties list
+- **WHEN** the rule is configured with `[true, { properties: ["padding", "color"] }]`
+- **THEN** only `padding` and `color` SHALL be enforced
+- **AND** other properties like `gap` or `font-size` SHALL be allowed with raw values

--- a/openspec/specs/shell-layout/spec.md
+++ b/openspec/specs/shell-layout/spec.md
@@ -1,0 +1,21 @@
+# shell-layout Specification
+
+## Purpose
+
+Defines the PWA shell layout structure for `my-app`, ensuring overlay custom elements are excluded from CSS Grid flow so that `bottom-nav-bar` stays pinned at the viewport bottom and `position: sticky` headers work correctly within scroll containers.
+## Requirements
+### Requirement: Overlay elements excluded from grid flow
+All overlay custom elements (`pwa-install-prompt`, `notification-prompt`, `toast-notification`, `error-banner`, `coach-mark`) SHALL be removed from normal document flow so they do not create implicit CSS Grid rows in the `my-app` shell layout.
+
+#### Scenario: Bottom nav stays at viewport bottom
+- **WHEN** the dashboard page has enough events to require scrolling
+- **THEN** `bottom-nav-bar` SHALL remain visible and pinned at the bottom of the viewport at all times
+
+#### Scenario: Stage header sticks on scroll
+- **WHEN** the user scrolls the live-highway event list downward
+- **THEN** the stage header (HOME STAGE / NEAR STAGE / AWAY STAGE) SHALL remain fixed at the top of the scroll container and not scroll away
+
+#### Scenario: Overlay elements remain functional
+- **WHEN** an overlay element activates (e.g., toast notification, coach-mark spotlight)
+- **THEN** the overlay SHALL render correctly via the browser top-layer API, unaffected by the flow removal
+


### PR DESCRIPTION
## 🔗 Related Issue

N/A — housekeeping to sync OpenSpec artifacts with implementation

## 📝 Summary of Changes

Archive completed changes and fix inconsistencies between OpenSpec spec artifacts and actual implementations.

### Archived changes
- **fix-sticky-layout**: Mark visual verification tasks as complete, add implementation note about defensive `block-size: 0` retention
- **stylelint-plugin-cube-css**: Full archive with all 6 generated specs

### Spec fixes
- **cube-css-layer-enforcement**: Add missing `tokens` layer to canonical 7-layer order (`reset, tokens, global, composition, utility, block, exception`)
- **cube-css-layer-constraints**: Align `no-visual-in-composition` error message with implementation
- **cube-css-structural-rules**: Align `block-max-lines` error message with implementation
- **cube-css-token-enforcement**: Align `require-token-variables` error message, exclude `tokens` layer from enforcement
- **shell-layout**: Fill in Purpose (was TBD)
- All 6 cube-css specs: Add Purpose sections

### New change artifacts
- **hydrate-user-profile-on-startup**: Proposal, design, spec, and tasks for user profile hydration. Includes graceful degradation requirement for AppTask.activating() error handling.

## ✅ Self-Checklist

- [x] I have linked the related issue.
- [x] I have updated the relevant documentation (e.g., `README.md`) if needed.
- [x] I have run `buf lint` and `buf format` locally and all checks have passed.
- [x] My proto definitions follow the project's style guidelines and validation rules.
- [x] Breaking changes have been justified and documented if applicable.
