### PR TITLE
docs: add festival orb effects spec and update DNA orb UI spec

### DIFF
--- a/openspec/changes/archive/2026-03-15-festival-orb-effects/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-15-festival-orb-effects/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-14

--- a/openspec/changes/archive/2026-03-15-festival-orb-effects/design.md
+++ b/openspec/changes/archive/2026-03-15-festival-orb-effects/design.md
@@ -1,0 +1,138 @@
+## Context
+
+The DNA Orb on the Discover page uses Canvas 2D with Matter.js physics. The current visual pipeline renders: bubbles → absorption animations → orb, all in a single `render()` method in `dna-orb-canvas.ts`. The orb is a fixed 70px radius glass sphere with 60 internal particles, rendered by `orb-renderer.ts` (200 lines). Visual intensity is driven by a single `orbIntensity` scalar (followCount/20) combined with a diminishing-returns `baseIntensity` curve. Both values saturate early — by 6 follows the orb is visually maxed out with nowhere to go.
+
+The bubble area is bounded by a Matter.js static wall at `canvasHeight - 160` (hardcoded `orbZoneHeight`). The "MUSIC DNA · N" label is a DOM element positioned via CSS over the canvas.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Each follow produces a visibly distinct escalation in visual effects (festival stage metaphor)
+- Orb grows in size, pushing the bubble play area upward naturally
+- New effect layers (orbitals, rays, shockwave, comet trail, ground glow) are added progressively
+- `stage-effects.ts` encapsulates all stage-level parameter calculation as pure functions, fully unit-testable
+- Existing FPS monitoring and quality scaling continues to work, degrading new effects gracefully
+
+**Non-Goals:**
+- Applying festival aesthetic to other pages (dashboard, my-artists) — separate change
+- WebGL/shader-based rendering — stay on Canvas 2D
+- Sound effects or haptic feedback
+- Changing the bubble physics behavior (gravity, restitution, etc.)
+
+## Decisions
+
+### 1. Separate `stage-effects.ts` for parameter calculation
+
+**Decision**: Extract all follow-count → visual-parameter mapping into a pure module `stage-effects.ts`.
+
+**Rationale**: The escalation system has ~15 parameters that change per follow. Keeping the calculation separate from rendering means: (a) unit tests cover the parameter curve without needing Canvas mocks, (b) future pages that want festival-style effects can import the same module, (c) tuning is localized to one file.
+
+**Alternative considered**: Inline everything in `orb-renderer.ts`. Rejected because it would push the file to ~450 lines with interleaved calculation and draw calls, making tuning harder.
+
+**Interface**:
+```typescript
+interface StageParams {
+  level: number              // 0-based stage level (= followCount, uncapped)
+  orbRadius: number          // 60 → 120 (asymptotic)
+  breathAmplitude: number    // 0 → 0.05
+  breathSpeed: number        // 1.5 → 3.0
+  orbitalCount: number       // 0 → 12
+  orbitalSpeedMultiplier: number
+  lightRayCount: number      // 0 → 6
+  lightRayAlpha: number      // 0 → 0.15
+  lightRayRotationSpeed: number
+  groundGlowAlpha: number    // 0 → 0.2
+  shockwaveEnabled: boolean
+  cometTrailEnabled: boolean
+  glowAlpha: number          // outer glow alpha
+  particleVisibilityRatio: number // 0.1 → 1.0
+}
+
+function getStageParams(followCount: number): StageParams
+```
+
+### 2. Orb radius growth formula
+
+**Decision**: `orbRadius = min(120, 60 + followCount * 8)` for follows 1-6, then logarithmic growth: `60 + 48 + log2(followCount - 5) * 8` for 7+.
+
+**Rationale**: Linear growth (8px/follow) gives immediate visible feedback for the first 6 follows (the tutorial target is 3). Logarithmic tail prevents the orb from consuming the entire canvas while still rewarding continued follows.
+
+**Alternative considered**: Pure logarithmic from the start. Rejected because the initial follows need dramatic size jumps to feel rewarding.
+
+### 3. Dynamic Matter.js wall repositioning
+
+**Decision**: Add `updateOrbZone(radius: number)` to `BubblePhysics`. When the orb radius changes, the bottom wall is repositioned to `canvasHeight - (radius * 2 + 20)`, giving the orb its radius plus 20px breathing room above the wall.
+
+**Rationale**: Matter.js supports repositioning static bodies via `Body.setPosition()`. This is the simplest approach — no wall recreation needed.
+
+**Alternative considered**: Recreating walls on each follow. Rejected because `setPosition` on an existing static body is cheaper and avoids re-adding to the composite.
+
+### 4. Render layer ordering
+
+**Decision**: Extend the render pipeline to 7 layers:
+
+```
+0. Ground glow          (below everything)
+1. Light rays           (additive blend, behind bubbles)
+2. Bubbles              (existing)
+3. Comet trails         (behind absorption bubble, ahead of field bubbles)
+4. Absorption animations (existing)
+5. Orb body             (existing, with breathing pulse)
+6. Orbital particles    (foreground, on top of orb)
+7. Shockwave rings      (foreground, expanding outward)
+```
+
+**Rationale**: Ground glow and light rays go behind bubbles to create depth. Orbitals and shockwaves go on top of the orb because they're foreground spectacle. Comet trails are behind the absorption bubble body so the artist name remains readable.
+
+### 5. Additive blending for light effects
+
+**Decision**: Use `globalCompositeOperation = 'screen'` for light rays and ground glow, wrapped in `ctx.save()/restore()` to avoid affecting other layers.
+
+**Rationale**: Additive blending makes overlapping lights brighter, matching real stage lighting. `'screen'` is well-supported and GPU-accelerated on all target browsers.
+
+### 6. Comet trail implementation
+
+**Decision**: Store the last 12 frame positions in a circular buffer on each `AbsorptionAnimation`. Render as segmented lines with decreasing width (4px → 1px) and opacity (0.7 → 0.05) from head to tail, colored with the artist's hue.
+
+**Rationale**: A circular buffer avoids allocations. 12 points at 60fps covers ~200ms of trail, long enough to be visible on the curved bezier path. Line segments are cheaper than bezier curves for the trail itself.
+
+**Alternative considered**: Render trail as a series of circles (dots). Rejected because connected lines give a smoother comet appearance.
+
+### 7. Shockwave ring lifecycle
+
+**Decision**: Shockwave rings are stored as a small array (`maxConcurrent = 3`) in `OrbRenderer`. Each ring has: `radius` (starts at orbRadius, expands to orbRadius × 3), `alpha` (0.6 → 0), `lineWidth` (3 → 0.5), `hue`, and progresses over 800ms. Completed rings are recycled.
+
+**Rationale**: Object pooling (max 3) avoids GC. 800ms duration is long enough to be seen but short enough to not linger. The ring inherits the absorbed artist's hue for color continuity.
+
+### 8. Orbital particle management
+
+**Decision**: Pre-allocate orbital slots (max 12) in `OrbRenderer`. Each orbital has: `angle`, `orbitalRadius` (1.3-1.8 × orbRadius), `speed`, `size` (2-5px), `hue`. Visible count is `stageParams.orbitalCount`. Orbitals are rendered as small radial gradients (glow dots).
+
+**Rationale**: Pre-allocation matches the existing pattern for inner particles. Max 12 keeps draw calls reasonable. Each orbital is 1 `arc()` + 1 small `radialGradient`, which is efficient.
+
+### 9. Color palette accumulation
+
+**Decision**: Maintain a `colorPalette: number[]` (max 20 hues) in `OrbRenderer`. Each `injectColor(hue)` call appends to the palette. Orbital particles and light rays sample colors from the palette, distributing them evenly.
+
+**Rationale**: This naturally enriches the visual diversity as more artists are followed. The palette array is trivially cheap. Capping at 20 prevents unbounded growth while covering the full hue spectrum.
+
+### 10. Unit test strategy
+
+**Decision**: Test `stage-effects.ts` exhaustively with Vitest. Test key state transitions in `OrbRenderer` (shockwave lifecycle, color palette, orbital count changes). Do not test Canvas draw calls directly.
+
+**Rationale**: `getStageParams()` is a pure function — ideal for unit tests. OrbRenderer state logic (palette, shockwave pool, orbital slots) can be tested by calling methods and asserting state, without needing a Canvas context. Asserting actual pixel output would require canvas mocking and provides little value.
+
+**Test coverage targets**:
+- `stage-effects.ts`: Every parameter at follow counts 0, 1, 3, 5, 6, 10, 20 (boundary values)
+- `OrbRenderer`: shockwave spawn/complete lifecycle, color palette accumulation and cap, orbital count changes, breathing pulse state, `prefers-reduced-motion` behavior
+- `AbsorptionAnimator`: comet trail point accumulation and circular buffer behavior
+
+## Risks / Trade-offs
+
+- **[Mobile performance with all effects active]** → Mitigated by existing FPS monitoring (`monitorPerformance`). When FPS drops below 40, reduce `orbitalCount` and `lightRayCount` via `qualityScale`. Ground glow and shockwave rings are single draw calls and negligible.
+
+- **[Orb growth compresses bubble area]** → At max orb size (120px radius), the bottom wall sits at ~canvasHeight - 260, leaving roughly 60% of the canvas for bubbles on a typical mobile screen (800px viewport). With ~30 bubbles this is still comfortable. If it feels cramped, the growth ceiling can be tuned in `stage-effects.ts` without touching rendering code.
+
+- **[Additive blending artifacts]** → `screen` blending on semi-transparent backgrounds can produce unexpected brightness. Mitigated by keeping light ray alpha low (max 0.15) and always wrapping in save/restore.
+
+- **[Breaking existing spec assertions]** → The `artist-discovery-dna-orb-ui` spec has specific assertions about `baseIntensity` formula and fixed thresholds. These will be superseded by the updated spec. The delta spec must clearly mark which scenarios are replaced.

