### PR TITLE
docs(openspec): sync festival-orb-effects spec for concert effects

### DIFF
--- a/openspec/changes/archive/2026-03-15-enhance-dna-orb-concert-effects/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-15-enhance-dna-orb-concert-effects/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-15

--- a/openspec/changes/archive/2026-03-15-enhance-dna-orb-concert-effects/design.md
+++ b/openspec/changes/archive/2026-03-15-enhance-dna-orb-concert-effects/design.md
@@ -1,0 +1,124 @@
+## Context
+
+The DNA Orb in `src/components/dna-orb/` uses Canvas 2D to render a growing glass sphere with inner particles, orbital dots, light rays, shockwaves, and ground glow. All visual parameters are driven by `getStageParams(followCount)` in `stage-effects.ts`, which returns a `StageParams` object consumed by `OrbRenderer`.
+
+Current state:
+- Inner particles are small dots (1-3px) scattered via `Math.random()` — no trails, no fluid motion
+- Light rays are monochrome triangles (max 6, alpha 0.15, fixed 0.15 rad width)
+- Orbitals are small glow dots (2-5px, glow radius = size * 2)
+- Full escalation takes 8+ follows; users typically follow 5-10 artists during onboarding
+- The orb interior is mostly empty space at larger radii
+
+All rendering uses `CanvasRenderingContext2D`. No WebGL, no external animation libraries beyond Matter.js (physics only). Performance target is 60fps on Pixel 7 class devices.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Make the follow action feel dramatically rewarding — every follow should produce visible, exciting change
+- Reach full visual intensity at follow 5 (compressed from 8+)
+- Create a "live concert stage" atmosphere through layered lighting effects
+- Maintain 60fps on mobile at maximum effect intensity
+- Respect `prefers-reduced-motion`
+
+**Non-Goals:**
+- WebGL migration — Canvas 2D is sufficient for the effect count
+- Audio/haptic feedback — out of scope for this visual-only change
+- Changing the bubble physics, absorption animation paths, or Matter.js integration
+- Modifying the orb's max radius (stays at 120px) or growth formula shape
+
+## Decisions
+
+### 1. Vortex trails via position history buffer
+
+**Decision**: Each `OrbParticle` gains a `trail: {x, y}[]` ring buffer (length 6). On each `update()`, the current position is pushed. `render()` draws a tapered `lineTo` path instead of a single `arc`.
+
+**Why not a shader/blur approach**: Canvas 2D has no efficient motion blur. A trail buffer is O(n) memory and O(n) draw calls — both trivial at 60 particles × 6 trail points = 360 line segments.
+
+**Why 6 trail points**: Enough to show a smooth curve at 60fps (~100ms of trail). More points increase visual noise without adding perceived fluidity.
+
+### 2. Nebula as rotating radial gradients with screen compositing
+
+**Decision**: Add 2-3 `createRadialGradient` calls inside the orb, each rotated at different speeds using `translate`/`rotate` transforms. Colors sampled from `colorPalette`. Composited with `globalCompositeOperation = 'screen'`.
+
+**Why not pre-rendered textures**: Textures would need to change color dynamically as the palette grows. Runtime gradients are cheap at the orb's pixel area (~45,000 px² at max radius) and allow palette-reactive colors.
+
+**Why screen compositing**: Additive blending makes overlapping nebula layers glow brighter at intersections — natural light behavior that enhances the "energy" feel.
+
+### 3. Laser rays with per-ray linear gradients and randomized widths
+
+**Decision**: Replace the single `fillStyle` color with a `createLinearGradient` from orb center to ray tip. Each ray gets a randomized `halfWidth` (0.08-0.25 rad) seeded at init. Some rays rotate counter-clockwise.
+
+**Why gradient over flat fill**: A gradient fading to transparent at the tip eliminates the hard triangle edge, making rays look like actual light beams rather than colored wedges.
+
+**Why counter-rotation**: A mix of CW/CCW rays creates visual complexity without increasing ray count. Two rays crossing paths catch the eye more than two rays moving in parallel.
+
+### 4. Orbital comet tails via arc segments
+
+**Decision**: Each orbital particle draws a trailing arc segment (30-45 degrees behind its current angle) with a gradient from full opacity to transparent. Size increased to 4-8px with glow radius = size × 4.
+
+**Why arc, not trail buffer**: Orbitals follow a circular path, so the trail is always a perfect arc. Drawing an arc segment is a single `ctx.arc()` call — cheaper than a multi-point trail.
+
+### 5. Strobe as single-frame overlay + staggered shockwaves
+
+**Decision**: On `pulse()`, draw a full-canvas `fillRect` with `rgba(255,255,255,0.15)` for exactly 1 frame. Simultaneously fire 2-3 shockwaves at 50ms stagger (using the existing `ShockwaveRing` pool, increased from 3 to 5 slots). Spike all light ray alpha to 0.8 for 200ms.
+
+**Why 0.15 alpha**: Higher values (0.3+) cause discomfort on OLED screens in dark rooms. 0.15 is perceptible as a flash without being harsh. Reduced-motion users skip the flash entirely.
+
+### 6. Beat sync via shared sine modulator
+
+**Decision**: Add a `beatPhase` value computed as `Math.sin(time * beatBPM * Math.PI / 30)` in `update()`. This value (range -1 to 1) is sampled by light rays (alpha ±0.05) and orbitals (size ±10%). `beatBPM` scales from 1.0 at follow 1 to 2.0 at follow 5.
+
+**Why a shared sine**: All effects pulsing to the same beat creates coherence. Independent oscillators would look chaotic rather than rhythmic.
+
+**Why subtle amplitude (±5-10%)**: The beat should be felt, not seen. If the pulsation is too obvious, it becomes distracting rather than atmospheric.
+
+### 7. Escalation compression to follow 5
+
+**Decision**: Retune `getStageParams()` thresholds:
+
+| Effect | Current unlock | New unlock | Max at |
+|--------|---------------|------------|--------|
+| Orbitals | follow 2 | follow 1 | follow 4 |
+| Ground glow | follow 2 | follow 1 | follow 4 |
+| Nebula | _(new)_ | follow 2 | follow 4 |
+| Light rays | follow 4 | follow 2 | follow 5 |
+| Comet trail | follow 4 | follow 3 | follow 3 |
+| Shockwave | follow 5 | follow 3 | follow 3 |
+| Beat sync | _(new)_ | follow 2 | follow 5 |
+| Strobe flash | _(new)_ | follow 3 | follow 3 |
+| Vortex trails | _(new)_ | follow 1 | follow 3 |
+| Orbital comets | _(new)_ | follow 2 | follow 4 |
+| Full show | follow 8+ | follow 5 | follow 5 |
+
+**Why not follow 3**: At follow 3 the user hasn't invested enough to justify maximum spectacle. Follow 5 is the "hook point" — enough commitment to reward, few enough that most onboarding users reach it.
+
+### 8. StageParams interface extension
+
+**Decision**: Add new fields to `StageParams`:
+
+```typescript
+interface StageParams {
+  // ... existing fields ...
+  nebulaLayerCount: number       // 0-3
+  nebulaAlpha: number            // 0-0.25
+  vortexTrailLength: number      // 0-6
+  beatBPM: number                // 0-2.0
+  strobeEnabled: boolean         // false until follow 3
+  orbitalTailArc: number         // 0-45 (degrees)
+  orbitalSize: number            // base orbital dot size 2-8
+  lightRayWidthMin: number       // 0.08
+  lightRayWidthMax: number       // 0.25
+}
+```
+
+All new fields follow the same pattern: computed from `followCount` in `getStageParams()`, consumed read-only by `OrbRenderer`.
+
+## Risks / Trade-offs
+
+**[Gradient count at max stage] → Mitigation**: At follow 5+, the renderer creates ~20 gradients per frame (3 nebula + 12-16 laser + orb glow). On low-end devices this could cause jank. **Mitigation**: `setParticleScale()` already exists for performance throttling; extend it to also reduce nebula layers and laser count. Add a frame-time check: if `delta > 20ms` for 3 consecutive frames, auto-reduce particle scale.
+
+**[Visual coherence — too many effects] → Mitigation**: All new effects use the same `colorPalette` as source, and `screen` compositing keeps them light-additive. Beat sync ties them to a shared rhythm. If the result is still chaotic, individual effect amplitudes can be tuned down without architectural changes.
+
+**[Test maintenance] → Mitigation**: `stage-effects.spec.ts` boundary values all change. New `StageParams` fields need new assertions. This is straightforward but must be done carefully to avoid false passes on old thresholds.
+
+**[Reduced motion users see degraded experience] → Mitigation**: Vortex trails, beat sync, strobe, and orbital tails are all motion-dependent and will be suppressed. Nebula layers (static overlay) and enlarged orbital dots (static size) still provide visual richness for reduced-motion users.

