### PR TITLE
docs(openspec): archive improve-search-bar and add unify-follow-state-store

### DIFF
--- a/openspec/changes/archive/2026-03-17-improve-search-bar/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-17-improve-search-bar/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-16

--- a/openspec/changes/archive/2026-03-17-improve-search-bar/design.md
+++ b/openspec/changes/archive/2026-03-17-improve-search-bar/design.md
@@ -1,0 +1,79 @@
+## Context
+
+Discovery ページの検索結果リストは DOM ベースの `<ul>/<li>` で描画され、各行の右端に小さな `<button>` (+ アイコン) が follow のタップ領域となっている。follow 状態は `BubblePool.followedIds` (private Set) と `DiscoveryRoute.poolFollowedIds` (ReadonlySet コピー) の二重管理になっており、テンプレートは `isArtistFollowed()` メソッド経由でバインドしているため Aurelia のリアクティビティが機能していない。
+
+バブルビューでは Matter.js + Canvas 2D でバブルを描画し、タップ時に `AbsorptionAnimator` が Bézier 曲線で orb に吸い込むアニメーションを再生する。検索結果からの follow にはこの演出がなく、無反応のまま検索画面に留まる。
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- 検索結果の行全体をタップ可能にし、モバイルでの操作性を改善する
+- follow 済みアーティストの状態を正しくリアクティブに表示する（✓ + disabled）
+- 検索から follow した際にバブルビューに戻り、orb 吸収アニメーションで視覚フィードバックを提供する
+- follow 状態の dual-state を解消し、BubblePool を single source of truth にする
+
+**Non-Goals:**
+
+- follow 状態管理の Store 統合（別 change `unify-follow-state-store` で対応）
+- 検索結果からの連続 follow（follow → similar artist 追加で自然に次の発見につながるため不要）
+- 検索 UI 自体のリデザイン（入力フィールド、クリアボタン等は変更しない）
+
+## Decisions
+
+### 1. 行全体タップ化: `<li>` に click handler、`<button>` + `<svg-icon>` を削除
+
+**選択**: `<li>` 要素に `click.trigger` を付与し、follow ボタンと + アイコンを完全に削除する。
+
+**理由**: follow 済みの行は disabled 表示で視覚的に区別されるため、+ アイコンが無くても「タップ = follow」はコンテキスト上自明。ボタンを残すと「ボタンに見えるのに行全体がタップ領域」という UX の矛盾が生じる。
+
+**代替案**: ボタンを装飾的に残す → 混乱の元になるため却下。
+
+### 2. リアクティビティ修正: BubblePool.followedIds を public にし、テンプレートから直接 Set.has() バインド
+
+**選択**: `BubblePool.followedIds` を `public readonly` に変更し、テンプレートで `followedIds.has(artist.id)` を直接バインドする。`DiscoveryRoute.poolFollowedIds` と `isArtistFollowed()` を削除。
+
+**理由**: Aurelia 2 は `Set.has()` をネイティブに観測できる（公式ドキュメント確認済み）。`Set.add()` / `Set.delete()` が呼ばれると `.has()` バインディングが自動再評価される。メソッド呼び出し (`isArtistFollowed()`) はブラックボックスで Aurelia が内部依存を追跡できないため、直接バインドが必要。
+
+**代替案**: `poolFollowedIds` の再代入パターンを活かしテンプレートから参照 → dual-state が残るため却下。Store 統合 → スコープが大きいため別 change に分離。
+
+### 3. DiscoveryRoute に followedIds getter を追加
+
+**選択**: `public get followedIds(): ReadonlySet<string>` を追加し、`this.pool.followedIds` を返す。テンプレートは `followedIds.has(artist.id)` でバインド。
+
+**理由**: `pool` 自体を public にせず、テンプレートに必要な最小限のインターフェースだけ公開する。BubblePool のテスト容易性を損なわない。
+
+### 4. follow 後のバブルビュー遷移 + 吸収アニメーション
+
+**選択**: `onFollowFromSearch()` のフローを以下に変更:
+
+```
+onFollowFromSearch(artist)
+  ├─ followArtist(artist)          ← optimistic follow
+  ├─ exitSearchMode()              ← isSearchMode=false, canvas resume
+  └─ dnaOrbCanvas.spawnAndAbsorb(artist, spawnPosition)
+       ├─ spawnBubblesAt([artist], x, y)   ← バブルエリアやや上部
+       ├─ 即座に absorb 開始
+       ├─ orbRenderer.injectColor()         ← on absorption completion
+       └─ dispatch 'need-more-bubbles' event ← immediately on spawnAndAbsorb call
+```
+
+**spawn 位置**: バブルエリア上部（canvas height の 15-20% 付近）。検索バーの直下に現れ、orb に向かって降りていく軌道が自然。
+
+**理由**: 既存の `AbsorptionAnimator` と `spawnBubblesAt` を組み合わせるだけで実現可能。新規アニメーション実装は不要。
+
+**代替案**: 検索結果上でオーバーレイ再生 → canvas が pause 中のため別レイヤーが必要で複雑。却下。
+
+### 5. dna-orb-canvas に `spawnAndAbsorb()` メソッドを追加
+
+**選択**: 「spawn → 即吸収」を 1 つの public メソッドとして追加する。
+
+**理由**: spawn と absorb を別々に呼ぶと、タイミング制御が呼び出し側に漏れる。物理エンジンにバブルを追加した直後に吸収を開始する一連の処理をカプセル化する。既存の `onArtistSelected` イベントハンドラのロジック（physics remove → absorption start）を再利用。
+
+## Risks / Trade-offs
+
+**[Risk] Aurelia の Set 観測が深いプロパティチェーンで機能しない可能性** → `followedIds` getter 経由のバインドが正しく動作するか、実装時にコンポーネントテストで検証する。問題があれば `pool` を直接 public にするフォールバック。
+
+**[Risk] exitSearchMode → canvas resume のタイミングで spawn が早すぎる** → `requestAnimationFrame` で 1 フレーム遅延させれば解決。canvas の `resume()` は同期的に render loop を再開するため、通常は即座に spawn 可能。
+
+**[Trade-off] + アイコン削除による affordance の低下** → 行全体のホバー/アクティブスタイル（背景色変化、cursor: pointer）で「タップ可能」を伝える。follow 済みは opacity 低下 + ✓ アイコンで明確に区別。

