### PR TITLE
docs(landing-page): update spec for always-visible dual CTA buttons

### DIFF
--- a/openspec/changes/archive/2026-03-18-welcome-cta-redesign/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-18-welcome-cta-redesign/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-18

--- a/openspec/changes/archive/2026-03-18-welcome-cta-redesign/design.md
+++ b/openspec/changes/archive/2026-03-18-welcome-cta-redesign/design.md
@@ -1,0 +1,61 @@
+## Context
+
+The welcome page (`/`) is the first screen unauthenticated users see. It currently uses a single boolean getter `showGetStarted` (derived from `onboarding.isCompleted`) to toggle between two mutually exclusive button states. The onboarding step is persisted in localStorage and restored on page load via the `@aurelia/state` middleware.
+
+The `canLoad()` guard already handles authenticated users (redirect to dashboard) and mid-onboarding users (redirect to current step). The welcome page only renders for unauthenticated users who are either brand new or have completed onboarding but logged out.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Always present both "Get Started" and "Log In" on the welcome page so any user can take the correct action regardless of localStorage state
+- Fix the accessibility gap on the secondary CTA (missing `href`/`tabindex` on `<a>`)
+- Consolidate `onboarding.complete()` to a single call site in `guest-data-merge-service.ts`
+- Preserve guest artist data when re-entering onboarding via "Get Started"
+
+**Non-Goals:**
+- Redesigning the welcome page layout or visual hierarchy beyond the CTA area
+- Adding server-side onboarding state (no backend changes)
+- Changing the onboarding step progression or route guard logic
+- Modifying the OAuth/Zitadel integration
+
+## Decisions
+
+### 1. Both CTAs as `<button>` elements with primary/secondary styling
+
+Replace the current `if.bind` toggle and `<a>` link with two always-visible `<button>` elements.
+
+- "Get Started" uses the existing `.welcome-btn-primary` style (brand color fill)
+- "Log In" uses a new `.welcome-btn-secondary` style (outline/ghost variant)
+
+**Why not keep `<a>` for login?** The login action calls `authService.signIn()` which triggers a programmatic redirect — it's not a navigation link. `<button>` is semantically correct and resolves the a11y issue without needing `href="#"` hacks or `role="link"`.
+
+**Why not a single button that changes label?** Users should always see both options. A returning user on a new device needs "Log In" visible without depending on localStorage. A user who completed onboarding but abandoned OAuth needs "Get Started" to retry.
+
+### 2. Remove `showGetStarted` getter entirely
+
+The getter and its `if.bind` bindings are the sole source of conditional rendering. With both CTAs always visible, this getter has no remaining consumers. Delete it to keep the ViewModel clean.
+
+### 3. Remove `guest/clearAll` from `handleGetStarted()`
+
+Currently `handleGetStarted()` dispatches both `guest/clearAll` and `onboarding/reset`. The `guest/clearAll` wipes followed artists — destructive if the user already went through discovery on a previous attempt. Keep only `onboarding/reset` so the user re-enters onboarding at the discovery step with their previous artist selections intact.
+
+**Trade-off:** If stale guest data causes issues (e.g., artists that no longer exist), the discovery page already handles missing data gracefully via its error boundary. The benefit of preserving data outweighs this edge case.
+
+### 4. Consolidate `onboarding.complete()` in merge service only
+
+Remove the call at `auth-callback-route.ts:43-45`. The `guest-data-merge-service.ts:51` call already executes unconditionally at the end of `merge()`, which runs immediately after. Having two call sites is confusing and the first one (`auth-callback-route`) fires before merge completes, which breaks the semantic that "completed = all guest data has been merged."
+
+### 5. Secondary button styling approach
+
+Use a ghost/outline variant that pairs with the primary button:
+- Transparent background with a subtle border
+- Same dimensions as primary (`min-block-size: 48px`, full width)
+- Brand color text, hover fills lightly
+
+This maintains visual hierarchy (primary = Get Started, secondary = Log In) while keeping both equally accessible as tap targets.
+
+## Risks / Trade-offs
+
+- **Two prominent CTAs may increase decision fatigue** → Mitigated by clear visual hierarchy (filled primary vs outline secondary) and distinct labels. The current design already shows two CTAs for new users (button + link); this change just makes both consistently visible.
+- **Preserving stale guest data on re-enter** → Low risk. Discovery page renders from store state and handles missing artist images/data. Worst case: user sees previously followed artists pre-selected in the bubble UI, which is actually helpful context.
+- **localStorage cleared = always shows both CTAs** → This is now the intended behavior, not a bug. Both paths are always available regardless of persisted state.