--- a/openspec/changes/archive/2026-03-15-enhance-dna-orb-concert-effects/proposal.md
+++ b/openspec/changes/archive/2026-03-15-enhance-dna-orb-concert-effects/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+The DNA Orb's current visual effects are too subtle to create excitement during the follow action. Inner particles are small dots (1-3px), light rays are few and monochrome, orbital particles lack presence, and the orb interior feels empty as it grows. The escalation takes 8+ follows to reach full effect, which is too slow to reward users during onboarding. We need concert-grade visual intensity that reaches its peak at follow 5 to make every follow feel impactful and the experience feel like a live music event.
+
+## What Changes
+
+- **Vortex Flow**: Replace scattered inner dot particles with fluid-like swirling trails that create a water vortex effect inside the orb. Each particle draws a tapered trail of its recent positions.
+- **Nebula Fill**: Add 2-3 layered radial gradients that slowly rotate inside the orb, filling empty space with colorful nebula clouds that use the accumulated color palette.
+- **Laser Show upgrade**: Increase max light rays from 6 to 12-16, add per-ray linear gradients (root-to-tip color shift), randomize beam widths, mix in counter-rotating rays, and add tip flares.
+- **Orbital Comets**: Enlarge orbital particles (4-8px), add comet tails trailing each orbital, increase glow radius, and introduce elliptical orbit paths at higher stages.
+- **Strobe Flash**: Add a brief full-canvas white flash on follow, stagger 2-3 rapid shockwaves, and spike all light ray alpha momentarily.
+- **Beat Sync**: Add a subtle BPM-style pulsation (synced sine wave) that modulates light ray alpha, orbital glow, and orb radius to create rhythmic "breathing" that increases tempo with follow count.
+- **Escalation retuning**: Compress the full-show unlock from follow 8 to follow 5. All effects visible and at maximum intensity by the 5th follow.
+
+## Capabilities
+
+### New Capabilities
+
+_(none — all effects are enhancements to the existing festival-orb-effects capability)_
+
+### Modified Capabilities
+
+- `festival-orb-effects`: Stage escalation compressed to follow 5 max. Six new visual layers added (vortex trails, nebula fill, laser gradients, orbital comets, strobe flash, beat sync). All existing `StageParams` thresholds and max values change.
+
+## Impact
+
+- **Frontend only** — all changes are in `src/components/dna-orb/` (orb-renderer.ts, stage-effects.ts, dna-orb-canvas.ts)
+- **No backend or API changes**
+- **No new dependencies** — all effects use Canvas 2D APIs already in use
+- **Test updates** — `stage-effects.spec.ts` and `orb-renderer.spec.ts` boundary values change due to retuned thresholds
+- **Performance budget** — additional gradient and lineTo calls; estimated well within 60fps on mobile at max orb radius (120px fill area)

