### PR TITLE
docs(spec): add email verification requirements

### DIFF
--- a/openspec/changes/archive/2026-03-17-email-verification/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-17-email-verification/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-13

--- a/openspec/changes/archive/2026-03-17-email-verification/design.md
+++ b/openspec/changes/archive/2026-03-17-email-verification/design.md
@@ -1,0 +1,34 @@
+## Design Decisions
+
+### Zitadel Action (already implemented)
+
+`add-email-claim.js` already injects both `email` and `email_verified` claims into access tokens via `PRE_ACCESS_TOKEN_CREATION`. Machine users (no `human` field) are skipped. No changes needed.
+
+### Backend: Claims + JWTValidator + Interceptor
+
+**Claims struct** — Add `EmailVerified bool` field to `auth.Claims`.
+
+**JWTValidator** — Extract `email_verified` from JWT private claims. The claim is a boolean set by the Zitadel Action. If the claim is missing, default to `false` (fail-closed). This extraction happens alongside the existing `email` extraction in `ValidateToken()`.
+
+**ClaimsBridgeInterceptor** — No changes needed. The interceptor already bridges `*Claims` from authn info to context. The new field is carried automatically.
+
+**Email verification enforcement** — Add a new `EmailVerificationInterceptor` as a Connect-RPC interceptor that checks `Claims.EmailVerified`. This is separate from `ClaimsBridgeInterceptor` to maintain single responsibility:
+- Runs after `ClaimsBridgeInterceptor` (claims must be in context first)
+- Reads claims from context via `GetClaims()`
+- If claims exist and `EmailVerified == false`, returns `connect.CodeUnauthenticated` with message "email verification required"
+- If claims are nil (public endpoint, machine user), passes through — the existing auth layer already handles access control
+- Skips check if `Email` is empty (machine user token without email claim)
+
+**Why a separate interceptor instead of modifying ClaimsBridgeInterceptor**: The bridge interceptor's responsibility is context propagation, not authorization. Mixing enforcement into it would violate SRP and make it harder to disable the check for specific scenarios (e.g., machine users).
+
+### Frontend: Auth Callback Check
+
+In `auth-callback-route.ts`, after `handleCallback()` returns the user, check `user.profile.email_verified`. If `false` or `undefined`, set an error message and return `true` (render error) instead of proceeding to provisioning. The error message should instruct the user to check their email for a verification link.
+
+This check happens before `provisionUser()` to prevent creating backend users with unverified emails.
+
+## Integration Order
+
+1. Backend changes first (Claims, JWTValidator, interceptor) — these are independent
+2. Frontend change — can be done in parallel since it only reads the ID token, not the access token
+3. Both PRs can be merged independently since the Zitadel Action already emits the claims

--- a/openspec/changes/archive/2026-03-17-email-verification/proposal.md
+++ b/openspec/changes/archive/2026-03-17-email-verification/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+Signup 時に入力された email アドレスが検証されていない。Zitadel の Hosted Login は SMTP 設定があれば自動で OTP 検証を挟むが、現在 SMTP が未設定のためスキップされている。未検証メールのユーザーがシステムに入ると、通知の不達、なりすまし、データ品質低下のリスクがある。
+
+SMTP 設定は cloud-provisioning (Postmark + Zitadel SmtpConfig) の別 change で対応する前提。この change では Frontend と Backend に `email_verified` の defense-in-depth チェックを追加し、SMTP 設定完了後に即座にシステム全体でメール検証が機能する状態にする。
+
+## What Changes
+
+- Zitadel Action (`add-email-claim.js`) を拡張し、access token に `email_verified` claim を注入する
+- Backend の `Claims` struct に `EmailVerified` フィールドを追加し、`JWTValidator` で抽出する
+- Backend の `ClaimsBridgeInterceptor` で `email_verified == false` の場合 `CodeUnauthenticated` を返す
+- Frontend の `auth-callback.ts` で OIDC ID token の `email_verified` を確認し、未検証の場合はエラー表示する
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `authentication`: `email_verified` claim の検証要件を追加。Backend は access token の `email_verified` claim が `true` でないリクエストを拒否する。Frontend は callback 時に ID token の `email_verified` を確認する。
+
+## Impact
+
+- **cloud-provisioning**: `add-email-claim.js` に `email_verified` claim 追加（Zitadel Action）
+- **backend**: `internal/infrastructure/auth/` — Claims struct, JWTValidator, ClaimsBridgeInterceptor の変更
+- **frontend**: `src/routes/auth-callback.ts` — email_verified チェック追加、未検証時のエラーハンドリング
+- **E2E テスト**: テスト用ユーザーは email_verified = true が前提。Zitadel Action が dev 環境で動作している必要あり

