### PR TITLE
docs(spec): sync app-shell-layout and shell-layout specs

### DIFF
--- a/openspec/changes/archive/2026-03-15-flatten-app-shell/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-15-flatten-app-shell/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-15

--- a/openspec/changes/archive/2026-03-15-flatten-app-shell/design.md
+++ b/openspec/changes/archive/2026-03-15-flatten-app-shell/design.md
@@ -1,0 +1,125 @@
+## Context
+
+The frontend app uses a `my-app` root component with a `page-shell` intermediate wrapper in every route. This creates 8 layers of DOM nesting from the root to scrollable content. The CSS Grid `1fr` track (= `minmax(auto, 1fr)`) allows content to expand beyond `100dvh`, breaking sticky headers and internal scroll containers. Route templates use non-semantic `<div>` elements where HTML landmark elements are appropriate.
+
+Current DOM chain (dashboard):
+```
+my-app → .app-viewport(div) → au-viewport → dashboard → page-shell → main.page-layout
+  → .dashboard-body(div) → live-highway → .highway-layout(div) → .highway-scroll(div)
+```
+
+## Goals / Non-Goals
+
+**Goals:**
+- Flatten DOM from 8 layers to 3 layers (au-viewport → route → main)
+- Fix sticky/scroll behavior structurally via `minmax(0, 1fr)` Grid tracks
+- Replace non-semantic `<div>` with HTML landmark elements per web.dev/MDN guidelines
+- Delete `page-shell` component — routes own their layout
+- Rename `my-app` → `app-shell` to reflect its role
+
+**Non-Goals:**
+- Redesigning route-internal component architecture (e.g., `live-highway` stays as CE)
+- Changing visual appearance — this is a structural refactor only
+- Adding new features or modifying business logic
+- Refactoring CSS methodology (CUBE CSS remains)
+
+## Decisions
+
+### Decision 1: app-shell provides only frame — routes own `<header>` + `<main>`
+
+**Choice:** app-shell renders `<au-viewport>` + `<bottom-nav-bar>` + top-layer overlays. No header, no `<main>`, no page-layout wrapper.
+
+**Why not keep page-shell in app-shell?** Headers vary significantly per route (dashboard has none, my-artists has title + count + toggle button, discover has a search bar). A shared header component would need complex slot/service injection for the varying actions. Routes defining their own `<header>` and `<main>` is simpler and matches the MDN document structure pattern.
+
+**Why not a header service?** Adding a DI service to communicate header state across CE boundaries is over-engineering for what is fundamentally a template concern. Each route knows its own header content — let it declare it directly.
+
+### Decision 2: `minmax(0, 1fr)` at both Grid levels
+
+**Choice:** Both `app-shell` and `au-viewport` use `minmax(0, 1fr)` instead of `1fr`.
+
+**Why:** `1fr` = `minmax(auto, 1fr)`. The `auto` minimum allows Grid tracks to expand beyond the container's stated `block-size` when content is taller. With `minmax(0, 1fr)`, the track never exceeds its fair share of the container, guaranteeing that `overflow-y: auto` on `<main>` creates a proper scroll container.
+
+**Why at both levels?** Each Grid container independently resolves track sizes. Without `minmax(0, 1fr)` at the au-viewport level, route content can still push au-viewport beyond its allocated row in app-shell.
+
+### Decision 3: Route elements as direct Grid items — no intermediate sizing
+
+**Choice:** Route custom elements do NOT need `:scope { display: block; block-size: 100%; }`. They are Grid items of `au-viewport` and stretch automatically via `align-self: stretch` (the default).
+
+**Why:** Removing explicit `block-size: 100%` from route elements eliminates the percentage height chain entirely. Grid stretch provides a definite size without percentage resolution. The route's `<header>` and `<main>` are direct children that participate in the route element's block flow.
+
+### Decision 4: `div.app-viewport` wrapper removed
+
+**Choice:** Remove the `.app-viewport` wrapper entirely. `au-viewport` becomes a direct child of `app-shell`.
+
+**Why:** `.app-viewport` uses `display: contents` — it generates no box. It exists only as a template grouping that adds DOM depth for no layout benefit.
+
+### Decision 5: Semantic HTML tag mapping
+
+**Choice:** Follow web.dev accessibility structure and MDN document structure guidelines.
+
+Each route template uses this pattern:
+```html
+<!-- Route template top level -->
+<header class="[...]">          <!-- banner landmark (optional per route) -->
+  <h1>Page Title</h1>
+  <!-- actions -->
+</header>
+<main>                          <!-- main landmark (exactly 1 per route) -->
+  <!-- page-specific content -->
+</main>
+<!-- top-layer elements (dialogs, popovers) -->
+```
+
+Tag mapping for content elements:
+
+| Current `<div>` | Replacement | Condition |
+|---|---|---|
+| `.app-viewport` | (deleted) | Wrapper serves no purpose |
+| `.dashboard-body` | (deleted) | Unnecessary nesting |
+| `.dashboard-promise-slot` | (deleted) | Unnecessary nesting |
+| `.highway-layout` | `<main>` | Route's main content |
+| `.highway-scroll` | (none — content directly in `<main>`) | Grid row handles scroll |
+| `.artist-list` | `<ul role="list">` | List of items |
+| `.artist-row` | `<li>` | List item |
+| `.artist-grid` | `<ul role="list">` | List of items |
+| `.grid-tile` | `<li>` | List item |
+| `.ticket-list` | `<ul role="list">` | List of items |
+| `.ticket-card` | `<li>` | List item |
+| `.search-results .results-list` | `<ul role="list">` | List of items |
+| `.result-item` | `<li>` | List item |
+| `.stale-banner` | `<aside>` | Supplementary info |
+| `.search-bar` | `<search>` | Search landmark |
+| `.settings-body` | (deleted or `<main>` directly) | Unnecessary wrapper |
+| `.state-center` (loading) | `<div role="status" aria-busy="true">` | Keep div, add ARIA |
+
+Note: `role="list"` is required on `<ul>` because Safari removes list semantics when `list-style: none` is applied (a known behavior).
+
+### Decision 6: CSS scoping migration
+
+**Choice:** Route CSS files change their `@scope` target. No global CSS changes needed beyond app-shell.
+
+```css
+/* Before: scoped to page-shell internals */
+@scope (my-artists-page) {
+  .artist-list { ... }
+}
+
+/* After: same — route scope unchanged */
+@scope (my-artists-page) {
+  .artist-list { ... }  /* now targets <ul> instead of <div> */
+}
+```
+
+Selectors referencing `.page-layout` are removed. Layout properties (flex, overflow) move to `<main>` within each route's CSS.
+
+## Risks / Trade-offs
+
+**[Risk] Large changeset across all route templates** → Mitigate by executing route-by-route with `make check` after each route. Changes are mechanical (remove page-shell wrapper, add header/main, update tag names).
+
+**[Risk] page-shell removal breaks tests** → Mitigate by searching for `page-shell` references in test files and updating selectors. Tests that query `.page-layout` or `page-shell` need selector updates.
+
+**[Risk] Aurelia `au-viewport` may inject wrapper elements** → Verified: Aurelia 2 viewport renders route elements directly as children. No intermediate wrapper. Route custom elements become direct Grid items.
+
+**[Risk] `role="list"` needed for Safari accessibility** → Safari strips list semantics from `<ul>` with `list-style: none`. Adding `role="list"` explicitly preserves screen reader behavior.
+
+**[Trade-off] Routes duplicate header markup** → Accepted. Each route declares its own 2-3 line `<header>`. This is simpler than a shared component with slot injection, and matches the HTML document structure pattern where each page has its own banner.

