### PR TITLE
docs(spec): archive email-provider-setup and sync specs

### DIFF
--- a/openspec/changes/archive/2026-03-18-email-provider-setup/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-18-email-provider-setup/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-13

--- a/openspec/changes/archive/2026-03-18-email-provider-setup/design.md
+++ b/openspec/changes/archive/2026-03-18-email-provider-setup/design.md
@@ -1,0 +1,85 @@
+## Context
+
+Zitadel Cloud's Hosted Login includes an email verification step (OTP code send and entry) during Self-Registration. However, without a custom SMTP provider configured, verification emails are not sent and this step does not function.
+
+The current cloud-provisioning repo manages Zitadel's OIDC app, Login Policy, and Token Actions via Pulumi. SMTP configuration is not yet managed as IaC.
+
+Postmark is adopted as the email provider. A dedicated mail subdomain is created, and DKIM / Return-Path records are configured in DNS to establish delivery authentication.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Configure Postmark SMTP in Zitadel Cloud to enable the Hosted Login email verification flow
+- Create mail subdomains `mail.liverty-music.app` (prod) / `mail.dev.liverty-music.app` (dev) with DKIM + Return-Path records
+- Separate Postmark Servers for dev and prod
+- Inject the `email_verified` claim into access tokens so the backend can verify it
+- Manage the Postmark Server API Token via Pulumi ESC (stored as a secret)
+
+**Non-Goals:**
+
+- Backend / frontend code changes (handled in a separate change `email-verification`)
+- Postmark account creation, Server creation, Sender Signature setup (manual tasks)
+- Email template customization (use Zitadel defaults)
+- Staging environment setup (dev / prod only)
+
+## Decisions
+
+### 1. Dedicated mail subdomain
+
+Create `mail.liverty-music.app` (prod) / `mail.dev.liverty-music.app` (dev) as mail-specific subdomains.
+
+**Rationale**: Isolate email sending reputation from the web domain. Bounce rate increases or spam classification will not affect `liverty-music.app` itself. If the provider changes in the future, only the mail subdomain DNS records need updating.
+
+**Alternative**: Send directly from the root domain `liverty-music.app`. Simpler but lacks reputation isolation and risks DKIM records conflicting with other DNS records on the root domain.
+
+### 2. DNS record placement
+
+- **prod** (`mail.liverty-music.app`): Cloudflare DNS (added to the existing zone)
+- **dev** (`mail.dev.liverty-music.app`): GCP Cloud DNS (because `dev.liverty-music.app` is NS-delegated to GCP Cloud DNS)
+
+**Rationale**: `dev.liverty-music.app` is already NS-delegated from Cloudflare to GCP Cloud DNS. Placing `mail.dev.liverty-music.app` records in Cloudflare would not resolve.
+
+### 3. SMTP credential management
+
+Postmark uses the same Server API Token as both the SMTP username and password. A single config field `postmark.serverApiToken` is stored as a secret in Pulumi ESC and assigned to both the `user` and `password` fields of the `zitadel.SmtpConfig` resource.
+
+**Rationale**: Postmark's SMTP authentication model uses the Server API Token for both fields. Storing it under separate `smtpUser` / `smtpPassword` names would be misleading. A single `serverApiToken` field accurately represents the credential and avoids duplication. GCP Secret Manager + ESO pipeline is unnecessary since Zitadel Cloud connects to SMTP directly (no need to inject into K8s Pods).
+
+**Alternative**: Store `smtpUser` and `smtpPassword` as separate fields. Rejected because they hold the same value, and the naming obscures the fact that Postmark uses a single token.
+
+### 4. Required field in ZitadelConfig
+
+Add `postmarkServerApiToken` as a required field on the `ZitadelConfig` interface.
+
+**Rationale**: SMTP is a prerequisite for email verification and must be configured in all environments. Making it optional risks configuration omissions.
+
+### 5. SmtpConfig component placement
+
+Create `src/zitadel/components/smtp.ts` to manage the `zitadel.SmtpConfig` resource.
+
+**Rationale**: Follows the existing pattern (`frontend.ts`, `token-action.ts`) of separating components by function.
+
+### 6. Extending add-email-claim.js
+
+Add `email_verified` claim injection to the existing `addEmailClaim` Action script instead of creating a new Action.
+
+**Rationale**: Both claims use the same `PRE_ACCESS_TOKEN_CREATION` trigger and the same user object. A separate Action would add TriggerActions management complexity. A single line addition to the existing script suffices.
+
+**Alternative**: Create a separate `addEmailVerifiedClaim` Action. Correct from a separation-of-concerns perspective but not worth the management overhead.
+
+### 7. Sender address design
+
+- dev: `noreply@mail.dev.liverty-music.app`
+- prod: `noreply@mail.liverty-music.app`
+- Reply-to: Not set (transactional emails; replies are not expected)
+
+## Risks / Trade-offs
+
+**[Postmark Sender Signature verification delay]** — Postmark domain verification requires DNS record propagation, which can take up to 48 hours. Mitigation: Configure dev first and proceed to prod after dev verification succeeds.
+
+**[Zitadel SmtpConfig Pulumi provider limitation]** — The `@pulumiverse/zitadel` SmtpConfig resource lacks an `active` property. Behavior with multiple SMTP configurations is undefined. Mitigation: Create only one SmtpConfig per environment and confirm no existing SMTP configuration exists in the Zitadel Console beforehand.
+
+**[email_verified claim reliability]** — The `email_verified` claim injected via the Zitadel Action depends on the user object's `isEmailVerified` field. A Zitadel bug or API change could produce inaccurate values. Mitigation: The backend treats a missing claim as unverified (fail-closed).
+
+**[Email delivery in dev environment]** — Dev environment emails are actually sent. Test accounts may receive a high volume of emails. Mitigation: Postmark dev Server transactional streams have default rate limits. Adopt an operational convention of using `+dev` suffix for test email addresses.