--- a/openspec/changes/archive/2026-03-15-enhance-dna-orb-concert-effects/specs/festival-orb-effects/spec.md
+++ b/openspec/changes/archive/2026-03-15-enhance-dna-orb-concert-effects/specs/festival-orb-effects/spec.md
@@ -1,0 +1,304 @@
+## ADDED Requirements
+
+### Requirement: Vortex flow trails inside the orb
+Inner particles SHALL draw tapered trails of their recent positions to create a fluid, swirling vortex effect inside the orb.
+
+#### Scenario: Trail buffer accumulation
+- **WHEN** the orb animation loop runs with `vortexTrailLength > 0`
+- **THEN** each inner particle SHALL store its most recent positions in a ring buffer of length `stageParams.vortexTrailLength`
+- **AND** one position SHALL be recorded per `update()` call
+
+#### Scenario: Trail rendering as tapered lines
+- **WHEN** inner particles are rendered
+- **AND** `vortexTrailLength > 0`
+- **THEN** each particle SHALL draw a path connecting its trail positions using `lineTo`
+- **AND** the line width SHALL taper from `particleSize * 1.5` at the head to `0.5` at the tail
+- **AND** the opacity SHALL decrease from the particle's base opacity at the head to `0.05` at the tail
+
+#### Scenario: Vortex trails appear at follow 1
+- **WHEN** the follow count is 1 or more
+- **THEN** `stageParams.vortexTrailLength` SHALL be greater than 0
+- **AND** at follow 3 or more, `vortexTrailLength` SHALL be at its maximum value of 6
+
+#### Scenario: Vortex trails respect reduced motion
+- **WHEN** `prefers-reduced-motion: reduce` is active
+- **THEN** trails SHALL NOT be drawn (particles render as single dots as before)
+
+---
+
+### Requirement: Nebula fill layers
+The orb SHALL display rotating radial gradient layers inside its body to fill empty space with colorful nebula-like clouds.
+
+#### Scenario: Nebula layer rendering
+- **WHEN** `stageParams.nebulaLayerCount > 0`
+- **THEN** the renderer SHALL draw that many radial gradients inside the orb boundary
+- **AND** each gradient SHALL use colors sampled from the accumulated `colorPalette`
+- **AND** each layer SHALL rotate at a distinct speed (each layer offset by a different angular velocity)
+- **AND** layers SHALL be composited using `globalCompositeOperation = 'screen'`
+
+#### Scenario: Nebula layers appear at follow 2
+- **WHEN** the follow count is 2
+- **THEN** `stageParams.nebulaLayerCount` SHALL be 1
+- **AND** at follow 4 or more, `nebulaLayerCount` SHALL be at its maximum value of 3
+
+#### Scenario: Nebula alpha is bounded
+- **WHEN** nebula layers are rendered
+- **THEN** the combined alpha of all layers SHALL NOT exceed 0.25
+- **AND** `stageParams.nebulaAlpha` SHALL control the per-layer alpha
+
+#### Scenario: Nebula uses default color when palette is empty
+- **WHEN** nebula layers are rendered and `colorPalette` is empty
+- **THEN** layers SHALL use the default hue of 260 (purple)
+
+#### Scenario: Nebula respects reduced motion
+- **WHEN** `prefers-reduced-motion: reduce` is active
+- **THEN** nebula layers SHALL render at fixed angles (no rotation) but remain visible
+
+---
+
+### Requirement: Strobe flash on follow
+A brief full-canvas flash and rapid shockwave burst SHALL fire when a follow action triggers a pulse.
+
+#### Scenario: White flash overlay
+- **WHEN** `pulse()` is called and `stageParams.strobeEnabled` is true
+- **THEN** the renderer SHALL draw a full-canvas `fillRect` with `rgba(255, 255, 255, 0.15)` for exactly 1 frame
+- **AND** the flash SHALL be cleared on the next frame automatically (no manual cleanup)
+
+#### Scenario: Staggered shockwave burst
+- **WHEN** `pulse()` is called and `stageParams.strobeEnabled` is true
+- **THEN** the renderer SHALL spawn 2-3 shockwave rings with 50ms stagger between each
+- **AND** the shockwave pool size SHALL be at least 5 to accommodate the burst
+
+#### Scenario: Light ray alpha spike
+- **WHEN** `pulse()` is called
+- **THEN** all light ray alphas SHALL spike to 0.8 and decay back to `stageParams.lightRayAlpha` over 200ms
+
+#### Scenario: Strobe enabled at follow 3
+- **WHEN** the follow count is 3 or more
+- **THEN** `stageParams.strobeEnabled` SHALL be true
+
+#### Scenario: Strobe respects reduced motion
+- **WHEN** `prefers-reduced-motion: reduce` is active
+- **THEN** the white flash and alpha spike SHALL be suppressed
+- **AND** shockwaves SHALL also be suppressed (existing behavior)
+
+---
+
+### Requirement: Beat sync pulsation
+A shared sinusoidal beat SHALL modulate multiple visual parameters to create a rhythmic, concert-like atmosphere.
+
+#### Scenario: Beat phase calculation
+- **WHEN** `stageParams.beatBPM > 0` and reduced motion is not active
+- **THEN** the renderer SHALL compute `beatPhase = Math.sin(time * beatBPM * Math.PI / 30)` on each `update()`
+- **AND** `beatPhase` SHALL range from -1 to 1
+
+#### Scenario: Beat modulates light rays
+- **WHEN** beat sync is active and light rays are rendered
+- **THEN** each ray's effective alpha SHALL be `stageParams.lightRayAlpha * (1 + beatPhase * 0.1)`
+
+#### Scenario: Beat modulates orbital glow
+- **WHEN** beat sync is active and orbitals are rendered
+- **THEN** each orbital's effective size SHALL be `orbitalSize * (1 + beatPhase * 0.1)`
+
+#### Scenario: Beat BPM scales with follow count
+- **WHEN** the follow count is 2
+- **THEN** `stageParams.beatBPM` SHALL be greater than 0
+- **AND** at follow 5, `beatBPM` SHALL be at its maximum value of 2.0
+
+#### Scenario: Beat sync respects reduced motion
+- **WHEN** `prefers-reduced-motion: reduce` is active
+- **THEN** `beatPhase` SHALL be fixed at 0 (no pulsation)
+
+---
+
+### Requirement: Orbital comet tails
+Orbital particles SHALL display trailing arc segments to create a comet-like appearance.
+
+#### Scenario: Orbital tail rendering
+- **WHEN** `stageParams.orbitalTailArc > 0`
+- **THEN** each orbital particle SHALL draw an arc segment trailing behind its current angle
+- **AND** the arc span SHALL be `stageParams.orbitalTailArc` degrees
+- **AND** the arc SHALL use a gradient from the orbital's color at full opacity to transparent
+
+#### Scenario: Orbital tails appear at follow 2
+- **WHEN** the follow count is 2
+- **THEN** `stageParams.orbitalTailArc` SHALL be greater than 0
+- **AND** at follow 4 or more, `orbitalTailArc` SHALL be at its maximum value of 45 degrees
+
+#### Scenario: Orbital size increase
+- **WHEN** follow count is 1 or more
+- **THEN** `stageParams.orbitalSize` SHALL determine the base orbital dot size
+- **AND** the size SHALL range from 4 at follow 1 to 8 at follow 4+
+- **AND** the glow radius SHALL be `orbitalSize * 4`
+
+#### Scenario: Orbital tails respect reduced motion
+- **WHEN** `prefers-reduced-motion: reduce` is active
+- **THEN** orbital tails SHALL NOT be drawn (orbitals render as static dots)
+
+---
+
+## MODIFIED Requirements
+
+### Requirement: Stage-level escalation system
+The system SHALL calculate visual effect parameters from the follow count using a stage-level model, where each follow advances the stage by one level. The calculation SHALL be implemented as a pure function in `stage-effects.ts`, separate from rendering logic. Full visual intensity SHALL be reached at follow 5.
+
+#### Scenario: Stage parameters at zero follows
+- **WHEN** the follow count is 0
+- **THEN** `getStageParams(0)` SHALL return `orbRadius` of 60, `orbitalCount` of 0, `lightRayCount` of 0, `groundGlowAlpha` of 0, `shockwaveEnabled` as false, `cometTrailEnabled` as false, `nebulaLayerCount` of 0, `vortexTrailLength` of 0, `beatBPM` of 0, `strobeEnabled` as false, `orbitalTailArc` of 0, and `orbitalSize` of 2
+
+#### Scenario: Stage parameters at one follow
+- **WHEN** the follow count is 1
+- **THEN** `getStageParams(1)` SHALL return `orbRadius` of 72, `breathAmplitude` greater than 0, `orbitalCount` of 2, `particleVisibilityRatio` greater than 0.3, `groundGlowAlpha` greater than 0, `vortexTrailLength` of 2, and `orbitalSize` of 4
+
+#### Scenario: Stage parameters at two follows
+- **WHEN** the follow count is 2
+- **THEN** `getStageParams(2)` SHALL return `orbitalCount` of 5, `lightRayCount` of 2, `nebulaLayerCount` of 1, `beatBPM` greater than 0, and `orbitalTailArc` greater than 0
+
+#### Scenario: Stage parameters at three follows
+- **WHEN** the follow count is 3
+- **THEN** `getStageParams(3)` SHALL return `shockwaveEnabled` as true, `cometTrailEnabled` as true, `strobeEnabled` as true, `vortexTrailLength` of 6, and `lightRayCount` of 6
+
+#### Scenario: Stage parameters at four follows
+- **WHEN** the follow count is 4
+- **THEN** `getStageParams(4)` SHALL return `nebulaLayerCount` of 3, `orbitalTailArc` of 45, `orbitalSize` of 8, and `orbitalCount` of 11
+
+#### Scenario: Stage parameters at five follows (full show)
+- **WHEN** the follow count is 5
+- **THEN** `getStageParams(5)` SHALL return maximum intensity values: `lightRayCount` of 12 or more, `orbitalCount` of 12, `beatBPM` of 2.0, `lightRayAlpha` of 0.35 or more, and all effect features enabled
+
+#### Scenario: Stage parameters at six or more follows
+- **WHEN** the follow count is 6 or more
+- **THEN** `getStageParams` SHALL return the same maximum intensity values as follow 5 (all effects capped at full show level)
+
+#### Scenario: Orb radius growth ceiling
+- **WHEN** the follow count exceeds 20
+- **THEN** the `orbRadius` SHALL NOT exceed 120
+
+#### Scenario: Stage params are deterministic
+- **WHEN** `getStageParams` is called multiple times with the same follow count
+- **THEN** it SHALL return identical results each time (pure function, no side effects)
+
+---
+
+### Requirement: Light rays
+Radial light beams SHALL emanate from the orb at higher stage levels, using additive blending, per-ray gradient coloring, and randomized beam widths.
+
+#### Scenario: Light rays appear at follow 2
+- **WHEN** the follow count reaches 2
+- **THEN** 2 light rays SHALL appear, rendered as triangular shapes extending from the orb center
+- **AND** rays SHALL rotate over time with some rays rotating counter-clockwise
+
+#### Scenario: Light ray count and intensity scale with stage
+- **WHEN** the follow count increases beyond 2
+- **THEN** the ray count SHALL increase up to `stageParams.lightRayCount` (maximum 12-16)
+- **AND** the ray alpha SHALL increase up to `stageParams.lightRayAlpha` (maximum 0.35-0.4)
+
+#### Scenario: Light ray gradient coloring
+- **WHEN** light rays are rendered
+- **THEN** each ray SHALL use a `createLinearGradient` from orb center to ray tip
+- **AND** the gradient SHALL shift hue by +30 to +60 degrees from root to tip
+- **AND** the gradient SHALL fade to transparent at the tip
+
+#### Scenario: Light ray width variation
+- **WHEN** light rays are initialized
+- **THEN** each ray SHALL have a `halfWidth` randomly assigned between `stageParams.lightRayWidthMin` and `stageParams.lightRayWidthMax`
+
+#### Scenario: Light ray blending
+- **WHEN** light rays are rendered
+- **THEN** `globalCompositeOperation` SHALL be set to `'screen'` for the ray drawing
+- **AND** the composition mode SHALL be restored after ray rendering (via `save`/`restore`)
+
+#### Scenario: Light rays respect reduced motion
+- **WHEN** `prefers-reduced-motion: reduce` is active
+- **THEN** light rays SHALL be rendered at a fixed angle (no rotation)
+
+---
+
+### Requirement: Orbital particles
+Glowing particles SHALL orbit outside the orb, with count and speed increasing per stage level, enlarged size, and comet-like tails.
+
+#### Scenario: Orbital appearance at follow 1
+- **WHEN** the follow count reaches 1
+- **THEN** 2 orbital particles SHALL appear, circling the orb at a radius between 1.3x and 1.8x the orb radius
+
+#### Scenario: Orbital count increases with stage
+- **WHEN** the follow count increases
+- **THEN** the visible orbital count SHALL match `stageParams.orbitalCount`
+- **AND** new orbitals SHALL use colors from the accumulated color palette
+
+#### Scenario: Orbital rendering with enlarged size
+- **WHEN** orbital particles are rendered
+- **THEN** each SHALL be drawn as a radial gradient (glow dot) of `stageParams.orbitalSize` (4-8px)
+- **AND** the glow radius SHALL be `orbitalSize * 4`
+- **AND** each SHALL have an independent angular velocity
+
+#### Scenario: Orbitals respect reduced motion
+- **WHEN** `prefers-reduced-motion: reduce` is active
+- **THEN** orbital particles SHALL be positioned statically (no rotation)
+
+---
+
+### Requirement: Shockwave rings on follow
+Expanding colored rings SHALL burst from the orb each time an artist is followed, with support for rapid multi-ring bursts.
+
+#### Scenario: Shockwave spawns on absorption complete
+- **WHEN** a bubble absorption animation completes (progress reaches 1.0)
+- **AND** `stageParams.shockwaveEnabled` is true
+- **THEN** a shockwave ring SHALL spawn at the orb center
+- **AND** the ring color SHALL use the absorbed artist's hue
+
+#### Scenario: Shockwave ring animation
+- **WHEN** a shockwave ring is active
+- **THEN** its radius SHALL expand from `orbRadius` to `orbRadius * 3` over 800ms
+- **AND** its alpha SHALL decrease from 0.6 to 0
+- **AND** its lineWidth SHALL decrease from 3 to 0.5
+
+#### Scenario: Shockwave ring pool size
+- **WHEN** the shockwave pool is initialized
+- **THEN** at least 5 shockwave ring slots SHALL be available to accommodate staggered bursts
+
+#### Scenario: Shockwave respects reduced motion
+- **WHEN** `prefers-reduced-motion: reduce` is active
+- **THEN** shockwave rings SHALL NOT be spawned
+
+---
+
+### Requirement: Unit test coverage for stage effects
+The `stage-effects.ts` module SHALL be covered by unit tests verifying parameter correctness at key follow counts, including all new StageParams fields.
+
+#### Scenario: Boundary value tests
+- **WHEN** unit tests run for `getStageParams`
+- **THEN** tests SHALL verify correct parameters at follow counts 0, 1, 2, 3, 4, 5, 6, 10, and 20
+- **AND** tests SHALL verify the new fields: `nebulaLayerCount`, `nebulaAlpha`, `vortexTrailLength`, `beatBPM`, `strobeEnabled`, `orbitalTailArc`, `orbitalSize`, `lightRayWidthMin`, `lightRayWidthMax`
+
+#### Scenario: Monotonic growth assertions
+- **WHEN** unit tests run
+- **THEN** tests SHALL verify that `orbRadius`, `orbitalCount`, `lightRayCount`, `groundGlowAlpha`, `nebulaLayerCount`, `orbitalTailArc`, `orbitalSize`, and `beatBPM` are monotonically non-decreasing as follow count increases from 0 to 20
+
+#### Scenario: Ceiling assertions
+- **WHEN** unit tests run
+- **THEN** tests SHALL verify that `orbRadius` never exceeds 120, `orbitalCount` never exceeds 12, `nebulaLayerCount` never exceeds 3, and `nebulaAlpha` never exceeds 0.25
+
+#### Scenario: Full show at follow 5
+- **WHEN** unit tests run
+- **THEN** tests SHALL verify that `getStageParams(5)` returns maximum intensity values for all effect parameters
+- **AND** `getStageParams(6)` SHALL return the same maximum values as `getStageParams(5)` for all capped parameters
+
+### Requirement: Unit test coverage for OrbRenderer state
+OrbRenderer state transitions SHALL be covered by unit tests, including new effect state.
+
+#### Scenario: Shockwave lifecycle test
+- **WHEN** a shockwave is spawned and updated until completion
+- **THEN** tests SHALL verify it becomes inactive after 800ms of updates
+
+#### Scenario: Color palette accumulation test
+- **WHEN** `injectColor` is called 25 times
+- **THEN** the palette SHALL contain exactly 20 entries (FIFO cap)
+
+#### Scenario: Orbital count reflects stage params
+- **WHEN** `setFollowCount` is called with increasing values
+- **THEN** the visible orbital count SHALL match the corresponding `stageParams.orbitalCount`
+
+#### Scenario: Shockwave pool accommodates burst
+- **WHEN** 5 shockwaves are spawned in rapid succession
+- **THEN** all 5 SHALL be active simultaneously