--- a/openspec/changes/archive/2026-03-17-email-verification/specs/authentication/spec.md
+++ b/openspec/changes/archive/2026-03-17-email-verification/specs/authentication/spec.md
@@ -1,0 +1,94 @@
+## ADDED Requirements
+
+### Requirement: Email Verified Claim Injection
+
+The system SHALL inject the `email_verified` claim into JWT access tokens via a Zitadel Action at the `PRE_ACCESS_TOKEN_CREATION` trigger, alongside the existing `email` claim.
+
+**Rationale**: Zitadel does not include `email_verified` in access tokens by default. The backend requires this claim to enforce email verification at the API layer.
+
+#### Scenario: Human user with verified email
+
+- **WHEN** a human user with a verified email address requests an access token
+- **THEN** the Zitadel Action SHALL set `email_verified` claim to `true` in the access token
+
+#### Scenario: Human user with unverified email
+
+- **WHEN** a human user with an unverified email address requests an access token
+- **THEN** the Zitadel Action SHALL set `email_verified` claim to `false` in the access token
+
+#### Scenario: Machine user (service account)
+
+- **WHEN** a machine user requests an access token
+- **THEN** the Zitadel Action SHALL skip `email_verified` injection (no `human` field present)
+- **AND** the token SHALL be issued without the `email_verified` claim
+
+### Requirement: Backend Email Verification Enforcement
+
+The system SHALL reject authenticated requests where the access token's `email_verified` claim is not `true`, returning `connect.CodeUnauthenticated`.
+
+**Rationale**: Defense-in-depth. Even though Zitadel's Hosted Login enforces email verification when SMTP is configured, the backend SHALL independently verify the claim to guard against API-created users or misconfigured identity providers.
+
+#### Scenario: Request with verified email
+
+- **WHEN** an authenticated request includes a valid JWT with `email_verified: true`
+- **THEN** the system SHALL allow the request to proceed to the RPC handler
+- **AND** the `EmailVerified` field SHALL be available in `Claims`
+
+#### Scenario: Request with unverified email
+
+- **WHEN** an authenticated request includes a valid JWT with `email_verified: false`
+- **THEN** the system SHALL reject the request with `connect.CodeUnauthenticated`
+- **AND** the error message SHALL indicate that email verification is required
+
+#### Scenario: Request with missing email_verified claim
+
+- **WHEN** an authenticated request includes a valid JWT without the `email_verified` claim
+- **THEN** the system SHALL reject the request with `connect.CodeUnauthenticated`
+- **AND** the error message SHALL indicate that email verification is required
+
+#### Scenario: Machine user token without email_verified
+
+- **WHEN** an authenticated request uses a machine user token (no `email_verified` claim, no `email` claim)
+- **THEN** the system SHALL allow the request if it passes existing validation
+- **AND** the `email_verified` check SHALL be skipped for tokens without an `email` claim
+
+### Requirement: Frontend Email Verification Check
+
+The system SHALL verify the user's `email_verified` status during the OIDC callback and display an error if the email is not verified.
+
+**Rationale**: Immediate user feedback. Rather than letting the user reach the dashboard and fail on every API call, the frontend SHALL catch unverified emails at the earliest opportunity and guide the user.
+
+#### Scenario: Callback with verified email
+
+- **WHEN** the OIDC callback processes a token where `email_verified` is `true` in the ID token profile
+- **THEN** the system SHALL proceed with normal flow (provisioning, merge, redirect to dashboard)
+
+#### Scenario: Callback with unverified email
+
+- **WHEN** the OIDC callback processes a token where `email_verified` is `false` or missing in the ID token profile
+- **THEN** the system SHALL NOT proceed to user provisioning or guest data merge
+- **AND** the system SHALL display an error message instructing the user to verify their email
+- **AND** the system SHALL provide a way to return to the login flow
+
+## MODIFIED Requirements
+
+### Requirement: JWT Token Validation
+
+The system SHALL validate JWT tokens from ZITADEL using the JWKS endpoint.
+
+**Rationale**: Industry-standard JWT validation ensures secure authentication without requiring direct integration with the identity provider for every request.
+
+#### Scenario: Valid Token
+
+- **WHEN** a request includes a valid JWT token in the Authorization header
+- **THEN** the system validates the token signature using ZITADEL's public keys
+- **AND** verifies the issuer matches the configured ZITADEL instance
+- **AND** verifies the token has not expired
+- **AND** extracts the user ID from the `sub` claim
+- **AND** extracts the `email_verified` claim from the token's private claims
+
+#### Scenario: Invalid Token
+
+- **WHEN** a request includes an invalid or expired JWT token
+- **THEN** the system rejects the request with `connect.CodeUnauthenticated`
+- **AND** logs the authentication failure for security monitoring

