### PR TITLE
docs(openspec): sync specs and archive relax-email-verification

### DIFF
--- a/openspec/changes/archive/2026-03-18-relax-email-verification/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-18-relax-email-verification/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-18

--- a/openspec/changes/archive/2026-03-18-relax-email-verification/design.md
+++ b/openspec/changes/archive/2026-03-18-relax-email-verification/design.md
@@ -1,0 +1,74 @@
+## Context
+
+Email verification was implemented as a hard gate across the stack (Zitadel OTP → Frontend callback check → Backend interceptor). With Postmark SMTP now configured, Zitadel's Hosted Login blocks the OIDC authorization flow during Self-Registration until the user completes email OTP verification. On mobile, this requires switching apps to copy a code — a high-friction step that causes abandonment. No current feature requires verified email.
+
+The `email_verified` claim infrastructure (Zitadel Action `add-email-claim.js`, backend `Claims.EmailVerified` field, JWT extraction) should be preserved for future use. Only the enforcement layers are removed.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Allow users with `email_verified=false` to use all current features without restriction
+- Eliminate the OTP step during Zitadel Self-Registration so the OIDC flow completes immediately
+- Optimize the auth callback to avoid unnecessary `Create` RPC calls for returning users
+- Preserve `email_verified` claim infrastructure for future per-feature enforcement
+
+**Non-Goals:**
+- Building a custom email verification flow (Zitadel handles this)
+- Adding in-app email verification prompts (future work, when a feature needs it)
+- Removing the Zitadel Action or `Claims.EmailVerified` backend field
+
+## Decisions
+
+### 1. Remove backend `EmailVerificationInterceptor` entirely (not disable)
+
+Delete `email_verification.go`, its test file, and the interceptor chain entry in `connect.go`. The `Claims.EmailVerified` field and its extraction in `JWTValidator` remain — they are read-only and cost nothing.
+
+**Alternative**: Keep the interceptor but with an empty allowlist. Rejected — YAGNI. When a feature needs email verification, it should be enforced at the use-case layer (per-RPC), not as a blanket interceptor. Re-adding a blanket interceptor later would be trivial if needed.
+
+### 2. Remove frontend `email_verified` gate in auth callback
+
+Remove the `email_verified` check and `signOut()` call in `auth-callback-route.ts`. Unverified users proceed through the normal provisioning and redirect flow.
+
+### 3. Refactor frontend provisioning: ensureLoaded-first (B plan)
+
+Current flow calls `provisionUser()` on every callback, relying on `ALREADY_EXISTS` being silently swallowed. Change to:
+
+1. Call `ensureLoaded()` (which calls `UserService.Get` RPC)
+2. If the user exists → proceed (no Create RPC needed)
+3. If NotFound → call `provisionUser()` → call `ensureLoaded()` again
+
+The NotFound detection happens in the callback handler (not in `ensureLoaded()` itself), since `ensureLoaded()` is a general-purpose method used elsewhere.
+
+**Alternative**: Pass `isSignUp` state through the OIDC flow. Rejected — `oidc-client-ts` does not surface the original `prompt` parameter in the callback `User` object.
+
+### 4. Disable Zitadel email verification during Self-Registration
+
+The `@pulumiverse/zitadel` Pulumi provider's `LoginPolicy` resource does not expose an email verification setting. Zitadel's Hosted Login automatically shows the OTP step when SMTP is configured — there is no policy toggle.
+
+**Approach**: Add a Zitadel Action on the `INTERNAL_AUTHENTICATION / PRE_CREATION` flow that calls `api.setEmailVerified(true)` before the user is created. Since the email is already marked verified at creation time, Zitadel skips the OTP step entirely.
+
+```
+Self-Registration Flow:
+  1. User enters email
+  2. Passkey registration
+  3. PRE_CREATION Action fires → api.setEmailVerified(true)
+  4. User created with email already verified
+  5. No OTP step (email already verified)
+  6. OIDC redirect → /auth/callback
+```
+
+**Why PRE_CREATION over POST_CREATION**: The `PRE_CREATION` trigger has `setEmailVerified(bool)` in its API, which modifies the user data before creation. `POST_CREATION` only provides `appendUserGrant` — it cannot modify email verification status after creation.
+
+**Trade-off**: With auto-verification, `email_verified` will be `true` from the start for all new users. This means the claim cannot distinguish "actually clicked verification link" from "auto-verified at creation". This is acceptable because:
+- No current feature needs to distinguish these states
+- If a future feature needs proof-of-email (e.g., sending transactional email), a re-verification flow can be introduced at that point
+
+**Implementation**: New Zitadel Action script `auto-verify-email.js` using the `PRE_CREATION` trigger in the `INTERNAL_AUTHENTICATION` flow.
+
+## Risks / Trade-offs
+
+**[Auto-verify loses email verification signal]** → Acceptable for now. No feature requires verified email. If needed later, re-verification can be triggered per-feature. The Zitadel Action and `email_verified` claim infrastructure remain in place.
+
+**[Zitadel Action API compatibility]** → The `PRE_CREATION` trigger and user verification API depend on Zitadel's Actions runtime. If the API changes, the Action will fail. Mitigation: `allowedToFail: false` in staging/prod blocks token issuance on script error. In dev, `allowedToFail: true` allows iteration.
+
+**[ensureLoaded NotFound race condition]** → If two tabs trigger callback simultaneously, both may see NotFound and call Create. The backend handles this via the existing `ALREADY_EXISTS` graceful handling, so this is safe.

