### PR TITLE
docs(specs): remove stale banner requirement from dashboard spec

### DIFF
--- a/openspec/changes/archive/2026-03-16-remove-stale-banner/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-16-remove-stale-banner/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-15

--- a/openspec/changes/archive/2026-03-16-remove-stale-banner/design.md
+++ b/openspec/changes/archive/2026-03-16-remove-stale-banner/design.md
@@ -1,0 +1,30 @@
+## Context
+
+The dashboard currently tracks an `isStale` flag that is set when `loadDashboardEvents()` fails but cached `dateGroups` exist. This drives a warning banner in the template and splits the catch block into two code paths (full error vs stale). Removing this simplifies the ViewModel, template, and styles.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Remove all stale banner UI, logic, and styles
+- When a reload fails with cached data present, silently display the cached data
+- Keep the full error state (inline-error) for first-load failures (no cached data)
+
+**Non-Goals:**
+- Changing the dashboard data loading strategy or caching layer
+- Adding any replacement notification mechanism
+
+## Decisions
+
+### Silent fallback on reload failure
+
+When `loadDashboardEvents()` fails and `dateGroups.length > 0`, the catch block will simply log the error and suppress the throw. The template catch branch only needs the `inline-error` path (for empty cache). The stale `<live-highway>` branch inside catch is removed because the `<live-highway>` in the `then` branch already rendered the cached data.
+
+**Alternative considered:** Replace banner with a subtle toast notification. Rejected — even a toast implies something is wrong when the displayed data is still valid.
+
+### Remove `retry()` method
+
+`retry()` is only called from the stale banner's button. With the banner removed, `retry()` has no caller. The next `loading()` lifecycle call handles re-fetching automatically.
+
+## Risks / Trade-offs
+
+- **Truly stale data goes unnoticed** → Acceptable. Concert data changes extremely rarely. If a user needs fresh data, pull-to-refresh or page navigation triggers `loading()` again.

--- a/openspec/changes/archive/2026-03-16-remove-stale-banner/design.md
+++ b/openspec/changes/archive/2026-03-16-remove-stale-banner/design.md
@@ -1,6 +1,6 @@
 ## Context
 
-The dashboard currently tracks an `isStale` flag that is set when `loadDashboardEvents()` fails but cached `dateGroups` exist. This drives a warning banner in the template and splits the catch block into two code paths (full error vs stale). Removing this simplifies the ViewModel, template, and styles.
+The dashboard currently tracks an `isStale` flag that is set when `loadData()` fails but cached `dateGroups` exist. This drives a warning banner in the template and splits the catch block into two code paths (full error vs stale). Removing this simplifies the ViewModel, template, and styles.
 
 ## Goals / Non-Goals
 