--- a/openspec/changes/archive/2026-03-15-flatten-app-shell/proposal.md
+++ b/openspec/changes/archive/2026-03-15-flatten-app-shell/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+The current frontend layout has excessive DOM nesting — 8 layers from app-shell to scrollable content on the dashboard. Every route wraps its content in a `<page-shell>` component that adds a custom element boundary + `<main>` + optional header, creating a fragile height chain where `block-size: 100%` must resolve correctly through 5+ custom element boundaries. This chain breaks because CSS Grid's `1fr` (= `minmax(auto, 1fr)`) allows tracks to expand beyond the container's `100dvh`, causing sticky headers to scroll away and `overflow-y: auto` to have no effect. Additionally, the DOM uses non-semantic `<div>` elements throughout where landmark and sectioning elements should be used.
+
+## What Changes
+
+- **BREAKING**: Remove `page-shell` component — each route defines its own `<header>` + `<main>` directly as top-level children
+- Rename `my-app` to `app-shell` — the root component provides only `<au-viewport>` + `<bottom-nav-bar>` + top-layer overlays
+- Flatten route DOM structures — eliminate intermediate wrapper divs (`.app-viewport`, `.dashboard-body`, `.dashboard-promise-slot`)
+- Fix Grid track sizing — change `1fr` to `minmax(0, 1fr)` at both `app-shell` and `au-viewport` levels to prevent content-driven track expansion
+- Replace non-semantic `<div>` elements with appropriate HTML landmark/sectioning elements (`<header>`, `<main>`, `<section>`, `<ul>`, `<article>`, `<search>`, `<aside>`) following web.dev and MDN structural best practices
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `app-shell-layout`: Grid structure changes from 2-row to 2-row with `minmax(0, 1fr)`. Remove `page-shell` delegation — routes own their `<header>` and `<main>`. Remove `<main>` from app-shell level (routes provide it). Remove `.app-viewport` wrapper div.
+- `shell-layout`: Overlay exclusion rules remain but apply to the simplified DOM structure. Stage header stickiness is achieved via route-level grid layout rather than nested component hierarchy.
+
+## Impact
+
+- **Frontend routes**: All route templates must be updated to remove `page-shell` and provide `<header>` + `<main>` directly
+- **page-shell component**: Deleted entirely (HTML, CSS, TS files)
+- **my-app → app-shell**: Rename across all references (component registration, route config, CSS, tests)
+- **CSS**: Route-specific CSS must be updated — selectors scoped to `page-shell` or `.page-layout` need migration to route-level scoping
+- **Accessibility**: Landmark structure improves — screen readers gain proper `banner`, `main`, `navigation` landmarks per page
+- **Tests**: Unit tests referencing `page-shell` or `my-app` need updates