--- a/openspec/changes/archive/2026-03-15-enhance-dna-orb-concert-effects/tasks.md
+++ b/openspec/changes/archive/2026-03-15-enhance-dna-orb-concert-effects/tasks.md
@@ -1,0 +1,52 @@
+## 1. StageParams interface and escalation retuning
+
+- [x] 1.1 Extend `StageParams` interface with new fields: `nebulaLayerCount`, `nebulaAlpha`, `vortexTrailLength`, `beatBPM`, `strobeEnabled`, `orbitalTailArc`, `orbitalSize`, `lightRayWidthMin`, `lightRayWidthMax`
+- [x] 1.2 Retune `getStageParams()` thresholds so all effects reach max at follow 5, with earlier unlocks (orbitals at 1, light rays at 2, shockwave/strobe at 3, full show at 5)
+- [x] 1.3 Increase orb radius growth per follow (orbRadius 72 at follow 1 instead of 68)
+
+## 2. Vortex flow trails
+
+- [x] 2.1 Add `trail: {x: number, y: number}[]` ring buffer to `OrbParticle` interface
+- [x] 2.2 Record particle positions in `update()` and manage ring buffer rotation
+- [x] 2.3 Replace single `arc()` draw with tapered `lineTo` trail path in `render()`, respecting reduced motion
+
+## 3. Nebula fill layers
+
+- [x] 3.1 Add `renderNebula()` method to `OrbRenderer` that draws 1-3 rotating radial gradients inside the orb using `screen` compositing
+- [x] 3.2 Sample colors from `colorPalette` (fallback to hue 260), rotate each layer at different speeds
+- [x] 3.3 Integrate `renderNebula()` into the render pipeline in `dna-orb-canvas.ts`
+
+## 4. Laser show upgrade
+
+- [x] 4.1 Add per-ray `halfWidth` randomization at init (range: `lightRayWidthMin` to `lightRayWidthMax`)
+- [x] 4.2 Replace single `fillStyle` with `createLinearGradient` per ray (hue shift +30-60 degrees root-to-tip, fade to transparent)
+- [x] 4.3 Add counter-rotating rays (alternate direction flags on init)
+- [x] 4.4 Increase max light ray count to 12-16 and max alpha to 0.35-0.4
+
+## 5. Orbital comets
+
+- [x] 5.1 Increase orbital particle size to use `stageParams.orbitalSize` (4-8px) with glow radius `size * 4`
+- [x] 5.2 Add trailing arc segment rendering per orbital (`orbitalTailArc` degrees behind current angle, gradient to transparent)
+
+## 6. Strobe flash
+
+- [x] 6.1 Add `strobeFlash` flag to `OrbRenderer`, set on `pulse()` when `strobeEnabled`, cleared after 1 frame
+- [x] 6.2 Render full-canvas `fillRect` with `rgba(255,255,255,0.15)` when `strobeFlash` is active
+- [x] 6.3 Increase shockwave pool from 3 to 5 slots
+- [x] 6.4 Spawn 2-3 staggered shockwaves on `pulse()` when `strobeEnabled` (50ms intervals via accumulated delta)
+- [x] 6.5 Add light ray alpha spike to 0.8 on `pulse()`, decaying over 200ms
+
+## 7. Beat sync
+
+- [x] 7.1 Add `beatPhase` calculation in `update()`: `Math.sin(time * beatBPM * PI / 30)`
+- [x] 7.2 Apply beat modulation to light ray alpha (±0.1 factor)
+- [x] 7.3 Apply beat modulation to orbital size (±10% factor)
+- [x] 7.4 Suppress beat sync when `prefers-reduced-motion` is active
+
+## 8. Tests
+
+- [x] 8.1 Update `stage-effects.spec.ts` boundary value tests for new thresholds (follow 0-6, 10, 20) and new fields
+- [x] 8.2 Add monotonic growth assertions for new fields (`nebulaLayerCount`, `orbitalTailArc`, `orbitalSize`, `beatBPM`)
+- [x] 8.3 Add ceiling assertions for new fields (`nebulaLayerCount <= 3`, `nebulaAlpha <= 0.25`)
+- [x] 8.4 Add full-show-at-follow-5 assertion (follow 5 values == follow 6 values for capped params)
+- [x] 8.5 Update `orb-renderer.spec.ts` for shockwave pool size (5 concurrent) and any new render state