--- a/openspec/changes/archive/2026-03-18-email-provider-setup/proposal.md
+++ b/openspec/changes/archive/2026-03-18-email-provider-setup/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+Zitadel Cloud has no custom SMTP provider configured, so email verification codes are not sent during Self-Registration. The default Zitadel Cloud SMTP is intended for development and testing only; production requires a dedicated SMTP provider. This change introduces Postmark as the email provider and establishes the email delivery infrastructure.
+
+## What Changes
+
+- Define the Postmark SMTP connection as a `zitadel.SmtpConfig` Pulumi resource and configure it in Zitadel Cloud
+- Create dedicated mail subdomains: `mail.liverty-music.app` (prod) / `mail.dev.liverty-music.app` (dev)
+- Add DKIM TXT and Return-Path CNAME records to Cloudflare DNS (prod) and GCP Cloud DNS (dev)
+- Add a `postmarkServerApiToken` field to `ZitadelConfig` and manage it per environment via Pulumi ESC
+- Separate Postmark Servers for dev and prod, each with an independent API token
+- Extend the `add-email-claim.js` Zitadel Action to inject the `email_verified` claim into access tokens
+
+## Capabilities
+
+### New Capabilities
+
+- `email-provider`: Postmark SMTP provider configuration, DNS authentication (DKIM / Return-Path), and mail subdomain management
+
+### Modified Capabilities
+
+- `authentication`: Add `email_verified` claim injection to the Zitadel Action. Establish the prerequisite for the Hosted Login Self-Registration flow to perform email verification
+- `secret-management`: Add the Postmark Server API Token to Pulumi ESC (stored as a secret)
+
+## Impact
+
+- **cloud-provisioning**: Add SmtpConfig component under `src/zitadel/`, extend ZitadelConfig, modify the Action script, add DNS records (Cloudflare + GCP Cloud DNS)
+- **Pulumi ESC**: Add `postmark.serverApiToken` to dev / prod environments
+- **Postmark**: Account setup, Server creation (dev / prod), and Sender Signature (domain verification) are manual tasks
+- **No impact on existing services**: No backend or frontend code changes required (email_verified enforcement is handled in a separate change `email-verification`)

--- a/openspec/changes/archive/2026-03-18-email-provider-setup/specs/authentication/spec.md
+++ b/openspec/changes/archive/2026-03-18-email-provider-setup/specs/authentication/spec.md
@@ -13,6 +13,7 @@ The system SHALL validate JWT tokens from ZITADEL using the JWKS endpoint.
 - **AND** verifies the issuer matches the configured ZITADEL instance
 - **AND** verifies the token has not expired
 - **AND** extracts the user ID from the `sub` claim
