### PR TITLE
docs: sync extract-shared-custom-elements specs and archive

### DIFF
--- a/openspec/changes/archive/2026-03-18-extract-shared-custom-elements/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-18-extract-shared-custom-elements/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-17

--- a/openspec/changes/archive/2026-03-18-extract-shared-custom-elements/design.md
+++ b/openspec/changes/archive/2026-03-18-extract-shared-custom-elements/design.md
@@ -1,0 +1,120 @@
+## Context
+
+The Aurelia 2 frontend has grown to 25 components and 9 routes. Dialog/sheet patterns were implemented independently per feature, resulting in 5 separate dialog implementations with nearly identical CSS for backdrop, handle-bar, slide-in transitions, and scroll containers. The event-detail-sheet was recently optimized to use the Popover API with CSS scroll-snap dismiss — this is the gold standard implementation that all dialogs should adopt.
+
+Current state:
+- **event-detail-sheet**: Popover API, scroll-snap dismiss, backdrop opacity linked to scroll progress
+- **user-home-selector**: `showModal()` API, CSS translate transition, backdrop click dismiss
+- **settings language-selector**: Copy-pasted CSS from user-home-selector (~80 lines)
+- **hype-notification-dialog**: `showModal()`, centered, no transition
+- **error-banner**: `showModal()`, centered, no transition
+- **tickets center-dialogs**: `showModal()`, centered, no transition
+- **notification-prompt / pwa-install-prompt**: `popover="manual"`, top-positioned, 99% identical CSS
+
+The app uses CUBE CSS methodology with `@layer` cascade ordering and `@scope` for component isolation.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Eliminate ~350+ lines of duplicated CSS across dialog, prompt, and spinner patterns
+- Create Storybook-testable primitive CEs that enforce consistent UX
+- Simplify DOM structure by removing redundant wrapper elements
+- Establish `<bottom-sheet>` as the single dialog primitive for all overlay content
+- Rename components to match their actual UX roles (snack-bar, toast)
+
+**Non-Goals:**
+- Refactoring business logic within consuming components (ViewModels stay as-is)
+- Extracting button styles into a CE (deferred to a follow-up change)
+- Adding new features to any of the consolidated components
+- Changing visual design or animations beyond what's needed for unification
+
+## Decisions
+
+### D1: All dialogs become bottom-sheets (no center dialog variant)
+
+The `<bottom-sheet>` CE uses the Popover API exclusively. All current center-dialog usages (hype-notification-dialog, error-banner, tickets QR/generating dialogs) migrate to bottom-sheet presentation.
+
+**Rationale**: Mobile-first app where thumb reach matters. Bottom sheets are the standard mobile pattern for contextual content. Maintaining two presentation modes adds complexity for marginal benefit.
+
+**Alternative considered**: Keep a `position` bindable (`center` | `bottom`). Rejected — adds API surface for a pattern we want to eliminate.
+
+### D2: Popover API over `showModal()`
+
+All `<bottom-sheet>` instances use `popover="auto"` (light dismiss) by default, with `popover="manual"` for non-dismissable cases. No `showModal()` usage.
+
+**Rationale**: Popover API provides free light dismiss (Escape, click-outside, Android back gesture) without manual event handling. The event-detail-sheet already proves this works well. `showModal()` requires manual backdrop-click and cancel-event handling.
+
+**Migration for user-home-selector**: Replace `showModal()`/`close()` with `showPopover()`/`hidePopover()`. Remove `handleCancel()` and `handleBackdropClick()` methods.
+
+### D3: Scroll-snap dismiss for all bottom-sheets
+
+Every `<bottom-sheet>` gets the scroll-snap dismiss zone (swipe down to close). The `dismissable` bindable controls whether the dismiss zone is rendered.
+
+**Rationale**: Consistent gesture-based UX across all sheets. Users learn one interaction pattern.
+
+### D4: `<bottom-sheet>` API — minimal bindables
+
+```typescript
+export class BottomSheet {
+  @bindable open = false      // two-way: controls visibility
+  @bindable dismissable = true // false: no dismiss zone, popover="manual"
+}
+```
+
+The CE dispatches a `'sheet-closed'` CustomEvent when dismissed (light dismiss, scroll-snap, or backdrop click). The parent responds by setting `open = false`.
+
+**Rationale**: Two bindables cover all current use cases. `open` is the universal control. `dismissable` handles onboarding lock-in and required-selection scenarios.
+
+### D5: `<toast>` replaces notification-prompt + pwa-install-prompt
+
+A single `<toast>` CE with `popover="manual"` positioned at the top of the viewport. Content is fully slotted.
+
+```typescript
+export class Toast {
+  @bindable open = false
+}
+```
+
+**Rationale**: The two prompt components have identical HTML structure and 99% identical CSS. The only difference is the icon (emoji vs SVG) — handled by slotting.
+
+### D6: `toast-notification` renamed to `<snack-bar>`
+
+Rename only — no functional changes. The existing `Toast` class in `toast.ts` is renamed to `Snack` (or `SnackMessage`) to avoid collision with the new `<toast>` CE.
+
+**Rationale**: "Snack bar" accurately describes an auto-dismissing notification at the bottom. "Toast" describes a user-action banner at the top. This aligns with Material Design terminology.
+
+### D7: `<loading-spinner>` as standalone CE
+
+```typescript
+export class LoadingSpinner {
+  @bindable size: 'sm' | 'md' | 'lg' = 'md'
+}
+```
+
+HTML: `<output role="status" aria-busy="true"><span class="spinner"></span></output>`
+
+**Rationale**: Spinner is a visual primitive like `<svg-icon>`. It has 6 CSS properties — this is a Block in CUBE terms, not a utility. CE enables Storybook isolation and consistent ARIA semantics.
+
+### D8: `<state-placeholder>` simplified to icon + slot
+
+```typescript
+export class StatePlaceholder {
+  @bindable icon = ''
+}
+```
+
+All content (title, description, buttons, spinner) goes through `<au-slot>`. Remove dead `ctaLabel` bindable and `title`/`description` bindables.
+
+**Rationale**: Current `title`/`description` bindables duplicate what `<au-slot>` already provides. Most usages already slot custom content. Single `icon` bindable remains because every state-placeholder uses an icon at the top.
+
+## Risks / Trade-offs
+
+**[R1] Center-dialog content may feel awkward in bottom-sheet** → Small content (hype-notification-dialog) will have a short bottom-sheet. This is acceptable — mobile apps commonly show small bottom sheets. The content fills naturally with `max-block-size: fit-content` on the sheet body.
+
+**[R2] Popover API browser support** → Popover API is Baseline 2024 (Chrome 114+, Safari 17+, Firefox 125+). The app already uses it in event-detail-sheet without polyfill. No new risk.
+
+**[R3] Scroll-snap dismiss on short content** → If the sheet body is shorter than the viewport, the dismiss zone scroll distance is minimal. Mitigation: ensure `min-block-size` on the sheet-page so there's always enough scroll travel for the snap engine.
+
+**[R4] Renaming toast-notification → snack-bar** → All import paths and template references must be updated. Grep for `toast-notification` and `Toast` class references. The `Toast` EventAggregator event class rename to `Snack`/`SnackMessage` touches ~8 files.
+
+**[R5] Removing title/description bindables from state-placeholder** → All current usages must migrate to slotted content. This is straightforward but touches 4-5 template files.