--- a/openspec/changes/archive/2026-03-17-improve-search-bar/proposal.md
+++ b/openspec/changes/archive/2026-03-17-improve-search-bar/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+Discovery ページの検索バーには 3 つの UX 問題がある。(1) follow ボタンが小さな + アイコンのみでモバイルでタップしにくい、(2) follow 済みアーティストに ✓ / disabled が表示されない（Aurelia のリアクティビティが BubblePool 内部の Set 変更を検知できない dual-state バグ）、(3) follow 後にフィードバックがなく検索画面に留まったままになる。これらを改善し、検索からの follow 体験をバブルタップと同等にする。
+
+## What Changes
+
+- 検索結果の行（result-item）全体をタップ可能領域に変更し、+ アイコンボタンを削除する
+- follow 済みアーティストの検索結果に ✓ アイコン + disabled + 視覚的フィードバックを正しく表示する
+  - BubblePool.followedIds を public readonly に変更し、テンプレートから Aurelia ネイティブの Set 観測で直接バインド
+  - DiscoveryRoute.poolFollowedIds（dual-state コピー）と isArtistFollowed() メソッドを削除
+- follow 後にバブルビューへ自動遷移し、吸収アニメーションを再生する
+  - 検索モード終了 → canvas resume → バブルエリア上部に一時バブル spawn → AbsorptionAnimator で orb 吸収 → 後続処理（similar artist 追加、concert search）
+
+## Capabilities
+
+### New Capabilities
+
+- `search-follow-absorption`: 検索結果から follow した際のバブルビュー遷移と orb 吸収アニメーションの振る舞い
+
+### Modified Capabilities
+
+- `artist-discovery-dna-orb-ui`: 検索結果 UI の変更（行全体タップ化、+ アイコン削除）と follow 後の自動遷移
+- `aurelia-reactivity`: BubblePool.followedIds の公開と Aurelia ネイティブ Set 観測によるテンプレートバインディング
+
+## Impact
+
+- `frontend/src/services/bubble-pool.ts` — followedIds の可視性変更
+- `frontend/src/routes/discovery/discovery-route.ts` — poolFollowedIds 削除、onFollowFromSearch フロー変更
+- `frontend/src/routes/discovery/discovery-route.html` — テンプレートバインディング変更、result-item 構造変更
+- `frontend/src/routes/discovery/discovery-route.css` — result-item のインタラクティブスタイル
+- `frontend/src/components/dna-orb/dna-orb-canvas.ts` — 外部からの spawn + 即吸収 API（既存の spawnBubblesAt + absorb を組み合わせ）

--- a/openspec/changes/archive/2026-03-17-improve-search-bar/specs/artist-discovery-dna-orb-ui/spec.md
+++ b/openspec/changes/archive/2026-03-17-improve-search-bar/specs/artist-discovery-dna-orb-ui/spec.md
@@ -1,0 +1,57 @@
+## MODIFIED Requirements
+
+### Requirement: Similar Artist Chain Reaction
+The system SHALL generate new artist recommendations dynamically using the backend ArtistService.ListSimilar RPC with a limit parameter. The frontend SHALL call the Follow RPC when a user taps an artist bubble. The fetch SHALL NOT directly mutate the bubble pool — the caller SHALL manage eviction and insertion via `addToPool()`.
+
+#### Scenario: Similar artist bubble spawning
+- **WHEN** a user taps an artist bubble
+- **THEN** the system SHALL call the backend `ArtistService.ListSimilar` RPC with the selected artist's ID and `limit=30`
+- **AND** the system SHALL deduplicate the results (excluding seen and followed artists)
+- **AND** the system SHALL add results to the pool via `addToPool()`, evicting oldest bubbles if the pool would exceed 50
+- **AND** evicted bubbles SHALL be faded out before new bubbles spawn
+- **AND** new bubbles representing similar artists SHALL spawn from the original bubble's position
+- **AND** the new bubbles SHALL appear with a "pop" emergence animation
+- **AND** the new bubbles SHALL integrate into the physics-based layout
+
+#### Scenario: Follow RPC called on bubble tap
+- **WHEN** a user taps an artist bubble
+- **THEN** the frontend SHALL call `this.artistClient.follow({ artistId: new ArtistId({ value: artist.id }) })`
+- **AND** the call SHALL be non-blocking (fire-and-forget with error logging)
+- **AND** the local state SHALL update immediately without waiting for the RPC response
+
+#### Scenario: Similar artist spawning after search follow
+- **WHEN** a user follows an artist from the search results and the absorption animation completes
+- **THEN** the system SHALL trigger the same similar artist loading as a direct bubble tap
+- **AND** new similar artist bubbles SHALL spawn from the orb position
+
+## ADDED Requirements
+
+### Requirement: Search result item is fully tappable
+Each search result item SHALL use the entire row as the interactive tap area, replacing the small follow button.
+
+#### Scenario: Full row tap to follow
+- **WHEN** the search results list is displayed
+- **THEN** each result item row SHALL be tappable across its full width and height
+- **AND** tapping anywhere on the row SHALL trigger the follow action for that artist
+- **AND** the row SHALL NOT contain a separate follow button or + icon
+
+#### Scenario: Visual affordance for tappable rows
+- **WHEN** search result items are displayed
+- **THEN** each unfollowed row SHALL display `cursor: pointer` on hover
+- **AND** each row SHALL show a background color change on hover/active state
+- **AND** the row SHALL have sufficient touch target size (minimum 48px height)
+
+#### Scenario: Followed artist row is visually distinct and non-interactive
+- **WHEN** a search result item represents an already-followed artist
+- **THEN** the row SHALL display a ✓ (check) icon
+- **AND** the row SHALL appear visually muted (reduced opacity or distinct styling)
+- **AND** tapping the row SHALL have no effect (no duplicate follow, no animation)
+
+### Requirement: Spawn and absorb API on canvas
+The `DnaOrbCanvas` component SHALL expose a `spawnAndAbsorb` method that combines spawning a temporary bubble and immediately starting its absorption animation.
+
+#### Scenario: spawnAndAbsorb creates and absorbs a bubble
+- **WHEN** `spawnAndAbsorb(artist, x, y)` is called
+- **THEN** the canvas SHALL start the absorption animation from (x, y) toward the orb center
+- **AND** on completion, the canvas SHALL call `orbRenderer.injectColor()` with the artist's hue
+- **AND** the canvas SHALL dispatch the `need-more-bubbles` custom event to trigger similar artist loading