--- a/openspec/changes/archive/2026-03-18-relax-email-verification/proposal.md
+++ b/openspec/changes/archive/2026-03-18-relax-email-verification/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+Zitadel's Hosted Login blocks the OIDC authorization flow until the user completes the email OTP step during Self-Registration. On mobile, this requires switching to the mail app, copying the OTP, and returning to the PWA — a high-friction experience that causes abandonment. Since no current feature requires a verified email, enforcing verification at signup provides no user value while adding a significant conversion barrier.
+
+## What Changes
+
+- **BREAKING**: Remove backend `EmailVerificationInterceptor` — `email_verified=false` users are no longer blocked from RPC calls
+- **BREAKING**: Remove frontend `email_verified` check in `/auth/callback` — unverified users proceed normally through provisioning and dashboard redirect
+- Configure Zitadel Login Policy to disable mandatory email verification during Self-Registration, allowing the OIDC flow to complete immediately
+- Optimize frontend auth callback: call `provisionUser` only when `ensureLoaded` returns NotFound (instead of on every callback)
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `authentication`: Remove "Backend Email Verification Enforcement" and "Frontend Email Verification Check" requirements. Keep "Email Verified Claim Injection" (Zitadel Action still injects the claim for future use).
+- `identity-management`: Add requirement to disable email verification enforcement during Self-Registration in Login Policy.
+- `user-auth`: Update registration callback scenario — remove email verification gate, add ensureLoaded-first provisioning flow.
+
+## Impact
+
+- **backend**: Delete `EmailVerificationInterceptor` and its test. Remove from interceptor chain in `connect.go`.
+- **frontend**: Modify `auth-callback-route.ts` (remove email_verified check, refactor provisioning flow). Update `auth-callback-route.spec.ts`.
+- **cloud-provisioning**: Modify Zitadel Login Policy Pulumi component to disable email verification on registration.
+- **specification**: Update `authentication`, `identity-management`, and `user-auth` specs.

