### PR TITLE
feat(specs): modernize artist list specifications

### DIFF
--- a/openspec/changes/archive/2026-03-14-modernize-artist-list/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-14-modernize-artist-list/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-13

--- a/openspec/changes/archive/2026-03-14-modernize-artist-list/design.md
+++ b/openspec/changes/archive/2026-03-14-modernize-artist-list/design.md
@@ -1,0 +1,212 @@
+## Context
+
+Current DOM structure (6 levels deep):
+
+```
+.artist-list (overflow-y: auto, flex: 1)
+  .artist-list-inner (padding only)          ← unnecessary wrapper
+    .artist-list-item (overflow: hidden)     ← clip wrapper for swipe
+      .delete-zone (position: absolute)      ← always in DOM, every row
+      .artist-row (flex, transform)          ← JS-driven translateX per frame
+        .indicator
+        .name
+        <hype-inline-slider>                 ← independent grid context
+```
+
+Problems:
+- `.artist-list-inner` exists only for padding — can be applied to `.artist-list` directly
+- `.artist-list-item` exists only to clip `.artist-row` during swipe — unnecessary if swipe uses scroll-snap (scroll container clips by default)
+- `.delete-zone` is position-absolute behind every row — always rendered even when not swiping
+- `.artist-row` transform is driven by JS touch handlers on the main thread
+
+## Goals / Non-Goals
+
+**Goals:**
+- Flatten DOM from 6 levels to 3 levels
+- Move swipe tracking from main thread (JS) to compositor thread (native scroll)
+- Align hype header columns with slider dots via shared `grid-template-areas`
+- Add smooth dismiss animation via View Transitions API
+- Remove long-press unfollow from list view
+
+**Non-Goals:**
+- Changing the hype-inline-slider component API (props/events)
+- Modifying the Grid (Festival) view
+- Adding new unfollow gestures (e.g., button-based)
+
+## Decisions
+
+### 1. Flattened DOM structure
+
+Target structure (3 levels deep):
+
+```
+.artist-list (overflow-y: auto, padding)
+  header.hype-legend
+    (grid: 2fr 1fr 1fr 1fr 1fr)
+    areas: "spacer watch home nearby away"
+
+  .artist-row (overflow-x: auto, scroll-snap-type: x mandatory)
+    .artist-row-content (grid: 2fr 1fr 1fr 1fr 1fr)
+      areas: "name watch home nearby away"
+      [name]: .artist-identity (indicator + name)
+      [col 2/-1]: <hype-inline-slider>
+    .dismiss-end (scroll-snap-align: end)
+```
+
+Changes from current:
+- `.artist-list-inner` removed — padding moves to `.artist-list`
+- `.artist-list-item` removed — `.artist-row` is now the direct child
+- `.delete-zone` removed — replaced by `.dismiss-end` inside the scroll container
+- `.artist-row` changes role from "swipeable content" to "scroll container"
+- `.artist-row-content` is the new grid layout element
+
+### 2. Scroll-snap swipe-to-dismiss
+
+Each `.artist-row` is a horizontal scroll container:
+
+```css
+.artist-row {
+  display: flex;
+  overflow-x: auto;
+  scroll-snap-type: x mandatory;
+  scrollbar-width: none;
+}
+
+.artist-row-content {
+  flex: 0 0 100%;
+  scroll-snap-align: start;
+}
+
+.dismiss-end {
+  flex: 0 0 5rem;
+  scroll-snap-align: end;
+}
+```
+
+Swipe behavior:
+- User swipes left → native horizontal scroll (compositor thread, no jank)
+- `scroll-snap` snaps to either "content" (cancel) or "dismiss-end" (trigger delete)
+- A single `scroll` event listener checks `scrollLeft > threshold` to trigger dismiss
+- No `touchstart`/`touchmove`/`touchend` handlers needed
+
+```
+Normal state:
+┌─ .artist-row (viewport) ──────────────────┐
+│ ┌─ .artist-row-content ─────────────────┐ │ .dismiss-end
+│ │ ● Taylor Swift   ·  ·  ●  ·          │ │ (off-screen)
+│ └───────────────────────────────────────┘ │
+└───────────────────────────────────────────┘
+
+After swipe left:
+        ┌─ .artist-row (viewport) ──────────────────┐
+        │ ───────────────────────────┐ ┌────────────┐│
+        │ ·  ●  ·                    │ │     🗑️     ││
+        │ ───────────────────────────┘ └────────────┘│
+        └───────────────────────────────────────────┘
+```
+
+**Why scroll-snap over JS transform:**
+- Scroll runs on the compositor thread — zero main-thread work during swipe
+- `scroll-snap-type: x mandatory` handles snap-back automatically
+- No clip wrapper needed — scroll container clips by definition
+- `scrollbar-width: none` hides the scrollbar
+- Accessible by default — screen readers can navigate via scroll semantics
+
+### 3. Column alignment via shared `grid-template-areas`
+
+Header and artist-row-content use identical grid definitions:
+
+```css
+/* Shared pattern */
+grid-template-columns: 2fr repeat(4, 1fr);
+```
+
+**Header:**
+```css
+.hype-legend {
+  display: grid;
+  grid-template-columns: 2fr repeat(4, 1fr);
+  grid-template-areas: "spacer  watch  home  nearby  away";
+}
+```
+
+```
+┌───────────┬────────┬────────┬────────┬────────┐
+│  spacer   │ watch  │  home  │ nearby │  away  │
+│   (2fr)   │ (1fr)  │ (1fr)  │ (1fr)  │ (1fr)  │
+│           │   👀   │   🔥   │  🔥🔥  │ 🔥🔥🔥 │
+└───────────┴────────┴────────┴────────┴────────┘
+```
+
+First `.hype-legend-item` starts at `grid-column: 2` to skip the spacer.
+
+**Artist row content:**
+```css
+.artist-row-content {
+  display: grid;
+  grid-template-columns: 2fr repeat(4, 1fr);
+  grid-template-areas: "name  watch  home  nearby  away";
+}
+```
+
+```
+┌───────────────────┬────────┬────────┬────────┬────────┐
+│       name        │ watch  │  home  │ nearby │  away  │
+│      (2fr)        │ (1fr)  │ (1fr)  │ (1fr)  │ (1fr)  │
+│ ● Taylor Swift    │   ·    │   ·    │   ●    │   ·    │
+└───────────────────┴────────┴────────┴────────┴────────┘
+```
+
+Alignment is guaranteed: both elements share the same `fr` ratio at the same parent width. The header and `.artist-row-content` both inherit the full width of `.artist-list` (minus padding), so column lines match exactly.
+
+`<hype-inline-slider>` spans `grid-column: 2 / -1`. Its internal `repeat(4, 1fr)` grid subdivides the same 4-column span as the header, so dots align with emojis automatically.
+
+### 4. View Transitions dismiss animation
+
+When an artist is removed from the list, the remaining rows should reflow smoothly:
+
+```typescript
+async executeDismiss(artist: FollowedArtist) {
+  if (!document.startViewTransition) {
+    await this.unfollowArtist(artist);
+    return;
+  }
+  document.startViewTransition(async () => {
+    await this.unfollowArtist(artist);
+  });
+}
+```
+
+Each `.artist-row` gets a unique `view-transition-name` so the browser can animate individual rows sliding up to fill the gap. No manual animation CSS required — the browser interpolates between old and new DOM states.
+
+```css
+.artist-row {
+  view-transition-name: var(--_vt-name);
+}
+```
+
+The `--_vt-name` custom property is set per-row via inline style bound to the artist ID.
+
+### 5. Name area internal structure
+
+The `name` grid area contains indicator + artist name, wrapped in `.artist-identity`:
+
+```html
+<div class="artist-identity">
+  <span class="artist-indicator" style="background: ${artist.color}"></span>
+  <span class="artist-name">${artist.name}</span>
+</div>
+```
+
+Styled as `display: flex; gap: var(--space-xs); align-items: center; min-inline-size: 0` for horizontal layout with ellipsis truncation.
+
+### 6. Long-press removal
+
+Long-press unfollow is removed from list view entirely. The only unfollow gesture is swipe-to-dismiss. This simplifies the event handling (no `setTimeout` timers, no `clearLongPressTimer`). Grid (Festival) view retains its own long-press context menu as a separate concern.
+
+## Risks / Trade-offs
+
+- **[Risk] Nested scroll containers (vertical list + horizontal swipe)** → Browser handles direction disambiguation natively. The `.artist-row` has horizontal scroll, `.artist-list` has vertical scroll. Browsers disambiguate based on initial gesture direction. Needs device testing to confirm feel
+- **[Risk] View Transitions API browser support** → Fallback: if `document.startViewTransition` is undefined, execute unfollow immediately without animation. Progressive enhancement, not a hard dependency
+- **[Risk] `scrollbar-width: none` support** → Baseline 2024. Fully supported in Chrome, Firefox, Safari 16+. No concern for target audience
+- **[Risk] Hype slider tap vs horizontal scroll conflict** → `scroll-snap` only activates on horizontal drag. Taps on dots fire `click` events normally. The slider dots have `touch-action: manipulation` which prevents double-tap zoom but allows click

