### PR TITLE
feat!: unify ConcertId and EventId into single EventId type

### DIFF
--- a/openspec/changes/unify-concert-event-id/.openspec.yaml
+++ b/openspec/changes/unify-concert-event-id/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-18

--- a/openspec/changes/unify-concert-event-id/design.md
+++ b/openspec/changes/unify-concert-event-id/design.md
@@ -1,0 +1,60 @@
+## Context
+
+The proto schema has two wrapper types for the same underlying UUID:
+
+- `ConcertId` in `concert.proto` — used only by the `Concert` message
+- `EventId` in `ticket.proto` — used by `Ticket`, `Entry`, and `TicketJourney`
+
+Both resolve to `events.id` in the database. The Go domain model already treats them as one concept: `Concert` embeds `Event`, sharing a single `ID` field.
+
+Additionally, `EventId` is currently defined in `ticket.proto`, which is semantically incorrect — an event identifier is a top-level domain concept, not a ticket sub-concept. The `Event` message in `event.proto` already references `EventId` via an import from `ticket.proto`.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Eliminate `ConcertId` message and unify on `EventId` as the single event identifier type
+- Relocate `EventId` to `event.proto` where it semantically belongs
+- Maintain wire compatibility where possible (same field numbers, same UUID format)
+
+**Non-Goals:**
+
+- Renaming the `Concert` message or `ConcertService` RPC — the "concert" concept remains valid as a domain-specific view of an event
+- Changing database schema — `events.id` and `concerts.event_id` are already correct
+- Modifying the Go `entity.Concert` / `entity.Event` structs — they already use a single `ID` field
+
+## Decisions
+
+### 1. Move EventId to event.proto
+
+**Decision**: Relocate the `EventId` message from `ticket.proto` to `event.proto`.
+
+**Why**: `EventId` is a core entity identifier. It belongs alongside the `Event` message, not nested inside ticket definitions. `ticket.proto` will import it from `event.proto`.
+
+**Alternative considered**: Create a new `ids.proto` for all ID types. Rejected — the project convention is to co-locate ID types with their parent entity (e.g., `ArtistId` in `artist.proto`, `VenueId` in `venue.proto`).
+
+### 2. Replace ConcertId with EventId in Concert message
+
+**Decision**: Change `Concert.id` from `ConcertId id = 1` to `EventId id = 1`.
+
+**Why**: The field number stays the same (1), and both types wrap `string value = 1` with UUID validation. The wire format is identical — only the generated type name changes. This aligns the proto schema with the Go entity and database where the ID has always been an event ID.
+
+**Alternative considered**: Keep `ConcertId` as a type alias (documentation-only). Rejected — it preserves the naming confusion and adds maintenance burden.
+
+### 3. Delete ConcertId message entirely
+
+**Decision**: Remove the `ConcertId` message from `concert.proto` rather than deprecating it.
+
+**Why**: `ConcertId` is only used in `concert.proto` line 15. No other proto file references it. Clean removal is simpler than maintaining a deprecated type. The `buf skip breaking` label will be applied to the PR.
+
+### 4. Update concert.proto imports
+
+**Decision**: Add `import "liverty_music/entity/v1/event.proto"` to `concert.proto` (if not already present) to access `EventId`.
+
+## Risks / Trade-offs
+
+- **[Breaking change for generated clients]** → Mitigated by the fact that `ConcertId` has zero usage outside `concert.proto`. Backend mapper changes are mechanical (`ConcertId` → `EventId`). Frontend changes are similarly straightforward. All repos will be updated in coordinated PRs after BSR regeneration.
+
+- **[ticket.proto breaking change from removing EventId]** → `EventId` is moved, not deleted. `ticket.proto` will import it from `event.proto`. Existing fields (`Ticket.event_id`) keep the same type and field number. Wire-compatible.
+
+- **[buf breaking check will flag removed message]** → Apply `buf skip breaking` label to the specification PR. The change is intentional and coordinated.