--- a/openspec/changes/archive/2026-03-18-welcome-cta-redesign/proposal.md
+++ b/openspec/changes/archive/2026-03-18-welcome-cta-redesign/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+The welcome page currently switches between "Get Started" and "Log In" based on `onboardingStep` stored in localStorage. This creates UX problems: returning users on a new device or after clearing browser data see "Get Started" instead of "Log In"; users who completed onboarding but abandoned OAuth signup see only "Log In" with no path back to onboarding; and the `<a>` login link lacks `href`/`tabindex`, breaking keyboard navigation and screen reader access. Additionally, `onboarding.complete()` is called redundantly in two places, and the `handleGetStarted()` method unnecessarily clears guest artist data.
+
+## What Changes
+
+- **Always show both CTAs**: Remove the `showGetStarted` conditional toggle. Display "Get Started" (primary) and "Log In" (secondary) buttons on every visit, regardless of localStorage state.
+- **Both CTAs as `<button>` elements**: Replace the secondary `<a>` login link with a styled `<button>`, fixing the accessibility gap and making the two actions visually parallel.
+- **Consolidate `onboarding.complete()`**: Remove the redundant call in `auth-callback-route.ts`; keep only the one in `guest-data-merge-service.ts` at the end of the merge flow.
+- **Stop clearing guest data on "Get Started"**: Remove `guest/clearAll` dispatch from `handleGetStarted()`, preserving previously followed artists when re-entering onboarding.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `landing-page`: Remove conditional CTA switching; always render both "Get Started" and "Log In" buttons. Remove the "completed user sees Login only" scenario.
+
+## Impact
+
+- **Frontend** (`frontend/`):
+  - `src/routes/welcome/welcome-route.ts` — Remove `showGetStarted` getter, remove `guest/clearAll` dispatch
+  - `src/routes/welcome/welcome-route.html` — Remove `if.bind` conditionals, add secondary button
+  - `src/routes/welcome/welcome-route.css` — Add `.welcome-btn-secondary` style
+  - `src/routes/auth-callback/auth-callback-route.ts` — Remove redundant `onboarding.complete()` call
+- **Tests**: Update welcome-route and auth-callback-route unit tests
+- **No backend or API changes**

--- a/openspec/changes/archive/2026-03-18-welcome-cta-redesign/specs/landing-page/spec.md
+++ b/openspec/changes/archive/2026-03-18-welcome-cta-redesign/specs/landing-page/spec.md
@@ -1,4 +1,4 @@
-## Requirements
+## MODIFIED Requirements
 
 ### Requirement: Passkey Authentication CTA
 
@@ -47,3 +47,11 @@ The system SHALL redirect already-authenticated users away from the landing page
 - **THEN** the system SHALL display the landing page with an error toast: "Could not determine account status. Please try signing in again."
 - **AND** the system SHALL NOT crash to a white screen
 - **AND** the system SHALL allow the user to manually navigate via the Log In button
+
+## REMOVED Requirements
+
+### Requirement: Completed user sees Login only
+
+**Reason**: Replaced by the "always show both CTAs" behavior. The conditional toggle based on `onboardingStep === COMPLETED` created UX problems when localStorage was cleared or when accessing from a different device.
+
+**Migration**: No migration needed. The `showGetStarted` getter and its `if.bind` conditionals are removed. Both buttons render unconditionally.

--- a/openspec/changes/archive/2026-03-18-welcome-cta-redesign/tasks.md
+++ b/openspec/changes/archive/2026-03-18-welcome-cta-redesign/tasks.md
@@ -1,0 +1,26 @@
+## 1. Welcome Route ViewModel
+
+- [x] 1.1 Remove `showGetStarted` getter from `welcome-route.ts`
+- [x] 1.2 Remove `guest/clearAll` dispatch from `handleGetStarted()` (keep `onboarding/reset` and `setStep`)
+
+## 2. Welcome Route Template
+
+- [x] 2.1 Remove `if.bind="showGetStarted"` and `if.bind="!showGetStarted"` conditionals — render both buttons unconditionally
+- [x] 2.2 Replace the `<a>` login link (`<p>` + `<a>` block) with a `<button>` element using `.welcome-btn-secondary` class
+- [x] 2.3 Update i18n keys if needed (verify "Log In" label works for the secondary button)
+
+## 3. Welcome Route Styles
+
+- [x] 3.1 Add `.welcome-btn-secondary` style (outline/ghost variant: transparent background, subtle border, brand color text, same 48px min height as primary)
+- [x] 3.2 Remove `.welcome-login-hint` and `.welcome-login-link` styles (no longer used)
+
+## 4. Consolidate onboarding.complete()
+
+- [x] 4.1 Remove the `if (this.onboarding.isOnboarding) { this.onboarding.complete() }` block from `auth-callback-route.ts` (lines 43-45)
+- [x] 4.2 Verify `guest-data-merge-service.ts:51` remains the single call site for `onboarding/complete`
+
+## 5. Tests
+
+- [x] 5.1 Update welcome-route unit tests: remove tests for `showGetStarted` toggle, add tests verifying both buttons render unconditionally
+- [x] 5.2 Update auth-callback-route unit tests: remove expectation for `onboarding.complete()` call in callback handler
+- [x] 5.3 Run `make check` in frontend to verify lint + tests pass


### PR DESCRIPTION
## 🔗 Related Issue

Closes #282

## 📝 Summary of Changes

Update the `landing-page` capability spec to reflect the welcome CTA redesign:

- **MODIFIED** `Passkey Authentication CTA`: Replace conditional CTA toggle with always-visible dual buttons (Get Started primary + Log In secondary). Both rendered as `<button>` elements for accessibility. Get Started no longer clears guest data.
- **MODIFIED** `Authenticated User Redirect`: Minor wording fix ("Login link" → "Log In button").
- **REMOVED** "Completed user sees Login only" scenario — replaced by always showing both CTAs.
- Archive `welcome-cta-redesign` change artifacts.

## ✅ Self-Checklist

- [x] I have linked the related issue.
- [x] I have updated the relevant documentation (e.g., `README.md`) if needed.
- [x] I have run `buf lint` and `buf format` locally and all checks have passed.
- [x] My proto definitions follow the project's style guidelines and validation rules.
- [x] Breaking changes have been justified and documented if applicable.
