### PR TITLE
feat: add TicketJourney entity and RPC service

### DIFF
--- a/openspec/changes/manage-ticket-status/.openspec.yaml
+++ b/openspec/changes/manage-ticket-status/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-18

--- a/openspec/changes/manage-ticket-status/design.md
+++ b/openspec/changes/manage-ticket-status/design.md
@@ -1,0 +1,134 @@
+## Context
+
+The Liverty Music platform currently auto-collects concert information and delivers push notifications to fans based on their followed artists and hype levels. Users can see upcoming concerts on a dashboard grouped by date and proximity lanes (home/nearby/away), and view concert details in a bottom sheet.
+
+However, there is no mechanism for users to track their personal ticket acquisition progress. In the Japanese live music market, ticket purchasing involves multiple stages: monitoring for ticket sales announcements, applying for lotteries (抽選), handling lottery results, and completing payment. Users currently manage this process manually outside the platform.
+
+This change introduces `TicketJourney` — a per-event, per-user status tracker integrated into the existing dashboard and detail sheet. It is a lightweight, user-driven feature with no automation or external integrations.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Allow users to set and change a personal ticket acquisition status for any event on their dashboard
+- Display the current status as a badge on dashboard concert cards for at-a-glance tracking
+- Provide status change controls in the event detail sheet
+- Keep the data model generic (event-level, not concert-specific) for future event type extensibility
+
+**Non-Goals:**
+- Automated status transitions (e.g., detecting lottery results or payment completion)
+- Ticket purchase links or payment integration
+- Notification triggers based on journey status (e.g., "payment deadline approaching")
+- Filtering or sorting dashboard concerts by journey status
+- History or audit log of status changes
+
+## State Transition Diagram
+
+The system does not enforce transitions — users can move freely between any states.
+The diagram below shows the **typical (expected) flow**, not a hard constraint.
+
+```mermaid
+stateDiagram-v2
+    [*] --> TRACKING : Start tracking
+
+    TRACKING --> APPLIED : Apply for lottery
+    TRACKING --> UNPAID : Immediate purchase
+
+    APPLIED --> LOST : Lottery failed
+    APPLIED --> UNPAID : Lottery won
+
+    LOST --> TRACKING : Try again
+    LOST --> [*] : Give up (delete)
+
+    UNPAID --> PAID : Payment completed
+    UNPAID --> LOST : Payment deadline expired
+
+    PAID --> [*] : Concert attended
+
+    note right of TRACKING : Waiting for ticket\nsales information
+    note right of APPLIED : Entered lottery\n(抽選申込済)
+    note right of LOST : Lottery failed or\npayment expired\n(落選・入金期限切れ)
+    note right of UNPAID : Awaiting payment\n(入金待ち)
+    note right of PAID : Ticket secured\n(チケット確保)
+```
+
+## Decisions
+
+### Decision 1: Entity References event_id, Not concert_id
+
+**Choice**: `TicketJourney` references `event_id` at both the proto and database levels.
+
+**Rationale**: The platform's entity model uses `event` as the generic scheduled performance, with `concert` as a music-specific specialization. The ticket acquisition workflow (tracking → applied → paid) is not music-specific — it applies to any ticketed event. Using `event_id` avoids a migration when the platform expands to other event types.
+
+In the database, the `concerts` table already uses `event_id` as its primary key (FK → events), so the join path from `ticket_journeys` to concert-specific data is straightforward.
+
+**Alternatives considered**:
+- *concert_id*: Rejected; would couple the feature to music events and require migration for future event types.
+
+---
+
+### Decision 2: Separate RPC Service (TicketJourneyService)
+
+**Choice**: New `rpc/ticket_journey/v1/ticket_journey_service.proto` with its own service definition.
+
+**Rationale**: The ticket journey is a distinct domain concern from the existing `TicketService` (SBT blockchain tickets) and `ConcertService` (event catalog). Following the 1-service-per-package pattern already established in the codebase (`follow/v1/`, `concert/v1/`, `ticket/v1/`), a dedicated package avoids conflating user-subjective tracking with system-authoritative ticket records.
+
+**Alternatives considered**:
+- *Add RPCs to TicketService*: Rejected; SBT ticket minting and user journey tracking are orthogonal concerns with different lifecycles.
+- *Add RPCs to ConcertService*: Rejected; ConcertService is a read-only catalog, adding user-specific mutations breaks its cohesion.
+
+---
+
+### Decision 3: SetStatus as Upsert (Not Separate Create/Update)
+
+**Choice**: A single `SetStatus` RPC that performs an upsert — creates the journey if it doesn't exist, or updates the status if it does.
+
+**Rationale**: From the user's perspective, setting a status on a concert is a single action regardless of whether they've tracked it before. Splitting into Create and Update would force the frontend to track existence state, adding complexity with no user benefit. The database supports this naturally with `INSERT ... ON CONFLICT DO UPDATE`.
+
+**Alternatives considered**:
+- *Separate Create + Update RPCs*: Rejected; adds frontend complexity and extra round-trips for no user benefit.
+
+---
+
+### Decision 4: ListByUser Returns event_id + status Only (Frontend Join)
+
+**Choice**: `ListByUser` returns a flat list of `(event_id, status)` pairs. The frontend joins this with the concert list already fetched from `ConcertService.ListByFollower`.
+
+**Rationale**: The dashboard already fetches the full concert catalog on load. Returning enriched concert data from `ListByUser` would duplicate that payload. A lightweight map (`event_id → status`) is simpler to fetch, cache, and merge. Both calls can be made in parallel on dashboard load.
+
+**Alternatives considered**:
+- *Embed Concert data in ListByUser response*: Rejected; duplicates data already available from ConcertService, increases payload size and coupling.
+
+---
+
+### Decision 5: No Timestamps on ticket_journeys Table
+
+**Choice**: The `ticket_journeys` table has no `created_at` or `updated_at` columns.
+
+**Rationale**: The journey status is a mutable, user-controlled label with no business logic depending on when it was set or changed. Adding timestamps would be speculative complexity. If analytics or history tracking is needed later, it can be added as a separate concern (e.g., an event log table).
+
+---
+
+### Decision 6: Status Enum Includes LOST for Lottery Failure
+
+**Choice**: `TicketJourneyStatus` includes a `LOST` state between `APPLIED` and `UNPAID`.
+
+**Rationale**: In the Japanese concert ticket market, lottery-based sales (抽選販売) are the dominant distribution method. Losing a lottery is a frequent, important event that affects the user's next action (re-apply for another round, try a different vendor, or give up). Without `LOST`, users would have to reset to `TRACKING` or leave `APPLIED` stale — both lose the information that they attempted and failed.
+
+---
+
+### Decision 7: No Enforced State Transitions
+
+**Choice**: The backend does not validate state transitions. Users can set any status at any time.
+
+**Rationale**: The ticket acquisition process in practice is non-linear. Users may skip states (immediate purchase skips `APPLIED`), go backward (re-enter `TRACKING` after `LOST` to try again), or jump (set `PAID` directly if they purchased outside the tracked flow). Enforcing a state machine would create friction without adding value, since the system has no way to verify the user's actual ticket status.
+
+---
+
+## Risks / Trade-offs
+
+| Risk | Mitigation |
+|------|------------|
+| `LOST` status accumulates stale entries for past events | Past events naturally leave the dashboard as their date passes. No cleanup needed for MVP; can add archival later if table grows. |
+| Users may not discover the status feature | Badge visibility on cards provides passive discovery. Detailed UX for the change controls in the detail sheet is deferred to implementation. |
+| Future need for timestamps or history | Can be added as a separate `ticket_journey_events` audit table without modifying the core table. |
+| Frontend must coordinate two parallel API calls on dashboard load | Both calls are independent and lightweight. `Promise.all` handles this naturally. If one fails, the dashboard still renders concerts (journey status gracefully degrades to "no status"). |

