### PR TITLE
feat(proto): add Fanart messages for artist image support

### DIFF
--- a/openspec/changes/artist-image/.openspec.yaml
+++ b/openspec/changes/artist-image/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-16

--- a/openspec/changes/artist-image/design.md
+++ b/openspec/changes/artist-image/design.md
@@ -1,0 +1,137 @@
+## Context
+
+Artist エンティティには画像情報がなく、フロントエンドでは名前ハッシュの HSL カラーのみで識別している。fanart.tv はコミュニティ駆動のアーティスト画像データベースで、MusicBrainz ID (MBID) をキーにアーティスト画像（thumb, background, logo, banner）を無料 API で提供している。
+
+既存の backend には以下の基盤がある:
+- `ARTIST.created` イベント（Watermill + NATS JetStream）
+- Last.fm / MusicBrainz クライアント（throttle + retry パターン）
+- concert-discovery CronJob（circuit breaker パターン）
+- ArtistNameConsumer（イベント駆動の非同期処理パターン）
+
+## Goals / Non-Goals
+
+**Goals:**
+- fanart.tv API から MBID ベースでアーティスト画像データを取得し DB に保存する
+- `ARTIST.created` イベントで即時取得（onboarding 時の dashboard ロゴ表示）
+- 定期 CronJob で画像データの更新とバックフィルを実施
+- Proto の Artist メッセージに Fanart を含め、RPC で best image を返却する
+
+**Non-Goals:**
+- フロントエンド側の画像表示実装（別 change）
+- 画像ファイルのダウンロード・自前ホスティング（fanart.tv URL を直接使用）
+- fanart.tv 以外の画像ソースへの抽象化
+
+## Decisions
+
+### 1. DB ストレージ: JSONB 単一カラム
+
+fanart.tv API レスポンスを `fanart` JSONB カラムにそのまま保存する。
+
+```sql
+ALTER TABLE artists
+    ADD COLUMN fanart JSONB,
+    ADD COLUMN fanart_synced_at TIMESTAMPTZ;
+```
+
+**Why**: fanart.tv のレスポンスは「外部キャッシュ」の性質。正規化テーブルに分解すると定期更新時の diff/upsert が複雑になる。JSONB なら丸ごと上書きで済む。画像選択ロジック（likes 最大）は Go 側で処理する。
+
+**Alternatives considered**:
+- `artist_images` 正規化テーブル: 1 アーティストで 10+ 行になりうる。定期更新時の diff が複雑。画像タイプ追加のたびにスキーマ対応が必要。
+- 画像タイプ別カラム (`thumb_url`, `logo_url`): best image 選択が DB 側に固定される。全候補データが失われる。
+
+### 2. Entity 設計: fanart.tv 構造をそのままドメインに出す
+
+fanart.tv を抽象化せず、ビジネスロジックの一部として扱う。Entity のフィールド構成は fanart.tv レスポンスと同一にする。
+
+```go
+type Fanart struct {
+    ArtistThumb      []FanartImage `json:"artistthumb"`
+    ArtistBackground []FanartImage `json:"artistbackground"`
+    HDMusicLogo      []FanartImage `json:"hdmusiclogo"`
+    MusicLogo        []FanartImage `json:"musiclogo"`
+    MusicBanner      []FanartImage `json:"musicbanner"`
+}
+
+type FanartImage struct {
+    ID    string `json:"id"`
+    URL   string `json:"url"`
+    Likes int    `json:"likes,string"`
+    Lang  string `json:"lang"`
+}
+```
+
+`Artist` struct に `Fanart *Fanart` と `FanartSyncTime *time.Time` を追加。
+
+**Why**: JSONB ↔ Go struct の変換が `json.Unmarshal` 一発で済む。fanart.tv の新しい画像タイプが追加された場合も struct にフィールドを足すだけ。
+
+### 3. Proto: Fanart メッセージで best image を返す
+
+Proto では各画像タイプに対して best image（likes 最大）の URL を 1 つだけ返す。
+
+```protobuf
+message Fanart {
+    optional Url artist_thumb = 1;
+    optional Url artist_background = 2;
+    optional Url hd_music_logo = 3;
+    optional Url music_logo = 4;
+    optional Url music_banner = 5;
+}
+
+message Artist {
+    ...
+    optional Fanart fanart = 4;
+}
+```
+
+**Why**: フロントエンドに全候補リストを返す必要はない。best image 選択はバックエンドの責務。ロゴのフォールバック（`hd_music_logo ?? music_logo`）はフロントエンド側で行う。
+
+### 4. 取得タイミング: Event Consumer + CronJob のハイブリッド
+
+| 仕組み | トリガー | 目的 |
+|--------|---------|------|
+| `ArtistImageConsumer` | `ARTIST.created` イベント | 即時取得（onboarding dashboard） |
+| `artist-image-sync` CronJob | 日次スケジュール | 定期更新 + バックフィル |
+
+両者は同じ `ArtistImageSyncUseCase` と fanart.tv クライアントを共有する。
+
+**Why**: onboarding フローで Artist フォロー直後に dashboard でロゴを表示する必要がある。CronJob だけでは最大 24h の遅延が発生する。
+
+### 5. fanart.tv クライアント: 既存パターン踏襲
+
+Last.fm クライアントと同じアーキテクチャで実装。
+
+- `infrastructure/music/fanarttv/client.go`
+- `throttle.Throttler` でレートリミット制御
+- `backoff.Retry` でリトライ（exponential backoff, max 4 tries）
+- `httpx.IsRetryableStatus` で 429/503/504 をリトライ対象に
+- API key は環境変数 `FANARTTV_API_KEY` から取得
+- `entity.ArtistImageResolver` インターフェースを実装
+
+### 6. Best Image 選択: likes 最大
+
+```go
+func BestByLikes(images []FanartImage) string {
+    // likes が最大の画像 URL を返す。空スライスなら空文字列。
+}
+```
+
+Entity のメソッドとして定義し、mapper 層から呼び出す。
+
+### 7. CronJob 設計: concert-discovery と同パターン
+
+- `cmd/job/artist-image-sync/main.go`
+- `di.InitializeImageSyncJobApp()` で DI 構成
+- `fanart IS NULL OR fanart_synced_at < now() - 7d` で対象選択（NULL 優先）
+- Circuit breaker: 3 連続失敗で停止
+- Exit 0（K8s リトライ防止）
+- K8s CronJob マニフェスト（concert-discovery をテンプレートに）
+
+## Risks / Trade-offs
+
+**[fanart.tv にアーティスト画像がない]** → Artist.Fanart が空のまま。フロントエンドは既存の HSL カラーにフォールバック（現状維持）。特にインディーズ/ローカルアーティストでカバー率が低い可能性あり。
+
+**[fanart.tv API ダウン]** → Retry + circuit breaker で制御。画像なしでもサービスの主機能（コンサート通知）には影響しない。
+
+**[fanart.tv ToS 変更・サービス終了]** → JSONB カラムのデータは残る。別ソースへの移行時は `ArtistImageResolver` インターフェース実装を差し替えるだけ。
+
+**[JSONB カラムサイズ]** → 1 アーティストあたり数 KB 程度（画像 URL のリスト）。数万アーティスト規模でも問題なし。

