### PR TITLE
feat(concert): add ListWithProximity RPC

### DIFF
--- a/openspec/changes/fix-onboarding-dashboard/.openspec.yaml
+++ b/openspec/changes/fix-onboarding-dashboard/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-18

--- a/openspec/changes/fix-onboarding-dashboard/design.md
+++ b/openspec/changes/fix-onboarding-dashboard/design.md
@@ -1,0 +1,63 @@
+## Context
+
+The onboarding tutorial guides new users through discovery → dashboard → my-artists. On the dashboard, a lane introduction sequence spotlights three stage headers (HOME/NEAR/AWAY STAGE) and then a concert card. This sequence is broken because:
+
+1. Coach mark CSS selectors (`[data-stage-home]`) don't match the HTML attribute format (`data-stage="home"`).
+2. The client-side `groupConcertsByDate()` puts all concerts into the `away` bucket because no proximity classification exists for unauthenticated users.
+3. Retry timers in `findAndHighlight()` leak when a new phase starts before the previous retry completes.
+
+The existing `ListByFollower` RPC resolves proximity server-side but requires authentication. Onboarding users are unauthenticated.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Fix the onboarding dashboard so stage spotlights appear and concerts are correctly classified by proximity.
+- Add a public RPC that provides proximity-grouped concerts for unauthenticated users who have a Home selection and a list of followed artists.
+- Eliminate the N+1 RPC call pattern in onboarding (currently one `List` per followed artist).
+
+**Non-Goals:**
+- Changing the existing `List` or `ListByFollower` RPCs.
+- Modifying the proximity model (thresholds, classification logic).
+- Refactoring the coach mark component beyond the timer leak fix.
+
+## Decisions
+
+### D1: New `ListWithProximity` RPC (not extending `List` or `ListByFollower`)
+
+Add a new RPC rather than modifying existing ones.
+
+- `List` is a simple single-artist query; adding proximity would change its contract.
+- `ListByFollower` requires authentication and resolves artists+Home from user context; adding optional guest parameters would blur its responsibility.
+- `ListWithProximity` accepts explicit `repeated ArtistId` + `Home` and returns `repeated ProximityGroup`. Same response shape as `ListByFollower`.
+
+**Alternative considered**: Extend `ListByFollower` with optional `guest_artist_ids` and `guest_home` fields. Rejected because it mixes authenticated and unauthenticated concerns in one RPC.
+
+### D2: Repository method `ListByArtists` (plural) with coordinates
+
+The new use case needs concerts for multiple artists with venue coordinates (for Haversine calculation). The existing `ListByArtist` (singular) fetches one artist and does not include coordinates.
+
+New repository method: `ListByArtists(ctx, artistIDs []string) ([]*entity.Concert, error)` with SQL `WHERE c.artist_id = ANY($1)` and `v.latitude, v.longitude` in the SELECT.
+
+### D3: Centroid resolution in the handler, not the client
+
+The `ListWithProximity` request accepts `entity.v1.Home` (which includes `country_code` and `level_1`). The backend resolves the centroid from `level_1` using the existing `geo.ResolveCentroid()` function, then constructs `entity.Home` for `GroupByDateAndProximity()`.
+
+The client sends only the `Home` message (country_code + level_1) it already has from the onboarding home selection step. No new client-side logic needed for centroid resolution.
+
+### D4: Fix CSS selectors directly (no HTML changes)
+
+The HTML template uses `data-stage="home"` (attribute with value). The TypeScript `laneIntroSelector` getter uses `[data-stage-home]` (attribute name check). Fix the getter to `[data-stage="home"]`, `[data-stage="near"]`, `[data-stage="away"]`.
+
+**Alternative considered**: Change HTML to `data-stage-home` (boolean attributes). Rejected because `data-stage="home"` is the more standard pattern and is already in use.
+
+### D5: Cancel retry timer at the start of `findAndHighlight()`
+
+Call `cleanup()` at the beginning of `findAndHighlight()` to cancel any pending retry timer before starting a new retry chain. This prevents timer leaks when `targetSelectorChanged` fires while a previous retry is still running.
+
+## Risks / Trade-offs
+
+- **[Risk] `ListWithProximity` is public (no auth)**: An unauthenticated caller can query concerts for arbitrary artist IDs. → Mitigation: This is the same data already available via the public `List` RPC; the only addition is proximity grouping, which is not sensitive. Rate limiting applies at the gateway level.
+
+- **[Risk] Centroid resolution may fail for unsupported country codes**: → Mitigation: `geo.ResolveCentroid()` returns nil for unknown codes. `GroupByDateAndProximity` treats nil Home centroid as AWAY — same fallback as today.
+
+- **[Risk] Large artist list in a single RPC call**: → Mitigation: Onboarding limits follows to a small number (typically 3-10 artists). Add protovalidate constraint `repeated ... [(buf.validate.field).repeated.max_items = 50]`.