--- a/openspec/changes/manage-ticket-status/proposal.md
+++ b/openspec/changes/manage-ticket-status/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+The platform currently auto-collects concert information and sends push notifications, but users have no way to track their personal ticket acquisition progress for each concert. In Japan's live music market, the ticket purchase process involves multiple stages (waiting for sales info, applying for lotteries, awaiting payment, completing payment) that users must manage manually across scattered tools. Adding per-event ticket journey tracking directly to the dashboard delivers the next step of the core product value: freeing users from the complexity of ticket management.
+
+## What Changes
+
+- Introduce a new `TicketJourney` entity representing a user's personal ticket acquisition status for a specific event.
+- Add a `TicketJourneyStatus` enum with five states: `TRACKING`, `APPLIED`, `LOST`, `UNPAID`, `PAID`.
+- Add a new `TicketJourneyService` RPC with `SetStatus`, `Delete`, and `ListByUser` operations.
+- Add a `ticket_journeys` database table with composite PK `(user_id, event_id)`.
+- Display ticket journey status as a badge on dashboard concert cards.
+- Add status change UI to the event detail sheet.
+
+## Capabilities
+
+### New Capabilities
+- `ticket-journey`: Per-event ticket acquisition tracking with status management, RPC service, and dashboard UI integration.
+
+### Modified Capabilities
+- `concert-detail`: Add ticket journey status display and change controls to the event detail sheet.
+- `live-events`: Add ticket journey status badge overlay to dashboard concert cards.
+
+## Impact
+
+- **specification**: New entity proto (`ticket_journey.proto`), new RPC service proto (`ticket_journey_service.proto`).
+- **backend**: New DB migration (`ticket_journeys` table), new entity/usecase/repository/handler layers for TicketJourney.
+- **frontend**: Extended `Concert` entity with optional journey status, new API client for `TicketJourneyService`, UI changes to `event-card` and `event-detail-sheet` components.
+- **BSR**: New generated Go and TypeScript packages for `ticket_journey` entity and service.

