### PR TITLE
docs(openspec): archive fix-aurelia-di-and-ci-smoke

### DIFF
--- a/openspec/changes/archive/2026-03-19-fix-aurelia-di-and-ci-smoke/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-19-fix-aurelia-di-and-ci-smoke/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-16

--- a/openspec/changes/archive/2026-03-19-fix-aurelia-di-and-ci-smoke/design.md
+++ b/openspec/changes/archive/2026-03-19-fix-aurelia-di-and-ci-smoke/design.md
@@ -1,0 +1,66 @@
+## Context
+
+The `207-refine-state-naming` branch introduced `@aurelia/state` with a Redux-style store (`IStore<AppState, AppAction>`). A convenience wrapper `resolveStore()` calls `resolve(IStore)` and is used at class field initialization time in 11 files. This triggers AUR0016 because the DI container is not active during field initializer evaluation for `IStore` (unlike `ILogger` which is registered earlier in the Aurelia bootstrap pipeline).
+
+The existing E2E smoke test (`e2e/smoke/no-console-errors.spec.ts`) would catch this error, but it only runs locally — the CI pipeline (`ci.yaml`) only executes vitest unit tests, not Playwright E2E tests.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Fix the AUR0016 runtime crash so all pages render correctly
+- Add the Playwright `smoke` project to CI as a parallel job so DI resolution failures are caught before merge
+
+**Non-Goals:**
+- Expanding E2E smoke test coverage to authenticated routes (requires OIDC session state in CI)
+- Changing the `@aurelia/state` store architecture or middleware
+- Adding Playwright to the `make check` pre-commit target (too slow for local dev)
+
+## Decisions
+
+### D1: Keep `resolve()` at field init, fix `IStore` registration timing
+
+**Choice**: Ensure `StateDefaultConfiguration.init()` registers `IStore` in a way compatible with Aurelia's `resolve()` at field initialization time.
+
+**Alternative considered**: Move all `resolveStore()` calls to constructor bodies or lifecycle hooks. Rejected because `resolve(ILogger)`, `resolve(IAuthService)`, etc. already work at field init — this is an established pattern in the codebase. The fix should target why `IStore` specifically fails, not change the DI pattern used everywhere.
+
+**Investigation needed during implementation**: Verify whether `StateDefaultConfiguration.init()` is correctly creating a singleton `IStore` registration. If the issue is in `@aurelia/state` itself, the workaround is to manually register `IStore` before calling `StateDefaultConfiguration.init()`.
+
+### D2: CI smoke job runs in parallel with existing jobs
+
+**Choice**: Add a `smoke` job to `ci.yaml` that runs in parallel with `lint`, `test`, and `security` (all gated by `changes` job).
+
+```
+ci.yaml job graph:
+
+  changes ──┬── lint
+            ├── test
+            ├── security
+            ├── smoke       ← NEW (parallel)
+            └── ci-success  (waits for all)
+```
+
+**Rationale**: The smoke test launches a Vite dev server (`npm start`) and navigates 3 public routes — ~30-60s total. Running it in parallel avoids adding to the critical path.
+
+### D3: Use Playwright's built-in `webServer` config for CI
+
+**Choice**: Rely on `playwright.config.mjs`'s existing `webServer` block (`command: 'npm start'`, `port: 9000`, `reuseExistingServer: !process.env.CI`).
+
+**Rationale**: No custom server startup script needed. In CI, `process.env.CI` is truthy so Playwright will start the dev server fresh and wait for port 9000. The `smoke` project already configures `baseURL: 'http://localhost:9000'`.
+
+### D4: Install only Chromium for smoke job
+
+**Choice**: Use `npx playwright install --with-deps chromium` instead of installing all browsers.
+
+**Rationale**: The `smoke` project uses `devices['Desktop Chrome']` only. Installing all browsers adds ~300MB and 30s of unnecessary download time.
+
+## Risks / Trade-offs
+
+**[Risk] Vite dev server startup time in CI** → The dev server may take 10-20s to start. Playwright's `webServer` config handles this by waiting for the port. Set `timeout-minutes: 5` on the job as a safety net.
+
+**[Risk] Flaky smoke tests due to timing** → The test uses `waitForTimeout(2000)` for async init. In CI this should be sufficient since no network calls are made (backend is not running, and network errors are excluded). If flaky, increase to 3000ms.
+
+**[Risk] `@aurelia/state` IStore registration may be an upstream bug** → If the fix requires a workaround for an `@aurelia/state` RC issue, document it clearly with a link to the upstream issue tracker.
+
+## Open Questions
+
+- Is the `IStore` resolution failure caused by registration ordering in `main.ts`, or by `StateDefaultConfiguration.init()` not creating a standard DI registration? → Investigate during implementation.