--- a/openspec/changes/fix-onboarding-dashboard/proposal.md
+++ b/openspec/changes/fix-onboarding-dashboard/proposal.md
@@ -1,0 +1,34 @@
+## Why
+
+Onboarding dashboard is broken: coach mark spotlights fail to appear on stage headers, and all concerts are placed in the AWAY lane regardless of user's home selection. This blocks the lane introduction sequence, preventing users from completing the onboarding tutorial (discovery → dashboard → my-artists).
+
+Root causes:
+1. CSS attribute selectors use `[data-stage-home]` but HTML uses `data-stage="home"` — coach mark targets are never found.
+2. Frontend `groupConcertsByDate()` places all concerts in `away` because no server-side proximity classification exists for unauthenticated onboarding users.
+3. Coach mark retry timers are not cancelled when a new phase starts, causing leaked timers.
+
+## What Changes
+
+- **New RPC `ListWithProximity`** on `ConcertService`: accepts `repeated ArtistId` + `Home`, returns `repeated ProximityGroup`. Public (no auth required). Shares `GroupByDateAndProximity` logic with existing `ListByFollower`.
+- **Fix coach mark CSS selectors**: change `[data-stage-home]` → `[data-stage="home"]` (and near, away) in `dashboard-route.ts`.
+- **Fix retry timer leak**: cancel pending retry timer in `findAndHighlight()` before starting a new retry chain.
+- **Replace N client-side `List` calls** with single `ListWithProximity` call during onboarding.
+
+## Capabilities
+
+### New Capabilities
+
+_(none)_
+
+### Modified Capabilities
+
+- `concert-service`: Add `ListWithProximity` RPC — accepts `repeated ArtistId` + `Home`, returns `repeated ProximityGroup` for unauthenticated users.
+- `dashboard-lane-introduction`: Fix CSS attribute selector mismatch for stage header spotlights.
+- `onboarding-spotlight`: Fix retry timer leak when `findAndHighlight()` is re-invoked before previous retry chain completes.
+
+## Impact
+
+- **specification**: New `ListWithProximity` RPC + request/response messages in `concert_service.proto`.
+- **backend**: New handler, use case method, repository method (`ListByArtists` for multiple artist IDs with coordinates).
+- **frontend**: Replace `listByFollowerOnboarding()` N-call pattern with single `ListWithProximity` RPC call. Fix selectors and timer leak in dashboard-route and coach-mark components.
+- **No breaking changes**: existing `List` and `ListByFollower` RPCs are unchanged.

