### PR TITLE
docs(openspec): sync festival-ui-refresh specs and archive

### DIFF
--- a/openspec/changes/archive/2026-03-16-festival-ui-refresh/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-16-festival-ui-refresh/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-16

--- a/openspec/changes/archive/2026-03-16-festival-ui-refresh/design.md
+++ b/openspec/changes/archive/2026-03-16-festival-ui-refresh/design.md
@@ -1,0 +1,79 @@
+## Context
+
+The Liverty Music frontend uses a CUBE CSS architecture with design tokens centralized in `tokens.css`. The current palette is a dark-first theme with muted purple brand colors and near-black surfaces (`oklch(14.5%)`). The dashboard uses a 3-lane subgrid layout for HOME/NEAR/AWAY stages but all lanes share the same monochrome visual treatment.
+
+The existing token system is well-structured — all components reference `--color-*`, `--font-*`, `--shadow-*` tokens rather than hardcoded values. This means a palette swap at the token level propagates automatically to all components. Component-level CSS changes are only needed where new tokens (stage colors) are introduced or where new visual effects (gradients, glows) are added.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Transform the visual tone from "dark and subdued" to "vibrant festival" by updating design token values
+- Give each dashboard stage (HOME/NEAR/AWAY) a distinct color identity
+- Upgrade typography to festival-appropriate display + body fonts
+- Consolidate tone-and-manner into `tokens.css` — all color, font, and shadow definitions live in `:root` custom properties; components reference tokens only
+- Maintain WCAG AA contrast ratios with the new palette
+- Follow CUBE CSS layer discipline: compositions stay layout-only; visual treatment (stage colors, glows) lives in block/exception layers
+
+**Non-Goals:**
+- No layout/structure changes — the 3-lane subgrid, app-shell grid, and component hierarchy remain unchanged
+- No new components or routes
+- No backend, API, or data model changes
+- No light theme — this remains dark-first (but warmer/more colorful dark)
+- No animation overhaul — existing keyframes and transitions stay
+- No new composition primitives — existing compositions (`flow`, `cluster`, `stack`, `wrapper`, `grid-auto`, `center`) are sufficient
+
+## Decisions
+
+### 1. Token-level palette swap (not component-level overrides)
+
+**Decision**: Change token values in `tokens.css` `:root` rather than adding component-scoped color overrides.
+
+**Rationale**: The existing token architecture already ensures all components reference central tokens. Changing values at the source gives us site-wide consistency with minimal file changes. Components only need modification where new tokens (stage colors) are consumed.
+
+**Alternative considered**: CSS custom property overrides per-component or per-route. Rejected because it fragments the design system and creates maintenance burden.
+
+### 2. OKLCH color space preserved with relative color syntax for derived values
+
+**Decision**: Keep all color definitions in OKLCH. Use relative color syntax (`oklch(from var(--token) l c h / N%)`) for derived values like shadows and opacity variants.
+
+**Rationale**: OKLCH is already used throughout. Relative color syntax ensures derived values (shadow glows, border accents) stay in sync when the source token changes — no hardcoded oklch literals scattered across files. This aligns with the CUBE CSS principle of tokens as single source of truth.
+
+### 3. Font loading strategy: additive, not replacement
+
+**Decision**: Add Righteous and Poppins via new Google Fonts `<link>` tags. Retain the existing Outfit `<link>` as it serves as the second fallback in the `--font-display` stack.
+
+**Rationale**: Google Fonts is already in the CSP allowlist. Using `display=swap` prevents invisible text during load. Keeping Outfit loaded means graceful degradation if Google Fonts CDN is slow for the new fonts. The font stack `"Righteous", "Outfit", system-ui` ensures progressive enhancement.
+
+**Alternative considered**: Self-hosting fonts via `@font-face` in the bundle. Rejected for now — adds build complexity; Google Fonts CDN with preconnect is sufficient for current scale.
+
+### 4. Stage colors as first-class tokens, applied via block/exception pattern
+
+**Decision**: Add `--color-stage-home`, `--color-stage-near`, `--color-stage-away` to `:root` in `tokens.css`. Apply them in component block layers via `data-stage` attribute selectors (CUBE CSS exception pattern).
+
+**Rationale**: Stage identity is a core domain concept. Making them first-class tokens means any component can reference them. The visual application (background color, text color) belongs in each component's block `@scope`, not in a composition — CUBE CSS compositions must remain layout-only (no color, font-style, shadows, backgrounds).
+
+**Alternative considered**: Creating a `.stage-banner` composition class. Rejected because compositions must not contain visual treatment per CUBE CSS methodology. The `data-stage` attribute is already present in the HTML template, making it a natural exception selector.
+
+### 5. Righteous font-weight: 400 only
+
+**Decision**: All uses of `--font-display` SHALL use `font-weight: normal` (400) or omit weight entirely.
+
+**Rationale**: Righteous ships only weight 400. Specifying `font-weight: 700` (currently used in stage headers, page headers, and event card titles) causes browsers to synthesize faux-bold, which looks poor with display typefaces. Righteous is inherently bold-looking at its native weight.
+
+### 6. Bottom nav glow via box-shadow + pseudo-element gradient border
+
+**Decision**: Use `box-shadow` for active tab glow. Use a `::before` pseudo-element with `background-image: linear-gradient(...)` for the gradient top border.
+
+**Rationale**: `box-shadow` is GPU-composited, doesn't affect layout, and works with existing `transition: color`. The gradient border uses `::before` instead of `border-image` because `border-image` disables `border-radius` per CSS spec — even though the current nav has no radius, this prevents future breakage.
+
+## Risks / Trade-offs
+
+**[Risk] Contrast regression with new palette** → All new color combinations will be verified against WCAG AA (4.5:1 for body text, 3:1 for large text). The deep navy surface (`oklch(18%)`) is still dark enough to provide strong contrast with near-white text. Stage banner text uses `--color-surface-base` (dark) on vibrant backgrounds — requires verification.
+
+**[Risk] Google Fonts dependency for three fonts** → If Google Fonts CDN is unavailable: Righteous falls back to Outfit (still loaded), Poppins falls back to system-ui. No broken layout, just reduced visual flair.
+
+**[Risk] Stage colors too saturated for card backgrounds** → Stage color tokens use moderate chroma (0.18–0.25) at medium lightness (68–75%). For card backgrounds, components will use `oklch(from var(--color-stage-*) l c h / N%)` relative color syntax to reduce opacity. Full-chroma values are intended for stage header backgrounds only.
+
+**[Trade-off] Righteous is a single-weight font** → This limits heading weight variation. Accepted because the font's inherent boldness and distinctive character compensate. Existing `font-weight: 700` declarations must be updated to `normal` to prevent faux-bold.
+
+**[Risk] Relative color syntax in shadow tokens** → `oklch(from var(...) l c h / N%)` is Baseline Newly Available (2024). All target browsers support it. No fallback needed for the current user base.