--- a/openspec/changes/archive/2026-03-17-email-verification/tasks.md
+++ b/openspec/changes/archive/2026-03-17-email-verification/tasks.md
@@ -1,0 +1,13 @@
+## Tasks
+
+### Backend
+
+- [x] Add `EmailVerified bool` field to `Claims` struct in `internal/infrastructure/auth/context.go`
+- [x] Extract `email_verified` claim in `JWTValidator.ValidateToken()` — default to `false` if missing
+- [x] Add `EmailVerificationInterceptor` in `internal/infrastructure/auth/email_verification.go` — check `Claims.EmailVerified`, return `connect.CodeUnauthenticated` if false, skip if no email claim (machine user)
+- [x] Wire `EmailVerificationInterceptor` into the Connect-RPC handler chain (after `ClaimsBridgeInterceptor`)
+- [x] Update tests: `context_test.go`, `jwt_validator_test.go`, new `email_verification_test.go`, update `authn_test.go` if needed
+
+### Frontend
+
+- [x] In `auth-callback-route.ts`, check `user.profile.email_verified` after `handleCallback()` — if not verified, display error and block provisioning

--- a/openspec/specs/authentication/spec.md
+++ b/openspec/specs/authentication/spec.md
@@ -21,6 +21,7 @@ The system SHALL validate JWT tokens from ZITADEL using the JWKS endpoint.
 - **AND** verifies the issuer matches the configured ZITADEL instance
 - **AND** verifies the token has not expired
 - **AND** extracts the user ID from the `sub` claim
+- **AND** extracts the `email_verified` claim from the token's private claims
 
 #### Scenario: Invalid Token
 
@@ -91,6 +92,76 @@ The system SHALL allow public access to the gRPC health check endpoint without a
 - **WHEN** a request to any non-health RPC endpoint (e.g., ArtistService/Search) does not include an Authorization header
 - **THEN** the system SHALL reject the request with `connect.CodeUnauthenticated`
 