--- a/openspec/changes/artist-image/proposal.md
+++ b/openspec/changes/artist-image/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+Artist のカード表示（my-artists ページ、dashboard コンサートカード）やロゴ表示（dashboard）に画像がない。現在は名前ハッシュによる HSL カラーのみで視覚的識別を行っているが、ファンが直感的にアーティストを認識できる画像・ロゴが必要。fanart.tv API が MusicBrainz ID ベースでアーティスト画像を提供しており、既存の MBID 資産を活用できる。
+
+## What Changes
+
+- Artist エンティティに fanart.tv から取得した画像データ（Fanart）を追加
+- fanart.tv API クライアントを backend に実装（既存の Last.fm / MusicBrainz クライアントと同パターン）
+- `ARTIST.created` イベントで非同期に画像を即時取得（onboarding 時の dashboard ロゴ表示に必要）
+- 定期 CronJob (`artist-image-sync`) で画像データの更新とバックフィルを実施
+- Proto の Artist メッセージに Fanart メッセージを追加し、mapper で best image（likes 最大）を選択して返却
+- DB の artists テーブルに `fanart` (JSONB) と `fanart_synced_at` (TIMESTAMPTZ) カラムを追加
+
+## Capabilities
+
+### New Capabilities
+
+- `artist-image`: fanart.tv からアーティスト画像（thumb, background, logo, banner）を取得・保存・配信する仕組み
+
+### Modified Capabilities
+
+- `artist-service-infrastructure`: Artist エンティティへの Fanart フィールド追加、ArtistRepository への UpdateFanart 操作追加
+
+## Impact
+
+- **Proto**: `liverty_music.entity.v1.Artist` に `Fanart` メッセージ追加（非破壊的変更）
+- **Backend**: entity, usecase, adapter/event, adapter/rpc/mapper, infrastructure/music/fanarttv, infrastructure/database/rdb, cmd/job, di 各レイヤーに変更
+- **DB**: artists テーブルへのカラム追加マイグレーション
+- **K8s**: artist-image-sync CronJob マニフェスト追加、FANARTTV_API_KEY の Secret/ConfigMap 管理
+- **Frontend**: スコープ外（別 change で対応）