--- a/openspec/changes/archive/2026-03-17-improve-search-bar/specs/aurelia-reactivity/spec.md
+++ b/openspec/changes/archive/2026-03-17-improve-search-bar/specs/aurelia-reactivity/spec.md
@@ -1,0 +1,21 @@
+## ADDED Requirements
+
+### Requirement: Collection observation via native Set binding
+Template bindings that need to observe membership in a `Set` SHALL bind directly to `Set.has()` instead of delegating through view model methods, to leverage Aurelia 2's native collection observation.
+
+#### Scenario: Template binding observes Set.has() reactively
+- **WHEN** a template expression uses `someSet.has(value)` in a binding
+- **AND** `someSet.add(value)` or `someSet.delete(value)` is called
+- **THEN** the binding SHALL re-evaluate and the DOM SHALL update to reflect the new membership state
+
+#### Scenario: View model exposes Set via getter for template consumption
+- **WHEN** a service owns a `Set` that must be observed in a template
+- **THEN** the view model SHALL expose it via a `public get` accessor returning `ReadonlySet<T>`
+- **AND** the template SHALL bind to `getter.has(value)` directly
+- **AND** the view model SHALL NOT maintain a copy of the Set for reactivity purposes
+
+#### Scenario: Method calls wrapping Set.has() are not reactive
+- **WHEN** a template expression calls a view model method (e.g., `isItemSelected(id)`) that internally calls `this.someSet.has(id)`
+- **THEN** Aurelia SHALL NOT automatically track the Set dependency inside the method
+- **AND** the binding SHALL NOT re-evaluate when the Set contents change
+- **AND** this pattern SHALL be avoided in favor of direct `Set.has()` binding

--- a/openspec/changes/archive/2026-03-17-improve-search-bar/specs/search-follow-absorption/spec.md
+++ b/openspec/changes/archive/2026-03-17-improve-search-bar/specs/search-follow-absorption/spec.md
@@ -1,0 +1,27 @@
+## ADDED Requirements
+
+### Requirement: Search result follow triggers bubble view transition and absorption animation
+When a user follows an artist from the search results, the system SHALL transition back to the bubble view and play the orb absorption animation, providing the same visual feedback as a direct bubble tap.
+
+#### Scenario: Follow from search triggers absorption
+- **WHEN** a user taps a search result item for an unfollowed artist
+- **THEN** the system SHALL execute the follow action (optimistic UI update)
+- **AND** the system SHALL exit search mode (clear results, hide search result list)
+- **AND** the system SHALL resume the bubble canvas
+- **AND** the system SHALL spawn a temporary bubble at the upper area of the bubble canvas (approximately 15-20% from top)
+- **AND** the system SHALL immediately start the absorption animation for that bubble toward the orb
+- **AND** on absorption completion, `OrbRenderer.injectColor` SHALL be called with the bubble's hue
+- **AND** the system SHALL immediately dispatch the `need-more-bubbles` custom event to trigger similar artist loading (not deferred until absorption completion)
+
+#### Scenario: Search input is cleared after follow
+- **WHEN** a user follows an artist from the search results
+- **THEN** the search query input SHALL be cleared
+- **AND** the search mode SHALL be deactivated
+
+#### Scenario: Follow failure rolls back and stays in search mode
+- **WHEN** a user taps a search result item
+- **AND** the follow action fails (network error or backend error)
+- **THEN** the system SHALL NOT exit search mode
+- **AND** the system SHALL NOT spawn or absorb a bubble
+- **AND** the system SHALL display an error toast notification
+- **AND** the search results SHALL remain visible and interactive