--- a/openspec/changes/manage-ticket-status/specs/concert-detail/spec.md
+++ b/openspec/changes/manage-ticket-status/specs/concert-detail/spec.md
@@ -1,0 +1,86 @@
+## MODIFIED Requirements
+
+### Requirement: Concert Detail View
+
+The system SHALL provide a detail view for a selected concert using a popover-based sheet (not a modal dialog), ensuring compatibility with coach mark overlays in the top layer.
+
+#### Scenario: Open detail from dashboard
+
+- **WHEN** a user taps a concert card on the dashboard
+- **THEN** the system SHALL open a bottom sheet displaying the concert detail
+- **AND** the sheet SHALL use `popover="auto"` with `showPopover()` by default
+- **AND** the sheet element SHALL be a `<dialog>` providing native dialog semantics (implicit `role="dialog"`)
+- **AND** the URL SHALL update to `/concerts/:id` via `history.pushState` without triggering full page navigation
+- **AND** the sheet SHALL be anchored flush to the bottom edge of the viewport
+
+#### Scenario: Open detail during onboarding Step 4
+
+- **WHEN** a user taps a concert card during onboarding Step 3 (advancing to Step 4)
+- **THEN** the sheet SHALL use `popover="manual"` with `showPopover()` (non-dismissible per onboarding spec)
+- **AND** the popover attribute SHALL be set to `"manual"` before calling `showPopover()`
+
+#### Scenario: Display venue information
+
+- **WHEN** the concert detail view is open
+- **THEN** it SHALL display the venue name (`listed_venue_name`) and administrative area (`venue.admin_area`) if available
+
+#### Scenario: Google Maps link
+
+- **WHEN** the concert detail view is open
+- **THEN** it SHALL render a tappable link that opens Google Maps with a query composed of venue name and admin area
+
+#### Scenario: Ticket / official info link
+
+- **WHEN** the concert detail view is open and `source_url` is present
+- **THEN** it SHALL render a "View Official Info" button linking to `source_url` in a new tab
+
+#### Scenario: Display ticket journey status
+
+- **WHEN** the concert detail view is open
+- **AND** the user has a ticket journey for this event
+- **THEN** the sheet SHALL display the current ticket journey status
+- **AND** the sheet SHALL provide controls to change the status to any valid `TicketJourneyStatus` value
+
+#### Scenario: Set ticket journey status from detail view
+
+- **WHEN** the user selects a new status from the journey status controls
+- **THEN** the system SHALL call `TicketJourneyService.SetStatus` with the event_id and selected status
+- **AND** the displayed status SHALL update to reflect the change
+
+#### Scenario: Start tracking from detail view
+
+- **WHEN** the concert detail view is open
+- **AND** the user has no ticket journey for this event
+- **THEN** the sheet SHALL provide a control to begin tracking (set initial status)
+
+#### Scenario: Remove ticket journey from detail view
+
+- **WHEN** the user removes the journey status from the detail view controls
+- **THEN** the system SHALL call `TicketJourneyService.Delete` with the event_id
+- **AND** the status display SHALL revert to the untracked state
+
+#### Scenario: Dismiss sheet via light dismiss (non-onboarding)
+
+- **WHEN** the user is NOT in onboarding Step 4
+- **AND** the user clicks outside the sheet or presses Escape
+- **THEN** the sheet SHALL be dismissed via the Popover API's native light dismiss behavior
+- **AND** the URL SHALL revert to the dashboard URL via `history.replaceState`
+
+#### Scenario: Dismiss sheet via swipe down (non-onboarding)
+
+- **WHEN** the user is NOT in onboarding Step 4
+- **AND** the user swipes down on any part of the sheet surface beyond the dismiss threshold
+- **THEN** the sheet SHALL call `hidePopover()` and the URL SHALL revert to the dashboard URL
+
+#### Scenario: Dismiss sheet via browser back button
+
+- **WHEN** the detail sheet is open
+- **AND** the user presses the browser back button (triggering a `popstate` event)
+- **THEN** the sheet SHALL close via `hidePopover()`
+- **AND** the sheet SHALL NOT call `history.replaceState` (the browser has already navigated back)
+
+#### Scenario: Sheet non-dismissible during onboarding Step 4
+
+- **WHEN** the user is at onboarding Step 4
+- **THEN** the sheet SHALL NOT be dismissible (no swipe-down, no outside tap, no escape key)
+- **AND** the coach mark overlay SHALL appear above the sheet in the top layer, targeting `[data-nav-my-artists]`