--- a/openspec/changes/archive/2026-03-15-festival-orb-effects/proposal.md
+++ b/openspec/changes/archive/2026-03-15-festival-orb-effects/proposal.md
@@ -1,0 +1,35 @@
+## Why
+
+The DNA Orb's visual effects plateau quickly — by 6 follows, `effectiveIntensity` is already capped at 1.0, yet the orb looks static and subdued. The fixed 70px radius, limited blue-purple palette, and 1-second swirl decay fail to convey the excitement of building a music identity. The onboarding experience should feel like arriving at a festival where the lights escalate with every act, not watching a screensaver.
+
+## What Changes
+
+- **Growing orb**: Orb radius scales from 60px → 120px based on follow count, pushing the bubble area upward via dynamic Matter.js wall repositioning
+- **Stage-level escalation system**: Each follow advances a "stage level" that unlocks new visual effects (breathing pulse → orbital particles → light rays → shockwave rings), replacing the current single `orbIntensity` scalar
+- **Orbital particles**: Glowing particles orbit outside the orb, increasing in count and speed per stage level
+- **Light rays**: Radial beams emanate from the orb (stage 4+), rotating slowly with `screen` composite blending for additive light
+- **Shockwave rings**: Expanding color rings burst from the orb on each follow
+- **Comet trail on absorption**: Absorbed bubbles leave a colored polyline trail (8-12 frame positions) that fades along the path
+- **Ground glow**: Soft gradient reflection at the screen bottom, intensity tied to stage level
+- **Color palette accumulation**: Artist hues are stored in a palette array, enriching orbital and ray colors toward a rainbow spectrum
+- **Remove "MUSIC DNA · N" label**: The orb-label element and associated CSS are deleted
+- **Unit test coverage**: `stage-effects.ts` (pure parameter calculation) and visual effect state transitions are covered by Vitest tests
+
+## Capabilities
+
+### New Capabilities
+
+- `festival-orb-effects`: Stage-level escalation system, orbital particles, light rays, shockwave rings, comet trails, ground glow, and growing orb behavior
+
+### Modified Capabilities
+
+- `artist-discovery-dna-orb-ui`: Orb visual evolution requirements change from intensity-scalar model to stage-level model; orb-label requirement is removed; absorption animation gains comet trail; orbZoneHeight becomes dynamic
+
+## Impact
+
+- **Frontend components**: `orb-renderer.ts` (major rewrite), `absorption-animator.ts` (comet trail), `bubble-physics.ts` (dynamic wall), `dna-orb-canvas.ts` (orchestration + render order)
+- **New file**: `stage-effects.ts` — pure calculation of stage parameters from follow count
+- **Template/CSS**: `discover-page.html` (remove orb-label), `discover-page.css` (remove `.orb-label` rules)
+- **Tests**: New test files for `stage-effects.ts` and effect state transitions
+- **No backend changes**: Purely frontend visual enhancement
+- **Performance**: Additional Canvas draw calls (orbitals, rays, glow); mitigated by existing FPS monitoring and quality scaling

