### PR TITLE
docs(openspec): sync hype-inline-slider spec after reactivity fix

### DIFF
--- a/openspec/changes/archive/2026-03-16-bug-fix-set-hype/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-16-bug-fix-set-hype/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-16

--- a/openspec/changes/archive/2026-03-16-bug-fix-set-hype/design.md
+++ b/openspec/changes/archive/2026-03-16-bug-fix-set-hype/design.md
@@ -1,0 +1,50 @@
+## Context
+
+The `hype-inline-slider` component currently accepts a `hypeLevel: HypeStop` (string union: `'watch' | 'home' | 'nearby' | 'away'`). The parent route converts `HypeType` enum → `HypeStop` string via a method call `hypeStop(artist)`. Aurelia 2 cannot observe property changes inside method calls when the argument reference is stable, causing the UI to not reflect optimistic updates.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Fix the reactivity bug so the slider visually updates after hype changes.
+- Simplify the data flow by removing the `HypeStop` indirection.
+- Use native `<input type="radio">` for accessibility.
+
+**Non-Goals:**
+- Redesigning the slider visuals or interaction model.
+- Changing backend `SetHype` RPC behavior.
+- Modifying the grid view context menu (it binds `contextMenuArtist.hype` directly and already works).
+
+## Decisions
+
+### 1. Component accepts `HypeType` enum directly
+
+The `hype-inline-slider` component will accept `@bindable hype: HypeType` instead of `@bindable hypeLevel: HypeStop`. The component maps `HypeType` values to internal stop indices for rendering.
+
+**Why:** Eliminates the parent-side conversion function that broke reactivity. The template binding `hype.bind="artist.hype"` gives Aurelia a direct property path to observe.
+
+**Alternative considered:** Keep `HypeStop` and fix the template with `hype-level.bind="hypeStop(artist.hype)"`. Rejected because it preserves unnecessary indirection — the `HypeStop` type adds no value over the proto enum.
+
+### 2. Internal stops array uses `HypeType` values
+
+The component's `stops` array changes from `['watch', 'home', 'nearby', 'away']` to `[HypeType.WATCH, HypeType.HOME, HypeType.NEARBY, HypeType.AWAY]`. Template iteration and active-state comparison use enum values directly.
+
+**Why:** No string conversion needed anywhere. The `data-active` check becomes `stop === hype` with both sides being `HypeType`.
+
+### 3. Event detail uses `HypeType` instead of `HypeStop`
+
+The `hype-changed` custom event detail changes from `{ artistId, level: HypeStop }` to `{ artistId, hype: HypeType }`. The parent handler no longer needs `HYPE_FROM_STOP` conversion.
+
+**Why:** Aligns the event contract with the proto enum used everywhere else.
+
+### 4. Native `<fieldset>` + `<input type="radio">` (no ARIA roles)
+
+Use native `<fieldset>` with a visually hidden `<legend>` as the group container. Each stop is a `<label>` wrapping a visually hidden `<input type="radio">` and a visual dot `<span>`. Radio inputs use Aurelia 2's `model.bind`/`checked.bind` pattern. For unauthenticated users, `click` is intercepted with `preventDefault()` to block selection.
+
+**Why:** Per MDN guidance, native HTML radio inputs are preferred over ARIA `role="radiogroup"`/`role="radio"` when no special reason exists to use ARIA. Native radios provide built-in keyboard navigation, focus management, and screen reader support without custom ARIA attributes.
+
+**Alternative considered:** ARIA `role="radiogroup"` on a `<div>` with `role="radio"` buttons. Rejected because native HTML elements provide the same semantics with less code and better browser support.
+
+## Risks / Trade-offs
+
+- **Test updates required** → Tests reference `HypeStop` and `hypeLevel`. Straightforward find-and-replace.
+- **CSS `data-level` attribute values change** → CSS selectors use `[data-level="watch"]` etc. These change to `[data-level="1"]` etc. (HypeType enum values). Low risk — contained within the component's scoped CSS.