--- a/openspec/changes/manage-ticket-status/specs/live-events/spec.md
+++ b/openspec/changes/manage-ticket-status/specs/live-events/spec.md
@@ -1,0 +1,43 @@
+## MODIFIED Requirements
+
+### Requirement: Concert Schedue Data Model
+
+The system MUST define standard data structures for core concert entities to ensure consistency across services.
+
+#### Scenario: Artist Definition
+
+- **WHEN** an artist is represented
+- **THEN** it MUST include a unique ID, name, and a list of official media channels.
+
+#### Scenario: Venue Definition
+
+- **WHEN** a venue is represented
+- **THEN** it MUST include a unique ID and name.
+- **AND** it MAY include an administrative area (`admin_area`) as an ISO 3166-2 subdivision code representing the venue's geographic administrative division (e.g., `JP-13` for Tokyo, `JP-40` for Fukuoka).
+
+#### Scenario: Concert Definition
+
+- **WHEN** a concert is represented
+- **THEN** it MUST include the artist ID, venue ID, local date (`local_date`), title, and start time.
+- **AND** it MAY include open time, source URL, listed venue name, and an embedded `Venue` object.
+- **AND** all primitive scalar fields (date, time, title, URL, venue name) SHALL be represented as VO wrapper messages.
+
+#### Scenario: Event Definition
+
+- **WHEN** an event is represented
+- **THEN** it MUST include a unique ID, an embedded `Venue` object, title, and local date.
+- **AND** it MAY include start time, open time, and merkle root.
+- **AND** all primitive scalar fields SHALL be represented as VO wrapper messages.
+- **AND** it SHALL NOT include `create_time` or `update_time` fields.
+
+#### Scenario: Concert card displays ticket journey badge
+
+- **WHEN** a concert is rendered on the dashboard
+- **AND** the user has a ticket journey for that concert's event
+- **THEN** the concert card SHALL display a badge indicating the current `TicketJourneyStatus`
+
+#### Scenario: Concert card without ticket journey
+
+- **WHEN** a concert is rendered on the dashboard
+- **AND** the user has no ticket journey for that concert's event
+- **THEN** the concert card SHALL NOT display a journey status badge

