### PR TITLE
docs(openspec): archive completed change artifacts

### DIFF
--- a/openspec/changes/archive/2026-03-15-add-action-logging/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-15-add-action-logging/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-15

--- a/openspec/changes/archive/2026-03-15-add-action-logging/design.md
+++ b/openspec/changes/archive/2026-03-15-add-action-logging/design.md
@@ -1,0 +1,37 @@
+## Context
+
+The `addEmailClaim` Zitadel Action (`cloud-provisioning/src/zitadel/scripts/add-email-claim.js`) injects the `email` claim into JWT access tokens. Currently the script has no logging, making it impossible to determine whether the Action fires, succeeds, or fails silently on Zitadel Cloud.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Add diagnostic logging to `addEmailClaim` so execution is observable via Zitadel Cloud Console Events.
+
+**Non-Goals:**
+- Fixing the root cause of the missing email claim (that depends on what the logs reveal).
+- Adding logging to other Actions or flows.
+
+## Decisions
+
+### Use `zitadel/log` module
+
+**Choice**: `require("zitadel/log")` with `logger.log()` / `logger.warn()`.
+
+**Alternatives considered**:
+- `api.v1.claims.appendLogIntoClaims()` — embeds logs in the JWT. Useful but the current bug causes a 401 before the token reaches the frontend, so these logs would be invisible.
+
+**Rationale**: `zitadel/log` writes to Zitadel's execution log, viewable in the Cloud Console Events UI regardless of whether the token is ultimately accepted by the backend.
+
+### Log on both success and failure paths
+
+- **Success path**: `logger.log()` with the email value — confirms the Action fired and the claim was set.
+- **Failure path**: `logger.warn()` with `JSON.stringify(user)` — captures the actual `user` object structure to diagnose why `user.human.email` is falsy.
+
+### Keep ECMAScript 5.1 compatibility
+
+Zitadel Actions run in an ES5.1 runtime. No optional chaining (`?.`), no template literals, no `const`/`let`.
+
+## Risks / Trade-offs
+
+- **PII in logs**: The email address and user object will appear in Zitadel execution logs. Acceptable in dev; review before enabling in prod. → Mitigation: remove or reduce logging after the bug is resolved.
+- **`JSON.stringify(user)` size**: The user object could be large. → Mitigation: only called in the failure branch, which is the diagnostic scenario.

--- a/openspec/changes/archive/2026-03-15-add-action-logging/proposal.md
+++ b/openspec/changes/archive/2026-03-15-add-action-logging/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+Signup flow fails with `401 Unauthorized: token missing email claim`. The Zitadel `addEmailClaim` Action is supposed to inject the `email` claim into JWT access tokens, but it's unclear whether the Action is firing or failing silently. Without logging, there is no observability into Action execution on Zitadel Cloud.
+
+## What Changes
+
+- Add `zitadel/log` logging to the `addEmailClaim` Action script to log both successful claim injection and failure cases.
+- Log the email value on success and the `user` object structure on failure for diagnostics.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+None. This is a diagnostics-only change to an infrastructure script — no spec-level behavior changes.
+
+## Impact
+
+- **cloud-provisioning**: `src/zitadel/scripts/add-email-claim.js` — add logging via `require("zitadel/log")`
+- **Zitadel Cloud**: Action script update requires `pulumi up` to deploy
+- **No API, schema, or frontend changes**

--- a/openspec/changes/archive/2026-03-15-add-action-logging/tasks.md
+++ b/openspec/changes/archive/2026-03-15-add-action-logging/tasks.md
@@ -1,0 +1,10 @@
+## 1. Implementation
+
+- [x] 1.1 Add `require("zitadel/log")` and logging to `cloud-provisioning/src/zitadel/scripts/add-email-claim.js`
+- [x] 1.2 Run `make check` in cloud-provisioning to verify linting passes
+
+## 2. Deploy & Verify
+
+- [x] 2.1 Run `pulumi preview` to confirm only the Action script resource changes
+- [x] 2.2 Run `pulumi up` to deploy the updated Action to Zitadel Cloud (requires user approval)
+- [x] 2.3 Trigger a signup flow and check Zitadel Console Events for Action logs

--- a/openspec/changes/archive/2026-03-15-force-reauth-dev-signin/proposal.md
+++ b/openspec/changes/archive/2026-03-15-force-reauth-dev-signin/proposal.md
@@ -1,0 +1,19 @@
+## Why
+
+In dev environment, Zitadel's session cookie (`passwordCheckLifetime: 240h`) keeps users authenticated for 10 days without re-prompting for passkey. This makes it impossible to test with different users without manually clearing Zitadel domain cookies. Developers waste time debugging auth flows because the session silently reuses the previous user's credentials.
+
+## What Changes
+
+- **Add `prompt: 'login'` to `signIn()` in dev mode**: When running in dev environment (`import.meta.env.DEV`), pass `prompt: 'login'` to `signinRedirect()` to force Zitadel to re-authenticate via passkey on every sign-in, ignoring existing session cookies.
+- **No change in prod**: Production sign-in continues to reuse sessions for smooth UX.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `frontend-auth-flow`: `signIn()` gains environment-aware prompt parameter. Dev forces re-authentication; prod preserves session reuse.
+
+## Impact
+
+- **Frontend**: `src/services/auth-service.ts` — one-line change to `signIn()`
+- **No backend, proto, or infrastructure changes required**

--- a/openspec/changes/archive/2026-03-15-force-reauth-dev-signin/tasks.md
+++ b/openspec/changes/archive/2026-03-15-force-reauth-dev-signin/tasks.md
@@ -1,0 +1,7 @@
+## Tasks
+
+### Frontend
+
+- [x] **FE-1**: Add environment-aware `prompt` parameter to `signIn()` in `auth-service.ts`
+  - Pass `prompt: 'login'` when `import.meta.env.DEV` is true
+  - No parameter in production (existing behavior preserved)


### PR DESCRIPTION
## Summary
Archive completed OpenSpec change artifacts:
- `add-action-logging`: Zitadel Action logging for debugging email claim issues
- `force-reauth-dev-signin`: Force re-authentication in dev environment

## Test plan
- [x] No code changes, documentation only
