### PR TITLE
Add Google Chat notification to app-error-log-alerting spec

### DIFF
--- a/openspec/changes/archive/2026-03-16-google-chat-alert/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-16-google-chat-alert/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-16

--- a/openspec/changes/archive/2026-03-16-google-chat-alert/design.md
+++ b/openspec/changes/archive/2026-03-16-google-chat-alert/design.md
@@ -1,0 +1,48 @@
+## Context
+
+現在、GCP Cloud Monitoring のアラート通知は Slack のみに送信されている。Slack Notification Channel は OAuth フローの制約により GCP Console で手動作成し、チャネル ID を Pulumi ESC に格納して参照している。
+
+Google Chat が Workspace で利用可能になり、GCP Cloud Monitoring は 2023年10月から `google_chat` type の Notification Channel をサポートしている。Slack と異なり、Google Chat チャネルは API 経由で作成可能なため、Pulumi リソースとして完全に IaC 管理できる。
+
+## Goals / Non-Goals
+
+**Goals:**
+- 既存の全 Alert Policy に Google Chat Notification Channel を追加し、Slack と並行で通知を受信
+- Google Chat チャネルを Pulumi リソースとして作成・管理
+- 環境ごとに異なる Chat スペースを使用（dev / prod）
+
+**Non-Goals:**
+- Slack チャネルの廃止（並行運用を維持）
+- Alert Policy のフィルタ条件やレート制限の変更
+- ArgoCD 通知の設定
+
+## Decisions
+
+### 1. Google Chat Notification Channel を Pulumi リソースとして作成
+
+**選択**: `gcp.monitoring.NotificationChannel` を `monitoring.ts` 内で作成
+**代替案**: Slack と同様に GCP Console で手動作成 → ID を ESC に格納
+**理由**: Google Chat は OAuth 不要で `space_id` のみで API 作成可能。IaC 管理することでインフラの一貫性を保てる。
+
+### 2. space_id を Pulumi ESC に格納
+
+**選択**: ESC の `pulumiConfig.gcp.monitoring.googleChatSpaces.alertBackend` に space_id を格納
+**代替案**: Pulumi config や定数ファイルにハードコード
+**理由**: 環境ごとに異なる値で、既存の Slack チャネル ID と同じ管理パターンに揃える。
+
+### 3. GcpConfig に googleChatSpaces フィールドを追加
+
+**選択**: `monitoring` オブジェクト内に `slackNotificationChannels` と並列で `googleChatSpaces` を追加
+**代替案**: 汎用の `notificationChannels` 配列に統合
+**理由**: Slack と Google Chat は作成方法が異なる（Slack は参照のみ、Google Chat は Pulumi で作成）。型レベルで区別することで、各チャネル種別の扱いの違いを明示する。
+
+### 4. MonitoringComponent の notificationChannels を統合配列で渡す
+
+**選択**: `MonitoringComponent` 内部で Slack チャネル参照と Google Chat チャネルリソースの ID を1つの配列にまとめ、各 AlertPolicy に渡す
+**理由**: Alert Policy 側は通知先の種類を区別しない。配列を結合するだけでよく、既存のアラート構造を変更せずに済む。
+
+## Risks / Trade-offs
+
+- **Google Chat スペースの Monitoring アプリ未インストール** → チャネル作成は成功するが通知が届かない。前提条件として手動インストールが必要（今回は済み）。
+- **space_id の誤設定** → 通知が別のスペースに送られるか、チャネル作成が失敗する。ESC の値設定時に検証する。
+- **Slack と Google Chat の二重通知** → 意図的な並行運用だが、通知疲れの可能性あり。運用を見て調整。

--- a/openspec/changes/archive/2026-03-16-google-chat-alert/proposal.md
+++ b/openspec/changes/archive/2026-03-16-google-chat-alert/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+Google Chat が Workspace で利用可能になったため、既存の Slack アラートに加えて Google Chat スペースにもアラート通知を送りたい。Slack と並行運用し、チームが Google Chat でもアラートを受け取れるようにする。
+
+## What Changes
+
+- GCP Cloud Monitoring の Notification Channel に Google Chat (`google_chat` type) を追加
+- 既存の全 Alert Policy（backend ERROR log × 3 + Atlas migration failure）に Google Chat チャネルを紐づけ
+- Google Chat チャネルは Pulumi でリソースとして作成・管理（Slack と異なり OAuth 不要で IaC 対応可能）
+- 環境ごとに別の Chat スペースを使用（dev / prod）
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `app-error-log-alerting`: 通知先に Google Chat を追加。Slack と並行して Google Chat スペースにもアラート通知を送信する要件を追加。
+
+## Impact
+
+- **cloud-provisioning**: `monitoring.ts` に NotificationChannel リソース追加、Alert Policy の notificationChannels 配列に Google Chat チャネルを追加
+- **cloud-provisioning**: `project.ts` の `GcpConfig` インターフェースに Google Chat 設定フィールド追加
+- **cloud-provisioning**: `index.ts` の MonitoringComponent 呼び出しに新設定を渡す
+- **Pulumi ESC**: 各環境に `space_id` を格納（dev: `AAQAU_szLxU`, prod: `AAQA2yo_JVw`）
+- **前提条件**: 各 Chat スペースに Google Cloud Monitoring アプリがインストール済み（完了済み）

