### PR TITLE
docs(specs): update layout specs for route :scope grid pattern

### DIFF
--- a/openspec/changes/archive/2026-03-16-fix-header-footer-scroll/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-16-fix-header-footer-scroll/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-15

--- a/openspec/changes/archive/2026-03-16-fix-header-footer-scroll/design.md
+++ b/openspec/changes/archive/2026-03-16-fix-header-footer-scroll/design.md
@@ -1,0 +1,98 @@
+## Context
+
+The bottom-nav-bar and page headers scroll with content on dashboard, my-artists, tickets, and settings pages. The existing specs (`app-shell-layout`, `shell-layout`) prescribe height containment via `au-viewport { display: grid }` in `app-shell.css`, but this approach has a fundamental flaw: it skips the route component CE boundary.
+
+Investigation of Aurelia 2 source code (`packages/router/src/resources/viewport.ts`) confirmed that `au-viewport` is a template-less custom element. Routed components are attached via `appendChild`. As a CSS Grid item, `au-viewport` undergoes blockification and receives `align-self: stretch`, giving it a definite block-size without any explicit styling.
+
+The current architecture violates CUBE CSS methodology by having `app-shell.css` style `au-viewport` and `live-highway` — components that should own their own display.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Fix header/footer scrolling on all route pages
+- Establish a clear height-constraint chain from `app-shell` through every CE boundary
+- Each route component declares its own layout structure via `:scope` with `grid-template-areas`
+- Remove cross-component styling from `app-shell.css`
+- Convert stale-banner from grid row to fixed overlay
+
+**Non-Goals:**
+- Extract shared `<page-header>` CE (follow-up task — reduces duplication but separate scope)
+- Change app-shell grid to use `position: fixed` for bottom-nav-bar (current grid approach is correct)
+- Modify any business logic or routing behavior
+
+## Decisions
+
+### D1: Route components declare `:scope` grid layout with `grid-template-areas`
+
+Every route component starts with:
+```css
+:scope {
+    display: grid;
+    grid-template-areas: "header" "main";  /* varies per page */
+    grid-template-rows: auto 1fr;
+    block-size: 100%;
+    min-block-size: 0;
+}
+```
+
+**Why `block-size: 100%`**: `au-viewport` has a definite block-size from grid stretch. `100%` passes this through the CE boundary.
+
+**Why `min-block-size: 0`**: Grid items default to `min-block-size: auto`, preventing shrink below content size. `0` allows descendants to activate `overflow`.
+
+**Why `grid-template-areas`**: Makes layout structure self-documenting. A developer reads the CSS and immediately sees the page skeleton.
+
+**Alternative considered**: `display: flex; flex-direction: column` — rejected because grid-template-areas provides better readability and flex-based layouts are what currently cause the confusion with orphaned `flex: 1` / `flex-shrink: 0` properties.
+
+### D2: app-shell only styles itself
+
+Remove `au-viewport { ... }` and `live-highway { ... }` rules. App-shell declares only:
+```css
+:scope {
+    display: grid;
+    grid-template-areas: "viewport" "nav";
+    grid-template-rows: 1fr auto;
+    block-size: 100dvh;
+}
+```
+
+**Why not `minmax(0, 1fr)`**: With `min-block-size: 0` set on each route component's `:scope`, the min-content constraint is handled at each CE boundary rather than at the app-shell level. `1fr` is simpler and sufficient.
+
+**Alternative considered**: Keep `au-viewport` styling but add route `:scope` — rejected because external CE styling is the root cause of fragility and CUBE CSS violations.
+
+### D3: live-highway owns its display
+
+Move from app-shell.css to live-highway.css `:scope`:
+```css
+:scope {
+    display: block;
+    block-size: 100%;
+    min-block-size: 0;
+}
+```
+
+### D4: Stale-banner becomes fixed overlay
+
+The stale-data warning is a transient status notification (appears when API reload fails but cached data exists). It belongs alongside `toast-notification` and `error-banner` as an overlay, not a structural grid row.
+
+- Use `position: fixed` with `inset-block-start: 0` and `inset-inline: 0`
+- Add appropriate `z-index` to appear above content but below top-layer elements
+- Dashboard grid simplifies to single area: `"main"`
+
+### Height-Constraint Chain (after fix)
+
+```
+app-shell (grid, 100dvh)
+  ├─ [area: viewport]  au-viewport (grid item → blockified, stretch)
+  │    └─ <dashboard> :scope { grid, block-size: 100%, min-block-size: 0 }
+  │         └─ [area: main]
+  │              └─ <live-highway> :scope { block, block-size: 100%, min-block-size: 0 }
+  │                   └─ .highway-layout (grid, block-size: 100%)
+  │                        └─ .highway-scroll (overflow-block: auto) ← ACTIVATES
+  └─ [area: nav]  <bottom-nav-bar> ← FIXED
+```
+
+## Risks / Trade-offs
+
+- **[Risk] `1fr` instead of `minmax(0, 1fr)` at app-shell level** → Mitigated by `min-block-size: 0` on each route `:scope`. If a route forgets this, content could push nav-bar off screen. Playwright tests catch this.
+- **[Risk] Stale-banner overlay occludes content** → Use `z-index` layering and auto-dismiss or manual dismiss. Existing toast-notification pattern already solves this.
+- **[Risk] Discover page has different layout structure** → Requires investigation during implementation to determine correct `grid-template-areas`. Design pattern is the same; specific areas may differ.