--- a/openspec/changes/archive/2026-03-18-extract-shared-custom-elements/proposal.md
+++ b/openspec/changes/archive/2026-03-18-extract-shared-custom-elements/proposal.md
@@ -1,0 +1,40 @@
+## Why
+
+The frontend has accumulated significant CSS duplication and structural repetition across dialog, prompt, and state-display components. Five separate dialog implementations share nearly identical backdrop/handle-bar/slide-in CSS (~200 lines duplicated). Two prompt components have 99% identical CSS (~90 lines). Spinner and empty-state patterns are independently re-implemented in multiple route CSS files. Extracting shared Custom Elements eliminates this duplication, creates Storybook-testable primitives, and simplifies the DOM structure across the app.
+
+## What Changes
+
+- **New `<bottom-sheet>` CE**: Unifies all dialog/modal/sheet implementations (event-detail-sheet, user-home-selector, language-selector in settings, hype-notification-dialog, error-banner, tickets center-dialogs) into a single CE using the popover API + scroll-snap dismiss pattern from event-detail-sheet.
+- **New `<toast>` CE**: Merges notification-prompt and pwa-install-prompt into a single popover="manual" top-banner CE. Replaces both existing components.
+- **Rename `toast-notification` to `<snack-bar>`**: The existing auto-dismissing notification component gets a name that accurately reflects its role (snackbar pattern), freeing the "toast" name for the prompt banner CE.
+- **New `<loading-spinner>` CE**: Extracts the repeated spinner block pattern (currently duplicated in tickets-route, my-artists-route, auth-callback-route) into a standalone CE with size variants. Enables independent Storybook testing.
+- **Simplify `<state-placeholder>`**: Remove unused `ctaLabel` bindable and `title`/`description` bindables. Keep only `@bindable icon` and use `<au-slot>` for all content. Loading states use slotted `<loading-spinner>` instead of custom inline markup.
+- **Delete redundant CSS**: ~350+ lines of duplicated CSS removed from component and route files after consolidation.
+
+## Capabilities
+
+### New Capabilities
+
+- `bottom-sheet-ce`: Shared bottom-sheet Custom Element providing popover-based slide-up dialog with scroll-snap dismiss, backdrop opacity fade, and handle-bar.
+- `toast-ce`: Shared toast Custom Element providing popover="manual" top-banner for user-action prompts (notification permission, PWA install).
+- `loading-spinner-ce`: Shared loading-spinner Custom Element providing animated spinner with size variants (sm, md, lg).
+
+### Modified Capabilities
+
+- `design-system`: Addition of three new shared CEs to the component library; rename of toast-notification to snack-bar.
+- `semantic-dom`: Simplified DOM structure across dialog/prompt/state components by removing redundant wrapper elements.
+
+## Impact
+
+- **Frontend components** (6 deleted/merged, 3 new, 1 renamed, 1 simplified):
+  - Deleted: standalone dialog CSS in event-detail-sheet, user-home-selector, hype-notification-dialog, error-banner, notification-prompt, pwa-install-prompt
+  - New: `components/bottom-sheet/`, `components/toast/`, `components/loading-spinner/`
+  - Renamed: `components/toast-notification/` → `components/snack-bar/`
+  - Simplified: `components/state-placeholder/`
+- **Frontend routes** (CSS reduction):
+  - settings-route.css: ~140 lines removed (language-selector sheet CSS)
+  - tickets-route.css: ~35 lines removed (spinner + center-dialog CSS)
+  - my-artists-route.css: ~18 lines removed (spinner + state-center CSS)
+- **Import references**: All files importing renamed/deleted components need import path updates.
+- **Storybook**: New stories needed for bottom-sheet, toast, loading-spinner CEs.
+- **No backend or API changes**.

--- a/openspec/changes/archive/2026-03-18-extract-shared-custom-elements/specs/bottom-sheet-ce/spec.md
+++ b/openspec/changes/archive/2026-03-18-extract-shared-custom-elements/specs/bottom-sheet-ce/spec.md
@@ -1,0 +1,76 @@
+## ADDED Requirements
+
+### Requirement: Bottom Sheet Custom Element
+The system SHALL provide a `<bottom-sheet>` custom element as the single dialog primitive for all overlay content, using the Popover API with CSS scroll-snap dismiss.
+
+#### Scenario: Basic open/close via bindable
+- **WHEN** `<bottom-sheet open.bind="isOpen">` has `open` set to `true`
+- **THEN** the CE SHALL call `showPopover()` on the internal `<dialog>` element
+- **AND** the sheet SHALL animate in from the bottom via CSS `transform: translateY(100%)` → `translateY(0)` using `@starting-style`
+- **WHEN** `open` is set to `false`
+- **THEN** the CE SHALL call `hidePopover()` and the sheet SHALL animate out
+
+#### Scenario: Scroll-snap dismiss
+- **WHEN** the sheet is open and `dismissable` is `true`
+- **THEN** a dismiss zone SHALL be rendered above the sheet content as a scroll-snap target
+- **AND** swiping down SHALL scroll to the dismiss zone, triggering close on `scrollend`
+- **AND** the `::backdrop` opacity SHALL track scroll progress in real-time via a CSS custom property
+
+#### Scenario: Non-dismissable mode
+- **WHEN** `dismissable` is `false`
+- **THEN** the CE SHALL use `popover="manual"` instead of `popover="auto"`
+- **AND** the dismiss zone SHALL NOT be rendered
+- **AND** light dismiss (Escape, click-outside) SHALL be disabled
+
+#### Scenario: Dismissable mode with light dismiss
+- **WHEN** `dismissable` is `true` (default)
+- **THEN** the CE SHALL use `popover="auto"`
+- **AND** pressing Escape, clicking outside, or Android back gesture SHALL close the sheet
+- **AND** the CE SHALL handle the `toggle` event to detect light dismiss and dispatch `sheet-closed`
+
+#### Scenario: Sheet closed event
+- **WHEN** the sheet is closed by any mechanism (light dismiss, scroll-snap, programmatic)
+- **THEN** the CE SHALL dispatch a `sheet-closed` CustomEvent with `bubbles: true`
+- **AND** the parent component SHALL respond by setting `open` to `false`
+
+#### Scenario: Backdrop click dismiss
+- **WHEN** the user clicks the transparent area above the sheet card
+- **THEN** the CE SHALL initiate a smooth scroll to the dismiss zone
+- **AND** the sheet SHALL close via the scroll-snap dismiss mechanism
+
+#### Scenario: Handle bar rendering
+- **WHEN** the sheet is open
+- **THEN** a handle bar (2.5rem wide, 0.25rem tall, rounded) SHALL be rendered at the top of the sheet body
+- **AND** the handle bar SHALL be styled with `oklch(100% 0 0deg / 20%)` background
+
+#### Scenario: Sheet body structure
+- **WHEN** the sheet is rendered
+- **THEN** the sheet body SHALL have `border-radius: var(--radius-sheet)` on top corners
+- **AND** background SHALL be `var(--color-surface-raised)`
+- **AND** box-shadow SHALL be `var(--shadow-sheet)`
+- **AND** `max-block-size` SHALL be `90dvh`
+- **AND** overflow-y SHALL be `auto` for scrollable content
+
+#### Scenario: Slotted content
+- **WHEN** content is placed inside `<bottom-sheet>`
+- **THEN** it SHALL be projected via `<au-slot>` into the sheet body below the handle bar
+
+#### Scenario: Focus management
+- **WHEN** the sheet opens
+- **THEN** the sheet `<dialog>` element SHALL receive focus
+- **WHEN** the sheet closes
+- **THEN** focus SHALL return to the element that was focused before the sheet opened
+
+#### Scenario: History integration
+- **WHEN** the sheet opens
+- **THEN** a history entry SHALL NOT be pushed by the CE itself
+- **AND** consuming components MAY manage history state independently via `open` binding
+
+#### Scenario: Reduced motion
+- **WHEN** `prefers-reduced-motion: reduce` is active
+- **THEN** all transition durations SHALL be reduced to `var(--transition-fast)`
+
+#### Scenario: Detach cleanup
+- **WHEN** the CE is detached from the DOM while the sheet is open
+- **THEN** all event listeners (popstate, toggle) SHALL be removed
+- **AND** no memory leaks SHALL occur