--- a/openspec/changes/archive/2026-03-15-festival-orb-effects/specs/artist-discovery-dna-orb-ui/spec.md
+++ b/openspec/changes/archive/2026-03-15-festival-orb-effects/specs/artist-discovery-dna-orb-ui/spec.md
@@ -1,0 +1,71 @@
+# Artist Discovery DNA Orb UI — Delta
+
+## MODIFIED Requirements
+
+### Requirement: Bubble Absorption Animation
+The system SHALL provide satisfying visual feedback when users select artists by animating bubbles into the DNA Orb, with accumulating visual intensity and comet trail effects.
+
+#### Scenario: Artist selection with absorption effect
+- **WHEN** a user taps an artist bubble
+- **THEN** the bubble SHALL shrink and trace a path toward the DNA Orb at the bottom
+- **AND** the bubble SHALL be absorbed into the orb with a dissolve effect
+- **AND** if comet trail is enabled by the current stage level, the bubble SHALL leave a colored trail along its path
+- **AND** on absorption completion, the orb SHALL trigger a shockwave ring (if enabled by stage level)
+- **AND** the orb's color SHALL incorporate the absorbed bubble's hue
+
+#### Scenario: Color injection uses bubble's existing hue
+- **WHEN** a bubble is absorbed into the orb
+- **THEN** `OrbRenderer.injectColor` SHALL be called with the same hue used to render that bubble's gradient
+- **AND** 10-15 particles SHALL be replaced with the injected hue (with +/- 20 degree random variance)
+- **AND** `swirlIntensity` SHALL spike to 1.0 for a transient visual burst
+- **AND** the hue SHALL be appended to the color palette for use by orbital particles and light rays
+
+#### Scenario: Orb visual evolution with stage-level escalation
+- **WHEN** the user follows more artists
+- **THEN** the orb's visual presentation SHALL be determined by `getStageParams(followCount)` from `stage-effects.ts`
+- **AND** the orb radius, orbital count, light ray count, breathing amplitude, and ground glow SHALL all be driven by the returned `StageParams`
+- **AND** each follow SHALL produce a visibly distinct escalation in effects
+
+#### Scenario: First follow has maximum visual impact
+- **WHEN** the user follows their first artist (followCount goes from 0 to 1)
+- **THEN** the orb radius SHALL increase from 60 to 68
+- **AND** the breathing pulse SHALL begin
+- **AND** the visible particle count SHALL increase noticeably
+
+#### Scenario: Effective swirl combines base and transient
+- **WHEN** the orb animation loop runs
+- **THEN** the particle speed multiplier SHALL be `1 + (baseIntensity + swirlIntensity) * 2`
+- **AND** `swirlIntensity` SHALL decay over ~1000ms as before
+- **AND** `baseIntensity` SHALL NOT decay within the same page session
+
+---
+
+### Requirement: DNA Extraction UI Concept
+The system SHALL provide a gamified artist discovery interface using a "DNA Extraction" metaphor with an interactive orb (glass sphere) UI that collects user preferences, with visual differentiation per artist and onboarding guidance.
+
+#### Scenario: Initial bubble display with DNA Orb
+- **WHEN** a user reaches the Artist Discovery step after authentication
+- **THEN** the system SHALL display approximately 30 artist bubbles in the center area using physics-based animation
+- **AND** the system SHALL display a "Music DNA Orb" (glass sphere UI) at the bottom of the screen
+- **AND** the orb SHALL serve as a visual inventory for collected artists
+
+#### Scenario: Per-artist bubble color differentiation
+- **WHEN** artist bubbles are rendered
+- **THEN** each bubble SHALL have a unique gradient color derived from the artist's name using a deterministic HSL-based algorithm
+- **AND** the colors SHALL provide visual variety across the bubble field (not uniform purple)
+
+#### Scenario: Onboarding guidance overlay
+- **WHEN** the Artist Discovery screen is displayed for the first time during onboarding
+- **THEN** the system SHALL display a popover guide explaining the interaction (per `onboarding-popover-guide` capability)
+- **AND** the popover SHALL dismiss via light-dismiss or explicit close
+
+#### Scenario: Background visual depth
+- **WHEN** the Artist Discovery screen is displayed
+- **THEN** the background SHALL include subtle visual elements (e.g., particle field, starfield, or animated gradient) to create depth
+- **AND** these elements SHALL NOT compete with the foreground bubbles and orb for attention
+
+## REMOVED Requirements
+
+### Requirement: Orb label text
+**Reason**: The "MUSIC DNA · N" label is removed to reduce visual clutter. The orb's growing size and escalating effects now communicate progress more effectively than a text label.
+**Migration**: No migration needed. The orb-label DOM element and `.orb-label` CSS rules are deleted. The follow count is still available via the `followedCount` bindable for accessibility (screen reader status text).