--- a/openspec/changes/archive/2026-03-19-fix-aurelia-di-and-ci-smoke/proposal.md
+++ b/openspec/changes/archive/2026-03-19-fix-aurelia-di-and-ci-smoke/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+Every page on dev.liverty-music.app crashes with AUR0016 (`ISyntaxInterpreter` DI resolution failure) after the `207-refine-state-naming` branch introduced `@aurelia/state`. The root cause is `resolveStore()` called at class field initialization time in 11 service/route files, outside an active DI container context. This error was not caught because the E2E smoke test (`no-console-errors.spec.ts`) is not executed in CI — only locally.
+
+## What Changes
+
+- Fix the AUR0016 DI resolution error by correcting the `resolveStore()` call timing in all affected files
+- Add a CI job that runs the Playwright `smoke` project in parallel with existing lint/test/security jobs
+- Verify the fix via the existing `e2e/smoke/no-console-errors.spec.ts` test
+
+## Capabilities
+
+### New Capabilities
+
+_(none — this is a bugfix and CI improvement)_
+
+### Modified Capabilities
+
+- `component-smoke-tests`: Add requirement that E2E console error smoke tests MUST run in CI, not just locally
+- `state-management`: Add requirement that store resolution must occur within an active DI context (constructor or lifecycle hook), never at field initialization time
+
+## Impact
+
+- **Frontend services/routes** (11 files): `resolveStore()` call site changes
+- **CI pipeline**: New parallel `smoke` job in `ci.yaml` (adds ~30-60s)
+- **State infrastructure**: `store-interface.ts` may need API adjustment to prevent misuse

--- a/openspec/changes/archive/2026-03-19-fix-aurelia-di-and-ci-smoke/specs/component-smoke-tests/spec.md
+++ b/openspec/changes/archive/2026-03-19-fix-aurelia-di-and-ci-smoke/specs/component-smoke-tests/spec.md
@@ -1,0 +1,25 @@
+## MODIFIED Requirements
+
+### Requirement: E2E console error smoke test
+The test suite SHALL navigate to each public route in a real browser and verify that no console errors are emitted during page load. This test MUST execute in CI as a parallel job, not only locally.
+
+#### Scenario: Public route loads without console errors
+- **WHEN** Playwright navigates to a public route (e.g., `/`, `/welcome`, `/about`, `/discover`)
+- **THEN** the page SHALL load successfully
+- **AND** no `console.error` messages SHALL be emitted
+- **AND** the test SHALL fail if any console error is detected
+
+#### Scenario: Network errors are excluded from assertion
+- **WHEN** a console error is caused by a failed network request (e.g., backend unavailable)
+- **THEN** the test SHALL exclude network-related errors from the assertion
+- **AND** only application-level errors (template compilation, JS exceptions) SHALL cause test failure
+
+#### Scenario: CI runs smoke tests in parallel with lint and unit tests
+- **WHEN** a pull request is opened or updated with frontend source changes
+- **THEN** CI SHALL execute the Playwright `smoke` project as a job that runs in parallel with `lint`, `test`, and `security` jobs
+- **AND** the `ci-success` gate SHALL require the `smoke` job to pass
+
+#### Scenario: CI installs only required browser
+- **WHEN** the `smoke` CI job installs Playwright browsers
+- **THEN** it SHALL install only Chromium (not Firefox or WebKit)
+- **AND** include OS-level dependencies via `--with-deps`

--- a/openspec/changes/archive/2026-03-19-fix-aurelia-di-and-ci-smoke/specs/state-management/spec.md
+++ b/openspec/changes/archive/2026-03-19-fix-aurelia-di-and-ci-smoke/specs/state-management/spec.md
@@ -1,0 +1,19 @@
+## ADDED Requirements
+
+### Requirement: Store resolution requires active DI context
+The `resolveStore()` helper and any direct `resolve(IStore)` call SHALL only be used within an active Aurelia DI context (class field initializers of DI-managed classes, constructors, or lifecycle hooks). The `IStore` registration via `StateDefaultConfiguration.init()` SHALL be compatible with Aurelia's `resolve()` function at class field initialization time.
+
+#### Scenario: Service resolves IStore at field initialization
+- **WHEN** a DI-managed service class uses `resolveStore()` at field initialization time (e.g., `private readonly store = resolveStore()`)
+- **THEN** the DI container SHALL successfully resolve `IStore` and return the singleton store instance
+- **AND** no AUR0016 error SHALL be thrown
+
+#### Scenario: Route component resolves IStore at field initialization
+- **WHEN** a route component uses `resolveStore()` at field initialization time
+- **THEN** the DI container SHALL successfully resolve `IStore` and return the singleton store instance
+- **AND** no AUR0016 error SHALL be thrown
+
+#### Scenario: Application boots without DI resolution errors
+- **WHEN** the Aurelia application starts with `StateDefaultConfiguration.init()` registered
+- **THEN** all pages SHALL render without AUR0016 or similar DI resolution errors
+- **AND** the E2E smoke test SHALL detect zero console errors on public routes