--- a/openspec/changes/manage-ticket-status/specs/ticket-journey/spec.md
+++ b/openspec/changes/manage-ticket-status/specs/ticket-journey/spec.md
@@ -1,0 +1,99 @@
+## ADDED Requirements
+
+### Requirement: Ticket Journey Entity
+
+The system SHALL define a `TicketJourney` entity representing a user's personal ticket acquisition status for a specific event. Each journey is uniquely identified by the combination of user and event.
+
+#### Scenario: TicketJourney data model
+
+- **WHEN** a ticket journey is represented
+- **THEN** it SHALL include a `user_id` (UserId), `event_id` (EventId), and `status` (TicketJourneyStatus)
+- **AND** the composite key SHALL be `(user_id, event_id)` — one journey per user per event
+
+#### Scenario: TicketJourneyStatus enum values
+
+- **WHEN** a ticket journey status is represented
+- **THEN** it SHALL be one of: `TRACKING`, `APPLIED`, `LOST`, `UNPAID`, `PAID`
+- **AND** `UNSPECIFIED` (value 0) SHALL exist as the default proto value but SHALL NOT be accepted in API requests
+- **AND** `LOST` SHALL represent both lottery failure (落選) and payment deadline expiration (入金期限切れ)
+
+### Requirement: Set Ticket Journey Status
+
+The system SHALL allow an authenticated user to set (create or update) their ticket journey status for a given event via a single upsert operation.
+
+#### Scenario: Set status on a new journey
+
+- **WHEN** an authenticated user calls `SetStatus` with an `event_id` and `status`
+- **AND** no journey exists for that user and event
+- **THEN** the system SHALL create a new `TicketJourney` with the given status
+- **AND** the user_id SHALL be derived from the authentication context
+
+#### Scenario: Update status on an existing journey
+
+- **WHEN** an authenticated user calls `SetStatus` with an `event_id` and `status`
+- **AND** a journey already exists for that user and event
+- **THEN** the system SHALL update the existing journey's status
+
+#### Scenario: Any status transition is allowed
+
+- **WHEN** a user calls `SetStatus` with any valid status value
+- **THEN** the system SHALL accept the transition regardless of the current status
+- **AND** the system SHALL NOT enforce a state machine or transition rules
+
+#### Scenario: Invalid status value rejected
+
+- **WHEN** a user calls `SetStatus` with `UNSPECIFIED` or an undefined enum value
+- **THEN** the system SHALL return an `INVALID_ARGUMENT` error
+
+#### Scenario: Invalid event_id rejected
+
+- **WHEN** a user calls `SetStatus` with a malformed or missing `event_id`
+- **THEN** the system SHALL return an `INVALID_ARGUMENT` error
+
+### Requirement: Delete Ticket Journey
+
+The system SHALL allow an authenticated user to remove their ticket journey for a given event.
+
+#### Scenario: Delete an existing journey
+
+- **WHEN** an authenticated user calls `Delete` with an `event_id`
+- **AND** a journey exists for that user and event
+- **THEN** the system SHALL remove the journey record
+
+#### Scenario: Delete a non-existent journey
+
+- **WHEN** an authenticated user calls `Delete` with an `event_id`
+- **AND** no journey exists for that user and event
+- **THEN** the system SHALL return successfully (idempotent delete)
+
+### Requirement: List Ticket Journeys by User
+
+The system SHALL allow an authenticated user to retrieve all their ticket journeys.
+
+#### Scenario: User has journeys
+
+- **WHEN** an authenticated user calls `ListByUser`
+- **THEN** the system SHALL return all `TicketJourney` records for that user
+- **AND** each record SHALL contain `event_id` and `status`
+
+#### Scenario: User has no journeys
+
+- **WHEN** an authenticated user calls `ListByUser`
+- **AND** the user has no ticket journeys
+- **THEN** the system SHALL return an empty list
+
+### Requirement: Ticket Journey Database Schema
+
+The system SHALL store ticket journeys in a `ticket_journeys` table with a composite primary key.
+
+#### Scenario: Table structure
+
+- **WHEN** the `ticket_journeys` table is created
+- **THEN** it SHALL have columns: `user_id` (UUID, FK → users), `event_id` (UUID, FK → events), `status` (SMALLINT)
+- **AND** the primary key SHALL be `(user_id, event_id)`
+- **AND** it SHALL NOT include `created_at` or `updated_at` columns
+
+#### Scenario: Upsert operation
+
+- **WHEN** a `SetStatus` operation targets an existing `(user_id, event_id)` pair
+- **THEN** the database SHALL perform `INSERT ... ON CONFLICT (user_id, event_id) DO UPDATE SET status`