--- a/openspec/specs/festival-orb-effects/spec.md
+++ b/openspec/specs/festival-orb-effects/spec.md
@@ -3,31 +3,35 @@
 ## Requirements
 
 ### Requirement: Stage-level escalation system
-The system SHALL calculate visual effect parameters from the follow count using a stage-level model, where each follow advances the stage by one level. The calculation SHALL be implemented as a pure function in `stage-effects.ts`, separate from rendering logic.
+The system SHALL calculate visual effect parameters from the follow count using a stage-level model, where each follow advances the stage by one level. The calculation SHALL be implemented as a pure function in `stage-effects.ts`, separate from rendering logic. Full visual intensity SHALL be reached at follow 5.
 
 #### Scenario: Stage parameters at zero follows
 - **WHEN** the follow count is 0
-- **THEN** `getStageParams(0)` SHALL return `orbRadius` of 60, `orbitalCount` of 0, `lightRayCount` of 0, `groundGlowAlpha` of 0, `shockwaveEnabled` as false, and `cometTrailEnabled` as false
+- **THEN** `getStageParams(0)` SHALL return `orbRadius` of 60, `orbitalCount` of 0, `lightRayCount` of 0, `groundGlowAlpha` of 0, `shockwaveEnabled` as false, `cometTrailEnabled` as false, `nebulaLayerCount` of 0, `vortexTrailLength` of 0, `beatBPM` of 0, `strobeEnabled` as false, `orbitalTailArc` of 0, and `orbitalSize` of 2
 
 #### Scenario: Stage parameters at one follow
 - **WHEN** the follow count is 1
