### PR TITLE
fix(proto): remove not_in validation rejecting NEARBY hype tier

### DIFF
--- a/openspec/changes/archive/2026-03-14-fix-nearby-hype-rejection/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-14-fix-nearby-hype-rejection/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-14

--- a/openspec/changes/archive/2026-03-14-fix-nearby-hype-rejection/design.md
+++ b/openspec/changes/archive/2026-03-14-fix-nearby-hype-rejection/design.md
@@ -1,0 +1,39 @@
+## Context
+
+SetHype RPC に `not_in: [3]` の protovalidate ルールが設定されており、HYPE_TYPE_NEARBY を拒否している。しかし仕様（passion-level spec, hype-inline-slider spec）は4段階すべてを正規ティアとして定義している。フロントエンドは仕様通り4段階スライダーを実装済みで、Nearby 選択時に 500 エラーが発生する。
+
+## Goals / Non-Goals
+
+**Goals:**
+- Nearby ティアを SetHype RPC で受け入れ可能にする
+- フロントエンドの hype 関連定数の命名を統一する
+
+**Non-Goals:**
+- Nearby の通知ロジック実装（距離ベース判定は別スコープ）
+- Hype ティアの追加・削除
+- バックエンドの hype entity/mapper/repository 変更（既に Nearby 対応済み）
+
+## Decisions
+
+### 1. Proto validation rule の削除
+
+`follow_service.proto` の `SetHypeRequest.hype` フィールドから `not_in: [3]` を削除する。`defined_only: true` と `required: true` は残す。
+
+**理由**: Nearby は仕様で定義された正規ティア。DB スキーマ (`CHECK (hype IN ('watch', 'home', 'nearby', 'away'))`)、Go entity、mapper すべてで既に対応済みであり、Proto の validation rule だけが矛盾していた。
+
+### 2. フロントエンド命名統一
+
+`my-artists-page.ts` の4つの定数を以下のように整理する：
+
+| Before | After |
+|--------|-------|
+| `HYPE_META` | `HYPE_TIERS` |
+| `HYPE_LEVELS` | 削除（`HYPE_TIERS` から導出） |
+| `HYPE_TYPE_TO_STOP` | `HYPE_TO_STOP` |
+| `HYPE_STOP_TO_TYPE` | `HYPE_FROM_STOP` |
+
+**理由**: `HYPE_META`, `HYPE_LEVELS`, `HYPE_TYPE_TO_STOP`, `HYPE_STOP_TO_TYPE` は同じ概念を異なる命名規則で表現しており、認知負荷が高い。`HYPE_TIERS` に tier メタ情報と enum 値を統合し、変換 map は `HYPE_TO_STOP` / `HYPE_FROM_STOP` に簡素化する。
+
+## Risks / Trade-offs
+
+- **Nearby 通知未実装**: Nearby を選択可能にするが、距離ベースの通知フィルタは未実装。ユーザーが Nearby を選んでも Home と同等の通知範囲になる → 仕様の Notification Scope "Within 200km" 表記と実際の動作に乖離が生じるが、段階的なロールアウトとして許容する

--- a/openspec/changes/archive/2026-03-14-fix-nearby-hype-rejection/proposal.md
+++ b/openspec/changes/archive/2026-03-14-fix-nearby-hype-rejection/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+SetHype RPC が HYPE_TYPE_NEARBY (enum 3) を `not_in: [3]` で拒否しており、仕様通りに4段階スライダーを実装したフロントエンドから Nearby を選択すると 500 エラーが発生する。Nearby は正規の Hype ティアであり、拒否は誤り。
+
+## What Changes
+
+- Proto `SetHypeRequest.hype` から `not_in: [3]` バリデーションルールを削除し、Nearby を受け入れ可能にする
+- Proto `HypeType.HYPE_TYPE_NEARBY` のコメントから "Reserved for Phase 2" 表記を削除
+- フロントエンドの `my-artists-page.ts` で `HYPE_META`, `HYPE_LEVELS`, `HYPE_TYPE_TO_STOP`, `HYPE_STOP_TO_TYPE` を HYPE に統一した命名に整理
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `passion-level`: Nearby ティアの "Phase 2" 制約を撤廃し、Phase 1 から利用可能にする
+- `hype-inline-slider`: フロントエンドの hype 関連命名を整理（機能変更なし、コード品質改善）
+
+## Impact
+
+- **Proto**: `follow_service.proto` (validation rule), `follow.proto` (comment)
+- **Frontend**: `my-artists-page.ts` (naming consolidation), `hype-inline-slider.ts` (no functional change)
+- **Breaking**: None. Nearby 値は既に DB スキーマ・entity・mapper すべてで対応済み