--- a/openspec/changes/artist-image/specs/artist-image/spec.md
+++ b/openspec/changes/artist-image/specs/artist-image/spec.md
@@ -1,0 +1,116 @@
+## ADDED Requirements
+
+### Requirement: Fanart Entity
+The system SHALL define a `Fanart` entity that mirrors the fanart.tv API response structure. The entity SHALL contain the following image collection fields: `ArtistThumb`, `ArtistBackground`, `HDMusicLogo`, `MusicLogo`, `MusicBanner`. Each collection SHALL contain zero or more `FanartImage` entries with `ID`, `URL`, `Likes`, and `Lang` fields.
+
+#### Scenario: Fanart with all image types populated
+- **WHEN** fanart.tv returns data for an artist with all image types
+- **THEN** the `Fanart` entity SHALL contain non-empty slices for `ArtistThumb`, `ArtistBackground`, `HDMusicLogo`, `MusicLogo`, and `MusicBanner`
+
+#### Scenario: Fanart with partial image types
+- **WHEN** fanart.tv returns data with only some image types (e.g., only `ArtistThumb` and `HDMusicLogo`)
+- **THEN** the `Fanart` entity SHALL contain non-empty slices for the available types and empty slices for the missing types
+
+### Requirement: Best Image Selection
+The system SHALL provide a `BestByLikes` function that selects the image with the highest `Likes` count from a given `FanartImage` slice. The function SHALL return an empty string when the input slice is empty.
+
+#### Scenario: Multiple images with different likes
+- **WHEN** `BestByLikes` is called with a slice containing images with likes values [3, 7, 1]
+- **THEN** the function SHALL return the URL of the image with 7 likes
+
+#### Scenario: Empty image slice
+- **WHEN** `BestByLikes` is called with an empty slice
+- **THEN** the function SHALL return an empty string
+
+### Requirement: Fanart Proto Message
+The system SHALL define a `Fanart` protobuf message within `liverty_music.entity.v1` containing optional URL fields for each image type: `artist_thumb`, `artist_background`, `hd_music_logo`, `music_logo`, `music_banner`. Each field SHALL use a dedicated wrapper message with URI validation. The `Artist` message SHALL include an `optional Fanart fanart` field.
+
+#### Scenario: Artist with fanart data
+- **WHEN** an Artist is serialized to proto and fanart data exists
+- **THEN** the `fanart` field SHALL contain a `Fanart` message with best image URLs populated for each available image type
+
+#### Scenario: Artist without fanart data
+- **WHEN** an Artist is serialized to proto and no fanart data exists
+- **THEN** the `fanart` field SHALL be absent (optional not set)
+
+### Requirement: Fanart Proto Mapper
+The mapper layer SHALL convert the domain `Fanart` entity (with full image arrays) to the proto `Fanart` message (with single best URL per type) using `BestByLikes` for selection.
+
+#### Scenario: Mapper selects best images
+- **WHEN** a domain Artist with Fanart data is mapped to proto
+- **THEN** each proto Fanart field SHALL contain the URL of the image with the highest likes count from the corresponding domain field
+
+### Requirement: Fanart Database Storage
+The system SHALL store fanart.tv API response data in a `fanart` JSONB column on the `artists` table. The system SHALL also store the synchronization timestamp in a `fanart_synced_at` TIMESTAMPTZ column.
+
+#### Scenario: Fanart data persisted
+- **WHEN** fanart data is fetched for an artist
+- **THEN** the `fanart` JSONB column SHALL contain the parsed response data and `fanart_synced_at` SHALL be set to the current timestamp
+
+#### Scenario: Fanart data updated
+- **WHEN** fanart data is re-fetched for an artist that already has fanart data
+- **THEN** the `fanart` JSONB column SHALL be overwritten with the new data and `fanart_synced_at` SHALL be updated
+
+### Requirement: ArtistImageResolver Interface
+The system SHALL define an `ArtistImageResolver` interface in the entity layer with a method `ResolveImages(ctx, mbid) (*Fanart, error)` that fetches image data from an external source using the artist's MusicBrainz ID.
+
+#### Scenario: Successful image resolution
+- **WHEN** `ResolveImages` is called with a valid MBID that has fanart.tv data
+- **THEN** it SHALL return a populated `Fanart` entity
+
+#### Scenario: No images found
+- **WHEN** `ResolveImages` is called with an MBID that has no fanart.tv data
+- **THEN** it SHALL return `nil` without error
+
+#### Scenario: External service failure
+- **WHEN** the external image service is unavailable
+- **THEN** it SHALL return an `Unavailable` error
+
+### Requirement: fanart.tv API Client
+The system SHALL implement the `ArtistImageResolver` interface using the fanart.tv API v3 endpoint `GET /v3/music/{mbid}`. The client SHALL use the existing throttle and retry patterns (exponential backoff, max 4 retries). Authentication SHALL use a project API key provided via `FANARTTV_API_KEY` environment variable.
+
+#### Scenario: Successful API call
+- **WHEN** the client calls fanart.tv with a valid MBID
+- **THEN** it SHALL parse the JSON response into a `Fanart` entity
+
+#### Scenario: Artist not found on fanart.tv
+- **WHEN** fanart.tv returns HTTP 404 for an MBID
+- **THEN** the client SHALL return `nil` without error
+
+#### Scenario: Rate limited
+- **WHEN** fanart.tv returns HTTP 429
+- **THEN** the client SHALL retry with exponential backoff respecting the `Retry-After` header
+
+### Requirement: Immediate Image Fetch on Artist Creation
+The system SHALL subscribe to `ARTIST.created` events and asynchronously fetch fanart data for newly created artists. This ensures images are available shortly after onboarding when artists are followed.
+
+#### Scenario: New artist created with MBID
+- **WHEN** an `ARTIST.created` event is received with a non-empty MBID
+- **THEN** the consumer SHALL call `ArtistImageResolver.ResolveImages` and persist the result via `ArtistRepository.UpdateFanart`
+
+#### Scenario: fanart.tv has no data for the artist
+- **WHEN** `ResolveImages` returns nil for the new artist
+- **THEN** the consumer SHALL update `fanart_synced_at` to the current time without setting fanart data
+
+#### Scenario: fanart.tv is unavailable
+- **WHEN** `ResolveImages` returns an error
+- **THEN** the consumer SHALL return the error (Watermill retry middleware will retry with exponential backoff, eventually sending to poison queue)
+
+### Requirement: Periodic Image Sync CronJob
+The system SHALL run a daily CronJob (`artist-image-sync`) that refreshes stale fanart data and backfills artists without fanart data. The job SHALL select artists where `fanart IS NULL` (prioritized) or `fanart_synced_at` is older than 7 days. The job SHALL use a circuit breaker pattern (stop after 3 consecutive failures).
+
+#### Scenario: Backfill artist without fanart
+- **WHEN** the CronJob runs and finds artists with `fanart IS NULL`
+- **THEN** it SHALL fetch fanart data for each and persist the result
+
+#### Scenario: Refresh stale fanart
+- **WHEN** the CronJob runs and finds artists with `fanart_synced_at` older than 7 days
+- **THEN** it SHALL re-fetch fanart data and overwrite the existing JSONB
+
+#### Scenario: Circuit breaker activation
+- **WHEN** 3 consecutive fanart.tv API calls fail
+- **THEN** the job SHALL stop processing remaining artists and exit with code 0
+
+#### Scenario: SIGTERM during processing
+- **WHEN** the job receives SIGTERM while processing
+- **THEN** the job SHALL stop processing and exit gracefully