--- a/openspec/changes/archive/2026-03-16-fix-header-footer-scroll/proposal.md
+++ b/openspec/changes/archive/2026-03-16-fix-header-footer-scroll/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+The bottom-nav-bar and page headers scroll with content instead of staying fixed. Despite existing specs (`app-shell-layout`, `shell-layout`) defining height containment via `au-viewport { display: grid }`, the actual height-constraint chain breaks at route component CE boundaries — `<dashboard>`, `<my-artists-page>`, etc. lack `:scope` layout definitions, so `overflow` never activates and the entire page scrolls.
+
+The root cause is a design flaw: `app-shell.css` externally styles child custom elements (`au-viewport`, `live-highway`), violating CUBE CSS methodology. When an intermediate CE (the route component) has no explicit `display` or `block-size`, the height chain breaks regardless of what the parent or grandchild declares.
+
+## What Changes
+
+- **Remove external CE styling from app-shell**: Delete `au-viewport` and `live-highway` layout rules from `app-shell.css`. Each component owns its own display and sizing.
+- **Require `:scope` grid layout on every route component**: Each route page declares its own structure using `display: grid` + `grid-template-areas` + `block-size: 100%` + `min-block-size: 0`. This makes the height chain explicit at every CE boundary.
+- **Move `live-highway` display to its own CSS**: `live-highway.css` `:scope` declares its own display instead of inheriting from app-shell.
+- **Convert dashboard stale-banner to fixed overlay**: The stale-data warning is a transient notification, not a structural page region. Move it to `position: fixed` overlay, consistent with `toast-notification` and `error-banner`.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `app-shell-layout`: Remove requirement for app-shell to style `au-viewport` with CSS Grid. App-shell only styles itself. Route components own their own height chain. Update `grid-template-rows` to use `grid-template-areas`.
+- `shell-layout`: Remove requirement for `live-highway` to receive `block-size: 100%` from app-shell. `live-highway` owns its own `:scope` display.
+
+## Impact
+
+- **Frontend CSS**: `app-shell.css`, `dashboard.css`, `my-artists-page.css`, `tickets-page.css`, `settings-page.css`, `discover-page.css`, `live-highway.css`
+- **Frontend HTML**: `dashboard.html` (stale-banner becomes fixed overlay)
+- **Specs**: `app-shell-layout/spec.md`, `shell-layout/spec.md` (height chain requirements updated)
+- **No backend, proto, or cloud-provisioning changes**