--- a/openspec/changes/archive/2026-03-17-improve-search-bar/tasks.md
+++ b/openspec/changes/archive/2026-03-17-improve-search-bar/tasks.md
@@ -1,0 +1,32 @@
+## 1. Follow 状態のリアクティビティ修正
+
+- [x] 1.1 `BubblePool.followedIds` を `private` → `public readonly` に変更
+- [x] 1.2 `DiscoveryRoute` に `public get followedIds(): ReadonlySet<string>` getter を追加（`this.pool.followedIds` を返す）
+- [x] 1.3 `DiscoveryRoute.poolFollowedIds` プロパティを削除
+- [x] 1.4 `DiscoveryRoute.isArtistFollowed()` メソッドを削除
+- [x] 1.5 `followArtist()` 内の `poolFollowedIds` 手動同期コード（`new Set(...).add()` と rollback の `Set.delete()`）を削除
+- [x] 1.6 テンプレートのバインディングを `isArtistFollowed(artist.id)` → `followedIds.has(artist.id)` に変更（disabled, data-followed, if.bind すべて）
+
+## 2. 検索結果の行全体タップ化
+
+- [x] 2.1 `<li>` 要素に `click.trigger="onFollowFromSearch(artist)"` を追加
+- [x] 2.2 `<li>` に `followedIds.has(artist.id)` による disabled 判定を追加（follow 済みならイベント無視）
+- [x] 2.3 `<button class="follow-button">` と `<svg-icon name="plus">` を削除
+- [x] 2.4 follow 済み行に ✓ アイコンを表示（`<svg-icon if.bind="followedIds.has(artist.id)" name="check">`）
+- [x] 2.5 CSS: `.result-item` にインタラクティブスタイル追加（cursor: pointer, hover/active 背景色変化, 最小 48px 高さ）
+- [x] 2.6 CSS: follow 済み行のスタイル（opacity 低下、cursor: default）
+- [x] 2.7 CSS: `.follow-button` 関連スタイルを削除
+
+## 3. Follow 後の吸収アニメーション
+
+- [x] 3.1 `DnaOrbCanvas` に `spawnAndAbsorb(artist: ArtistBubble, x: number, y: number)` メソッドを追加
+- [x] 3.2 `spawnAndAbsorb` 内: physics body 作成 → 即 remove → AbsorptionAnimator 開始 → injectColor → need-more-bubbles イベント dispatch
+- [x] 3.3 `DiscoveryRoute.onFollowFromSearch()` のフローを変更: followArtist → exitSearchMode → clearSearch → canvas resume → spawnAndAbsorb（バブルエリア上部 15-20%）
+- [x] 3.4 follow 失敗時は検索モードに留まるようエラーハンドリングを調整
+
+## 4. テスト
+
+- [x] 4.1 `BubblePool` ユニットテスト: `markFollowed` 後に `followedIds.has()` が `true` を返すことを検証
+- [x] 4.2 `BubblePool` ユニットテスト: `unmarkFollowed` 後に `followedIds.has()` が `false` を返すことを検証
+- [x] 4.3 `BubblePool` ユニットテスト: `dedup` が followed artist を除外することを検証
+- [x] 4.4 `make check` が通ることを確認（lint + test）

--- a/openspec/changes/unify-follow-state-store/.openspec.yaml
+++ b/openspec/changes/unify-follow-state-store/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-16

--- a/openspec/changes/unify-follow-state-store/design.md
+++ b/openspec/changes/unify-follow-state-store/design.md
@@ -1,0 +1,88 @@
+## Context
+
+`improve-search-bar` change で BubblePool.followedIds を public にし、テンプレートからの直接 Set 観測で dual-state バグを解消した。しかし follow 状態の管理は依然として BubblePool (Set)、DiscoveryRoute (followedArtists 配列)、Store (guest.follows、onboarding 時のみ) に分散している。
+
+既存の `@aurelia/state` Store は onboarding/guest 状態を Redux スタイルで管理しており、reducer は pure function としてテスト可能。この仕組みを discovery の follow 状態にも拡張することで、状態管理を一元化する。
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- follow 状態の single source of truth を `@aurelia/state` Store に置く
+- follow/unfollow/rollback を `dispatch()` のみで実行できるようにする
+- reducer を pure function としてユニットテスト可能にする
+- `@aurelia/state` のリアクティビティによりテンプレートバインディングを自動更新する
+- BubblePool から follow 追跡の責務を除去し、pool 管理に集中させる
+
+**Non-Goals:**
+
+- Onboarding と Authenticated の follow フローの統合（現在 guest.follows と backend RPC で分岐するロジックはそのまま維持）
+- follow 状態の localStorage 永続化（discovery slice は session-scoped; onboarding の guest.follows は既存の永続化で対応）
+- DnaOrbCanvas の followedIds 参照方法の変更（canvas は引き続き外部から `followedIds` bindable を受け取る）
+
+## Decisions
+
+### 1. discovery slice の state shape: `followedArtists: FollowedArtist[]`
+
+**選択**: `DiscoveryState.followedArtists` を `{ id: string; name: string; mbid: string }[]` として定義。
+
+**理由**: `ArtistBubble` は UI 固有のプロパティ (x, y, radius, imageUrl) を含むため、Store に入れるべきではない。Store には follow 状態の判定とリスト表示に必要な最小限のフィールドのみ保持する。follow 判定用の `followedIds` (string[]) は getter で derived する。
+
+**代替案**: `followedIds: string[]` のみ保持 → follow 済みアーティストの名前が必要な箇所 (seed similar, toast 等) で困るため却下。
+
+### 2. `guest.follows` との関係: 共存、統合しない
+
+**選択**: `discovery.followedArtists` と `guest.follows` を別 slice として共存させる。
+
+**理由**:
+- `guest.follows` は onboarding 専用で localStorage に永続化される（ページリロード後も復元）
+- `discovery.followedArtists` は session-scoped（ページ遷移後は backend から再取得）
+- Onboarding 時は `discovery/follow` dispatch と `guest/follow` dispatch を両方実行する（FollowServiceClient が後者を担当）
+- 統合するとライフサイクルの違い（永続化 vs session）を混在させることになる
+
+### 3. BubblePool.dedup: followedIds を引数で注入
+
+**選択**: `dedup(bubbles: ArtistBubble[], followedIds: ReadonlySet<string>): ArtistBubble[]`
+
+**理由**: BubblePool が Store に依存するのを避ける。BubblePool は plain class として DI 不要のままテスト可能。呼び出し側 (DiscoveryRoute) が Store から followedIds を取得して渡す。
+
+### 4. テンプレートバインディング: Store state から derived getter
+
+**選択**: DiscoveryRoute に以下の getter を追加:
+
+```ts
+public get followedIds(): ReadonlySet<string> {
+  return new Set(this.store.getState().discovery.followedArtists.map(a => a.id))
+}
+```
+
+テンプレートは `followedIds.has(artist.id)` でバインド。
+
+**理由**: `@aurelia/state` の dispatch は Store 変更を Aurelia に通知し、Store を参照する getter のバインディングが再評価される。`improve-search-bar` change で導入した `followedIds.has()` のテンプレートパターンをそのまま維持できる。
+
+**パフォーマンス**: followedArtists が < 100 件のため、毎回 Set を生成するコストは無視できる。将来的に問題になれば `@computed` でキャッシュ可能。
+
+### 5. Optimistic update + rollback パターン
+
+```ts
+// follow
+store.dispatch({ type: 'discovery/follow', artist: { id, name, mbid } })
+
+// rollback (on error)
+store.dispatch({ type: 'discovery/unfollow', artistId: id })
+```
+
+**理由**: reducer は pure function なので rollback も単純な dispatch。batch() も不要（1 dispatch = 1 state update）。
+
+## Risks / Trade-offs
+
+**[Risk] getter で毎回 `new Set()` を生成する** → < 100 件では問題にならない。プロファイリングで問題が見つかれば `@computed` でキャッシュする。
+
+**[Risk] `@aurelia/state` の dispatch が getter バインディングの再評価をトリガーしない可能性** → 実装時にコンポーネントテストで検証。問題があれば `@watch` で明示的に observe する。
+
+**[Trade-off] `guest.follows` と `discovery.followedArtists` の二重管理が残る** → ライフサイクルの違い（永続化 vs session）のため意図的に分離。統合は onboarding フローのリファクタリング時に検討。
+
+## Open Questions
+
+- `discovery.followedArtists` を persistenceMiddleware で localStorage に永続化する必要はあるか？（現状は session-scoped で十分と判断）
+- canvas の `followedIds` bindable は Store 参照の getter 経由で更新されるか、または明示的な `@watch` が必要か？