--- a/openspec/changes/archive/2026-03-16-google-chat-alert/specs/app-error-log-alerting/spec.md
+++ b/openspec/changes/archive/2026-03-16-google-chat-alert/specs/app-error-log-alerting/spec.md
@@ -1,0 +1,50 @@
+## ADDED Requirements
+
+### Requirement: Notification via Google Chat
+
+The system SHALL send alert notifications to a configured Google Chat space when an Incident is opened, in addition to the existing Slack notification.
+
+Google Chat Notification Channels SHALL be created as Pulumi resources (type: `google_chat`) using the `space_id` stored in Pulumi ESC. Unlike Slack channels, Google Chat channels do not require manual GCP Console creation.
+
+Each environment (dev, prod) SHALL have its own Google Chat space for alert notifications.
+
+#### Scenario: ERROR log triggers Google Chat notification
+
+- **WHEN** an Alert Policy detects an ERROR log and opens an Incident
+- **THEN** a notification SHALL be sent to the configured Google Chat space
+- **AND** a notification SHALL also be sent to the configured Slack channel (parallel operation)
+
+#### Scenario: Atlas migration failure triggers Google Chat notification
+
+- **WHEN** the Atlas migration Alert Policy detects a failure and opens an Incident
+- **THEN** a notification SHALL be sent to the configured Google Chat space
+- **AND** a notification SHALL also be sent to the configured Slack channel (parallel operation)
+
+#### Scenario: Google Chat Notification Channel is created via Pulumi
+
+- **WHEN** `pulumi up` is executed with `monitoring.googleChatSpaces.alertBackend` configured in ESC
+- **THEN** a `gcp.monitoring.NotificationChannel` resource SHALL be created with type `google_chat` and label `space_id` from ESC
+
+#### Scenario: Google Chat space requires Monitoring app pre-installed
+
+- **WHEN** a new environment needs Google Chat alerts
+- **THEN** the Google Cloud Monitoring app SHALL be installed in the target Chat space before running `pulumi up`
+- **AND** the `space_id` SHALL be stored in Pulumi ESC under `monitoring.googleChatSpaces.alertBackend`
+
+## MODIFIED Requirements
+
+### Requirement: Infrastructure as Code
+
+All monitoring resources (Alert Policies, Notification Channels, API enablement) SHALL be managed as Pulumi resources in `cloud-provisioning/src/gcp/components/monitoring.ts`.
+
+Slack Notification Channels are referenced (not created) by Pulumi. They are created manually via GCP Console and their channel IDs are stored in Pulumi ESC.
+
+Google Chat Notification Channels are created and managed by Pulumi as `gcp.monitoring.NotificationChannel` resources using `space_id` from Pulumi ESC.
+
+#### Scenario: Pulumi deployment creates monitoring resources
+
+- **WHEN** `pulumi up` is executed
+- **THEN** the Alert Policies and Error Reporting API enablement SHALL be created or updated as defined in the Pulumi code
+- **AND** the Slack Notification Channel SHALL be referenced by its channel ID from Pulumi ESC
+- **AND** the Google Chat Notification Channel SHALL be created with its space_id from Pulumi ESC
+- **AND** all Alert Policies SHALL include both Slack and Google Chat notification channels

--- a/openspec/changes/archive/2026-03-16-google-chat-alert/tasks.md
+++ b/openspec/changes/archive/2026-03-16-google-chat-alert/tasks.md
@@ -1,0 +1,23 @@
+## 1. Pulumi ESC Configuration
+
+- [x] 1.1 Add `pulumiConfig.gcp.monitoring.googleChatSpaces.alertBackend` to `liverty-music/dev` ESC environment with space_id `AAQAU_szLxU`
+- [x] 1.2 Add `pulumiConfig.gcp.monitoring.googleChatSpaces.alertBackend` to `liverty-music/prod` ESC environment with space_id `AAQA2yo_JVw`
+
+## 2. GcpConfig Interface Update
+
+- [x] 2.1 Add `googleChatSpaces` field to the `monitoring` object in `GcpConfig` interface (`project.ts`)
+
+## 3. MonitoringComponent Update
+
+- [x] 3.1 Add `googleChatSpaceIds` parameter to `MonitoringComponentArgs` interface (`monitoring.ts`)
+- [x] 3.2 Create `gcp.monitoring.NotificationChannel` resource with type `google_chat` and `space_id` label (`monitoring.ts`)
+- [x] 3.3 Merge Slack channel references and Google Chat channel IDs into a single `notificationChannels` array for Alert Policies (`monitoring.ts`)
+
+## 4. Integration
+
+- [x] 4.1 Pass `googleChatSpaces` config from `index.ts` to `MonitoringComponent`
+
+## 5. Verification
+
+- [x] 5.1 Run `make lint-ts` to verify TypeScript compiles without errors
+- [x] 5.2 Run `pulumi preview` on dev stack to verify resource changes