--- a/openspec/changes/archive/2026-03-16-fix-header-footer-scroll/specs/app-shell-layout/spec.md
+++ b/openspec/changes/archive/2026-03-16-fix-header-footer-scroll/specs/app-shell-layout/spec.md
@@ -1,0 +1,90 @@
+## MODIFIED Requirements
+
+### Requirement: Conditional Navigation Display
+The system SHALL conditionally show or hide the navigation bar based on the current route context. The navigation bar SHALL be visible on all pages except the Landing Page and auth callback.
+
+#### Scenario: App shell uses CSS Grid layout with named areas
+- **WHEN** the application shell renders
+- **THEN** the root container SHALL use CSS Grid with `grid-template-areas: "viewport" "nav"` and `grid-template-rows: 1fr auto`
+- **AND** the container height SHALL be `100dvh` (dynamic viewport height)
+- **AND** `<au-viewport>` SHALL be a direct child of the root container (no intermediate wrapper div)
+- **AND** `<au-viewport>` SHALL NOT receive any layout styling from `app-shell.css` — its block-size is determined by grid stretch (blockification of grid items)
+- **AND** `<bottom-nav-bar>` SHALL occupy the `nav` area as a normal flow child
+- **AND** the navigation bar SHALL NOT use `position: fixed`, `position: absolute`, or the Popover API
+
+#### Scenario: Navigation hidden on Landing Page and auth callback only
+- **WHEN** the user is on the Landing Page or Auth Callback route
+- **THEN** the system SHALL NOT display the bottom navigation bar
+- **AND** the `1fr` row SHALL expand to fill the full `100dvh` height
+
+#### Scenario: Navigation shown during onboarding (discover, dashboard, my-artists)
+- **WHEN** the user is on the Artist Discovery, Dashboard, or My Artists route during onboarding
+- **THEN** the system SHALL display the bottom navigation bar
+- **AND** navigation SHALL be restricted by the existing route guards (`AuthHook.canLoad()`)
+- **AND** the system SHALL NOT apply additional click prevention on the navigation bar
+
+#### Scenario: Navigation shown on post-onboarding routes
+- **WHEN** the user is on the Dashboard or post-onboarding routes
+- **THEN** the system SHALL display the bottom navigation bar in the `nav` grid area
+- **AND** the navigation bar SHALL include tab icons and labels for Home, Discover, My Artists, Tickets, and Settings
+
+#### Scenario: Navigation remains visible beneath area setup dialog
+- **WHEN** the first-visit area setup dialog is displayed on the Dashboard
+- **THEN** the area setup dialog SHALL render via `<dialog>` `showModal()` in the browser's Top Layer
+- **AND** the bottom navigation bar SHALL remain in its normal grid position beneath the Top Layer
+- **AND** the `::backdrop` pseudo-element SHALL visually dim the entire page including the navigation bar
+
+#### Scenario: Dashboard icon data attribute for coach mark targeting
+- **WHEN** the bottom navigation bar renders
+- **THEN** the Dashboard tab link SHALL include a `data-nav-dashboard` attribute
+- **AND** the My Artists tab link SHALL include a `data-nav-my-artists` attribute
+
+#### Scenario: Pages do not compensate for navigation bar height
+- **WHEN** any route component renders inside the `<au-viewport>` element
+- **THEN** the route component SHALL NOT apply viewport-relative height constraints (e.g., `100dvh`, `100vh`) or bottom padding (e.g., `pb-14`) to account for the navigation bar
+- **AND** the CSS Grid layout SHALL ensure the route content fills the available space within the `1fr` track
+
+---
+
+### Requirement: Route components own page structure
+Each route component SHALL define its own HTML document structure using semantic landmark elements AND its own CSS layout using `:scope` grid declarations. The app shell SHALL NOT provide a shared page layout wrapper or style child custom elements.
+
+#### Scenario: Route provides header and main landmarks
+- **WHEN** a route component renders inside `<au-viewport>`
+- **THEN** the route template SHALL contain exactly one `<main>` element as a top-level child
+- **AND** the route template MAY contain one `<header>` element as a top-level sibling before `<main>`
+- **AND** top-layer elements (`<dialog>`, popover components) MAY appear as top-level siblings after `<main>`
+
+#### Scenario: Route `:scope` declares grid layout with areas
+- **WHEN** a route component's CSS is loaded
+- **THEN** the `:scope` rule SHALL declare `display: grid` with `grid-template-areas` naming every structural region
+- **AND** the `:scope` rule SHALL declare `grid-template-rows` matching the areas
+- **AND** the `:scope` rule SHALL declare `block-size: 100%` to inherit the definite height from `au-viewport`
+- **AND** the `:scope` rule SHALL declare `min-block-size: 0` to allow overflow activation on descendants
+- **AND** each structural child element SHALL be assigned to its grid area via `grid-area`
+
+#### Scenario: No page-shell wrapper
+- **WHEN** any route component renders
+- **THEN** the route template SHALL NOT use a `<page-shell>` custom element
+- **AND** the `page-shell` component SHALL NOT exist in the codebase
+
+#### Scenario: App-shell does not style child custom elements
+- **WHEN** `app-shell.css` is loaded
+- **THEN** the file SHALL NOT contain selectors targeting `au-viewport`, `live-highway`, or any route component custom element
+- **AND** overlay elements (`pwa-install-prompt`, `toast-notification`, `error-banner`, `coach-mark`) MAY be styled in `app-shell.css` as they are direct children requiring flow removal
+
+---
+
+### Requirement: Stale-data warning uses overlay pattern
+The dashboard stale-data warning SHALL render as a fixed-position overlay, consistent with the application's notification pattern (`toast-notification`, `error-banner`).
+
+#### Scenario: Stale banner appears as fixed overlay
+- **WHEN** the dashboard data reload fails and previous data exists (`isStale === true`)
+- **THEN** the stale-data warning SHALL render as a `position: fixed` element at the top of the viewport
+- **AND** the warning SHALL NOT occupy a grid row in the dashboard layout
+- **AND** the warning SHALL appear above page content but below top-layer elements (dialogs, popovers)
+
+#### Scenario: Stale banner does not affect scroll behavior
+- **WHEN** the stale-data warning is visible
+- **THEN** the `live-highway` scroll area SHALL occupy the full `main` grid area
+- **AND** scrolling the concert list SHALL NOT move the stale-data warning