--- a/openspec/changes/archive/2026-03-18-extract-shared-custom-elements/specs/design-system/spec.md
+++ b/openspec/changes/archive/2026-03-18-extract-shared-custom-elements/specs/design-system/spec.md
@@ -1,0 +1,108 @@
+## MODIFIED Requirements
+
+### Requirement: State Placeholder Component
+The system SHALL provide a `<state-placeholder>` custom element for displaying empty, error, and informational states with a consistent centered layout.
+
+#### Scenario: Rendering with icon only
+- **WHEN** `<state-placeholder icon="music">` is rendered with slotted content
+- **THEN** the component SHALL display an xl-sized svg-icon
+- **AND** the slotted content SHALL be projected via `<au-slot>` below the icon
+- **AND** the content SHALL be vertically and horizontally centered
+
+#### Scenario: No icon
+- **WHEN** `<state-placeholder>` is rendered without an `icon` attribute
+- **THEN** no svg-icon SHALL be rendered
+- **AND** only the slotted content SHALL be displayed
+
+#### Scenario: Custom content via slot
+- **WHEN** child content is placed inside `<state-placeholder>`
+- **THEN** the content SHALL be projected via `<au-slot>`
+- **AND** this SHALL allow pages to provide titles, descriptions, buttons, links, or `<loading-spinner>` elements
+
+## REMOVED Requirements
+
+### Requirement: State Placeholder Component — title and description bindables
+**Reason**: Replaced by `<au-slot>` content projection. The `title`, `description`, and `ctaLabel` bindables are redundant with slotted content and add unnecessary API surface.
+**Migration**: Replace `<state-placeholder title="X" description="Y">` with `<state-placeholder icon="..."><h2>X</h2><p>Y</p></state-placeholder>`.
+
+## MODIFIED Requirements
+
+### Requirement: Toast Notification Component
+The system SHALL provide a `<snack-bar>` custom element (renamed from `<toast-notification>`) that displays transient status messages using the Popover API, with each snack as an independent `popover="manual"` element managed by browser-native entry/exit transitions.
+
+#### Scenario: Snack display on event publish
+- **WHEN** a `Snack` event is published via `IEventAggregator`
+- **THEN** the component SHALL create a new element with `popover="manual"` attribute
+- **AND** the element SHALL be made visible via `showPopover()`
+- **AND** the snack SHALL display the event's `message` text and an icon matching the `severity`
+
+#### Scenario: Auto-dismiss after duration
+- **WHEN** a snack is displayed
+- **THEN** the component SHALL call `hidePopover()` after the snack's `durationMs` (default 2500ms)
+- **AND** the CSS exit transition SHALL play before the element is removed from the Top Layer
+
+#### Scenario: Programmatic dismiss via handle
+- **WHEN** a caller invokes `snack.handle.dismiss()`
+- **THEN** `hidePopover()` SHALL be called immediately
+- **AND** the auto-dismiss timer SHALL be cleared
+- **AND** the `onDismiss` callback SHALL fire exactly once
+
+#### Scenario: DOM cleanup after exit transition
+- **WHEN** a snack's `hidePopover()` triggers and the CSS exit transition completes
+- **THEN** the popover's `toggle` event SHALL fire with `newState === 'closed'`
+- **AND** the component SHALL remove the snack from its internal array
+- **AND** the component SHALL NOT rely on `transitionend` events for cleanup
+
+#### Scenario: Multiple simultaneous snacks
+- **WHEN** multiple `Snack` events are published in rapid succession
+- **THEN** each snack SHALL be an independent popover element in the Top Layer
+- **AND** dismissing one snack SHALL NOT interfere with other snacks' transitions or lifecycle
+- **AND** snacks SHALL stack vertically in a flex-column layout container
+
+#### Scenario: Snack action button
+- **WHEN** a `Snack` event includes an `action` option with `label` and `callback`
+- **THEN** the snack SHALL display an action button with the given label
+- **AND** clicking the button SHALL invoke the callback and dismiss the snack
+
+#### Scenario: Reduced motion preference
+- **WHEN** `prefers-reduced-motion: reduce` is active
+- **THEN** the snack SHALL still be dismissed and removed correctly
+- **AND** a `@media (prefers-reduced-motion: reduce)` CSS rule SHALL set `transition-duration: 0s` on `.snack-item` to suppress animation
+
+#### Scenario: CSS entry animation
+- **WHEN** a snack popover is opened via `showPopover()`
+- **THEN** the snack SHALL animate from `opacity: 0; transform: translateY(-1rem)` to `opacity: 1; transform: translateY(0)`
+- **AND** the entry state SHALL be defined via `@starting-style` inside `:popover-open`
+
+#### Scenario: CSS exit animation
+- **WHEN** a snack popover is closed via `hidePopover()`
+- **THEN** the snack SHALL animate from `opacity: 1; transform: translateY(0)` to `opacity: 0; transform: translateY(-1rem)`
+- **AND** the transition SHALL include `display allow-discrete` and `overlay allow-discrete` to keep the element visible in the Top Layer until the animation completes
+
+#### Scenario: Snack severity visual variants
+- **WHEN** a snack has severity `info`
+- **THEN** the background SHALL use the brand gradient (`--color-brand-primary` to `--color-brand-secondary`)
+- **WHEN** a snack has severity `warning`
+- **THEN** the background SHALL use a warm amber gradient
+- **WHEN** a snack has severity `error`
+- **THEN** the background SHALL use a deep red gradient
+
+#### Scenario: Accessibility
+- **WHEN** a snack is displayed
+- **THEN** the snack element SHALL have `role="status"` for screen reader announcement
+- **AND** the snack SHALL be non-modal (SHALL NOT make background content inert)
+
+#### Scenario: Top Layer stacking with dialogs
+- **WHEN** a snack is shown while a `<dialog>` is open via `showModal()`
+- **THEN** the snack popover SHALL appear above the dialog because `showPopover()` appends to the top of the Top Layer stack
+- **AND** no manual `hidePopover()`/`showPopover()` re-insertion SHALL be needed
+
+## RENAMED Requirements
+
+### Requirement: Toast Notification Component
+- **FROM:** Toast Notification Component (`<toast-notification>`)
+- **TO:** Snack Bar Component (`<snack-bar>`)
+
+### Requirement: Toast event class
+- **FROM:** `Toast` class in `toast.ts`
+- **TO:** `Snack` class in `snack.ts`