--- a/openspec/changes/archive/2026-03-14-modernize-artist-list/proposal.md
+++ b/openspec/changes/archive/2026-03-14-modernize-artist-list/proposal.md
@@ -1,0 +1,35 @@
+## Why
+
+The My Artists list view has two structural problems rooted in excessive DOM nesting:
+
+1. **Hype header-to-slider misalignment** — The header emoji columns and slider dots use independent grid contexts at different DOM depths, so their column lines never match.
+2. **JS-driven swipe** — Swipe-to-unfollow uses manual `touchstart`/`touchmove`/`touchend` handlers with per-frame `transform` updates on the main thread. This requires a clip wrapper (`artist-list-item`) and an absolute-positioned delete zone behind each row, adding 2 unnecessary DOM layers and blocking compositor-thread optimization.
+
+Both problems disappear by flattening the DOM and adopting modern Web Platform primitives: CSS `scroll-snap` for swipe, `grid-template-areas` for column alignment, and View Transitions API for dismiss animation.
+
+## What Changes
+
+- **Flatten DOM**: Remove `.artist-list-inner` (padding-only wrapper) and merge `.artist-list-item` + `.artist-row` into a single `.artist-row` element
+- **Replace JS swipe with scroll-snap**: Each `.artist-row` becomes a horizontal scroll container with `scroll-snap-type: x mandatory`. A `.dismiss-end` element replaces the absolute-positioned `.delete-zone`
+- **Remove all touch handlers**: Delete `onTouchStart`, `onTouchMove`, `onTouchEnd`, `swipeOffset`, `swipedArtistId`, and long-press timer logic
+- **Add View Transitions dismiss animation**: Use `document.startViewTransition()` for smooth list reflow when an artist is removed
+- **Align columns with `grid-template-areas`**: Header and artist-row-content share `2fr repeat(4, 1fr)` with named areas `"name watch home nearby away"`
+- **Remove long-press unfollow**: Swipe-to-dismiss is the only unfollow gesture in list view
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `hype-inline-slider`: Header and slider column alignment now enforced via shared grid-template-columns with named areas
+- `my-artists`: Artist row structure changes — swipe-to-unfollow moves from JS touch handlers to CSS scroll-snap; long-press unfollow removed from list view; View Transitions dismiss animation added
+
+## Impact
+
+- `frontend/src/routes/my-artists/my-artists-page.html` — DOM restructure (flatten 2 layers), replace touch bindings with scroll event
+- `frontend/src/routes/my-artists/my-artists-page.css` — New grid layout, scroll-snap styles, remove delete-zone/swipe styles
+- `frontend/src/routes/my-artists/my-artists-page.ts` — Remove touch handlers, swipe state, long-press logic; add scroll-based dismiss + View Transitions
+- `frontend/src/components/hype-inline-slider/hype-inline-slider.css` — No changes (internal grid unchanged)