--- a/openspec/changes/archive/2026-03-15-festival-orb-effects/specs/festival-orb-effects/spec.md
+++ b/openspec/changes/archive/2026-03-15-festival-orb-effects/specs/festival-orb-effects/spec.md
@@ -1,0 +1,249 @@
+# Festival Orb Effects
+
+## ADDED Requirements
+
+### Requirement: Stage-level escalation system
+The system SHALL calculate visual effect parameters from the follow count using a stage-level model, where each follow advances the stage by one level. The calculation SHALL be implemented as a pure function in `stage-effects.ts`, separate from rendering logic.
+
+#### Scenario: Stage parameters at zero follows
+- **WHEN** the follow count is 0
+- **THEN** `getStageParams(0)` SHALL return `orbRadius` of 60, `orbitalCount` of 0, `lightRayCount` of 0, `groundGlowAlpha` of 0, `shockwaveEnabled` as false, and `cometTrailEnabled` as false
+
+#### Scenario: Stage parameters at one follow
+- **WHEN** the follow count is 1
+- **THEN** `getStageParams(1)` SHALL return `orbRadius` of 68, `breathAmplitude` greater than 0, `orbitalCount` of 0, and `particleVisibilityRatio` greater than 0.3
+
+#### Scenario: Stage parameters at two follows
+- **WHEN** the follow count is 2
+- **THEN** `getStageParams(2)` SHALL return `orbitalCount` of 2 and `groundGlowAlpha` greater than 0
+
+#### Scenario: Stage parameters at four follows
+- **WHEN** the follow count is 4
+- **THEN** `getStageParams(4)` SHALL return `lightRayCount` of 2, `cometTrailEnabled` as true, and `orbitalCount` of 6
+
+#### Scenario: Stage parameters at five follows
+- **WHEN** the follow count is 5
+- **THEN** `getStageParams(5)` SHALL return `shockwaveEnabled` as true and `lightRayCount` of 4
+
+#### Scenario: Stage parameters at six or more follows
+- **WHEN** the follow count is 6 or more
+- **THEN** `getStageParams` SHALL return `lightRayCount` of 6, `orbitalCount` of 10 or more, and all effect features enabled
+
+#### Scenario: Orb radius growth ceiling
+- **WHEN** the follow count exceeds 20
+- **THEN** the `orbRadius` SHALL NOT exceed 120
+
+#### Scenario: Stage params are deterministic
+- **WHEN** `getStageParams` is called multiple times with the same follow count
+- **THEN** it SHALL return identical results each time (pure function, no side effects)
+
+---
+
+### Requirement: Growing orb with dynamic bubble boundary
+The orb SHALL grow in radius as the user follows more artists, and the Matter.js physics boundary SHALL move upward to accommodate the larger orb, pushing bubbles into a smaller play area.
+
+#### Scenario: Orb radius increases on follow
+- **WHEN** the follow count increases from N to N+1
+- **THEN** the orb radius SHALL increase according to the stage params formula
+- **AND** the orb SHALL render at the new radius on the next frame
+
+#### Scenario: Matter.js bottom wall repositions
+- **WHEN** the orb radius changes
+- **THEN** the bottom wall position SHALL update to `canvasHeight - (orbRadius * 2 + 20)`
+- **AND** existing bubbles SHALL be pushed upward by the physics engine if they overlap the new wall position
+
+#### Scenario: Bubble area remains usable at maximum orb size
+- **WHEN** the orb is at maximum radius (120px)
+- **THEN** at least 55% of the canvas height SHALL remain available for bubble physics
+
+---
+
+### Requirement: Breathing pulse animation
+The orb SHALL exhibit a continuous breathing animation that increases in amplitude and speed with the stage level.
+
+#### Scenario: Breathing at stage 1+
+- **WHEN** the follow count is 1 or more
+- **THEN** the orb radius SHALL oscillate using a sinusoidal function
+- **AND** the amplitude SHALL be determined by `stageParams.breathAmplitude`
+- **AND** the speed SHALL be determined by `stageParams.breathSpeed`
+
+#### Scenario: No breathing at stage 0
+- **WHEN** the follow count is 0
+- **THEN** the orb radius SHALL remain static (breathAmplitude = 0)
+
+#### Scenario: Breathing respects reduced motion
+- **WHEN** `prefers-reduced-motion: reduce` is active
+- **THEN** the breathing animation SHALL be suppressed (amplitude forced to 0)
+
+---
+
+### Requirement: Orbital particles
+Glowing particles SHALL orbit outside the orb, with count and speed increasing per stage level.
+
+#### Scenario: Orbital appearance at stage 2
+- **WHEN** the follow count reaches 2
+- **THEN** 2 orbital particles SHALL appear, circling the orb at a radius between 1.3x and 1.8x the orb radius
+
+#### Scenario: Orbital count increases with stage
+- **WHEN** the follow count increases
+- **THEN** the visible orbital count SHALL match `stageParams.orbitalCount`
+- **AND** new orbitals SHALL use colors from the accumulated color palette
+
+#### Scenario: Orbital rendering
+- **WHEN** orbital particles are rendered
+- **THEN** each SHALL be drawn as a small radial gradient (glow dot) of 2-5px
+- **AND** each SHALL have an independent angular velocity
+
+#### Scenario: Orbitals respect reduced motion
+- **WHEN** `prefers-reduced-motion: reduce` is active
+- **THEN** orbital particles SHALL be positioned statically (no rotation)
+
+---
+
+### Requirement: Light rays
+Radial light beams SHALL emanate from the orb at higher stage levels, using additive blending.
+
+#### Scenario: Light rays appear at stage 4
+- **WHEN** the follow count reaches 4
+- **THEN** 2 light rays SHALL appear, rendered as triangular gradients extending from the orb center
+- **AND** rays SHALL rotate slowly over time
+
+#### Scenario: Light ray count and intensity scale with stage
+- **WHEN** the follow count increases beyond 4
+- **THEN** the ray count SHALL increase up to `stageParams.lightRayCount`
+- **AND** the ray alpha SHALL increase up to `stageParams.lightRayAlpha`
+
+#### Scenario: Light ray blending
+- **WHEN** light rays are rendered
+- **THEN** `globalCompositeOperation` SHALL be set to `'screen'` for the ray drawing
+- **AND** the composition mode SHALL be restored after ray rendering (via `save`/`restore`)
+
+#### Scenario: Light rays respect reduced motion
+- **WHEN** `prefers-reduced-motion: reduce` is active
+- **THEN** light rays SHALL be rendered at a fixed angle (no rotation)
+
+---
+
+### Requirement: Shockwave rings on follow
+An expanding colored ring SHALL burst from the orb each time an artist is followed.
+
+#### Scenario: Shockwave spawns on absorption complete
+- **WHEN** a bubble absorption animation completes (progress reaches 1.0)
+- **AND** `stageParams.shockwaveEnabled` is true
+- **THEN** a shockwave ring SHALL spawn at the orb center
+- **AND** the ring color SHALL use the absorbed artist's hue
+
+#### Scenario: Shockwave ring animation
+- **WHEN** a shockwave ring is active
+- **THEN** its radius SHALL expand from `orbRadius` to `orbRadius * 3` over 800ms
+- **AND** its alpha SHALL decrease from 0.6 to 0
+- **AND** its lineWidth SHALL decrease from 3 to 0.5
+
+#### Scenario: Shockwave ring cleanup
+- **WHEN** a shockwave ring's alpha reaches 0
+- **THEN** it SHALL be recycled (marked inactive for reuse)
+- **AND** at most 3 shockwave rings SHALL be active simultaneously
+
+#### Scenario: Shockwave respects reduced motion
+- **WHEN** `prefers-reduced-motion: reduce` is active
+- **THEN** shockwave rings SHALL NOT be spawned
+
+---
+
+### Requirement: Comet trail on absorption
+Absorbed bubbles SHALL leave a colored trail along their bezier path.
+
+#### Scenario: Trail point accumulation
+- **WHEN** a bubble absorption animation is in progress
+- **THEN** the current position SHALL be recorded each frame
+- **AND** the system SHALL retain the most recent 12 positions in a circular buffer
+
+#### Scenario: Trail rendering
+- **WHEN** the comet trail is rendered
+- **THEN** trail points SHALL be connected with line segments
+- **AND** line width SHALL decrease from 4px (head) to 1px (tail)
+- **AND** opacity SHALL decrease from 0.7 (head) to 0.05 (tail)
+- **AND** the trail color SHALL use the artist's hue
+
+#### Scenario: Comet trail gated by stage level
+- **WHEN** `stageParams.cometTrailEnabled` is false
+- **THEN** trail points SHALL NOT be recorded and no trail SHALL be rendered
+
+---
+
+### Requirement: Ground glow
+A soft gradient reflection SHALL appear at the bottom of the canvas, tied to stage level.
+
+#### Scenario: Ground glow appearance
+- **WHEN** the follow count reaches 2
+- **THEN** a vertical linear gradient SHALL render at the bottom 15% of the canvas
+- **AND** the gradient alpha SHALL be `stageParams.groundGlowAlpha`
+
+#### Scenario: Ground glow color matches orb
+- **WHEN** the ground glow is rendered
+- **THEN** its hue SHALL match the dominant hue of the orb's accumulated color palette
+
+#### Scenario: Ground glow uses additive blending
+- **WHEN** the ground glow is rendered
+- **THEN** `globalCompositeOperation` SHALL be set to `'screen'`
+- **AND** the composition mode SHALL be restored after rendering
+
+---
+
+### Requirement: Color palette accumulation
+The orb SHALL accumulate a palette of artist hues as users follow artists, enriching the visual diversity of effects.
+
+#### Scenario: Palette grows on inject
+- **WHEN** `injectColor(hue)` is called
+- **THEN** the hue SHALL be appended to the color palette array
+
+#### Scenario: Palette cap
+- **WHEN** the palette reaches 20 entries
+- **THEN** new hues SHALL replace the oldest entry (FIFO)
+
+#### Scenario: Palette colors distributed to effects
+- **WHEN** orbital particles or light rays are rendered
+- **THEN** their colors SHALL be sampled from the accumulated palette, distributed evenly across entries
+
+---
+
+### Requirement: Unit test coverage for stage effects
+The `stage-effects.ts` module SHALL be covered by unit tests verifying parameter correctness at key follow counts.
+
+#### Scenario: Boundary value tests
+- **WHEN** unit tests run for `getStageParams`
+- **THEN** tests SHALL verify correct parameters at follow counts 0, 1, 2, 3, 4, 5, 6, 10, and 20
+
+#### Scenario: Monotonic growth assertions
+- **WHEN** unit tests run
+- **THEN** tests SHALL verify that `orbRadius`, `orbitalCount`, `lightRayCount`, and `groundGlowAlpha` are monotonically non-decreasing as follow count increases from 0 to 20
+
+#### Scenario: Ceiling assertions
+- **WHEN** unit tests run
+- **THEN** tests SHALL verify that `orbRadius` never exceeds 120 and `orbitalCount` never exceeds 12
+
+### Requirement: Unit test coverage for OrbRenderer state
+OrbRenderer state transitions SHALL be covered by unit tests.
+
+#### Scenario: Shockwave lifecycle test
+- **WHEN** a shockwave is spawned and updated until completion
+- **THEN** tests SHALL verify it becomes inactive after 800ms of updates
+
+#### Scenario: Color palette accumulation test
+- **WHEN** `injectColor` is called 25 times
+- **THEN** the palette SHALL contain exactly 20 entries (FIFO cap)
+
+#### Scenario: Orbital count reflects stage params
+- **WHEN** `setFollowCount` is called with increasing values
+- **THEN** the visible orbital count SHALL match the corresponding `stageParams.orbitalCount`
+
+### Requirement: Unit test coverage for AbsorptionAnimator comet trail
+The comet trail's circular buffer behavior SHALL be covered by unit tests.
+
+#### Scenario: Trail buffer accumulation
+- **WHEN** an absorption animation runs for 20 frames
+- **THEN** the trail buffer SHALL contain exactly 12 entries (the most recent 12)
+
+#### Scenario: Trail disabled at low stage
+- **WHEN** comet trail is disabled via stage params
+- **THEN** the trail buffer SHALL remain empty regardless of animation progress

