### PR TITLE
docs(openspec): archive fix-settings-page-bugs

### DIFF
--- a/openspec/changes/archive/2026-03-16-fix-settings-page-bugs/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-16-fix-settings-page-bugs/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-16

--- a/openspec/changes/archive/2026-03-16-fix-settings-page-bugs/design.md
+++ b/openspec/changes/archive/2026-03-16-fix-settings-page-bugs/design.md
@@ -1,0 +1,9 @@
+## Context
+
+Small bugfix — no design artifact needed. Both fixes are straightforward data-flow corrections in existing components.
+
+## Decisions
+
+1. **Home area i18n key**: Store the romaji i18n key (via `translationKey()`) instead of the Japanese display name (via `shortDisplayName()`). This aligns `currentHome` with the i18n translation file keys.
+
+2. **Language selector UI**: Use a bottom sheet dialog (same pattern as `UserHomeSelector`) rather than the immediate `cycleLanguage()` toggle. Consistent UX across settings page interactions.

--- a/openspec/changes/archive/2026-03-16-fix-settings-page-bugs/proposal.md
+++ b/openspec/changes/archive/2026-03-16-fix-settings-page-bugs/proposal.md
@@ -1,0 +1,46 @@
+# Fix Settings Page Bugs
+
+**Status:** proposed
+**Repos:** frontend
+**Type:** bugfix
+
+## Problem
+
+Two bugs on the Settings page (`/settings`):
+
+### 1. Home area displays raw i18n key
+
+The "ホームエリア" row shows `userHome.prefectures.福岡` instead of the translated prefecture name (e.g., "福岡").
+
+**Root cause:** `currentHome` stores the Japanese display name via `shortDisplayName()` (e.g., `'福岡'`), but the i18n translation keys use romaji (e.g., `'fukuoka'`). The lookup `i18n.tr('userHome.prefectures.福岡')` fails and i18next returns the key as-is.
+
+### 2. Language selector toggles immediately instead of showing a menu
+
+Tapping the "言語" row instantly cycles `ja → en → ja` instead of presenting a selection UI. The chevron icon (`>`) implies a menu will open, but no menu exists.
+
+## Solution
+
+### Bug 1: Store i18n key instead of display name
+
+Add a `translationKey()` function to `iso3166.ts` that maps an ISO code to its i18n key (the existing `entry.key` field). Replace `shortDisplayName()` usage in `settings-page.ts` with this function.
+
+- `settings-page.ts` line 42: `shortDisplayName(code)` → `translationKey(code)`
+- `settings-page.ts` line 55: same change
+- `shortDisplayName` import removed (function itself kept if used elsewhere, deleted if unused)
+
+### Bug 2: Replace cycle with language selection UI
+
+Replace `cycleLanguage()` with a proper selection mechanism. Since only 2 languages exist (`ja`, `en`), a lightweight approach is appropriate:
+
+- **Option A:** Bottom sheet (consistent with home area selector pattern)
+- **Option B:** Inline radio/list within the settings card
+
+Recommend **Option A** for consistency with existing UX patterns, but keep implementation minimal given only 2 options.
+
+## Scope
+
+- `frontend/src/constants/iso3166.ts` — add `translationKey()` export
+- `frontend/src/routes/settings/settings-page.ts` — fix `currentHome` storage, replace `cycleLanguage()`
+- `frontend/src/routes/settings/settings-page.html` — update language row to open selector
+- New component or inline template for language selection UI
+- Update affected tests

--- a/openspec/changes/archive/2026-03-16-fix-settings-page-bugs/proposal.md
+++ b/openspec/changes/archive/2026-03-16-fix-settings-page-bugs/proposal.md
@@ -1,6 +1,5 @@
 # Fix Settings Page Bugs
 
-**Status:** proposed
 **Repos:** frontend
 **Type:** bugfix
 

--- a/openspec/changes/archive/2026-03-16-fix-settings-page-bugs/tasks.md
+++ b/openspec/changes/archive/2026-03-16-fix-settings-page-bugs/tasks.md
@@ -1,0 +1,10 @@
+# Tasks
+
+## frontend
+
+- [x] Add `translationKey(code: string): string` to `iso3166.ts` that returns `entry.key` for an ISO code
+- [x] In `settings-page.ts`, replace `shortDisplayName(code)` with `translationKey(code)` in both `loading()` and `onHomeSelected()`
+- [x] Remove `shortDisplayName` import from `settings-page.ts`; delete the function from `iso3166.ts` if no other consumers exist
+- [x] Replace `cycleLanguage()` with a language selector UI (bottom sheet or inline list)
+- [x] Update `settings-page.html` language row to open the selector instead of calling `cycleLanguage()`
+- [x] Update unit tests for settings page


### PR DESCRIPTION
## Description

Archive the completed fix-settings-page-bugs OpenSpec change.

This change fixed two bugs on the frontend settings page:
1. Home area displaying raw i18n key instead of translated name
2. Language selector toggling immediately instead of showing a selection UI

Implementation PR: liverty-music/frontend#199

## Type of Change

- [x] docs: Documentation only changes

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