--- a/openspec/changes/manage-ticket-status/tasks.md
+++ b/openspec/changes/manage-ticket-status/tasks.md
@@ -1,0 +1,50 @@
+## 1. Proto — Entity and RPC Definitions
+
+> Proto files in `specification/proto/liverty_music/`. BSR publishes generated code after release.
+
+- [x] 1.1 Define `entity/v1/ticket_journey.proto`: `TicketJourney` message (user_id, event_id, status) and `TicketJourneyStatus` enum (UNSPECIFIED, TRACKING, APPLIED, LOST, UNPAID, PAID)
+- [x] 1.2 Define `rpc/ticket_journey/v1/ticket_journey_service.proto`: `TicketJourneyService` with `SetStatus`, `Delete`, `ListByUser` RPCs
+- [x] 1.3 Add protovalidate constraints: required fields, defined_only on status enum, UUID validation on event_id
+- [x] 1.4 Run `buf lint` and `buf breaking` to verify proto changes
+
+## 2. Backend — Database Migration
+
+- [x] 2.1 Write Atlas migration: CREATE TABLE `ticket_journeys` (user_id UUID FK → users, event_id UUID FK → events, status SMALLINT, PRIMARY KEY (user_id, event_id))
+- [x] 2.2 Verify migration applies cleanly on local PostgreSQL and is backward-compatible
+
+## 3. Backend — Entity and Repository
+
+- [x] 3.1 Define `TicketJourney` entity in `internal/entity/ticket_journey.go`
+- [x] 3.2 Define `TicketJourneyRepository` port interface in `internal/usecase/port/`
+- [x] 3.3 Implement `TicketJourneyRepository` with pgx in `internal/infrastructure/database/rdb/`: Upsert, Delete, ListByUser queries
+
+## 4. Backend — Use Case
+
+- [x] 4.1 Implement `TicketJourneyUseCase` in `internal/usecase/ticket_journey_uc.go`: SetStatus (upsert), Delete, ListByUser
+- [x] 4.2 Write unit tests for use case methods
+
+## 5. Backend — RPC Handler and DI
+
+- [x] 5.1 Implement `TicketJourneyServiceHandler` in `internal/adapter/rpc/ticket_journey/`: proto ↔ entity mapping, auth context extraction
+- [x] 5.2 Register handler in Google Wire DI configuration (`internal/di/`)
+- [x] 5.3 Register route in server mux setup
+
+## 6. Frontend — API Client and Data Integration
+
+- [x] 6.1 Add `TicketJourneyService` Connect client to frontend service layer
+- [x] 6.2 Extend `DashboardService.loadDashboardEvents()` to fetch `ListByUser` in parallel with `ListByFollower`
+- [x] 6.3 Extend `Concert` entity with optional `journeyStatus` field
+- [x] 6.4 Build `Map<eventId, TicketJourneyStatus>` from ListByUser response and merge into Concert objects
+
+## 7. Frontend — Concert Card Badge
+
+- [x] 7.1 Add ticket journey status badge element to `event-card.html` template (visible only when `journeyStatus` is set)
+- [x] 7.2 Style the badge per status value using CUBE CSS methodology with `data-journey-status` attribute
+
+## 8. Frontend — Detail Sheet Status Controls
+
+- [x] 8.1 Add ticket journey status display and change controls to `event-detail-sheet.html`
+- [x] 8.2 Implement status change handler: call `TicketJourneyService.SetStatus`, update local state
+- [x] 8.3 Implement "start tracking" control for events with no journey (initial status selection)
+- [x] 8.4 Implement "remove tracking" control: call `TicketJourneyService.Delete`, clear local state
+- [x] 8.5 Ensure status changes on the detail sheet reflect immediately on the dashboard card badge