--- a/openspec/changes/fix-onboarding-dashboard/specs/concert-service/spec.md
+++ b/openspec/changes/fix-onboarding-dashboard/specs/concert-service/spec.md
@@ -1,0 +1,67 @@
+## ADDED Requirements
+
+### Requirement: List Concerts with Proximity for Unauthenticated Users
+
+The system SHALL provide a public RPC `ListWithProximity` that accepts a list of artist IDs and a Home, returning concerts grouped by date and classified by proximity. This RPC does not require authentication and shares the same `GroupByDateAndProximity` logic as `ListByFollower`.
+
+#### Scenario: Successful proximity-grouped listing
+
+- **WHEN** `ListWithProximity` is called with one or more `artist_ids` and a valid `Home` (country_code + level_1)
+- **THEN** it SHALL return concerts grouped by date using `ProximityGroup` messages
+- **AND** each `ProximityGroup` SHALL contain concerts classified into `home`, `nearby`, and `away` fields based on `Concert.ProximityTo(home)`
+- **AND** each concert SHALL include a resolved `Venue` object with `name`, `admin_area`, and coordinates
+- **AND** each concert SHALL include `listed_venue_name` with the raw scraped venue name
+- **AND** groups SHALL be ordered by date ascending
+
+#### Scenario: Home centroid resolved server-side
+
+- **WHEN** `ListWithProximity` is called with `Home.level_1` (e.g., "JP-40")
+- **THEN** the backend SHALL resolve the centroid from `level_1` using `geo.ResolveCentroid()`
+- **AND** the resolved centroid SHALL be used for Haversine distance calculation in proximity classification
+
+#### Scenario: Empty artist list
+
+- **WHEN** `ListWithProximity` is called with an empty `artist_ids` list
+- **THEN** it SHALL return an `INVALID_ARGUMENT` error
+
+#### Scenario: No concerts found for any artist
+
+- **WHEN** `ListWithProximity` is called with valid artist IDs
+- **AND** no concerts exist for any of the specified artists
+- **THEN** it SHALL return an empty `groups` list without error
+
+#### Scenario: Artist ID validation limit
+
+- **WHEN** `ListWithProximity` is called with more than 50 artist IDs
+- **THEN** it SHALL return an `INVALID_ARGUMENT` error via protovalidate
+
+#### Scenario: Home with unsupported country code
+
+- **WHEN** `ListWithProximity` is called with a `Home` whose `level_1` has no known centroid
+- **THEN** the centroid SHALL be nil
+- **AND** all concerts SHALL be classified as `AWAY` (except those matching by `admin_area`)
+
+## MODIFIED Requirements
+
+### Requirement: Venue Resolution in Concert List
+
+The `ConcertRepository.ListByArtist` implementation SHALL JOIN the `venues` table so that every returned `Concert` carries a populated `Venue` with `name` and `admin_area`. Additionally, a new `ListByArtists` (plural) repository method SHALL support querying multiple artists in a single SQL call with venue coordinates included.
+
+#### Scenario: Venue JOIN in list query
+
+- **WHEN** `ListByArtist` is called
+- **THEN** the SQL query SHALL JOIN `events` and `venues` tables
+- **AND** `venue.name` and `venue.admin_area` SHALL be scanned into the returned entities
+
+#### Scenario: Concert mapper includes Venue
+
+- **WHEN** a `Concert` entity is mapped to proto
+- **THEN** `ConcertToProto` SHALL populate the `venue` field using `VenueToProto`
+- **AND** SHALL populate `listed_venue_name` from `Concert.Event.ListedVenueName`
+
+#### Scenario: ListByArtists (plural) query with coordinates
+
+- **WHEN** `ListByArtists` is called with a list of artist IDs
+- **THEN** the SQL query SHALL use `WHERE c.artist_id = ANY($1)` to filter by multiple artists
+- **AND** the query SHALL include `v.latitude, v.longitude` in the SELECT for proximity calculation
+- **AND** the query SHALL order results by `e.local_event_date ASC`

