### PR TITLE
feat(entity): add LogoColorProfile message to Fanart

### DIFF
--- a/openspec/changes/logo-color-analysis/design.md
+++ b/openspec/changes/logo-color-analysis/design.md
@@ -56,13 +56,13 @@ Logos are classified into three types based on pixel analysis:
 
 ### Decision 4: Store analysis inside existing `fanart` JSONB
 
-**Choice:** Add a `logoAnalysis` key to the existing `fanart` JSONB column rather than a separate column.
+**Choice:** Add a `logoColorProfile` key to the existing `fanart` JSONB column rather than a separate column.
 
 ```json
 {
   "artistthumb": [...],
   "hdmusiclogo": [...],
-  "logoAnalysis": {
+  "logoColorProfile": {
     "dominantHue": 210,
     "dominantLightness": 0.15,
     "isChromatic": true
@@ -72,34 +72,34 @@ Logos are classified into three types based on pixel analysis:
 
 **Why?** The analysis is derived from and tightly coupled to the logo data. It should be refreshed whenever fanart data is refreshed. Keeping it in the same JSONB ensures atomicity and avoids schema migration for a new column.
 
-### Decision 5: Proto extension — `LogoAnalysis` message inside `Fanart`
+### Decision 5: Proto extension — `LogoColorProfile` message inside `Fanart`
 
 ```protobuf
 message Fanart {
   // ... existing fields ...
-  optional LogoAnalysis logo_analysis = 6;
+  optional LogoColorProfile logo_color_profile = 6;
 }
 