@@ -17,7 +17,7 @@ The dashboard currently tracks an `isStale` flag that is set when `loadDashboard
 
 ### Silent fallback on reload failure
 
-When `loadDashboardEvents()` fails and `dateGroups.length > 0`, the catch block will simply log the error and suppress the throw. The template catch branch only needs the `inline-error` path (for empty cache). The stale `<live-highway>` branch inside catch is removed because the `<live-highway>` in the `then` branch already rendered the cached data.
+When `loadData()` fails and `dateGroups.length > 0`, the catch block will simply log the error and suppress the throw. The template catch branch only needs the `inline-error` path (for empty cache). The stale `<live-highway>` branch inside catch is removed because the `<live-highway>` in the `then` branch already rendered the cached data.
 
 **Alternative considered:** Replace banner with a subtle toast notification. Rejected — even a toast implies something is wrong when the displayed data is still valid.
 

--- a/openspec/changes/archive/2026-03-16-remove-stale-banner/proposal.md
+++ b/openspec/changes/archive/2026-03-16-remove-stale-banner/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+The dashboard displays a "stale data" warning banner when an API reload fails but previous concert data exists. However, concert information is inherently stable — once published, event details rarely change. The banner unnecessarily alarms users by implying their data may be outdated when it is effectively still accurate. Silently showing cached data is the correct UX for this domain.
+
+## What Changes
+
+- Remove the stale data warning banner from the dashboard UI (template, styles, logic)
+- Remove the `isStale` state and `retry()` method from the Dashboard ViewModel
+- Remove stale-related i18n keys from locale files
+- Simplify the error/catch template branch: when previous data exists and a reload fails, show previous data silently without any warning
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `typography-focused-dashboard`: Remove the stale data warning banner requirement from the "Three-Lane Live Highway Layout" requirement
+
+## Impact
+
+- `frontend/src/routes/dashboard.ts` — remove `isStale`, `retry()`, simplify `loadData()` catch
+- `frontend/src/routes/dashboard.html` — remove stale banner markup, simplify catch template
+- `frontend/src/routes/dashboard.css` — remove stale banner styles
+- `frontend/src/locales/en/translation.json` — remove `dashboard.stale.*` keys
+- `frontend/src/locales/ja/translation.json` — remove `dashboard.stale.*` keys
+- `frontend/test/routes/dashboard.spec.ts` — remove stale-related test cases

--- a/openspec/changes/archive/2026-03-16-remove-stale-banner/specs/typography-focused-dashboard/spec.md
+++ b/openspec/changes/archive/2026-03-16-remove-stale-banner/specs/typography-focused-dashboard/spec.md
@@ -1,0 +1,22 @@
+## MODIFIED Requirements
+
+### Requirement: Three-Lane Live Highway Layout
+The system SHALL display live events in a three-column equal-width timeline layout organized by geographical proximity and date, with festival-style sticky STAGE headers and a dark-themed aesthetic. The dashboard SHALL handle data loading errors gracefully and distinguish between empty data and error states.
+
+#### Scenario: Dashboard data loading uses promise.bind
+- **WHEN** the dashboard loads event data
+- **THEN** the template SHALL use `promise.bind` to declaratively handle pending, success, and error states
+- **AND** the pending state SHALL display loading skeletons matching the three-lane card layout
+- **AND** the error state SHALL display an error message with a "Retry" button
+
+#### Scenario: Dashboard displays empty state
+- **WHEN** the dashboard data loads successfully but no events are found
+- **THEN** the system SHALL display an empty state message (distinct from the error state)
+- **AND** the empty state SHALL NOT be confused with a loading failure
+
+#### Scenario: Dashboard silently displays cached data on refresh failure
+- **WHEN** the dashboard has previously loaded data successfully
+- **AND** a subsequent data refresh fails
+- **THEN** the system SHALL continue displaying the previously loaded data silently
+- **AND** the system SHALL NOT display any warning banner or stale data indicator
+- **AND** the error SHALL be logged for observability but not surfaced to the user

--- a/openspec/changes/archive/2026-03-16-remove-stale-banner/tasks.md
+++ b/openspec/changes/archive/2026-03-16-remove-stale-banner/tasks.md
@@ -1,0 +1,25 @@
+## 1. ViewModel cleanup
+
+- [x] 1.1 Remove `isStale` property from `dashboard.ts`
+- [x] 1.2 Remove `retry()` method from `dashboard.ts`
+- [x] 1.3 Simplify `loadData()` catch block: when `dateGroups.length > 0`, log the error and return (do not set isStale, do not re-throw)
+
+## 2. Template cleanup
+
+- [x] 2.1 Remove the stale banner `<aside>` block from `dashboard.html`
+- [x] 2.2 Remove the `if.bind="!isStale"` condition from `<inline-error>` in catch block
+- [x] 2.3 Remove the stale `<live-highway>` branch (`if.bind="isStale"`) from catch block
+
+## 3. Styles cleanup
+
+- [x] 3.1 Remove all stale banner CSS (`.dashboard-stale-banner`, `.dashboard-stale-icon`, `.dashboard-stale-retry`, `--_stale-*` custom properties) from `dashboard.css`
+
+## 4. i18n cleanup
+
+- [x] 4.1 Remove `dashboard.stale.*` keys from `en/translation.json`
+- [x] 4.2 Remove `dashboard.stale.*` keys from `ja/translation.json`
+
+## 5. Tests
+
+- [x] 5.1 Remove stale-related test cases from `test/routes/dashboard.spec.ts`
+- [x] 5.2 Run `make check` to verify no regressions

--- a/openspec/specs/typography-focused-dashboard/spec.md
+++ b/openspec/specs/typography-focused-dashboard/spec.md
@@ -20,12 +20,12 @@ The system SHALL display live events in a three-column equal-width timeline layo
 - **THEN** the system SHALL display an empty state message (distinct from the error state)
 - **AND** the empty state SHALL NOT be confused with a loading failure
 
-#### Scenario: Dashboard displays stale data on refresh failure
+#### Scenario: Dashboard silently displays cached data on refresh failure
 - **WHEN** the dashboard has previously loaded data successfully
 - **AND** a subsequent data refresh fails
-- **THEN** the system SHALL continue displaying the previously loaded data
-- **AND** the system SHALL display a warning banner: "Data may be outdated. Refresh failed."
-- **AND** the banner SHALL include a "Retry" button
+- **THEN** the system SHALL continue displaying the previously loaded data silently
+- **AND** the system SHALL NOT display any warning banner or stale data indicator
+- **AND** the error SHALL be logged for observability but not surfaced to the user
 
 #### Scenario: Equal-width three-lane grid
 - **WHEN** the dashboard renders the event grid


### PR DESCRIPTION
## 🔗 Related Issue

close: liverty-music/frontend#201

## 📝 Summary of Changes

Update the `typography-focused-dashboard` spec to replace the stale data warning banner requirement with silent cached data display on refresh failure. Concert data is inherently stable, so warning users about potentially outdated data is misleading.

- Replace "Dashboard displays stale data on refresh failure" scenario with "Dashboard silently displays cached data on refresh failure"
- Archive the `remove-stale-banner` OpenSpec change

## ✅ Self-Checklist

- [x] I have linked the related issue.
- [x] I have updated the relevant documentation (e.g., `README.md`) if needed.
- [x] I have run `buf lint` and `buf format` locally and all checks have passed.
- [x] My proto definitions follow the project's style guidelines and validation rules.
- [x] Breaking changes have been justified and documented if applicable.