--- a/openspec/changes/archive/2026-03-16-fix-header-footer-scroll/specs/shell-layout/spec.md
+++ b/openspec/changes/archive/2026-03-16-fix-header-footer-scroll/specs/shell-layout/spec.md
@@ -1,9 +1,5 @@
-# shell-layout Specification
+## MODIFIED Requirements
 
-## Purpose
-
-Defines the PWA shell layout structure for `app-shell`, ensuring overlay custom elements are excluded from CSS Grid flow so that `bottom-nav-bar` stays pinned at the viewport bottom and `position: sticky` headers work correctly within scroll containers.
-## Requirements
 ### Requirement: Overlay elements excluded from grid flow
 All overlay custom elements (`pwa-install-prompt`, `notification-prompt`, `toast-notification`, `error-banner`, `coach-mark`) SHALL be removed from normal document flow so they do not create implicit CSS Grid rows in the `app-shell` shell layout.
 
@@ -22,4 +18,3 @@ All overlay custom elements (`pwa-install-prompt`, `notification-prompt`, `toast
 #### Scenario: Overlay elements remain functional
 - **WHEN** an overlay element activates (e.g., toast notification, coach-mark spotlight)
 - **THEN** the overlay SHALL render correctly via the browser top-layer API, unaffected by the flow removal
-

--- a/openspec/changes/archive/2026-03-16-fix-header-footer-scroll/tasks.md
+++ b/openspec/changes/archive/2026-03-16-fix-header-footer-scroll/tasks.md
@@ -1,0 +1,31 @@
+## 1. app-shell.css — Remove External CE Styling and Add Areas
+
+- [x] 1.1 Replace `:scope` grid declaration with `grid-template-areas: "viewport" "nav"` and `grid-template-rows: 1fr auto`
+- [x] 1.2 Remove `au-viewport { display: grid; grid-template-rows: minmax(0, 1fr); }` rule
+- [x] 1.3 Remove `live-highway { display: block; block-size: 100%; }` rule
+
+## 2. Route Component `:scope` Grid Declarations
+
+- [x] 2.1 `dashboard.css`: Add `:scope { display: grid; grid-template-areas: "main"; grid-template-rows: 1fr; block-size: 100%; min-block-size: 0; }` and assign `grid-area: main` to `.dashboard-main`
+- [x] 2.2 `my-artists-page.css`: Add `:scope` grid with areas `"header" "main"`, rows `auto 1fr`, `block-size: 100%`, `min-block-size: 0`. Assign `grid-area` to `.page-header` and `main`. Remove orphaned flex properties (`flex: 1`, `flex-shrink: 0`)
+- [x] 2.3 `tickets-page.css`: Same pattern — add `:scope` grid, assign `grid-area` to `.page-header` and `main`. Remove orphaned flex properties
+- [x] 2.4 `settings-page.css`: Same pattern — add `:scope` grid, assign `grid-area` to `.page-header` and `main`. Remove orphaned flex properties
+- [x] 2.5 `discover-page.css`: Investigate layout structure, add `:scope` grid with appropriate `grid-template-areas`. Remove orphaned flex properties
+
+## 3. live-highway — Own Its Display
+
+- [x] 3.1 Add `:scope { display: block; block-size: 100%; min-block-size: 0; }` to `live-highway.css`
+
+## 4. Dashboard Stale-Banner Overlay Conversion
+
+- [x] 4.1 Update stale-banner CSS: change from grid-row to `position: fixed; inset-block-start: 0; inset-inline: 0` with appropriate `z-index`
+- [x] 4.2 Verify stale-banner in `dashboard.html` is outside grid flow and does not affect layout
+
+## 5. Verification
+
+- [x] 5.1 Playwright: dashboard — bottom-nav-bar remains visible when scrolling long concert list
+- [x] 5.2 Playwright: my-artists — bottom-nav-bar and page-header remain fixed when scrolling artist list
+- [x] 5.3 Playwright: tickets — same fixed header/footer verification (covered by mobile-layout project)
+- [x] 5.4 Playwright: settings — same fixed header/footer verification (covered by mobile-layout project)
+- [x] 5.5 Playwright: dashboard stale-banner overlay renders correctly above content
+- [x] 5.6 Run `make check` — lint passes, tests pass (1 pre-existing flaky test in orb-renderer unrelated to CSS changes)

--- a/openspec/specs/app-shell-layout/spec.md
+++ b/openspec/specs/app-shell-layout/spec.md
@@ -23,19 +23,19 @@ The system SHALL display proper brand identity elements across the application.
 ### Requirement: Conditional Navigation Display
 The system SHALL conditionally show or hide the navigation bar based on the current route context. The navigation bar SHALL be visible on all pages except the Landing Page and auth callback.
 
-#### Scenario: App shell uses CSS Grid layout with height containment
+#### Scenario: App shell uses CSS Grid layout with named areas
 - **WHEN** the application shell renders
-- **THEN** the root container SHALL use CSS Grid with `grid-template-rows: minmax(0, 1fr) min-content`
+- **THEN** the root container SHALL use CSS Grid with `grid-template-areas: "viewport" "nav"` and `grid-template-rows: 1fr auto`
 - **AND** the container height SHALL be `100dvh` (dynamic viewport height)
 - **AND** `<au-viewport>` SHALL be a direct child of the root container (no intermediate wrapper div)
-- **AND** `<au-viewport>` SHALL use CSS Grid (`grid-template-rows: minmax(0, 1fr)`) to provide a definite, constrained height to route components
-- **AND** `<bottom-nav-bar>` SHALL occupy the `min-content` row as a normal flow child
+- **AND** `<au-viewport>` SHALL NOT receive any layout styling from `app-shell.css` — its block-size is determined by grid stretch (blockification of grid items)
+- **AND** `<bottom-nav-bar>` SHALL occupy the `nav` area as a normal flow child
 - **AND** the navigation bar SHALL NOT use `position: fixed`, `position: absolute`, or the Popover API
 
 #### Scenario: Navigation hidden on Landing Page and auth callback only
 - **WHEN** the user is on the Landing Page or Auth Callback route
 - **THEN** the system SHALL NOT display the bottom navigation bar
-- **AND** the `minmax(0, 1fr)` row SHALL expand to fill the full `100dvh` height
+- **AND** the `1fr` row SHALL expand to fill the full `100dvh` height
 
 #### Scenario: Navigation shown during onboarding (discover, dashboard, my-artists)
 - **WHEN** the user is on the Artist Discovery, Dashboard, or My Artists route during onboarding
@@ -45,7 +45,7 @@ The system SHALL conditionally show or hide the navigation bar based on the curr
 
 #### Scenario: Navigation shown on post-onboarding routes
 - **WHEN** the user is on the Dashboard or post-onboarding routes
-- **THEN** the system SHALL display the bottom navigation bar in the `min-content` grid row
+- **THEN** the system SHALL display the bottom navigation bar in the `nav` grid area
 - **AND** the navigation bar SHALL include tab icons and labels for Home, Discover, My Artists, Tickets, and Settings
 
 #### Scenario: Navigation remains visible beneath area setup dialog
@@ -62,12 +62,12 @@ The system SHALL conditionally show or hide the navigation bar based on the curr
 #### Scenario: Pages do not compensate for navigation bar height
 - **WHEN** any route component renders inside the `<au-viewport>` element
 - **THEN** the route component SHALL NOT apply viewport-relative height constraints (e.g., `100dvh`, `100vh`) or bottom padding (e.g., `pb-14`) to account for the navigation bar
-- **AND** the CSS Grid layout SHALL ensure the route content fills the available space within the `minmax(0, 1fr)` track
+- **AND** the CSS Grid layout SHALL ensure the route content fills the available space within the `1fr` track
 
 ---
 
 ### Requirement: Route components own page structure
-Each route component SHALL define its own HTML document structure using semantic landmark elements. The app shell SHALL NOT provide a shared page layout wrapper.
+Each route component SHALL define its own HTML document structure using semantic landmark elements AND its own CSS layout using `:scope` grid declarations. The app shell SHALL NOT provide a shared page layout wrapper or style child custom elements.
 
 #### Scenario: Route provides header and main landmarks
 - **WHEN** a route component renders inside `<au-viewport>`
@@ -75,15 +75,39 @@ Each route component SHALL define its own HTML document structure using semantic
 - **AND** the route template MAY contain one `<header>` element as a top-level sibling before `<main>`
 - **AND** top-layer elements (`<dialog>`, popover components) MAY appear as top-level siblings after `<main>`
 
-#### Scenario: Route main element fills available space
-- **WHEN** the route's `<main>` element renders inside the Grid area
-- **THEN** `<main>` SHALL receive its height from Grid stretch (no `block-size: 100%` needed)
-- **AND** `<main>` SHALL use `overflow-y: auto` when its content may exceed the available height
+#### Scenario: Route `:scope` declares grid layout with areas
+- **WHEN** a route component's CSS is loaded
+- **THEN** the `:scope` rule SHALL declare `display: grid` with `grid-template-areas` naming every structural region
+- **AND** the `:scope` rule SHALL declare `grid-template-rows` matching the areas
+- **AND** the `:scope` rule SHALL declare `block-size: 100%` to inherit the definite height from `au-viewport`
+- **AND** the `:scope` rule SHALL declare `min-block-size: 0` to allow overflow activation on descendants
+- **AND** each structural child element SHALL be assigned to its grid area via `grid-area`
 
 #### Scenario: No page-shell wrapper
 - **WHEN** any route component renders
 - **THEN** the route template SHALL NOT use a `<page-shell>` custom element
 - **AND** the `page-shell` component SHALL NOT exist in the codebase
+
+#### Scenario: App-shell does not style child custom elements
+- **WHEN** `app-shell.css` is loaded
+- **THEN** the file SHALL NOT contain selectors targeting `au-viewport`, `live-highway`, or any route component custom element
+- **AND** overlay elements (`pwa-install-prompt`, `toast-notification`, `error-banner`, `coach-mark`) MAY be styled in `app-shell.css` as they are direct children requiring flow removal
+
+---
+
+### Requirement: Stale-data warning uses overlay pattern
+The dashboard stale-data warning SHALL render as a fixed-position overlay, consistent with the application's notification pattern (`toast-notification`, `error-banner`).
+
+#### Scenario: Stale banner appears as fixed overlay
+- **WHEN** the dashboard data reload fails and previous data exists (`isStale === true`)
+- **THEN** the stale-data warning SHALL render as a `position: fixed` element at the top of the viewport
+- **AND** the warning SHALL NOT occupy a grid row in the dashboard layout
+- **AND** the warning SHALL appear above page content but below top-layer elements (dialogs, popovers)
+
+#### Scenario: Stale banner does not affect scroll behavior
+- **WHEN** the stale-data warning is visible
+- **THEN** the `live-highway` scroll area SHALL occupy the full `main` grid area
+- **AND** scrolling the concert list SHALL NOT move the stale-data warning
 
 ---
 

--- a/openspec/specs/shell-layout/spec.md
+++ b/openspec/specs/shell-layout/spec.md
@@ -16,7 +16,7 @@ All overlay custom elements (`pwa-install-prompt`, `notification-prompt`, `toast
 - **WHEN** the user scrolls the live-highway event list downward
 - **THEN** the stage header (HOME STAGE / NEAR STAGE / AWAY STAGE) SHALL remain fixed above the scrollable content
 - **AND** the stage header SHALL be a `<header>` element inside the `live-highway` CE, outside the scrollable `.highway-scroll` area
-- **AND** the `live-highway` CE SHALL use CSS Grid (`grid-template-rows: auto 1fr`) to separate the fixed header from the scrollable content
+- **AND** the `live-highway` CE SHALL contain a `.highway-layout` child element using CSS Grid (`grid-template-rows: auto 1fr`) to separate the fixed header from the scrollable content
 - **AND** the `live-highway` CE SHALL declare its own `:scope { display: block; block-size: 100%; min-block-size: 0; }` to inherit height from the route component
 
 #### Scenario: Overlay elements remain functional


### PR DESCRIPTION
## Summary

Sync delta specs from fix-header-footer-scroll change into main specs and archive the completed change.

### Spec Changes

**app-shell-layout/spec.md**:
- "Conditional Navigation Display": grid-template-areas replaces minmax(0, 1fr), au-viewport must not receive layout styling from app-shell
- "Route components own page structure": add :scope grid declaration requirement with grid-template-areas, block-size: 100%, min-block-size: 0. Add scenario: app-shell does not style child CEs
- NEW "Stale-data warning uses overlay pattern": dashboard stale-banner uses position: fixed overlay

**shell-layout/spec.md**:
- "Overlay elements excluded from grid flow": route components use min-block-size: 0 for overflow containment
- "Stage header sticks within route scroll container": live-highway owns :scope display

### Archive
- Archived fix-header-footer-scroll change (all 17 tasks complete)

## Test plan
- [ ] Spec formatting is valid markdown
- [ ] No breaking changes to proto definitions