+### Requirement: Email Verified Claim Injection
+
+The system SHALL inject the `email_verified` claim into JWT access tokens via a Zitadel Action at the `PRE_ACCESS_TOKEN_CREATION` trigger, alongside the existing `email` claim.
+
+**Rationale**: Zitadel does not include `email_verified` in access tokens by default. The backend requires this claim to enforce email verification at the API layer.
+
+#### Scenario: Human user with verified email
+
+- **WHEN** a human user with a verified email address requests an access token
+- **THEN** the Zitadel Action SHALL set `email_verified` claim to `true` in the access token
+
+#### Scenario: Human user with unverified email
+
+- **WHEN** a human user with an unverified email address requests an access token
+- **THEN** the Zitadel Action SHALL set `email_verified` claim to `false` in the access token
+
+#### Scenario: Machine user (service account)
+
+- **WHEN** a machine user requests an access token
+- **THEN** the Zitadel Action SHALL skip `email_verified` injection (no `human` field present)
+- **AND** the token SHALL be issued without the `email_verified` claim
+
+### Requirement: Backend Email Verification Enforcement
+
+The system SHALL reject authenticated requests where the access token's `email_verified` claim is not `true`, returning `connect.CodeUnauthenticated`.
+
+**Rationale**: Defense-in-depth. Even though Zitadel's Hosted Login enforces email verification when SMTP is configured, the backend SHALL independently verify the claim to guard against API-created users or misconfigured identity providers.
+
+#### Scenario: Request with verified email
+
+- **WHEN** an authenticated request includes a valid JWT with `email_verified: true`
+- **THEN** the system SHALL allow the request to proceed to the RPC handler
+- **AND** the `EmailVerified` field SHALL be available in `Claims`
+
+#### Scenario: Request with unverified email
+
+- **WHEN** an authenticated request includes a valid JWT with `email_verified: false`
+- **THEN** the system SHALL reject the request with `connect.CodeUnauthenticated`
+- **AND** the error message SHALL indicate that email verification is required
+
+#### Scenario: Request with missing email_verified claim
+
+- **WHEN** an authenticated request includes a valid JWT without the `email_verified` claim
+- **THEN** the system SHALL reject the request with `connect.CodeUnauthenticated`
+- **AND** the error message SHALL indicate that email verification is required
+
+#### Scenario: Machine user token without email_verified
+
+- **WHEN** an authenticated request uses a machine user token (no `email_verified` claim, no `email` claim)
+- **THEN** the system SHALL allow the request if it passes existing validation
+- **AND** the `email_verified` check SHALL be skipped for tokens without an `email` claim
+
+### Requirement: Frontend Email Verification Check
+
+The system SHALL verify the user's `email_verified` status during the OIDC callback and display an error if the email is not verified.
+
+**Rationale**: Immediate user feedback. Rather than letting the user reach the dashboard and fail on every API call, the frontend SHALL catch unverified emails at the earliest opportunity and guide the user.
+
+#### Scenario: Callback with verified email
+
+- **WHEN** the OIDC callback processes a token where `email_verified` is `true` in the ID token profile
+- **THEN** the system SHALL proceed with normal flow (provisioning, merge, redirect to dashboard)
+
+#### Scenario: Callback with unverified email
+
+- **WHEN** the OIDC callback processes a token where `email_verified` is `false` or missing in the ID token profile
+- **THEN** the system SHALL NOT proceed to user provisioning or guest data merge
+- **AND** the system SHALL display an error message instructing the user to verify their email
+- **AND** the system SHALL provide a way to return to the login flow
+
 ### Non-Functional Requirements
 
 ### Requirement: JWKS Caching
@@ -143,6 +214,7 @@ The system SHALL return `connect.CodeUnauthenticated` for failed authentication 
 - **JWT Validator**: Validates tokens using `github.com/lestrrat-go/jwx/v2`
 - **authn-go Middleware**: `connectrpc/authn-go` HTTP middleware for default-deny authentication at the HTTP layer
 - **Claims Bridge Interceptor**: Connect-RPC interceptor that converts `authn.GetInfo(ctx)` to `auth.WithClaims(ctx)` for backward compatibility
+- **Email Verification Interceptor**: Connect-RPC interceptor that enforces `email_verified` claim for human users, skipping machine users and public endpoints
 - **Context Utilities**: Type-safe user ID propagation through request context
 
 ### Configuration


### PR DESCRIPTION
## Related Issue

No linked issue (spec-only change).

## Summary of Changes

- Add email verification enforcement requirements (backend + frontend) to authentication spec
- Add Zitadel Action `email_verified` claim injection requirement
- Archive completed email-verification change artifacts (proposal, design, delta spec, tasks)

## Test plan

- [ ] Verify spec renders correctly on GitHub
- [ ] Confirm archived change contains all artifacts

## Self-Checklist

- [x] No proto changes in this PR (spec-only).
- [x] Documentation updated (authentication spec synced).
- [x] No breaking changes.
