### PR TITLE
docs: add OpenSpec artifacts for component smoke tests

### DIFF
--- a/openspec/changes/add-component-smoke-tests/.openspec.yaml
+++ b/openspec/changes/add-component-smoke-tests/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-15

--- a/openspec/changes/add-component-smoke-tests/design.md
+++ b/openspec/changes/add-component-smoke-tests/design.md
@@ -1,0 +1,81 @@
+## Context
+
+Aurelia 2 compiles templates at runtime (JIT). There is no AOT compilation step or static analysis tool to catch template errors before the app runs. The existing test suite has:
+
+- **Vitest**: Setup with `@aurelia/testing` and JSDOM (`test/setup.ts`), but zero unit/smoke tests exist under `src/`.
+- **Playwright E2E**: Layout tests exist (`e2e/layout/`) but only verify bounding boxes, not rendering correctness or console errors.
+- **Coverage thresholds**: Configured in `vitest.config.ts` (55% statements) but effectively untested since no test files exist.
+
+The `bottom-nav-bar` component has had an invalid `<template switch.bind>` since commit `d03d188` (2026-02-25) — undetected for 18 days.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Catch template compilation errors (AUR0703, etc.) in CI before they reach production.
+- Cover all custom elements registered in `main.ts` with mount smoke tests.
+- Catch runtime console errors on public routes via E2E smoke tests.
+- Fix the two existing bugs (switch surrogate, pointer-events).
+
+**Non-Goals:**
+
+- Full behavioral/interaction testing of each component (future work).
+- Testing route-level page components (these are lazy-loaded and have heavy DI requirements).
+- Achieving high code coverage — these are compile-pass/fail tests only.
+
+## Decisions
+
+### D1: Vitest mount tests using `createFixture` (not `renderComponent`)
+
+**Decision**: Use `@aurelia/testing`'s `createFixture()` to mount each component in isolation.
+
+**Why**: `createFixture` is the recommended API for Aurelia 2 testing. It handles component registration, template compilation, and lifecycle — exactly what we need to trigger AUR0703-class errors.
+
+**Alternative considered**: `renderComponent()` — lower-level, requires more manual setup. Not needed for compile-only smoke tests.
+
+### D2: One test file, `describe.each` over component list
+
+**Decision**: A single file `test/smoke/component-compile.spec.ts` with a data-driven loop over all components.
+
+**Why**: Adding a new component only requires adding one entry to an array. Minimizes boilerplate. Each component gets its own test case name for clear failure reporting.
+
+**Alternative considered**: One test file per component — too much overhead for smoke tests that only verify compilation.
+
+### D3: DI stubs via inline shared registrations
+
+**Decision**: Define a `sharedRegistrations` array inline in `test/smoke/component-compile.spec.ts`, reusing existing mock factories from `test/helpers/` (`createMockRouter`, `createMockI18n`, `createMockErrorBoundary`).
+
+**Why**: Most components `resolve()` DI tokens. Without stubs, `createFixture` throws missing-registration errors before reaching template compilation. The stubs need to satisfy the type shape but don't need real behavior. A separate `mock-registry.ts` file was unnecessary since the existing `test/helpers/` mocks already provide the required stubs.
+
+**Alternative considered**: Separate `test/smoke/mock-registry.ts` — unnecessary indirection when `test/helpers/` mocks already exist and the registration array is small.
+
+### D4: Exclude `dna-orb` from mount tests
+
+**Decision**: Skip `dna-orb` component (Canvas + Matter.js physics). Already excluded from coverage in `vitest.config.ts`.
+
+**Why**: Requires `HTMLCanvasElement.getContext()` which JSDOM does not support. Would need `jest-canvas-mock` or similar — not worth the complexity for a smoke test.
+
+### D5: E2E console-error test for public routes only
+
+**Decision**: Playwright test navigates to public routes (`/`, `/welcome`, `/about`, `/discover`) and asserts zero `console.error` messages.
+
+**Why**: Public routes don't require auth state setup. Catches runtime errors (including template compilation) in a real browser. Authenticated routes are out of scope — they need auth storage state which is a separate concern.
+
+### D6: `bottom-nav-bar` fix — use `<span>` as switch host
+
+**Decision**: Replace `<template switch.bind="tab.icon">` with `<span switch.bind="tab.icon">`.
+
+**Why**: `<span>` is inline, doesn't break the `<a>` element's content model (unlike `<div>` which is block-level inside `<a>` in flow content). The `<span>` acts as an invisible wrapper — add `display: contents` in CSS so it doesn't affect layout.
+
+**Alternative considered**: `<div>` — valid in Aurelia but semantically wrong inside `<a>` with inline content.
+
+## Risks / Trade-offs
+
+**[Risk] DI mock drift** — Mock registry could become stale as services evolve.
+→ Mitigation: Smoke tests fail fast when a new DI token is missing, prompting an update. Keep mocks minimal (empty objects with required properties).
+
+**[Risk] JSDOM limitations** — Some components may use browser APIs not available in JSDOM (beyond canvas).
+→ Mitigation: Skip those components with a documented reason. The E2E smoke test provides a second safety net in a real browser.
+
+**[Risk] False sense of security** — Smoke tests only verify compilation, not behavior.
+→ Mitigation: Document clearly that these are compile-only tests. Behavioral tests are a separate initiative.