+- **AND** extracts the `email_verified` claim from the token's private claims
 
 #### Scenario: Invalid Token
 

--- a/openspec/changes/archive/2026-03-18-email-provider-setup/specs/authentication/spec.md
+++ b/openspec/changes/archive/2026-03-18-email-provider-setup/specs/authentication/spec.md
@@ -1,0 +1,45 @@
+## MODIFIED Requirements
+
+### Requirement: JWT Token Validation
+
+The system SHALL validate JWT tokens from ZITADEL using the JWKS endpoint.
+
+**Rationale**: Industry-standard JWT validation ensures secure authentication without requiring direct integration with the identity provider for every request.
+
+#### Scenario: Valid Token
+
+- **WHEN** a request includes a valid JWT token in the Authorization header
+- **THEN** the system validates the token signature using ZITADEL's public keys
+- **AND** verifies the issuer matches the configured ZITADEL instance
+- **AND** verifies the token has not expired
+- **AND** extracts the user ID from the `sub` claim
+
+#### Scenario: Invalid Token
+
+- **WHEN** a request includes an invalid or expired JWT token
+- **THEN** the system rejects the request with `connect.CodeUnauthenticated`
+- **AND** logs the authentication failure for security monitoring
+
+## ADDED Requirements
+
+### Requirement: email_verified claim injection in access token
+
+The Zitadel Action `addEmailClaim` SHALL inject the `email_verified` claim into JWT access tokens alongside the existing `email` claim. The value MUST reflect the user's `isEmailVerified` status from the Zitadel user object.
+
+#### Scenario: Verified user receives email_verified=true
+
+- **WHEN** a user with a verified email address authenticates
+- **THEN** the issued access token SHALL contain `"email_verified": true`
+- **AND** the existing `email` claim SHALL continue to be present
+
+#### Scenario: Unverified user receives email_verified=false
+
+- **WHEN** a user with an unverified email address authenticates
+- **THEN** the issued access token SHALL contain `"email_verified": false`
+- **AND** the existing `email` claim SHALL continue to be present
+
+#### Scenario: Machine user token is unaffected
+
+- **WHEN** a machine user (service account) authenticates
+- **THEN** the access token SHALL NOT contain `email_verified` claim
+- **AND** the existing guard for missing `human` field SHALL prevent errors