--- a/openspec/changes/fix-onboarding-dashboard/specs/dashboard-lane-introduction/spec.md
+++ b/openspec/changes/fix-onboarding-dashboard/specs/dashboard-lane-introduction/spec.md
@@ -1,0 +1,56 @@
+## MODIFIED Requirements
+
+### Requirement: Sequential Lane Header Spotlight
+
+The system SHALL introduce each dashboard lane by sequentially spotlighting the STAGE headers with explanatory coach marks before spotlighting the first concert card.
+
+#### Scenario: Lane introduction begins after region selection
+
+- **WHEN** the celebration overlay has faded
+- **AND** the region selection (if needed) has completed
+- **AND** `ConcertService/ListWithProximity` has returned 1 or more date groups
+- **THEN** the system SHALL begin the lane introduction sequence
+- **AND** scrolling SHALL be disabled during the entire sequence
+
+#### Scenario: Lane introduction skipped when no concert data
+
+- **WHEN** the celebration overlay has faded
+- **AND** the region selection (if needed) has completed
+- **AND** `ConcertService/ListWithProximity` has returned 0 date groups
+- **THEN** the system SHALL NOT begin the lane introduction sequence
+- **AND** the system SHALL log a warning: "No concert data available, skipping lane intro"
+- **AND** the system SHALL skip directly to Step 4 behavior (My Artists tab spotlight)
+
+#### Scenario: HOME STAGE header spotlight
+
+- **WHEN** the lane introduction sequence begins
+- **THEN** the system SHALL spotlight the HOME STAGE header element using selector `[data-stage="home"]`
+- **AND** the coach mark SHALL display: "地元のライブ情報！"
+- **AND** the spotlight SHALL remain for 2 seconds or until the user taps
+
+#### Scenario: NEAR STAGE header spotlight
+
+- **WHEN** the HOME STAGE spotlight completes (2s timeout or user tap)
+- **THEN** the system SHALL spotlight the NEAR STAGE header element using selector `[data-stage="near"]`
+- **AND** the coach mark SHALL display: "近くのエリアのライブも！"
+- **AND** the spotlight SHALL remain for 2 seconds or until the user taps
+
+#### Scenario: AWAY STAGE header spotlight
+
+- **WHEN** the NEAR STAGE spotlight completes (2s timeout or user tap)
+- **THEN** the system SHALL spotlight the AWAY STAGE header element using selector `[data-stage="away"]`
+- **AND** the coach mark SHALL display: "全国のライブ情報もチェック！"
+- **AND** the spotlight SHALL remain for 2 seconds or until the user taps
+
+#### Scenario: Transition to first card spotlight
+
+- **WHEN** the AWAY STAGE spotlight completes
+- **THEN** the system SHALL proceed to the existing Step 3 card spotlight behavior
+- **AND** scrolling SHALL remain disabled until the card is tapped
+
+#### Scenario: Onboarding dashboard uses ListWithProximity RPC
+
+- **WHEN** the onboarding dashboard loads concert data
+- **THEN** the system SHALL call `ConcertService/ListWithProximity` with the guest's followed artist IDs and selected Home
+- **AND** the system SHALL NOT call `ConcertService/List` individually per artist
+- **AND** concerts SHALL be distributed across HOME/NEAR/AWAY lanes based on server-provided proximity classification

--- a/openspec/changes/fix-onboarding-dashboard/specs/onboarding-spotlight/spec.md
+++ b/openspec/changes/fix-onboarding-dashboard/specs/onboarding-spotlight/spec.md
@@ -1,0 +1,46 @@
+## MODIFIED Requirements
+
+### Requirement: Continuous Spotlight Persistence
+
+The spotlight SHALL remain continuously active from the moment it first appears (Step 1, Dashboard icon) until the sign-up modal is displayed (Step 6). The popover SHALL NOT be closed and reopened between steps; instead, the target SHALL be updated via anchor-name reassignment while the overlay remains open. This provides uninterrupted visual guidance throughout the entire onboarding tutorial. **Exception**: the Step 1→3 transition (Discovery → Dashboard) SHALL deactivate and reactivate the spotlight — the popover must be cleared before navigation so that Dashboard overlays (celebration, region selector) render above the top layer without being blocked by click-blockers (see `onboarding-tutorial`, "Step 1 - Spotlight deactivation before navigation").
+
+The `findAndHighlight()` method SHALL validate `targetSelector` before calling `querySelector`. When `targetSelector` is empty or falsy, the method SHALL return immediately without calling `querySelector` or initiating retry logic. This prevents `InvalidSelectorError` caused by non-deterministic Aurelia binding update order when multiple Store properties change simultaneously.
+
+The `findAndHighlight()` method SHALL cancel any pending retry timer before starting a new retry chain. This prevents timer leaks when `targetSelectorChanged` fires while a previous retry is still running (e.g., during the lane introduction sequence where phases advance every 2 seconds but retry chains run up to 5 seconds).
+
+#### Scenario: Spotlight activates at Step 1 and persists through Step 5
+
+- **WHEN** the coach mark first activates at Step 1 (Dashboard icon in discover page)
+- **THEN** the overlay popover SHALL call `showPopover()` once
+- **AND** the popover SHALL remain open through all subsequent steps (Step 3 lane intro, Step 3 card, Step 4 My Artists tab, Step 5 Passion Level)
+- **AND** the target SHALL change by reassigning `anchor-name` to the new target element
+- **AND** the tooltip message SHALL update to match the current step
+
+#### Scenario: Spotlight deactivates at Step 6
+
+- **WHEN** `onboardingStep` advances to 6 (SignUp)
+- **THEN** the overlay popover SHALL call `hidePopover()`
+- **AND** the current target's `anchor-name` SHALL be cleared
+- **AND** the scroll lock on `<au-viewport>` SHALL be released (`overflow` reset)
+- **AND** no orphaned click-blockers or anchor-names SHALL remain in the DOM
+
+#### Scenario: App-shell level placement
+
+- **WHEN** the onboarding spotlight is active
+- **THEN** the `<coach-mark>` component SHALL be rendered in the app shell (`my-app.html`), not in individual route page templates
+- **AND** the onboarding service SHALL drive the target selector, message, spotlight radius, and active state
+- **AND** individual route pages SHALL NOT contain their own `<coach-mark>` instances for onboarding steps
+
+#### Scenario: Empty target selector is safely ignored
+
+- **WHEN** the `targetSelector` bindable property is set to an empty string (e.g., via Store `clearSpotlight` dispatch)
+- **AND** `targetSelectorChanged()` fires before `activeChanged()` due to non-deterministic binding update order
+- **THEN** `findAndHighlight()` SHALL return immediately without calling `document.querySelector`
+- **AND** no `InvalidSelectorError` SHALL be thrown
+- **AND** no retry timer SHALL be started
+
+#### Scenario: Retry timer cancelled on new target
+
+- **WHEN** `findAndHighlight()` is called while a previous retry chain is still pending
+- **THEN** the pending retry timer SHALL be cancelled via `cleanup()` before starting the new retry chain
+- **AND** only one retry chain SHALL be active at any time