--- a/openspec/changes/archive/2026-03-18-extract-shared-custom-elements/specs/loading-spinner-ce/spec.md
+++ b/openspec/changes/archive/2026-03-18-extract-shared-custom-elements/specs/loading-spinner-ce/spec.md
@@ -1,0 +1,35 @@
+## ADDED Requirements
+
+### Requirement: Loading Spinner Custom Element
+The system SHALL provide a `<loading-spinner>` custom element as a visual primitive for animated loading indicators with size variants.
+
+#### Scenario: Default rendering
+- **WHEN** `<loading-spinner>` is rendered without attributes
+- **THEN** the CE SHALL display a circular spinner with `md` size (2rem)
+- **AND** the spinner SHALL use a border-based animation: solid border with one transparent side
+- **AND** the border color SHALL derive from `var(--color-brand-accent)` at 30% opacity with `border-block-start-color` at full opacity
+- **AND** `animation: spin 0.8s linear infinite` SHALL be applied
+
+#### Scenario: Size variants
+- **WHEN** `<loading-spinner size="sm">` is rendered
+- **THEN** the spinner SHALL be 1rem with 1.5px border
+- **WHEN** `<loading-spinner size="md">` is rendered
+- **THEN** the spinner SHALL be 2rem with 2px border
+- **WHEN** `<loading-spinner size="lg">` is rendered
+- **THEN** the spinner SHALL be 2.5rem with 3px border
+
+#### Scenario: Accessibility semantics
+- **WHEN** the spinner is rendered
+- **THEN** the host element SHALL be an `<output>` with `role="status"` and `aria-busy="true"`
+
+#### Scenario: Color inheritance
+- **WHEN** the spinner is placed inside a container with custom `--color-brand-accent`
+- **THEN** the spinner border color SHALL inherit from that custom property
+
+#### Scenario: Reduced motion
+- **WHEN** `prefers-reduced-motion: reduce` is active
+- **THEN** the spin animation SHALL be paused or removed
+
+#### Scenario: CUBE CSS layer
+- **WHEN** the spinner CSS is loaded
+- **THEN** all styles SHALL be defined within `@layer block` using `@scope (loading-spinner)`

--- a/openspec/changes/archive/2026-03-18-extract-shared-custom-elements/specs/semantic-dom/spec.md
+++ b/openspec/changes/archive/2026-03-18-extract-shared-custom-elements/specs/semantic-dom/spec.md
@@ -1,0 +1,22 @@
+## ADDED Requirements
+
+### Requirement: Dialog consolidation to bottom-sheet CE
+All interactive overlay components SHALL use `<bottom-sheet>` as their dialog primitive instead of implementing custom `<dialog>` elements with duplicated CSS.
+
+#### Scenario: Existing dialog components migrated
+- **WHEN** event-detail-sheet, user-home-selector, hype-notification-dialog, error-banner, or any route-local dialog renders an overlay
+- **THEN** the overlay SHALL be rendered via `<bottom-sheet open.bind="..." dismissable.bind="...">` with slotted content
+- **AND** the component SHALL NOT contain its own dialog positioning, backdrop, handle-bar, or slide-in CSS
+
+#### Scenario: Route-local dialogs eliminated
+- **WHEN** settings-route renders the language selector or tickets-route renders QR/generating dialogs
+- **THEN** these SHALL use `<bottom-sheet>` with slotted content
+- **AND** the route CSS SHALL NOT contain dialog/modal/sheet CSS rules
+
+### Requirement: Prompt consolidation to toast CE
+All top-positioned user-action prompts SHALL use `<toast>` as their presentation primitive.
+
+#### Scenario: Existing prompt components migrated
+- **WHEN** notification-prompt or pwa-install-prompt renders a permission/install banner
+- **THEN** the banner SHALL be rendered via `<toast open.bind="...">` with slotted content
+- **AND** the component SHALL NOT contain its own popover positioning or banner CSS

--- a/openspec/changes/archive/2026-03-18-extract-shared-custom-elements/specs/toast-ce/spec.md
+++ b/openspec/changes/archive/2026-03-18-extract-shared-custom-elements/specs/toast-ce/spec.md
@@ -1,0 +1,40 @@
+## ADDED Requirements
+
+### Requirement: Toast Custom Element
+The system SHALL provide a `<toast>` custom element as a top-positioned popover banner for user-action prompts (notification permission, PWA install).
+
+#### Scenario: Basic open/close via bindable
+- **WHEN** `<toast open.bind="isVisible">` has `open` set to `true`
+- **THEN** the CE SHALL call `showPopover()` on the internal `<dialog popover="manual">`
+- **AND** the banner SHALL appear at the top of the viewport with slide-down animation
+- **WHEN** `open` is set to `false`
+- **THEN** the CE SHALL call `hidePopover()`
+
+#### Scenario: Fixed top positioning
+- **WHEN** the toast is open
+- **THEN** the element SHALL be positioned at `inset-block-start: 0` with `inset-inline: 1rem`
+- **AND** background SHALL be `var(--color-surface-raised)`
+- **AND** border SHALL be `1px solid var(--color-border-subtle)`
+- **AND** border-radius SHALL be `var(--radius-card)`
+- **AND** box-shadow SHALL be `var(--shadow-card-glow)`
+
+#### Scenario: Slotted content
+- **WHEN** content is placed inside `<toast>`
+- **THEN** it SHALL be projected via `<au-slot>` into the popover body
+- **AND** consuming components SHALL provide their own icon, title, description, and action buttons
+
+#### Scenario: Non-modal overlay
+- **WHEN** the toast is displayed
+- **THEN** it SHALL use `popover="manual"` (no light dismiss)
+- **AND** background content SHALL remain interactive (not inert)
+
+#### Scenario: Entry/exit animation
+- **WHEN** the toast opens
+- **THEN** it SHALL animate via `@starting-style` from `opacity: 0; translate: 0 -1rem` to `opacity: 1; translate: 0 0`
+- **WHEN** the toast closes
+- **THEN** it SHALL transition to `opacity: 0; translate: 0 -1rem`
+- **AND** `display` and `overlay` transitions SHALL use `allow-discrete`
+
+#### Scenario: Toast closed event
+- **WHEN** the toast is closed
+- **THEN** the CE SHALL dispatch a `toast-closed` CustomEvent with `bubbles: true`