-- **THEN** `getStageParams(1)` SHALL return `orbRadius` of 68, `breathAmplitude` greater than 0, `orbitalCount` of 0, and `particleVisibilityRatio` greater than 0.3
+- **THEN** `getStageParams(1)` SHALL return `orbRadius` of 72, `breathAmplitude` greater than 0, `orbitalCount` of 2, `particleVisibilityRatio` greater than 0.3, `groundGlowAlpha` greater than 0, `vortexTrailLength` of 2, and `orbitalSize` of 4
 
 #### Scenario: Stage parameters at two follows
 - **WHEN** the follow count is 2
-- **THEN** `getStageParams(2)` SHALL return `orbitalCount` of 2 and `groundGlowAlpha` greater than 0
+- **THEN** `getStageParams(2)` SHALL return `orbitalCount` of 5, `lightRayCount` of 2, `nebulaLayerCount` of 1, `beatBPM` greater than 0, and `orbitalTailArc` greater than 0
+
+#### Scenario: Stage parameters at three follows
+- **WHEN** the follow count is 3
+- **THEN** `getStageParams(3)` SHALL return `shockwaveEnabled` as true, `cometTrailEnabled` as true, `strobeEnabled` as true, `vortexTrailLength` of 6, and `lightRayCount` of 6
 
 #### Scenario: Stage parameters at four follows
 - **WHEN** the follow count is 4
-- **THEN** `getStageParams(4)` SHALL return `lightRayCount` of 2, `cometTrailEnabled` as true, and `orbitalCount` of 6
+- **THEN** `getStageParams(4)` SHALL return `nebulaLayerCount` of 3, `orbitalTailArc` of 45, `orbitalSize` of 8, and `orbitalCount` of 11
 
-#### Scenario: Stage parameters at five follows
+#### Scenario: Stage parameters at five follows (full show)
 - **WHEN** the follow count is 5
-- **THEN** `getStageParams(5)` SHALL return `shockwaveEnabled` as true and `lightRayCount` of 4
+- **THEN** `getStageParams(5)` SHALL return maximum intensity values: `lightRayCount` of 12 or more, `orbitalCount` of 12, `beatBPM` of 2.0, `lightRayAlpha` of 0.35 or more, and all effect features enabled
 
 #### Scenario: Stage parameters at six or more follows
 - **WHEN** the follow count is 6 or more
-- **THEN** `getStageParams` SHALL return `lightRayCount` of 6, `orbitalCount` of 10 or more, and all effect features enabled
+- **THEN** `getStageParams` SHALL return the same maximum intensity values as follow 5 (all effects capped at full show level)
 
 #### Scenario: Orb radius growth ceiling
 - **WHEN** the follow count exceeds 20
@@ -78,10 +82,10 @@ The orb SHALL exhibit a continuous breathing animation that increases in amplitu
 ---
 
 ### Requirement: Orbital particles
-Glowing particles SHALL orbit outside the orb, with count and speed increasing per stage level.
+Glowing particles SHALL orbit outside the orb, with count and speed increasing per stage level, enlarged size, and comet-like tails.
 
-#### Scenario: Orbital appearance at stage 2
-- **WHEN** the follow count reaches 2
+#### Scenario: Orbital appearance at follow 1
+- **WHEN** the follow count reaches 1
 - **THEN** 2 orbital particles SHALL appear, circling the orb at a radius between 1.3x and 1.8x the orb radius
 
 #### Scenario: Orbital count increases with stage
@@ -89,9 +93,10 @@ Glowing particles SHALL orbit outside the orb, with count and speed increasing p
 - **THEN** the visible orbital count SHALL match `stageParams.orbitalCount`
 - **AND** new orbitals SHALL use colors from the accumulated color palette
 
-#### Scenario: Orbital rendering
+#### Scenario: Orbital rendering with enlarged size
 - **WHEN** orbital particles are rendered
-- **THEN** each SHALL be drawn as a small radial gradient (glow dot) of 2-5px
+- **THEN** each SHALL be drawn as a radial gradient (glow dot) of `stageParams.orbitalSize` (4-8px)
+- **AND** the glow radius SHALL be `orbitalSize * 4`
 - **AND** each SHALL have an independent angular velocity
 
 #### Scenario: Orbitals respect reduced motion
@@ -101,17 +106,27 @@ Glowing particles SHALL orbit outside the orb, with count and speed increasing p
 ---
 
 ### Requirement: Light rays
-Radial light beams SHALL emanate from the orb at higher stage levels, using additive blending.
+Radial light beams SHALL emanate from the orb at higher stage levels, using additive blending, per-ray gradient coloring, and randomized beam widths.
 
-#### Scenario: Light rays appear at stage 4
-- **WHEN** the follow count reaches 4
-- **THEN** 2 light rays SHALL appear, rendered as triangular gradients extending from the orb center
-- **AND** rays SHALL rotate slowly over time
+#### Scenario: Light rays appear at follow 2
+- **WHEN** the follow count reaches 2
+- **THEN** 2 light rays SHALL appear, rendered as triangular shapes extending from the orb center
+- **AND** rays SHALL rotate over time with some rays rotating counter-clockwise
 
 #### Scenario: Light ray count and intensity scale with stage