--- a/proto/liverty_music/entity/v1/ticket_journey.proto
+++ b/proto/liverty_music/entity/v1/ticket_journey.proto
@@ -1,0 +1,67 @@
+syntax = "proto3";
+
+// Package liverty_music.entity.v1 defines core business entities for the Liverty Music platform.
+package liverty_music.entity.v1;
+
+import "buf/validate/validate.proto";
+import "liverty_music/entity/v1/ticket.proto";
+import "liverty_music/entity/v1/user.proto";
+
+option go_package = "github.com/liverty-music/specification/gen/go/liverty_music/entity/v1;entityv1";
+
+// TicketJourneyStatus represents where a fan stands in the ticket acquisition process
+// for a specific event. The statuses model the typical flow of purchasing concert tickets
+// in the Japanese live music market, where lottery-based sales (抽選販売) are the dominant
+// distribution method.
+//
+// The system does not enforce a specific transition order — fans may set any status at
+// any time to match their real-world situation. The typical progression is:
+//
+//	TRACKING → APPLIED → UNPAID → PAID    (lottery route)
+//	TRACKING → UNPAID → PAID              (immediate purchase)
+//	APPLIED → LOST                        (lottery failure)
+//	UNPAID → LOST                         (payment deadline expired)
+//	LOST → TRACKING                       (retry with next round)
+enum TicketJourneyStatus {
+  // Default value; must not be used in API requests.
+  TICKET_JOURNEY_STATUS_UNSPECIFIED = 0;
+
+  // The fan is monitoring this event for ticket sales information.
+  // This is the initial status when a fan begins tracking an event.
+  TICKET_JOURNEY_STATUS_TRACKING = 1;
+
+  // The fan has applied for a ticket lottery (抽選申込済).
+  // Skipped when tickets are available for immediate purchase.
+  TICKET_JOURNEY_STATUS_APPLIED = 2;
+
+  // The fan lost a ticket lottery (落選) or missed the payment deadline (入金期限切れ).
+  // From here, the fan may return to TRACKING to try again in a subsequent round.
+  TICKET_JOURNEY_STATUS_LOST = 3;
+
+  // The fan has won a lottery or purchased a ticket and is awaiting payment (入金待ち).
+  TICKET_JOURNEY_STATUS_UNPAID = 4;
+
+  // The fan has completed payment and secured the ticket (チケット確保).
+  TICKET_JOURNEY_STATUS_PAID = 5;
+}
+
+// TicketJourney represents a fan's personal ticket acquisition status for a specific event.
+// It captures where the fan stands in the process of obtaining a ticket — from initial
+// interest through lottery application to payment completion.
+//
+// Each fan may have at most one journey per event. The journey is entirely user-managed:
+// the system does not automate transitions or verify the fan's actual ticket status.
+message TicketJourney {
+  // user_id identifies the fan who owns this journey.
+  UserId user_id = 1 [(buf.validate.field).required = true];
+
+  // event_id identifies the event this journey tracks.
+  // References events (not concerts) to support future non-music event types.
+  EventId event_id = 2 [(buf.validate.field).required = true];
+
+  // status is the fan's current position in the ticket acquisition process.
+  TicketJourneyStatus status = 3 [
+    (buf.validate.field).required = true,
+    (buf.validate.field).enum.defined_only = true
+  ];
+}

