### PR TITLE
docs(openspec): sync onboarding-spotlight spec for empty selector fix

### DIFF
--- a/openspec/changes/archive/2026-03-18-fix-coach-mark-empty-selector/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-18-fix-coach-mark-empty-selector/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-18

--- a/openspec/changes/archive/2026-03-18-fix-coach-mark-empty-selector/design.md
+++ b/openspec/changes/archive/2026-03-18-fix-coach-mark-empty-selector/design.md
@@ -1,0 +1,32 @@
+## Context
+
+`coach-mark` コンポーネントは app-shell に1つだけ配置され、`@aurelia/state` Store 経由で `targetSelector` / `active` がバインドされる。Store の `clearSpotlight` dispatch は `spotlightTarget = ''` と `spotlightActive = false` を同時に設定するが、Aurelia のバインディング更新順序は非決定的であり、`targetSelectorChanged()` が `activeChanged()` より先に発火するケースがある。
+
+## Goals / Non-Goals
+
+**Goals:**
+- `querySelector` に空文字が渡されることによる `InvalidSelectorError` を防止する
+- Aurelia のバインディング更新順序に依存しない堅牢な実装にする
+
+**Non-Goals:**
+- Store の状態設計の変更（`spotlightTarget = ''` は「ターゲットなし」のセマンティクスとして妥当）
+- `dashboard-route.ts` の `laneIntroSelector` getter の変更（呼び出し元のガードは正しく機能している）
+
+## Decisions
+
+### 修正箇所: `coach-mark.ts` の `findAndHighlight()` に入力バリデーション追加
+
+**選択肢:**
+
+| Option | 内容 | 評価 |
+|--------|------|------|
+| A. `findAndHighlight()` に早期リターン | `if (!this.targetSelector) return` を先頭に追加 | **採用** — 防御的、1行、副作用なし |
+| B. `targetSelectorChanged()` にガード追加 | `if (!this.targetSelector) { this.deactivate(); return }` | 過剰 — deactivate は `activeChanged` の責務 |
+| C. Store で `spotlightTarget` を nullable に | `null` のときバインディングが変わらないようにする | 過剰 — Store 設計を変える必要がある |
+
+**理由:** Option A は `querySelector` の呼び出し元として入力を検証する責務を果たす。Aurelia のバインディング順序という外部要因に依存しない設計になる。
+
+## Risks / Trade-offs
+
+- **リスク:** 空セレクタを silent に無視するため、将来的に本来空であるべきでないケースも見逃す可能性がある
+  → **緩和:** 既存の `MAX_RETRY_MS` 超過時のエラーログで検出可能。空セレクタはリトライ自体が不要なので、リトライループに入らず即座にリターンする方が正しい

--- a/openspec/changes/archive/2026-03-18-fix-coach-mark-empty-selector/proposal.md
+++ b/openspec/changes/archive/2026-03-18-fix-coach-mark-empty-selector/proposal.md
@@ -1,0 +1,23 @@
+## Why
+
+Onboarding 完了後に `/dashboard` へ遷移すると、`querySelector('')` が呼ばれて `InvalidSelectorError` が発生する。`@aurelia/state` の Store dispatch で `spotlightTarget` と `spotlightActive` が同時に変更された際、Aurelia のバインディング更新順序が非決定的であるため、`targetSelector` が空文字に変わった時点でまだ `active` が `true` のままコールバックが発火するレースコンディションが原因。
+
+## What Changes
+
+- `coach-mark.ts` の `findAndHighlight()` メソッドに空セレクタの早期リターンガードを追加
+- `querySelector` に無効な引数が渡されることを防止
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `onboarding-spotlight`: coach-mark コンポーネントが空セレクタに対して防御的に振る舞うようになる
+
+## Impact
+
+- `frontend/src/components/coach-mark/coach-mark.ts` — 1行の早期リターン追加
+- 他のコンポーネント・サービス・API への影響なし