-- **WHEN** the follow count increases beyond 4
-- **THEN** the ray count SHALL increase up to `stageParams.lightRayCount`
-- **AND** the ray alpha SHALL increase up to `stageParams.lightRayAlpha`
+- **WHEN** the follow count increases beyond 2
+- **THEN** the ray count SHALL increase up to `stageParams.lightRayCount` (maximum 12-16)
+- **AND** the ray alpha SHALL increase up to `stageParams.lightRayAlpha` (maximum 0.35-0.4)
+
+#### Scenario: Light ray gradient coloring
+- **WHEN** light rays are rendered
+- **THEN** each ray SHALL use a `createLinearGradient` from orb center to ray tip
+- **AND** the gradient SHALL shift hue by +30 to +60 degrees from root to tip
+- **AND** the gradient SHALL fade to transparent at the tip
+
+#### Scenario: Light ray width variation
+- **WHEN** light rays are initialized
+- **THEN** each ray SHALL have a `halfWidth` randomly assigned between `stageParams.lightRayWidthMin` and `stageParams.lightRayWidthMax`
 
 #### Scenario: Light ray blending
 - **WHEN** light rays are rendered
@@ -125,7 +140,7 @@ Radial light beams SHALL emanate from the orb at higher stage levels, using addi
 ---
 
 ### Requirement: Shockwave rings on follow
-An expanding colored ring SHALL burst from the orb each time an artist is followed.
+Expanding colored rings SHALL burst from the orb each time an artist is followed, with support for rapid multi-ring bursts.
 
 #### Scenario: Shockwave spawns on absorption complete
 - **WHEN** a bubble absorption animation completes (progress reaches 1.0)
@@ -139,10 +154,9 @@ An expanding colored ring SHALL burst from the orb each time an artist is follow
 - **AND** its alpha SHALL decrease from 0.6 to 0
 - **AND** its lineWidth SHALL decrease from 3 to 0.5
 
-#### Scenario: Shockwave ring cleanup
-- **WHEN** a shockwave ring's alpha reaches 0
-- **THEN** it SHALL be recycled (marked inactive for reuse)
-- **AND** at most 3 shockwave rings SHALL be active simultaneously
+#### Scenario: Shockwave ring pool size
+- **WHEN** the shockwave pool is initialized
+- **THEN** at least 5 shockwave ring slots SHALL be available to accommodate staggered bursts
 
 #### Scenario: Shockwave respects reduced motion
 - **WHEN** `prefers-reduced-motion: reduce` is active
@@ -207,23 +221,166 @@ The orb SHALL accumulate a palette of artist hues as users follow artists, enric
 
 ---
 
+### Requirement: Vortex flow trails inside the orb
+Inner particles SHALL draw tapered trails of their recent positions to create a fluid, swirling vortex effect inside the orb.
+
+#### Scenario: Trail buffer accumulation
+- **WHEN** the orb animation loop runs with `vortexTrailLength > 0`
+- **THEN** each inner particle SHALL store its most recent positions in a ring buffer of length `stageParams.vortexTrailLength`
+- **AND** one position SHALL be recorded per `update()` call
+
+#### Scenario: Trail rendering as tapered lines
+- **WHEN** inner particles are rendered
+- **AND** `vortexTrailLength > 0`
+- **THEN** each particle SHALL draw a path connecting its trail positions using `lineTo`
+- **AND** the line width SHALL taper from `particleSize * 1.5` at the head to `0.5` at the tail
+- **AND** the opacity SHALL decrease from the particle's base opacity at the head to `0.05` at the tail
+
+#### Scenario: Vortex trails appear at follow 1
+- **WHEN** the follow count is 1 or more
+- **THEN** `stageParams.vortexTrailLength` SHALL be greater than 0
+- **AND** at follow 3 or more, `vortexTrailLength` SHALL be at its maximum value of 6
+
+#### Scenario: Vortex trails respect reduced motion
+- **WHEN** `prefers-reduced-motion: reduce` is active
+- **THEN** trails SHALL NOT be drawn (particles render as single dots as before)
+
+---
+
+### Requirement: Nebula fill layers
+The orb SHALL display rotating radial gradient layers inside its body to fill empty space with colorful nebula-like clouds.
+
+#### Scenario: Nebula layer rendering
+- **WHEN** `stageParams.nebulaLayerCount > 0`
+- **THEN** the renderer SHALL draw that many radial gradients inside the orb boundary
+- **AND** each gradient SHALL use colors sampled from the accumulated `colorPalette`
+- **AND** each layer SHALL rotate at a distinct speed (each layer offset by a different angular velocity)
+- **AND** layers SHALL be composited using `globalCompositeOperation = 'screen'`
+
+#### Scenario: Nebula layers appear at follow 2
+- **WHEN** the follow count is 2
+- **THEN** `stageParams.nebulaLayerCount` SHALL be 1
+- **AND** at follow 4 or more, `nebulaLayerCount` SHALL be at its maximum value of 3
+
+#### Scenario: Nebula alpha is bounded
+- **WHEN** nebula layers are rendered
+- **THEN** the combined alpha of all layers SHALL NOT exceed 0.25
+- **AND** `stageParams.nebulaAlpha` SHALL control the per-layer alpha
+
+#### Scenario: Nebula uses default color when palette is empty
+- **WHEN** nebula layers are rendered and `colorPalette` is empty
+- **THEN** layers SHALL use the default hue of 260 (purple)
+
+#### Scenario: Nebula respects reduced motion
+- **WHEN** `prefers-reduced-motion: reduce` is active
+- **THEN** nebula layers SHALL render at fixed angles (no rotation) but remain visible
+
+---
+
+### Requirement: Strobe flash on follow
+A brief full-canvas flash and rapid shockwave burst SHALL fire when a follow action triggers a pulse.
+
+#### Scenario: White flash overlay
+- **WHEN** `pulse()` is called and `stageParams.strobeEnabled` is true
+- **THEN** the renderer SHALL draw a full-canvas `fillRect` with `rgba(255, 255, 255, 0.15)` for exactly 1 frame
+- **AND** the flash SHALL be cleared on the next frame automatically (no manual cleanup)
+
+#### Scenario: Staggered shockwave burst
+- **WHEN** `pulse()` is called and `stageParams.strobeEnabled` is true
+- **THEN** the renderer SHALL spawn 2-3 shockwave rings with 50ms stagger between each
+- **AND** the shockwave pool size SHALL be at least 5 to accommodate the burst
+
+#### Scenario: Light ray alpha spike
+- **WHEN** `pulse()` is called
+- **THEN** all light ray alphas SHALL spike to 0.8 and decay back to `stageParams.lightRayAlpha` over 200ms
+
+#### Scenario: Strobe enabled at follow 3
+- **WHEN** the follow count is 3 or more
+- **THEN** `stageParams.strobeEnabled` SHALL be true
+
+#### Scenario: Strobe respects reduced motion
+- **WHEN** `prefers-reduced-motion: reduce` is active
+- **THEN** the white flash and alpha spike SHALL be suppressed
+- **AND** shockwaves SHALL also be suppressed (existing behavior)
+
+---
+
+### Requirement: Beat sync pulsation
+A shared sinusoidal beat SHALL modulate multiple visual parameters to create a rhythmic, concert-like atmosphere.
+
+#### Scenario: Beat phase calculation
+- **WHEN** `stageParams.beatBPM > 0` and reduced motion is not active
+- **THEN** the renderer SHALL compute `beatPhase = Math.sin(time * beatBPM * 2 * Math.PI)` on each `update()`
+- **AND** `beatPhase` SHALL range from -1 to 1
+
+#### Scenario: Beat modulates light rays
+- **WHEN** beat sync is active and light rays are rendered
+- **THEN** each ray's effective alpha SHALL be `stageParams.lightRayAlpha * (1 + beatPhase * 0.1)`
+
+#### Scenario: Beat modulates orbital glow
+- **WHEN** beat sync is active and orbitals are rendered
+- **THEN** each orbital's effective size SHALL be `orbitalSize * (1 + beatPhase * 0.1)`
+
+#### Scenario: Beat BPM scales with follow count
+- **WHEN** the follow count is 2
+- **THEN** `stageParams.beatBPM` SHALL be greater than 0
+- **AND** at follow 5, `beatBPM` SHALL be at its maximum value of 2.0
+
+#### Scenario: Beat sync respects reduced motion
+- **WHEN** `prefers-reduced-motion: reduce` is active
+- **THEN** `beatPhase` SHALL be fixed at 0 (no pulsation)
+
+---
+
+### Requirement: Orbital comet tails
+Orbital particles SHALL display trailing arc segments to create a comet-like appearance.
+
+#### Scenario: Orbital tail rendering
+- **WHEN** `stageParams.orbitalTailArc > 0`
+- **THEN** each orbital particle SHALL draw an arc segment trailing behind its current angle
+- **AND** the arc span SHALL be `stageParams.orbitalTailArc` degrees
+- **AND** the arc SHALL use a gradient from the orbital's color at full opacity to transparent
+
+#### Scenario: Orbital tails appear at follow 2
+- **WHEN** the follow count is 2
+- **THEN** `stageParams.orbitalTailArc` SHALL be greater than 0
+- **AND** at follow 4 or more, `orbitalTailArc` SHALL be at its maximum value of 45 degrees
+
+#### Scenario: Orbital size increase
+- **WHEN** follow count is 1 or more
+- **THEN** `stageParams.orbitalSize` SHALL determine the base orbital dot size
+- **AND** the size SHALL range from 4 at follow 1 to 8 at follow 4+
+- **AND** the glow radius SHALL be `orbitalSize * 4`
+
+#### Scenario: Orbital tails respect reduced motion
+- **WHEN** `prefers-reduced-motion: reduce` is active
+- **THEN** orbital tails SHALL NOT be drawn (orbitals render as static dots)
+
+---
+
 ### Requirement: Unit test coverage for stage effects