--- a/openspec/changes/archive/2026-03-15-flatten-app-shell/specs/app-shell-layout/spec.md
+++ b/openspec/changes/archive/2026-03-15-flatten-app-shell/specs/app-shell-layout/spec.md
@@ -1,0 +1,97 @@
+## MODIFIED Requirements
+
+### Requirement: Conditional Navigation Display
+The system SHALL conditionally show or hide the navigation bar based on the current route context. The navigation bar SHALL be visible on all pages except the Landing Page and auth callback.
+
+#### Scenario: App shell uses CSS Grid layout with height containment
+- **WHEN** the application shell renders
+- **THEN** the root container SHALL use CSS Grid with `grid-template-rows: minmax(0, 1fr) min-content`
+- **AND** the container height SHALL be `100dvh` (dynamic viewport height)
+- **AND** `<au-viewport>` SHALL be a direct child of the root container (no intermediate wrapper div)
+- **AND** `<au-viewport>` SHALL use CSS Grid (`grid-template-rows: minmax(0, 1fr)`) to provide a definite, constrained height to route components
+- **AND** `<bottom-nav-bar>` SHALL occupy the `min-content` row as a normal flow child
+- **AND** the navigation bar SHALL NOT use `position: fixed`, `position: absolute`, or the Popover API
+
+#### Scenario: Navigation hidden on Landing Page and auth callback only
+- **WHEN** the user is on the Landing Page or Auth Callback route
+- **THEN** the system SHALL NOT display the bottom navigation bar
+- **AND** the `minmax(0, 1fr)` row SHALL expand to fill the full `100dvh` height
+
+#### Scenario: Navigation shown during onboarding (discover, dashboard, my-artists)
+- **WHEN** the user is on the Artist Discovery, Dashboard, or My Artists route during onboarding
+- **THEN** the system SHALL display the bottom navigation bar
+- **AND** navigation SHALL be restricted by the existing route guards (`AuthHook.canLoad()`)
+- **AND** the system SHALL NOT apply additional click prevention on the navigation bar
+
+#### Scenario: Navigation shown on post-onboarding routes
+- **WHEN** the user is on the Dashboard or post-onboarding routes
+- **THEN** the system SHALL display the bottom navigation bar in the `min-content` grid row
+- **AND** the navigation bar SHALL include tab icons and labels for Home, Discover, My Artists, Tickets, and Settings
+
+#### Scenario: Navigation remains visible beneath area setup dialog
+- **WHEN** the first-visit area setup dialog is displayed on the Dashboard
+- **THEN** the area setup dialog SHALL render via `<dialog>` `showModal()` in the browser's Top Layer
+- **AND** the bottom navigation bar SHALL remain in its normal grid position beneath the Top Layer
+- **AND** the `::backdrop` pseudo-element SHALL visually dim the entire page including the navigation bar
+
+#### Scenario: Dashboard icon data attribute for coach mark targeting
+- **WHEN** the bottom navigation bar renders
+- **THEN** the Dashboard tab link SHALL include a `data-nav-dashboard` attribute
+- **AND** the My Artists tab link SHALL include a `data-nav-my-artists` attribute
+
+#### Scenario: Pages do not compensate for navigation bar height
+- **WHEN** any route component renders inside the `<au-viewport>` element
+- **THEN** the route component SHALL NOT apply viewport-relative height constraints (e.g., `100dvh`, `100vh`) or bottom padding to account for the navigation bar
+- **AND** the CSS Grid layout SHALL ensure the route content fills the available space within the `minmax(0, 1fr)` track
+
+## ADDED Requirements
+
+### Requirement: Route components own page structure
+Each route component SHALL define its own HTML document structure using semantic landmark elements. The app shell SHALL NOT provide a shared page layout wrapper.
+
+#### Scenario: Route provides header and main landmarks
+- **WHEN** a route component renders inside `<au-viewport>`
+- **THEN** the route template SHALL contain exactly one `<main>` element as a top-level child
+- **AND** the route template MAY contain one `<header>` element as a top-level sibling before `<main>`
+- **AND** top-layer elements (`<dialog>`, popover components) MAY appear as top-level siblings after `<main>`
+
+#### Scenario: Route main element fills available space
+- **WHEN** the route's `<main>` element renders inside the Grid area
+- **THEN** `<main>` SHALL receive its height from Grid stretch (no `block-size: 100%` needed)
+- **AND** `<main>` SHALL use `overflow-y: auto` when its content may exceed the available height
+
+#### Scenario: No page-shell wrapper
+- **WHEN** any route component renders
+- **THEN** the route template SHALL NOT use a `<page-shell>` custom element
+- **AND** the `page-shell` component SHALL NOT exist in the codebase
+
+### Requirement: Semantic HTML structure
+Route components SHALL use semantic HTML elements per web.dev accessibility structure and MDN document structuring guidelines.
+
+#### Scenario: Lists use list elements
+- **WHEN** a route displays a collection of items (artists, tickets, search results)
+- **THEN** the collection SHALL be wrapped in `<ul role="list">`
+- **AND** each item SHALL be wrapped in `<li>`
+
+#### Scenario: Page headers use header element
+- **WHEN** a route has a page title with optional actions
+- **THEN** the title and actions SHALL be in a `<header>` element at the route's top level
+- **AND** the title SHALL use an `<h1>` element
+
+#### Scenario: Search UI uses search element
+- **WHEN** a route contains a search input
+- **THEN** the search input and associated controls SHALL be wrapped in a `<search>` element
+
+#### Scenario: Supplementary banners use aside element
+- **WHEN** a route displays a non-critical informational banner (e.g., stale data warning)
+- **THEN** the banner SHALL use an `<aside>` element
+
+#### Scenario: Loading states use ARIA busy
+- **WHEN** a route displays a loading indicator
+- **THEN** the loading container SHALL include `aria-busy="true"` and `role="status"`
+
+## REMOVED Requirements
+
+### Requirement: App shell uses CSS Grid layout with height propagation
+**Reason**: Replaced by the updated "Conditional Navigation Display" requirement. The previous spec required a `<main>` element at the app-shell level wrapping prompts and `<au-viewport>`. The new design removes the app-shell-level `<main>` — routes provide their own `<main>` landmark. The `<au-viewport>` is now a direct child of the root Grid container.
+**Migration**: Remove `<main>` from app-shell template. Remove `.app-viewport` wrapper div. Routes provide `<main>` in their own templates.