--- a/openspec/changes/add-component-smoke-tests/design.md
+++ b/openspec/changes/add-component-smoke-tests/design.md
@@ -61,13 +61,13 @@ The `bottom-nav-bar` component has had an invalid `<template switch.bind>` since
 
 **Why**: Public routes don't require auth state setup. Catches runtime errors (including template compilation) in a real browser. Authenticated routes are out of scope — they need auth storage state which is a separate concern.
 
-### D6: `bottom-nav-bar` fix — use `<span>` as switch host
+### D6: `svg-icon` fix — use `<span>` as switch host
 
-**Decision**: Replace `<template switch.bind="tab.icon">` with `<span switch.bind="tab.icon">`.
+**Decision**: Replace `<template switch.bind="name">` with `<span switch.bind="name" class="icon-switch">` in `svg-icon.html`. The original AUR0703 bug was in `bottom-nav-bar.html`, but commit 779e579 moved it to `svg-icon.html` by extracting inline SVGs into the `<svg-icon>` component.
 
-**Why**: `<span>` is inline, doesn't break the `<a>` element's content model (unlike `<div>` which is block-level inside `<a>` in flow content). The `<span>` acts as an invisible wrapper — add `display: contents` in CSS so it doesn't affect layout.
+**Why**: `<span>` is inline, doesn't affect the component's content model. Add `display: contents` in CSS so the wrapper is invisible to layout.
 
-**Alternative considered**: `<div>` — valid in Aurelia but semantically wrong inside `<a>` with inline content.
+**Alternative considered**: `<div>` — valid in Aurelia but semantically heavier than needed for an inline icon component.
 
 ## Risks / Trade-offs
 