--- a/openspec/changes/archive/2026-03-14-modernize-artist-list/specs/hype-inline-slider/spec.md
+++ b/openspec/changes/archive/2026-03-14-modernize-artist-list/specs/hype-inline-slider/spec.md
@@ -1,0 +1,37 @@
+## MODIFIED Requirements
+
+### Requirement: Sticky Header Legend
+
+The My Artists list view SHALL display a sticky header row showing hype tier icons and emotion-based labels, aligned with slider stop positions using a shared grid column definition.
+
+#### Scenario: Header renders with 4 columns
+
+- **WHEN** the My Artists page renders in list view
+- **THEN** the system SHALL display a sticky header row below the page title
+- **AND** the header SHALL contain 4 equally-spaced columns: 👀 チェック, 🔥 地元, 🔥🔥 近くも, 🔥🔥🔥 どこでも！
+- **AND** the header SHALL use `position: sticky; inset-block-start: 0` with `backdrop-filter: blur(8px)` on the surface-raised background
+- **AND** each column SHALL vertically align with the corresponding dot stop on artist row sliders
+- **AND** the header and artist row content SHALL share the same `grid-template-columns: 2fr repeat(4, 1fr)` definition with `grid-template-areas` to ensure column alignment
+
+#### Scenario: Header column alignment matches artist row dot positions
+
+- **WHEN** the header and any artist row are visible simultaneously
+- **THEN** the center of each header label SHALL be horizontally aligned with the center of the corresponding dot in the artist row slider
+- **AND** this alignment SHALL be achieved by both elements using `grid-template-columns: 2fr repeat(4, 1fr)` at the same parent width
+
+#### Scenario: Header remains visible during scroll
+
+- **WHEN** the user scrolls the artist list
+- **THEN** the sticky header SHALL remain visible at the top of the scroll container
+- **AND** the header SHALL have a `[data-hype-header]` attribute for coach mark targeting
+
+### Requirement: Slider dot positions align with header columns
+
+The 4 slider dot stops SHALL be positioned to vertically align with the 4 header legend columns using a shared CSS Grid column template.
+
+#### Scenario: Slider spans header dot columns
+
+- **WHEN** the page renders
+- **THEN** the hype-inline-slider component SHALL span grid columns 2 through 5 of the artist row content grid
+- **AND** the slider's internal `repeat(4, 1fr)` grid SHALL subdivide the same width as the header's 4 dot columns
+- **AND** alignment SHALL be maintained across viewport widths