--- a/openspec/changes/archive/2026-03-15-festival-orb-effects/tasks.md
+++ b/openspec/changes/archive/2026-03-15-festival-orb-effects/tasks.md
@@ -1,0 +1,71 @@
+## 1. Stage Effects Module
+
+- [x] 1.1 Create `src/components/dna-orb/stage-effects.ts` with `StageParams` interface and `getStageParams(followCount)` pure function
+- [x] 1.2 Implement parameter curves: orbRadius (60→120, linear then log), breathAmplitude, breathSpeed, orbitalCount (0→12), lightRayCount (0→6), lightRayAlpha, groundGlowAlpha, shockwaveEnabled, cometTrailEnabled, particleVisibilityRatio
+- [x] 1.3 Create `src/components/dna-orb/stage-effects.spec.ts` — boundary value tests at follow counts 0, 1, 2, 3, 4, 5, 6, 10, 20; monotonic growth assertions; ceiling assertions (orbRadius ≤ 120, orbitalCount ≤ 12)
+
+## 2. Growing Orb & Dynamic Physics Boundary
+
+- [x] 2.1 In `bubble-physics.ts`, add `updateOrbZone(orbRadius: number)` method that repositions the bottom wall to `canvasHeight - (orbRadius * 2 + 20)` using `Matter.Body.setPosition()`
+- [x] 2.2 In `orb-renderer.ts`, change `orbRadius` from fixed 70 to a dynamic value set by `setFollowCount()` using `stageParams.orbRadius`
+- [x] 2.3 In `orb-renderer.ts`, add breathing pulse: multiply orbRadius by `1 + sin(time * breathSpeed) * breathAmplitude`, suppress when `prefers-reduced-motion`
+- [x] 2.4 In `dna-orb-canvas.ts`, wire `followedCountChanged` to call `physics.updateOrbZone(stageParams.orbRadius)` and pass new radius to `orbRenderer`
+
+## 3. Orbital Particles
+
+- [x] 3.1 In `orb-renderer.ts`, add pre-allocated orbital slots (max 12) with angle, orbitalRadius (1.3-1.8x orbRadius), speed, size (2-5px), hue
+- [x] 3.2 In `update()`, rotate orbitals by their angular velocity (suppress rotation for reduced motion)
+- [x] 3.3 In `render()`, draw visible orbitals (count from stageParams) as small radial gradient glow dots after the orb body, sampling colors from the color palette
+
+## 4. Light Rays
+
+- [x] 4.1 In `orb-renderer.ts`, add light ray rendering: triangular gradients from orb center, count and alpha from stageParams
+- [x] 4.2 Add slow rotation over time (fixed angle for reduced motion)
+- [x] 4.3 Use `globalCompositeOperation = 'screen'` wrapped in `save()/restore()`, render before bubbles (layer 1)
+
+## 5. Shockwave Rings
+
+- [x] 5.1 In `orb-renderer.ts`, add shockwave ring pool (max 3): `spawnShockwave(hue)` method that initializes radius at orbRadius, alpha at 0.6, lineWidth at 3
+- [x] 5.2 In `update()`, expand radius to orbRadius×3 over 800ms, decay alpha to 0, decrease lineWidth to 0.5; mark inactive on completion
+- [x] 5.3 In `render()`, draw active shockwave rings as `arc()` + `stroke()` after orbitals
+- [x] 5.4 Suppress shockwave spawning when `prefers-reduced-motion`
+
+## 6. Comet Trail on Absorption
+
+- [x] 6.1 In `absorption-animator.ts`, add `trailPoints` circular buffer (max 12) to `AbsorptionAnimation`; record current position each frame when `cometTrailEnabled` is true
+- [x] 6.2 In `render()`, draw trail as segmented lines: width 4→1px, opacity 0.7→0.05, colored with artist hue; render before the absorption bubble body (layer 3)
+- [x] 6.3 Pass `cometTrailEnabled` from `dna-orb-canvas.ts` to the absorption animator based on current stageParams
+
+## 7. Ground Glow
+
+- [x] 7.1 In `orb-renderer.ts`, add ground glow rendering: vertical linearGradient at bottom 15% of canvas, alpha from stageParams, hue from dominant palette color
+- [x] 7.2 Use `globalCompositeOperation = 'screen'` wrapped in `save()/restore()`, render as layer 0 (behind everything)
+
+## 8. Color Palette Accumulation
+
+- [x] 8.1 In `orb-renderer.ts`, add `colorPalette: number[]` (max 20, FIFO on overflow) populated by `injectColor()`
+- [x] 8.2 Distribute palette colors to orbital particles and light rays (evenly across entries)
+
+## 9. Render Pipeline & Orchestration
+
+- [x] 9.1 In `dna-orb-canvas.ts`, update `render()` to draw layers in order: ground glow → light rays → bubbles → comet trails → absorption → orb body → orbitals → shockwaves
+- [x] 9.2 Wire absorption completion to trigger `orbRenderer.spawnShockwave(hue)` in addition to existing `injectColor(hue)`
+- [x] 9.3 Replace `orbIntensity` scalar usage with stageParams-driven rendering throughout
+
+## 10. Remove Orb Label
+
+- [x] 10.1 Delete the `orb-label` div from `discover-page.html`
+- [x] 10.2 Delete `.orb-label` CSS rules from `discover-page.css`
+- [x] 10.3 Verify screen reader status text (`srStatusText`) still reports follow count
+
+## 11. OrbRenderer & AbsorptionAnimator Unit Tests
+
+- [x] 11.1 Create `src/components/dna-orb/orb-renderer.spec.ts` — shockwave lifecycle (spawn → 800ms update → inactive), color palette FIFO cap at 20, orbital count reflects stageParams
+- [x] 11.2 Create `src/components/dna-orb/absorption-animator.spec.ts` — trail buffer accumulates to max 12, trail disabled when cometTrailEnabled is false
+- [x] 11.3 Test `prefers-reduced-motion` suppression: breathing amplitude 0, orbital rotation suppressed, shockwave suppressed
+
+## 12. Integration & Polish
+
+- [x] 12.1 Run `make check` (lint + test) and fix any failures
+- [x] 12.2 Manual visual testing: verify each stage level (0-6+) produces visibly distinct escalation
+- [x] 12.3 Performance verification: confirm 60fps on mobile emulation with all effects active at stage 6+