--- a/openspec/changes/archive/2026-03-16-bug-fix-set-hype/proposal.md
+++ b/openspec/changes/archive/2026-03-16-bug-fix-set-hype/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+Tapping a hype dot on the My Artists slider completes the `SetHype` RPC successfully but the UI does not update. The root cause is that the template binding `hype-level.bind="hypeStop(artist)"` passes the `artist` object reference to a method call; Aurelia 2 observes the reference (which never changes) rather than the mutated `artist.hype` property, so the binding never re-evaluates after an optimistic update.
+
+## What Changes
+
+- Replace the `HypeStop` string intermediary with direct `HypeType` enum binding (`hype.bind="artist.hype"`), making the dependency explicit to Aurelia's observation system.
+- Remove `hypeStop()`, `HYPE_TO_STOP`, and `HYPE_FROM_STOP` from the route; the slider component accepts `HypeType` directly and handles conversion internally.
+- Add `role="radiogroup"` / `role="radio"` + `aria-checked` accessibility semantics to the slider component.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `hype-inline-slider`: Remove `HypeStop` indirection from the public API; accept `HypeType` directly. Add ARIA radiogroup semantics.
+
+## Impact
+
+- **frontend**: `hype-inline-slider` component (TS, HTML), `my-artists-route` (TS, HTML), and their tests.
+- No backend, proto, or infrastructure changes required.

--- a/openspec/changes/archive/2026-03-16-bug-fix-set-hype/specs/hype-inline-slider/spec.md
+++ b/openspec/changes/archive/2026-03-16-bug-fix-set-hype/specs/hype-inline-slider/spec.md
@@ -1,35 +1,4 @@
-# Capability: Hype Inline Slider
-
-## Purpose
-
-Provide a 1-tap inline slider for setting hype level per artist in the My Artists list view, with a sticky header legend and artist-color glow on the active dot.
-
-## Requirements
-
-### Requirement: Sticky Header Legend
-
-The My Artists list view SHALL display a sticky header row showing hype tier icons and emotion-based labels, aligned with slider stop positions using a shared grid column definition.
-
-#### Scenario: Header renders with 4 columns
-
-- **WHEN** the My Artists page renders in list view
-- **THEN** the system SHALL display a sticky header row below the page title
-- **AND** the header SHALL contain 4 equally-spaced columns: 👀 チェック, 🔥 地元, 🔥🔥 近くも, 🔥🔥🔥 どこでも！
-- **AND** the header SHALL use `position: sticky; inset-block-start: 0` with `backdrop-filter: blur(8px)` on the surface-raised background
-- **AND** each column SHALL vertically align with the corresponding dot stop on artist row sliders
-- **AND** the header and artist row content SHALL share the same `grid-template-columns: 2fr repeat(4, 1fr)` definition with `grid-template-areas` to ensure column alignment
-
-#### Scenario: Header column alignment matches artist row dot positions
-
-- **WHEN** the header and any artist row are visible simultaneously
-- **THEN** the center of each header label SHALL be horizontally aligned with the center of the corresponding dot in the artist row slider
-- **AND** this alignment SHALL be achieved by both elements using `grid-template-columns: 2fr repeat(4, 1fr)` at the same parent width
-
-#### Scenario: Header remains visible during scroll
-
-- **WHEN** the user scrolls the artist list
-- **THEN** the sticky header SHALL remain visible at the top of the scroll container
-- **AND** the header SHALL have a `[data-hype-header]` attribute for coach mark targeting
+## MODIFIED Requirements
 
 ### Requirement: Inline Dot Slider
 
@@ -96,13 +65,10 @@ The slider SHALL use native HTML `<fieldset>` with a visually hidden `<legend>` 
 - **AND** the selected radio SHALL be `checked` via Aurelia's `model.bind`/`checked.bind` pattern
 - **AND** for unauthenticated users, `click` SHALL be intercepted with `preventDefault()` to block selection
 
-### Requirement: Slider dot positions align with header columns
+## REMOVED Requirements
 
-The 4 slider dot stops SHALL be positioned to vertically align with the 4 header legend columns using a shared CSS Grid column template.
+### Requirement: HypeStop string constants
 
