### PR TITLE
docs(openspec): archive simplify-frontend-naming

### DIFF
--- a/openspec/changes/archive/2026-03-16-simplify-frontend-naming/proposal.md
+++ b/openspec/changes/archive/2026-03-16-simplify-frontend-naming/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+The frontend `routes/` directory has three naming inconsistencies that make navigation and grep difficult:
+
+1. **Redundant `-page` suffix** — Files repeat the concept already expressed by the directory: `routes/discover/discover-page.ts`.
+2. **Inconsistent directory nesting** — `dashboard` and `auth-callback` sit flat in `routes/` while all others use subdirectories. `welcome-page` and `about-page` live in `src/` rather than `routes/`.
+3. **`discover` vs `discovery` naming split** — The route directory is `discover/`, the i18n has both `"discover"` and `"discovery"` namespaces (with duplicate keys), and class names use `Discover`. The backend uses `discovery` consistently.
+
+## What Changes
+
+- Rename all route component files from `-page` suffix to `-route` suffix (e.g. `discover-page.ts` → `discovery-route.ts`)
+- Move `welcome-page`, `about-page` from `src/` into `routes/` subdirectories
+- Move `dashboard`, `auth-callback` from flat files into their own `routes/` subdirectories
+- Rename `routes/discover/` directory to `routes/discovery/` and update all class names, URL paths, nav references, and icon switch-cases
+- Merge i18n `"discover"` namespace into `"discovery"`, deduplicate keys (keep `"discovery"` values for duplicates)
+- Update all route class names to use `-Route` suffix (e.g. `DiscoverPage` → `DiscoveryRoute`, `Dashboard` → `DashboardRoute`)
+
+## Capabilities
+
+### Modified Capabilities
+
+- `frontend-landing-page`: Route component file renamed and relocated (`welcome-page` → `routes/welcome/welcome-route`)
+- `bottom-navigation-shell`: Nav path updated from `discover` to `discovery`
+- `artist-discovery-ui`: Directory, class, i18n namespace unified to `discovery`
+
+## Impact
+
+- **Frontend**: File moves, class renames, i18n namespace merge, URL path change (`/discover` → `/discovery`)
+- **Backend**: No changes
+- **Protobuf/API**: No changes
+- **Database**: No changes
+- **Infrastructure**: No changes
+- **Breaking URL change**: `/discover` → `/discovery` (acceptable — app is pre-launch, no external links exist)

--- a/openspec/changes/archive/2026-03-16-simplify-frontend-naming/tasks.md
+++ b/openspec/changes/archive/2026-03-16-simplify-frontend-naming/tasks.md
@@ -1,0 +1,9 @@
+## Tasks
+
+- [x] **Task 1: Move and rename route files** — Move all route components to consistent `routes/<name>/<name>-route.*` structure and rename classes (`WelcomePage` → `WelcomeRoute`, etc.)
+- [x] **Task 2: Update app-shell.ts route imports** — Update all `component: import(...)` paths and the `fallback` path to point to new file locations.
+- [x] **Task 3: Unify `discover` → `discovery` in code references** — onboarding-service, bottom-nav-bar, svg-icon, dashboard-route, my-artists-route, welcome-route, bubble-pool
+- [x] **Task 4: Merge i18n namespaces** — Merge `"discover"` keys into `"discovery"` in both locales, delete old namespace, update `nav.discover` → `nav.discovery`
+- [x] **Task 5: Update i18n key references in code** — Replace `discover.*` i18n keys with `discovery.*` in route templates and TypeScript files
+- [x] **Task 6: Update test files** — Update imports and class references in unit and E2E test files
+- [x] **Task 7: Verify build and lint** — `make check` passes (lint, typecheck, 574 unit tests)


### PR DESCRIPTION
## 🔗 Related Issue

Related: liverty-music/frontend#203, liverty-music/frontend#204

## 📝 Summary of Changes

Archive the completed OpenSpec change for the frontend route file renaming and discover-to-discovery unification refactoring.

- Proposal and tasks artifacts archived to openspec/changes/archive/2026-03-16-simplify-frontend-naming/
- All 7 tasks completed and verified
- No proto changes (frontend-only refactoring)

## ✅ Self-Checklist

- [x] I have linked the related issue.
- [x] I have updated the relevant documentation if needed.
- [x] I have run buf lint and buf format locally and all checks have passed.
- [x] My proto definitions follow the project's style guidelines and validation rules.
- [x] Breaking changes have been justified and documented if applicable.