--- a/openspec/changes/artist-image/specs/artist-service-infrastructure/spec.md
+++ b/openspec/changes/artist-image/specs/artist-service-infrastructure/spec.md
@@ -1,0 +1,16 @@
+## MODIFIED Requirements
+
+### Requirement: Standalone Artist Service
+The system SHALL provide a dedicated `ArtistService` that is independent of the `ConcertService` for managing artist-related operations. The service SHALL return Artist entities with populated Fanart data when available.
+
+#### Scenario: Service initialization
+- **WHEN** the backend application starts
+- **THEN** the `ArtistService` SHALL be registered as a separate RPC handler with its own set of dependencies (repositories, external clients)
+
+#### Scenario: Artist response includes fanart
+- **WHEN** any Artist RPC method returns an Artist entity that has Fanart data in the database
+- **THEN** the response SHALL include the `fanart` field with best image URLs selected by likes count
+
+#### Scenario: Artist response without fanart
+- **WHEN** any Artist RPC method returns an Artist entity without Fanart data
+- **THEN** the response SHALL omit the `fanart` field (optional not set)

--- a/openspec/changes/artist-image/tasks.md
+++ b/openspec/changes/artist-image/tasks.md
@@ -1,0 +1,68 @@
+## 1. Proto (specification repo)
+
+- [x] 1.1 Add `FanartImageUrl` wrapper message to `entity/v1/entity.proto` with URI validation
+- [x] 1.2 Add `Fanart` message to `entity/v1/artist.proto` with optional fields: `artist_thumb`, `artist_background`, `hd_music_logo`, `music_logo`, `music_banner`
+- [x] 1.3 Add `optional Fanart fanart` field to `Artist` message
+- [x] 1.4 Run `buf lint` and `buf format -w` to validate
+
+## 2. Database Migration (backend repo)
+
+- [x] 2.1 Add `fanart JSONB` and `fanart_synced_at TIMESTAMPTZ` columns to `artists` table in `schema.sql`
+- [x] 2.2 Generate Atlas migration with `atlas migrate diff --env local add-artist-fanart`
+- [x] 2.3 Add migration file to `k8s/atlas/base/kustomization.yaml`
+
+## 3. Entity Layer (backend repo)
+
+- [x] 3.1 Add `Fanart` and `FanartImage` structs to `internal/entity/` with JSON tags matching fanart.tv field names
+- [x] 3.2 Add `Fanart *Fanart` and `FanartSyncTime *time.Time` fields to `Artist` struct
+- [x] 3.3 Implement `BestByLikes([]FanartImage) string` function
+- [x] 3.4 Define `ArtistImageResolver` interface with `ResolveImages(ctx, mbid) (*Fanart, error)`
+- [x] 3.5 Add `UpdateFanart(ctx, id, fanart, syncTime)` method to `ArtistRepository` interface
+
+## 4. Infrastructure: fanart.tv Client (backend repo)
+
+- [x] 4.1 Create `internal/infrastructure/music/fanarttv/client.go` implementing `ArtistImageResolver`
+- [x] 4.2 Implement `GET /v3/music/{mbid}` with throttle, retry, and error handling (follow lastfm client pattern)
+- [x] 4.3 Handle HTTP 404 as nil return (no images), HTTP 429 with retry
+- [x] 4.4 Add `FANARTTV_API_KEY` to `pkg/config/config.go`
+
+## 5. Infrastructure: Database Repository (backend repo)
+
+- [x] 5.1 Implement `UpdateFanart` in `artist_repo.go` (UPDATE fanart JSONB and fanart_synced_at)
+- [x] 5.2 Update existing artist query methods to include `fanart` and `fanart_synced_at` columns
+- [x] 5.3 Add `ListStaleOrMissingFanart(ctx, staleDuration, limit)` query for CronJob
+
+## 6. UseCase Layer (backend repo)
+
+- [x] 6.1 Create `ArtistImageSyncUseCase` with `SyncArtistImage(ctx, artistID, mbid)` method
+- [x] 6.2 Implement: resolve images → update fanart (or sync time only if nil) flow
+
+## 7. Event Consumer (backend repo)
+
+- [x] 7.1 Create `ArtistImageConsumer` in `internal/adapter/event/` subscribing to `ARTIST.created`
+- [x] 7.2 Wire consumer into `cmd/consumer/main.go` router
+- [x] 7.3 Update DI in `internal/di/consumer.go`
+
+## 8. CronJob (backend repo)
+
+- [x] 8.1 Create `cmd/job/artist-image-sync/main.go` (follow concert-discovery pattern)
+- [x] 8.2 Implement batch processing with circuit breaker (3 consecutive failures)
+- [x] 8.3 Add DI initializer `InitializeImageSyncJobApp` in `internal/di/`
+
+## 9. RPC Mapper (backend repo)
+
+- [x] 9.1 Update `internal/adapter/rpc/mapper/artist.go` to map `Fanart` entity → proto using `BestByLikes`
+
+## 10. Kubernetes Manifests (cloud-provisioning repo)
+
+- [x] 10.1 Create `artist-image-sync` CronJob manifest (template from concert-discovery)
+- [x] 10.2 Add `FANARTTV_API_KEY` to ExternalSecret / Secret configuration
+- [x] 10.3 Mount API key env var in both consumer Deployment and CronJob
+
+## 11. Tests (backend repo)
+
+- [x] 11.1 Unit test `BestByLikes` function
+- [x] 11.2 Unit test fanart.tv client with httptest server
+- [x] 11.3 Integration test `UpdateFanart` and `ListStaleOrMissingFanart` repository methods
+- [x] 11.4 Unit test `ArtistImageConsumer` handler
+- [ ] 11.5 Unit test proto mapper with fanart data (blocked: requires BSR-generated types)