--- a/openspec/changes/add-component-smoke-tests/proposal.md
+++ b/openspec/changes/add-component-smoke-tests/proposal.md
@@ -7,7 +7,7 @@ A critical AUR0703 template compilation error (`switch` on surrogate `<template>
 - Add a Vitest smoke test suite that mounts every Aurelia 2 custom element via `@aurelia/testing`, verifying template compilation succeeds without error.
 - Add a Playwright E2E smoke test that navigates to each public route and asserts zero console errors.
 - Fix the two bugs discovered during investigation:
-  - `bottom-nav-bar.html`: Replace `<template switch.bind>` (invalid surrogate + template controller) with a valid host element.
+  - `svg-icon.html`: Replace `<template switch.bind>` (invalid surrogate + template controller) with `<span switch.bind>` + `display: contents`. The AUR0703 bug moved here from `bottom-nav-bar.html` via commit 779e579.
   - `error-banner.css`: Add `pointer-events: auto` to `.error-dialog` to override the inherited `pointer-events: none` from `my-app.css`.
 
 ## Capabilities
@@ -24,6 +24,6 @@ A critical AUR0703 template compilation error (`switch` on surrogate `<template>
 
 - **frontend/test/**: New smoke test files using `@aurelia/testing` and `createFixture`.
 - **frontend/e2e/**: New console-error smoke spec.
-- **frontend/src/components/bottom-nav-bar/**: Template fix (`<template>` → valid element for `switch.bind`).
+- **frontend/src/components/svg-icon/**: Template fix (`<template switch.bind>` → `<span switch.bind>` + `display: contents`) — AUR0703 bug moved here by commit 779e579.
 - **frontend/src/components/error-banner/**: CSS fix for dialog pointer-events.
 - **CI**: Smoke tests run as part of existing `make test` / `make test:e2e` pipelines — no new CI jobs needed.

--- a/openspec/changes/add-component-smoke-tests/proposal.md
+++ b/openspec/changes/add-component-smoke-tests/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+A critical AUR0703 template compilation error (`switch` on surrogate `<template>`) shipped to production undetected because no test verifies that Aurelia 2 component templates compile successfully. Aurelia 2 uses JIT compilation — template errors only surface at runtime. Without mount-level tests, any template syntax mistake becomes a production incident.
+
+## What Changes
+
+- Add a Vitest smoke test suite that mounts every Aurelia 2 custom element via `@aurelia/testing`, verifying template compilation succeeds without error.
+- Add a Playwright E2E smoke test that navigates to each public route and asserts zero console errors.
+- Fix the two bugs discovered during investigation:
+  - `bottom-nav-bar.html`: Replace `<template switch.bind>` (invalid surrogate + template controller) with a valid host element.
+  - `error-banner.css`: Add `pointer-events: auto` to `.error-dialog` to override the inherited `pointer-events: none` from `my-app.css`.
+
+## Capabilities
+
+### New Capabilities
+
+- `component-smoke-tests`: Vitest mount tests that verify all custom element templates compile without AUR0703-class errors. Playwright console-error smoke tests for public routes.
+
+### Modified Capabilities
+
+- `frontend-error-handling`: Fix error dialog pointer-events so buttons respond to taps.
+
+## Impact
+
+- **frontend/test/**: New smoke test files using `@aurelia/testing` and `createFixture`.
+- **frontend/e2e/**: New console-error smoke spec.
+- **frontend/src/components/bottom-nav-bar/**: Template fix (`<template>` → valid element for `switch.bind`).
+- **frontend/src/components/error-banner/**: CSS fix for dialog pointer-events.
+- **CI**: Smoke tests run as part of existing `make test` / `make test:e2e` pipelines — no new CI jobs needed.

--- a/openspec/changes/add-component-smoke-tests/specs/component-smoke-tests/spec.md
+++ b/openspec/changes/add-component-smoke-tests/specs/component-smoke-tests/spec.md
@@ -1,0 +1,56 @@
+# Component Smoke Tests
+
+## Purpose
+
+Defines the smoke testing requirements that verify all Aurelia 2 custom element templates compile without errors. These tests serve as a safety net against template compilation errors (AUR0703 and similar) that are only detectable at runtime due to Aurelia 2's JIT compilation model.
+
+## ADDED Requirements
+
+### Requirement: Component mount smoke tests
+The test suite SHALL mount every globally-registered Aurelia 2 custom element via `@aurelia/testing` `createFixture()` and verify that template compilation completes without throwing.
+
+#### Scenario: Valid component template compiles successfully
+- **WHEN** a custom element with a valid template is mounted via `createFixture()`
+- **THEN** the fixture SHALL be created without errors
+- **AND** the test SHALL pass
+
+#### Scenario: Invalid template controller usage is detected
+- **WHEN** a custom element template uses a template controller (e.g., `switch`, `if`, `repeat`) on a surrogate `<template>` element
+- **THEN** the `createFixture()` call SHALL throw an AUR0703 error
+- **AND** the test SHALL fail with a clear error message identifying the component
+
+#### Scenario: All registered components are covered
+- **WHEN** the smoke test suite runs
+- **THEN** it SHALL test every custom element registered in `main.ts` via `.register()`
+- **AND** components explicitly excluded (e.g., `dna-orb` due to Canvas dependency) SHALL be documented with a reason in the test file
+
+---
+
+### Requirement: DI mock registry for smoke tests
+The test suite SHALL provide a shared mock registry that supplies minimal DI stubs for common service tokens, enabling components to be mounted in isolation.
+
+#### Scenario: Component with DI dependencies mounts successfully
+- **WHEN** a component resolves DI tokens (e.g., `IRouter`, `I18N`, `IAuthService`)
+- **THEN** the mock registry SHALL provide stub implementations that satisfy the dependency resolution
+- **AND** the stubs SHALL implement the minimal interface required (empty methods, default property values)
+
+#### Scenario: Missing DI stub causes clear failure
+- **WHEN** a component resolves a DI token not present in the mock registry
+- **THEN** the test SHALL fail with a DI resolution error identifying the missing token
+- **AND** the developer SHALL add the missing stub to the mock registry
+
+---
+
+### Requirement: E2E console error smoke test
+The test suite SHALL navigate to each public route in a real browser and verify that no console errors are emitted during page load.
+
+#### Scenario: Public route loads without console errors
+- **WHEN** Playwright navigates to a public route (e.g., `/`, `/welcome`, `/about`, `/discover`)
+- **THEN** the page SHALL load successfully
+- **AND** no `console.error` messages SHALL be emitted
+- **AND** the test SHALL fail if any console error is detected
+
+#### Scenario: Network errors are excluded from assertion
+- **WHEN** a console error is caused by a failed network request (e.g., backend unavailable)
+- **THEN** the test SHALL exclude network-related errors from the assertion
+- **AND** only application-level errors (template compilation, JS exceptions) SHALL cause test failure

--- a/openspec/changes/add-component-smoke-tests/specs/frontend-error-handling/spec.md
+++ b/openspec/changes/add-component-smoke-tests/specs/frontend-error-handling/spec.md
@@ -1,0 +1,36 @@
+# Frontend Error Handling — Delta
+
+## MODIFIED Requirements
+
+### Requirement: Error Banner UI in Root Component
+The system SHALL display an error banner in the root component (`my-app`) when `ErrorBoundaryService.currentError` is set.
+
+#### Scenario: Error banner renders with error details
+- **WHEN** `ErrorBoundaryService.currentError` is not null
+- **THEN** the root component SHALL display an error banner overlaying the current page content
+- **AND** the banner SHALL display a user-friendly error message
+- **AND** the banner SHALL display the Error ID prominently
+- **AND** the banner SHALL provide a "Copy Error Details" button
+- **AND** the banner SHALL provide a "Report to GitHub" button
+- **AND** the banner SHALL provide a "Dismiss" button
+- **AND** the banner SHALL provide a "Reload Page" button
+
+#### Scenario: Error banner buttons are interactive
+- **WHEN** the error banner dialog is displayed via `showModal()`
+- **THEN** all buttons within the dialog SHALL respond to click and tap events
+- **AND** the dialog element SHALL override the inherited `pointer-events: none` from the parent `<error-banner>` custom element with `pointer-events: auto`
+- **AND** the `::backdrop` pseudo-element SHALL NOT block pointer events from reaching the dialog content
+
+#### Scenario: Copy Error Details generates Markdown report
+- **WHEN** the user clicks "Copy Error Details"
+- **THEN** the system SHALL copy a Markdown-formatted error report to the clipboard
+- **AND** the report SHALL include: Error ID, timestamp, current URL, error message, stack trace, browser user agent, recent breadcrumbs (last 10), and recent network errors
+- **AND** the report SHALL NOT include authentication tokens or sensitive headers
+- **AND** the system SHALL display a brief confirmation toast "Error details copied"
+
+#### Scenario: Report to GitHub opens pre-filled issue
+- **WHEN** the user clicks "Report to GitHub"
+- **THEN** the system SHALL open a new browser tab to `https://github.com/liverty-music/frontend/issues/new`
+- **AND** the URL SHALL include query parameters for `title` (containing Error ID) and `body` (containing the Markdown error report)
+- **AND** the URL SHALL include a `labels` parameter with value `bug`
+- **AND** the "Report to GitHub" button SHALL be rate-limited to one click per 60 seconds

--- a/openspec/changes/add-component-smoke-tests/tasks.md
+++ b/openspec/changes/add-component-smoke-tests/tasks.md
@@ -1,0 +1,25 @@
+## 1. Bug Fixes
+
+- [x] 1.1 Fix `bottom-nav-bar.html`: already resolved by commit 779e579 (replaced inline SVGs with `<svg-icon>` component)
+- [x] 1.2 Fix `error-banner.css`: add `pointer-events: auto` to `.error-dialog` rule
+- [x] 1.3 Fix `svg-icon.html`: replace root `<template switch.bind>` (surrogate) with `<span switch.bind>` + `display: contents` — same AUR0703 bug moved here by commit 779e579
+
+## 2. DI Mock Registry
+
+- [x] 2.1 Reuse existing `test/helpers/` mocks (mock-router, mock-i18n, mock-logger, mock-error-boundary) — no separate mock-registry needed
+
+## 3. Component Mount Smoke Tests
+
+- [x] 3.1 Create `test/smoke/component-compile.spec.ts` with `it.each` loop over all globally-registered custom elements from `main.ts`
+- [x] 3.2 Verify each component mounts via `createFixture()` without throwing
+- [x] 3.3 Document excluded components (dna-orb: JSDOM lacks canvas support) in the test file
+
+## 4. E2E Console Error Smoke Test
+
+- [x] 4.1 Create `e2e/smoke/no-console-errors.spec.ts` that navigates to public routes (`/`, `/welcome`, `/about`, `/discover`)
+- [x] 4.2 Assert zero `console.error` messages per route, excluding network errors
+
+## 5. Verification
+
+- [x] 5.1 Run `npx vitest run` — all smoke tests pass (4/4). 3 pre-existing failures in unrelated tests (missing BSR-generated `follow_pb.js`)
+- [x] 5.2 Run `npx playwright test --project=smoke` — all 4 E2E smoke tests pass


### PR DESCRIPTION
## Related Issue

Related to liverty-music/frontend#185

## Summary of Changes

Add OpenSpec change artifacts for the `add-component-smoke-tests` change:

- **proposal.md**: Documents the AUR0703 bug, error dialog pointer-events bug, and the need for smoke tests
- **design.md**: 6 design decisions (createFixture approach, data-driven tests, DI stubs, dna-orb exclusion, public-routes-only E2E, span switch host)
- **specs/component-smoke-tests/spec.md**: 3 requirements — mount smoke tests, DI mock registry, E2E console error tests
- **specs/frontend-error-handling/spec.md**: Delta spec for error banner button interactivity fix
- **tasks.md**: 11 implementation tasks (all complete)

No proto changes — this is documentation-only (OpenSpec artifacts).

## Self-Checklist

- [x] I have linked the related issue.
- [x] I have updated the relevant documentation (e.g., `README.md`) if needed.
- [x] No proto changes — `buf lint`/`buf format` not applicable.
- [x] No breaking changes.