--- a/openspec/specs/app-error-log-alerting/spec.md
+++ b/openspec/specs/app-error-log-alerting/spec.md
@@ -85,6 +85,37 @@ Slack Notification Channels MUST be created manually through the GCP Console bec
 - **THEN** the Slack Notification Channel SHALL be created via GCP Console (Monitoring > Alerting > Edit notification channels > Slack)
 - **AND** the channel ID SHALL be stored in Pulumi ESC under `monitoring.slackNotificationChannels.alertBackend`
 
+### Requirement: Notification via Google Chat
+
+The system SHALL send alert notifications to a configured Google Chat space when an Incident is opened, in addition to the existing Slack notification.
+
+Google Chat Notification Channels SHALL be created as Pulumi resources (type: `google_chat`) using the `space_id` stored in Pulumi ESC. Unlike Slack channels, Google Chat channels do not require manual GCP Console creation.
+
+Each environment (dev, prod) SHALL have its own Google Chat space for alert notifications.
+
+#### Scenario: ERROR log triggers Google Chat notification
+
+- **WHEN** an Alert Policy detects an ERROR log and opens an Incident
+- **THEN** a notification SHALL be sent to the configured Google Chat space
+- **AND** a notification SHALL also be sent to the configured Slack channel (parallel operation)
+
+#### Scenario: Atlas migration failure triggers Google Chat notification
+
+- **WHEN** the Atlas migration Alert Policy detects a failure and opens an Incident
+- **THEN** a notification SHALL be sent to the configured Google Chat space
+- **AND** a notification SHALL also be sent to the configured Slack channel (parallel operation)
+
+#### Scenario: Google Chat Notification Channel is created via Pulumi
+
+- **WHEN** `pulumi up` is executed with `monitoring.googleChatSpaces.alertBackend` configured in ESC
+- **THEN** a `gcp.monitoring.NotificationChannel` resource SHALL be created with type `google_chat` and label `space_id` from ESC
+
+#### Scenario: Google Chat space requires Monitoring app pre-installed
+
+- **WHEN** a new environment needs Google Chat alerts
+- **THEN** the Google Cloud Monitoring app SHALL be installed in the target Chat space before running `pulumi up`
+- **AND** the `space_id` SHALL be stored in Pulumi ESC under `monitoring.googleChatSpaces.alertBackend`
+
 ### Requirement: Notification rate limiting
 
 The system SHALL suppress repeated notifications for the same Incident, sending at most one notification per 12-hour period (`notificationRateLimit.period = 43200s`).
@@ -130,12 +161,16 @@ The system SHALL have the `clouderrorreporting.googleapis.com` API enabled to al
 
 ### Requirement: Infrastructure as Code
 
-All monitoring resources (Alert Policies, API enablement) SHALL be managed as Pulumi resources in `cloud-provisioning/src/gcp/components/monitoring.ts`.
+All monitoring resources (Alert Policies, Notification Channels, API enablement) SHALL be managed as Pulumi resources in `cloud-provisioning/src/gcp/components/monitoring.ts`.
 
 Slack Notification Channels are referenced (not created) by Pulumi. They are created manually via GCP Console and their channel IDs are stored in Pulumi ESC.
+
+Google Chat Notification Channels are created and managed by Pulumi as `gcp.monitoring.NotificationChannel` resources using `space_id` from Pulumi ESC.
 
 #### Scenario: Pulumi deployment creates monitoring resources
 
 - **WHEN** `pulumi up` is executed
 - **THEN** the Alert Policies and Error Reporting API enablement SHALL be created or updated as defined in the Pulumi code
 - **AND** the Slack Notification Channel SHALL be referenced by its channel ID from Pulumi ESC
+- **AND** the Google Chat Notification Channel SHALL be created with its space_id from Pulumi ESC
+- **AND** all Alert Policies SHALL include both Slack and Google Chat notification channels


### PR DESCRIPTION
## 🔗 Related Issue

Closes #261

## 📝 Summary of Changes

Add Google Chat notification requirement to the `app-error-log-alerting` spec. Google Chat spaces will receive alert notifications in parallel with existing Slack channels.

- **ADDED**: "Notification via Google Chat" requirement with 4 scenarios covering ERROR log alerts, Atlas migration failure alerts, Pulumi channel creation, and Monitoring app prerequisites
- **MODIFIED**: "Infrastructure as Code" requirement to include Google Chat NotificationChannel management via Pulumi
- Archived the `google-chat-alert` change artifacts

## ✅ Self-Checklist

- [x] I have linked the related issue.
- [x] I have updated the relevant documentation (e.g., `README.md`) if needed.
- [x] I have run `buf lint` and `buf format` locally and all checks have passed.
- [x] My proto definitions follow the project's style guidelines and validation rules.
- [x] Breaking changes have been justified and documented if applicable.