--- a/openspec/changes/unify-follow-state-store/proposal.md
+++ b/openspec/changes/unify-follow-state-store/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+Discovery ページの follow 状態が `BubblePool.followedIds` (Set)、`DiscoveryRoute.followedArtists` (配列)、`@aurelia/state` Store の `guest.follows` (onboarding 時) の 3 箇所に分散しており、follow/rollback 時に 4 箇所を手動同期する必要がある。これは `improve-search-bar` change で表面化したリアクティビティバグの根本原因であり、follow ロジックの正確性とテスタビリティを確保するために状態管理を `@aurelia/state` Store に一元化する。
+
+## What Changes
+
+- `AppState` に `discovery` slice を追加: `followedArtists: FollowedArtist[]` を管理
+- `AppAction` に `discovery/follow` と `discovery/unfollow` アクションを追加
+- `appReducer` に discovery slice のケースを追加（pure function、テスト容易）
+- `BubblePool` から follow 追跡を除去: `followedIds` Set、`markFollowed()`、`unmarkFollowed()`、`isFollowed()` を削除。`dedup()` は `followedIds` を引数で受け取る形に変更
+- `DiscoveryRoute` を Store ベースに移行: `followedArtists` と `poolFollowedIds` を削除し、Store state から derived。follow/rollback は `dispatch()` のみ
+- テンプレートバインディングを Store state 参照に変更（`@aurelia/state` がリアクティビティを保証）
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `state-management`: `AppState` に `discovery` slice 追加、`discovery/follow` と `discovery/unfollow` アクションを追加
+- `bubble-pool-lifecycle`: `BubblePool` から follow 追跡責務を除去し、`dedup` のシグネチャを変更
+
+## Impact
+
+- `frontend/src/state/app-state.ts` — `DiscoveryState` interface と `discovery` slice 追加
+- `frontend/src/state/actions.ts` — `discovery/follow`、`discovery/unfollow` アクション追加
+- `frontend/src/state/reducer.ts` — discovery slice のケース追加
+- `frontend/src/services/bubble-pool.ts` — follow 関連メソッド削除、`dedup(bubbles, followedIds)` に変更
+- `frontend/src/routes/discovery/discovery-route.ts` — Store ベースに移行、followedArtists/poolFollowedIds 削除
+- `frontend/src/routes/discovery/discovery-route.html` — テンプレートバインディング更新
+- 依存: `improve-search-bar` change が先行して完了している前提

--- a/openspec/changes/unify-follow-state-store/specs/bubble-pool-lifecycle/spec.md
+++ b/openspec/changes/unify-follow-state-store/specs/bubble-pool-lifecycle/spec.md
@@ -1,0 +1,25 @@
+## MODIFIED Requirements
+
+### Requirement: Bubble pool deduplication
+The system SHALL remove duplicate and already-followed artists from the bubble pool. Follow state SHALL be provided externally rather than tracked internally by the pool.
+
+#### Scenario: Deduplication on initial load (Step 2)
+- **WHEN** the bubble pool is populated from any source
+- **THEN** the caller SHALL provide a `followedIds: ReadonlySet<string>` parameter to the dedup method
+- **AND** the system SHALL remove artists that match any already-seen artist by name (case-insensitive), internal ID, or MBID
+- **AND** the system SHALL remove artists whose ID is in the provided `followedIds` set
+- **AND** the system SHALL cap the pool at a maximum of 50 bubbles
+
+#### Scenario: Deduplication after tap refill (Step 5)
+- **WHEN** similar artists are added to the pool after a tap
+- **THEN** the system SHALL apply the same deduplication rules as Step 2
+- **AND** the caller SHALL provide the current `followedIds` from the Store
+- **AND** already-seen artists from prior fetches SHALL be excluded
+
+## REMOVED Requirements
+
+### Requirement: Internal follow tracking in BubblePool
+
+**Reason**: Follow state management is moving to `@aurelia/state` Store as the single source of truth. BubblePool's internal `followedIds` Set, `markFollowed()`, `unmarkFollowed()`, and `isFollowed()` are redundant and create dual-state bugs.
+
+**Migration**: Remove `followedIds` Set, `markFollowed()`, `unmarkFollowed()`, `isFollowed()` from BubblePool. All callers that called `pool.markFollowed(id)` SHALL instead dispatch `discovery/follow` to the Store. All callers that called `pool.isFollowed(id)` SHALL instead check Store state. The `dedup()` method SHALL accept `followedIds` as a parameter.