--- a/openspec/changes/archive/2026-03-14-modernize-artist-list/specs/my-artists/spec.md
+++ b/openspec/changes/archive/2026-03-14-modernize-artist-list/specs/my-artists/spec.md
@@ -1,0 +1,34 @@
+## MODIFIED Requirements
+
+### Requirement: Artist List Row
+
+Each artist row in the My Artists list view SHALL be a horizontal scroll-snap container with the artist content and a dismiss trigger.
+
+#### Scenario: Artist row layout
+
+- **WHEN** an artist row is rendered in list view
+- **THEN** the row SHALL be a horizontal scroll container with `scroll-snap-type: x mandatory` and hidden scrollbar
+- **AND** the row content SHALL display the artist name (left) and inline dot slider (right) using `grid-template-areas: "name watch home nearby away"`
+- **AND** the artist name SHALL truncate with ellipsis if it exceeds available space
+- **AND** a dismiss trigger element SHALL be placed after the content as the scroll-snap end target
+
+#### Scenario: Swipe-to-dismiss unfollows artist
+
+- **WHEN** the user swipes an artist row left past the dismiss threshold
+- **THEN** the scroll-snap SHALL snap to the dismiss-end position
+- **AND** the system SHALL trigger unfollow for that artist
+- **AND** if the View Transitions API is available, the remaining rows SHALL animate smoothly to fill the gap
+- **AND** if the View Transitions API is unavailable, the unfollow SHALL execute immediately without animation
+
+#### Scenario: Swipe cancel snaps back
+
+- **WHEN** the user swipes an artist row left but does NOT pass the dismiss threshold
+- **THEN** the scroll-snap SHALL snap back to the start position (content fully visible)
+- **AND** no unfollow action SHALL be triggered
+
+## REMOVED Requirements
+
+### Requirement: Long-press unfollow in list view
+
+**Reason**: Replaced by swipe-to-dismiss as the sole unfollow gesture in list view. Long-press added complexity (setTimeout timers, conflict with scroll) without clear UX benefit when swipe is available.
+**Migration**: Remove `onLongPress`, `clearLongPressTimer`, and `LONG_PRESS_MS` from my-artists-page. Grid (Festival) view retains its own long-press context menu independently.