--- a/openspec/changes/archive/2026-03-16-festival-ui-refresh/proposal.md
+++ b/openspec/changes/archive/2026-03-16-festival-ui-refresh/proposal.md
@@ -1,0 +1,39 @@
+## Why
+
+The current dark theme (near-black surfaces, muted purple brand colors) feels heavy and subdued for a music platform. Users should feel the excitement of a live music festival when browsing upcoming concerts. Refreshing the visual tone to a vibrant, festival-inspired palette will make the app feel energetic and fun — especially the dashboard timetable, which should evoke the colorful stage-separated layouts seen at real music festivals like Wild Bunch Fest.
+
+## What Changes
+
+- **Color palette overhaul**: Replace muted purple/violet brand colors with vibrant festival palette (hot pink primary, electric blue secondary, lime green accent). Shift surface colors from near-black to deep navy with color warmth.
+- **Stage identity colors**: Introduce per-stage color tokens (HOME = orange, NEAR = cyan, AWAY = magenta) so each lane is visually distinct in the dashboard timetable.
+- **Typography upgrade**: Switch display font from Outfit to Righteous (festival/entertainment display face) and add Poppins as body font for a cleaner, more energetic feel.
+- **Dashboard stage headers**: Color-code each stage header span with its stage color background, creating a bold festival timetable banner row.
+- **Navigation vibrancy**: Add glow effects to active bottom nav tabs and gradient border accent.
+- **Shadow & glow updates**: Adjust card glow and shadow tokens to reference new brand colors.
+- **Text color warmth**: Shift secondary/muted text from neutral gray to slightly warm tinted values for cohesion with the new palette.
+
+## Capabilities
+
+### New Capabilities
+
+_None — this change modifies existing visual tokens and styles, not new behavioral capabilities._
+
+### Modified Capabilities
+
+- `design-system`: Color tokens, font tokens, shadow tokens, and border tokens are all changing values. New stage color tokens are added. Typography families change from Outfit/system-ui to Righteous/Poppins.
+- `typography-focused-dashboard`: Stage headers gain per-stage background colors. Lane separators use stage color accents. Date separators get gradient treatment.
+
+## Impact
+
+- **Frontend only** — no backend, API, or protobuf changes.
+- **Files affected**:
+  - `src/styles/tokens.css` — all token values updated, stage color tokens added
+  - `src/styles/global.css` — body background, link colors
+  - `src/styles/compositions.css` — potential new festival-themed compositions
+  - `src/routes/dashboard/dashboard-route.css` — stage header colors, lane accents
+  - `src/components/bottom-nav-bar/bottom-nav-bar.css` — nav glow effects
+  - `src/components/page-header/page-header.css` — header gradient
+  - `src/components/live-highway/event-card.css` — glow adjustments
+  - `index.html` — Google Fonts link updated (Righteous + Poppins)
+- **Dependencies**: Google Fonts CDN (Righteous, Poppins) — already allowed by CSP `style-src` and `font-src` directives.
+- **Design system spec**: Token values change but token names remain stable — no component API breakage.