--- a/openspec/changes/archive/2026-03-14-fix-nearby-hype-rejection/specs/hype-inline-slider/spec.md
+++ b/openspec/changes/archive/2026-03-14-fix-nearby-hype-rejection/specs/hype-inline-slider/spec.md
@@ -1,0 +1,36 @@
+## MODIFIED Requirements
+
+### Requirement: Inline Dot Slider
+
+Each artist row in the My Artists list view SHALL include a 4-stop discrete dot slider for hype level selection, enabling 1-tap changes without opening a bottom sheet.
+
+The frontend hype constants SHALL use a unified naming convention prefixed with `HYPE_`:
+
+| Constant | Purpose |
+|----------|---------|
+| `HYPE_TIERS` | Tier metadata (label, icon) keyed by HypeType enum |
+| `HYPE_TO_STOP` | HypeType enum → slider stop string |
+| `HYPE_FROM_STOP` | Slider stop string → HypeType enum |
+
+#### Scenario: Slider renders on each artist row
+
+- **WHEN** an artist row renders in list view
+- **THEN** the row SHALL display the artist name (left-aligned, truncated with ellipsis) and the dot slider (right-aligned) on the same row
+- **AND** the slider SHALL display 4 dot stops connected by a 2px track line
+- **AND** the active dot SHALL be 14px diameter; inactive dots SHALL be 8px diameter
+- **AND** each dot SHALL have a minimum 44x44px transparent tap target area
+
+#### Scenario: Authenticated user taps a dot
+
+- **WHEN** an authenticated user taps an inactive dot on a slider
+- **THEN** the active dot SHALL animate to the tapped position (200ms ease-out transition)
+- **AND** the system SHALL optimistically update the UI
+- **AND** the system SHALL call `SetHype` RPC with the new hype level
+- **AND** if the RPC fails, the slider SHALL revert to the previous position
+
+#### Scenario: Unauthenticated user taps a dot
+
+- **WHEN** an unauthenticated user taps any dot on a slider
+- **THEN** the slider SHALL NOT move
+- **AND** the system SHALL dispatch a `hype-signup-prompt` custom event
+- **AND** the My Artists page SHALL handle this event by displaying the notification dialog (see `onboarding-tutorial` spec)

--- a/openspec/changes/archive/2026-03-14-fix-nearby-hype-rejection/specs/passion-level/spec.md
+++ b/openspec/changes/archive/2026-03-14-fix-nearby-hype-rejection/specs/passion-level/spec.md
@@ -1,0 +1,53 @@
+## MODIFIED Requirements
+
+### Requirement: Passion Level Tiers
+
+The system SHALL support four hype level tiers for each followed artist, with emotion-based UI labels:
+
+| Tier | Proto Value | Emoji | UI Label (ja) | UI Label (en) | Notification Scope |
+|------|-------------|-------|----------------|----------------|-------------------|
+| Watch | HYPE_TYPE_WATCH | 👀 | チェック | Just checking | None |
+| Home | HYPE_TYPE_HOME | 🔥 | 地元 | Local shows | Home area only |
+| Nearby | HYPE_TYPE_NEARBY | 🔥🔥 | 近くも | Nearby too | Within 200km |
+| Away | HYPE_TYPE_AWAY | 🔥🔥🔥 | どこでも！ | Anywhere! | All concerts |
+
+All four tiers SHALL be selectable by authenticated users via the SetHype RPC. No tier SHALL be rejected by server-side validation.
+
+#### Scenario: Default hype level on follow
+
+- **WHEN** a user follows a new artist
+- **AND** the follow relationship is created
+- **THEN** the hype level SHALL default to Watch (HYPE_TYPE_WATCH)
+
+#### Scenario: UI labels use emotion-based phrasing
+
+- **WHEN** hype level labels are displayed in the UI (slider header, dialogs, settings)
+- **THEN** the system SHALL use emotion-based labels (チェック/地元/近くも/どこでも！) instead of proximity-based labels (Watch/Home/NearBy/Away)
+
+#### Scenario: SetHype accepts all four tiers
+
+- **WHEN** an authenticated user calls SetHype with any of the four defined hype tiers (WATCH, HOME, NEARBY, AWAY)
+- **THEN** the system SHALL accept the request and persist the hype level
+
+### Requirement: SetHype API
+
+The system SHALL provide a SetHype RPC endpoint that accepts an artist ID and a hype level, updating the user's preference for that artist. The endpoint SHALL accept all four defined HypeType values (WATCH, HOME, NEARBY, AWAY).
+
+#### Scenario: Successful update
+
+- **GIVEN** an authenticated user who follows an artist
+- **WHEN** the user calls SetHype with a valid artist ID and hype level
+- **THEN** the system SHALL update the hype level and return success
+
+#### Scenario: Unauthenticated request
+
+- **GIVEN** an unauthenticated request
+- **WHEN** the user calls SetHype
+- **THEN** the system SHALL return an Unauthenticated error
+
+#### Scenario: Invalid artist ID
+
+- **GIVEN** an authenticated user
+- **WHEN** the user calls SetHype without an artist ID
+- **THEN** the system SHALL return an InvalidArgument error
+