--- a/openspec/changes/archive/2026-03-18-extract-shared-custom-elements/tasks.md
+++ b/openspec/changes/archive/2026-03-18-extract-shared-custom-elements/tasks.md
@@ -1,0 +1,109 @@
+## 1. Create `<bottom-sheet>` CE
+
+- [x] 1.1 Create `components/bottom-sheet/bottom-sheet.ts` — ViewModel with `@bindable open`, `@bindable dismissable`, popover API, scroll-snap dismiss, backdrop opacity tracking, focus management, toggle event handling, detach cleanup
+- [x] 1.2 Create `components/bottom-sheet/bottom-sheet.html` — `<dialog>` with scroll-snap container, dismiss zone, sheet-page, sheet-body, handle-bar, `<au-slot>`
+- [x] 1.3 Create `components/bottom-sheet/bottom-sheet.css` — Extract shared dialog/backdrop/handle-bar/transition CSS from event-detail-sheet.css into `@layer block` with `@scope (bottom-sheet)`
+- [x] 1.4 Register `<bottom-sheet>` in `main.ts`
+
+## 2. Create `<loading-spinner>` CE
+
+- [x] 2.1 Create `components/loading-spinner/loading-spinner.ts` — ViewModel with `@bindable size: 'sm' | 'md' | 'lg'`
+- [x] 2.2 Create `components/loading-spinner/loading-spinner.html` — `<output role="status" aria-busy="true">` with spinner element
+- [x] 2.3 Create `components/loading-spinner/loading-spinner.css` — Spinner block styles with size variants via `data-size`, reduced motion support
+- [x] 2.4 Register `<loading-spinner>` in `main.ts`
+
+## 3. Create `<toast>` CE
+
+- [x] 3.1 Create `components/toast/toast.ts` — ViewModel with `@bindable open`, popover="manual" management, `toast-closed` event dispatch
+- [x] 3.2 Create `components/toast/toast.html` — `<dialog popover="manual">` with `<au-slot>` for content
+- [x] 3.3 Create `components/toast/toast.css` — Top-positioned popover styles, entry/exit animation via `@starting-style`
+- [x] 3.4 Register `<toast>` in `main.ts`
+
+## 4. Rename `toast-notification` → `snack-bar`
+
+- [x] 4.1 Rename `components/toast-notification/` directory to `components/snack-bar/`
+- [x] 4.2 Rename all files: `toast-notification.*` → `snack-bar.*`
+- [x] 4.3 Rename ViewModel class `ToastNotification` → `SnackBar`
+- [x] 4.4 Rename `Toast` event class to `Snack` in `snack.ts` (was `toast.ts`)
+- [x] 4.5 Update all import references across the codebase (grep for `toast-notification`, `Toast`, `toast.ts`)
+- [x] 4.6 Update `main.ts` registration
+- [x] 4.7 Update CSS `@scope` selector from `toast-notification` to `snack-bar`
+
+## 5. Simplify `<state-placeholder>`
+
+- [x] 5.1 Remove `title`, `description`, `ctaLabel` bindables from `state-placeholder.ts` — keep only `@bindable icon`
+- [x] 5.2 Update `state-placeholder.html` — remove conditional `<h2>` and `<p>`, keep only `<svg-icon>` + `<au-slot>`
+- [x] 5.3 Remove `.state-title` and `.state-desc` from `state-placeholder.css`
+- [x] 5.4 Update all consumers to use slotted content instead of bindables (dashboard-route, tickets-route, my-artists-route)
+
+## 6. Migrate `event-detail-sheet` to `<bottom-sheet>`
+
+- [x] 6.1 Replace `<dialog>` in event-detail-sheet.html with `<bottom-sheet open.bind="isOpen" dismissable.bind="isDismissable">`
+- [x] 6.2 Move sheet content (hero, header, details, actions) into the `<au-slot>`
+- [x] 6.3 Remove dialog/backdrop/handle-bar/scroll-snap CSS from event-detail-sheet.css — keep only content-specific styles (hero, artist-header, detail-rows, buttons)
+- [x] 6.4 Simplify event-detail-sheet.ts — remove `showPopover()`/`hidePopover()`, scroll tracking, toggle event, popstate handling; listen for `sheet-closed` event instead
+- [x] 6.5 Handle history pushState/replaceState in event-detail-sheet.ts (CE-external concern)
+
+## 7. Migrate `user-home-selector` to `<bottom-sheet>`
+
+- [x] 7.1 Replace `<dialog>` in user-home-selector.html with `<bottom-sheet open.bind="isOpen" dismissable.bind="!required">`
+- [x] 7.2 Move selector content (handle, steps, grids) into the `<au-slot>`
+- [x] 7.3 Remove dialog/backdrop/handle-bar CSS from user-home-selector.css — keep only content-specific styles (selector-grid, selector-btn, etc.)
+- [x] 7.4 Simplify user-home-selector.ts — remove `showModal()`/`close()`, `handleBackdropClick()`, `handleCancel()`; use `open` binding + `sheet-closed` event
+
+## 8. Migrate `settings-route` language selector to `<bottom-sheet>`
+
+- [x] 8.1 Replace inline `<dialog class="language-selector">` in settings-route.html with `<bottom-sheet open.bind="languageSelectorOpen">`
+- [x] 8.2 Move language list content into the `<au-slot>`
+- [x] 8.3 Delete all `dialog.language-selector` CSS from settings-route.css (~140 lines)
+- [x] 8.4 Simplify settings-route.ts — remove `openLanguageSelector()`/`closeLanguageSelector()` dialog management; use `open` binding
+
+## 9. Migrate `hype-notification-dialog` to `<bottom-sheet>`
+
+- [x] 9.1 Replace `<dialog>` in hype-notification-dialog.html with `<bottom-sheet open.bind="active">`
+- [x] 9.2 Move notification content into the `<au-slot>`
+- [x] 9.3 Delete all dialog CSS from hype-notification-dialog.css — keep only content-specific styles
+- [x] 9.4 Simplify hype-notification-dialog.ts — remove `showModal()`/`close()`; use `open` binding
+
+## 10. Migrate `error-banner` to `<bottom-sheet>`
+
+- [x] 10.1 Replace `<dialog>` in error-banner.html with `<bottom-sheet open.bind="errorBoundary.currentError" dismissable.bind="false">`
+- [x] 10.2 Move error content into the `<au-slot>`
+- [x] 10.3 Delete dialog CSS from error-banner.css — keep only content-specific styles
+- [x] 10.4 Simplify error-banner.ts — remove `showModal()`/`close()` in `@watch`; use `open` binding
+
+## 11. Migrate `tickets-route` dialogs to `<bottom-sheet>`
+
+- [x] 11.1 Replace generating-dialog and qr-dialog in tickets-route.html with `<bottom-sheet>` instances
+- [x] 11.2 Delete `.center-dialog`, `.dialog-card`, `.dialog-title`, `.dialog-desc`, `.dialog-hint`, `.dialog-close-btn` CSS from tickets-route.css
+- [x] 11.3 Delete `.state-center`, `.spinner`, `.spinner-lg`, `.spinner-sm`, `.state-text` CSS from tickets-route.css
+- [x] 11.4 Replace inline loading markup with `<state-placeholder>` + `<loading-spinner>`
+
+## 12. Migrate `notification-prompt` to `<toast>`
+
+- [x] 12.1 Replace `<dialog popover="manual">` in notification-prompt.html with `<toast open.bind="isVisible">`
+- [x] 12.2 Move prompt content (emoji, title, description, buttons) into the `<au-slot>`
+- [x] 12.3 Delete all popover/banner CSS from notification-prompt.css — keep only content-specific styles
+- [x] 12.4 Simplify notification-prompt.ts — remove `showPopover()`/`hidePopover()` management
+
+## 13. Migrate `pwa-install-prompt` to `<toast>`
+
+- [x] 13.1 Replace `<dialog popover="manual">` in pwa-install-prompt.html with `<toast open.bind="isVisible">`
+- [x] 13.2 Move prompt content (icon, title, description, buttons) into the `<au-slot>`
+- [x] 13.3 Delete all popover/banner CSS from pwa-install-prompt.css — keep only content-specific styles
+
+## 14. Migrate `my-artists-route` spinner/state
+
+- [x] 14.1 Replace inline spinner markup with `<loading-spinner>`
+- [x] 14.2 Delete `.spinner` CSS from my-artists-route.css (`.state-center` kept for loading layout)
+- [x] 14.3 Update empty state to use simplified `<state-placeholder icon="music">` with slotted content (already using slots)
+
+## 15. Verification
+
+- [x] 15.1 Run `make check` — lint + typecheck + unit tests pass (pre-existing warnings only; our changes clean)
+- [x] 15.2 Run `npm run build` — production build succeeds
+- [x] 15.3 Manual smoke test: open/close bottom-sheet on dashboard (event detail), settings (home selector, language selector), my-artists (hype notification), tickets (QR dialog)
+- [x] 15.4 Manual smoke test: notification-prompt and pwa-install-prompt display correctly as `<toast>`
+- [x] 15.5 Manual smoke test: snack-bar (renamed) still displays correctly
+- [x] 15.6 Manual smoke test: loading spinners render at correct sizes
+- [x] 15.7 Verify no orphaned CSS — grep for deleted class names across all files