--- a/openspec/changes/archive/2026-03-16-festival-ui-refresh/specs/design-system/spec.md
+++ b/openspec/changes/archive/2026-03-16-festival-ui-refresh/specs/design-system/spec.md
@@ -1,0 +1,126 @@
+## MODIFIED Requirements
+
+### Requirement: Design Token Definition
+The system SHALL define a centralized set of design tokens using plain CSS custom properties in `src/styles/tokens.css` to ensure visual consistency across all screens.
+
+#### Scenario: Color tokens defined
+- **WHEN** the design system is initialized
+- **THEN** the system SHALL define the following color token groups via CSS custom properties in `tokens.css`:
+  - `--color-brand-primary`: oklch(65% 0.28 350deg) (hot pink)
+  - `--color-brand-secondary`: oklch(62% 0.25 255deg) (electric blue)
+  - `--color-brand-accent`: oklch(82% 0.22 140deg) (lime green)
+  - `--color-surface-base`: oklch(18% 0.04 275deg) (deep navy)
+  - `--color-surface-raised`: oklch(22% 0.04 275deg)
+  - `--color-surface-overlay`: oklch(26% 0.04 275deg)
+  - `--color-text-primary`: oklch(98.5% 0 0deg)
+  - `--color-text-secondary`: oklch(82% 0.02 275deg) (warm-tinted light gray)
+  - `--color-text-muted`: oklch(60% 0.03 275deg) (warm-tinted dim gray)
+- **AND** all components SHALL reference these tokens instead of hardcoded color values
+- **AND** tokens SHALL be defined on `:root` using standard CSS custom property syntax, not Tailwind's `@theme` directive
+
+#### Scenario: Stage color tokens defined
+- **WHEN** the design system is initialized
+- **THEN** the system SHALL define per-stage identity color tokens:
+  - `--color-stage-home`: oklch(72% 0.2 55deg) (orange)
+  - `--color-stage-near`: oklch(75% 0.18 195deg) (cyan)
+  - `--color-stage-away`: oklch(68% 0.25 330deg) (magenta)
+- **AND** components needing stage-aware styling SHALL reference these tokens
+- **AND** stage colors SHALL be applied via `data-stage` attribute selectors in the block layer (CUBE CSS exception pattern), not in the composition layer
+
+#### Scenario: Typography tokens defined
+- **WHEN** the design system is initialized
+- **THEN** the system SHALL define font family tokens:
+  - `--font-display`: "Righteous", "Outfit", system-ui, sans-serif for hero copy, card headlines, section titles
+  - `--font-body`: "Poppins", system-ui, -apple-system, sans-serif for paragraphs, labels, metadata
+- **AND** the system SHALL define a type scale with sizes for mega (4xl or larger), heading (2xl-3xl), body (base-lg), caption (xs-sm)
+
+#### Scenario: Righteous font-weight constraint
+- **WHEN** `--font-display` resolves to Righteous
+- **THEN** components SHALL use `font-weight: normal` (400) or omit weight entirely for Righteous-rendered text
+- **AND** components SHALL NOT specify `font-weight: 700` or higher when using `--font-display`, as Righteous provides only weight 400 and higher values trigger faux-bold rendering
+
+#### Scenario: Border color tokens defined
+- **WHEN** the design system is initialized
+- **THEN** the system SHALL define border color tokens:
+  - `--color-border-subtle`: oklch(98.5% 0 0deg / 12%)
+  - `--color-border-muted`: oklch(98.5% 0 0deg / 22%)
+
+#### Scenario: Shadow tokens reference brand color via relative color syntax
+- **WHEN** the design system is initialized
+- **THEN** the system SHALL define shadow tokens using relative color syntax referencing `--color-brand-primary`:
+  - `--shadow-card-glow`: 0 4px 24px -4px oklch(from var(--color-brand-primary) l c h / 20%)
+  - `--shadow-button`: 0 4px 16px -2px oklch(from var(--color-brand-primary) l c h / 30%)
+- **AND** the `--shadow-sheet` and `--shadow-soft` tokens SHALL remain unchanged
+- **AND** shadow tokens SHALL NOT contain hardcoded oklch values; they SHALL always derive from brand color tokens
+
+#### Scenario: Shape tokens defined
+- **WHEN** the design system is initialized
+- **THEN** the system SHALL define radius tokens: `--radius-card` (1rem), `--radius-button` (0.75rem), `--radius-sheet` (1.5rem)
+
+#### Scenario: Spacing scale tokens defined
+- **WHEN** the design system is initialized
+- **THEN** the system SHALL define a fluid spacing scale using `clamp()` with tokens from `--space-3xs` through `--space-3xl`
+- **AND** composition primitives and block styles SHALL reference these spacing tokens instead of fixed pixel values
+
+#### Scenario: Container query breakpoint tokens defined
+- **WHEN** the design system is initialized
+- **THEN** the system SHALL define container query breakpoint tokens for component-level responsive design:
+  - `--container-sm`: 320px
+  - `--container-md`: 480px
+  - `--container-lg`: 640px
+- **AND** components using Container Queries SHALL reference these tokens for consistent breakpoints
+
+#### Scenario: View transition tokens defined
+- **WHEN** the design system is initialized
+- **THEN** the system SHALL define view transition duration and easing tokens:
+  - `--transition-route-duration`: 200ms
+  - `--transition-route-easing`: ease-out
+- **AND** route transitions SHALL reference these tokens instead of hardcoded values
+
+### Requirement: Display Font Loading
+The system SHALL load and apply display and body fonts with appropriate fallback and performance optimization.
+
+#### Scenario: Font preloading
+- **WHEN** the application loads
+- **THEN** the system SHALL preconnect to the font provider domains (fonts.googleapis.com and fonts.gstatic.com) in the HTML head
+- **AND** the preconnect to `fonts.gstatic.com` SHALL include the `crossorigin` attribute
+- **AND** the system SHALL load Righteous (weight 400) and Poppins (weights 300, 400, 500, 600, 700) with `font-display: swap`
+- **AND** the existing Outfit font `<link>` SHALL be retained as a fallback for `--font-display`
+- **AND** the system SHALL use Outfit as the second fallback for `--font-display` and system-ui as the fallback for `--font-body`
+
+## ADDED Requirements
+
+### Requirement: Stage-Colored Header Block
+The dashboard stage header SHALL apply per-stage identity colors via `data-stage` attribute selectors within the block layer (`@scope (dashboard-route)`), following the CUBE CSS exception pattern.
+
+#### Scenario: Stage header color via data-stage exception
+- **WHEN** a stage header span has `data-stage="home"`
+- **THEN** the background SHALL use `--color-stage-home`
+- **WHEN** a stage header span has `data-stage="near"`
+- **THEN** the background SHALL use `--color-stage-near`
+- **WHEN** a stage header span has `data-stage="away"`
+- **THEN** the background SHALL use `--color-stage-away`
+- **AND** text color SHALL be `--color-surface-base` (dark on vibrant background) for contrast
+
+#### Scenario: Stage header typography
+- **WHEN** stage header text is rendered
+- **THEN** the text SHALL use `--font-display` with `font-weight: normal` (400, matching Righteous single weight)
+- **AND** the text SHALL be uppercase with centered alignment
+
+#### Scenario: WCAG contrast on stage headers
+- **WHEN** stage header text is rendered
+- **THEN** the text-to-background contrast ratio SHALL meet WCAG AA (4.5:1 for normal text, 3:1 for large text)
+
+### Requirement: Nav Glow Block Styling
+The bottom navigation bar SHALL apply glow and gradient effects within its own block layer (`@scope (bottom-nav-bar)`), not in the composition layer.
+
+#### Scenario: Active nav tab glow
+- **WHEN** a navigation tab is in active state (`data-active="true"`)
+- **THEN** the tab SHALL display a subtle box-shadow glow using `--color-brand-accent` at reduced opacity
+- **AND** the glow SHALL transition smoothly using `--transition-normal`
+
+#### Scenario: Nav top border gradient via pseudo-element
+- **WHEN** the bottom navigation bar is rendered
+- **THEN** the top border area SHALL display a gradient from `--color-brand-primary` through `--color-brand-secondary` to `--color-brand-accent`
+- **AND** the gradient SHALL be implemented via a `::before` pseudo-element with `background-image: linear-gradient(...)` and `block-size: 1px`
+- **AND** the implementation SHALL NOT use `border-image` (which disables `border-radius`)