--- a/openspec/changes/unify-concert-event-id/proposal.md
+++ b/openspec/changes/unify-concert-event-id/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+The proto `Concert` message uses `ConcertId` as its identifier, but the underlying Go entity and database both use `event_id` (the `events` table). Meanwhile, the ticket/entry domain already uses `EventId` for the same underlying UUID. This naming split creates cognitive overhead for developers and risks cross-domain bugs where someone assumes `ConcertId` and `EventId` are different identifiers.
+
+Fixing this now is cheap — `ConcertId` is only referenced in 3 places within `concert.proto`. The longer we wait, the more downstream consumers will depend on the `ConcertId` type.
+
+## What Changes
+
+- **BREAKING**: Remove the `ConcertId` message from `concert.proto`.
+- **BREAKING**: Change `Concert.id` field type from `ConcertId` to `EventId`.
+- Move the `EventId` message definition from `ticket.proto` to `event.proto`, where it belongs as a first-class entity identifier alongside `Event`.
+- Update `ticket.proto` to import `EventId` from its new location.
+- Update all RPC request/response messages that reference `ConcertId` (currently none outside `concert.proto`).
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `concert-service`: The `Concert` entity's identifier type changes from `ConcertId` to `EventId`, aligning the proto schema with the database and Go domain model.
+- `event-management`: `EventId` is relocated from `ticket.proto` to `event.proto` as the canonical event identifier.
+
+## Impact
+
+- **Proto (specification)**: `concert.proto`, `event.proto`, `ticket.proto` modified. Breaking change requires a semver major or minor bump with breaking label.
+- **Backend (Go)**: RPC mapper must map `Concert.ID` ↔ `EventId` instead of `ConcertId`. `ConcertId` type removed from generated code.
+- **Frontend (TypeScript)**: Any references to `ConcertId` type in generated client code must switch to `EventId`.
+- **BSR consumers**: All downstream packages regenerated after release. Draft PRs for backend/frontend can be prepared in advance.

--- a/openspec/changes/unify-concert-event-id/specs/concert-service/spec.md
+++ b/openspec/changes/unify-concert-event-id/specs/concert-service/spec.md
@@ -1,0 +1,49 @@
+## MODIFIED Requirements
+
+### Requirement: Concert Service
+
+The system SHALL provide a gRPC service to manage concerts and artists.
+
+#### Scenario: List Concerts by Artist
+
+- **WHEN** `List` is called with a valid `artist_id`
+- **THEN** it returns a list of concerts associated with that artist
+- **AND** each concert SHALL include an `EventId` (not `ConcertId`) as its identifier
+- **AND** each concert SHALL include a resolved `Venue` object with `name` and `admin_area` if available
+- **AND** each concert SHALL include `listed_venue_name` with the raw scraped venue name
+- **AND** returns an empty list if no concerts are found (not an error)
+
+#### Scenario: List All Artists
+
+- **WHEN** `ListArtists` is called
+- **THEN** it returns a list of all artists in the system
+
+#### Scenario: Create Artist
+
+- **WHEN** `CreateArtist` is called with a valid name
+- **THEN** a new artist is created and returned with a generated ID
+- **AND** the artist is persistable
+
+#### Scenario: Create Artist with Invalid Name
+
+- **WHEN** `CreateArtist` is called with an empty name
+- **THEN** it returns an `INVALID_ARGUMENT` error
+
+### Requirement: Venue Resolution in Concert List
+
+The `ConcertRepository.ListByArtist` implementation SHALL JOIN the `venues` table so that every returned `Concert` carries a populated `Venue` with `name` and `admin_area`.
+
+#### Scenario: Concert mapper includes Venue
+
+- **WHEN** a `Concert` entity is mapped to proto
+- **THEN** `ConcertToProto` SHALL populate the `id` field using `EventId` (not `ConcertId`)
+- **AND** SHALL populate the `venue` field using `VenueToProto`
+- **AND** SHALL populate `listed_venue_name` from `Concert.Event.ListedVenueName`
+
+## REMOVED Requirements
+
+### Requirement: ConcertId type-safe identifier
+
+**Reason**: `ConcertId` is replaced by `EventId`. The `Concert` proto message SHALL use `EventId` as its identifier type, aligning with the database (`events.id`) and Go domain model (`entity.Event.ID`).
+
+**Migration**: All references to `ConcertId` in generated client code (Go, TypeScript) SHALL be replaced with `EventId`. The wire format is unchanged (field number 1, wrapped UUID string).

--- a/openspec/changes/unify-concert-event-id/specs/event-management/spec.md
+++ b/openspec/changes/unify-concert-event-id/specs/event-management/spec.md
@@ -1,0 +1,20 @@
+## MODIFIED Requirements
+
+### Requirement: Generic Event Management
+
+The system SHALL support a generic `Event` entity that encapsulates common event properties: ID, Title, VenueID, LocalEventDate, StartTime, OpenTime, and SourceURL. The `EventId` message SHALL be defined in `event.proto` as the canonical event identifier for the platform.
+
+#### Scenario: Event Persistence
+- **WHEN** a generic event is created
+- **THEN** it is persisted in the `events` table with a unique identifier
+- **AND** it can be retrieved independently of specific event types (like Concerts)
+
+#### Scenario: EventId is the canonical event identifier
+- **WHEN** any entity or RPC references an event identifier
+- **THEN** it SHALL use `EventId` from `event.proto`
+- **AND** `EventId` SHALL NOT be defined in `ticket.proto` or any other file
+
+#### Scenario: Concert uses EventId
+- **WHEN** a `Concert` proto message is defined
+- **THEN** its `id` field SHALL be of type `EventId` (not `ConcertId`)
+- **AND** the `ConcertId` message SHALL NOT exist in the schema