--- a/openspec/specs/artist-discovery-dna-orb-ui/spec.md
+++ b/openspec/specs/artist-discovery-dna-orb-ui/spec.md
@@ -72,7 +72,8 @@ The system SHALL provide satisfying visual feedback when users select artists by
 
 #### Scenario: Effective swirl combines base and transient
 - **WHEN** the orb animation loop runs
-- **THEN** the particle speed multiplier SHALL be `1 + (baseIntensity + swirlIntensity) * 2`
+- **THEN** `baseIntensity` SHALL be computed as `1 - 1 / (1 + followCount * 0.5)` (diminishing returns curve)
+- **AND** the particle speed multiplier SHALL be `1 + (baseIntensity + swirlIntensity) * 2`
 - **AND** `swirlIntensity` SHALL decay over ~1000ms as before
 - **AND** `baseIntensity` SHALL NOT decay within the same page session
 

--- a/openspec/specs/artist-discovery-dna-orb-ui/spec.md
+++ b/openspec/specs/artist-discovery-dna-orb-ui/spec.md
@@ -33,11 +33,6 @@ The system SHALL provide a gamified artist discovery interface using a "DNA Extr
 - **THEN** the system SHALL display a popover guide explaining the interaction (per `onboarding-popover-guide` capability)
 - **AND** the popover SHALL dismiss via light-dismiss or explicit close
 
-#### Scenario: Orb label text
-- **WHEN** the DNA Orb is displayed
-- **THEN** the system SHALL display a label near the orb indicating its purpose (e.g., "Music DNA" or the current follow count)
-- **AND** the label SHALL update dynamically as artists are followed
-
 #### Scenario: Background visual depth
 - **WHEN** the Artist Discovery screen is displayed
 - **THEN** the background SHALL include subtle visual elements (e.g., particle field, starfield, or animated gradient) to create depth
@@ -46,44 +41,34 @@ The system SHALL provide a gamified artist discovery interface using a "DNA Extr
 ---
 
 ### Requirement: Bubble Absorption Animation
-The system SHALL provide satisfying visual feedback when users select artists by animating bubbles into the DNA Orb, with accumulating visual intensity.
+The system SHALL provide satisfying visual feedback when users select artists by animating bubbles into the DNA Orb, with accumulating visual intensity and comet trail effects.
 
 #### Scenario: Artist selection with absorption effect
 - **WHEN** a user taps an artist bubble
 - **THEN** the bubble SHALL shrink and trace a path toward the DNA Orb at the bottom
 - **AND** the bubble SHALL be absorbed into the orb with a dissolve effect
-- **AND** the orb's internal effects (swirling light, particles) SHALL intensify
-- **AND** the orb's color SHALL incorporate the absorbed bubble's hue (from the existing `artistHue` computation)
+- **AND** if comet trail is enabled by the current stage level, the bubble SHALL leave a colored trail along its path
+- **AND** on absorption completion, the orb SHALL trigger a shockwave ring (if enabled by stage level)
+- **AND** the orb's color SHALL incorporate the absorbed bubble's hue
 
 #### Scenario: Color injection uses bubble's existing hue
 - **WHEN** a bubble is absorbed into the orb
 - **THEN** `OrbRenderer.injectColor` SHALL be called with the same hue used to render that bubble's gradient
 - **AND** 10-15 particles SHALL be replaced with the injected hue (with +/- 20 degree random variance)
 - **AND** `swirlIntensity` SHALL spike to 1.0 for a transient visual burst
+- **AND** the hue SHALL be appended to the color palette for use by orbital particles and light rays
 
-#### Scenario: Orb visual evolution with accumulating baseIntensity
+#### Scenario: Orb visual evolution with stage-level escalation
 - **WHEN** the user follows more artists
-- **THEN** `OrbRenderer.baseIntensity` SHALL increase per follow using the formula: `baseIntensity = 1 - 1 / (1 + followCount * 0.5)`
-- **AND** the effective intensity for glow, particle count, and swirl speed SHALL be computed as `intensity + baseIntensity`
-- **AND** `swirlIntensity` spike decay SHALL apply on top of the elevated base, making each successive follow's swirl more dramatic
+- **THEN** the orb's visual presentation SHALL be determined by `getStageParams(followCount)` from `stage-effects.ts`
+- **AND** the orb radius, orbital count, light ray count, breathing amplitude, and ground glow SHALL all be driven by the returned `StageParams`
+- **AND** each follow SHALL produce a visibly distinct escalation in effects
 
 #### Scenario: First follow has maximum visual impact
 - **WHEN** the user follows their first artist (followCount goes from 0 to 1)