--- a/openspec/changes/unify-follow-state-store/specs/state-management/spec.md
+++ b/openspec/changes/unify-follow-state-store/specs/state-management/spec.md
@@ -1,0 +1,108 @@
+## MODIFIED Requirements
+
+### Requirement: AppState type definition
+
+The system SHALL define a single `AppState` interface as the Store's state shape, containing `onboarding`, `guest`, and `discovery` slices.
+
+#### Scenario: AppState structure
+
+- **WHEN** the `AppState` interface is defined
+- **THEN** it SHALL contain an `onboarding` object with `step` (OnboardingStepValue string literal), `spotlightTarget` (string), `spotlightMessage` (string), `spotlightRadius` (string), and `spotlightActive` (boolean)
+- **AND** it SHALL contain a `guest` object with `follows` (GuestFollow array) and `home` (string | null)
+- **AND** it SHALL contain a `discovery` object with `followedArtists` (FollowedArtist array)
+
+#### Scenario: FollowedArtist shape
+
+- **WHEN** the `FollowedArtist` interface is defined
+- **THEN** it SHALL contain `id` (string), `name` (string), and `mbid` (string)
+
+#### Scenario: Discovery initial state
+
+- **WHEN** the application initializes
+- **THEN** `discovery.followedArtists` SHALL be an empty array
+
+### Requirement: Action type definition
+
+The system SHALL define all state mutations as a discriminated union `AppAction` type, ensuring type-safe dispatch.
+
+#### Scenario: Onboarding actions
+
+- **WHEN** the `AppAction` type is defined
+- **THEN** it SHALL include `onboarding/advance` (with `step` payload), `onboarding/setSpotlight` (with `target`, `message`, optional `radius`), `onboarding/clearSpotlight`, `onboarding/complete`, and `onboarding/reset`
+
+#### Scenario: Guest actions
+
+- **WHEN** the `AppAction` type is defined
+- **THEN** it SHALL include `guest/follow` (with `artistId`, `name`), `guest/unfollow` (with `artistId`), `guest/setUserHome` (with `code`), and `guest/clearAll`
+
+#### Scenario: Discovery actions
+
+- **WHEN** the `AppAction` type is defined
+- **THEN** it SHALL include `discovery/follow` (with `artist: FollowedArtist`) and `discovery/unfollow` (with `artistId: string`)
+
+### Requirement: Reducer as pure function
+
+The system SHALL implement a single `appReducer` function that returns a new state for each action, without side effects.
+
+#### Scenario: Reducer handles onboarding/advance
+
+- **WHEN** `onboarding/advance` is dispatched with a step value
+- **THEN** the reducer SHALL return a new state with `onboarding.step` set to the given value
+- **AND** the original state SHALL NOT be mutated
+
+#### Scenario: Reducer handles guest/follow
+
+- **WHEN** `guest/follow` is dispatched with an `artistId` and `name`
+- **THEN** the reducer SHALL return a new state with the artist appended to `guest.follows`
+- **AND** if the `artistId` already exists in `follows`, the reducer SHALL return the current state unchanged
+
+#### Scenario: Reducer handles guest/unfollow
+
+- **WHEN** `guest/unfollow` is dispatched with an `artistId`
+- **THEN** the reducer SHALL return a new state with the artist removed from `guest.follows`
+
+#### Scenario: Reducer handles guest/setUserHome
+
+- **WHEN** `guest/setUserHome` is dispatched with a `code`
+- **THEN** the reducer SHALL return a new state with `guest.home` set to the given code
+
+#### Scenario: Reducer handles guest/clearAll
+
+- **WHEN** `guest/clearAll` is dispatched
+- **THEN** the reducer SHALL return a new state with `guest.follows` as an empty array and `guest.home` as null
+
+#### Scenario: Reducer handles onboarding/setSpotlight
+
+- **WHEN** `onboarding/setSpotlight` is dispatched with `target`, `message`, and optional `radius`
+- **THEN** the reducer SHALL return a new state with `spotlightTarget`, `spotlightMessage`, `spotlightRadius` (default `'12px'` if not provided), and `spotlightActive` set to true
+
+#### Scenario: Reducer handles onboarding/clearSpotlight
+
+- **WHEN** `onboarding/clearSpotlight` is dispatched
+- **THEN** the reducer SHALL return a new state with `spotlightTarget` and `spotlightMessage` set to empty string, `spotlightRadius` reset to `'12px'`, and `spotlightActive` set to false
+
+#### Scenario: Reducer handles onboarding/complete
+
+- **WHEN** `onboarding/complete` is dispatched
+- **THEN** the reducer SHALL return a new state with `onboarding.step` set to `'completed'` and spotlight cleared (target/message empty, radius `'12px'`, active false)
+
+#### Scenario: Reducer handles onboarding/reset
+
+- **WHEN** `onboarding/reset` is dispatched
+- **THEN** the reducer SHALL return a new state with `onboarding` reset to initial values (step = `'lp'`, spotlight inactive)
+
+#### Scenario: Reducer handles discovery/follow
+
+- **WHEN** `discovery/follow` is dispatched with an `artist` object containing `id`, `name`, and `mbid`
+- **THEN** the reducer SHALL return a new state with the artist appended to `discovery.followedArtists`
+- **AND** if the `artist.id` already exists in `followedArtists`, the reducer SHALL return the current state unchanged
+
+#### Scenario: Reducer handles discovery/unfollow
+
+- **WHEN** `discovery/unfollow` is dispatched with an `artistId`
+- **THEN** the reducer SHALL return a new state with the artist removed from `discovery.followedArtists`
+
+#### Scenario: Unknown action passthrough
+
+- **WHEN** an unrecognized action type is dispatched
+- **THEN** the reducer SHALL return the current state unchanged (same reference)

