### PR TITLE
docs(openspec): archive artist-image-ui and add new changes

### DIFF
--- a/openspec/changes/archive/2026-03-17-artist-image-ui/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-17-artist-image-ui/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-16

--- a/openspec/changes/archive/2026-03-17-artist-image-ui/design.md
+++ b/openspec/changes/archive/2026-03-17-artist-image-ui/design.md
@@ -1,0 +1,77 @@
+## Context
+
+The backend Artist proto message now includes an optional `Fanart` field with five image types: `artist_thumb` (1000x1000 portrait), `artist_background` (1920x1080 backdrop), `hd_music_logo` (800x310 transparent), `music_logo` (400x155 transparent), and `music_banner` (1000x185 wide). The RPC mapper (`ArtistToProto`) correctly maps `entity.Fanart` to proto when present, and the `artist-image-sync` CronJob populates the `artist_fanart` table from fanart.tv.
+
+However, the `ListFollowed` RPC's SQL query (`followListByUserQuery`) only selects `a.id, a.name, a.mbid, fa.hype` from the `artists` table — it does not JOIN `artist_fanart`, so `entity.Artist.Fanart` is always `nil` in the response. The backend needs to be updated to load fanart data when listing followed artists.
+
+The frontend currently:
+- Uses hash-based HSL colors (`artistColor(name)`) as the sole visual identifier
+- Has no `<img>` elements anywhere in the app
+- Dashboard events are rendered via `event-card` component with `artist-color` custom attribute
+- My-artists grid tiles use CSS gradients derived from the generated color
+- Both Dashboard and My Artists call `ListFollowed` but the response never contains fanart data due to the missing JOIN
+
+## Goals / Non-Goals
+
+**Goals:**
+- Display artist logos on dashboard event cards (replacing text when available)
+- Show artist background images in the event detail sheet hero area
+- Use artist thumbnails as grid tile backgrounds on the my-artists page
+- Graceful fallback to existing HSL color visuals when images are unavailable
+
+**Non-Goals:**
+- Image caching or service worker preloading (browser cache is sufficient for now)
+- My-artists list view changes (list view keeps existing dot + text layout)
+- DNA Orb / discovery bubble images (Canvas-based, high implementation cost)
+- Downloading/self-hosting images (continue using fanart.tv CDN URLs directly)
+
+## Decisions
+
+### 1. Data Flow: Extend existing ListFollowed mapping
+
+Add fanart URL fields to the existing `FollowedArtistInfo` and `LiveEvent` interfaces. Extract URLs in the service client layer with the logo fallback chain: `hd_music_logo?.value ?? music_logo?.value`.
+
+**Why**: No new RPC calls needed. The data is already in the ListFollowed response but currently discarded during mapping. Minimal change surface.
+
+### 2. Image Loading: Native `<img>` with `loading="lazy"` + `decoding="async"`
+
+Use standard `<img>` elements with native lazy loading rather than IntersectionObserver or a custom component.
+
+**Why**: All target browsers support `loading="lazy"`. No JavaScript overhead. The `decoding="async"` attribute prevents main-thread blocking during decode. Combined with fanart.tv CDN, this is sufficient for the image count (tens, not hundreds).
+
+### 3. Event Card Logo: Conditional `<img>` / `<span>` swap
+
+```html
+<img if.bind="event.logoUrl" src.bind="event.logoUrl" ... />
+<span else class="artist-name">${event.artistName}</span>
+```
+
+Transparent PNG logos on the existing `artist-color` gradient background. Constrain with `max-block-size` and `object-fit: contain` to fit card proportions.
+
+**Why**: Logos are transparent, so they naturally layer over the existing color scheme. Keeping the color background ensures visual consistency between logo and non-logo cards.
+
+### 4. Detail Sheet Hero: Conditional image block above header
+
+Insert a `<div class="sheet-hero">` with `background-image` above the existing `sheet-artist-header`. Only rendered when `artist_background` URL exists. Use `aspect-ratio: 16/9` with `object-fit: cover` and a bottom gradient fade into the sheet background.
+
+**Why**: The 1920x1080 background images are cinematic and benefit from a dedicated display area. Placing above (not behind) text avoids readability issues. Conditional rendering means no layout shift for artists without backgrounds.
+
+### 5. Grid Tile Thumbnail: CSS `background-image` with gradient overlay
+
+Set `artist_thumb` as `background-image` on the grid tile, layered under the existing gradient overlay (`linear-gradient(to top, black/60%, transparent)`). Fall back to the existing color gradient when no thumbnail is available.
+
+**Why**: The existing gradient overlay already provides text readability. Adding a photo underneath maintains the same text contrast. CSS `background-image` with `onerror` fallback (clear the URL) handles broken images gracefully.
+
+### 6. Fanart Data Propagation: Dashboard uses a fanart lookup map
+
+Dashboard currently maps concerts to `LiveEvent` objects. Concert data includes `artistId` but not Artist details. Build a `Map<artistId, FanartUrls>` from the `ListFollowed` response, then look up fanart URLs when constructing `LiveEvent` objects.
+
+**Why**: Dashboard already calls `ListFollowed` (for hype levels). Enriching `LiveEvent` with image URLs from the same response avoids additional RPC calls. Artists not in the followed list simply have no images (acceptable — dashboard only shows followed artists' concerts).
+
+## Risks / Trade-offs
+
+**[fanart.tv CDN availability]** — Images load from fanart.tv's CDN. If slow or down, cards show fallback text/color immediately; images pop in when loaded. No loading spinners to avoid visual noise.
+
+**[Large background images on mobile]** — `artist_background` is 1920x1080. On slow connections, the detail sheet hero may load slowly. Acceptable because the sheet content below is usable immediately; the hero is enhancement-only.
+
+**[No image for most artists]** — fanart.tv coverage skews toward popular artists. Many followed artists will have no images, so the HSL color fallback must remain polished — it's not a degraded state, it's the default state with images as progressive enhancement.

--- a/openspec/changes/archive/2026-03-17-artist-image-ui/proposal.md
+++ b/openspec/changes/archive/2026-03-17-artist-image-ui/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+Artist cards on the dashboard and my-artists page display only text names with generated HSL colors. The backend now serves fanart.tv image data (logos, thumbnails, backgrounds) via the Artist.fanart proto field, but the frontend does not consume it yet. Displaying real artist images significantly improves visual recognition and the overall fan experience.
+
+## What Changes
+
+- Replace artist name text with transparent logo image (`hd_music_logo` / `music_logo`) on dashboard event cards, falling back to existing text when no logo is available
+- Add a hero background image (`artist_background`) to the event detail sheet when available, expanding the sheet vertically to accommodate the image above the existing content
+- Use artist thumbnail (`artist_thumb`) as background image on my-artists grid tiles, falling back to the existing gradient when unavailable
+
+## Capabilities
+
+### New Capabilities
+
+- `artist-image-ui`: Display fanart.tv artist images (logos, thumbnails, backgrounds) across dashboard and my-artists UI components
+
+### Modified Capabilities
+
+None. The backend already serves Fanart data in the Artist proto message. This change is frontend-only consumption.
+
+## Impact
+
+- **Frontend**: Changes to `follow-service-client.ts` (fanart field mapping), `live-event.ts` (new image URL fields), `event-card` component (logo display), `event-detail-sheet` component (hero image), `my-artists-route` (grid tile backgrounds)
+- **Proto**: No changes required. `Artist.fanart` already provides all needed image URLs
+- **Backend**: No changes required. RPC mapper already populates Fanart in Artist responses

--- a/openspec/changes/archive/2026-03-17-artist-image-ui/specs/artist-image-ui/spec.md
+++ b/openspec/changes/archive/2026-03-17-artist-image-ui/specs/artist-image-ui/spec.md
@@ -1,0 +1,65 @@
+## ADDED Requirements
+
+### Requirement: Event Card Logo Display
+The dashboard event card SHALL display the artist's transparent logo image instead of the text artist name when a logo URL is available. The system SHALL use `hd_music_logo` as the primary source and fall back to `music_logo` when `hd_music_logo` is unavailable. When neither logo is available, the card SHALL display the existing text artist name.
+
+#### Scenario: Artist has hd_music_logo
+- **WHEN** an event card renders for an artist with `hd_music_logo` in their fanart data
+- **THEN** the card SHALL display the `hd_music_logo` image with `object-fit: contain` instead of the text name
+
+#### Scenario: Artist has only music_logo
+- **WHEN** an event card renders for an artist with `music_logo` but no `hd_music_logo`
+- **THEN** the card SHALL display the `music_logo` image as fallback
+
+#### Scenario: Artist has no logo
+- **WHEN** an event card renders for an artist without any logo in their fanart data
+- **THEN** the card SHALL display the existing text artist name with the current styling
+
+#### Scenario: Logo image fails to load
+- **WHEN** the logo image URL returns an error or times out
+- **THEN** the card SHALL fall back to displaying the text artist name
+
+### Requirement: Event Detail Sheet Hero Image
+The event detail sheet SHALL display the artist's background image as a hero section above the existing artist header when `artist_background` is available. The hero image SHALL NOT be displayed when no background image exists, preserving the current layout.
+
+#### Scenario: Artist has background image
+- **WHEN** the detail sheet opens for an event whose artist has `artist_background` in their fanart data
+- **THEN** the sheet SHALL display the background image in a hero section above the artist header with `aspect-ratio: 16/9` and `object-fit: cover`
+
+#### Scenario: Artist has no background image
+- **WHEN** the detail sheet opens for an event whose artist has no `artist_background`
+- **THEN** the sheet SHALL render the existing layout without a hero section
+
+#### Scenario: Hero image with gradient fade
+- **WHEN** the hero image is displayed
+- **THEN** the bottom edge of the hero section SHALL fade into the sheet background color via a gradient overlay to ensure visual continuity
+
+### Requirement: My Artists Grid Tile Thumbnail
+The my-artists grid tile SHALL display the artist's thumbnail image (`artist_thumb`) as a background image when available. The existing gradient overlay SHALL remain on top to ensure text readability. When no thumbnail is available, the tile SHALL display the existing color gradient.
+
+#### Scenario: Artist has thumbnail
+- **WHEN** a grid tile renders for an artist with `artist_thumb` in their fanart data
+- **THEN** the tile SHALL display the thumbnail as `background-image` with `object-fit: cover`, layered under the existing gradient overlay
+
+#### Scenario: Artist has no thumbnail
+- **WHEN** a grid tile renders for an artist without `artist_thumb`
+- **THEN** the tile SHALL display the existing color gradient background
+
+#### Scenario: Thumbnail image fails to load
+- **WHEN** the thumbnail image URL returns an error
+- **THEN** the tile SHALL fall back to the existing color gradient background
+
+### Requirement: Fanart Data Propagation
+The frontend service layer SHALL extract fanart image URLs from the `Artist.fanart` proto field in `ListFollowed` responses and propagate them to the `LiveEvent` and `FollowedArtist` view models for consumption by UI components.
+
+#### Scenario: ListFollowed returns artist with fanart
+- **WHEN** the `ListFollowed` RPC returns an artist with populated fanart data
+- **THEN** the service layer SHALL map `hd_music_logo`, `music_logo`, `artist_background`, and `artist_thumb` URLs to the corresponding view model fields
+
+#### Scenario: ListFollowed returns artist without fanart
+- **WHEN** the `ListFollowed` RPC returns an artist without fanart data
+- **THEN** the view model image URL fields SHALL be undefined or empty, triggering fallback display in UI components
+
+#### Scenario: Dashboard events enriched with fanart
+- **WHEN** the dashboard constructs `LiveEvent` objects from concert data
+- **THEN** the system SHALL look up fanart URLs by artist ID from the `ListFollowed` response and attach them to the `LiveEvent`

--- a/openspec/changes/archive/2026-03-17-artist-image-ui/tasks.md
+++ b/openspec/changes/archive/2026-03-17-artist-image-ui/tasks.md
@@ -1,0 +1,41 @@
+## 0. Backend: Include Fanart in ListFollowed Response
+
+- [x] 0.1 Update `followListByUserQuery` in `follow_repo.go` to LEFT JOIN `artist_fanart` table and scan fanart columns into `entity.Artist.Fanart`
+- [x] 0.2 Add/update integration test for `ListByUser` to verify fanart fields are populated when present and nil when absent
+- [x] 0.3 Run `make check` in backend
+
+## 1. Data Layer: Fanart URL Propagation (Frontend)
+
+- [x] 1.1 Add `logoUrl?`, `backgroundUrl?`, `thumbUrl?` fields to `FollowedArtistInfo` interface in `follow-service-client.ts`
+- [x] 1.2 Map `artist.fanart` fields to `FollowedArtistInfo` in `listFollowed()` with logo fallback chain (`hd_music_logo?.value ?? music_logo?.value`)
+- [x] 1.3 Add `logoUrl?`, `backgroundUrl?` fields to `LiveEvent` interface in `live-event.ts`
+- [x] 1.4 Add `thumbUrl?`, `logoUrl?` fields to `FollowedArtist` interface in `my-artists-route.ts`
+- [x] 1.5 Map fanart URLs from `FollowedArtistInfo` to `FollowedArtist` in `my-artists-route.ts` loading()
+- [x] 1.6 Build a `Map<string, FanartUrls>` from ListFollowed response in the dashboard service and enrich `LiveEvent` objects with `logoUrl` and `backgroundUrl`
+
+## 2. Event Card: Logo Image
+
+- [x] 2.1 Update `event-card.html` template: conditional `<img>` for logo with `<span>` fallback for text
+- [x] 2.2 Add logo image CSS in `event-card.css`: `object-fit: contain`, `max-block-size`, `loading="lazy"`, `decoding="async"`
+- [x] 2.3 Handle image load error: fall back to text display on `error` event
+
+## 3. Event Detail Sheet: Hero Background Image
+
+- [x] 3.1 Update `event-detail-sheet.html`: add conditional `sheet-hero` div above `sheet-artist-header` when `backgroundUrl` exists
+- [x] 3.2 Add hero CSS in `event-detail-sheet.css`: `aspect-ratio: 16/9`, `object-fit: cover`, gradient fade at bottom edge
+- [x] 3.3 Pass `backgroundUrl` to event-detail-sheet component (already on LiveEvent via task 1.3)
+
+## 4. My Artists Grid: Thumbnail Background
+
+- [x] 4.1 Update `my-artists-route.html` grid tile: add inline `background-image` style when `thumbUrl` exists
+- [x] 4.2 Add thumbnail background CSS in `my-artists-route.css`: ensure gradient overlay remains on top for text readability
+- [x] 4.3 Handle thumbnail load error: clear background-image to fall back to gradient
+
+## 5. Verification
+
+- [x] 5.1 Visual verification: event cards show logo for artists with fanart, text for others
+- [x] 5.2 Visual verification: detail sheet shows hero image when background exists
+- [x] 5.3 Visual verification: grid tiles show thumbnail when available, gradient when not
+- [x] 5.4 Run `make check` (lint + test) — all lint passes, 607 unit tests pass, E2E timeouts are pre-existing
+- [x] 5.5 E2E tests for 5.1–5.3 (6/6 pass with mock RPC data in `e2e/artist-image-ui.spec.ts`)
+- [x] 5.6 Add `https://assets.fanart.tv` to CSP `img-src` in `index.html` for production fanart.tv images

--- a/openspec/changes/frontend-entity-layer/.openspec.yaml
+++ b/openspec/changes/frontend-entity-layer/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-17

--- a/openspec/changes/frontend-entity-layer/design.md
+++ b/openspec/changes/frontend-entity-layer/design.md
@@ -1,0 +1,99 @@
+## Context
+
+The Go backend defines domain types in `internal/entity/` — plain structs with clear naming (`Artist`, `FollowedArtist`, `Fanart`, `Concert`, `Hype`). The frontend has no equivalent layer; instead, each service or component defines its own interface to flatten proto wrapper types (`ArtistId.value`, `Url.value`). This results in:
+
+- 3 interfaces for the same "followed artist" concept (`FollowedArtistInfo`, `FollowedArtist`, inline type in dashboard-service)
+- Domain types co-located with UI logic (e.g., `LiveEvent` inside `components/live-highway/`)
+- Naming divergence from Go (`HypeLevel` vs `Hype`, `LiveEvent` vs `Concert`)
+
+Additionally, the grid view feature in My Artists is being removed because the thumbnail display quality is insufficient — this cleanup is bundled here since it removes the `FollowedArtist` interface in `my-artists-route.ts` that would otherwise need migration.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Single source of truth for frontend domain types in `src/entities/`
+- Naming alignment with Go `internal/entity/` (file names, type names, field names)
+- Proto-to-entity mapping happens once, in service clients
+- Remove grid view feature from My Artists
+
+**Non-Goals:**
+- Introducing entity methods / business logic (keep entities as plain interfaces for now)
+- Migrating `ArtistBubble` (discovery-specific UI type, not a domain entity)
+- Changing the proto-generated types or BSR workflow
+- Adding entity validation (protovalidate handles this at the RPC boundary)
+
+## Decisions
+
+### 1. Plain interfaces, not classes
+
+Use TypeScript `interface` (not `class`) for entity types. Entities are data containers — no constructors, no methods, no inheritance. Services create entity objects via object literals during proto mapping.
+
+**Why over classes:** Interfaces are zero-runtime-cost, work naturally with Aurelia's observation system, and align with how proto-generated `PlainMessage<T>` types work. Classes would add constructor boilerplate with no benefit.
+
+### 2. File and type naming aligned with Go entity package
+
+| Go entity file | Go type | Frontend file | Frontend type |
+|---|---|---|---|
+| `artist.go` | `Artist` | `artist.ts` | `Artist` |
+| `artist.go` | `Fanart` | `artist.ts` | `Fanart` |
+| `follow.go` | `FollowedArtist` | `follow.ts` | `FollowedArtist` |
+| `follow.go` | `Hype` | `follow.ts` | `Hype` |
+| `concert.go` | `Concert` | `concert.ts` | `Concert` (rename from `LiveEvent`) |
+| `concert.go` | `ProximityGroup` | `concert.ts` | `DateGroup` (keep — UI groups by date label, not proximity) |
+| `proximity.go` | `Proximity` | `concert.ts` | `LaneType` (keep — UI uses lane metaphor) |
+
+**Divergence rationale:** `DateGroup` and `LaneType` are UI-presentation concepts that don't map 1:1 to Go's `ProximityGroup` / `Proximity`. Forcing Go names here would reduce clarity in templates. `Concert` replaces `LiveEvent` since it directly maps to the Go entity.
+
+### 3. UI-only fields are allowed on entities
+
+Frontend entities may include fields that don't exist in Go, annotated with comments:
+
+```typescript
+export interface Concert {
+  // --- mapped from proto ---
+  id: string
+  artistName: string
+  artistId: string
+  // ...
+
+  // --- UI-only ---
+  hypeLevel: HypeLevel  // derived from follow hype
+  matched: boolean       // computed per lane
+  logoUrl?: string       // from artist fanart
+  backgroundUrl?: string // from artist fanart
+}
+```
+
+This avoids creating a separate "view model" wrapper just for 1-2 extra fields.
+
+### 4. Backward-compatible re-exports during migration
+
+`components/live-highway/live-event.ts` will become a re-export barrel:
+
+```typescript
+export type { Concert as LiveEvent, DateGroup, HypeLevel, LaneType } from '../../entities/concert'
+```
+
+This avoids updating every import in one shot. The re-export file can be removed in a follow-up cleanup if desired, but it keeps the diff focused.
+
+### 5. Grid view removal scope
+
+Remove from `my-artists-route.*`:
+- `ViewMode` type, `viewMode` property, `toggleView()` method
+- Grid toggle button in template
+- `<ul class="artist-grid">` section and all grid tile markup
+- Context menu dialog (`<dialog>`) and all related methods
+- Grid touch handlers (`onGridTouchStart`, `onGridTouchEnd`, `gridLongPressTimer`)
+- `tileSpan()`, `onThumbError()`
+- All `.artist-grid`, `.grid-tile*` CSS rules
+- `thumbUrl` from `FollowedArtist` entity (grid-only field)
+
+Keep: `logoUrl` on `FollowedArtist` — used by event cards via dashboard service.
+
+## Risks / Trade-offs
+
+- **Rename `LiveEvent` → `Concert`** → Templates and tests use `LiveEvent` extensively. Using re-exports minimizes blast radius, but any direct references to the type name in templates (`LiveEvent` in `repeat.for`) will need updating. Risk: missed references causing runtime errors.
+  → Mitigation: `make check` (typecheck + lint + test) catches all type errors at build time.
+
+- **Two changes bundled (entity layer + grid removal)** → Larger PR, harder to review.
+  → Mitigation: Grid removal is mechanically simple (delete code). Entity migration is type-safe (compiler catches mismatches). Both are self-contained within the frontend repo.

--- a/openspec/changes/frontend-entity-layer/proposal.md
+++ b/openspec/changes/frontend-entity-layer/proposal.md
@@ -1,0 +1,34 @@
+## Why
+
+Frontend domain types are scattered across service clients, route ViewModels, and component files — each defining its own interface for the same concept (e.g., `FollowedArtistInfo`, `FollowedArtist`, `LocalFollowedArtist`). This creates redundant proto-to-POJO mapping, naming inconsistency with the Go backend entity layer, and makes it hard to find where a domain concept is defined. Introducing a dedicated `src/entities/` layer consolidates domain types in one place, aligned with Go's `internal/entity/` package.
+
+## What Changes
+
+- Create `src/entities/` directory with entity modules mirroring Go's `internal/entity/` naming:
+  - `artist.ts` — `Artist` (id, name, mbid, fanart URLs)
+  - `follow.ts` — `FollowedArtist` (artist + hype), `Hype` type
+  - `concert.ts` — `LiveEvent`, `DateGroup`, `HypeLevel`, `LaneType` (relocated from `components/live-highway/live-event.ts`)
+  - `venue.ts` — venue-related types if applicable
+- Replace `FollowedArtistInfo` (follow-service-client.ts), `FollowedArtist` (my-artists-route.ts), and inline artist map types (dashboard-service.ts) with unified entity types
+- Move `LiveEvent` / `DateGroup` from `components/live-highway/live-event.ts` to `entities/concert.ts`
+- Update all import paths across services, routes, and components
+- Remove `grid view` feature from My Artists (toggle button, grid template, grid CSS, context menu, touch handlers, `tileSpan`, `onThumbError`, `ViewMode` type)
+
+## Capabilities
+
+### New Capabilities
+- `frontend-entity-layer`: Centralized domain type definitions for the frontend, aligned with Go backend entity naming
+
+### Modified Capabilities
+
+## Impact
+
+- `src/services/follow-service-client.ts` — Remove `FollowedArtistInfo`, map to entity types
+- `src/services/dashboard-service.ts` — Remove inline artist map type, use entity types
+- `src/routes/my-artists/my-artists-route.ts` — Remove `FollowedArtist` interface, `ViewMode`, grid-related methods; import from entities
+- `src/routes/my-artists/my-artists-route.html` — Remove grid view section, toggle button, context menu dialog
+- `src/routes/my-artists/my-artists-route.css` — Remove `.artist-grid`, `.grid-tile*` styles
+- `src/components/live-highway/live-event.ts` — Becomes re-export from `entities/concert.ts`
+- `src/components/live-highway/event-card.ts` — Update import path
+- `src/components/live-highway/event-detail-sheet.ts` — Update import path
+- All test files referencing moved types

--- a/openspec/changes/frontend-entity-layer/specs/frontend-entity-layer/spec.md
+++ b/openspec/changes/frontend-entity-layer/specs/frontend-entity-layer/spec.md
@@ -1,0 +1,59 @@
+## ADDED Requirements
+
+### Requirement: Entity directory structure
+The frontend SHALL have a `src/entities/` directory containing domain type definitions. Each file SHALL be named to match the corresponding Go backend entity file in `internal/entity/`.
+
+#### Scenario: Entity files exist with Go-aligned names
+- **WHEN** a developer looks for the frontend equivalent of a Go entity type
+- **THEN** they find it at `src/entities/{same_filename}.ts` (e.g., `artist.go` → `artist.ts`, `follow.go` → `follow.ts`, `concert.go` → `concert.ts`)
+
+### Requirement: Artist entity
+The `src/entities/artist.ts` file SHALL export an `Artist` interface with fields: `id` (string), `name` (string), `mbid` (string), `fanart` (optional `Fanart`). The `Fanart` interface SHALL export fields for image URLs: `artistThumb`, `artistBackground`, `hdMusicLogo`, `musicLogo`, `musicBanner` (all optional strings).
+
+#### Scenario: Artist with full fanart
+- **WHEN** a service maps a proto `Artist` message that has all fanart fields populated
+- **THEN** the resulting `Artist` entity SHALL have a `fanart` object with all URL strings set
+
+#### Scenario: Artist without fanart
+- **WHEN** a service maps a proto `Artist` message with no fanart
+- **THEN** the resulting `Artist` entity SHALL have `fanart` as `undefined`
+
+### Requirement: FollowedArtist entity
+The `src/entities/follow.ts` file SHALL export a `FollowedArtist` interface containing an `Artist` reference and a `Hype` value. The `Hype` type SHALL be a string union aligned with Go's `Hype` constants: `'watch'`, `'home'`, `'nearby'`, `'away'`.
+
+#### Scenario: FollowedArtist from ListFollowed RPC
+- **WHEN** the follow service client receives a ListFollowed response
+- **THEN** it SHALL map each proto `FollowedArtist` to an entity `FollowedArtist` with flattened artist fields and a string `Hype` value
+
+### Requirement: Concert entity
+The `src/entities/concert.ts` file SHALL export a `Concert` interface (replacing the former `LiveEvent` interface) with the same fields. It SHALL also export `DateGroup`, `HypeLevel`, and `LaneType` types.
+
+#### Scenario: Backward compatibility via re-export
+- **WHEN** existing components import `LiveEvent` from the old path (`components/live-highway/live-event.ts`)
+- **THEN** they SHALL receive the `Concert` type via a re-export alias (`export type { Concert as LiveEvent }`)
+
+#### Scenario: Concert type used in templates
+- **WHEN** a template iterates over concerts
+- **THEN** the bound properties SHALL match the `Concert` interface fields
+
+### Requirement: Single mapping point
+Proto-to-entity mapping SHALL occur exclusively in service client classes. No route, component, or other consumer SHALL directly access proto wrapper types (e.g., `ArtistId.value`, `Url.value`).
+
+#### Scenario: Service returns entity types
+- **WHEN** `FollowServiceClient.listFollowed()` is called
+- **THEN** it SHALL return `FollowedArtist[]` (entity type), not proto classes or intermediate interfaces
+
+#### Scenario: Dashboard service uses entity types
+- **WHEN** `DashboardService` builds `DateGroup[]`
+- **THEN** it SHALL consume `FollowedArtist` entities from the follow service, not define its own inline type
+
+### Requirement: Grid view removal
+The My Artists route SHALL display artists in list view only. The grid toggle button, grid layout, context menu dialog, and all grid-specific interaction handlers SHALL be removed.
+
+#### Scenario: My Artists page loads
+- **WHEN** a user navigates to My Artists
+- **THEN** artists are displayed in list view with no toggle button to switch views
+
+#### Scenario: No grid-related CSS
+- **WHEN** the My Artists stylesheet is loaded
+- **THEN** it SHALL NOT contain `.artist-grid`, `.grid-tile`, or related grid layout rules

--- a/openspec/changes/frontend-entity-layer/specs/frontend-entity-layer/spec.md
+++ b/openspec/changes/frontend-entity-layer/specs/frontend-entity-layer/spec.md
@@ -19,7 +19,7 @@ The `src/entities/artist.ts` file SHALL export an `Artist` interface with fields
 - **THEN** the resulting `Artist` entity SHALL have `fanart` as `undefined`
 
 ### Requirement: FollowedArtist entity
-The `src/entities/follow.ts` file SHALL export a `FollowedArtist` interface containing an `Artist` reference and a `Hype` value. The `Hype` type SHALL be a string union aligned with Go's `Hype` constants: `'watch'`, `'home'`, `'nearby'`, `'away'`.
+The `src/entities/follow.ts` file SHALL export a `FollowedArtist` interface with flattened artist fields (`id`, `name`) and a `Hype` value. The `Hype` type SHALL be a string union aligned with Go's `Hype` constants: `'watch'`, `'home'`, `'nearby'`, `'away'`. Optional fanart URLs (`logoUrl`, `backgroundUrl`) SHALL be included for UI consumption.
 
 #### Scenario: FollowedArtist from ListFollowed RPC
 - **WHEN** the follow service client receives a ListFollowed response

--- a/openspec/changes/frontend-entity-layer/tasks.md
+++ b/openspec/changes/frontend-entity-layer/tasks.md
@@ -1,37 +1,37 @@
 ## 1. Create Entity Layer
 
-- [ ] 1.1 Create `src/entities/artist.ts` with `Artist` and `Fanart` interfaces (fields: id, name, mbid, fanart)
-- [ ] 1.2 Create `src/entities/follow.ts` with `FollowedArtist` interface (artist fields + hype) and `Hype` string union type
-- [ ] 1.3 Create `src/entities/concert.ts` with `Concert` interface (renamed from `LiveEvent`), `DateGroup`, `HypeLevel`, `LaneType`
-- [ ] 1.4 Create `src/entities/index.ts` barrel export
+- [x] 1.1 Create `src/entities/artist.ts` with `Artist` and `Fanart` interfaces (fields: id, name, mbid, fanart)
+- [x] 1.2 Create `src/entities/follow.ts` with `FollowedArtist` interface (artist fields + hype) and `Hype` string union type
+- [x] 1.3 Create `src/entities/concert.ts` with `Concert` interface (renamed from `LiveEvent`), `DateGroup`, `HypeLevel`, `LaneType`
+- [x] 1.4 Create `src/entities/index.ts` barrel export
 
 ## 2. Migrate Service Clients to Entity Types
 
-- [ ] 2.1 Update `follow-service-client.ts`: remove `FollowedArtistInfo` interface, return `FollowedArtist[]` from entity layer
-- [ ] 2.2 Update `dashboard-service.ts`: replace inline artist map type with `FollowedArtist` entity, import `Concert`/`DateGroup`/`HypeLevel`/`LaneType` from entities
+- [x] 2.1 Update `follow-service-client.ts`: remove `FollowedArtistInfo` interface, return `FollowedArtist[]` from entity layer
+- [x] 2.2 Update `dashboard-service.ts`: replace inline artist map type with `FollowedArtist` entity, import `Concert`/`DateGroup`/`HypeLevel`/`LaneType` from entities
 
 ## 3. Migrate Components
 
-- [ ] 3.1 Replace `components/live-highway/live-event.ts` contents with re-exports from `entities/concert.ts` (`export type { Concert as LiveEvent, ... }`)
-- [ ] 3.2 Update `event-card.ts` imports if directly referencing `live-event.ts` types
-- [ ] 3.3 Update `event-detail-sheet.ts` imports if directly referencing `live-event.ts` types
+- [x] 3.1 Replace `components/live-highway/live-event.ts` contents with re-exports from `entities/concert.ts` (`export type { Concert as LiveEvent, ... }`)
+- [x] 3.2 Update `event-card.ts` imports if directly referencing `live-event.ts` types
+- [x] 3.3 Update `event-detail-sheet.ts` imports if directly referencing `live-event.ts` types
 
 ## 4. Remove Grid View from My Artists
 
-- [ ] 4.1 Remove grid toggle button from `my-artists-route.html` (svg-icon list/grid toggle)
-- [ ] 4.2 Remove `<ul class="artist-grid">` section and all grid tile markup from template
-- [ ] 4.3 Remove context menu `<dialog>` from template
-- [ ] 4.4 Remove `viewMode === 'list'` condition from list `<ul>` (make list always visible)
-- [ ] 4.5 Remove from `my-artists-route.ts`: `ViewMode` type, `viewMode` property, `toggleView()`, `tileSpan()`, `onThumbError()`, `contextMenuArtist`, `contextMenuDialog`, all context menu methods, grid touch handlers, `gridLongPressTimer`
-- [ ] 4.6 Remove from `my-artists-route.css`: `.artist-grid`, `.grid-tile`, `.grid-tile::before`, `.grid-tile-content`, `.grid-tile-name`, `.grid-tile-hype`, span selectors
-- [ ] 4.7 Update `my-artists-route.ts`: replace local `FollowedArtist` interface with import from `entities/follow.ts`, remove `thumbUrl` field
+- [x] 4.1 Remove grid toggle button from `my-artists-route.html` (svg-icon list/grid toggle)
+- [x] 4.2 Remove `<ul class="artist-grid">` section and all grid tile markup from template
+- [x] 4.3 Remove context menu `<dialog>` from template
+- [x] 4.4 Remove `viewMode === 'list'` condition from list `<ul>` (make list always visible)
+- [x] 4.5 Remove from `my-artists-route.ts`: `ViewMode` type, `viewMode` property, `toggleView()`, `tileSpan()`, `onThumbError()`, `contextMenuArtist`, `contextMenuDialog`, all context menu methods, grid touch handlers, `gridLongPressTimer`
+- [x] 4.6 Remove from `my-artists-route.css`: `.artist-grid`, `.grid-tile`, `.grid-tile::before`, `.grid-tile-content`, `.grid-tile-name`, `.grid-tile-hype`, span selectors
+- [x] 4.7 Update `my-artists-route.ts`: replace local `FollowedArtist` interface with import from `entities/follow.ts`, remove `thumbUrl` field
 
 ## 5. Update Tests
 
-- [ ] 5.1 Update unit tests referencing `FollowedArtistInfo` or `LiveEvent` to use new entity types
-- [ ] 5.2 Remove or update E2E tests for grid view (`artist-image-ui.spec.ts` grid scenarios)
+- [x] 5.1 Update unit tests referencing `FollowedArtistInfo` or `LiveEvent` to use new entity types
+- [x] 5.2 Remove or update E2E tests for grid view (`artist-image-ui.spec.ts` grid scenarios)
 
 ## 6. Verification
 
-- [ ] 6.1 Run `make check` (lint + typecheck + test) — all pass
-- [ ] 6.2 Run `npm run build` — production build succeeds
+- [x] 6.1 Run `make check` (lint + typecheck + test) — all pass
+- [x] 6.2 Run `npm run build` — production build succeeds

--- a/openspec/changes/frontend-entity-layer/tasks.md
+++ b/openspec/changes/frontend-entity-layer/tasks.md
@@ -1,0 +1,37 @@
+## 1. Create Entity Layer
+
+- [ ] 1.1 Create `src/entities/artist.ts` with `Artist` and `Fanart` interfaces (fields: id, name, mbid, fanart)
+- [ ] 1.2 Create `src/entities/follow.ts` with `FollowedArtist` interface (artist fields + hype) and `Hype` string union type
+- [ ] 1.3 Create `src/entities/concert.ts` with `Concert` interface (renamed from `LiveEvent`), `DateGroup`, `HypeLevel`, `LaneType`
+- [ ] 1.4 Create `src/entities/index.ts` barrel export
+
+## 2. Migrate Service Clients to Entity Types
+
+- [ ] 2.1 Update `follow-service-client.ts`: remove `FollowedArtistInfo` interface, return `FollowedArtist[]` from entity layer
+- [ ] 2.2 Update `dashboard-service.ts`: replace inline artist map type with `FollowedArtist` entity, import `Concert`/`DateGroup`/`HypeLevel`/`LaneType` from entities
+
+## 3. Migrate Components
+
+- [ ] 3.1 Replace `components/live-highway/live-event.ts` contents with re-exports from `entities/concert.ts` (`export type { Concert as LiveEvent, ... }`)
+- [ ] 3.2 Update `event-card.ts` imports if directly referencing `live-event.ts` types
+- [ ] 3.3 Update `event-detail-sheet.ts` imports if directly referencing `live-event.ts` types
+
+## 4. Remove Grid View from My Artists
+
+- [ ] 4.1 Remove grid toggle button from `my-artists-route.html` (svg-icon list/grid toggle)
+- [ ] 4.2 Remove `<ul class="artist-grid">` section and all grid tile markup from template
+- [ ] 4.3 Remove context menu `<dialog>` from template
+- [ ] 4.4 Remove `viewMode === 'list'` condition from list `<ul>` (make list always visible)
+- [ ] 4.5 Remove from `my-artists-route.ts`: `ViewMode` type, `viewMode` property, `toggleView()`, `tileSpan()`, `onThumbError()`, `contextMenuArtist`, `contextMenuDialog`, all context menu methods, grid touch handlers, `gridLongPressTimer`
+- [ ] 4.6 Remove from `my-artists-route.css`: `.artist-grid`, `.grid-tile`, `.grid-tile::before`, `.grid-tile-content`, `.grid-tile-name`, `.grid-tile-hype`, span selectors
+- [ ] 4.7 Update `my-artists-route.ts`: replace local `FollowedArtist` interface with import from `entities/follow.ts`, remove `thumbUrl` field
+
+## 5. Update Tests
+
+- [ ] 5.1 Update unit tests referencing `FollowedArtistInfo` or `LiveEvent` to use new entity types
+- [ ] 5.2 Remove or update E2E tests for grid view (`artist-image-ui.spec.ts` grid scenarios)
+
+## 6. Verification
+
+- [ ] 6.1 Run `make check` (lint + typecheck + test) — all pass
+- [ ] 6.2 Run `npm run build` — production build succeeds

--- a/openspec/changes/logo-color-analysis/.openspec.yaml
+++ b/openspec/changes/logo-color-analysis/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-17

--- a/openspec/changes/logo-color-analysis/design.md
+++ b/openspec/changes/logo-color-analysis/design.md
@@ -1,0 +1,122 @@
+## Context
+
+Event cards display artist logos (clearLOGO PNGs from fanart.tv) on colored backgrounds. The background hue is currently derived from a deterministic hash of the artist name (`color-generator.ts`), which has no relationship to the logo's actual colors. This causes visibility issues where logo and background colors are too similar.
+
+The fanart sync pipeline (CronJob + NATS event consumer) already downloads fanart metadata. This change extends it to also download the best logo image, analyze its pixels, and store color metadata alongside the existing fanart JSONB.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Ensure artist logos are always visually distinguishable from their card background
+- Preserve color variety across the app (avoid monotone dark/light backgrounds)
+- Keep the analysis pipeline within the existing sync infrastructure (no new services)
+
+**Non-Goals:**
+- Real-time / client-side color extraction (ruled out due to CORS and performance)
+- Storing the logo image itself (only metadata; images are served directly from fanart.tv CDN)
+- Changing the matched/unmatched card visual system (spotlight effects remain hue-driven)
+
+## Decisions
+
+### Decision 1: Store hue + lightness metadata, not a computed background color
+
+**Choice:** Store `dominantHue`, `dominantLightness`, and `isChromatic` as analysis output. The frontend derives the final background color from these values.
+
+**Why not store a complete background color?**
+The current CSS architecture derives 6+ color variants from a single `--artist-hue` custom property (spotlight glow, dim background, border, shadow). Storing a finished `oklch(...)` string would break this derivation chain and force frontend redesign. Storing raw analysis data preserves CSS flexibility and allows design iteration without re-running the sync pipeline.
+
+### Decision 2: Three-class logo classification
+
+Logos are classified into three types based on pixel analysis:
+
+| Type | Condition | Background Strategy |
+|------|-----------|-------------------|
+| `CHROMATIC` | >30% of non-transparent pixels have OKLCH chroma > 0.04 | Use logo's dominant hue (same hue, low chroma background) so the logo color pops |
+| `ACHROMATIC_LIGHT` | Predominantly achromatic, mean lightness > 0.6 | Use name-hash hue freely (any hue works against white logos), keep background dark |
+| `ACHROMATIC_DARK` | Predominantly achromatic, mean lightness ≤ 0.6 | Use name-hash hue freely, raise background lightness so dark logo is visible |
+
+**Why not just complementary hue (hue+180)?** Complementary colors maximize hue distance but can produce garish combinations (red logo on cyan). For chromatic logos, the logo's own hue with a desaturated background is more aesthetically pleasing — the logo becomes the color accent.
+
+**Why keep name-hash for achromatic logos?** White and black logos have no color information. Using the name-hash preserves the existing color variety. Only lightness needs adjustment.
+
+### Decision 3: Color extraction in Go using standard library
+
+**Algorithm:**
+1. Download the best logo image (PNG) via HTTP
+2. Decode with `image/png`
+3. Iterate all pixels, skip fully transparent (alpha < 10)
+4. Convert each pixel sRGB → Linear RGB → OKLab → OKLCH using fixed-coefficient matrix math
+5. Classify pixel as chromatic (chroma > 0.04) or achromatic
+6. For chromatic pixels, build a hue histogram (36 bins of 10° each)
+7. Output: peak hue from histogram, mean lightness, chromatic ratio
+
+**Why OKLCH over HSL?** OKLCH is perceptually uniform — equal numeric differences correspond to equal perceived differences. HSL has well-known issues where "50% lightness" varies wildly by hue. Since the goal is perceptual contrast, OKLCH is the right space. The frontend already uses OKLCH in CSS (`oklch()` function).
+
+**Why no external library?** The sRGB→OKLab conversion is a 3x3 matrix multiply + cube root. ~30 lines of Go. Adding a dependency for this is not justified.
+
+### Decision 4: Store analysis inside existing `fanart` JSONB
+
+**Choice:** Add a `logoAnalysis` key to the existing `fanart` JSONB column rather than a separate column.
+
+```json
+{
+  "artistthumb": [...],
+  "hdmusiclogo": [...],
+  "logoAnalysis": {
+    "dominantHue": 210,
+    "dominantLightness": 0.15,
+    "isChromatic": true
+  }
+}
+```
+
+**Why?** The analysis is derived from and tightly coupled to the logo data. It should be refreshed whenever fanart data is refreshed. Keeping it in the same JSONB ensures atomicity and avoids schema migration for a new column.
+
+### Decision 5: Proto extension — `LogoAnalysis` message inside `Fanart`
+
+```protobuf
+message Fanart {
+  // ... existing fields ...
+  optional LogoAnalysis logo_analysis = 6;
+}
+
+message LogoAnalysis {
+  float dominant_hue = 1;        // 0-360, OKLCH hue angle
+  float dominant_lightness = 2;  // 0-1, OKLCH lightness
+  bool is_chromatic = 3;         // true if logo has significant color
+}
+```
+
+**Why inside Fanart?** LogoAnalysis is meaningless without fanart data — it's derived from the logo image. Placing it as a peer field on `Artist` would create a confusing ownership model.
+
+### Decision 6: Frontend fallback chain
+
+```
+if (artist.fanart?.logoAnalysis) {
+  // Use analysis-driven hue + lightness
+  if (logoAnalysis.isChromatic) {
+    hue = logoAnalysis.dominantHue  // logo's own hue family
+  } else {
+    hue = hash(artistName)          // preserve variety
+  }
+  bgLightness = derived from logoAnalysis.dominantLightness
+} else if (artist.fanart) {
+  // Has fanart but no analysis (transition period)
+  hue = hash(artistName)
+} else {
+  // No fanart at all
+  hue = hash(artistName)
+}
+```
+
+Fully backward-compatible. The `artist-color` custom attribute gains an optional `logoAnalysis` input. When absent, behavior is identical to current.
+
+## Risks / Trade-offs
+
+**[Risk] Logo image download adds latency to sync pipeline** → The sync job already throttles API calls. Logo download is one additional HTTP request per artist. Given the daily cadence and circuit breaker, this is acceptable. The consumer path (ARTIST.created) adds ~200ms for the image download.
+
+**[Risk] Some logos may have misleading dominant colors** (e.g., a red logo with a tiny blue accent that skews the histogram) → The 36-bin histogram with >30% chromatic threshold is conservative. Edge cases can be tuned by adjusting the threshold.
+
+**[Risk] OKLCH chroma threshold (0.04) may misclassify near-gray colors** → This is a tuning parameter. Start conservative and adjust based on visual results.
+
+**[Trade-off] Analysis is only as fresh as the sync cycle** → If fanart.tv updates a logo, the analysis won't update until the next sync (daily or 7-day refresh). This is acceptable since logo changes are rare.

--- a/openspec/changes/logo-color-analysis/proposal.md
+++ b/openspec/changes/logo-color-analysis/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+Artist logos (clearLOGO from fanart.tv) displayed on event cards have poor visibility when the card background color clashes with the logo's dominant color. The current background hue is derived from a hash of the artist name, which has no relationship to the logo's actual colors. This leads to dark logos on dark backgrounds (e.g., SPYAIR) and same-hue logos on same-hue backgrounds (e.g., Suchmos red logo on reddish background).
+
+## What Changes
+
+- The fanart sync pipeline (CronJob + event consumer) will analyze each artist's best logo image to extract dominant color properties (hue, lightness, chromaticity).
+- Analysis results will be stored alongside existing fanart data in the `fanart` JSONB column.
+- The proto `Fanart` message will be extended with a `LogoAnalysis` message containing the extracted color metadata.
+- The frontend will use `LogoAnalysis` to compute an optimal card background color that maximizes logo visibility while preserving color variety across the app.
+
+## Capabilities
+
+### New Capabilities
+- `logo-color-analysis`: Automatic extraction of logo dominant color properties and optimal background color derivation for artist event cards.
+
+### Modified Capabilities
+- `artist-image`: The Fanart entity, proto message, and sync pipeline gain a `LogoAnalysis` sub-entity populated during image sync.
+
+## Impact
+
+- **specification**: `Fanart` proto message extended with `LogoAnalysis` sub-message.
+- **backend**: Fanart entity gains `LogoAnalysis` field. Sync job and event consumer updated to download logo PNG and run color extraction. Mapper updated to include analysis in proto response.
+- **frontend**: `color-generator.ts` and `artist-color` custom attribute updated to prefer `LogoAnalysis` data over name-hash hue. CSS custom properties may include `--artist-bg-lightness`.
+- **dependencies**: No new external dependencies. Go `image/png` + `image/color` standard library suffice for pixel analysis. OKLCH conversion uses fixed matrix math (no library needed).

--- a/openspec/changes/logo-color-analysis/specs/artist-image/spec.md
+++ b/openspec/changes/logo-color-analysis/specs/artist-image/spec.md
@@ -1,0 +1,53 @@
+## MODIFIED Requirements
+
+### Requirement: Fanart Entity
+The system SHALL define a `Fanart` entity that mirrors the fanart.tv API response structure. The entity SHALL contain the following image collection fields: `ArtistThumb`, `ArtistBackground`, `HDMusicLogo`, `MusicLogo`, `MusicBanner`. Each collection SHALL contain zero or more `FanartImage` entries with `ID`, `URL`, `Likes`, and `Lang` fields. The entity SHALL also contain an optional `LogoAnalysis` field holding the extracted dominant color properties of the best logo image.
+
+#### Scenario: Fanart with all image types populated
+- **WHEN** fanart.tv returns data for an artist with all image types
+- **THEN** the `Fanart` entity SHALL contain non-empty slices for `ArtistThumb`, `ArtistBackground`, `HDMusicLogo`, `MusicLogo`, and `MusicBanner`
+
+#### Scenario: Fanart with partial image types
+- **WHEN** fanart.tv returns data with only some image types (e.g., only `ArtistThumb` and `HDMusicLogo`)
+- **THEN** the `Fanart` entity SHALL contain non-empty slices for the available types and empty slices for the missing types
+
+#### Scenario: Fanart with logo analysis
+- **WHEN** fanart data includes a logo image that has been analyzed
+- **THEN** the `Fanart` entity SHALL contain a non-nil `LogoAnalysis` with `DominantHue`, `DominantLightness`, and `IsChromatic` fields
+
+### Requirement: Fanart Proto Message
+The system SHALL define a `Fanart` protobuf message within `liverty_music.entity.v1` containing optional URL fields for each image type: `artist_thumb`, `artist_background`, `hd_music_logo`, `music_logo`, `music_banner`. Each field SHALL use a dedicated wrapper message with URI validation. The message SHALL also include an `optional LogoAnalysis logo_analysis` field. The `Artist` message SHALL include an `optional Fanart fanart` field.
+
+#### Scenario: Artist with fanart data
+- **WHEN** an Artist is serialized to proto and fanart data exists
+- **THEN** the `fanart` field SHALL contain a `Fanart` message with best image URLs populated for each available image type
+
+#### Scenario: Artist without fanart data
+- **WHEN** an Artist is serialized to proto and no fanart data exists
+- **THEN** the `fanart` field SHALL be absent (optional not set)
+
+#### Scenario: Artist with logo analysis in fanart
+- **WHEN** an Artist is serialized to proto and logo analysis data exists
+- **THEN** the `fanart.logo_analysis` field SHALL contain a `LogoAnalysis` message
+
+### Requirement: Fanart Proto Mapper
+The mapper layer SHALL convert the domain `Fanart` entity (with full image arrays) to the proto `Fanart` message (with single best URL per type) using `BestByLikes` for selection. The mapper SHALL also convert the domain `LogoAnalysis` to the proto `LogoAnalysis` message when present.
+
+#### Scenario: Mapper selects best images
+- **WHEN** a domain Artist with Fanart data is mapped to proto
+- **THEN** each proto Fanart field SHALL contain the URL of the image with the highest likes count from the corresponding domain field
+
+#### Scenario: Mapper includes logo analysis
+- **WHEN** a domain Artist with Fanart and LogoAnalysis is mapped to proto
+- **THEN** the proto Fanart message SHALL include the `logo_analysis` field with dominant hue, lightness, and chromaticity
+
+### Requirement: Fanart Database Storage
+The system SHALL store fanart.tv API response data in a `fanart` JSONB column on the `artists` table. The system SHALL also store the synchronization timestamp in a `fanart_synced_at` TIMESTAMPTZ column. Logo analysis results SHALL be stored within the same `fanart` JSONB under a `logoAnalysis` key.
+
+#### Scenario: Fanart data persisted with analysis
+- **WHEN** fanart data is fetched and logo analysis is performed
+- **THEN** the `fanart` JSONB column SHALL contain both the parsed response data and the `logoAnalysis` object, and `fanart_synced_at` SHALL be set to the current timestamp
+
+#### Scenario: Fanart data persisted without analysis
+- **WHEN** fanart data is fetched but no logo image is available for analysis
+- **THEN** the `fanart` JSONB column SHALL contain the parsed response data without a `logoAnalysis` key

--- a/openspec/changes/logo-color-analysis/specs/logo-color-analysis/spec.md
+++ b/openspec/changes/logo-color-analysis/specs/logo-color-analysis/spec.md
@@ -1,0 +1,84 @@
+## ADDED Requirements
+
+### Requirement: Logo Color Extraction
+The system SHALL analyze artist logo images (clearLOGO PNGs) to extract dominant color properties. The analysis SHALL decode the PNG, iterate all non-transparent pixels (alpha >= 10), convert each pixel from sRGB to OKLCH color space, and classify pixels as chromatic (chroma > 0.04) or achromatic.
+
+#### Scenario: Chromatic logo (e.g., colored text/symbol)
+- **WHEN** a logo image has more than 30% of non-transparent pixels with OKLCH chroma > 0.04
+- **THEN** the analysis SHALL return `isChromatic = true`, `dominantHue` as the peak of a 36-bin (10° each) hue histogram, and `dominantLightness` as the mean lightness of all non-transparent pixels
+
+#### Scenario: Achromatic light logo (e.g., white text)
+- **WHEN** a logo image has 30% or fewer chromatic pixels and a mean lightness > 0.6
+- **THEN** the analysis SHALL return `isChromatic = false`, `dominantHue = 0` (unused), and `dominantLightness` reflecting the high lightness value
+
+#### Scenario: Achromatic dark logo (e.g., black text)
+- **WHEN** a logo image has 30% or fewer chromatic pixels and a mean lightness ≤ 0.6
+- **THEN** the analysis SHALL return `isChromatic = false`, `dominantHue = 0` (unused), and `dominantLightness` reflecting the low lightness value
+
+#### Scenario: Fully transparent image
+- **WHEN** a logo image has no non-transparent pixels (alpha >= 10)
+- **THEN** the analysis SHALL return nil (no analysis possible)
+
+### Requirement: sRGB to OKLCH Conversion
+The system SHALL convert sRGB pixel values to OKLCH color space using fixed-coefficient matrix math (sRGB → Linear RGB → OKLab → OKLCH). The conversion SHALL use Go standard library types (`color.NRGBA`) with no external dependencies.
+
+#### Scenario: Pure white pixel
+- **WHEN** sRGB (255, 255, 255) is converted to OKLCH
+- **THEN** lightness SHALL be approximately 1.0 and chroma SHALL be approximately 0.0
+
+#### Scenario: Pure red pixel
+- **WHEN** sRGB (255, 0, 0) is converted to OKLCH
+- **THEN** lightness SHALL be approximately 0.63, chroma SHALL be > 0.2, and hue SHALL be approximately 29°
+
+#### Scenario: Pure black pixel
+- **WHEN** sRGB (0, 0, 0) is converted to OKLCH
+- **THEN** lightness SHALL be approximately 0.0 and chroma SHALL be approximately 0.0
+
+### Requirement: Logo Analysis Integration in Sync Pipeline
+The fanart sync pipeline (CronJob and ARTIST.created consumer) SHALL perform logo color analysis after fetching fanart data. The analysis SHALL use the best logo image selected by `BestByLikes` from `HDMusicLogo`, falling back to `MusicLogo` if `HDMusicLogo` is empty.
+
+#### Scenario: Artist has HDMusicLogo
+- **WHEN** fanart data is fetched and HDMusicLogo contains images
+- **THEN** the sync pipeline SHALL download the best HDMusicLogo image (by likes), run color analysis, and store the result in the `logoAnalysis` field of the fanart JSONB
+
+#### Scenario: Artist has only MusicLogo
+- **WHEN** fanart data is fetched and HDMusicLogo is empty but MusicLogo contains images
+- **THEN** the sync pipeline SHALL download the best MusicLogo image and run color analysis
+
+#### Scenario: Artist has no logo images
+- **WHEN** fanart data is fetched but neither HDMusicLogo nor MusicLogo contain images
+- **THEN** the sync pipeline SHALL store fanart data without a `logoAnalysis` field
+
+#### Scenario: Logo image download fails
+- **WHEN** the logo image HTTP request fails or returns non-200
+- **THEN** the sync pipeline SHALL log a warning and store fanart data without a `logoAnalysis` field (non-fatal)
+
+### Requirement: LogoAnalysis Proto Message
+The system SHALL define a `LogoAnalysis` protobuf message within `liverty_music.entity.v1` containing `dominant_hue` (float, 0-360), `dominant_lightness` (float, 0-1), and `is_chromatic` (bool). The `Fanart` message SHALL include an `optional LogoAnalysis logo_analysis` field.
+
+#### Scenario: Artist with logo analysis data
+- **WHEN** an Artist with logo analysis is serialized to proto
+- **THEN** the `fanart.logo_analysis` field SHALL contain a `LogoAnalysis` message with the extracted values
+
+#### Scenario: Artist without logo analysis data
+- **WHEN** an Artist without logo analysis is serialized to proto
+- **THEN** the `fanart.logo_analysis` field SHALL be absent (optional not set)
+
+### Requirement: Frontend Background Color Derivation
+The frontend SHALL use `LogoAnalysis` data to determine the card background `--artist-hue` custom property. For chromatic logos (`isChromatic = true`), the hue SHALL be set to `dominantHue` (logo's own hue family). For achromatic logos, the hue SHALL fall back to the existing name-hash algorithm. When no `LogoAnalysis` is available, the existing name-hash algorithm SHALL be used unchanged.
+
+#### Scenario: Chromatic logo card background
+- **WHEN** an event card renders for an artist with `isChromatic = true` and `dominantHue = 0` (red)
+- **THEN** `--artist-hue` SHALL be set to `0` (same hue family as the logo, with low-chroma background per CSS)
+
+#### Scenario: Achromatic light logo card background
+- **WHEN** an event card renders for an artist with `isChromatic = false` and `dominantLightness = 0.85`
+- **THEN** `--artist-hue` SHALL be set to the name-hash value and background lightness SHALL remain dark (logo is light, background is dark for contrast)
+
+#### Scenario: Achromatic dark logo card background
+- **WHEN** an event card renders for an artist with `isChromatic = false` and `dominantLightness = 0.15`
+- **THEN** `--artist-hue` SHALL be set to the name-hash value and background lightness SHALL be raised to ensure the dark logo is visible
+
+#### Scenario: No logo analysis available
+- **WHEN** an event card renders for an artist without `LogoAnalysis`
+- **THEN** `--artist-hue` SHALL be computed from the artist name hash (existing behavior)

--- a/openspec/changes/logo-color-analysis/tasks.md
+++ b/openspec/changes/logo-color-analysis/tasks.md
@@ -1,0 +1,47 @@
+## 0. Specification: Proto Schema
+
+- [ ] 0.1 Add `LogoAnalysis` message to `artist.proto` with `dominant_hue` (float), `dominant_lightness` (float), `is_chromatic` (bool)
+- [ ] 0.2 Add `optional LogoAnalysis logo_analysis = 6` field to the `Fanart` message
+- [ ] 0.3 Run `buf lint` and `buf format -w`
+- [ ] 0.4 Create specification PR, merge, create release → BSR publishes
+
+## 1. Backend: Color Extraction (Entity Layer)
+
+- [ ] 1.1 Add `LogoAnalysis` struct to `entity/fanart.go` with `DominantHue float64`, `DominantLightness float64`, `IsChromatic bool` and JSON tags
+- [ ] 1.2 Add `LogoAnalysis *LogoAnalysis` field to `Fanart` struct with `json:"logoAnalysis,omitempty"` tag
+- [ ] 1.3 Implement `oklch.go` in `entity/` with sRGB→LinearRGB→OKLab→OKLCH conversion (pure math, no external deps)
+- [ ] 1.4 Unit test `oklch.go`: pure white → L≈1.0 C≈0.0, pure red → L≈0.63 C>0.2 H≈29°, pure black → L≈0.0 C≈0.0
+- [ ] 1.5 Implement `AnalyzeLogo(img image.Image) *LogoAnalysis` in `entity/fanart.go`: skip transparent pixels, build hue histogram, classify chromatic/achromatic, return analysis
+- [ ] 1.6 Unit test `AnalyzeLogo`: chromatic image (>30% colored pixels), achromatic light image, achromatic dark image, fully transparent image → nil
+
+## 2. Backend: Sync Pipeline Integration
+
+- [ ] 2.1 Add `DownloadAndAnalyzeLogo(ctx, fanart *Fanart) *LogoAnalysis` to the image sync use case: select best logo URL (HDMusicLogo → MusicLogo fallback), HTTP GET, `image/png` decode, call `AnalyzeLogo`
+- [ ] 2.2 Update `SyncArtistImages` (CronJob path) to call `DownloadAndAnalyzeLogo` and set `fanart.LogoAnalysis` before persisting
+- [ ] 2.3 Update ARTIST.created consumer to call `DownloadAndAnalyzeLogo` after fetching fanart data
+- [ ] 2.4 Handle logo download failures gracefully: log warning, proceed with nil LogoAnalysis (non-fatal)
+- [ ] 2.5 Run `make check` in backend
+
+## 3. Backend: Proto Mapper
+
+- [ ] 3.1 Update `go.mod` with new BSR-generated proto (after step 0.4)
+- [ ] 3.2 Add `logoAnalysisToProto` function in `mapper/artist.go`
+- [ ] 3.3 Call `logoAnalysisToProto` from `fanartToProto` when `f.LogoAnalysis != nil`
+- [ ] 3.4 Unit test mapper: fanart with LogoAnalysis → proto has logo_analysis field, fanart without → proto has no logo_analysis
+
+## 4. Frontend: Background Color Derivation
+
+- [ ] 4.1 Update `follow-service-client.ts`: map `artist.fanart.logoAnalysis` fields to `FollowedArtistInfo` (`dominantHue?`, `dominantLightness?`, `isChromatic?`)
+- [ ] 4.2 Update `color-generator.ts`: add `artistHueFromAnalysis(analysis, artistName)` that returns analysis-driven hue for chromatic logos, name-hash for achromatic
+- [ ] 4.3 Update `artist-color` custom attribute to accept optional `LogoAnalysis` data and set `--artist-hue` and `--artist-bg-lightness` custom properties
+- [ ] 4.4 Update CSS to use `--artist-bg-lightness` for unmatched card backgrounds when available
+- [ ] 4.5 Propagate LogoAnalysis through `dashboard-service.ts` → `LiveEvent` → `event-card`
+
+## 5. Verification
+
+- [ ] 5.1 Run `make check` in backend
+- [ ] 5.2 Run `make check` in frontend
+- [ ] 5.3 Visual verification: chromatic logos (e.g., Suchmos) have logo-hue-family backgrounds
+- [ ] 5.4 Visual verification: achromatic dark logos (e.g., SPYAIR) have raised-lightness backgrounds
+- [ ] 5.5 Visual verification: achromatic light logos (e.g., UVERworld) retain dark backgrounds with colorful hues
+- [ ] 5.6 Visual verification: artists without fanart still use name-hash coloring (no regression)

--- a/openspec/specs/artist-image-ui/spec.md
+++ b/openspec/specs/artist-image-ui/spec.md
@@ -1,0 +1,48 @@
+### Requirement: Event Card Logo Display
+The dashboard event card SHALL display the artist's transparent logo image instead of the text artist name when a logo URL is available. The system SHALL use `hd_music_logo` as the primary source and fall back to `music_logo` when `hd_music_logo` is unavailable. When neither logo is available, the card SHALL display the existing text artist name.
+
+#### Scenario: Artist has hd_music_logo
+- **WHEN** an event card renders for an artist with `hd_music_logo` in their fanart data
+- **THEN** the card SHALL display the `hd_music_logo` image with `object-fit: contain` instead of the text name
+
+#### Scenario: Artist has only music_logo
+- **WHEN** an event card renders for an artist with `music_logo` but no `hd_music_logo`
+- **THEN** the card SHALL display the `music_logo` image as fallback
+
+#### Scenario: Artist has no logo
+- **WHEN** an event card renders for an artist without any logo in their fanart data
+- **THEN** the card SHALL display the existing text artist name with the current styling
+
+#### Scenario: Logo image fails to load
+- **WHEN** the logo image URL returns an error or times out
+- **THEN** the card SHALL fall back to displaying the text artist name
+
+### Requirement: Event Detail Sheet Hero Image
+The event detail sheet SHALL display the artist's background image as a hero section above the existing artist header when `artist_background` is available. The hero image SHALL NOT be displayed when no background image exists, preserving the current layout.
+
+#### Scenario: Artist has background image
+- **WHEN** the detail sheet opens for an event whose artist has `artist_background` in their fanart data
+- **THEN** the sheet SHALL display the background image in a hero section above the artist header with `aspect-ratio: 16/9` and `object-fit: cover`
+
+#### Scenario: Artist has no background image
+- **WHEN** the detail sheet opens for an event whose artist has no `artist_background`
+- **THEN** the sheet SHALL render the existing layout without a hero section
+
+#### Scenario: Hero image with gradient fade
+- **WHEN** the hero image is displayed
+- **THEN** the bottom edge of the hero section SHALL fade into the sheet background color via a gradient overlay to ensure visual continuity
+
+### Requirement: Fanart Data Propagation
+The frontend service layer SHALL extract fanart image URLs from the `Artist.fanart` proto field in `ListFollowed` responses and propagate them to the `LiveEvent` and `FollowedArtist` view models for consumption by UI components.
+
+#### Scenario: ListFollowed returns artist with fanart
+- **WHEN** the `ListFollowed` RPC returns an artist with populated fanart data
+- **THEN** the service layer SHALL map `hd_music_logo`, `music_logo`, `artist_background`, and `artist_thumb` URLs to the corresponding view model fields
+
+#### Scenario: ListFollowed returns artist without fanart
+- **WHEN** the `ListFollowed` RPC returns an artist without fanart data
+- **THEN** the view model image URL fields SHALL be undefined or empty, triggering fallback display in UI components
+
+#### Scenario: Dashboard events enriched with fanart
+- **WHEN** the dashboard constructs `LiveEvent` objects from concert data
+- **THEN** the system SHALL look up fanart URLs by artist ID from the `ListFollowed` response and attach them to the `LiveEvent`


### PR DESCRIPTION
## Related Issue

Refs #58

## Summary of Changes

- Archive the `artist-image-ui` change (tasks 5.1-5.3 complete) and sync its delta spec to main with 3 requirements: Event Card Logo Display, Event Detail Sheet Hero Image, and Fanart Data Propagation. Grid Tile Thumbnail requirement is excluded as it is being removed separately.
- Add `logo-color-analysis` change artifacts (proposal, design, specs, tasks) for backend dominant color extraction from artist logos.
- Add `frontend-entity-layer` change artifacts (proposal, design, specs, tasks) for introducing a structured entity layer in the frontend.

## Self-Checklist

- [x] I have linked the related issue.
- [x] I have updated the relevant documentation if needed.
- [x] No proto changes in this PR — openspec docs only.
- [x] Breaking changes have been justified and documented if applicable.