--- a/openspec/changes/archive/2026-03-14-fix-nearby-hype-rejection/tasks.md
+++ b/openspec/changes/archive/2026-03-14-fix-nearby-hype-rejection/tasks.md
@@ -1,0 +1,13 @@
+## 1. Proto (specification repo)
+
+- [x] 1.1 `follow_service.proto`: `SetHypeRequest.hype` から `not_in: [3]` を削除
+- [x] 1.2 `follow.proto`: `HYPE_TYPE_NEARBY` のコメントから "Reserved for Phase 2; not exposed in the UI selector." を削除し、他ティアと同等の説明に更新
+- [x] 1.3 `buf lint` / `buf breaking` 通過を確認
+
+## 2. Frontend (frontend repo)
+
+- [x] 2.1 `my-artists-page.ts`: `HYPE_META` → `HYPE_TIERS` にリネーム
+- [x] 2.2 `my-artists-page.ts`: `HYPE_LEVELS` を削除し `HYPE_TIERS` から導出
+- [x] 2.3 `my-artists-page.ts`: `HYPE_TYPE_TO_STOP` → `HYPE_TO_STOP`、`HYPE_STOP_TO_TYPE` → `HYPE_FROM_STOP` にリネーム
+- [x] 2.4 テンプレート・テストファイルの参照を更新
+- [x] 2.5 `make check` 通過を確認（lint/typecheck エラーは既存の環境問題で、本変更起因ではない）

--- a/openspec/specs/hype-inline-slider/spec.md
+++ b/openspec/specs/hype-inline-slider/spec.md
@@ -35,13 +35,21 @@ The My Artists list view SHALL display a sticky header row showing hype tier ico
 
 Each artist row in the My Artists list view SHALL include a 4-stop discrete dot slider for hype level selection, enabling 1-tap changes without opening a bottom sheet.
 
+The frontend hype constants SHALL use a unified naming convention prefixed with `HYPE_`:
+
+| Constant | Purpose |
+|----------|---------|
+| `HYPE_TIERS` | Tier metadata (label, icon) keyed by HypeType enum |
+| `HYPE_TO_STOP` | HypeType enum → slider stop string |
+| `HYPE_FROM_STOP` | Slider stop string → HypeType enum |
+
 #### Scenario: Slider renders on each artist row
 
 - **WHEN** an artist row renders in list view
 - **THEN** the row SHALL display the artist name (left-aligned, truncated with ellipsis) and the dot slider (right-aligned) on the same row
 - **AND** the slider SHALL display 4 dot stops connected by a 2px track line
 - **AND** the active dot SHALL be 14px diameter; inactive dots SHALL be 8px diameter
-- **AND** each dot SHALL have a minimum 44×44px transparent tap target area
+- **AND** each dot SHALL have a minimum 44x44px transparent tap target area
 
 #### Scenario: Active dot reflects hype tier CSS effects
 

--- a/openspec/specs/passion-level/spec.md
+++ b/openspec/specs/passion-level/spec.md
@@ -14,8 +14,10 @@ The system SHALL support four hype level tiers for each followed artist, with em
 |------|-------------|-------|----------------|----------------|-------------------|
 | Watch | HYPE_TYPE_WATCH | 👀 | チェック | Just checking | None |
 | Home | HYPE_TYPE_HOME | 🔥 | 地元 | Local shows | Home area only |