-The `stage-effects.ts` module SHALL be covered by unit tests verifying parameter correctness at key follow counts.
+The `stage-effects.ts` module SHALL be covered by unit tests verifying parameter correctness at key follow counts, including all new StageParams fields.
 
 #### Scenario: Boundary value tests
 - **WHEN** unit tests run for `getStageParams`
 - **THEN** tests SHALL verify correct parameters at follow counts 0, 1, 2, 3, 4, 5, 6, 10, and 20
+- **AND** tests SHALL verify the new fields: `nebulaLayerCount`, `nebulaAlpha`, `vortexTrailLength`, `beatBPM`, `strobeEnabled`, `orbitalTailArc`, `orbitalSize`, `lightRayWidthMin`, `lightRayWidthMax`
 
 #### Scenario: Monotonic growth assertions
 - **WHEN** unit tests run
-- **THEN** tests SHALL verify that `orbRadius`, `orbitalCount`, `lightRayCount`, and `groundGlowAlpha` are monotonically non-decreasing as follow count increases from 0 to 20
+- **THEN** tests SHALL verify that `orbRadius`, `orbitalCount`, `lightRayCount`, `groundGlowAlpha`, `nebulaLayerCount`, `orbitalTailArc`, `orbitalSize`, and `beatBPM` are monotonically non-decreasing as follow count increases from 0 to 20
 
 #### Scenario: Ceiling assertions
 - **WHEN** unit tests run
-- **THEN** tests SHALL verify that `orbRadius` never exceeds 120 and `orbitalCount` never exceeds 12
+- **THEN** tests SHALL verify that `orbRadius` never exceeds 120, `orbitalCount` never exceeds 12, `nebulaLayerCount` never exceeds 3, and `nebulaAlpha` never exceeds 0.25
+
+#### Scenario: Full show at follow 5
+- **WHEN** unit tests run
+- **THEN** tests SHALL verify that `getStageParams(5)` returns maximum intensity values for all effect parameters
+- **AND** `getStageParams(6)` SHALL return the same maximum values as `getStageParams(5)` for all capped parameters
 
 ### Requirement: Unit test coverage for OrbRenderer state
-OrbRenderer state transitions SHALL be covered by unit tests.
+OrbRenderer state transitions SHALL be covered by unit tests, including new effect state.
 
 #### Scenario: Shockwave lifecycle test
 - **WHEN** a shockwave is spawned and updated until completion
@@ -236,6 +393,10 @@ OrbRenderer state transitions SHALL be covered by unit tests.
 #### Scenario: Orbital count reflects stage params
 - **WHEN** `setFollowCount` is called with increasing values
 - **THEN** the visible orbital count SHALL match the corresponding `stageParams.orbitalCount`
+
+#### Scenario: Shockwave pool accommodates burst
+- **WHEN** 5 shockwaves are spawned in rapid succession
+- **THEN** all 5 SHALL be active simultaneously
 
 ### Requirement: Unit test coverage for AbsorptionAnimator comet trail
 The comet trail's circular buffer behavior SHALL be covered by unit tests.


### PR DESCRIPTION
## Related Issue

Refs: liverty-music/frontend#190

## Summary of Changes

Sync the festival-orb-effects main spec with the completed enhance-dna-orb-concert-effects change. This is a docs-only PR — no proto changes.

### Spec updates (openspec/specs/festival-orb-effects/spec.md)
- **5 new requirements added**: Vortex flow trails, Nebula fill layers, Strobe flash on follow, Beat sync pulsation, Orbital comet tails
- **6 requirements modified**: Stage escalation (compressed to follow 5), Orbital particles (enlarged 4-8px with comet tails), Light rays (per-ray gradients, randomized widths), Shockwave rings (5-slot pool), Unit test coverage (expanded for new fields)

### Archive
- Archived completed change to openspec/changes/archive/2026-03-15-enhance-dna-orb-concert-effects/

## Self-Checklist

- [x] I have linked the related issue.
- [x] I have updated the relevant documentation (e.g., README.md) if needed.
- [x] No proto changes — buf lint/format/breaking not applicable.
- [x] No breaking changes.