--- a/openspec/specs/bottom-sheet-ce/spec.md
+++ b/openspec/specs/bottom-sheet-ce/spec.md
@@ -1,0 +1,82 @@
+# Bottom Sheet Custom Element
+
+## Purpose
+
+Provides a `<bottom-sheet>` custom element as the single dialog primitive for all overlay content, using the Popover API with CSS scroll-snap dismiss.
+
+## Requirements
+
+### Requirement: Bottom Sheet Custom Element
+The system SHALL provide a `<bottom-sheet>` custom element as the single dialog primitive for all overlay content, using the Popover API with CSS scroll-snap dismiss.
+
+#### Scenario: Basic open/close via bindable
+- **WHEN** `<bottom-sheet open.bind="isOpen">` has `open` set to `true`
+- **THEN** the CE SHALL call `showPopover()` on the internal `<dialog>` element
+- **AND** the sheet SHALL animate in from the bottom via CSS `transform: translateY(100%)` → `translateY(0)` using `@starting-style`
+- **WHEN** `open` is set to `false`
+- **THEN** the CE SHALL call `hidePopover()` and the sheet SHALL animate out
+
+#### Scenario: Scroll-snap dismiss
+- **WHEN** the sheet is open and `dismissable` is `true`
+- **THEN** a dismiss zone SHALL be rendered above the sheet content as a scroll-snap target
+- **AND** swiping down SHALL scroll to the dismiss zone, triggering close on `scrollend`
+- **AND** the `::backdrop` opacity SHALL track scroll progress in real-time via a CSS custom property
+
+#### Scenario: Non-dismissable mode
+- **WHEN** `dismissable` is `false`
+- **THEN** the CE SHALL use `popover="manual"` instead of `popover="auto"`
+- **AND** the dismiss zone SHALL NOT be rendered
+- **AND** light dismiss (Escape, click-outside) SHALL be disabled
+
+#### Scenario: Dismissable mode with light dismiss
+- **WHEN** `dismissable` is `true` (default)
+- **THEN** the CE SHALL use `popover="auto"`
+- **AND** pressing Escape, clicking outside, or Android back gesture SHALL close the sheet
+- **AND** the CE SHALL handle the `toggle` event to detect light dismiss and dispatch `sheet-closed`
+
+#### Scenario: Sheet closed event
+- **WHEN** the sheet is closed by any mechanism (light dismiss, scroll-snap, programmatic)
+- **THEN** the CE SHALL dispatch a `sheet-closed` CustomEvent with `bubbles: true`
+- **AND** the parent component SHALL respond by setting `open` to `false`
+
+#### Scenario: Backdrop click dismiss
+- **WHEN** the user clicks the transparent area above the sheet card
+- **THEN** the CE SHALL initiate a smooth scroll to the dismiss zone
+- **AND** the sheet SHALL close via the scroll-snap dismiss mechanism
+
+#### Scenario: Handle bar rendering
+- **WHEN** the sheet is open
+- **THEN** a handle bar (2.5rem wide, 0.25rem tall, rounded) SHALL be rendered at the top of the sheet body
+- **AND** the handle bar SHALL be styled with `oklch(100% 0 0deg / 20%)` background
+
+#### Scenario: Sheet body structure
+- **WHEN** the sheet is rendered
+- **THEN** the sheet body SHALL have `border-radius: var(--radius-sheet)` on top corners
+- **AND** background SHALL be `var(--color-surface-raised)`
+- **AND** box-shadow SHALL be `var(--shadow-sheet)`
+- **AND** `max-block-size` SHALL be `90dvh`
+- **AND** overflow-y SHALL be `auto` for scrollable content
+
+#### Scenario: Slotted content
+- **WHEN** content is placed inside `<bottom-sheet>`
+- **THEN** it SHALL be projected via `<au-slot>` into the sheet body below the handle bar
+
+#### Scenario: Focus management
+- **WHEN** the sheet opens
+- **THEN** the sheet `<dialog>` element SHALL receive focus
+- **WHEN** the sheet closes
+- **THEN** focus SHALL return to the element that was focused before the sheet opened
+
+#### Scenario: History integration
+- **WHEN** the sheet opens
+- **THEN** a history entry SHALL NOT be pushed by the CE itself
+- **AND** consuming components MAY manage history state independently via `open` binding
+
+#### Scenario: Reduced motion
+- **WHEN** `prefers-reduced-motion: reduce` is active
+- **THEN** all transition durations SHALL be reduced to `var(--transition-fast)`
+
+#### Scenario: Detach cleanup
+- **WHEN** the CE is detached from the DOM while the sheet is open
+- **THEN** all event listeners (popstate, toggle) SHALL be removed
+- **AND** no memory leaks SHALL occur

--- a/openspec/specs/design-system/spec.md
+++ b/openspec/specs/design-system/spec.md
@@ -153,19 +153,21 @@ The system SHALL provide a centralized `<svg-icon>` custom element as the single
 ### Requirement: State Placeholder Component
 The system SHALL provide a `<state-placeholder>` custom element for displaying empty, error, and informational states with a consistent centered layout.
 
-#### Scenario: Empty state display
-- **WHEN** `<state-placeholder icon="music" title="No artists" description="Start exploring">` is rendered
-- **THEN** the component SHALL display an xl-sized svg-icon, a title heading, and a description paragraph
+#### Scenario: Rendering with icon only
+- **WHEN** `<state-placeholder icon="music">` is rendered with slotted content
+- **THEN** the component SHALL display an xl-sized svg-icon
+- **AND** the slotted content SHALL be projected via `<au-slot>` below the icon
 - **AND** the content SHALL be vertically and horizontally centered
 
-#### Scenario: Conditional content rendering
-- **WHEN** any of `icon`, `title`, or `description` props are empty
-- **THEN** the corresponding element SHALL NOT be rendered (via `if.bind`)
+#### Scenario: No icon
+- **WHEN** `<state-placeholder>` is rendered without an `icon` attribute
+- **THEN** no svg-icon SHALL be rendered
+- **AND** only the slotted content SHALL be displayed
 
 #### Scenario: Custom content via slot
 - **WHEN** child content is placed inside `<state-placeholder>`
-- **THEN** the content SHALL be projected via `<au-slot>` below the description
-- **AND** this SHALL allow pages to provide custom CTA buttons or links
+- **THEN** the content SHALL be projected via `<au-slot>`
+- **AND** this SHALL allow pages to provide titles, descriptions, buttons, links, or `<loading-spinner>` elements
 
 ---
 
@@ -194,72 +196,72 @@ The system SHALL provide a `<page-shell>` custom element that standardizes the p
 
 ---
 
-### Requirement: Toast Notification Component
-The system SHALL provide a `<toast-notification>` custom element that displays transient status messages using the Popover API, with each toast as an independent `popover="manual"` element managed by browser-native entry/exit transitions.
+### Requirement: Snack Bar Component
+The system SHALL provide a `<snack-bar>` custom element (renamed from `<toast-notification>`) that displays transient status messages using the Popover API, with each snack as an independent `popover="manual"` element managed by browser-native entry/exit transitions.
 