--- a/openspec/changes/archive/2026-03-18-email-provider-setup/specs/email-provider/spec.md
+++ b/openspec/changes/archive/2026-03-18-email-provider-setup/specs/email-provider/spec.md
@@ -1,0 +1,64 @@
+## ADDED Requirements
+
+### Requirement: Zitadel SMTP configuration via Pulumi
+
+The infrastructure SHALL provision a `zitadel.SmtpConfig` Pulumi resource that connects Zitadel Cloud to Postmark's SMTP server. The configuration MUST use `smtp.postmarkapp.com:587` with STARTTLS. Sender address MUST use the mail subdomain (`noreply@mail.<domain>`).
+
+#### Scenario: SmtpConfig resource creation for dev
+
+- **WHEN** the Pulumi dev stack is applied
+- **THEN** a `zitadel.SmtpConfig` resource is created with host `smtp.postmarkapp.com:587`
+- **AND** `senderAddress` is `noreply@mail.dev.liverty-music.app`
+- **AND** `senderName` is `Liverty Music`
+- **AND** `tls` is `true`
+- **AND** both `user` and `password` are set to the Postmark Server API Token read from ESC config key `postmark.serverApiToken`
+
+#### Scenario: SmtpConfig resource creation for prod
+
+- **WHEN** the Pulumi prod stack is applied
+- **THEN** a `zitadel.SmtpConfig` resource is created with host `smtp.postmarkapp.com:587`
+- **AND** `senderAddress` is `noreply@mail.liverty-music.app`
+
+### Requirement: Mail subdomain DNS records for DKIM authentication
+
+The infrastructure SHALL create DKIM TXT records and Return-Path CNAME records for Postmark domain authentication. Records for prod MUST be created in Cloudflare DNS. Records for dev MUST be created in GCP Cloud DNS (because `dev.liverty-music.app` is NS-delegated to GCP Cloud DNS).
+
+#### Scenario: Prod DKIM record in Cloudflare
+
+- **WHEN** Postmark provides a DKIM public key for `mail.liverty-music.app`
+- **THEN** a TXT record SHALL be created in Cloudflare DNS at `<selector>._domainkey.mail.liverty-music.app`
+- **AND** a CNAME record SHALL be created at `pm-bounces.mail.liverty-music.app` pointing to `pm.mtasv.net`
+
+#### Scenario: Dev DKIM record in GCP Cloud DNS
+
+- **WHEN** Postmark provides a DKIM public key for `mail.dev.liverty-music.app`
+- **THEN** a TXT record SHALL be created in GCP Cloud DNS at `<selector>._domainkey.mail.dev.liverty-music.app`
+- **AND** a CNAME record SHALL be created at `pm-bounces.mail.dev.liverty-music.app` pointing to `pm.mtasv.net`
+
+### Requirement: ZitadelConfig interface extension
+
+The `ZitadelConfig` interface SHALL include `postmarkServerApiToken` as a required string field. This single token is used as both the SMTP username and password, reflecting Postmark's authentication model.
+
+#### Scenario: Missing Postmark token causes type error
+
+- **WHEN** a Pulumi stack is configured without `postmark.serverApiToken` in ESC
+- **THEN** TypeScript compilation SHALL fail with a type error
+
+### Requirement: SmtpConfig component isolation
+
+The SMTP configuration SHALL be implemented as a separate component class in `src/zitadel/components/smtp.ts`, following the existing pattern of `frontend.ts` and `token-action.ts`.
+
+#### Scenario: Component instantiation
+
+- **WHEN** the `Zitadel` orchestrator class is constructed
+- **THEN** it SHALL instantiate the SMTP component with environment-specific sender address and the Postmark Server API Token
+- **AND** the SMTP component SHALL be exposed as a public readonly property
+
+### Requirement: Environment-specific Postmark Server separation
+
+Each environment (dev, prod) SHALL use a separate Postmark Server with an independent Server API Token. The token for each environment SHALL be stored in the corresponding Pulumi ESC environment.
+
+#### Scenario: Dev and prod use different API tokens
+
+- **WHEN** comparing the `postmark.serverApiToken` values across dev and prod ESC environments
+- **THEN** the values SHALL be different (each environment has its own Postmark Server token)

--- a/openspec/changes/archive/2026-03-18-email-provider-setup/specs/email-provider/spec.md
+++ b/openspec/changes/archive/2026-03-18-email-provider-setup/specs/email-provider/spec.md
@@ -18,6 +18,9 @@ The infrastructure SHALL provision a `zitadel.SmtpConfig` Pulumi resource that c
 - **WHEN** the Pulumi prod stack is applied
 - **THEN** a `zitadel.SmtpConfig` resource is created with host `smtp.postmarkapp.com:587`
 - **AND** `senderAddress` is `noreply@mail.liverty-music.app`
+- **AND** `senderName` is `Liverty Music`
+- **AND** `tls` is `true`
+- **AND** both `user` and `password` are set to the Postmark Server API Token read from ESC config key `postmark.serverApiToken`
 
 ### Requirement: Mail subdomain DNS records for DKIM authentication
 

--- a/openspec/changes/archive/2026-03-18-email-provider-setup/specs/secret-management/spec.md
+++ b/openspec/changes/archive/2026-03-18-email-provider-setup/specs/secret-management/spec.md
@@ -1,0 +1,21 @@
+## ADDED Requirements
+
+### Requirement: Postmark Server API Token in Pulumi ESC
+
+The Postmark Server API Token SHALL be stored in Pulumi ESC at the environment level (not common) under `pulumiConfig.postmark.serverApiToken` as a secret. Postmark uses the same token as both the SMTP username and password, so a single config field is sufficient.
+
+#### Scenario: Setting dev Postmark token
+
+- **WHEN** configuring the dev environment
+- **THEN** `esc env set liverty-music/dev pulumiConfig.postmark.serverApiToken "<value>" --secret` stores the Postmark Server API Token as encrypted
+
+#### Scenario: Setting prod Postmark token
+
+- **WHEN** configuring the prod environment
+- **THEN** `esc env set liverty-music/prod pulumiConfig.postmark.serverApiToken "<value>" --secret` stores the Postmark Server API Token as encrypted
+
+#### Scenario: Credentials are not in GCP Secret Manager
+
+- **WHEN** the Postmark Server API Token is needed
+- **THEN** it SHALL be consumed directly by Pulumi via ESC config
+- **AND** it SHALL NOT be provisioned as a GCP Secret Manager secret (Zitadel Cloud connects to SMTP directly, not via K8s pods)