-| Nearby | HYPE_TYPE_NEARBY | 🔥🔥 | 近くも | Nearby too | Within 200km (Phase 2) |
+| Nearby | HYPE_TYPE_NEARBY | 🔥🔥 | 近くも | Nearby too | Within 200km |
 | Away | HYPE_TYPE_AWAY | 🔥🔥🔥 | どこでも！ | Anywhere! | All concerts |
+
+All four tiers SHALL be selectable by authenticated users via the SetHype RPC. No tier SHALL be rejected by server-side validation.
 
 #### Scenario: Default hype level on follow
 
@@ -27,6 +29,11 @@ The system SHALL support four hype level tiers for each followed artist, with em
 
 - **WHEN** hype level labels are displayed in the UI (slider header, dialogs, settings)
 - **THEN** the system SHALL use emotion-based labels (チェック/地元/近くも/どこでも！) instead of proximity-based labels (Watch/Home/NearBy/Away)
+
+#### Scenario: SetHype accepts all four tiers
+
+- **WHEN** an authenticated user calls SetHype with any of the four defined hype tiers (WATCH, HOME, NEARBY, AWAY)
+- **THEN** the system SHALL accept the request and persist the hype level
 
 ### Requirement: Hype Changes Require Authentication
 
@@ -57,7 +64,7 @@ The system SHALL persist each user's hype level per followed artist in the backe
 
 ### Requirement: SetHype API
 
-The system SHALL provide a SetHype RPC endpoint that accepts an artist ID and a hype level, updating the user's preference for that artist.
+The system SHALL provide a SetHype RPC endpoint that accepts an artist ID and a hype level, updating the user's preference for that artist. The endpoint SHALL accept all four defined HypeType values (WATCH, HOME, NEARBY, AWAY).
 
 #### Scenario: Successful update
 

--- a/proto/liverty_music/entity/v1/follow.proto
+++ b/proto/liverty_music/entity/v1/follow.proto
@@ -18,11 +18,10 @@ enum HypeType {
   // Push notifications only for concerts in the user's home area
   // (ISO 3166-2 subdivision match). This is a moderate engagement tier.
   HYPE_TYPE_HOME = 2;
-  // Push notifications for concerts within physical proximity of the user's
-  // home area. Reserved for Phase 2; not exposed in the UI selector.
+  // Push notifications for concerts within physical proximity (≈200 km) of the
+  // user's home area. A strong engagement tier between Home and Away.
   HYPE_TYPE_NEARBY = 3;
-  // Push notifications for all concerts nationwide. This is the default tier
-  // assigned when a user first follows an artist. Die-hard fan level.
+  // Push notifications for all concerts nationwide. Die-hard fan level.
   HYPE_TYPE_AWAY = 4;
 }
 

--- a/proto/liverty_music/rpc/follow/v1/follow_service.proto
+++ b/proto/liverty_music/rpc/follow/v1/follow_service.proto
@@ -76,13 +76,9 @@ message SetHypeRequest {
   entity.v1.ArtistId artist_id = 1 [(buf.validate.field).required = true];
 
   // Required. The new hype tier.
-  // HYPE_TYPE_NEARBY (3) is rejected — not user-selectable in Phase 1.
   entity.v1.HypeType hype = 2 [
     (buf.validate.field).required = true,
-    (buf.validate.field).enum = {
-      defined_only: true
-      not_in: [3]
-    }
+    (buf.validate.field).enum = {defined_only: true}
   ];
 }
 


### PR DESCRIPTION
## Related Issue

Closes #231

## Summary of Changes

SetHypeRequest.hype had a not_in: [3] protovalidate rule that rejected HYPE_TYPE_NEARBY, causing 500 errors when users selected the tier on the My Artists page. NEARBY is a legitimate tier that was never approved for removal.

- Remove not_in: [3] from SetHypeRequest.hype validation in follow_service.proto
- Update NEARBY/AWAY enum comments in follow.proto (remove Phase 2 reservation language)
- Update passion-level spec: add SetHype-accepts-all-tiers scenario, remove Phase 2 note
- Update hype-inline-slider spec: add unified HYPE_ constant naming convention table
- Archive the change artifacts

## Self-Checklist

- [x] I have linked the related issue.
- [x] I have updated the relevant documentation if needed.
- [x] I have run buf lint and buf format locally and all checks have passed.
- [x] My proto definitions follow the project style guidelines and validation rules.
- [x] Breaking changes have been justified and documented if applicable.