--- a/proto/liverty_music/rpc/ticket_journey/v1/ticket_journey_service.proto
+++ b/proto/liverty_music/rpc/ticket_journey/v1/ticket_journey_service.proto
@@ -1,0 +1,77 @@
+syntax = "proto3";
+
+// Package liverty_music.rpc.ticket_journey.v1 provides the TicketJourneyService
+// for managing a fan's personal ticket acquisition tracking per event.
+package liverty_music.rpc.ticket_journey.v1;
+
+import "buf/validate/validate.proto";
+import "liverty_music/entity/v1/ticket.proto";
+import "liverty_music/entity/v1/ticket_journey.proto";
+
+option go_package = "github.com/liverty-music/specification/gen/go/liverty_music/rpc/ticket_journey/v1;ticketjourneyv1";
+
+// TicketJourneyService manages a fan's personal ticket acquisition journey for events.
+// It allows fans to track their progress through the ticket purchase lifecycle — from
+// monitoring ticket sales announcements, through lottery applications and payment, to
+// securing the ticket. All operations are scoped to the authenticated user.
+service TicketJourneyService {
+  // SetStatus creates or updates the fan's ticket journey status for a specific event.
+  // If no journey exists for the given event, one is created. If a journey already exists,
+  // its status is updated. No state transition rules are enforced — the fan may set any
+  // valid status at any time.
+  //
+  // Possible errors:
+  // - INVALID_ARGUMENT: The event_id is missing/invalid or the status is UNSPECIFIED/undefined.
+  // - UNAUTHENTICATED: The user identity could not be verified.
+  rpc SetStatus(SetStatusRequest) returns (SetStatusResponse);
+
+  // Delete removes the fan's ticket journey for a specific event.
+  // This is an idempotent operation — deleting a non-existent journey succeeds silently.
+  //
+  // Possible errors:
+  // - INVALID_ARGUMENT: The event_id is missing or invalid.
+  // - UNAUTHENTICATED: The user identity could not be verified.
+  rpc Delete(DeleteRequest) returns (DeleteResponse);
+
+  // ListByUser retrieves all ticket journeys for the authenticated fan.
+  // Returns a lightweight list of (event_id, status) pairs intended to be joined
+  // with concert data on the client side.
+  //
+  // Possible errors:
+  // - UNAUTHENTICATED: The user identity could not be verified.
+  rpc ListByUser(ListByUserRequest) returns (ListByUserResponse);
+}
+
+// SetStatusRequest specifies the event and desired status for the fan's ticket journey.
+message SetStatusRequest {
+  // Required. The event to set the journey status for.
+  liverty_music.entity.v1.EventId event_id = 1 [(buf.validate.field).required = true];
+
+  // Required. The status to set. Must be a defined value other than UNSPECIFIED.
+  liverty_music.entity.v1.TicketJourneyStatus status = 2 [
+    (buf.validate.field).required = true,
+    (buf.validate.field).enum.defined_only = true
+  ];
+}
+
+// SetStatusResponse is returned upon a successful status set operation.
+message SetStatusResponse {}
+
+// DeleteRequest specifies the event whose ticket journey should be removed.
+message DeleteRequest {
+  // Required. The event whose journey should be deleted.
+  liverty_music.entity.v1.EventId event_id = 1 [(buf.validate.field).required = true];
+}
+
+// DeleteResponse is returned upon a successful delete operation.
+message DeleteResponse {}
+
+// ListByUserRequest is the request for listing the authenticated fan's ticket journeys.
+// No fields are required; the user identity is determined from the authentication context.
+message ListByUserRequest {}
+
+// ListByUserResponse contains all ticket journeys for the authenticated fan.
+message ListByUserResponse {
+  // The fan's ticket journeys across all events.
+  repeated liverty_music.entity.v1.TicketJourney journeys = 1;
+}


### PR DESCRIPTION
## Related Issue

N/A — new feature

## Summary of Changes

- Define TicketJourney entity with TicketJourneyStatus enum (TRACKING, APPLIED, LOST, UNPAID, PAID) representing the user's ticket acquisition progress per event
- Define TicketJourneyService RPC with SetStatus, Delete, ListByUser operations
- All fields validated with protovalidate constraints (required, defined_only, UUID)
- Include OpenSpec change artifacts (proposal, design, specs, tasks)

## Self-Checklist

- [x] I have linked the related issue.
- [x] I have updated the relevant documentation (e.g., README.md) if needed.
- [x] I have run buf lint and buf format locally and all checks have passed.
- [x] My proto definitions follow the project's style guidelines and validation rules.
- [x] Breaking changes have been justified and documented if applicable.