--- a/openspec/changes/archive/2026-03-18-email-provider-setup/tasks.md
+++ b/openspec/changes/archive/2026-03-18-email-provider-setup/tasks.md
@@ -1,0 +1,38 @@
+## 1. Postmark manual setup
+
+- [x] 1.1 Create the dev Server (`liverty-music-dev`) in the Postmark account
+- [x] 1.2 Create the prod Server (`liverty-music-prod`) in the Postmark account
+- [x] 1.3 Add the domain `mail.dev.liverty-music.app` as a Sender Signature on the dev Server
+- [x] 1.4 Add the domain `mail.liverty-music.app` as a Sender Signature on the prod Server
+
+## 2. DNS record configuration
+
+- [x] 2.1 Create a Pulumi resource that adds the dev DKIM TXT record to GCP Cloud DNS (`dev.liverty-music.app` zone)
+- [x] 2.2 Add the dev Return-Path CNAME record (`pm-bounces.mail.dev.liverty-music.app` -> `pm.mtasv.net`) to GCP Cloud DNS
+- [x] 2.3 Create a Pulumi resource that adds the prod DKIM TXT record to Cloudflare DNS
+- [x] 2.4 Add the prod Return-Path CNAME record (`pm-bounces.mail.liverty-music.app` -> `pm.mtasv.net`) to Cloudflare DNS
+- [x] 2.5 Confirm DNS verification succeeds for both domains in Postmark
+
+## 3. Pulumi ESC configuration
+
+- [x] 3.1 Set the dev Postmark Server API Token via `esc env set liverty-music/dev pulumiConfig.postmark.serverApiToken --secret`
+- [x] 3.2 Set the prod Postmark Server API Token via `esc env set liverty-music/prod pulumiConfig.postmark.serverApiToken --secret`
+
+## 4. Zitadel SmtpConfig component
+
+- [x] 4.1 Add `postmarkServerApiToken: string` to the `ZitadelConfig` interface (`src/zitadel/index.ts`)
+- [x] 4.2 Create `src/zitadel/components/smtp.ts` and implement the `SmtpComponent` class
+- [x] 4.3 Instantiate `SmtpComponent` in the `Zitadel` orchestrator class
+- [x] 4.4 Implement per-environment sender address mapping (dev: `noreply@mail.dev.liverty-music.app`, prod: `noreply@mail.liverty-music.app`)
+
+## 5. Zitadel Action extension
+
+- [x] 5.1 Add `email_verified` claim injection to `add-email-claim.js` (`api.v1.claims.setClaim('email_verified', user.human.isEmailVerified)`)
+- [x] 5.2 Confirm the machine user guard also applies to the `email_verified` claim
+
+## 6. Verification
+
+- [x] 6.1 Confirm dev stack changes with `pulumi preview -s dev`
+- [x] 6.2 Confirm `make check` (lint-ts) passes
+- [x] 6.3 Deploy to dev and confirm that the email verification code is delivered during Self-Registration
+- [x] 6.4 Confirm the `email_verified` claim is included in the access token

--- a/openspec/specs/email-provider/spec.md
+++ b/openspec/specs/email-provider/spec.md
@@ -24,6 +24,9 @@ The infrastructure SHALL provision a `zitadel.SmtpConfig` Pulumi resource that c
 - **WHEN** the Pulumi prod stack is applied
 - **THEN** a `zitadel.SmtpConfig` resource is created with host `smtp.postmarkapp.com:587`
 - **AND** `senderAddress` is `noreply@mail.liverty-music.app`
+- **AND** `senderName` is `Liverty Music`
+- **AND** `tls` is `true`
+- **AND** both `user` and `password` are set to the Postmark Server API Token read from ESC config key `postmark.serverApiToken`
 
 ### Requirement: Mail subdomain DNS records for DKIM authentication
 