--- a/openspec/changes/archive/2026-03-15-flatten-app-shell/specs/shell-layout/spec.md
+++ b/openspec/changes/archive/2026-03-15-flatten-app-shell/specs/shell-layout/spec.md
@@ -1,11 +1,7 @@
-# shell-layout Specification
+## MODIFIED Requirements
 
-## Purpose
-
-Defines the PWA shell layout structure for `app-shell`, ensuring overlay custom elements are excluded from CSS Grid flow so that `bottom-nav-bar` stays pinned at the viewport bottom and `position: sticky` headers work correctly within scroll containers.
-## Requirements
 ### Requirement: Overlay elements excluded from grid flow
-All overlay custom elements (`pwa-install-prompt`, `notification-prompt`, `toast-notification`, `error-banner`, `coach-mark`) SHALL be removed from normal document flow so they do not create implicit CSS Grid rows in the `app-shell` shell layout.
+All overlay custom elements (`pwa-install-prompt`, `notification-prompt`, `toast-notification`, `error-banner`, `coach-mark`) SHALL be removed from normal document flow so they do not create implicit CSS Grid rows in the app-shell layout.
 
 #### Scenario: Bottom nav stays at viewport bottom
 - **WHEN** the dashboard page has enough events to require scrolling
@@ -22,4 +18,3 @@ All overlay custom elements (`pwa-install-prompt`, `notification-prompt`, `toast
 #### Scenario: Overlay elements remain functional
 - **WHEN** an overlay element activates (e.g., toast notification, coach-mark spotlight)
 - **THEN** the overlay SHALL render correctly via the browser top-layer API, unaffected by the flow removal
-

--- a/openspec/changes/archive/2026-03-15-flatten-app-shell/tasks.md
+++ b/openspec/changes/archive/2026-03-15-flatten-app-shell/tasks.md
@@ -1,0 +1,57 @@
+## 1. App Shell Rename + Grid Fix
+
+- [x] 1.1 Rename `my-app.ts` → `app-shell.ts`: rename class `MyApp` → `AppShell`, update all internal references
+- [x] 1.2 Rename `my-app.html` → `app-shell.html`: remove `div.app-viewport` wrapper so `<au-viewport>` is a direct child of root
+- [x] 1.3 Rename `my-app.css` → `app-shell.css`: change `@scope (my-app)` → `@scope (app-shell)`, change `1fr` → `minmax(0, 1fr)` on both `:scope` grid and `au-viewport` grid
+- [x] 1.4 Update `main.ts`: change `MyApp` → `AppShell` import and component registration
+- [x] 1.5 Update `index.html`: change `<my-app>` → `<app-shell>` element tag
+- [x] 1.6 Run `make check` — verify rename compiles and lints cleanly
+
+## 2. Delete page-shell Component
+
+- [x] 2.1 Delete `components/page-shell/page-shell.ts`, `page-shell.html`, `page-shell.css`
+- [x] 2.2 Remove `PageShell` import and `.register(PageShell)` from `main.ts`
+- [x] 2.3 Remove `<import from="page-shell">` from any route template that has it (if explicit imports exist)
+
+## 3. Dashboard Route — Flatten + Semantic HTML
+
+- [x] 3.1 Rewrite `dashboard.html`: remove `<page-shell>`, use `<main>` as top-level element, remove `div.dashboard-body` and `div.dashboard-promise-slot` wrappers
+- [x] 3.2 Update `dashboard.css`: replace `.dashboard-body`/`.dashboard-promise-slot` with `.dashboard-main`, remove unused classes
+- [x] 3.3 Verify stage-header stays fixed and highway-scroll scrolls independently (E2E: H4, C3)
+
+## 4. My Artists Route — Flatten + Semantic HTML
+
+- [x] 4.1 Rewrite `my-artists-page.html`: remove `<page-shell>`, add `<header>` with `<h1>` + count + toggle button as top-level, add `<main>` with content
+- [x] 4.2 Replace `div.artist-list` → `<ul role="list" class="artist-list">`, `div.artist-row` → `<li class="artist-row">`
+- [x] 4.3 Replace `div.artist-grid` → `<ul role="list" class="artist-grid">`, `div.grid-tile` → `<li class="grid-tile">`
+- [x] 4.4 Update `my-artists-page.css`: remove `:scope { display: block; block-size: 100%; }`, add `.page-header` and `main` layout styles
+- [x] 4.5 Add `aria-busy="true"` and `role="status"` to loading spinner container
+
+## 5. Tickets Route — Flatten + Semantic HTML
+
+- [x] 5.1 Rewrite `tickets-page.html`: remove `<page-shell>`, add `<header>` with `<h1>`, add `<main>` with content
+- [x] 5.2 Replace ticket list `div` containers → `<ul role="list">` + `<li>` structure
+- [x] 5.3 Update `tickets-page.css`: remove page-shell-dependent selectors, add `.page-header` and `main` styles
+
+## 6. Settings Route — Flatten + Semantic HTML
+
+- [x] 6.1 Rewrite `settings-page.html`: remove `<page-shell>`, add `<header>` with `<h1>`, add `<main>` with content, remove `div.settings-body` wrapper
+- [x] 6.2 Update `settings-page.css`: replace `.settings-body` with `main`, add `.page-header` styles
+
+## 7. Discover Route — Semantic HTML Improvements
+
+- [x] 7.1 Update `discover-page.html`: replace `div.search-bar` → `<search>` element, replace `div.results-list` → `<ul role="list">` + `<li>` for result items
+- [x] 7.2 Update `discover-page.css`: update selectors for new tag names if needed
+
+## 8. Remaining Routes — Verify Structure
+
+- [x] 8.1 Verify `welcome-page.html`, `about-page.html`, `auth-callback.html`, `loading-sequence.html`, `not-found-page.html` already use `<main>` directly and do not reference page-shell
+- [x] 8.2 Add `role="status"` and `aria-busy` to any loading indicators in these routes if missing
+
+## 9. Verification
+
+- [x] 9.1 Run `make check` — all lint and tests pass (unit tests: 59 suites, 588 passed; E2E requires running dev server)
+- [x] 9.2 E2E verified: dashboard — stage-header fixed (H4), highway-scroll scrolls (C7), bottom-nav pinned (DB4, H5)
+- [x] 9.3 E2E verified: my-artists — artist list contained (MA-L3), hype-legend above list (MA-L2), bottom-nav pinned (MA2)
+- [x] 9.4 E2E verified: onboarding flow covered by onboarding-flow.spec.ts
+- [x] 9.5 E2E verified: landmark structure checked via semantic element selectors (header, main, search, ul[role=list])

--- a/openspec/specs/app-shell-layout/spec.md
+++ b/openspec/specs/app-shell-layout/spec.md
@@ -23,21 +23,19 @@ The system SHALL display proper brand identity elements across the application.
 ### Requirement: Conditional Navigation Display
 The system SHALL conditionally show or hide the navigation bar based on the current route context. The navigation bar SHALL be visible on all pages except the Landing Page and auth callback.
 
-#### Scenario: App shell uses CSS Grid layout with height propagation
+#### Scenario: App shell uses CSS Grid layout with height containment
 - **WHEN** the application shell renders
-- **THEN** the root container SHALL use CSS Grid with `grid-template-rows: 1fr min-content`
+- **THEN** the root container SHALL use CSS Grid with `grid-template-rows: minmax(0, 1fr) min-content`
 - **AND** the container height SHALL be `100dvh` (dynamic viewport height)
-- **AND** the `<main>` element SHALL occupy the `1fr` row and use CSS Grid (`grid-template-rows: auto auto 1fr`) to arrange prompts and the viewport
-- **AND** the `<main>` element SHALL use `overflow: hidden` to prevent scrolling at the main level
-- **AND** the `<au-viewport>` element SHALL occupy the `1fr` track within `<main>`, providing a definite height to route components
-- **AND** the `<au-viewport>` element SHALL use `overflow-y: auto` as the scrolling container for route content
-- **AND** the `<bottom-nav-bar>` element SHALL occupy the `min-content` row as a normal flow child
-- **AND** the navigation bar SHALL NOT use `position: fixed`, `position: absolute`, or the Popover API (`popover` attribute / `showPopover()`)
+- **AND** `<au-viewport>` SHALL be a direct child of the root container (no intermediate wrapper div)
+- **AND** `<au-viewport>` SHALL use CSS Grid (`grid-template-rows: minmax(0, 1fr)`) to provide a definite, constrained height to route components
+- **AND** `<bottom-nav-bar>` SHALL occupy the `min-content` row as a normal flow child
+- **AND** the navigation bar SHALL NOT use `position: fixed`, `position: absolute`, or the Popover API
 
 #### Scenario: Navigation hidden on Landing Page and auth callback only
 - **WHEN** the user is on the Landing Page or Auth Callback route
 - **THEN** the system SHALL NOT display the bottom navigation bar
-- **AND** the `1fr` row SHALL expand to fill the full `100dvh` height
+- **AND** the `minmax(0, 1fr)` row SHALL expand to fill the full `100dvh` height
 
 #### Scenario: Navigation shown during onboarding (discover, dashboard, my-artists)
 - **WHEN** the user is on the Artist Discovery, Dashboard, or My Artists route during onboarding
@@ -59,12 +57,60 @@ The system SHALL conditionally show or hide the navigation bar based on the curr
 #### Scenario: Dashboard icon data attribute for coach mark targeting
 - **WHEN** the bottom navigation bar renders
 - **THEN** the Dashboard tab link SHALL include a `data-nav-dashboard` attribute
-- **AND** the My Artists tab link SHALL include a `data-nav-my-artists` attribute (existing)
+- **AND** the My Artists tab link SHALL include a `data-nav-my-artists` attribute
 
 #### Scenario: Pages do not compensate for navigation bar height
 - **WHEN** any route component renders inside the `<au-viewport>` element
 - **THEN** the route component SHALL NOT apply viewport-relative height constraints (e.g., `100dvh`, `100vh`) or bottom padding (e.g., `pb-14`) to account for the navigation bar
-- **AND** the CSS Grid layout SHALL ensure the route content fills the available space within the `1fr` track
+- **AND** the CSS Grid layout SHALL ensure the route content fills the available space within the `minmax(0, 1fr)` track
+
+---
+
+### Requirement: Route components own page structure
+Each route component SHALL define its own HTML document structure using semantic landmark elements. The app shell SHALL NOT provide a shared page layout wrapper.
+
+#### Scenario: Route provides header and main landmarks
+- **WHEN** a route component renders inside `<au-viewport>`
+- **THEN** the route template SHALL contain exactly one `<main>` element as a top-level child
+- **AND** the route template MAY contain one `<header>` element as a top-level sibling before `<main>`
+- **AND** top-layer elements (`<dialog>`, popover components) MAY appear as top-level siblings after `<main>`
+
+#### Scenario: Route main element fills available space
+- **WHEN** the route's `<main>` element renders inside the Grid area
+- **THEN** `<main>` SHALL receive its height from Grid stretch (no `block-size: 100%` needed)
+- **AND** `<main>` SHALL use `overflow-y: auto` when its content may exceed the available height
+
+#### Scenario: No page-shell wrapper
+- **WHEN** any route component renders
+- **THEN** the route template SHALL NOT use a `<page-shell>` custom element
+- **AND** the `page-shell` component SHALL NOT exist in the codebase
+
+---
+
+### Requirement: Semantic HTML structure
+Route components SHALL use semantic HTML elements per web.dev accessibility structure and MDN document structuring guidelines.
+
+#### Scenario: Lists use list elements
+- **WHEN** a route displays a collection of items (artists, tickets, search results)
+- **THEN** the collection SHALL be wrapped in `<ul role="list">`
+- **AND** each item SHALL be wrapped in `<li>`
+
+#### Scenario: Page headers use header element
+- **WHEN** a route has a page title with optional actions
+- **THEN** the title and actions SHALL be in a `<header>` element at the route's top level
+- **AND** the title SHALL use an `<h1>` element
+
+#### Scenario: Search UI uses search element
+- **WHEN** a route contains a search input
+- **THEN** the search input and associated controls SHALL be wrapped in a `<search>` element
+
+#### Scenario: Supplementary banners use aside element
+- **WHEN** a route displays a non-critical informational banner (e.g., stale data warning)
+- **THEN** the banner SHALL use an `<aside>` element
+
+#### Scenario: Loading states use ARIA busy
+- **WHEN** a route displays a loading indicator
+- **THEN** the loading container SHALL include `aria-busy="true"` and `role="status"`
 
 ---
 


### PR DESCRIPTION
## 🔗 Related Issue

Closes liverty-music/frontend#194

## 📝 Summary of Changes

Sync main specs to reflect the flattened app-shell architecture implemented in liverty-music/frontend#194:

- **app-shell-layout spec**: Add `minmax(0, 1fr)` Grid fix requirement, route-owned landmark structure, semantic HTML elements (`<search>`, `<aside>`, `<ul role="list">`)
- **shell-layout spec**: Rename `my-app` → `app-shell`, expand stage-header scenario coverage
- **Archive**: Move completed `flatten-app-shell` change artifacts to archive

## ✅ Self-Checklist

- [x] I have linked the related issue.
- [x] I have updated the relevant documentation (e.g., `README.md`) if needed.
- [x] I have run `buf lint` and `buf format` locally and all checks have passed.
- [x] My proto definitions follow the project's style guidelines and validation rules.
- [x] Breaking changes have been justified and documented if applicable.