--- a/openspec/changes/archive/2026-03-16-festival-ui-refresh/specs/typography-focused-dashboard/spec.md
+++ b/openspec/changes/archive/2026-03-16-festival-ui-refresh/specs/typography-focused-dashboard/spec.md
@@ -1,10 +1,4 @@
-# Capability: Typography-Focused Dashboard
-
-## Purpose
-
-Display upcoming concerts in a three-lane layout (HOME STAGE, NEAR STAGE, AWAY STAGE) with typography-focused card design and visual mutations for high-priority artists.
-
-## Requirements
+## MODIFIED Requirements
 
 ### Requirement: Three-Lane Live Highway Layout
 The system SHALL display live events in a three-column equal-width timeline layout organized by geographical proximity and date, with festival-style sticky STAGE headers using per-stage identity colors and a vibrant dark-themed aesthetic. The dashboard SHALL handle data loading errors gracefully and distinguish between empty data and error states.
@@ -77,41 +71,3 @@ The system SHALL display live events in a three-column equal-width timeline layo
 - **THEN** the separator background SHALL use a linear gradient from `--color-stage-home` through `--color-stage-near` to `--color-stage-away` at 10% opacity
 - **AND** the date text SHALL use `--color-brand-accent` color
 - **AND** the separator SHALL maintain `position: sticky` with `inset-block-start: 0` behavior and `backdrop-filter: blur(4px)`