-- **THEN** `baseIntensity` SHALL jump from 0.00 to 0.33 (the largest single-follow delta)
-- **AND** the visible particle count SHALL increase noticeably (from ~10% to ~40% of max)
-- **AND** the orb glow radius SHALL expand visibly
-
-#### Scenario: Diminishing returns on later follows
-- **WHEN** the user follows their 5th artist
-- **THEN** `baseIntensity` SHALL be approximately 0.71
-- **AND** the delta from the 4th follow SHALL be approximately +0.05
-- **AND** the orb SHALL still show a transient `swirlIntensity` spike and color injection, even though the base level change is small
-
-#### Scenario: baseIntensity resets on page navigation
-- **WHEN** the user navigates away from the discover page and returns
-- **THEN** `baseIntensity` SHALL reset to 0
-- **AND** `followCount` for intensity purposes SHALL reset to 0
-- **AND** the orb SHALL start from its default visual state
+- **THEN** the orb radius SHALL increase from 60 to 68
+- **AND** the breathing pulse SHALL begin
+- **AND** the visible particle count SHALL increase noticeably
 
 #### Scenario: Effective swirl combines base and transient
 - **WHEN** the orb animation loop runs

--- a/openspec/specs/festival-orb-effects/spec.md
+++ b/openspec/specs/festival-orb-effects/spec.md
@@ -1,0 +1,249 @@
+# Festival Orb Effects
+
+## ADDED Requirements
+
+### Requirement: Stage-level escalation system
+The system SHALL calculate visual effect parameters from the follow count using a stage-level model, where each follow advances the stage by one level. The calculation SHALL be implemented as a pure function in `stage-effects.ts`, separate from rendering logic.
+
+#### Scenario: Stage parameters at zero follows
+- **WHEN** the follow count is 0
+- **THEN** `getStageParams(0)` SHALL return `orbRadius` of 60, `orbitalCount` of 0, `lightRayCount` of 0, `groundGlowAlpha` of 0, `shockwaveEnabled` as false, and `cometTrailEnabled` as false
+
+#### Scenario: Stage parameters at one follow
+- **WHEN** the follow count is 1
+- **THEN** `getStageParams(1)` SHALL return `orbRadius` of 68, `breathAmplitude` greater than 0, `orbitalCount` of 0, and `particleVisibilityRatio` greater than 0.3
+
+#### Scenario: Stage parameters at two follows
+- **WHEN** the follow count is 2
+- **THEN** `getStageParams(2)` SHALL return `orbitalCount` of 2 and `groundGlowAlpha` greater than 0
+
+#### Scenario: Stage parameters at four follows
+- **WHEN** the follow count is 4
+- **THEN** `getStageParams(4)` SHALL return `lightRayCount` of 2, `cometTrailEnabled` as true, and `orbitalCount` of 6
+
+#### Scenario: Stage parameters at five follows
+- **WHEN** the follow count is 5
+- **THEN** `getStageParams(5)` SHALL return `shockwaveEnabled` as true and `lightRayCount` of 4
+
+#### Scenario: Stage parameters at six or more follows
+- **WHEN** the follow count is 6 or more
+- **THEN** `getStageParams` SHALL return `lightRayCount` of 6, `orbitalCount` of 10 or more, and all effect features enabled
+
+#### Scenario: Orb radius growth ceiling
+- **WHEN** the follow count exceeds 20
+- **THEN** the `orbRadius` SHALL NOT exceed 120
+
+#### Scenario: Stage params are deterministic
+- **WHEN** `getStageParams` is called multiple times with the same follow count
+- **THEN** it SHALL return identical results each time (pure function, no side effects)
+
+---
+
+### Requirement: Growing orb with dynamic bubble boundary
+The orb SHALL grow in radius as the user follows more artists, and the Matter.js physics boundary SHALL move upward to accommodate the larger orb, pushing bubbles into a smaller play area.
+
+#### Scenario: Orb radius increases on follow
+- **WHEN** the follow count increases from N to N+1
+- **THEN** the orb radius SHALL increase according to the stage params formula
+- **AND** the orb SHALL render at the new radius on the next frame
+
+#### Scenario: Matter.js bottom wall repositions
+- **WHEN** the orb radius changes
+- **THEN** the bottom wall position SHALL update to `canvasHeight - (orbRadius * 2 + 20)`
+- **AND** existing bubbles SHALL be pushed upward by the physics engine if they overlap the new wall position
+
+#### Scenario: Bubble area remains usable at maximum orb size
+- **WHEN** the orb is at maximum radius (120px)
+- **THEN** at least 55% of the canvas height SHALL remain available for bubble physics
+
+---
+
+### Requirement: Breathing pulse animation
+The orb SHALL exhibit a continuous breathing animation that increases in amplitude and speed with the stage level.
+
+#### Scenario: Breathing at stage 1+
+- **WHEN** the follow count is 1 or more
+- **THEN** the orb radius SHALL oscillate using a sinusoidal function
+- **AND** the amplitude SHALL be determined by `stageParams.breathAmplitude`
+- **AND** the speed SHALL be determined by `stageParams.breathSpeed`
+
+#### Scenario: No breathing at stage 0
+- **WHEN** the follow count is 0
+- **THEN** the orb radius SHALL remain static (breathAmplitude = 0)
+
+#### Scenario: Breathing respects reduced motion
+- **WHEN** `prefers-reduced-motion: reduce` is active
+- **THEN** the breathing animation SHALL be suppressed (amplitude forced to 0)
+
+---
+
+### Requirement: Orbital particles
+Glowing particles SHALL orbit outside the orb, with count and speed increasing per stage level.
+
+#### Scenario: Orbital appearance at stage 2
+- **WHEN** the follow count reaches 2
+- **THEN** 2 orbital particles SHALL appear, circling the orb at a radius between 1.3x and 1.8x the orb radius
+
+#### Scenario: Orbital count increases with stage
+- **WHEN** the follow count increases
+- **THEN** the visible orbital count SHALL match `stageParams.orbitalCount`
+- **AND** new orbitals SHALL use colors from the accumulated color palette
+
+#### Scenario: Orbital rendering
+- **WHEN** orbital particles are rendered
+- **THEN** each SHALL be drawn as a small radial gradient (glow dot) of 2-5px
+- **AND** each SHALL have an independent angular velocity
+
+#### Scenario: Orbitals respect reduced motion
+- **WHEN** `prefers-reduced-motion: reduce` is active
+- **THEN** orbital particles SHALL be positioned statically (no rotation)
+
+---
+
+### Requirement: Light rays
+Radial light beams SHALL emanate from the orb at higher stage levels, using additive blending.
+
+#### Scenario: Light rays appear at stage 4
+- **WHEN** the follow count reaches 4
+- **THEN** 2 light rays SHALL appear, rendered as triangular gradients extending from the orb center
+- **AND** rays SHALL rotate slowly over time
+
+#### Scenario: Light ray count and intensity scale with stage
+- **WHEN** the follow count increases beyond 4
+- **THEN** the ray count SHALL increase up to `stageParams.lightRayCount`
+- **AND** the ray alpha SHALL increase up to `stageParams.lightRayAlpha`
+
+#### Scenario: Light ray blending
+- **WHEN** light rays are rendered
+- **THEN** `globalCompositeOperation` SHALL be set to `'screen'` for the ray drawing
+- **AND** the composition mode SHALL be restored after ray rendering (via `save`/`restore`)
+
+#### Scenario: Light rays respect reduced motion
+- **WHEN** `prefers-reduced-motion: reduce` is active
+- **THEN** light rays SHALL be rendered at a fixed angle (no rotation)
+
+---
+
+### Requirement: Shockwave rings on follow
+An expanding colored ring SHALL burst from the orb each time an artist is followed.
+
+#### Scenario: Shockwave spawns on absorption complete
+- **WHEN** a bubble absorption animation completes (progress reaches 1.0)
+- **AND** `stageParams.shockwaveEnabled` is true
+- **THEN** a shockwave ring SHALL spawn at the orb center
+- **AND** the ring color SHALL use the absorbed artist's hue
+
+#### Scenario: Shockwave ring animation
+- **WHEN** a shockwave ring is active
+- **THEN** its radius SHALL expand from `orbRadius` to `orbRadius * 3` over 800ms
+- **AND** its alpha SHALL decrease from 0.6 to 0
+- **AND** its lineWidth SHALL decrease from 3 to 0.5
+
+#### Scenario: Shockwave ring cleanup
+- **WHEN** a shockwave ring's alpha reaches 0
+- **THEN** it SHALL be recycled (marked inactive for reuse)
+- **AND** at most 3 shockwave rings SHALL be active simultaneously
+
+#### Scenario: Shockwave respects reduced motion
+- **WHEN** `prefers-reduced-motion: reduce` is active
+- **THEN** shockwave rings SHALL NOT be spawned
+
+---
+
+### Requirement: Comet trail on absorption
+Absorbed bubbles SHALL leave a colored trail along their bezier path.
+
+#### Scenario: Trail point accumulation
+- **WHEN** a bubble absorption animation is in progress
+- **THEN** the current position SHALL be recorded each frame
+- **AND** the system SHALL retain the most recent 12 positions in a circular buffer
+
+#### Scenario: Trail rendering
+- **WHEN** the comet trail is rendered
+- **THEN** trail points SHALL be connected with line segments
+- **AND** line width SHALL decrease from 4px (head) to 1px (tail)
+- **AND** opacity SHALL decrease from 0.7 (head) to 0.05 (tail)
+- **AND** the trail color SHALL use the artist's hue
+
+#### Scenario: Comet trail gated by stage level
+- **WHEN** `stageParams.cometTrailEnabled` is false
+- **THEN** trail points SHALL NOT be recorded and no trail SHALL be rendered
+
+---
+
+### Requirement: Ground glow
+A soft gradient reflection SHALL appear at the bottom of the canvas, tied to stage level.
+
+#### Scenario: Ground glow appearance
+- **WHEN** the follow count reaches 2
+- **THEN** a vertical linear gradient SHALL render at the bottom 15% of the canvas
+- **AND** the gradient alpha SHALL be `stageParams.groundGlowAlpha`
+
+#### Scenario: Ground glow color matches orb
+- **WHEN** the ground glow is rendered
+- **THEN** its hue SHALL match the dominant hue of the orb's accumulated color palette
+
+#### Scenario: Ground glow uses additive blending
+- **WHEN** the ground glow is rendered
+- **THEN** `globalCompositeOperation` SHALL be set to `'screen'`
+- **AND** the composition mode SHALL be restored after rendering
+
+---
+
+### Requirement: Color palette accumulation
+The orb SHALL accumulate a palette of artist hues as users follow artists, enriching the visual diversity of effects.
+
+#### Scenario: Palette grows on inject
+- **WHEN** `injectColor(hue)` is called
+- **THEN** the hue SHALL be appended to the color palette array
+
+#### Scenario: Palette cap
+- **WHEN** the palette reaches 20 entries
+- **THEN** new hues SHALL replace the oldest entry (FIFO)
+
+#### Scenario: Palette colors distributed to effects
+- **WHEN** orbital particles or light rays are rendered
+- **THEN** their colors SHALL be sampled from the accumulated palette, distributed evenly across entries
+
+---
+
+### Requirement: Unit test coverage for stage effects
+The `stage-effects.ts` module SHALL be covered by unit tests verifying parameter correctness at key follow counts.
+
+#### Scenario: Boundary value tests
+- **WHEN** unit tests run for `getStageParams`
+- **THEN** tests SHALL verify correct parameters at follow counts 0, 1, 2, 3, 4, 5, 6, 10, and 20
+
+#### Scenario: Monotonic growth assertions
+- **WHEN** unit tests run
+- **THEN** tests SHALL verify that `orbRadius`, `orbitalCount`, `lightRayCount`, and `groundGlowAlpha` are monotonically non-decreasing as follow count increases from 0 to 20
+
+#### Scenario: Ceiling assertions
+- **WHEN** unit tests run
+- **THEN** tests SHALL verify that `orbRadius` never exceeds 120 and `orbitalCount` never exceeds 12
+
+### Requirement: Unit test coverage for OrbRenderer state
+OrbRenderer state transitions SHALL be covered by unit tests.
+
+#### Scenario: Shockwave lifecycle test
+- **WHEN** a shockwave is spawned and updated until completion
+- **THEN** tests SHALL verify it becomes inactive after 800ms of updates
+
+#### Scenario: Color palette accumulation test
+- **WHEN** `injectColor` is called 25 times
+- **THEN** the palette SHALL contain exactly 20 entries (FIFO cap)
+
+#### Scenario: Orbital count reflects stage params
+- **WHEN** `setFollowCount` is called with increasing values
+- **THEN** the visible orbital count SHALL match the corresponding `stageParams.orbitalCount`
+
+### Requirement: Unit test coverage for AbsorptionAnimator comet trail
+The comet trail's circular buffer behavior SHALL be covered by unit tests.
+
+#### Scenario: Trail buffer accumulation
+- **WHEN** an absorption animation runs for 20 frames
+- **THEN** the trail buffer SHALL contain exactly 12 entries (the most recent 12)
+
+#### Scenario: Trail disabled at low stage
+- **WHEN** comet trail is disabled via stage params
+- **THEN** the trail buffer SHALL remain empty regardless of animation progress

--- a/openspec/specs/festival-orb-effects/spec.md
+++ b/openspec/specs/festival-orb-effects/spec.md
@@ -1,6 +1,6 @@
 # Festival Orb Effects
 
-## ADDED Requirements
+## Requirements
 
 ### Requirement: Stage-level escalation system
 The system SHALL calculate visual effect parameters from the follow count using a stage-level model, where each follow advances the stage by one level. The calculation SHALL be implemented as a pure function in `stage-effects.ts`, separate from rendering logic.


### PR DESCRIPTION
## Summary
- Add new `festival-orb-effects` capability spec defining stage-level visual escalation system (10 requirements: growing orb, orbital particles, light rays, shockwave rings, comet trails, ground glow, color palette, breathing pulse, unit test coverage)
- Update `artist-discovery-dna-orb-ui` spec: replace baseIntensity accumulation with stage-driven rendering via `getStageParams()`, add comet trail and shockwave gating, remove orb label text requirement
- Archive the completed change

close: #235