--- a/openspec/changes/unify-concert-event-id/tasks.md
+++ b/openspec/changes/unify-concert-event-id/tasks.md
@@ -1,0 +1,28 @@
+## 1. Proto Schema Changes (specification repo)
+
+- [x] 1.1 Move `EventId` message from `ticket.proto` to `event.proto`
+- [x] 1.2 Update `ticket.proto` to import `EventId` from `event.proto` (remove local definition)
+- [x] 1.3 Replace `ConcertId` with `EventId` in `Concert.id` field (concert.proto line 15)
+- [x] 1.4 Delete `ConcertId` message from `concert.proto` (lines 49-53)
+- [x] 1.5 Add `import "liverty_music/entity/v1/event.proto"` to `concert.proto`
+- [x] 1.6 Run `buf lint` and `buf format -w` to validate schema
+- [x] 1.7 Verify `buf breaking` flags expected changes (will use `buf skip breaking` label on PR)
+
+## 2. Backend Changes (backend repo)
+
+- [ ] 2.1 Update RPC mapper `ConcertToProto` to use `entityv1.EventId` instead of `entityv1.ConcertId`
+- [ ] 2.2 Remove any remaining references to `ConcertId` in mapper or handler code
+- [ ] 2.3 Run `go build ./...` to verify compilation after BSR gen publishes new types
+- [ ] 2.4 Run backend tests to verify no regressions
+
+## 3. Frontend Changes (frontend repo)
+
+- [ ] 3.1 Search for `ConcertId` references in TypeScript code and replace with `EventId`
+- [ ] 3.2 Run `make lint` and `make test` to verify no regressions
+
+## 4. Release Coordination
+
+- [ ] 4.1 Create specification PR with `buf skip breaking` label
+- [ ] 4.2 Merge specification PR and create GitHub Release (triggers BSR gen)
+- [ ] 4.3 Create backend PR (draft until BSR gen completes)
+- [ ] 4.4 Create frontend PR (draft until BSR gen completes)

--- a/proto/liverty_music/entity/v1/concert.proto
+++ b/proto/liverty_music/entity/v1/concert.proto
@@ -5,6 +5,7 @@ package liverty_music.entity.v1;
 import "buf/validate/validate.proto";
 import "liverty_music/entity/v1/artist.proto";
 import "liverty_music/entity/v1/entity.proto";
+import "liverty_music/entity/v1/event.proto";
 import "liverty_music/entity/v1/venue.proto";
 
 // Concert represents a specific music live event.