-
-### Requirement: Must Go Mutation UI
-
-When a Must Go artist's event appears in Lane 2 (Region) or Lane 3 (Other), the event card SHALL visually mutate to draw attention.
-
-#### Scenario: Must Go event in Region lane
-
-- **GIVEN** a Must Go artist has an event in the Region lane
-- **WHEN** the dashboard renders that event
-- **THEN** the card SHALL be expanded with a badge, vivid accent color with glow shadow, and bolder typography
-
-#### Scenario: Must Go event in Other lane
-
-- **GIVEN** a Must Go artist has an event in the Other lane
-- **WHEN** the dashboard renders that event
-- **THEN** the card SHALL be promoted from text-only to card style with a badge, background color, and ring border
-
-#### Scenario: Must Go event in Main lane is not mutated
-
-- **GIVEN** a Must Go artist has an event in the Main lane
-- **WHEN** the dashboard renders that event
-- **THEN** the card SHALL render normally (Main lane cards are already prominent)
-
-#### Scenario: Non-Must-Go events are not mutated
-
-- **GIVEN** an artist with Local Only or Keep an Eye passion level
-- **WHEN** the dashboard renders their event in any lane
-- **THEN** the card SHALL render in its normal style without mutation
-
-### Requirement: Mutation Layout Handling
-
-The dashboard layout SHALL accommodate mutated cards without breaking lane alignment.
-
-#### Scenario: Multiple mutated cards on same date
-
-- **GIVEN** multiple Must Go artists have events on the same date in Lane 2 or Lane 3
-- **WHEN** the dashboard renders that date group
-- **THEN** all mutated cards SHALL render without overflow, stacking vertically within their lane