-#### Scenario: Toast display on event publish
-- **WHEN** a `Toast` event is published via `IEventAggregator`
+#### Scenario: Snack display on event publish
+- **WHEN** a `Snack` event is published via `IEventAggregator`
 - **THEN** the component SHALL create a new element with `popover="manual"` attribute
 - **AND** the element SHALL be made visible via `showPopover()`
-- **AND** the toast SHALL display the event's `message` text and an icon matching the `severity`
+- **AND** the snack SHALL display the event's `message` text and an icon matching the `severity`
 
 #### Scenario: Auto-dismiss after duration
-- **WHEN** a toast is displayed
-- **THEN** the component SHALL call `hidePopover()` after the toast's `durationMs` (default 2500ms)
+- **WHEN** a snack is displayed
+- **THEN** the component SHALL call `hidePopover()` after the snack's `durationMs` (default 2500ms)
 - **AND** the CSS exit transition SHALL play before the element is removed from the Top Layer
 
 #### Scenario: Programmatic dismiss via handle
-- **WHEN** a caller invokes `toast.handle.dismiss()`
+- **WHEN** a caller invokes `snack.handle.dismiss()`
 - **THEN** `hidePopover()` SHALL be called immediately
 - **AND** the auto-dismiss timer SHALL be cleared
 - **AND** the `onDismiss` callback SHALL fire exactly once
 
 #### Scenario: DOM cleanup after exit transition
-- **WHEN** a toast's `hidePopover()` triggers and the CSS exit transition completes
+- **WHEN** a snack's `hidePopover()` triggers and the CSS exit transition completes
 - **THEN** the popover's `toggle` event SHALL fire with `newState === 'closed'`
-- **AND** the component SHALL remove the toast from its internal array
+- **AND** the component SHALL remove the snack from its internal array
 - **AND** the component SHALL NOT rely on `transitionend` events for cleanup
 
-#### Scenario: Multiple simultaneous toasts
-- **WHEN** multiple `Toast` events are published in rapid succession
-- **THEN** each toast SHALL be an independent popover element in the Top Layer
-- **AND** dismissing one toast SHALL NOT interfere with other toasts' transitions or lifecycle
-- **AND** toasts SHALL stack vertically in a flex-column layout container
+#### Scenario: Multiple simultaneous snacks
+- **WHEN** multiple `Snack` events are published in rapid succession
+- **THEN** each snack SHALL be an independent popover element in the Top Layer
+- **AND** dismissing one snack SHALL NOT interfere with other snacks' transitions or lifecycle
+- **AND** snacks SHALL stack vertically in a flex-column layout container
 
-#### Scenario: Toast action button
-- **WHEN** a `Toast` event includes an `action` option with `label` and `callback`
-- **THEN** the toast SHALL display an action button with the given label
-- **AND** clicking the button SHALL invoke the callback and dismiss the toast
+#### Scenario: Snack action button
+- **WHEN** a `Snack` event includes an `action` option with `label` and `callback`
+- **THEN** the snack SHALL display an action button with the given label
+- **AND** clicking the button SHALL invoke the callback and dismiss the snack
 
 #### Scenario: Reduced motion preference
 - **WHEN** `prefers-reduced-motion: reduce` is active
-- **THEN** the toast SHALL still be dismissed and removed correctly
-- **AND** a `@media (prefers-reduced-motion: reduce)` CSS rule SHALL set `transition-duration: 0s` on `.toast-item` to suppress animation
+- **THEN** the snack SHALL still be dismissed and removed correctly
+- **AND** a `@media (prefers-reduced-motion: reduce)` CSS rule SHALL set `transition-duration: 0s` on `.snack-item` to suppress animation
 
 #### Scenario: CSS entry animation
-- **WHEN** a toast popover is opened via `showPopover()`
-- **THEN** the toast SHALL animate from `opacity: 0; transform: translateY(-1rem)` to `opacity: 1; transform: translateY(0)`
+- **WHEN** a snack popover is opened via `showPopover()`
+- **THEN** the snack SHALL animate from `opacity: 0; transform: translateY(-1rem)` to `opacity: 1; transform: translateY(0)`
 - **AND** the entry state SHALL be defined via `@starting-style` inside `:popover-open`
 
 #### Scenario: CSS exit animation
-- **WHEN** a toast popover is closed via `hidePopover()`
-- **THEN** the toast SHALL animate from `opacity: 1; transform: translateY(0)` to `opacity: 0; transform: translateY(-1rem)`
+- **WHEN** a snack popover is closed via `hidePopover()`
+- **THEN** the snack SHALL animate from `opacity: 1; transform: translateY(0)` to `opacity: 0; transform: translateY(-1rem)`
 - **AND** the transition SHALL include `display allow-discrete` and `overlay allow-discrete` to keep the element visible in the Top Layer until the animation completes
 
-#### Scenario: Toast severity visual variants
-- **WHEN** a toast has severity `info`
+#### Scenario: Snack severity visual variants
+- **WHEN** a snack has severity `info`
 - **THEN** the background SHALL use the brand gradient (`--color-brand-primary` to `--color-brand-secondary`)
-- **WHEN** a toast has severity `warning`
+- **WHEN** a snack has severity `warning`
 - **THEN** the background SHALL use a warm amber gradient
-- **WHEN** a toast has severity `error`
+- **WHEN** a snack has severity `error`
 - **THEN** the background SHALL use a deep red gradient
 
 #### Scenario: Accessibility
-- **WHEN** a toast is displayed
-- **THEN** the toast element SHALL have `role="status"` for screen reader announcement
-- **AND** the toast SHALL be non-modal (SHALL NOT make background content inert)
+- **WHEN** a snack is displayed
+- **THEN** the snack element SHALL have `role="status"` for screen reader announcement
+- **AND** the snack SHALL be non-modal (SHALL NOT make background content inert)
 
 #### Scenario: Top Layer stacking with dialogs
-- **WHEN** a toast is shown while a `<dialog>` is open via `showModal()`
-- **THEN** the toast popover SHALL appear above the dialog because `showPopover()` appends to the top of the Top Layer stack
+- **WHEN** a snack is shown while a `<dialog>` is open via `showModal()`
+- **THEN** the snack popover SHALL appear above the dialog because `showPopover()` appends to the top of the Top Layer stack
 - **AND** no manual `hidePopover()`/`showPopover()` re-insertion SHALL be needed