--- a/openspec/changes/archive/2026-03-19-fix-aurelia-di-and-ci-smoke/tasks.md
+++ b/openspec/changes/archive/2026-03-19-fix-aurelia-di-and-ci-smoke/tasks.md
@@ -1,0 +1,17 @@
+## 1. Fix AUR0016 DI Resolution Error
+
+- [x] 1.1 Investigate why `resolve(IStore)` fails at field init while `resolve(ILogger)` succeeds — check `StateDefaultConfiguration.init()` registration behavior
+- [x] 1.2 Fix the `IStore` registration or `resolveStore()` call sites so all 11 affected files resolve without AUR0016
+- [x] 1.3 Run `make test` to verify existing unit tests still pass after the fix
+
+## 2. Add Playwright Smoke Job to CI
+
+- [x] 2.1 Add `smoke` job to `frontend/.github/workflows/ci.yaml` running in parallel with `lint`, `test`, `security` (gated by `changes`)
+- [x] 2.2 Install only Chromium via `npx playwright install --with-deps chromium`
+- [x] 2.3 Run `npx playwright test --project=smoke` in the job
+- [x] 2.4 Add `smoke` and `smoke-skip` to the `ci-success` job's `needs` and `allowed-skips`
+
+## 3. Verify
+
+- [x] 3.1 Run `npx playwright test --project=smoke` locally to confirm the DI fix resolves the console errors
+- [x] 3.2 Run `make check` to verify lint + unit tests pass

--- a/openspec/specs/component-smoke-tests/spec.md
+++ b/openspec/specs/component-smoke-tests/spec.md
@@ -54,3 +54,13 @@ The test suite SHALL navigate to each public route in a real browser and verify 
 - **WHEN** a console error is caused by a failed network request (e.g., backend unavailable)
 - **THEN** the test SHALL exclude network-related errors from the assertion
 - **AND** only application-level errors (template compilation, JS exceptions) SHALL cause test failure
+
+#### Scenario: CI runs smoke tests in parallel with lint and unit tests
+- **WHEN** a pull request is opened or updated with frontend source changes
+- **THEN** CI SHALL execute the Playwright `smoke` project as a job that runs in parallel with `lint`, `test`, and `security` jobs
+- **AND** the `ci-success` gate SHALL require the `smoke` job to pass
+
+#### Scenario: CI installs only required browser
+- **WHEN** the `smoke` CI job installs Playwright browsers
+- **THEN** it SHALL install only Chromium (not Firefox or WebKit)
+- **AND** include OS-level dependencies via `--with-deps`

--- a/openspec/specs/state-management/spec.md
+++ b/openspec/specs/state-management/spec.md
@@ -150,6 +150,28 @@ The system SHALL hydrate initial state from localStorage, validating string step
 - **WHEN** localStorage contains an unrecognized step value
 - **THEN** `loadPersistedState()` SHALL fall back to `'lp'` and overwrite localStorage
 
+### Requirement: Store resolution requires active DI context
+
+The `resolveStore()` helper and any direct `resolve(IStore)` call SHALL only be used within an active Aurelia DI context (class field initializers of DI-managed classes, constructors, or lifecycle hooks). The `IStore` registration via `StateDefaultConfiguration.init()` SHALL be compatible with Aurelia's `resolve()` function at class field initialization time.
+
+#### Scenario: Service resolves IStore at field initialization
+
+- **WHEN** a DI-managed service class uses `resolveStore()` at field initialization time (e.g., `private readonly store = resolveStore()`)
+- **THEN** the DI container SHALL successfully resolve `IStore` and return the singleton store instance
+- **AND** no AUR0016 error SHALL be thrown
+
+#### Scenario: Route component resolves IStore at field initialization
+
+- **WHEN** a route component uses `resolveStore()` at field initialization time
+- **THEN** the DI container SHALL successfully resolve `IStore` and return the singleton store instance
+- **AND** no AUR0016 error SHALL be thrown
+
+#### Scenario: Application boots without DI resolution errors
+
+- **WHEN** the Aurelia application starts with `StateDefaultConfiguration.init()` registered
+- **THEN** all pages SHALL render without AUR0016 or similar DI resolution errors
+- **AND** the E2E smoke test SHALL detect zero console errors on public routes
+
 ## REMOVED Requirements
 
 ### Requirement: LOADING step


### PR DESCRIPTION
## Related Issue

Closes #209

## Summary of Changes

Sync delta specs from the `fix-aurelia-di-and-ci-smoke` change to main specs and archive the change:

- **state-management**: Add "Store resolution requires active DI context" requirement (3 scenarios) ensuring `resolveStore()` works at field initialization time without AUR0016 errors
- **component-smoke-tests**: Add CI parallel smoke job and Chromium-only install scenarios (2 scenarios) to the E2E console error smoke test requirement

## Self-Checklist

- [x] I have linked the related issue.
- [x] I have updated the relevant documentation (e.g., `README.md`) if needed.
- [x] I have run `buf lint` and `buf format` locally and all checks have passed.
- [x] My proto definitions follow the project's style guidelines and validation rules.
- [x] Breaking changes have been justified and documented if applicable.