--- a/openspec/changes/archive/2026-03-18-relax-email-verification/specs/authentication/spec.md
+++ b/openspec/changes/archive/2026-03-18-relax-email-verification/specs/authentication/spec.md
@@ -1,0 +1,37 @@
+## MODIFIED Requirements
+
+### Requirement: Email Verified Claim Injection
+
+The system SHALL inject the `email_verified` claim into JWT access tokens via a Zitadel Action at the `PRE_ACCESS_TOKEN_CREATION` trigger, alongside the existing `email` claim.
+
+**Rationale**: Zitadel does not include `email_verified` in access tokens by default. The claim is preserved for future per-feature enforcement even though no current feature requires it.
+
+#### Scenario: Human user with verified email
+
+- **WHEN** a human user with a verified email address requests an access token
+- **THEN** the Zitadel Action SHALL set `email_verified` claim to `true` in the access token
+
+#### Scenario: Human user with unverified email
+
+- **WHEN** a human user with an unverified email address requests an access token
+- **THEN** the Zitadel Action SHALL set `email_verified` claim to `false` in the access token
+
+#### Scenario: Machine user (service account)
+
+- **WHEN** a machine user requests an access token
+- **THEN** the Zitadel Action SHALL skip `email_verified` injection (no `human` field present)
+- **AND** the token SHALL be issued without the `email_verified` claim
+
+## REMOVED Requirements
+
+### Requirement: Backend Email Verification Enforcement
+
+**Reason**: No current feature requires a verified email. Enforcing `email_verified` at the interceptor level blocks all RPC calls for unverified users, preventing service usage entirely. Future features that require verified email will enforce it at the use-case layer on a per-RPC basis.
+
+**Migration**: Delete `EmailVerificationInterceptor` and remove it from the interceptor chain. The `Claims.EmailVerified` field and JWT extraction logic remain unchanged for future use.
+
+### Requirement: Frontend Email Verification Check
+
+**Reason**: The frontend gate signed out users with unverified email and displayed an error with no recovery path. With the backend enforcement also removed, this check serves no purpose and blocks legitimate users.
+
+**Migration**: Remove the `email_verified` check and `signOut()` call from `auth-callback-route.ts`. Unverified users proceed through the normal provisioning and redirect flow.

--- a/openspec/changes/archive/2026-03-18-relax-email-verification/specs/identity-management/spec.md
+++ b/openspec/changes/archive/2026-03-18-relax-email-verification/specs/identity-management/spec.md
@@ -1,0 +1,27 @@
+## ADDED Requirements
+
+### Requirement: Auto-Verify Email on Self-Registration
+
+The system SHALL automatically mark a user's email as verified before account creation during Zitadel Self-Registration, via a Zitadel Action on the `INTERNAL_AUTHENTICATION / PRE_CREATION` flow that calls `api.setEmailVerified(true)`.
+
+**Rationale**: Zitadel's Hosted Login blocks the OIDC authorization flow with an OTP step when SMTP is configured and email is unverified. Setting email as verified before creation skips this step, allowing the OIDC flow to complete immediately after passkey registration. The `LoginPolicy` resource does not expose an email verification toggle.
+
+#### Scenario: New user registers via Self-Registration
+
+- **WHEN** a new user completes Self-Registration (email + passkey)
+- **THEN** the `PRE_CREATION` Zitadel Action SHALL call `api.setEmailVerified(true)` before user creation
+- **AND** the user SHALL be created with email already verified
+- **AND** the OIDC authorization flow SHALL complete without an OTP step
+- **AND** the user SHALL be redirected to `/auth/callback` immediately
+
+#### Scenario: Action failure in production
+
+- **WHEN** the auto-verify Action fails in staging or production
+- **THEN** the registration flow SHALL fail (`allowedToFail: false`)
+- **AND** the error SHALL be logged for investigation
+
+#### Scenario: Action failure in development
+
+- **WHEN** the auto-verify Action fails in the dev environment
+- **THEN** the registration flow SHALL continue (`allowedToFail: true`)
+- **AND** the user MAY see the OTP step as a fallback

--- a/openspec/changes/archive/2026-03-18-relax-email-verification/specs/user-auth/spec.md
+++ b/openspec/changes/archive/2026-03-18-relax-email-verification/specs/user-auth/spec.md
@@ -1,3 +1,5 @@
+## MODIFIED Requirements
+
 ### Requirement: Sign Up / Sign In
 
 The system SHALL provide Passkey authentication via Zitadel. For new users, authentication is triggered at the end of the onboarding tutorial (Step 6) via a non-dismissible modal. For returning users, authentication is available via a [Login] link on the landing page.

