### PR TITLE
docs(openspec): extract-page-header-ce change artifacts

### DIFF
--- a/openspec/changes/extract-page-header-ce/.openspec.yaml
+++ b/openspec/changes/extract-page-header-ce/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-16

--- a/openspec/changes/extract-page-header-ce/design.md
+++ b/openspec/changes/extract-page-header-ce/design.md
@@ -1,0 +1,50 @@
+## Context
+
+Three route pages (my-artists, settings, tickets) share an identical `<header class="[ page-header ]">` pattern with the same CSS block (~17 lines each): `grid-area: header`, padding, border, background, and nested `h1` typography. my-artists adds flexbox + gap for its extra action elements (count badge, view-toggle button). There is no existing `page-header` component — the pattern is copy-pasted per route.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Single source of truth for page-header markup and styles.
+- Slot-based extensibility so routes can inject trailing actions without forking the component.
+- Follow CUBE CSS methodology: header styles live in the component's block layer; routes only add route-specific overrides for slotted content.
+
+**Non-Goals:**
+
+- Back button / navigation behavior — out of scope.
+- Sticky/scroll-aware header behavior — not currently used, not adding it.
+- Abstracting the route-level grid layout (`grid-template-areas: "header" "main"`) — stays in each route's `:scope`.
+
+## Decisions
+
+### 1. Light DOM CE with `<au-slot>` (not Shadow DOM)
+
+The header needs to participate in the parent route's CSS Grid (`grid-area: header`). Light DOM keeps this simple — no `::part()` or slot styling workarounds needed.
+
+**Alternative considered:** Shadow DOM with `::part()` exports — rejected because the header is a layout primitive, not a style-encapsulated widget. Shadow DOM adds complexity with no benefit here.
+
+### 2. Single `title-key` bindable + default `<au-slot>`
+
+The CE accepts:
+- `title-key` (string) — i18n key passed to `t` binding on the `<h1>`.
+- Default `<au-slot>` — optional trailing content (badges, buttons).
+
+This covers all 3 current use cases:
+- settings/tickets: `<page-header title-key="settings.title"></page-header>` (no slot content)
+- my-artists: `<page-header title-key="nav.myArtists"><span>...</span><button>...</button></page-header>`
+
+**Alternative considered:** Multiple named slots (`actions`, `badge`) — rejected as over-engineering. A single default slot is sufficient; route templates already own the markup for their actions.
+
+### 3. Flexbox layout with `h1 { flex: 1 }` as the base
+
+The header uses `display: flex; align-items: center; gap: var(--space-3xs)`. The `<h1>` gets `flex: 1` to push any slotted actions to the end. This works for both the title-only case (settings/tickets) and the title+actions case (my-artists) without conditional styling.
+
+### 4. Global registration in `main.ts`
+
+Same pattern as `StatePlaceholder`, `SvgIcon`, `BottomNavBar` — globally registered CEs that are used across multiple routes.
+
+## Risks / Trade-offs
+
+- **Slot content styling**: Slotted elements (artist-count, toggle-view-btn) remain styled in the route's CSS. This is intentional — the CE owns the header chrome, routes own their action styling. → No mitigation needed; this follows CUBE CSS block responsibility.
+- **`grid-area` coupling**: The CE's host element needs `grid-area: header` to sit in the route grid. This is handled by the CE's own CSS (`:scope { grid-area: header }`). → If a future route uses a different grid area name, it can override via the cascade.