-#### Scenario: Slider spans header dot columns
+**Reason**: The `HYPE_TO_STOP` and `HYPE_FROM_STOP` conversion tables and the `HypeStop` type are replaced by direct `HypeType` enum usage. The indirection added complexity and caused a reactivity bug.
 
-- **WHEN** the page renders
-- **THEN** the hype-inline-slider component SHALL span grid columns 2 through 5 of the artist row content grid
-- **AND** the slider's internal `repeat(4, 1fr)` grid SHALL subdivide the same width as the header's 4 dot columns
-- **AND** alignment SHALL be maintained across viewport widths
+**Migration**: The component accepts `HypeType` directly. Remove `hypeStop()` method and conversion constants from `my-artists-route.ts`. Update event handlers to use `HypeType` instead of `HypeStop`.

--- a/openspec/changes/archive/2026-03-16-bug-fix-set-hype/tasks.md
+++ b/openspec/changes/archive/2026-03-16-bug-fix-set-hype/tasks.md
@@ -1,0 +1,22 @@
+## 1. Component: hype-inline-slider
+
+- [x] 1.1 Change `@bindable hypeLevel: HypeStop` to `@bindable hype: HypeType` in `hype-inline-slider.ts`
+- [x] 1.2 Replace `stops` array from `HypeStop[]` to `HypeType[]` (`[HypeType.WATCH, HypeType.HOME, HypeType.NEARBY, HypeType.AWAY]`)
+- [x] 1.3 Update `selectHype()` to dispatch `hype-changed` with `{ artistId, hype: HypeType }` detail
+- [x] 1.4 Remove the `HypeStop` type export from `hype-inline-slider.ts`
+- [x] 1.5 Update `hype-inline-slider.html`: add `role="radiogroup"` + `aria-label` to container, `role="radio"` + `aria-checked` to buttons
+- [x] 1.6 Update `hype-inline-slider.html`: change `data-active` and `data-level` bindings to use `HypeType` values
+- [x] 1.7 Update `hype-inline-slider.css`: change `data-level` selectors from string names (`"watch"`, `"home"`, etc.) to enum values (`"1"`, `"2"`, `"3"`, `"4"`)
+
+## 2. Route: my-artists-route
+
+- [x] 2.1 Remove `HypeStop` import, `HYPE_TO_STOP`, `HYPE_FROM_STOP`, and `hypeStop()` method from `my-artists-route.ts`
+- [x] 2.2 Update `onHypeChanged()` to read `HypeType` from event detail directly (no `HYPE_FROM_STOP` conversion)
+- [x] 2.3 Update `my-artists-route.html`: change `hype-level.bind="hypeStop(artist)"` to `hype.bind="artist.hype"`
+- [x] 2.4 Update `my-artists-route.html`: remove `hype-inline-slider` import alias if `HypeStop` type import was part of it
+
+## 3. Tests
+
+- [x] 3.1 Update `hype-inline-slider.spec.ts`: replace `HypeStop` references with `HypeType`, update event detail assertions
+- [x] 3.2 Update `my-artists-route.spec.ts`: remove `hypeStop()` tests, update `onHypeChanged` test event details
+- [x] 3.3 Run `make check` and verify all tests pass


### PR DESCRIPTION
## Related Issue

Closes #259

## Summary of Changes

Sync the hype-inline-slider capability spec to reflect the frontend bug fix:

- Remove `HYPE_TO_STOP` / `HYPE_FROM_STOP` / `HYPE_TIERS` constant table from the "Inline Dot Slider" requirement
- Add requirement text for direct `HypeType` enum binding and native radio input semantics
- Add scenarios: "Parent binds HypeType directly" and "Native radio input semantics"
- Update existing scenarios to reference `HypeType` enum values (1, 2, 3, 4) for `data-level`
- Archive the `bug-fix-set-hype` change artifacts

## Self-Checklist

- [x] I have linked the related issue.
- [x] I have updated the relevant documentation (e.g., `README.md`) if needed.
- [x] I have run `buf lint` and `buf format` locally and all checks have passed.
- [x] My proto definitions follow the project's style guidelines and validation rules.
- [x] Breaking changes have been justified and documented if applicable.