--- a/openspec/changes/archive/2026-03-16-festival-ui-refresh/tasks.md
+++ b/openspec/changes/archive/2026-03-16-festival-ui-refresh/tasks.md
@@ -1,0 +1,40 @@
+## 1. Design Tokens & Fonts
+
+- [x] 1.1 Update `index.html`: add Righteous + Poppins Google Fonts `<link>` tags (retain existing Outfit link as fallback), update `theme-color` meta to deep navy
+- [x] 1.2 Update `tokens.css`: replace brand color values (primary → hot pink, secondary → electric blue, accent → lime green)
+- [x] 1.3 Update `tokens.css`: add stage color tokens (`--color-stage-home`, `--color-stage-near`, `--color-stage-away`)
+- [x] 1.4 Update `tokens.css`: replace surface color values (base/raised/overlay → deep navy with hue)
+- [x] 1.5 Update `tokens.css`: update text color values (secondary/muted → warm-tinted gray)
+- [x] 1.6 Update `tokens.css`: update border color opacity values (subtle → 12%, muted → 22%)
+- [x] 1.7 Update `tokens.css`: replace `--font-display` to Righteous-first stack, `--font-body` to Poppins-first stack
+- [x] 1.8 Update `tokens.css`: update shadow tokens to use relative color syntax (`oklch(from var(--color-brand-primary) l c h / N%)`)
+
+## 2. Global Styles Verification
+
+- [x] 2.1 Verify `global.css` body/link styles reference tokens correctly (no hardcoded colors to update)
+- [x] 2.2 Verify `compositions.css` requires no changes (compositions are layout-only, no visual treatment)
+
+## 3. Dashboard Festival Timetable (Block Layer)
+
+- [x] 3.1 Update `dashboard-route.css`: apply per-stage colors to `.stage-header > span` via `[data-stage]` attribute selectors within `@scope` (exception pattern)
+- [x] 3.2 Update `dashboard-route.css`: change `font-weight: 700` to `font-weight: normal` on stage header spans (Righteous single-weight constraint)
+- [x] 3.3 Update `dashboard-route.css`: lane columns get subtle stage-colored `border-block-start` accents
+- [x] 3.4 Update `dashboard-route.css`: date separator background uses stage-color gradient at low opacity
+
+## 4. Navigation & Headers (Block Layer)
+
+- [x] 4.1 Update `bottom-nav-bar.css`: replace `border-block-start` with `::before` pseudo-element gradient (primary → secondary → accent)
+- [x] 4.2 Update `bottom-nav-bar.css`: add active tab glow effect via `box-shadow` on `[data-active="true"]`
+- [x] 4.3 Update `page-header.css`: subtle gradient background and change `font-weight: 700` to `font-weight: normal`
+
+## 5. Event Card Adjustments (Block Layer)
+
+- [x] 5.1 Review `event-card.css`: verify glow/shadow effects work with new brand colors (token references should auto-propagate)
+- [x] 5.2 Update `event-card.css`: change `.artist-name` `font-weight: 800` to `font-weight: normal` (Righteous single-weight constraint)
+
+## 6. Verification
+
+- [x] 6.1 Run `make check` in frontend to verify lint + test pass
+- [x] 6.2 Verify WCAG AA contrast: stage header text (`--color-surface-base`) on each stage color background
+- [x] 6.3 Verify WCAG AA contrast: body text (`--color-text-primary`) on new surface-base background
+- [x] 6.4 Verify no `font-weight` values > 400 remain on elements using `--font-display`