--- a/openspec/changes/extract-page-header-ce/proposal.md
+++ b/openspec/changes/extract-page-header-ce/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+The `.page-header` pattern (HTML structure + CSS) is duplicated across 3 route pages (my-artists, settings, tickets) with identical base styles (~17 lines of CSS each). Extracting it into a shared Custom Element improves maintainability and ensures visual consistency when the header design evolves.
+
+## What Changes
+
+- Create a `page-header` Custom Element (CE) that encapsulates the shared header layout, typography, and border styling.
+- The CE accepts a `title-key` bindable (i18n translation key) and an `<au-slot>` for optional trailing actions (e.g., count badge, view-toggle button).
+- Replace inline `<header class="[ page-header ]">` markup in my-artists, settings, and tickets routes with `<page-header>`.
+- Remove duplicated `.page-header` CSS blocks from each route's stylesheet.
+- Register the CE globally in `main.ts` (same pattern as `StatePlaceholder`, `SvgIcon`).
+
+## Capabilities
+
+### New Capabilities
+
+- `page-header-ce`: Shared page-header Custom Element with i18n title and slot-based action area.
+
+### Modified Capabilities
+
+_(none — this is a refactor with no requirement-level changes to existing capabilities)_
+
+## Impact
+
+- **frontend/src/components/page-header/**: New CE (`.ts`, `.html`, `.css`)
+- **frontend/src/main.ts**: Add `PageHeader` global registration
+- **frontend/src/routes/my-artists/**: Replace header markup, remove `.page-header` CSS
+- **frontend/src/routes/settings/**: Replace header markup, remove `.page-header` CSS
+- **frontend/src/routes/tickets/**: Replace header markup, remove `.page-header` CSS

--- a/openspec/changes/extract-page-header-ce/specs/page-header-ce/spec.md
+++ b/openspec/changes/extract-page-header-ce/specs/page-header-ce/spec.md
@@ -1,0 +1,44 @@
+## ADDED Requirements
+
+### Requirement: Page header renders i18n title
+The `page-header` CE SHALL render a `<header>` element containing an `<h1>` whose text content is resolved from the `title-key` bindable via the i18n `t` binding.
+
+#### Scenario: Title-only header (settings, tickets)
+- **WHEN** `<page-header title-key="settings.title"></page-header>` is used with no slot content
+- **THEN** the header renders `<h1>` with the translated text for `settings.title` and no additional child elements
+
+#### Scenario: Title key changes dynamically
+- **WHEN** the `title-key` bindable value changes at runtime
+- **THEN** the `<h1>` text updates to reflect the new translation
+
+### Requirement: Page header supports trailing actions via slot
+The `page-header` CE SHALL provide a default `<au-slot>` after the `<h1>` element for optional trailing content (badges, buttons).
+
+#### Scenario: Header with slotted actions (my-artists)
+- **WHEN** `<page-header title-key="nav.myArtists"><span class="artist-count">(...)</span><button>...</button></page-header>` is used
+- **THEN** the `<h1>` is followed by the slotted `<span>` and `<button>`, laid out inline via flexbox with the title taking remaining space
+
+#### Scenario: No slot content provided
+- **WHEN** `<page-header title-key="nav.tickets"></page-header>` is used without children
+- **THEN** the header renders only the `<h1>` with no extra whitespace or empty wrapper
+
+### Requirement: Page header provides consistent visual styling
+The `page-header` CE SHALL encapsulate the shared header styles: padding, bottom border, background color, and `<h1>` typography (font-family, size, weight, letter-spacing).
+
+#### Scenario: Visual consistency across routes
+- **WHEN** `page-header` is rendered in my-artists, settings, and tickets routes
+- **THEN** all three headers share identical padding (`--space-xs`), border (`1px solid` at 10% white), background (`--color-surface-raised`), and `<h1>` typography
+
+### Requirement: Page header participates in route grid layout
+The `page-header` CE host element SHALL set `grid-area: header` so it integrates with the route's `grid-template-areas` without additional route-level CSS.
+
+#### Scenario: Header placed in grid area
+- **WHEN** a route defines `grid-template-areas: "header" "content"`
+- **THEN** the `page-header` CE occupies the `header` grid area automatically
+
+### Requirement: Page header is globally registered
+The `PageHeader` class SHALL be registered globally in `main.ts` so all routes can use `<page-header>` without per-route `<import>` statements.
+
+#### Scenario: Usage without explicit import
+- **WHEN** a route template uses `<page-header title-key="...">` without an `<import>` tag
+- **THEN** the component resolves and renders correctly

--- a/openspec/changes/extract-page-header-ce/tasks.md
+++ b/openspec/changes/extract-page-header-ce/tasks.md
@@ -1,0 +1,22 @@
+## 1. Create page-header Custom Element
+
+- [x] 1.1 Create `frontend/src/components/page-header/page-header.ts` with `titleKey` bindable
+- [x] 1.2 Create `frontend/src/components/page-header/page-header.html` with `<header>`, `<h1 t.bind="titleKey">`, and `<au-slot>`
+- [x] 1.3 Create `frontend/src/components/page-header/page-header.css` with shared styles (grid-area, padding, border, background, h1 typography, flexbox layout)
+
+## 2. Register globally
+
+- [x] 2.1 Import `PageHeader` in `frontend/src/main.ts` and add `.register(PageHeader)`
+
+## 3. Replace route headers
+
+- [x] 3.1 Replace `<header class="[ page-header ]">` in `my-artists-route.html` with `<page-header>` and move action elements into the slot
+- [x] 3.2 Remove `.page-header` CSS block from `my-artists-route.css`
+- [x] 3.3 Replace `<header class="[ page-header ]">` in `settings-route.html` with `<page-header>`
+- [x] 3.4 Remove `.page-header` CSS block from `settings-route.css`
+- [x] 3.5 Replace `<header class="[ page-header ]">` in `tickets-route.html` with `<page-header>`
+- [x] 3.6 Remove `.page-header` CSS block from `tickets-route.css`
+
+## 4. Verify
+
+- [x] 4.1 Run `make check` to ensure lint, typecheck, and tests pass


### PR DESCRIPTION
## Summary

Add OpenSpec change artifacts for extracting the duplicated `page-header` pattern into a shared Custom Element.

### Artifacts
- **proposal.md**: Motivation — 3 routes share identical header markup/CSS
- **design.md**: Light DOM CE with `title-key` bindable + `<au-slot>`, flexbox layout
- **specs/page-header-ce/spec.md**: 5 requirements, 6 scenarios
- **tasks.md**: 11 implementation tasks (all completed in frontend PR #205)

## Test plan
- [x] `openspec status --change extract-page-header-ce` shows all artifacts complete
- [x] Implementation verified against specs via `/opsx:verify`