--- a/openspec/changes/archive/2026-03-14-modernize-artist-list/tasks.md
+++ b/openspec/changes/archive/2026-03-14-modernize-artist-list/tasks.md
@@ -1,0 +1,43 @@
+## 1. DOM Restructure — my-artists-page.html
+
+- [x] 1.1 Remove `.artist-list-inner` wrapper; move its padding to `.artist-list`
+- [x] 1.2 Merge `.artist-list-item` and `.artist-row` into a single `.artist-row` element (scroll-snap container)
+- [x] 1.3 Add `.artist-row-content` inside `.artist-row` as the grid layout element
+- [x] 1.4 Wrap indicator + name in `.artist-identity` element inside `.artist-row-content`
+- [x] 1.5 Move `<hype-inline-slider>` inside `.artist-row-content`
+- [x] 1.6 Replace `.delete-zone` with `.dismiss-end` element after `.artist-row-content`
+- [x] 1.7 Remove all touch event bindings (`touchstart`, `touchmove`, `touchend`, `touchcancel`) and inline `transform` style from artist row
+
+## 2. Grid Alignment — my-artists-page.css
+
+- [x] 2.1 Update `.hype-legend` to `grid-template-columns: 2fr repeat(4, 1fr)` with `grid-template-areas: "spacer watch home nearby away"`
+- [x] 2.2 Set `.hype-legend-item:first-child` to `grid-column: 2`
+- [x] 2.3 Add `.hype-legend` padding-inline to match `.artist-list` padding
+- [x] 2.4 Style `.artist-row-content` as `display: grid; grid-template-columns: 2fr repeat(4, 1fr); grid-template-areas: "name watch home nearby away"`
+- [x] 2.5 Style `.artist-identity` with `grid-area: name; display: flex; gap; align-items: center; min-inline-size: 0`
+- [x] 2.6 Set `hype-inline-slider` to `grid-column: 2 / -1` within `.artist-row-content`
+
+## 3. Scroll-Snap Swipe — my-artists-page.css
+
+- [x] 3.1 Style `.artist-row` as horizontal scroll container: `overflow-x: auto; scroll-snap-type: x mandatory; scrollbar-width: none`
+- [x] 3.2 Style `.artist-row-content` with `flex: 0 0 100%; scroll-snap-align: start`
+- [x] 3.3 Style `.dismiss-end` with `flex: 0 0 5rem; scroll-snap-align: end` and danger background + trash icon
+- [x] 3.4 Remove all old styles: `.artist-list-inner`, `.artist-list-item`, `.delete-zone`, swipe-related `[data-swiping]` selectors
+
+## 4. View Transitions & Dismiss Logic — my-artists-page.ts
+
+- [x] 4.1 Add scroll event handler `checkDismiss()` that checks `scrollLeft > threshold` and triggers unfollow
+- [x] 4.2 Wrap unfollow in `document.startViewTransition()` with fallback for unsupported browsers
+- [x] 4.3 Set unique `view-transition-name` per `.artist-row` via `--_vt-name` custom property bound to artist ID
+- [x] 4.4 Delete `onTouchStart`, `onTouchMove`, `onTouchEnd` methods
+- [x] 4.5 Delete `swipeOffset`, `swipedArtistId`, `swipeTarget`, `isSwiping`, `touchStartX`, `touchStartY` properties
+- [x] 4.6 Delete `onLongPress`, `clearLongPressTimer`, `longPressTimer`, `LONG_PRESS_MS`
+
+## 5. Verification
+
+- [x] 5.1 Visual check: header emoji centers align with dot centers across all artist rows
+- [x] 5.2 Swipe left on artist row → dismiss-end appears, snap triggers unfollow
+- [x] 5.3 Partial swipe snaps back to start position
+- [x] 5.4 Vertical scrolling is not blocked by horizontal scroll containers
+- [x] 5.5 Hype slider dot taps still work (no conflict with horizontal scroll)
+- [x] 5.6 Run `make check` in frontend to confirm lint + tests pass

--- a/openspec/specs/hype-inline-slider/spec.md
+++ b/openspec/specs/hype-inline-slider/spec.md
@@ -8,15 +8,22 @@ Provide a 1-tap inline slider for setting hype level per artist in the My Artist
 
 ### Requirement: Sticky Header Legend
 
-The My Artists list view SHALL display a sticky header row showing hype tier icons and emotion-based labels, aligned with slider stop positions.
+The My Artists list view SHALL display a sticky header row showing hype tier icons and emotion-based labels, aligned with slider stop positions using a shared grid column definition.
 
 #### Scenario: Header renders with 4 columns
 
 - **WHEN** the My Artists page renders in list view
 - **THEN** the system SHALL display a sticky header row below the page title
 - **AND** the header SHALL contain 4 equally-spaced columns: 👀 チェック, 🔥 地元, 🔥🔥 近くも, 🔥🔥🔥 どこでも！
-- **AND** the header SHALL use `position: sticky; top: 0` with `backdrop-filter: blur(8px)` on the surface-raised background
+- **AND** the header SHALL use `position: sticky; inset-block-start: 0` with `backdrop-filter: blur(8px)` on the surface-raised background
 - **AND** each column SHALL vertically align with the corresponding dot stop on artist row sliders