--- a/openspec/changes/unify-follow-state-store/tasks.md
+++ b/openspec/changes/unify-follow-state-store/tasks.md
@@ -1,0 +1,31 @@
+## 1. Store に discovery slice を追加
+
+- [ ] 1.1 `app-state.ts` に `FollowedArtist` interface と `DiscoveryState` interface を追加
+- [ ] 1.2 `AppState` に `discovery: DiscoveryState` を追加し、`initialState` に空の `followedArtists` を設定
+- [ ] 1.3 `actions.ts` に `discovery/follow` と `discovery/unfollow` アクションを追加
+- [ ] 1.4 `reducer.ts` に `discovery/follow` ケースを追加（重複チェック付き）
+- [ ] 1.5 `reducer.ts` に `discovery/unfollow` ケースを追加
+
+## 2. BubblePool から follow 追跡を除去
+
+- [ ] 2.1 `BubblePool` から `followedIds` Set、`markFollowed()`、`unmarkFollowed()`、`isFollowed()` を削除
+- [ ] 2.2 `dedup()` のシグネチャを `dedup(bubbles, followedIds: ReadonlySet<string>)` に変更
+- [ ] 2.3 `reset()` から `followedIds.clear()` を削除
+
+## 3. DiscoveryRoute を Store ベースに移行
+
+- [ ] 3.1 `followedArtists` プロパティを削除し、Store state から derived する getter に置き換え
+- [ ] 3.2 `followedIds` getter を Store state の `discovery.followedArtists` から derived する `ReadonlySet<string>` に変更
+- [ ] 3.3 `followArtist()` 内の `pool.markFollowed()` を `store.dispatch({ type: 'discovery/follow', artist })` に置き換え
+- [ ] 3.4 `followArtist()` 内の rollback を `store.dispatch({ type: 'discovery/unfollow', artistId })` に簡素化
+- [ ] 3.5 `pool.dedup()` の呼び出し箇所に `followedIds` を引数として渡すよう修正（loadInitialArtists, reloadWithTag, getSimilarArtists, loadReplacementBubbles）
+- [ ] 3.6 `onArtistSelected` と `onFollowFromSearch` 内の `pool.isFollowed()` ガードを Store state チェックに変更
+- [ ] 3.7 canvas の `followedIds` bindable に Store derived の `followedIds` getter を渡すようテンプレートを更新
+
+## 4. テスト
+
+- [ ] 4.1 Reducer ユニットテスト: `discovery/follow` で followedArtists に追加されること
+- [ ] 4.2 Reducer ユニットテスト: `discovery/follow` で重複 ID が無視されること
+- [ ] 4.3 Reducer ユニットテスト: `discovery/unfollow` で followedArtists から削除されること
+- [ ] 4.4 BubblePool ユニットテスト: `dedup(bubbles, followedIds)` が followed artist を除外すること
+- [ ] 4.5 `make check` が通ることを確認（lint + test）

--- a/openspec/specs/artist-discovery-dna-orb-ui/spec.md
+++ b/openspec/specs/artist-discovery-dna-orb-ui/spec.md
@@ -128,6 +128,45 @@ The system SHALL generate new artist recommendations dynamically using the backe
 - **AND** the call SHALL be non-blocking (fire-and-forget with error logging)
 - **AND** the local state SHALL update immediately without waiting for the RPC response
 
+#### Scenario: Similar artist spawning after search follow
+- **WHEN** a user follows an artist from the search results and the absorption animation completes
+- **THEN** the system SHALL trigger the same similar artist loading as a direct bubble tap
+- **AND** new similar artist bubbles SHALL spawn from the orb position
+
+---
+
+### Requirement: Search result item is fully tappable
+Each search result item SHALL use the entire row as the interactive tap area, replacing the small follow button.
+
+#### Scenario: Full row tap to follow
+- **WHEN** the search results list is displayed
+- **THEN** each result item row SHALL be tappable across its full width and height
+- **AND** tapping anywhere on the row SHALL trigger the follow action for that artist
+- **AND** the row SHALL NOT contain a separate follow button or + icon
+
+#### Scenario: Visual affordance for tappable rows
+- **WHEN** search result items are displayed
+- **THEN** each unfollowed row SHALL display `cursor: pointer` on hover
+- **AND** each row SHALL show a background color change on hover/active state
+- **AND** the row SHALL have sufficient touch target size (minimum 48px height)
+
+#### Scenario: Followed artist row is visually distinct and non-interactive
+- **WHEN** a search result item represents an already-followed artist
+- **THEN** the row SHALL display a ✓ (check) icon
+- **AND** the row SHALL appear visually muted (reduced opacity or distinct styling)
+- **AND** tapping the row SHALL have no effect (no duplicate follow, no animation)
+
+---
+
+### Requirement: Spawn and absorb API on canvas
+The `DnaOrbCanvas` component SHALL expose a `spawnAndAbsorb` method that combines spawning a temporary bubble and immediately starting its absorption animation.
+
+#### Scenario: spawnAndAbsorb creates and absorbs a bubble
+- **WHEN** `spawnAndAbsorb(artist, x, y)` is called
+- **THEN** the canvas SHALL start the absorption animation from (x, y) toward the orb center
+- **AND** on completion, the canvas SHALL call `orbRenderer.injectColor()` with the artist's hue
+- **AND** the canvas SHALL dispatch the `need-more-bubbles` custom event to trigger similar artist loading
+
 ---
 
 ### Requirement: Completion Action via DNA Orb