--- a/openspec/specs/email-provider/spec.md
+++ b/openspec/specs/email-provider/spec.md
@@ -1,0 +1,99 @@
+# Email Provider Capability
+
+## Purpose
+
+Defines the Postmark SMTP provider configuration, DNS authentication (DKIM / Return-Path), and mail subdomain management for transactional email delivery through Zitadel Cloud.
+
+## Requirements
+
+### Requirement: Zitadel SMTP configuration via Pulumi
+
+The infrastructure SHALL provision a `zitadel.SmtpConfig` Pulumi resource that connects Zitadel Cloud to Postmark's SMTP server. The configuration MUST use `smtp.postmarkapp.com:587` with STARTTLS. Sender address MUST use the mail subdomain (`noreply@mail.<domain>`).
+
+#### Scenario: SmtpConfig resource creation for dev
+
+- **WHEN** the Pulumi dev stack is applied
+- **THEN** a `zitadel.SmtpConfig` resource is created with host `smtp.postmarkapp.com:587`
+- **AND** `senderAddress` is `noreply@mail.dev.liverty-music.app`
+- **AND** `senderName` is `Liverty Music`
+- **AND** `tls` is `true`
+- **AND** both `user` and `password` are set to the Postmark Server API Token read from ESC config key `postmark.serverApiToken`
+
+#### Scenario: SmtpConfig resource creation for prod
+
+- **WHEN** the Pulumi prod stack is applied
+- **THEN** a `zitadel.SmtpConfig` resource is created with host `smtp.postmarkapp.com:587`
+- **AND** `senderAddress` is `noreply@mail.liverty-music.app`
+
+### Requirement: Mail subdomain DNS records for DKIM authentication
+
+The infrastructure SHALL create DKIM TXT records and Return-Path CNAME records for Postmark domain authentication. Records for prod MUST be created in Cloudflare DNS. Records for dev MUST be created in GCP Cloud DNS (because `dev.liverty-music.app` is NS-delegated to GCP Cloud DNS).
+
+#### Scenario: Prod DKIM record in Cloudflare
+
+- **WHEN** Postmark provides a DKIM public key for `mail.liverty-music.app`
+- **THEN** a TXT record SHALL be created in Cloudflare DNS at `<selector>._domainkey.mail.liverty-music.app`
+- **AND** a CNAME record SHALL be created at `pm-bounces.mail.liverty-music.app` pointing to `pm.mtasv.net`
+
+#### Scenario: Dev DKIM record in GCP Cloud DNS
+
+- **WHEN** Postmark provides a DKIM public key for `mail.dev.liverty-music.app`
+- **THEN** a TXT record SHALL be created in GCP Cloud DNS at `<selector>._domainkey.mail.dev.liverty-music.app`
+- **AND** a CNAME record SHALL be created at `pm-bounces.mail.dev.liverty-music.app` pointing to `pm.mtasv.net`
+
+### Requirement: ZitadelConfig interface extension
+
+The `ZitadelConfig` interface SHALL include `postmarkServerApiToken` as a required string field. This single token is used as both the SMTP username and password, reflecting Postmark's authentication model.
+
+#### Scenario: Missing Postmark token causes type error
+
+- **WHEN** a Pulumi stack is configured without `postmark.serverApiToken` in ESC
+- **THEN** TypeScript compilation SHALL fail with a type error
+
+### Requirement: SmtpConfig component isolation
+
+The SMTP configuration SHALL be implemented as a separate component class in `src/zitadel/components/smtp.ts`, following the existing pattern of `frontend.ts` and `token-action.ts`.
+
+#### Scenario: Component instantiation
+
+- **WHEN** the `Zitadel` orchestrator class is constructed
+- **THEN** it SHALL instantiate the SMTP component with environment-specific sender address and the Postmark Server API Token
+- **AND** the SMTP component SHALL be exposed as a public readonly property
+
+### Requirement: Environment-specific Postmark Server separation
+
+Each environment (dev, prod) SHALL use a separate Postmark Server with an independent Server API Token. The token for each environment SHALL be stored in the corresponding Pulumi ESC environment.
+
+#### Scenario: Dev and prod use different API tokens
+
+- **WHEN** comparing the `postmark.serverApiToken` values across dev and prod ESC environments
+- **THEN** the values SHALL be different (each environment has its own Postmark Server token)
+
+## Architecture
+
+### Components
+
+- **SmtpComponent** (`src/zitadel/components/smtp.ts`): Pulumi ComponentResource managing the `zitadel.SmtpConfig` resource
+- **Zitadel orchestrator** (`src/zitadel/index.ts`): Instantiates SmtpComponent with environment-specific config
+
+### Configuration
+
+| ESC Key | Description |
+|---|---|
+| `pulumiConfig.postmark.serverApiToken` | Postmark Server API Token (secret) |
+
+### DNS Records
+
+| Environment | Record Type | Name | Value |
+|---|---|---|---|
+| prod | TXT | `<selector>._domainkey.mail.liverty-music.app` | DKIM public key |
+| prod | CNAME | `pm-bounces.mail.liverty-music.app` | `pm.mtasv.net` |
+| dev | TXT | `<selector>._domainkey.mail.dev.liverty-music.app` | DKIM public key |
+| dev | CNAME | `pm-bounces.mail.dev.liverty-music.app` | `pm.mtasv.net` |
+
+## Dependencies
+
+- `@pulumiverse/zitadel` - Zitadel Pulumi provider (SmtpConfig resource)
+- Postmark SMTP endpoint (`smtp.postmarkapp.com:587`)
+- Cloudflare DNS (prod records)
+- GCP Cloud DNS (dev records)