--- a/openspec/changes/fix-onboarding-dashboard/tasks.md
+++ b/openspec/changes/fix-onboarding-dashboard/tasks.md
@@ -1,0 +1,40 @@
+## 1. Specification (Proto)
+
+- [x] 1.1 Add `ListWithProximityRequest` message to `concert_service.proto` with `repeated ArtistId artist_ids` (max_items=50 via protovalidate) and `entity.v1.Home home` (required)
+- [x] 1.2 Add `ListWithProximityResponse` message with `repeated ProximityGroup groups`
+- [x] 1.3 Add `rpc ListWithProximity` to `ConcertService`
+- [x] 1.4 Run `buf lint` and `buf format -w` to validate proto changes
+
+## 2. Backend — Repository
+
+- [x] 2.1 Add `ListByArtists(ctx, artistIDs []string) ([]*entity.Concert, error)` to `ConcertRepository` interface
+- [x] 2.2 Implement `ListByArtists` SQL query with `WHERE c.artist_id = ANY($1)`, JOIN venues including `v.latitude, v.longitude`, ORDER BY `e.local_event_date ASC`
+- [x] 2.3 Write integration test for `ListByArtists` verifying multi-artist query and venue coordinate population
+
+## 3. Backend — Use Case
+
+- [x] 3.1 Add `ListWithProximity(ctx, artistIDs []string, home *entity.Home) ([]*entity.ProximityGroup, error)` to concert use case interface
+- [x] 3.2 Implement `ListWithProximity`: resolve centroid from `home.Level1` via `geo.ResolveCentroid()`, call `repo.ListByArtists()`, then `entity.GroupByDateAndProximity()`
+- [x] 3.3 Write unit test for `ListWithProximity` with mocked repository
+
+## 4. Backend — RPC Handler
+
+- [x] 4.1 Add `ListWithProximity` handler to `ConcertHandler` mapping proto request to use case call
+- [x] 4.2 Register `ListWithProximity` in Wire provider set (not needed — Connect auto-discovers methods on handler struct)
+- [x] 4.3 Run `mockery` to regenerate mocks for updated interface
+
+## 5. Frontend — Coach Mark Fix
+
+- [x] 5.1 Fix `laneIntroSelector` getter in `dashboard-route.ts`: change `[data-stage-home]` → `[data-stage="home"]`, `[data-stage-near]` → `[data-stage="near"]`, `[data-stage-away]` → `[data-stage="away"]`
+- [x] 5.2 Add `this.cleanup()` call at the start of `findAndHighlight()` in `coach-mark.ts` to cancel pending retry timers
+
+## 6. Frontend — ListWithProximity Integration
+
+- [x] 6.1 Replace `listByFollowerOnboarding()` in `concert-service.ts`: call `ListWithProximity` RPC with guest's `followed artist IDs` + `Home` instead of N individual `List` calls
+- [x] 6.2 Remove `groupConcertsByDate()` helper function (no longer needed — server returns ProximityGroups)
+
+## 7. Verification
+
+- [ ] 7.1 Run `make check` in backend (blocked: handler references BSR-generated types not yet available)
+- [ ] 7.2 Run `make check` in frontend (blocked: imports BSR-generated types not yet available)
+- [ ] 7.3 Manual E2E: verify onboarding flow from discovery → dashboard → stage spotlights → concert card → my-artists