--- a/openspec/specs/artist-discovery-dna-orb-ui/spec.md
+++ b/openspec/specs/artist-discovery-dna-orb-ui/spec.md
@@ -165,7 +165,7 @@ The `DnaOrbCanvas` component SHALL expose a `spawnAndAbsorb` method that combine
 - **WHEN** `spawnAndAbsorb(artist, x, y)` is called
 - **THEN** the canvas SHALL start the absorption animation from (x, y) toward the orb center
 - **AND** on completion, the canvas SHALL call `orbRenderer.injectColor()` with the artist's hue
-- **AND** the canvas SHALL dispatch the `need-more-bubbles` custom event to trigger similar artist loading
+- **AND** the canvas SHALL **immediately** dispatch the `need-more-bubbles` custom event (not deferred until absorption completion)
 
 ---
 

--- a/openspec/specs/aurelia-reactivity/spec.md
+++ b/openspec/specs/aurelia-reactivity/spec.md
@@ -52,3 +52,23 @@ Properties whose changes require imperative side effects (e.g., error display, a
 - **WHEN** a property decorated with `@observable` changes value
 - **THEN** the corresponding `<propertyName>Changed(newValue, oldValue)` handler SHALL execute
 - **AND** the handler SHALL perform only the side effect, not additional state mutations that could cascade
+
+### Requirement: Collection observation via native Set binding
+Template bindings that need to observe membership in a `Set` SHALL bind directly to `Set.has()` instead of delegating through view model methods, to leverage Aurelia 2's native collection observation.
+
+#### Scenario: Template binding observes Set.has() reactively
+- **WHEN** a template expression uses `someSet.has(value)` in a binding
+- **AND** `someSet.add(value)` or `someSet.delete(value)` is called
+- **THEN** the binding SHALL re-evaluate and the DOM SHALL update to reflect the new membership state
+
+#### Scenario: View model exposes Set via getter for template consumption
+- **WHEN** a service owns a `Set` that must be observed in a template
+- **THEN** the view model SHALL expose it via a `public get` accessor returning `ReadonlySet<T>`
+- **AND** the template SHALL bind to `getter.has(value)` directly
+- **AND** the view model SHALL NOT maintain a copy of the Set for reactivity purposes
+
+#### Scenario: Method calls wrapping Set.has() are not reactive
+- **WHEN** a template expression calls a view model method (e.g., `isItemSelected(id)`) that internally calls `this.someSet.has(id)`
+- **THEN** Aurelia SHALL NOT automatically track the Set dependency inside the method
+- **AND** the binding SHALL NOT re-evaluate when the Set contents change
+- **AND** this pattern SHALL be avoided in favor of direct `Set.has()` binding

--- a/openspec/specs/search-follow-absorption/spec.md
+++ b/openspec/specs/search-follow-absorption/spec.md
@@ -1,0 +1,33 @@
+# Search Follow Absorption
+
+## Purpose
+
+Defines the behavior when a user follows an artist from the search results, including the transition back to bubble view, absorption animation, and error handling.
+
+## Requirements
+
+### Requirement: Search result follow triggers bubble view transition and absorption animation
+When a user follows an artist from the search results, the system SHALL transition back to the bubble view and play the orb absorption animation, providing the same visual feedback as a direct bubble tap.
+
+#### Scenario: Follow from search triggers absorption
+- **WHEN** a user taps a search result item for an unfollowed artist
+- **THEN** the system SHALL execute the follow action (optimistic UI update)
+- **AND** the system SHALL exit search mode (clear results, hide search result list)
+- **AND** the system SHALL resume the bubble canvas
+- **AND** the system SHALL spawn a temporary bubble at the upper area of the bubble canvas (approximately 15-20% from top)
+- **AND** the system SHALL immediately start the absorption animation for that bubble toward the orb
+- **AND** on absorption completion, `OrbRenderer.injectColor` SHALL be called with the bubble's hue
+- **AND** the system SHALL immediately dispatch the `need-more-bubbles` custom event to trigger similar artist loading (not deferred until absorption completion)
+
+#### Scenario: Search input is cleared after follow
+- **WHEN** a user follows an artist from the search results
+- **THEN** the search query input SHALL be cleared
+- **AND** the search mode SHALL be deactivated
+
+#### Scenario: Follow failure rolls back and stays in search mode
+- **WHEN** a user taps a search result item
+- **AND** the follow action fails (network error or backend error)
+- **THEN** the system SHALL NOT exit search mode
+- **AND** the system SHALL NOT spawn or absorb a bubble
+- **AND** the system SHALL display an error toast notification
+- **AND** the search results SHALL remain visible and interactive


### PR DESCRIPTION
## 🔗 Related Issue

Closes #266

## 📝 Summary of Changes

Archive the completed `improve-search-bar` change and sync delta specs to main capabilities:

- **Archive**: `improve-search-bar` (21/21 tasks complete) → `archive/2026-03-17-improve-search-bar/`
- **Spec sync**:
  - `artist-discovery-dna-orb-ui`: Add tappable search rows, spawnAndAbsorb API, search follow spawn scenario
  - `aurelia-reactivity`: Add native Set binding requirement
  - `search-follow-absorption`: New capability spec
- **New change**: `unify-follow-state-store` artifacts (proposal, design, specs, tasks — follow-up change, not yet implemented)

## ✅ Self-Checklist

- [x] I have linked the related issue.
- [x] I have updated the relevant documentation (e.g., `README.md`) if needed.
- [x] I have run `buf lint` and `buf format` locally and all checks have passed.
- [x] My proto definitions follow the project's style guidelines and validation rules.
- [x] Breaking changes have been justified and documented if applicable.