--- a/openspec/changes/archive/2026-03-18-relax-email-verification/tasks.md
+++ b/openspec/changes/archive/2026-03-18-relax-email-verification/tasks.md
@@ -1,0 +1,21 @@
+## 1. Backend — Remove Email Verification Interceptor
+
+- [x] 1.1 Delete `internal/infrastructure/auth/email_verification.go`
+- [x] 1.2 Delete `internal/infrastructure/auth/email_verification_test.go`
+- [x] 1.3 Remove `EmailVerificationInterceptor{}` from interceptor chain in `internal/infrastructure/server/connect.go` (line 88) and its comment (line 72)
+
+## 2. Frontend — Remove email_verified gate and refactor provisioning
+
+- [x] 2.1 Remove `email_verified` check and `signOut()` call from `auth-callback-route.ts` (lines 41-46)
+- [x] 2.2 Refactor callback to ensureLoaded-first flow: call `ensureLoaded()` first, catch NotFound, then call `provisionUser()` only for new users
+- [x] 2.3 Update `auth-callback-route.spec.ts`: remove `email_verified: false` blocking test, update provisioning tests to match the new ensureLoaded-first flow
+
+## 3. Cloud-Provisioning — Auto-verify email on registration
+
+- [x] 3.1 Create `src/zitadel/scripts/auto-verify-email.js` — Zitadel Action script for `PRE_CREATION` trigger that auto-verifies the user's email
+- [x] 3.2 Add `autoVerifyEmailAction` and `preCreationTrigger` to `ActionsComponent` in `src/zitadel/components/token-action.ts`, using `FLOW_TYPE_INTERNAL_AUTHENTICATION` and `TRIGGER_TYPE_PRE_CREATION` (trigger type 2)`
+- [x] 3.3 Verify with `pulumi preview` that the new Action and TriggerActions resources are created correctly
+
+## 4. Specification — Update specs
+
+- [x] 4.1 Archive change artifacts to `openspec/specs/` (authentication, identity-management, user-auth) — run `/opsx:archive` after PRs are merged

--- a/openspec/specs/authentication/spec.md
+++ b/openspec/specs/authentication/spec.md
@@ -96,7 +96,7 @@ The system SHALL allow public access to the gRPC health check endpoint without a
 
 The system SHALL inject the `email_verified` claim into JWT access tokens via a Zitadel Action at the `PRE_ACCESS_TOKEN_CREATION` trigger, alongside the existing `email` claim.
 
-**Rationale**: Zitadel does not include `email_verified` in access tokens by default. The backend requires this claim to enforce email verification at the API layer.
+**Rationale**: Zitadel does not include `email_verified` in access tokens by default. The claim is preserved for future per-feature enforcement even though no current feature requires it.
 
 #### Scenario: Human user with verified email
 
@@ -113,54 +113,6 @@ The system SHALL inject the `email_verified` claim into JWT access tokens via a 
 - **WHEN** a machine user requests an access token
 - **THEN** the Zitadel Action SHALL skip `email_verified` injection (no `human` field present)
 - **AND** the token SHALL be issued without the `email_verified` claim
-
-### Requirement: Backend Email Verification Enforcement
-
-The system SHALL reject authenticated requests where the access token's `email_verified` claim is not `true`, returning `connect.CodeUnauthenticated`.
-
-**Rationale**: Defense-in-depth. Even though Zitadel's Hosted Login enforces email verification when SMTP is configured, the backend SHALL independently verify the claim to guard against API-created users or misconfigured identity providers.
-
-#### Scenario: Request with verified email
-
-- **WHEN** an authenticated request includes a valid JWT with `email_verified: true`
-- **THEN** the system SHALL allow the request to proceed to the RPC handler
-- **AND** the `EmailVerified` field SHALL be available in `Claims`
-
-#### Scenario: Request with unverified email
-
-- **WHEN** an authenticated request includes a valid JWT with `email_verified: false`
-- **THEN** the system SHALL reject the request with `connect.CodeUnauthenticated`
-- **AND** the error message SHALL indicate that email verification is required
-
-#### Scenario: Request with missing email_verified claim
-
-- **WHEN** an authenticated request includes a valid JWT without the `email_verified` claim
-- **THEN** the system SHALL reject the request with `connect.CodeUnauthenticated`
-- **AND** the error message SHALL indicate that email verification is required
-
-#### Scenario: Machine user token without email_verified
-
-- **WHEN** an authenticated request uses a machine user token (no `email_verified` claim, no `email` claim)
-- **THEN** the system SHALL allow the request if it passes existing validation
-- **AND** the `email_verified` check SHALL be skipped for tokens without an `email` claim
-
-### Requirement: Frontend Email Verification Check
-
-The system SHALL verify the user's `email_verified` status during the OIDC callback and display an error if the email is not verified.
-
-**Rationale**: Immediate user feedback. Rather than letting the user reach the dashboard and fail on every API call, the frontend SHALL catch unverified emails at the earliest opportunity and guide the user.
-
-#### Scenario: Callback with verified email
-
-- **WHEN** the OIDC callback processes a token where `email_verified` is `true` in the ID token profile
-- **THEN** the system SHALL proceed with normal flow (provisioning, merge, redirect to dashboard)
-
-#### Scenario: Callback with unverified email
-
-- **WHEN** the OIDC callback processes a token where `email_verified` is `false` or missing in the ID token profile
-- **THEN** the system SHALL NOT proceed to user provisioning or guest data merge
-- **AND** the system SHALL display an error message instructing the user to verify their email
-- **AND** the system SHALL provide a way to return to the login flow
 
 ### Non-Functional Requirements
 
@@ -214,7 +166,6 @@ The system SHALL return `connect.CodeUnauthenticated` for failed authentication 
 - **JWT Validator**: Validates tokens using `github.com/lestrrat-go/jwx/v2`
 - **authn-go Middleware**: `connectrpc/authn-go` HTTP middleware for default-deny authentication at the HTTP layer
 - **Claims Bridge Interceptor**: Connect-RPC interceptor that converts `authn.GetInfo(ctx)` to `auth.WithClaims(ctx)` for backward compatibility
-- **Email Verification Interceptor**: Connect-RPC interceptor that enforces `email_verified` claim for human users, skipping machine users and public endpoints
 - **Context Utilities**: Type-safe user ID propagation through request context
 
 ### Configuration

--- a/openspec/specs/identity-management/spec.md
+++ b/openspec/specs/identity-management/spec.md
@@ -46,3 +46,29 @@ The system SHALL establish a login policy that enforces passwordless authenticat
 - **AND** `PasswordlessType` SHALL be "ALLOWED"
 - **AND** `UserLogin` SHALL be false (Enforces Passkeys-only)
 - **AND** `AllowExternalIdp` SHALL be false
+
+### Requirement: Auto-Verify Email on Self-Registration
+
+The system SHALL automatically mark a user's email as verified before account creation during Zitadel Self-Registration, via a Zitadel Action on the `INTERNAL_AUTHENTICATION / PRE_CREATION` flow that calls `api.setEmailVerified(true)`.
+
+**Rationale**: Zitadel's Hosted Login blocks the OIDC authorization flow with an OTP step when SMTP is configured and email is unverified. Setting email as verified before creation skips this step, allowing the OIDC flow to complete immediately after passkey registration. The `LoginPolicy` resource does not expose an email verification toggle.
+
+#### Scenario: New user registers via Self-Registration
+
+- **WHEN** a new user completes Self-Registration (email + passkey)
+- **THEN** the `PRE_CREATION` Zitadel Action SHALL call `api.setEmailVerified(true)` before user creation
+- **AND** the user SHALL be created with email already verified
+- **AND** the OIDC authorization flow SHALL complete without an OTP step
+- **AND** the user SHALL be redirected to `/auth/callback` immediately
+
+#### Scenario: Action failure in production
+
+- **WHEN** the auto-verify Action fails in staging or production
+- **THEN** the registration flow SHALL fail (`allowedToFail: false`)
+- **AND** the error SHALL be logged for investigation
+
+#### Scenario: Action failure in development
+
+- **WHEN** the auto-verify Action fails in the dev environment
+- **THEN** the registration flow SHALL continue (`allowedToFail: true`)
+- **AND** the user MAY see the OTP step as a fallback


### PR DESCRIPTION
## Summary of Changes

Sync delta specs from `relax-email-verification` change to main specs and archive the change.

- **authentication**: Remove Backend Email Verification Enforcement and Frontend Email Verification Check requirements; update Email Verified Claim Injection rationale
- **identity-management**: Add Auto-Verify Email on Self-Registration requirement
- **user-auth**: Update Sign Up / Sign In callback flow to ensureLoaded-first pattern

## Commit Log

- docs(openspec): sync specs and archive relax-email-verification

## Self-Checklist

- [x] My changes follow the specification conventions of the project.