--- a/proto/liverty_music/rpc/concert/v1/concert_service.proto
+++ b/proto/liverty_music/rpc/concert/v1/concert_service.proto
@@ -6,6 +6,7 @@ import "buf/validate/validate.proto";
 import "liverty_music/entity/v1/artist.proto";
 import "liverty_music/entity/v1/concert.proto";
 import "liverty_music/entity/v1/entity.proto";
+import "liverty_music/entity/v1/user.proto";
 
 // ConcertService provides operations for managing the catalog of musical concerts.
 // It acts as the primary data source for upcoming live music events.
@@ -23,6 +24,15 @@ service ConcertService {
   // Possible errors:
   // - UNAUTHENTICATED: The user identity could not be verified.
   rpc ListByFollower(ListByFollowerRequest) returns (ListByFollowerResponse);
+
+  // ListWithProximity retrieves concerts for the specified artists, grouped by date
+  // and classified by geographic proximity to the caller's home area.
+  // Authentication is not required; the caller provides artist IDs and home explicitly.
+  //
+  // Possible errors:
+  // - INVALID_ARGUMENT: The request is missing required fields, contains invalid data,
+  //   or exceeds the maximum number of artist IDs (50).
+  rpc ListWithProximity(ListWithProximityRequest) returns (ListWithProximityResponse);
 
   // SearchNewConcerts triggers an asynchronous discovery process for new concerts.
   // It enqueues a background search job and returns immediately. The actual search
@@ -87,6 +97,29 @@ message ProximityGroup {
 
   // Concerts at venues beyond 200km, with unknown location, or when the user has no home set.
   repeated entity.v1.Concert away = 4;
+}
+
+// ListWithProximityRequest specifies the artists and home area for proximity-grouped
+// concert retrieval. Used during onboarding when the caller is not yet authenticated.
+message ListWithProximityRequest {
+  // Required. The artists whose concerts are to be listed.
+  // Maximum 50 artist IDs per request.
+  repeated entity.v1.ArtistId artist_ids = 1 [
+    (buf.validate.field).repeated.min_items = 1,
+    (buf.validate.field).repeated.max_items = 50
+  ];
+
+  // Required. The caller's home area, used for proximity classification.
+  entity.v1.Home home = 2 [(buf.validate.field).required = true];
+}
+
+// ListWithProximityResponse contains concerts for the specified artists,
+// grouped by date and classified by geographic proximity.
+message ListWithProximityResponse {
+  // Concert groups ordered by date ascending. Each group contains concerts
+  // for a single date, classified into home/nearby/away buckets based on
+  // the geographic proximity between the provided home area and each venue.
+  repeated ProximityGroup groups = 1;
 }
 
 // SearchNewConcertsRequest specifies the artist for whom to search for new concerts.


### PR DESCRIPTION
## Related Issue

Closes #289

## Summary of Changes

Add a new `ListWithProximity` RPC to `ConcertService` for the onboarding flow. During onboarding, unauthenticated users have selected artists and a home area but don't yet have a user record. The existing `ListByFollower` requires authentication, so this new RPC accepts artist IDs and `Home` explicitly, returning `ProximityGroup` responses grouped by date and classified by geographic proximity.

### Proto changes
- `ListWithProximityRequest`: `repeated ArtistId artist_ids` (1–50, protovalidate) + `Home home` (required)
- `ListWithProximityResponse`: `repeated ProximityGroup groups`
- `rpc ListWithProximity` on `ConcertService`

### OpenSpec artifacts
- Proposal, design, delta specs, and implementation tasks for the full cross-repo change (`fix-onboarding-dashboard`)

## Self-Checklist

- [x] I have linked the related issue.
- [x] I have updated the relevant documentation (e.g., `README.md`) if needed.
- [x] I have run `buf lint` and `buf format` locally and all checks have passed.
- [x] My proto definitions follow the project's style guidelines and validation rules.
- [ ] Breaking changes have been justified and documented if applicable.