--- a/openspec/changes/archive/2026-03-18-fix-coach-mark-empty-selector/specs/onboarding-spotlight/spec.md
+++ b/openspec/changes/archive/2026-03-18-fix-coach-mark-empty-selector/specs/onboarding-spotlight/spec.md
@@ -1,0 +1,38 @@
+## MODIFIED Requirements
+
+### Requirement: Continuous Spotlight Persistence
+
+The spotlight SHALL remain continuously active from the moment it first appears (Step 1, Dashboard icon) until the sign-up modal is displayed (Step 6). The popover SHALL NOT be closed and reopened between steps; instead, the target SHALL be updated via anchor-name reassignment while the overlay remains open. This provides uninterrupted visual guidance throughout the entire onboarding tutorial. **Exception**: the Step 1→3 transition (Discovery → Dashboard) SHALL deactivate and reactivate the spotlight — the popover must be cleared before navigation so that Dashboard overlays (celebration, region selector) render above the top layer without being blocked by click-blockers (see `onboarding-tutorial`, "Step 1 - Spotlight deactivation before navigation").
+
+The `findAndHighlight()` method SHALL validate `targetSelector` before calling `querySelector`. When `targetSelector` is empty or falsy, the method SHALL return immediately without calling `querySelector` or initiating retry logic. This prevents `InvalidSelectorError` caused by non-deterministic Aurelia binding update order when multiple Store properties change simultaneously.
+
+#### Scenario: Spotlight activates at Step 1 and persists through Step 5
+
+- **WHEN** the coach mark first activates at Step 1 (Dashboard icon in discover page)
+- **THEN** the overlay popover SHALL call `showPopover()` once
+- **AND** the popover SHALL remain open through all subsequent steps (Step 3 lane intro, Step 3 card, Step 4 My Artists tab, Step 5 Passion Level)
+- **AND** the target SHALL change by reassigning `anchor-name` to the new target element
+- **AND** the tooltip message SHALL update to match the current step
+
+#### Scenario: Spotlight deactivates at Step 6
+
+- **WHEN** `onboardingStep` advances to 6 (SignUp)
+- **THEN** the overlay popover SHALL call `hidePopover()`
+- **AND** the current target's `anchor-name` SHALL be removed
+- **AND** the scroll lock on `<au-viewport>` SHALL be released
+- **AND** no orphaned click-blockers or anchor-names SHALL remain in the DOM
+
+#### Scenario: App-shell level placement
+
+- **WHEN** the onboarding spotlight is active
+- **THEN** the `<coach-mark>` component SHALL be rendered in the app shell (`my-app.html`), not in individual route page templates
+- **AND** the onboarding service SHALL drive the target selector, message, spotlight radius, and active state
+- **AND** individual route pages SHALL NOT contain their own `<coach-mark>` instances for onboarding steps
+
+#### Scenario: Empty target selector is safely ignored
+
+- **WHEN** the `targetSelector` bindable property is set to an empty string (e.g., via Store `clearSpotlight` dispatch)
+- **AND** `targetSelectorChanged()` fires before `activeChanged()` due to non-deterministic binding update order
+- **THEN** `findAndHighlight()` SHALL return immediately without calling `document.querySelector`
+- **AND** no `InvalidSelectorError` SHALL be thrown
+- **AND** no retry timer SHALL be started

--- a/openspec/changes/archive/2026-03-18-fix-coach-mark-empty-selector/tasks.md
+++ b/openspec/changes/archive/2026-03-18-fix-coach-mark-empty-selector/tasks.md
@@ -1,0 +1,7 @@
+## 1. Fix
+
+- [x] 1.1 Add empty selector guard at the top of `findAndHighlight()` in `frontend/src/components/coach-mark/coach-mark.ts`
+
+## 2. Verify
+
+- [x] 2.1 Run `make check` in frontend to confirm lint and tests pass

--- a/openspec/specs/onboarding-spotlight/spec.md
+++ b/openspec/specs/onboarding-spotlight/spec.md
@@ -70,6 +70,8 @@ The coach mark overlay container SHALL use `popover="manual"` to render on the b
 
 The spotlight SHALL remain continuously active from the moment it first appears (Step 1, Dashboard icon) until the sign-up modal is displayed (Step 6). The popover SHALL NOT be closed and reopened between steps; instead, the target SHALL be updated via anchor-name reassignment while the overlay remains open. This provides uninterrupted visual guidance throughout the entire onboarding tutorial. **Exception**: the Step 1→3 transition (Discovery → Dashboard) SHALL deactivate and reactivate the spotlight — the popover must be cleared before navigation so that Dashboard overlays (celebration, region selector) render above the top layer without being blocked by click-blockers (see `onboarding-tutorial`, "Step 1 - Spotlight deactivation before navigation").
 
+The `findAndHighlight()` method SHALL validate `targetSelector` before calling `querySelector`. When `targetSelector` is empty or falsy, the method SHALL return immediately without calling `querySelector` or initiating retry logic. This prevents `InvalidSelectorError` caused by non-deterministic Aurelia binding update order when multiple Store properties change simultaneously.
+
 #### Scenario: Spotlight activates at Step 1 and persists through Step 5
 
 - **WHEN** the coach mark first activates at Step 1 (Dashboard icon in discover page)
@@ -92,6 +94,14 @@ The spotlight SHALL remain continuously active from the moment it first appears 
 - **THEN** the `<coach-mark>` component SHALL be rendered in the app shell (`my-app.html`), not in individual route page templates
 - **AND** the onboarding service SHALL drive the target selector, message, spotlight radius, and active state
 - **AND** individual route pages SHALL NOT contain their own `<coach-mark>` instances for onboarding steps
+
+#### Scenario: Empty target selector is safely ignored
+
+- **WHEN** the `targetSelector` bindable property is set to an empty string (e.g., via Store `clearSpotlight` dispatch)
+- **AND** `targetSelectorChanged()` fires before `activeChanged()` due to non-deterministic binding update order
+- **THEN** `findAndHighlight()` SHALL return immediately without calling `document.querySelector`
+- **AND** no `InvalidSelectorError` SHALL be thrown
+- **AND** no retry timer SHALL be started
 
 ### Requirement: Smooth Spotlight Movement via View Transitions API
 


### PR DESCRIPTION
## Related Issue

Refs: liverty-music/frontend#240

## Summary of Changes

Sync the `onboarding-spotlight` spec with the fix for coach-mark `InvalidSelectorError` and archive the completed change artifacts.

- Add "Empty target selector is safely ignored" scenario to the `Continuous Spotlight Persistence` requirement
- Add `findAndHighlight()` input validation clause to the requirement text
- Archive `fix-coach-mark-empty-selector` change (proposal, design, delta spec, tasks)

## Self-Checklist

- [x] I have linked the related issue.
- [x] I have updated the relevant documentation (e.g., `README.md`) if needed.
- [x] I have run `buf lint` and `buf format` locally and all checks have passed.
- [x] My proto definitions follow the project's style guidelines and validation rules.
- [x] Breaking changes have been justified and documented if applicable.