-message LogoAnalysis {
+message LogoColorProfile {
   float dominant_hue = 1;        // 0-360, OKLCH hue angle
   float dominant_lightness = 2;  // 0-1, OKLCH lightness
   bool is_chromatic = 3;         // true if logo has significant color
 }
 ```
 
-**Why inside Fanart?** LogoAnalysis is meaningless without fanart data — it's derived from the logo image. Placing it as a peer field on `Artist` would create a confusing ownership model.
+**Why inside Fanart?** LogoColorProfile is meaningless without fanart data — it's derived from the logo image. Placing it as a peer field on `Artist` would create a confusing ownership model.
 
 ### Decision 6: Frontend fallback chain
 
 ```
-if (artist.fanart?.logoAnalysis) {
+if (artist.fanart?.logoColorProfile) {
   // Use analysis-driven hue + lightness
-  if (logoAnalysis.isChromatic) {
-    hue = logoAnalysis.dominantHue  // logo's own hue family
+  if (logoColorProfile.isChromatic) {
+    hue = logoColorProfile.dominantHue  // logo's own hue family
   } else {
     hue = hash(artistName)          // preserve variety
   }
-  bgLightness = derived from logoAnalysis.dominantLightness
+  bgLightness = derived from logoColorProfile.dominantLightness
 } else if (artist.fanart) {
   // Has fanart but no analysis (transition period)
   hue = hash(artistName)
@@ -109,7 +109,22 @@ if (artist.fanart?.logoAnalysis) {
 }
 ```
 
-Fully backward-compatible. The `artist-color` custom attribute gains an optional `logoAnalysis` input. When absent, behavior is identical to current.
+Fully backward-compatible. The `artist-color` custom attribute gains an optional `logoColorProfile` input. When absent, behavior is identical to current.
+
+### Decision 7: Analyzed image must be the same image returned in proto
+
+**Choice:** The color analysis target is always the same image that the proto mapper selects via `BestByLikes` — HDMusicLogo first, falling back to MusicLogo. The analysis and the proto response must never reference different images.
+
+**Why?** If a different image were analyzed, the derived background color would not match the logo the user actually sees. The selection logic (`BestByLikes` with HDMusicLogo → MusicLogo fallback) is shared between the mapper and the analysis pipeline.
+
+### Decision 8: Decouple fanart API call from image analysis
+
+**Choice:** The color analysis function (`AnalyzeLogo`) is a pure function in the entity layer that accepts an `image.Image` and returns a `*LogoColorProfile`. It has no knowledge of HTTP, fanart.tv, or any I/O. The usecase layer orchestrates: select best logo URL → HTTP download → PNG decode → call `AnalyzeLogo`.
+
+**Why?** This separation ensures:
+- `AnalyzeLogo` is testable with synthetic images (no HTTP mocking needed)
+- The usecase layer can be tested by injecting a mock HTTP client that returns fixed PNG bytes
+- The analysis algorithm can evolve independently from the sync pipeline
 
 ## Risks / Trade-offs
 

--- a/openspec/changes/logo-color-analysis/proposal.md
+++ b/openspec/changes/logo-color-analysis/proposal.md
@@ -6,8 +6,8 @@ Artist logos (clearLOGO from fanart.tv) displayed on event cards have poor visib
 
 - The fanart sync pipeline (CronJob + event consumer) will analyze each artist's best logo image to extract dominant color properties (hue, lightness, chromaticity).
 - Analysis results will be stored alongside existing fanart data in the `fanart` JSONB column.
-- The proto `Fanart` message will be extended with a `LogoAnalysis` message containing the extracted color metadata.
-- The frontend will use `LogoAnalysis` to compute an optimal card background color that maximizes logo visibility while preserving color variety across the app.
+- The proto `Fanart` message will be extended with a `LogoColorProfile` message containing the extracted color metadata.
+- The frontend will use `LogoColorProfile` to compute an optimal card background color that maximizes logo visibility while preserving color variety across the app.
 
 ## Capabilities
 
@@ -15,11 +15,11 @@ Artist logos (clearLOGO from fanart.tv) displayed on event cards have poor visib
 - `logo-color-analysis`: Automatic extraction of logo dominant color properties and optimal background color derivation for artist event cards.
 
 ### Modified Capabilities
-- `artist-image`: The Fanart entity, proto message, and sync pipeline gain a `LogoAnalysis` sub-entity populated during image sync.
+- `artist-image`: The Fanart entity, proto message, and sync pipeline gain a `LogoColorProfile` sub-entity populated during image sync.
 
 ## Impact
 
-- **specification**: `Fanart` proto message extended with `LogoAnalysis` sub-message.
-- **backend**: Fanart entity gains `LogoAnalysis` field. Sync job and event consumer updated to download logo PNG and run color extraction. Mapper updated to include analysis in proto response.
-- **frontend**: `color-generator.ts` and `artist-color` custom attribute updated to prefer `LogoAnalysis` data over name-hash hue. CSS custom properties may include `--artist-bg-lightness`.
+- **specification**: `Fanart` proto message extended with `LogoColorProfile` sub-message.
+- **backend**: Fanart entity gains `LogoColorProfile` field. Sync job and event consumer updated to download logo PNG and run color extraction. Mapper updated to include analysis in proto response.
+- **frontend**: `color-generator.ts` and `artist-color` custom attribute updated to prefer `LogoColorProfile` data over name-hash hue. CSS custom properties may include `--artist-bg-lightness`.
 - **dependencies**: No new external dependencies. Go `image/png` + `image/color` standard library suffice for pixel analysis. OKLCH conversion uses fixed matrix math (no library needed).

--- a/openspec/changes/logo-color-analysis/specs/artist-image/spec.md
+++ b/openspec/changes/logo-color-analysis/specs/artist-image/spec.md
@@ -1,7 +1,7 @@
 ## MODIFIED Requirements
 
 ### Requirement: Fanart Entity
-The system SHALL define a `Fanart` entity that mirrors the fanart.tv API response structure. The entity SHALL contain the following image collection fields: `ArtistThumb`, `ArtistBackground`, `HDMusicLogo`, `MusicLogo`, `MusicBanner`. Each collection SHALL contain zero or more `FanartImage` entries with `ID`, `URL`, `Likes`, and `Lang` fields. The entity SHALL also contain an optional `LogoAnalysis` field holding the extracted dominant color properties of the best logo image.
+The system SHALL define a `Fanart` entity that mirrors the fanart.tv API response structure. The entity SHALL contain the following image collection fields: `ArtistThumb`, `ArtistBackground`, `HDMusicLogo`, `MusicLogo`, `MusicBanner`. Each collection SHALL contain zero or more `FanartImage` entries with `ID`, `URL`, `Likes`, and `Lang` fields. The entity SHALL also contain an optional `LogoColorProfile` field holding the extracted dominant color properties of the best logo image.
 
 #### Scenario: Fanart with all image types populated
 - **WHEN** fanart.tv returns data for an artist with all image types
@@ -13,10 +13,10 @@ The system SHALL define a `Fanart` entity that mirrors the fanart.tv API respons
 
 #### Scenario: Fanart with logo analysis
 - **WHEN** fanart data includes a logo image that has been analyzed
-- **THEN** the `Fanart` entity SHALL contain a non-nil `LogoAnalysis` with `DominantHue`, `DominantLightness`, and `IsChromatic` fields
+- **THEN** the `Fanart` entity SHALL contain a non-nil `LogoColorProfile` with `DominantHue`, `DominantLightness`, and `IsChromatic` fields
 
 ### Requirement: Fanart Proto Message
-The system SHALL define a `Fanart` protobuf message within `liverty_music.entity.v1` containing optional URL fields for each image type: `artist_thumb`, `artist_background`, `hd_music_logo`, `music_logo`, `music_banner`. Each field SHALL use a dedicated wrapper message with URI validation. The message SHALL also include an `optional LogoAnalysis logo_analysis` field. The `Artist` message SHALL include an `optional Fanart fanart` field.
+The system SHALL define a `Fanart` protobuf message within `liverty_music.entity.v1` containing optional URL fields for each image type: `artist_thumb`, `artist_background`, `hd_music_logo`, `music_logo`, `music_banner`. Each field SHALL use a dedicated wrapper message with URI validation. The message SHALL also include an `optional LogoColorProfile logo_color_profile` field. The `Artist` message SHALL include an `optional Fanart fanart` field.
 
 #### Scenario: Artist with fanart data
 - **WHEN** an Artist is serialized to proto and fanart data exists
@@ -28,26 +28,26 @@ The system SHALL define a `Fanart` protobuf message within `liverty_music.entity
 
 #### Scenario: Artist with logo analysis in fanart
 - **WHEN** an Artist is serialized to proto and logo analysis data exists
-- **THEN** the `fanart.logo_analysis` field SHALL contain a `LogoAnalysis` message
+- **THEN** the `fanart.logo_color_profile` field SHALL contain a `LogoColorProfile` message
 
 ### Requirement: Fanart Proto Mapper
-The mapper layer SHALL convert the domain `Fanart` entity (with full image arrays) to the proto `Fanart` message (with single best URL per type) using `BestByLikes` for selection. The mapper SHALL also convert the domain `LogoAnalysis` to the proto `LogoAnalysis` message when present.
+The mapper layer SHALL convert the domain `Fanart` entity (with full image arrays) to the proto `Fanart` message (with single best URL per type) using `BestByLikes` for selection. The mapper SHALL also convert the domain `LogoColorProfile` to the proto `LogoColorProfile` message when present.
 
 #### Scenario: Mapper selects best images
 - **WHEN** a domain Artist with Fanart data is mapped to proto
 - **THEN** each proto Fanart field SHALL contain the URL of the image with the highest likes count from the corresponding domain field
 
 #### Scenario: Mapper includes logo analysis
-- **WHEN** a domain Artist with Fanart and LogoAnalysis is mapped to proto
-- **THEN** the proto Fanart message SHALL include the `logo_analysis` field with dominant hue, lightness, and chromaticity
+- **WHEN** a domain Artist with Fanart and LogoColorProfile is mapped to proto
+- **THEN** the proto Fanart message SHALL include the `logo_color_profile` field with dominant hue, lightness, and chromaticity
 
 ### Requirement: Fanart Database Storage
-The system SHALL store fanart.tv API response data in a `fanart` JSONB column on the `artists` table. The system SHALL also store the synchronization timestamp in a `fanart_synced_at` TIMESTAMPTZ column. Logo analysis results SHALL be stored within the same `fanart` JSONB under a `logoAnalysis` key.
+The system SHALL store fanart.tv API response data in a `fanart` JSONB column on the `artists` table. The system SHALL also store the synchronization timestamp in a `fanart_synced_at` TIMESTAMPTZ column. Logo analysis results SHALL be stored within the same `fanart` JSONB under a `logoColorProfile` key.
 
 #### Scenario: Fanart data persisted with analysis
 - **WHEN** fanart data is fetched and logo analysis is performed
-- **THEN** the `fanart` JSONB column SHALL contain both the parsed response data and the `logoAnalysis` object, and `fanart_synced_at` SHALL be set to the current timestamp
+- **THEN** the `fanart` JSONB column SHALL contain both the parsed response data and the `logoColorProfile` object, and `fanart_synced_at` SHALL be set to the current timestamp
 
 #### Scenario: Fanart data persisted without analysis
 - **WHEN** fanart data is fetched but no logo image is available for analysis
-- **THEN** the `fanart` JSONB column SHALL contain the parsed response data without a `logoAnalysis` key
+- **THEN** the `fanart` JSONB column SHALL contain the parsed response data without a `logoColorProfile` key

--- a/openspec/changes/logo-color-analysis/specs/logo-color-analysis/spec.md
+++ b/openspec/changes/logo-color-analysis/specs/logo-color-analysis/spec.md
@@ -39,7 +39,7 @@ The fanart sync pipeline (CronJob and ARTIST.created consumer) SHALL perform log
 
 #### Scenario: Artist has HDMusicLogo
 - **WHEN** fanart data is fetched and HDMusicLogo contains images
-- **THEN** the sync pipeline SHALL download the best HDMusicLogo image (by likes), run color analysis, and store the result in the `logoAnalysis` field of the fanart JSONB
+- **THEN** the sync pipeline SHALL download the best HDMusicLogo image (by likes), run color analysis, and store the result in the `logoColorProfile` field of the fanart JSONB
 
 #### Scenario: Artist has only MusicLogo
 - **WHEN** fanart data is fetched and HDMusicLogo is empty but MusicLogo contains images
@@ -47,25 +47,25 @@ The fanart sync pipeline (CronJob and ARTIST.created consumer) SHALL perform log
 
 #### Scenario: Artist has no logo images
 - **WHEN** fanart data is fetched but neither HDMusicLogo nor MusicLogo contain images
-- **THEN** the sync pipeline SHALL store fanart data without a `logoAnalysis` field
+- **THEN** the sync pipeline SHALL store fanart data without a `logoColorProfile` field
 
 #### Scenario: Logo image download fails
 - **WHEN** the logo image HTTP request fails or returns non-200
-- **THEN** the sync pipeline SHALL log a warning and store fanart data without a `logoAnalysis` field (non-fatal)
+- **THEN** the sync pipeline SHALL log a warning and store fanart data without a `logoColorProfile` field (non-fatal)
 
-### Requirement: LogoAnalysis Proto Message
-The system SHALL define a `LogoAnalysis` protobuf message within `liverty_music.entity.v1` containing `dominant_hue` (float, 0-360), `dominant_lightness` (float, 0-1), and `is_chromatic` (bool). The `Fanart` message SHALL include an `optional LogoAnalysis logo_analysis` field.
+### Requirement: LogoColorProfile Proto Message
+The system SHALL define a `LogoColorProfile` protobuf message within `liverty_music.entity.v1` containing `dominant_hue` (float, 0-360), `dominant_lightness` (float, 0-1), and `is_chromatic` (bool). The `Fanart` message SHALL include an `optional LogoColorProfile logo_color_profile` field.
 
 #### Scenario: Artist with logo analysis data
 - **WHEN** an Artist with logo analysis is serialized to proto
-- **THEN** the `fanart.logo_analysis` field SHALL contain a `LogoAnalysis` message with the extracted values
+- **THEN** the `fanart.logo_color_profile` field SHALL contain a `LogoColorProfile` message with the extracted values
 
 #### Scenario: Artist without logo analysis data
 - **WHEN** an Artist without logo analysis is serialized to proto
-- **THEN** the `fanart.logo_analysis` field SHALL be absent (optional not set)
+- **THEN** the `fanart.logo_color_profile` field SHALL be absent (optional not set)
 
 ### Requirement: Frontend Background Color Derivation
-The frontend SHALL use `LogoAnalysis` data to determine the card background `--artist-hue` custom property. For chromatic logos (`isChromatic = true`), the hue SHALL be set to `dominantHue` (logo's own hue family). For achromatic logos, the hue SHALL fall back to the existing name-hash algorithm. When no `LogoAnalysis` is available, the existing name-hash algorithm SHALL be used unchanged.
+The frontend SHALL use `LogoColorProfile` data to determine the card background `--artist-hue` custom property. For chromatic logos (`isChromatic = true`), the hue SHALL be set to `dominantHue` (logo's own hue family). For achromatic logos, the hue SHALL fall back to the existing name-hash algorithm. When no `LogoColorProfile` is available, the existing name-hash algorithm SHALL be used unchanged.
 
 #### Scenario: Chromatic logo card background
 - **WHEN** an event card renders for an artist with `isChromatic = true` and `dominantHue = 0` (red)
@@ -80,5 +80,5 @@ The frontend SHALL use `LogoAnalysis` data to determine the card background `--a
 - **THEN** `--artist-hue` SHALL be set to the name-hash value and background lightness SHALL be raised to ensure the dark logo is visible
 
 #### Scenario: No logo analysis available
-- **WHEN** an event card renders for an artist without `LogoAnalysis`
+- **WHEN** an event card renders for an artist without `LogoColorProfile`
 - **THEN** `--artist-hue` SHALL be computed from the artist name hash (existing behavior)

--- a/openspec/changes/logo-color-analysis/tasks.md
+++ b/openspec/changes/logo-color-analysis/tasks.md
@@ -1,41 +1,41 @@
 ## 0. Specification: Proto Schema
 
-- [ ] 0.1 Add `LogoAnalysis` message to `artist.proto` with `dominant_hue` (float), `dominant_lightness` (float), `is_chromatic` (bool)
-- [ ] 0.2 Add `optional LogoAnalysis logo_analysis = 6` field to the `Fanart` message
-- [ ] 0.3 Run `buf lint` and `buf format -w`
+- [x] 0.1 Add `LogoColorProfile` message to `artist.proto` with `dominant_hue` (float), `dominant_lightness` (float), `is_chromatic` (bool)
+- [x] 0.2 Add `optional LogoColorProfile logo_color_profile = 6` field to the `Fanart` message
+- [x] 0.3 Run `buf lint` and `buf format -w`
 - [ ] 0.4 Create specification PR, merge, create release → BSR publishes
 
-## 1. Backend: Color Extraction (Entity Layer)
+## 1. Backend: Color Extraction (Entity Layer — Pure Functions)
 
-- [ ] 1.1 Add `LogoAnalysis` struct to `entity/fanart.go` with `DominantHue float64`, `DominantLightness float64`, `IsChromatic bool` and JSON tags
-- [ ] 1.2 Add `LogoAnalysis *LogoAnalysis` field to `Fanart` struct with `json:"logoAnalysis,omitempty"` tag
+- [ ] 1.1 Add `LogoColorProfile` struct to `entity/fanart.go` with `DominantHue float64`, `DominantLightness float64`, `IsChromatic bool` and JSON tags
+- [ ] 1.2 Add `LogoColorProfile *LogoColorProfile` field to `Fanart` struct with `json:"logoColorProfile,omitempty"` tag
 - [ ] 1.3 Implement `oklch.go` in `entity/` with sRGB→LinearRGB→OKLab→OKLCH conversion (pure math, no external deps)
 - [ ] 1.4 Unit test `oklch.go`: pure white → L≈1.0 C≈0.0, pure red → L≈0.63 C>0.2 H≈29°, pure black → L≈0.0 C≈0.0
-- [ ] 1.5 Implement `AnalyzeLogo(img image.Image) *LogoAnalysis` in `entity/fanart.go`: skip transparent pixels, build hue histogram, classify chromatic/achromatic, return analysis
-- [ ] 1.6 Unit test `AnalyzeLogo`: chromatic image (>30% colored pixels), achromatic light image, achromatic dark image, fully transparent image → nil
+- [ ] 1.5 Implement `AnalyzeLogo(img image.Image) *LogoColorProfile` in `entity/fanart.go`: pure function, no I/O. Skip transparent pixels, build hue histogram, classify chromatic/achromatic, return profile
+- [ ] 1.6 Unit test `AnalyzeLogo` with synthetic `image.NRGBA` images: chromatic image (>30% colored pixels), achromatic light image, achromatic dark image, fully transparent image → nil
 
-## 2. Backend: Sync Pipeline Integration
+## 2. Backend: Sync Pipeline Integration (Usecase Layer — Orchestration)
 
-- [ ] 2.1 Add `DownloadAndAnalyzeLogo(ctx, fanart *Fanart) *LogoAnalysis` to the image sync use case: select best logo URL (HDMusicLogo → MusicLogo fallback), HTTP GET, `image/png` decode, call `AnalyzeLogo`
-- [ ] 2.2 Update `SyncArtistImages` (CronJob path) to call `DownloadAndAnalyzeLogo` and set `fanart.LogoAnalysis` before persisting
-- [ ] 2.3 Update ARTIST.created consumer to call `DownloadAndAnalyzeLogo` after fetching fanart data
-- [ ] 2.4 Handle logo download failures gracefully: log warning, proceed with nil LogoAnalysis (non-fatal)
+- [ ] 2.1 Add usecase method that orchestrates logo color profiling: select best logo URL via `BestByLikes` (HDMusicLogo → MusicLogo fallback) — same selection as the proto mapper — then HTTP GET, `image/png` decode, call `AnalyzeLogo`
+- [ ] 2.2 Update `SyncArtistImages` (CronJob path) to call the profiling method and set `fanart.LogoColorProfile` before persisting
+- [ ] 2.3 Update ARTIST.created consumer to call the profiling method after fetching fanart data
+- [ ] 2.4 Handle logo download failures gracefully: log warning, proceed with nil LogoColorProfile (non-fatal)
 - [ ] 2.5 Run `make check` in backend
 
 ## 3. Backend: Proto Mapper
 
 - [ ] 3.1 Update `go.mod` with new BSR-generated proto (after step 0.4)
-- [ ] 3.2 Add `logoAnalysisToProto` function in `mapper/artist.go`
-- [ ] 3.3 Call `logoAnalysisToProto` from `fanartToProto` when `f.LogoAnalysis != nil`
-- [ ] 3.4 Unit test mapper: fanart with LogoAnalysis → proto has logo_analysis field, fanart without → proto has no logo_analysis
+- [ ] 3.2 Add `logoColorProfileToProto` function in `mapper/artist.go`
+- [ ] 3.3 Call `logoColorProfileToProto` from `fanartToProto` when `f.LogoColorProfile != nil`
+- [ ] 3.4 Unit test mapper: fanart with LogoColorProfile → proto has logo_color_profile field, fanart without → proto has no logo_color_profile
 
 ## 4. Frontend: Background Color Derivation
 
-- [ ] 4.1 Update `follow-service-client.ts`: map `artist.fanart.logoAnalysis` fields to `FollowedArtistInfo` (`dominantHue?`, `dominantLightness?`, `isChromatic?`)
-- [ ] 4.2 Update `color-generator.ts`: add `artistHueFromAnalysis(analysis, artistName)` that returns analysis-driven hue for chromatic logos, name-hash for achromatic
-- [ ] 4.3 Update `artist-color` custom attribute to accept optional `LogoAnalysis` data and set `--artist-hue` and `--artist-bg-lightness` custom properties
+- [ ] 4.1 Update `follow-service-client.ts`: map `artist.fanart.logoColorProfile` fields to `FollowedArtistInfo` (`dominantHue?`, `dominantLightness?`, `isChromatic?`)
+- [ ] 4.2 Update `color-generator.ts`: add `artistHueFromColorProfile(profile, artistName)` that returns profile-driven hue for chromatic logos, name-hash for achromatic
+- [ ] 4.3 Update `artist-color` custom attribute to accept optional `LogoColorProfile` data and set `--artist-hue` and `--artist-bg-lightness` custom properties
 - [ ] 4.4 Update CSS to use `--artist-bg-lightness` for unmatched card backgrounds when available
-- [ ] 4.5 Propagate LogoAnalysis through `dashboard-service.ts` → `LiveEvent` → `event-card`
+- [ ] 4.5 Propagate LogoColorProfile through `dashboard-service.ts` → `LiveEvent` → `event-card`
 
 ## 5. Verification
 

--- a/proto/liverty_music/entity/v1/artist.proto
+++ b/proto/liverty_music/entity/v1/artist.proto
@@ -92,12 +92,18 @@ message Fanart {
 message LogoColorProfile {
   // The dominant hue angle in the OKLCH color space (0–360 degrees).
   // Meaningful only when `is_chromatic` is true; ignored for achromatic logos.
-  float dominant_hue = 1;
+  float dominant_hue = 1 [(buf.validate.field).float = {
+    gte: 0
+    lte: 360
+  }];
 
   // The mean perceptual lightness of non-transparent pixels (0–1, OKLCH L).
   // Determines whether the logo is light or dark, which informs background
   // lightness adjustment.
-  float dominant_lightness = 2;
+  float dominant_lightness = 2 [(buf.validate.field).float = {
+    gte: 0
+    lte: 1
+  }];
 
   // Whether the logo contains significant color (> 30% of non-transparent
   // pixels have OKLCH chroma > 0.04). When false, the logo is essentially

--- a/proto/liverty_music/entity/v1/artist.proto
+++ b/proto/liverty_music/entity/v1/artist.proto
@@ -91,8 +91,9 @@ message Fanart {
 // background color that ensures the logo remains visually distinguishable.
 message LogoColorProfile {
   // The dominant hue angle in the OKLCH color space (0–360 degrees).
-  // Meaningful only when `is_chromatic` is true; ignored for achromatic logos.
-  float dominant_hue = 1 [(buf.validate.field).float = {
+  // Present only for chromatic logos (`is_chromatic` is true).
+  // Omitted for achromatic logos where hue is meaningless.
+  optional float dominant_hue = 1 [(buf.validate.field).float = {
     gte: 0
     lte: 360
   }];

--- a/proto/liverty_music/entity/v1/artist.proto
+++ b/proto/liverty_music/entity/v1/artist.proto
@@ -78,4 +78,29 @@ message Fanart {
 
   // A wide banner image for the artist (1000x185).
   optional Url music_banner = 5;
+
+  // Dominant color properties extracted from the best logo image.
+  // Used by the frontend to derive a card background color that
+  // maximizes contrast with the logo.
+  // Absent when no logo image is available or analysis has not been performed.
+  optional LogoColorProfile logo_color_profile = 6;
+}
+
+// LogoColorProfile summarizes the dominant color characteristics of an artist's
+// logo image. The frontend uses these values to compute an optimal card
+// background color that ensures the logo remains visually distinguishable.
+message LogoColorProfile {
+  // The dominant hue angle in the OKLCH color space (0–360 degrees).
+  // Meaningful only when `is_chromatic` is true; ignored for achromatic logos.
+  float dominant_hue = 1;
+
+  // The mean perceptual lightness of non-transparent pixels (0–1, OKLCH L).
+  // Determines whether the logo is light or dark, which informs background
+  // lightness adjustment.
+  float dominant_lightness = 2;
+
+  // Whether the logo contains significant color (> 30% of non-transparent
+  // pixels have OKLCH chroma > 0.04). When false, the logo is essentially
+  // grayscale and the frontend falls back to the artist-name hash for hue.
+  bool is_chromatic = 3;
 }


### PR DESCRIPTION
## 🔗 Related Issue

N/A — new capability, no prior issue.

## 📝 Summary of Changes

Add `LogoColorProfile` message to the `Fanart` proto, carrying OKLCH-based dominant color metadata (`dominant_hue`, `dominant_lightness`, `is_chromatic`) extracted from artist logo images. The frontend will use this data to derive card background colors that ensure logo visibility — replacing the current artist-name hash which can produce clashing backgrounds.

Also updates OpenSpec artifacts (proposal, design, specs, tasks) to rename from `LogoAnalysis` to `LogoColorProfile` and adds two new design decisions:
- **Decision 7**: Analyzed image must be the same image returned in proto
- **Decision 8**: Decouple fanart API call from image analysis (pure function in entity layer)

## ✅ Self-Checklist

- [x] I have linked the related issue.
- [x] I have updated the relevant documentation (e.g., `README.md`) if needed.
- [x] I have run `buf lint` and `buf format` locally and all checks have passed.
- [x] My proto definitions follow the project's style guidelines and validation rules.
- [ ] Breaking changes have been justified and documented if applicable.