--- a/openspec/specs/design-system/spec.md
+++ b/openspec/specs/design-system/spec.md
@@ -12,29 +12,56 @@ The system SHALL define a centralized set of design tokens using plain CSS custo
 #### Scenario: Color tokens defined
 - **WHEN** the design system is initialized
 - **THEN** the system SHALL define the following color token groups via CSS custom properties in `tokens.css`:
-  - `--color-brand-primary`: oklch(58.5% 0.233 277deg)
-  - `--color-brand-secondary`: oklch(54.1% 0.281 293deg)
-  - `--color-brand-accent`: oklch(78.9% 0.154 211deg)
-  - `--color-surface-base`: oklch(14.5% 0.014 286deg)
-  - `--color-surface-raised`: oklch(17.8% 0.014 286deg)
-  - `--color-surface-overlay`: oklch(21% 0.014 286deg)
+  - `--color-brand-primary`: oklch(65% 0.28 350deg) (hot pink)
+  - `--color-brand-secondary`: oklch(62% 0.25 255deg) (electric blue)
+  - `--color-brand-accent`: oklch(82% 0.22 140deg) (lime green)
+  - `--color-surface-base`: oklch(18% 0.04 275deg) (deep navy)
+  - `--color-surface-raised`: oklch(22% 0.04 275deg)
+  - `--color-surface-overlay`: oklch(26% 0.04 275deg)
   - `--color-text-primary`: oklch(98.5% 0 0deg)
-  - `--color-text-secondary`: oklch(78.8% 0.013 286deg)
-  - `--color-text-muted`: oklch(55.6% 0.014 286deg)
+  - `--color-text-secondary`: oklch(82% 0.02 275deg) (warm-tinted light gray)
+  - `--color-text-muted`: oklch(60% 0.03 275deg) (warm-tinted dim gray)
 - **AND** all components SHALL reference these tokens instead of hardcoded color values
 - **AND** tokens SHALL be defined on `:root` using standard CSS custom property syntax, not Tailwind's `@theme` directive
+
+#### Scenario: Stage color tokens defined
+- **WHEN** the design system is initialized
+- **THEN** the system SHALL define per-stage identity color tokens:
+  - `--color-stage-home`: oklch(72% 0.2 55deg) (orange)
+  - `--color-stage-near`: oklch(75% 0.18 195deg) (cyan)
+  - `--color-stage-away`: oklch(68% 0.25 330deg) (magenta)
+- **AND** components needing stage-aware styling SHALL reference these tokens
+- **AND** stage colors SHALL be applied via `data-stage` attribute selectors in the block layer (CUBE CSS exception pattern), not in the composition layer
 
 #### Scenario: Typography tokens defined
 - **WHEN** the design system is initialized
 - **THEN** the system SHALL define font family tokens:
-  - `--font-display`: "Outfit", system-ui, sans-serif for hero copy, card headlines, section titles
-  - `--font-body`: system-ui, -apple-system, sans-serif for paragraphs, labels, metadata
+  - `--font-display`: "Righteous", "Outfit", system-ui, sans-serif for hero copy, card headlines, section titles
+  - `--font-body`: "Poppins", system-ui, -apple-system, sans-serif for paragraphs, labels, metadata
 - **AND** the system SHALL define a type scale with sizes for mega (4xl or larger), heading (2xl-3xl), body (base-lg), caption (xs-sm)