+- **AND** the header and artist row content SHALL share the same `grid-template-columns: 2fr repeat(4, 1fr)` definition with `grid-template-areas` to ensure column alignment
+
+#### Scenario: Header column alignment matches artist row dot positions
+
+- **WHEN** the header and any artist row are visible simultaneously
+- **THEN** the center of each header label SHALL be horizontally aligned with the center of the corresponding dot in the artist row slider
+- **AND** this alignment SHALL be achieved by both elements using `grid-template-columns: 2fr repeat(4, 1fr)` at the same parent width
 
 #### Scenario: Header remains visible during scroll
 
@@ -67,8 +74,13 @@ Each artist row in the My Artists list view SHALL include a 4-stop discrete dot 
 - **AND** the system SHALL dispatch a `hype-signup-prompt` custom event
 - **AND** the My Artists page SHALL handle this event by displaying the notification dialog (see `onboarding-tutorial` spec)
 
-#### Scenario: Slider dot positions align with header columns
+### Requirement: Slider dot positions align with header columns
+
+The 4 slider dot stops SHALL be positioned to vertically align with the 4 header legend columns using a shared CSS Grid column template.
+
+#### Scenario: Slider spans header dot columns
 
 - **WHEN** the page renders
-- **THEN** the 4 slider dot stops SHALL be positioned to vertically align with the 4 header legend columns
-- **AND** alignment SHALL be maintained across viewport widths (CSS Grid shared column template)
+- **THEN** the hype-inline-slider component SHALL span grid columns 2 through 5 of the artist row content grid
+- **AND** the slider's internal `repeat(4, 1fr)` grid SHALL subdivide the same width as the header's 4 dot columns
+- **AND** alignment SHALL be maintained across viewport widths

--- a/openspec/specs/my-artists/spec.md
+++ b/openspec/specs/my-artists/spec.md
@@ -8,14 +8,29 @@ Display and manage the user's followed artists, providing list and grid views wi
 
 ### Requirement: Artist List Row
 
-Each artist row in the My Artists list view SHALL display the artist's name and an inline hype dot slider on the same row.
+Each artist row in the My Artists list view SHALL be a horizontal scroll-snap container with the artist content and a dismiss trigger.
 
 #### Scenario: Artist row layout
 
 - **WHEN** an artist row is rendered in list view
-- **THEN** the row SHALL display the artist name (left) and inline dot slider (right) on the same horizontal line
+- **THEN** the row SHALL be a horizontal scroll container with `scroll-snap-type: x mandatory` and hidden scrollbar
+- **AND** the row content SHALL display the artist name (left) and inline dot slider (right) using `grid-template-areas: "name watch home nearby away"`
 - **AND** the artist name SHALL truncate with ellipsis if it exceeds available space
-- **AND** the row SHALL have a minimum height of 44px
+- **AND** a dismiss trigger element SHALL be placed after the content as the scroll-snap end target
+
+#### Scenario: Swipe-to-dismiss unfollows artist
+
+- **WHEN** the user swipes an artist row left past the dismiss threshold
+- **THEN** the scroll-snap SHALL snap to the dismiss-end position
+- **AND** the system SHALL trigger unfollow for that artist
+- **AND** if the View Transitions API is available, the remaining rows SHALL animate smoothly to fill the gap
+- **AND** if the View Transitions API is unavailable, the unfollow SHALL execute immediately without animation
+
+#### Scenario: Swipe cancel snaps back
+
+- **WHEN** the user swipes an artist row left but does NOT pass the dismiss threshold
+- **THEN** the scroll-snap SHALL snap back to the start position (content fully visible)
+- **AND** no unfollow action SHALL be triggered
 
 #### Scenario: Hype slider replaces passion icon
 


### PR DESCRIPTION
## 🔗 Related Issue

Closes #225

## 📝 Summary of Changes

Update capability specs and archive change artifacts for the modernized artist list:

- **hype-inline-slider/spec.md**: Add shared `grid-template-columns` and `grid-template-areas` requirement for header-row column alignment, promote "Slider dot positions align with header columns" to standalone requirement, update `top: 0` to logical property `inset-block-start: 0`
- **my-artists/spec.md**: Rewrite Artist List Row as scroll-snap container with swipe-to-dismiss (View Transitions API), snap-back cancel, and remove long-press unfollow from list view
- **Archive**: Move modernize-artist-list change artifacts (proposal, design, specs, tasks) to archive

## ✅ Self-Checklist

- [x] I have linked the related issue.
- [x] I have updated the relevant documentation (e.g., `README.md`) if needed.
- [x] I have run `buf lint` and `buf format` locally and all checks have passed.
- [x] My proto definitions follow the project's style guidelines and validation rules.
- [x] Breaking changes have been justified and documented if applicable.
