### PR TITLE
docs: add argocd-google-chat-alerts openspec artifacts

### DIFF
--- a/openspec/changes/argocd-google-chat-alerts/.openspec.yaml
+++ b/openspec/changes/argocd-google-chat-alerts/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-16

--- a/openspec/changes/argocd-google-chat-alerts/design.md
+++ b/openspec/changes/argocd-google-chat-alerts/design.md
@@ -1,0 +1,75 @@
+## Context
+
+ArgoCD manages 10 Applications via the App of Apps pattern with automated sync and self-heal. The ArgoCD Helm chart (argo-cd 9.4.0) includes a Notifications controller that is currently disabled (`notifications.enabled: false`). Secrets are managed through Pulumi ESC → GCP Secret Manager → ESO (ExternalSecret Operator) → K8s Secret. The existing ClusterSecretStore restricts access to `backend` and `atlas-operator` namespaces only.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Enable ArgoCD Notifications controller with Google Chat as the notification service
+- Alert on sync failures, health degradation, and unknown sync states for all ArgoCD Applications
+- Maintain secret permission isolation between backend and ArgoCD namespaces
+- Manage the Google Chat webhook URL through the existing Pulumi ESC → GCP Secret Manager → ESO pipeline
+
+**Non-Goals:**
+- GCP Cloud Monitoring-based K8s event alerts (CrashLoopBackOff detail, Node conditions) — future work
+- Success/deploy notifications (on-deployed, on-sync-succeeded) — can be added later
+- Per-application notification customization — all apps get the same triggers via defaultTriggers
+- Custom notification templates with cardsV2 format — start with plain text messages
+
+## Decisions
+
+### D1: Dedicated ClusterSecretStore for ArgoCD namespace
+
+**Decision**: Create a new `ClusterSecretStore` (`google-secret-manager-argocd`) restricted to the `argocd` namespace, rather than adding `argocd` to the existing store's conditions.
+
+**Alternatives considered**:
+- Add `argocd` to existing ClusterSecretStore conditions — simpler but grants ArgoCD namespace ExternalSecrets access to the same GCP Secret Manager project as backend secrets. The ESO SA would be shared, meaning ArgoCD ExternalSecrets could potentially reference backend secret keys.
+- Namespace-scoped SecretStore in ArgoCD — requires a separate GCP SA with WIF binding, more infrastructure overhead.
+
+**Rationale**: A dedicated ClusterSecretStore uses the same ESO SA (which already has per-secret IAM bindings) but limits which namespaces can reference it. Combined with per-secret IAM on the GCP side, this provides defense-in-depth: even if the ClusterSecretStore allows argocd namespace, the ESO SA can only access secrets it has explicit IAM bindings for.
+
+### D2: Webhook URL managed through ESC → GCP Secret Manager → ESO
+
+**Decision**: Follow the existing secret management pattern:
+1. Store webhook URL in Pulumi ESC (`pulumiConfig.gcp.argocdGoogleChatWebhookUrl`)
+2. Pulumi creates a `gcp.secretmanager.Secret` with per-secret IAM binding for the ESO SA only (not backend-app SA)
+3. An `ExternalSecret` in argocd namespace syncs to a K8s Secret named `argocd-notifications-secret`
+4. ArgoCD Notifications controller references the secret key via `$` syntax in the service config
+
+**Rationale**: Consistent with the existing atlas-db-credentials and backend-secrets patterns. The webhook URL is a credential (contains auth token) and should not be stored in Git.
+
+### D3: Helm values.yaml for notifications configuration
+
+**Decision**: Configure triggers, templates, and service definitions directly in the ArgoCD Helm `values.yaml`, following the existing pattern where all ArgoCD config lives in this file.
+
+**Alternatives considered**:
+- Separate Kustomize patches for notifications-cm — adds complexity with no benefit since the Helm chart natively supports notifications config via values
+- Per-overlay values files — unnecessary since triggers and templates are environment-agnostic (only the webhook URL differs, and that's in the Secret)
+
+**Rationale**: The existing values.yaml already contains all ArgoCD configuration (server, controller, redis, etc.). Adding notifications config here maintains consistency. The Helm chart renders `argocd-notifications-cm` ConfigMap from these values.
+
+### D4: Use Helm `secret.create: false` with ESO-managed Secret
+
+**Decision**: Disable Helm-managed secret creation (`notifications.secret.create: false`) and let ESO create the `argocd-notifications-secret` K8s Secret instead.
+
+**Rationale**: The ArgoCD Notifications controller expects a Secret named `argocd-notifications-secret` in the `argocd` namespace. By default, the Helm chart creates this Secret. Since we manage credentials through ESO, we disable Helm secret creation and let the ExternalSecret resource own this Secret. This avoids conflicts between Helm and ESO managing the same resource.
+
+### D5: Use built-in catalog triggers with defaultTriggers
+
+**Decision**: Install the built-in trigger/template catalog and use `defaultTriggers` to apply `on-sync-failed`, `on-health-degraded`, and `on-sync-status-unknown` to all Applications without individual annotations.
+
+**Rationale**: defaultTriggers eliminates the need to annotate each of the 10 ArgoCD Applications individually. New Applications automatically inherit the triggers. Individual apps can opt out via annotation if needed.
+
+## Risks / Trade-offs
+
+**[ArgoCD health detection delay]** ArgoCD takes ~10 minutes to mark an application as Degraded after a pod becomes unhealthy.
+→ Acceptable for now. GCP Cloud Monitoring log-based alerts can be added later for faster, granular detection.
+
+**[Notification noise from self-heal loops]** Applications with `selfHeal: true` may trigger transient Degraded/Unknown states during auto-repair.
+→ The `on-health-degraded` trigger fires once per state change, not continuously. If noise becomes an issue, `oncePer` can be added to debounce.
+
+**[Webhook URL rotation]** Rotating the Google Chat webhook URL requires updating Pulumi ESC, running `pulumi up` to update GCP Secret Manager, then waiting for ESO refresh (1h default) or manually triggering a sync.
+→ Acceptable. Webhook URLs rarely rotate. ESO refresh interval can be decreased if needed.
+
+**[Helm chart upgrade compatibility]** Future ArgoCD Helm chart upgrades may change the notifications values schema.
+→ Low risk. The notifications values structure has been stable since ArgoCD 2.6+. Pin chart version (already done: 9.4.0).

--- a/openspec/changes/argocd-google-chat-alerts/proposal.md
+++ b/openspec/changes/argocd-google-chat-alerts/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+The current monitoring setup only covers application-level log errors (backend ERROR logs, Atlas migration failures) via GCP Cloud Monitoring. There is no alerting for Kubernetes deployment-level failures such as sync errors, health degradation (CrashLoopBackOff, ImagePullBackOff, OOMKilled), or unknown sync states. ArgoCD manages all workloads but its built-in Notifications feature is disabled, leaving a significant observability gap.
+
+## What Changes
+
+- Enable ArgoCD Notifications controller in the existing ArgoCD Helm deployment
+- Configure Google Chat as the notification destination using incoming webhooks
+- Set up default triggers for all ArgoCD Applications:
+  - `on-sync-failed` — detects sync operation failures (Error/Failed phase)
+  - `on-health-degraded` — detects health degradation (CrashLoopBackOff, ImagePullBackOff, probe failures, etc.)
+  - `on-sync-status-unknown` — detects unknown sync states (potential connectivity or config issues)
+- Create a dedicated ClusterSecretStore for the `argocd` namespace (separate from backend secrets)
+- Manage the Google Chat webhook URL through Pulumi ESC → GCP Secret Manager → ESO → K8s Secret pipeline
+
+## Capabilities
+
+### New Capabilities
+- `argocd-deployment-alerts`: Automated Google Chat notifications for ArgoCD Application sync failures, health degradation, and unknown sync states across all managed workloads.
+
+### Modified Capabilities
+<!-- No existing specs to modify -->
+
+## Impact
+
+- **K8s manifests**: ArgoCD Helm values (enable notifications), new ClusterSecretStore, new ExternalSecret in argocd namespace
+- **Pulumi code**: GcpConfig interface extended with webhook URL field, new GCP Secret Manager secret for the webhook URL
+- **Pulumi ESC**: New secret entry for Google Chat webhook URL per environment
+- **ArgoCD Applications**: All 10 apps receive notifications via `defaultTriggers` (no per-app annotation changes needed)
+- **Google Chat**: Requires a Space with an incoming webhook URL configured

--- a/openspec/changes/argocd-google-chat-alerts/specs/argocd-deployment-alerts/spec.md
+++ b/openspec/changes/argocd-google-chat-alerts/specs/argocd-deployment-alerts/spec.md
@@ -1,0 +1,64 @@
+## ADDED Requirements
+
+### Requirement: ArgoCD Notifications controller is enabled
+The ArgoCD Helm deployment SHALL have the Notifications controller enabled and running with resource requests and limits configured.
+
+#### Scenario: Notifications controller is running
+- **WHEN** ArgoCD is deployed with `notifications.enabled: true`
+- **THEN** the `argocd-notifications-controller` Deployment SHALL be created in the `argocd` namespace
+
+#### Scenario: Notifications controller has resource constraints
+- **WHEN** the Notifications controller pod is scheduled
+- **THEN** it SHALL have CPU and memory requests and limits set to prevent unbounded resource consumption
+
+### Requirement: Google Chat webhook service is configured
+The Notifications controller SHALL have a Google Chat service configured using an incoming webhook URL stored in a K8s Secret.
+
+#### Scenario: Service references webhook URL from Secret
+- **WHEN** the `argocd-notifications-cm` ConfigMap is rendered
+- **THEN** it SHALL contain a `service.googlechat` entry referencing the webhook URL via `$` variable syntax from `argocd-notifications-secret`
+
+#### Scenario: Webhook URL is managed through ESO
+- **WHEN** the `argocd-notifications-secret` K8s Secret is needed
+- **THEN** it SHALL be created by an ExternalSecret resource that syncs from GCP Secret Manager, not by the Helm chart
+
+### Requirement: Default triggers notify on error conditions
+All ArgoCD Applications SHALL receive notifications for sync failures, health degradation, and unknown sync states without requiring per-application annotations.
+
+#### Scenario: Sync failure triggers notification
+- **WHEN** an ArgoCD Application's sync operation enters `Error` or `Failed` phase
+- **THEN** a notification SHALL be sent to the configured Google Chat space
+
+#### Scenario: Health degradation triggers notification
+- **WHEN** an ArgoCD Application's health status becomes `Degraded` (e.g., CrashLoopBackOff, ImagePullBackOff, probe failure)
+- **THEN** a notification SHALL be sent to the configured Google Chat space
+
+#### Scenario: Unknown sync status triggers notification
+- **WHEN** an ArgoCD Application's sync status becomes `Unknown`
+- **THEN** a notification SHALL be sent to the configured Google Chat space
+
+#### Scenario: New applications automatically receive triggers
+- **WHEN** a new ArgoCD Application is created
+- **THEN** it SHALL receive all default triggers without any additional annotation
+
+### Requirement: ArgoCD secrets are isolated from backend secrets
+The ClusterSecretStore used by ArgoCD ExternalSecrets SHALL be separate from the one used by backend and atlas-operator namespaces.
+
+#### Scenario: Dedicated ClusterSecretStore for ArgoCD
+- **WHEN** the ArgoCD ExternalSecret references a ClusterSecretStore
+- **THEN** it SHALL use a store named `google-secret-manager-argocd` that is restricted to the `argocd` namespace only
+
+#### Scenario: Backend ClusterSecretStore is unchanged
+- **WHEN** the existing `google-secret-manager` ClusterSecretStore is evaluated
+- **THEN** its conditions SHALL remain restricted to `backend` and `atlas-operator` namespaces only
+
+### Requirement: Webhook URL is stored in Pulumi ESC and GCP Secret Manager
+The Google Chat webhook URL SHALL be managed through the Pulumi ESC → GCP Secret Manager pipeline with per-secret IAM bindings.
+
+#### Scenario: Webhook URL is provisioned via Pulumi
+- **WHEN** `pulumiConfig.gcp.argocdGoogleChatWebhookUrl` is set in Pulumi ESC
+- **THEN** Pulumi SHALL create a `gcp.secretmanager.Secret` named `argocd-google-chat-webhook-url` with the webhook URL as its version data
+
+#### Scenario: Only ESO SA has access to the webhook secret
+- **WHEN** the GCP Secret Manager secret for the webhook URL is created
+- **THEN** only the ESO service account SHALL have `SecretAccessor` IAM binding on this secret (not the backend-app SA)

--- a/openspec/changes/argocd-google-chat-alerts/tasks.md
+++ b/openspec/changes/argocd-google-chat-alerts/tasks.md
@@ -1,0 +1,30 @@
+## 1. Pulumi: Webhook URL Secret Management
+
+- [x] 1.1 Add `argocdGoogleChatWebhookUrl` field to `GcpConfig` interface in `src/gcp/components/project.ts`
+- [x] 1.2 Create `gcp.secretmanager.Secret` and `SecretVersion` for `argocd-google-chat-webhook-url` in `src/gcp/components/kubernetes.ts` with ESO-only IAM binding (no backend-app SA access)
+- [x] 1.3 Register webhook URL in Pulumi ESC dev environment: `esc env set liverty-music/dev pulumiConfig.gcp.argocdGoogleChatWebhookUrl "<url>" --secret`
+
+## 2. K8s: ClusterSecretStore for ArgoCD
+
+- [x] 2.1 Create `k8s/cluster/base/cluster-secret-store-argocd.yaml` — ClusterSecretStore restricted to `argocd` namespace with placeholder projectID
+- [x] 2.2 Add `cluster-secret-store-argocd.yaml` to `k8s/cluster/base/kustomization.yaml` resources
+- [x] 2.3 Create `k8s/cluster/overlays/dev/cluster-secret-store-argocd-patch.yaml` with dev projectID
+- [x] 2.4 Add patch target to `k8s/cluster/overlays/dev/kustomization.yaml`
+
+## 3. K8s: ArgoCD ExternalSecret
+
+- [x] 3.1 Create `k8s/namespaces/argocd/base/external-secret.yaml` — ExternalSecret that creates `argocd-notifications-secret` from GCP Secret Manager key `argocd-google-chat-webhook-url`
+
+## 4. K8s: Enable ArgoCD Notifications
+
+- [x] 4.1 Update `k8s/namespaces/argocd/base/values.yaml`: set `notifications.enabled: true` with resource requests/limits
+- [x] 4.2 Configure `notifications.secret.create: false` to let ESO manage the secret
+- [x] 4.3 Add `notifications.notifiers` with `service.googlechat` webhook config referencing `$google-chat-webhook-url`
+- [x] 4.4 Add `notifications.triggers` with `defaultTriggers` (on-sync-failed, on-health-degraded, on-sync-status-unknown) and trigger definitions
+- [x] 4.5 Add `notifications.templates` with notification templates for each trigger
+
+## 5. Validation
+
+- [x] 5.1 Run `kubectl kustomize --enable-helm k8s/namespaces/argocd/overlays/dev` and verify notifications resources render correctly
+- [x] 5.2 Run `kubectl kustomize k8s/cluster/overlays/dev` and verify both ClusterSecretStores render
+- [x] 5.3 Run `make check` to verify linting passes


### PR DESCRIPTION
## Related Issue
N/A — new observability capability (no proto changes)

## Summary of Changes

Add OpenSpec change artifacts for enabling ArgoCD Notifications with Google Chat alerts.

**Artifacts:**
- **proposal.md**: Motivation — no deployment-level alerting exists; ArgoCD Notifications is disabled
- **design.md**: Technical decisions — dedicated ClusterSecretStore, ESO-managed secret, Helm values config, defaultTriggers
- **specs/argocd-deployment-alerts/spec.md**: 5 requirements with 11 scenarios covering notifications controller, Google Chat service, default triggers, secret isolation, and webhook URL management
- **tasks.md**: 14 implementation tasks (all complete — implemented in cloud-provisioning PR #159)

**Implementation PR:** liverty-music/cloud-provisioning#159

## Self-Checklist

- [x] I have linked the related issue.
- [x] I have updated the relevant documentation (e.g., `README.md`) if needed.
- [x] No proto changes — `buf lint` / `buf format` / `buf breaking` not applicable.
- [x] My proto definitions follow the project's style guidelines and validation rules.
- [x] Breaking changes have been justified and documented if applicable.