--- a/openspec/specs/secret-management/spec.md
+++ b/openspec/specs/secret-management/spec.md
@@ -108,6 +108,28 @@ The backend Deployment SHALL consume secrets from the K8s Secret via `envFrom: s
 - **WHEN** the `backend-secrets` K8s Secret does not exist
 - **THEN** the pod fails to start with a clear error indicating the missing secret reference
 
+### Requirement: Postmark Server API Token in Pulumi ESC
+
+The Postmark Server API Token SHALL be stored in Pulumi ESC at the environment level (not common) under `pulumiConfig.postmark.serverApiToken` as a secret. Postmark uses the same token as both the SMTP username and password, so a single config field is sufficient.
+
+**Rationale**: Zitadel Cloud connects to Postmark SMTP directly, not via K8s pods. The token does not need to be provisioned in GCP Secret Manager or delivered via ESO. Pulumi ESC is the correct store for infrastructure-only secrets consumed during `pulumi up`.
+
+#### Scenario: Setting dev Postmark token
+
+- **WHEN** configuring the dev environment
+- **THEN** `esc env set liverty-music/dev pulumiConfig.postmark.serverApiToken "<value>" --secret` stores the Postmark Server API Token as encrypted
+
+#### Scenario: Setting prod Postmark token
+
+- **WHEN** configuring the prod environment
+- **THEN** `esc env set liverty-music/prod pulumiConfig.postmark.serverApiToken "<value>" --secret` stores the Postmark Server API Token as encrypted
+
+#### Scenario: Credentials are not in GCP Secret Manager
+
+- **WHEN** the Postmark Server API Token is needed
+- **THEN** it SHALL be consumed directly by Pulumi via ESC config
+- **AND** it SHALL NOT be provisioned as a GCP Secret Manager secret (Zitadel Cloud connects to SMTP directly, not via K8s pods)
+
 ### Requirement: Secret rotation propagation
 
 Secret updates in GCP Secret Manager SHALL propagate to running backend pods via automatic Deployment rolling restart.


### PR DESCRIPTION
## 🔗 Related Issue

N/A — follow-up to #275 (email verification spec)

## 📝 Summary of Changes

- Rewrite all email-provider-setup change artifacts (proposal, design, tasks, delta specs) from Japanese to English
- Update specs to reflect the `serverApiToken` refactor (replacing `smtpUser`/`smtpPassword` with a single Postmark Server API Token)
- Sync delta specs to main specs: create new `email-provider` capability spec, add Postmark token requirement to `secret-management` spec
- Archive the completed `email-provider-setup` change

## ✅ Self-Checklist

- [x] I have linked the related issue.
- [x] I have updated the relevant documentation (e.g., `README.md`) if needed.
- [x] I have run `buf lint` and `buf format` locally and all checks have passed.
- [x] My proto definitions follow the project's style guidelines and validation rules.
- [x] Breaking changes have been justified and documented if applicable.