+
+#### Scenario: Righteous font-weight constraint
+- **WHEN** `--font-display` resolves to Righteous
+- **THEN** components SHALL use `font-weight: normal` (400) or omit weight entirely for Righteous-rendered text
+- **AND** components SHALL NOT specify `font-weight: 700` or higher when using `--font-display`, as Righteous provides only weight 400 and higher values trigger faux-bold rendering
+
+#### Scenario: Border color tokens defined
+- **WHEN** the design system is initialized
+- **THEN** the system SHALL define border color tokens:
+  - `--color-border-subtle`: oklch(98.5% 0 0deg / 12%)
+  - `--color-border-muted`: oklch(98.5% 0 0deg / 22%)
+
+#### Scenario: Shadow tokens reference brand color via relative color syntax
+- **WHEN** the design system is initialized
+- **THEN** the system SHALL define shadow tokens using relative color syntax referencing `--color-brand-primary`:
+  - `--shadow-card-glow`: 0 4px 24px -4px oklch(from var(--color-brand-primary) l c h / 20%)
+  - `--shadow-button`: 0 4px 16px -2px oklch(from var(--color-brand-primary) l c h / 30%)
+- **AND** the `--shadow-sheet` and `--shadow-soft` tokens SHALL remain unchanged
+- **AND** shadow tokens SHALL NOT contain hardcoded oklch values; they SHALL always derive from brand color tokens
 
 #### Scenario: Shape tokens defined
 - **WHEN** the design system is initialized
 - **THEN** the system SHALL define radius tokens: `--radius-card` (1rem), `--radius-button` (0.75rem), `--radius-sheet` (1.5rem)
-- **AND** the system SHALL define shadow tokens: `--shadow-card-glow`, `--shadow-sheet`, `--shadow-button`
 
 #### Scenario: Spacing scale tokens defined
 - **WHEN** the design system is initialized
@@ -58,30 +85,16 @@ The system SHALL define a centralized set of design tokens using plain CSS custo
 
 ---
 
-### Requirement: Dark Theme as Default
-The system SHALL apply a dark-first visual theme consistently across all screens and components.
-
-#### Scenario: Dark background applied globally
-- **WHEN** any screen is rendered
-- **THEN** the body background SHALL use a dark gradient or solid dark color from the surface token palette
-- **AND** primary text SHALL be white or light gray (meeting WCAG AA contrast ratio against the dark background)
-
-#### Scenario: Dark theme consistency across onboarding
-- **WHEN** the user navigates from Landing Page -> Artist Discovery -> Loading -> Dashboard
-- **THEN** all screens SHALL use the same dark surface palette
-- **AND** there SHALL be no jarring light-to-dark or dark-to-light transitions between screens
-
----
-
 ### Requirement: Display Font Loading
-The system SHALL load and apply a display font for headings with appropriate fallback and performance optimization.
+The system SHALL load and apply display and body fonts with appropriate fallback and performance optimization.
 
 #### Scenario: Font preloading
 - **WHEN** the application loads
 - **THEN** the system SHALL preconnect to the font provider domains (fonts.googleapis.com and fonts.gstatic.com) in the HTML head
 - **AND** the preconnect to `fonts.gstatic.com` SHALL include the `crossorigin` attribute
-- **AND** the system SHALL load the display font with `font-display: swap` and include necessary weights (e.g., Bold 700, Extra-Bold 800) to prevent layout shifts or faux-bolding during load
-- **AND** the system SHALL use `system-ui` as the immediate fallback until the display font is ready
+- **AND** the system SHALL load Righteous (weight 400) and Poppins (weights 300, 400, 500, 600, 700) with `font-display: swap`
+- **AND** the existing Outfit font `<link>` SHALL be retained as a fallback for `--font-display`
+- **AND** the system SHALL use Outfit as the second fallback for `--font-display` and system-ui as the fallback for `--font-body`
 
 ---
 


### PR DESCRIPTION
## Related Issue

Refs liverty-music/frontend#211

## Summary of Changes

Sync delta specs from the `festival-ui-refresh` change into main specs and archive the completed change.

- **design-system/spec.md**: Updated color values to OKLCH, added stage identity colors (MAIN/SONIC/BUZZ/WILD), Righteous + Poppins font stack, border and shadow tokens with relative color syntax
- **typography-focused-dashboard/spec.md**: Updated stage headers to per-stage identity colors, added lane accents and date separator gradient scenarios
- **Archive**: Moved `festival-ui-refresh` change to `openspec/changes/archive/2026-03-16-festival-ui-refresh/`

## Self-Checklist

- [x] I have linked the related issue.
- [x] I have updated the relevant documentation (e.g., `README.md`) if needed.
- [x] I have run `buf lint` and `buf format` locally and all checks have passed.
- [x] My proto definitions follow the project's style guidelines and validation rules.
- [x] Breaking changes have been justified and documented if applicable.