--- a/openspec/specs/loading-spinner-ce/spec.md
+++ b/openspec/specs/loading-spinner-ce/spec.md
@@ -1,0 +1,41 @@
+# Loading Spinner Custom Element
+
+## Purpose
+
+Provides a `<loading-spinner>` custom element as a visual primitive for animated loading indicators with size variants.
+
+## Requirements
+
+### Requirement: Loading Spinner Custom Element
+The system SHALL provide a `<loading-spinner>` custom element as a visual primitive for animated loading indicators with size variants.
+
+#### Scenario: Default rendering
+- **WHEN** `<loading-spinner>` is rendered without attributes
+- **THEN** the CE SHALL display a circular spinner with `md` size (2rem)
+- **AND** the spinner SHALL use a border-based animation: solid border with one transparent side
+- **AND** the border color SHALL derive from `var(--color-brand-accent)` at 30% opacity with `border-block-start-color` at full opacity
+- **AND** `animation: spin 0.8s linear infinite` SHALL be applied
+
+#### Scenario: Size variants
+- **WHEN** `<loading-spinner size="sm">` is rendered
+- **THEN** the spinner SHALL be 1rem with 1.5px border
+- **WHEN** `<loading-spinner size="md">` is rendered
+- **THEN** the spinner SHALL be 2rem with 2px border
+- **WHEN** `<loading-spinner size="lg">` is rendered
+- **THEN** the spinner SHALL be 2.5rem with 3px border
+
+#### Scenario: Accessibility semantics
+- **WHEN** the spinner is rendered
+- **THEN** the host element SHALL be an `<output>` with `role="status"` and `aria-busy="true"`
+
+#### Scenario: Color inheritance
+- **WHEN** the spinner is placed inside a container with custom `--color-brand-accent`
+- **THEN** the spinner border color SHALL inherit from that custom property
+
+#### Scenario: Reduced motion
+- **WHEN** `prefers-reduced-motion: reduce` is active
+- **THEN** the spin animation SHALL be paused or removed
+
+#### Scenario: CUBE CSS layer
+- **WHEN** the spinner CSS is loaded
+- **THEN** all styles SHALL be defined within `@layer block` using `@scope (loading-spinner)`

--- a/openspec/specs/semantic-dom/spec.md
+++ b/openspec/specs/semantic-dom/spec.md
@@ -1,4 +1,10 @@
-## ADDED Requirements
+# Semantic DOM
+
+## Purpose
+
+Defines the rules for semantic HTML element usage and minimal div nesting across all frontend components, ensuring accessible, meaningful markup and reduced DOM complexity.
+
+## Requirements
 
 ### Requirement: Semantic HTML element usage
 
@@ -22,6 +28,8 @@ Loading/status indicators SHALL use `<output role="status">` instead of `<div ro
 - **WHEN** a `<div>` is used purely as a content wrapper without layout purpose
 - **THEN** it MUST be replaced with the appropriate semantic element or removed entirely
 
+---
+
 ### Requirement: Minimal div nesting depth
 
 Template nesting depth of `<div>` elements SHALL NOT exceed 2 levels within any component.
@@ -31,3 +39,28 @@ Wrapper `<div>` elements that serve no layout or semantic purpose SHALL be remov
 #### Scenario: Nesting depth check
 - **WHEN** a component template is rendered
 - **THEN** the maximum depth of nested `<div>` elements MUST NOT exceed 2 levels
+
+---
+
+### Requirement: Dialog consolidation to bottom-sheet CE
+All interactive overlay components SHALL use `<bottom-sheet>` as their dialog primitive instead of implementing custom `<dialog>` elements with duplicated CSS.
+
+#### Scenario: Existing dialog components migrated
+- **WHEN** event-detail-sheet, user-home-selector, hype-notification-dialog, error-banner, or any route-local dialog renders an overlay
+- **THEN** the overlay SHALL be rendered via `<bottom-sheet open.bind="..." dismissable.bind="...">` with slotted content
+- **AND** the component SHALL NOT contain its own dialog positioning, backdrop, handle-bar, or slide-in CSS
+
+#### Scenario: Route-local dialogs eliminated
+- **WHEN** settings-route renders the language selector or tickets-route renders QR/generating dialogs
+- **THEN** these SHALL use `<bottom-sheet>` with slotted content
+- **AND** the route CSS SHALL NOT contain dialog/modal/sheet CSS rules
+
+---
+
+### Requirement: Prompt consolidation to toast CE
+All top-positioned user-action prompts SHALL use `<toast>` as their presentation primitive.
+
+#### Scenario: Existing prompt components migrated
+- **WHEN** notification-prompt or pwa-install-prompt renders a permission/install banner
+- **THEN** the banner SHALL be rendered via `<toast open.bind="...">` with slotted content
+- **AND** the component SHALL NOT contain its own popover positioning or banner CSS

--- a/openspec/specs/toast-ce/spec.md
+++ b/openspec/specs/toast-ce/spec.md
@@ -1,0 +1,46 @@
+# Toast Custom Element
+
+## Purpose
+
+Provides a `<toast>` custom element as a top-positioned popover banner for user-action prompts (notification permission, PWA install).
+
+## Requirements
+
+### Requirement: Toast Custom Element
+The system SHALL provide a `<toast>` custom element as a top-positioned popover banner for user-action prompts (notification permission, PWA install).
+
+#### Scenario: Basic open/close via bindable
+- **WHEN** `<toast open.bind="isVisible">` has `open` set to `true`
+- **THEN** the CE SHALL call `showPopover()` on the internal `<dialog popover="manual">`
+- **AND** the banner SHALL appear at the top of the viewport with slide-down animation
+- **WHEN** `open` is set to `false`
+- **THEN** the CE SHALL call `hidePopover()`
+
+#### Scenario: Fixed top positioning
+- **WHEN** the toast is open
+- **THEN** the element SHALL be positioned at `inset-block-start: 0` with `inset-inline: 1rem`
+- **AND** background SHALL be `var(--color-surface-raised)`
+- **AND** border SHALL be `1px solid var(--color-border-subtle)`
+- **AND** border-radius SHALL be `var(--radius-card)`
+- **AND** box-shadow SHALL be `var(--shadow-card-glow)`
+
+#### Scenario: Slotted content
+- **WHEN** content is placed inside `<toast>`
+- **THEN** it SHALL be projected via `<au-slot>` into the popover body
+- **AND** consuming components SHALL provide their own icon, title, description, and action buttons
+
+#### Scenario: Non-modal overlay
+- **WHEN** the toast is displayed
+- **THEN** it SHALL use `popover="manual"` (no light dismiss)
+- **AND** background content SHALL remain interactive (not inert)
+
+#### Scenario: Entry/exit animation
+- **WHEN** the toast opens
+- **THEN** it SHALL animate via `@starting-style` from `opacity: 0; translate: 0 -1rem` to `opacity: 1; translate: 0 0`
+- **WHEN** the toast closes
+- **THEN** it SHALL transition to `opacity: 0; translate: 0 -1rem`
+- **AND** `display` and `overlay` transitions SHALL use `allow-discrete`
+
+#### Scenario: Toast closed event
+- **WHEN** the toast is closed
+- **THEN** the CE SHALL dispatch a `toast-closed` CustomEvent with `bubbles: true`


### PR DESCRIPTION
## 🔗 Related Issue

Closes #278

## 📝 Summary of Changes

Sync delta specs from the completed `extract-shared-custom-elements` change into main specs and archive the change.

### New capability specs
- **bottom-sheet-ce**: Dialog primitive using Popover API with CSS scroll-snap dismiss
- **loading-spinner-ce**: Animated loading indicator with sm/md/lg size variants
- **toast-ce**: Top-positioned popover banner for user-action prompts

### Updated capability specs
- **design-system**: State placeholder refactored to use `<au-slot>` instead of title/description bindables; toast-notification renamed to snack-bar
- **semantic-dom**: Added dialog consolidation to bottom-sheet and prompt consolidation to toast requirements

### Archived
- `openspec/changes/archive/2026-03-18-extract-shared-custom-elements/` — all 65/65 tasks complete

## ✅ Self-Checklist

- [x] I have linked the related issue.
- [x] I have updated the relevant documentation (e.g., `README.md`) if needed.
- [x] I have run `buf lint` and `buf format` locally and all checks have passed.
- [x] My proto definitions follow the project's style guidelines and validation rules.
- [x] Breaking changes have been justified and documented if applicable.