--- a/proto/liverty_music/entity/v1/artist.proto
+++ b/proto/liverty_music/entity/v1/artist.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package liverty_music.entity.v1;
 
 import "buf/validate/validate.proto";
+import "liverty_music/entity/v1/entity.proto";
 
 // Artist represents a musical performer or band.
 // This is a central entity that fans follow to stay informed about upcoming
@@ -16,6 +17,10 @@ message Artist {
 
   // Required. The unique identifier for the artist in MusicBrainz.
   Mbid mbid = 3 [(buf.validate.field).required = true];
+
+  // Community-curated artist images from fanart.tv.
+  // Absent when no image data has been fetched or the artist has no fanart.tv entry.
+  optional Fanart fanart = 4;
 }
 
 // ArtistId is a globally unique identifier for an artist.
@@ -58,4 +63,25 @@ message OfficialSiteId {
 message OfficialSiteUrl {
   // The URI value of the official site.
   string value = 1 [(buf.validate.field).string.uri = true];
+}
+
+// Fanart holds community-curated artist images sourced from fanart.tv.
+// Each field carries the best image URL (highest community votes) for that image type.
+// All fields are optional because fanart.tv coverage varies by artist.
+message Fanart {
+  // A square portrait or photo of the artist (1000x1000).
+  optional FanartImageUrl artist_thumb = 1;
+
+  // A high-resolution backdrop image (1920x1080).
+  optional FanartImageUrl artist_background = 2;
+
+  // A high-definition transparent logo of the artist name (800x310).
+  optional FanartImageUrl hd_music_logo = 3;
+
+  // A standard-definition transparent logo of the artist name (400x155).
+  // Used as a fallback when hd_music_logo is unavailable.
+  optional FanartImageUrl music_logo = 4;
+
+  // A wide banner image for the artist (1000x185).
+  optional FanartImageUrl music_banner = 5;
 }

--- a/proto/liverty_music/entity/v1/entity.proto
+++ b/proto/liverty_music/entity/v1/entity.proto
@@ -58,6 +58,18 @@ message SourceUrl {
   }];
 }
 