@@ -12,7 +13,7 @@ import "liverty_music/entity/v1/venue.proto";
 // connecting an artist to a specific venue at a scheduled time.
 message Concert {
   // The unique identifier of the concert event.
-  ConcertId id = 1 [(buf.validate.field).required = true];
+  EventId id = 1 [(buf.validate.field).required = true];
 
   // The unique identifier of the performing artist.
   ArtistId artist_id = 2 [(buf.validate.field).required = true];
@@ -44,10 +45,4 @@ message Concert {
   // The raw venue name as scraped from the source.
   // Preserves the original text separately from the normalised Venue.name.
   ListedVenueName listed_venue_name = 10;
-}
-
-// ConcertId is a globally unique identifier for a concert.
-message ConcertId {
-  // A UUID string representing the unique identity of the concert.
-  string value = 1 [(buf.validate.field).string.uuid = true];
 }

--- a/proto/liverty_music/entity/v1/event.proto
+++ b/proto/liverty_music/entity/v1/event.proto
@@ -6,10 +6,17 @@ package liverty_music.entity.v1;
 import "buf/validate/validate.proto";
 import "google/api/field_behavior.proto";
 import "liverty_music/entity/v1/entity.proto";
-import "liverty_music/entity/v1/ticket.proto";
 import "liverty_music/entity/v1/venue.proto";
 
 option go_package = "github.com/liverty-music/specification/gen/go/liverty_music/entity/v1;entityv1";
+
+// EventId uniquely identifies a music event (concert, live session, etc.) on the platform.
+// Events represent scheduled performances at a venue, and this identifier links tickets
+// and entry records back to the specific event they belong to.
+message EventId {
+  // value is the UUID that uniquely identifies this event across the platform.
+  string value = 1 [(buf.validate.field).string.uuid = true];
+}
 
 // Event represents a scheduled music performance at a venue, such as a concert or live session.
 // Events are the central business object connecting artists, venues, and fans. When an event

--- a/proto/liverty_music/entity/v1/ticket.proto
+++ b/proto/liverty_music/entity/v1/ticket.proto
@@ -6,6 +6,7 @@ package liverty_music.entity.v1;
 import "buf/validate/validate.proto";
 import "google/api/field_behavior.proto";
 import "google/protobuf/timestamp.proto";
+import "liverty_music/entity/v1/event.proto";
 import "liverty_music/entity/v1/user.proto";
 
 option go_package = "github.com/liverty-music/specification/gen/go/liverty_music/entity/v1;entityv1";
@@ -14,14 +15,6 @@ option go_package = "github.com/liverty-music/specification/gen/go/liverty_music
 // It wraps a UUID string to provide type safety and prevent accidental misuse of raw identifiers.
 message TicketId {
   // value is the UUID that uniquely identifies this ticket across the platform.
-  string value = 1 [(buf.validate.field).string.uuid = true];
-}
-
-// EventId uniquely identifies a music event (concert, live session, etc.) on the platform.
-// Events represent scheduled performances at a venue, and this identifier links tickets
-// and entry records back to the specific event they belong to.
-message EventId {
-  // value is the UUID that uniquely identifies this event across the platform.
   string value = 1 [(buf.validate.field).string.uuid = true];
 }
 

--- a/proto/liverty_music/entity/v1/ticket_journey.proto
+++ b/proto/liverty_music/entity/v1/ticket_journey.proto
@@ -4,7 +4,7 @@ syntax = "proto3";
 package liverty_music.entity.v1;
 
 import "buf/validate/validate.proto";
-import "liverty_music/entity/v1/ticket.proto";
+import "liverty_music/entity/v1/event.proto";
 import "liverty_music/entity/v1/user.proto";
 
 option go_package = "github.com/liverty-music/specification/gen/go/liverty_music/entity/v1;entityv1";

--- a/proto/liverty_music/rpc/entry/v1/entry_service.proto
+++ b/proto/liverty_music/rpc/entry/v1/entry_service.proto
@@ -5,7 +5,7 @@ syntax = "proto3";
 package liverty_music.rpc.entry.v1;
 
 import "buf/validate/validate.proto";
-import "liverty_music/entity/v1/ticket.proto";
+import "liverty_music/entity/v1/event.proto";
 
 option go_package = "github.com/liverty-music/specification/gen/go/liverty_music/rpc/entry/v1;entryv1";
 

--- a/proto/liverty_music/rpc/ticket/v1/ticket_service.proto
+++ b/proto/liverty_music/rpc/ticket/v1/ticket_service.proto
@@ -5,6 +5,7 @@ syntax = "proto3";
 package liverty_music.rpc.ticket.v1;
 
 import "buf/validate/validate.proto";
+import "liverty_music/entity/v1/event.proto";
 import "liverty_music/entity/v1/ticket.proto";
 
 option go_package = "github.com/liverty-music/specification/gen/go/liverty_music/rpc/ticket/v1;ticketv1";

--- a/proto/liverty_music/rpc/ticket_journey/v1/ticket_journey_service.proto
+++ b/proto/liverty_music/rpc/ticket_journey/v1/ticket_journey_service.proto
@@ -5,7 +5,7 @@ syntax = "proto3";
 package liverty_music.rpc.ticket_journey.v1;
 
 import "buf/validate/validate.proto";
-import "liverty_music/entity/v1/ticket.proto";
+import "liverty_music/entity/v1/event.proto";
 import "liverty_music/entity/v1/ticket_journey.proto";
 
 option go_package = "github.com/liverty-music/specification/gen/go/liverty_music/rpc/ticket_journey/v1;ticketjourneyv1";


### PR DESCRIPTION
## Summary

- **BREAKING**: Remove `ConcertId` message and replace with `EventId` in `Concert.id` field
- Move `EventId` definition from `ticket.proto` to `event.proto` as the canonical event identifier
- Fix cascading imports across `ticket_journey.proto`, `entry_service.proto`, `ticket_service.proto`, and `ticket_journey_service.proto`

## Motivation

The proto `ConcertId` and DB `events.id` refer to the same UUID but use different names, creating developer confusion and cross-domain bug risk. The Go entity and database already use `event_id` — this aligns the proto schema.

## Breaking Changes

| Change | Detail |
|--------|--------|
| `ConcertId` removed | Replaced by `EventId` |
| `Concert.id` type changed | `ConcertId` → `EventId` (same field number, same wire format) |
| `EventId` moved | From `ticket.proto` to `event.proto` |

## Test plan

- [x] `buf lint` passes
- [x] `buf format -w` applied
- [x] `buf breaking` confirms only expected changes
- [ ] CI buf-pr-checks pass
- [ ] After merge + release: update backend mapper (`ConcertId` → `EventId`)
- [ ] After merge + release: update frontend type references

Closes: #291