+// FanartImageUrl represents a URL pointing to an artist image hosted on fanart.tv.
+// Used within the Fanart message to provide community-curated artist visuals
+// such as thumbnails, logos, backgrounds, and banners.
+message FanartImageUrl {
+  // The URI value pointing to the fanart.tv hosted image. Must be a valid URI.
+  string value = 1 [(buf.validate.field).string = {
+    uri: true
+    min_len: 1
+    max_len: 2048
+  }];
+}
+
 // ListedVenueName represents the raw venue name as scraped from the source.
 // This preserves the original text separately from the normalized Venue.name,
 // which may have been corrected or standardised.


### PR DESCRIPTION
## Related Issue

Closes #255

## Summary of Changes

Add proto definitions to support fanart.tv artist image integration:

- **FanartImageUrl** wrapper message in `entity.proto` with URI validation (`uri: true`, `min_len: 1`, `max_len: 2048`)
- **Fanart** message in `artist.proto` with 5 optional image type fields: `artist_thumb`, `artist_background`, `hd_music_logo`, `music_logo`, `music_banner`
- **`optional Fanart fanart = 4`** field added to `Artist` message

Each field represents the best community-voted image URL for that image type, selected server-side via a `BestByLikes` function. This is a non-breaking additive change.

Also includes OpenSpec change artifacts (proposal, design, specs, tasks) documenting the full artist-image feature scope across specification, backend, and cloud-provisioning repos.

## Self-Checklist

- [x] I have linked the related issue.
- [x] I have updated the relevant documentation (e.g., README.md) if needed.
- [x] I have run `buf lint` and `buf format` locally and all checks have passed.
- [x] My proto definitions follow the project's style guidelines and validation rules.
- [x] Breaking changes have been justified and documented if applicable.
