### PR TITLE
feat(proto): add TicketEmail entity and TicketEmailService RPC

### DIFF
--- a/openspec/changes/ticket-email-import/.openspec.yaml
+++ b/openspec/changes/ticket-email-import/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-18

--- a/openspec/changes/ticket-email-import/design.md
+++ b/openspec/changes/ticket-email-import/design.md
@@ -1,0 +1,77 @@
+## Context
+
+Users receive ticket-related emails (lottery announcements, win/loss notifications) from Japanese ticketing platforms (e+, pia, Lawson Ticket). These emails contain critical deadlines (payment due dates, lottery periods) that are easy to lose track of across multiple concerts. The existing `TicketJourney` system only tracks status (TRACKING → APPLIED → UNPAID/PAID/LOST) without any associated deadline or metadata.
+
+Push notifications are already implemented. The `TicketJourney` entity and RPC service exist. The frontend is an Aurelia 2 PWA with Workbox-based Service Worker running on Android.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Enable users to import ticket emails from Gmail Android app via PWA Share Target with minimal friction
+- Parse unstructured Japanese email text into structured data using Vertex AI Gemini Flash
+- Persist parsed email data in a `ticket_emails` table linked to `TicketJourney`
+- Auto-update `TicketJourney` status based on parsed results
+- Provide a two-step flow: create (parse + persist) → update (user confirms/corrects)
+
+**Non-Goals:**
+- iOS support (PWA Share Target is not stable on iOS Safari)
+- Email forwarding / auto-ingestion (Phase 2)
+- Push notification scheduling for deadlines (separate change — infrastructure exists)
+- Supporting non-ticket emails or generic email import
+- Manual form entry for ticket data
+
+## Decisions
+
+### Decision 1: PWA Share Target as the input mechanism
+
+**Choice**: Web Share Target API (POST with `multipart/form-data`)
+
+**Rationale**: On Android, Gmail's share button passes email subject as `title` and plain-text body as `text`. This requires only a manifest entry and Service Worker handler — no native app, no Gmail Add-on, no email forwarding infrastructure.
+
+**Alternative considered**: Email forwarding with per-user ingest address. Rejected for Phase 1 because it requires email server infrastructure (MX records, SMTP ingest), per-user token management, and has higher PII risk (full email including headers stored server-side). PWA Share Target gives the user explicit control over what is shared.
+
+### Decision 2: Two-step API (CreateTicketEmail → UpdateTicketEmail)
+
+**Choice**: `CreateTicketEmail` persists the raw email + Gemini parse result immediately. `UpdateTicketEmail` applies user corrections and triggers `TicketJourney` status update.
+
+**Rationale**: Persisting on first call is more robust than a pure preview-then-confirm pattern. If the user's session drops after parsing, the data is not lost. The user can return and correct/confirm later. This also creates an audit trail of what was imported.
+
+**Alternative considered**: Parse-only preview (no DB write) then single create. Rejected because a session drop after an expensive Gemini call loses all work.
+
+### Decision 3: Vertex AI Gemini Flash for email parsing
+
+**Choice**: `gemini-3.0-flash` via Vertex AI Go SDK with structured output (response schema).
+
+**Rationale**: The system already runs on GCP (GKE + Cloud SQL). Gemini 3.0 Flash is cost-effective, fast (sub-second for short emails), and handles diverse Japanese email formats without per-vendor regex maintenance. Structured output via response schema ensures the model returns a defined JSON shape.
+
+**Alternative considered**: Per-vendor regex patterns. Rejected due to high maintenance cost — each ticketing platform has different email formats that change without notice.
+
+### Decision 4: TicketEmail as a separate table (not extending TicketJourney)
+
+**Choice**: New `ticket_emails` table with FK to `(user_id, event_id)` matching `ticket_journeys` composite key.
+
+**Rationale**: Multiple emails can be imported per concert per user (lottery announcement + result notification). The `ticket_journeys` table remains a simple status record. Parsed metadata (deadlines, URLs) lives in `ticket_emails`, and the most recent relevant values can be queried via a join or denormalized on write.
+
+### Decision 5: Frontend validation before API call
+
+**Choice**: Client-side regex validation to filter obviously non-ticket emails before sending to backend.
+
+**Rationale**: Avoids unnecessary Gemini API calls (cost + latency) for irrelevant emails. The regex checks for keywords common across Japanese ticketing platforms (e.g., "抽選", "当選", "落選", "チケット", "入金期限"). False negatives are acceptable — users can also manually enter data via existing `SetStatus`.
+
+### Decision 6: Artist matching on the client side
+
+**Choice**: The frontend searches the user's followed artists list against the email body text locally, then presents a dropdown for confirmation/override.
+
+**Rationale**: The followed artists list is already available on the client (loaded for dashboard). No additional API call needed. Fuzzy matching is not required — exact substring match of artist names suffices for Phase 1.
+
+## Risks / Trade-offs
+
+**[Risk] Gemini hallucination on dates/amounts** → Mitigation: Two-step flow ensures user reviews parsed data before it affects `TicketJourney` status. `UpdateTicketEmail` is the only path that triggers status changes.
+
+**[Risk] Gmail share data fidelity varies** → Mitigation: Gmail Android typically passes subject + plain-text body. HTML structure is lost but Gemini handles unstructured text well. If `text` is empty/truncated, the frontend validation step catches it early.
+
+**[Risk] Email body contains PII (name, address, phone)** → Mitigation: Step 5 of the import wizard shows the email body and allows editing before submission. Users can redact sensitive information. The `raw_body` field stores the user-edited version, not the original.
+
+**[Trade-off] Client-side artist matching is naive** → Acceptable for Phase 1 with a small followed-artists list. If users follow hundreds of artists, consider server-side search later.
+
+**[Trade-off] No offline support for import** → Share Target POST requires network connectivity to call Gemini. Acceptable because the import flow is inherently online (needs parsing). Offline queuing could be added later via Service Worker background sync.

--- a/openspec/changes/ticket-email-import/proposal.md
+++ b/openspec/changes/ticket-email-import/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+Users who follow multiple artists must manually track ticket lottery deadlines and payment due dates across dozens of emails from e+, pia, Lawson Ticket, etc. Missing a payment deadline means losing a won lottery ticket. PWA Share Target lets users import ticket-related emails directly from the Gmail Android app into Liverty Music with minimal effort (tap Share → select app → confirm), centralizing deadline management and enabling push notification reminders.
+
+## What Changes
+
+- Add PWA Share Target to `manifest.webmanifest` so the app appears in Android's share sheet
+- Add a multi-step email import wizard in the frontend: validation → artist matching → concert selection → body confirmation → submit
+- Add `TicketEmail` entity and two new RPCs (`CreateTicketEmail`, `UpdateTicketEmail`) for persisting and confirming parsed email data
+- Integrate Vertex AI Gemini Flash on the backend to parse unstructured email text into structured ticket data (lottery dates, payment deadlines, win/loss status)
+- Auto-update `TicketJourney` status based on parsed email content (TRACKING for lottery info, UNPAID/PAID/LOST for lottery results)
+- Add `ticket_emails` table to store imported email metadata and parsed results
+
+## Capabilities
+
+### New Capabilities
+
+- `ticket-email-import`: PWA Share Target integration, email validation, Gemini-based parsing, and structured data extraction from ticket-related emails
+
+### Modified Capabilities
+
+- `ticket-journey`: TicketJourney status is now also updated as a side effect of email import confirmation (TRACKING, UNPAID, PAID, LOST), in addition to manual user updates
+
+## Impact
+
+- **specification**: New `TicketEmail` entity proto, new `TicketEmailService` RPC definitions, `TicketEmailType` enum
+- **backend**: New service handler, Gemini Flash client integration, new DB table + repository, new migration
+- **frontend**: Share Target in manifest, Service Worker POST interception, new import wizard route/components, artist search + concert selection UI
+- **cloud-provisioning**: Vertex AI API enablement (if not already enabled), IAM service account permissions for Gemini

--- a/openspec/changes/ticket-email-import/specs/ticket-email-import/spec.md
+++ b/openspec/changes/ticket-email-import/specs/ticket-email-import/spec.md
@@ -1,0 +1,175 @@
+## ADDED Requirements
+
+### Requirement: TicketEmail Entity
+
+The system SHALL define a `TicketEmail` entity representing a parsed ticket-related email imported by a user. Each email is uniquely identified by an auto-generated ID and linked to a user and one or more events.
+
+#### Scenario: TicketEmail data model
+
+- **WHEN** a ticket email is represented
+- **THEN** it SHALL include `id` (TicketEmailId, UUIDv7), `user_id` (UserId), `event_id` (EventId), `email_type` (TicketEmailType), and `raw_body` (string)
+- **AND** it SHALL include nullable fields: `payment_deadline` (Timestamp), `lottery_start` (Timestamp), `lottery_end` (Timestamp), `application_url` (string)
+- **AND** it SHALL include `parsed_data` (JSON-structured parse result from Gemini)
+
+#### Scenario: TicketEmailType enum values
+
+- **WHEN** a ticket email type is represented
+- **THEN** it SHALL be one of: `LOTTERY_INFO` (lottery announcement with dates/URL), `LOTTERY_RESULT` (win/loss notification)
+- **AND** `UNSPECIFIED` (value 0) SHALL exist as the default proto value but SHALL NOT be accepted in API requests
+
+### Requirement: TicketEmail ID
+
+The system SHALL define a `TicketEmailId` wrapper message with UUID string validation, following the existing type-safe ID pattern.
+
+#### Scenario: TicketEmailId validation
+
+- **WHEN** a `TicketEmailId` is provided
+- **THEN** it SHALL contain a `value` field of type `string`
+- **AND** it SHALL be validated as a valid UUID format
+
+### Requirement: Create Ticket Email
+
+The system SHALL allow an authenticated user to create a ticket email record by submitting email text for parsing. The system persists the raw email, invokes Gemini Flash to parse it, and stores the structured result.
+
+#### Scenario: Create with lottery info email
+
+- **WHEN** an authenticated user calls `CreateTicketEmail` with `raw_body`, `email_type` = `LOTTERY_INFO`, and one or more `event_ids`
+- **THEN** the system SHALL parse the email body using Gemini Flash
+- **AND** the system SHALL extract `lottery_start`, `lottery_end`, and `application_url` if present
+- **AND** the system SHALL persist one `TicketEmail` record per `event_id`
+- **AND** the system SHALL return the created records with parsed data
+
+#### Scenario: Create with lottery result email
+
+- **WHEN** an authenticated user calls `CreateTicketEmail` with `raw_body`, `email_type` = `LOTTERY_RESULT`, and one or more `event_ids`
+- **THEN** the system SHALL parse the email body using Gemini Flash
+- **AND** the system SHALL extract win/loss status, `payment_deadline` (if applicable), and payment status (paid/unpaid)
+- **AND** the system SHALL persist one `TicketEmail` record per `event_id`
+- **AND** the system SHALL return the created records with parsed data
+
+#### Scenario: Gemini parse failure
+
+- **WHEN** the Gemini Flash API call fails or returns unparseable results
+- **THEN** the system SHALL return an `INTERNAL` error
+- **AND** the system SHALL NOT persist any `TicketEmail` records
+
+#### Scenario: User identity from auth context
+
+- **WHEN** `CreateTicketEmail` is called
+- **THEN** the `user_id` SHALL be derived from the authentication context, not from the request body
+
+### Requirement: Update Ticket Email
+
+The system SHALL allow an authenticated user to update a previously created ticket email record with corrections, and trigger `TicketJourney` status updates based on the confirmed data.
+
+#### Scenario: Confirm and update lottery info
+
+- **WHEN** an authenticated user calls `UpdateTicketEmail` with a `ticket_email_id` and corrected fields
+- **AND** the email type is `LOTTERY_INFO`
+- **THEN** the system SHALL update the `TicketEmail` record with the corrected values
+- **AND** the system SHALL set `TicketJourney` status to `TRACKING` for each associated event
+
+#### Scenario: Confirm lottery win with unpaid status
+
+- **WHEN** an authenticated user calls `UpdateTicketEmail` with a `ticket_email_id`
+- **AND** the confirmed data indicates lottery win with payment pending
+- **THEN** the system SHALL update the `TicketEmail` record
+- **AND** the system SHALL set `TicketJourney` status to `UNPAID` for each associated event
+
+#### Scenario: Confirm lottery win with paid status
+
+- **WHEN** an authenticated user calls `UpdateTicketEmail` with a `ticket_email_id`
+- **AND** the confirmed data indicates lottery win with payment already completed (e.g., credit card auto-charge)
+- **THEN** the system SHALL update the `TicketEmail` record
+- **AND** the system SHALL set `TicketJourney` status to `PAID` for each associated event
+
+#### Scenario: Confirm lottery loss
+
+- **WHEN** an authenticated user calls `UpdateTicketEmail` with a `ticket_email_id`
+- **AND** the confirmed data indicates lottery loss
+- **THEN** the system SHALL update the `TicketEmail` record
+- **AND** the system SHALL set `TicketJourney` status to `LOST` for each associated event
+
+#### Scenario: Update non-existent ticket email
+
+- **WHEN** an authenticated user calls `UpdateTicketEmail` with a `ticket_email_id` that does not exist
+- **THEN** the system SHALL return a `NOT_FOUND` error
+
+#### Scenario: Update another user's ticket email
+
+- **WHEN** an authenticated user calls `UpdateTicketEmail` with a `ticket_email_id` owned by a different user
+- **THEN** the system SHALL return a `NOT_FOUND` error (no information leak)
+
+### Requirement: TicketEmail Database Schema
+
+The system SHALL store ticket emails in a `ticket_emails` table.
+
+#### Scenario: Table structure
+
+- **WHEN** the `ticket_emails` table is created
+- **THEN** it SHALL have columns: `id` (UUID PK), `user_id` (UUID FK → users), `event_id` (UUID FK → events), `email_type` (SMALLINT), `raw_body` (TEXT), `parsed_data` (JSONB), `payment_deadline` (TIMESTAMPTZ nullable), `lottery_start` (TIMESTAMPTZ nullable), `lottery_end` (TIMESTAMPTZ nullable), `application_url` (TEXT nullable)
+- **AND** it SHALL have an index on `(user_id, event_id)` for efficient lookups
+
+### Requirement: PWA Share Target
+
+The frontend PWA SHALL register as a share target so that it appears in the Android share sheet when sharing content from Gmail.
+
+#### Scenario: Manifest share_target configuration
+
+- **WHEN** the PWA manifest is configured
+- **THEN** it SHALL include a `share_target` entry with `action` pointing to the email import route
+- **AND** it SHALL use `method: "POST"` and `enctype: "multipart/form-data"`
+- **AND** it SHALL accept `title` and `text` parameters
+
+#### Scenario: Service Worker intercepts share POST
+
+- **WHEN** the OS sends a POST request to the share target action URL
+- **THEN** the Service Worker SHALL intercept the request
+- **AND** it SHALL extract the `title` and `text` form fields
+- **AND** it SHALL navigate the client to the import wizard route with the shared data
+
+### Requirement: Email Import Wizard
+
+The frontend SHALL provide a multi-step wizard for importing ticket emails.
+
+#### Scenario: Step 1 — Email validation
+
+- **WHEN** the import wizard receives shared email text
+- **THEN** the frontend SHALL validate the text against ticket-related keywords using regex
+- **AND** if validation fails, the wizard SHALL display an error message and stop
+
+#### Scenario: Step 2 — Artist matching
+
+- **WHEN** email validation passes
+- **THEN** the frontend SHALL search the user's followed artists list for names present in the email body
+- **AND** if a match is found, it SHALL be auto-selected in the artist dropdown
+
+#### Scenario: Step 3 — Artist selection
+
+- **WHEN** artist matching is complete
+- **THEN** the user SHALL select an artist from a dropdown menu of their followed artists
+- **AND** the dropdown SHALL pre-select any auto-matched artist
+
+#### Scenario: Step 4 — Concert selection
+
+- **WHEN** an artist is selected
+- **THEN** the wizard SHALL display the user's concerts for that artist (from dashboard data)
+- **AND** the user SHALL select one or more concerts to associate with the email
+
+#### Scenario: Step 5 — Email body confirmation
+
+- **WHEN** concerts are selected
+- **THEN** the wizard SHALL display the email body that will be sent to the backend
+- **AND** the user SHALL be able to edit the body (e.g., to redact PII) before submission
+
+#### Scenario: Step 6 — Parse and create
+
+- **WHEN** the user confirms the email body
+- **THEN** the frontend SHALL call `CreateTicketEmail` with the email body, detected email type, and selected event IDs
+- **AND** the wizard SHALL display the parse results for user review
+
+#### Scenario: Step 7 — Confirm parsed results
+
+- **WHEN** parse results are displayed
+- **THEN** the user SHALL be able to correct any parsed fields (dates, status, URL)
+- **AND** upon confirmation, the frontend SHALL call `UpdateTicketEmail` with the corrected data

--- a/openspec/changes/ticket-email-import/specs/ticket-journey/spec.md
+++ b/openspec/changes/ticket-email-import/specs/ticket-journey/spec.md
@@ -1,0 +1,43 @@
+## MODIFIED Requirements
+
+### Requirement: Set Ticket Journey Status
+
+The system SHALL allow an authenticated user to set (create or update) their ticket journey status for a given event via a single upsert operation. Status can be set manually by the user or as a side effect of confirming a ticket email import.
+
+#### Scenario: Set status on a new journey
+
+- **WHEN** an authenticated user calls `SetStatus` with an `event_id` and `status`
+- **AND** no journey exists for that user and event
+- **THEN** the system SHALL create a new `TicketJourney` with the given status
+- **AND** the user_id SHALL be derived from the authentication context
+
+#### Scenario: Update status on an existing journey
+
+- **WHEN** an authenticated user calls `SetStatus` with an `event_id` and `status`
+- **AND** a journey already exists for that user and event
+- **THEN** the system SHALL update the existing journey's status
+
+#### Scenario: Any status transition is allowed
+
+- **WHEN** a user calls `SetStatus` with any valid status value
+- **THEN** the system SHALL accept the transition regardless of the current status
+- **AND** the system SHALL NOT enforce a state machine or transition rules
+
+#### Scenario: Invalid status value rejected
+
+- **WHEN** a user calls `SetStatus` with `UNSPECIFIED` or an undefined enum value
+- **THEN** the system SHALL return an `INVALID_ARGUMENT` error
+
+#### Scenario: Invalid event_id rejected
+
+- **WHEN** a user calls `SetStatus` with a malformed or missing `event_id`
+- **THEN** the system SHALL return an `INVALID_ARGUMENT` error
+
+#### Scenario: Status set via ticket email confirmation
+
+- **WHEN** a user confirms a ticket email import via `UpdateTicketEmail`
+- **THEN** the system SHALL set the `TicketJourney` status for each associated event based on the parsed email content
+- **AND** for `LOTTERY_INFO` emails, the status SHALL be set to `TRACKING`
+- **AND** for `LOTTERY_RESULT` emails with a win and pending payment, the status SHALL be set to `UNPAID`
+- **AND** for `LOTTERY_RESULT` emails with a win and completed payment, the status SHALL be set to `PAID`
+- **AND** for `LOTTERY_RESULT` emails with a loss, the status SHALL be set to `LOST`

--- a/openspec/changes/ticket-email-import/tasks.md
+++ b/openspec/changes/ticket-email-import/tasks.md
@@ -1,0 +1,61 @@
+## 1. Proto Definitions (specification)
+
+- [x] 1.1 Define `TicketEmailId` wrapper message in `entity/v1/ticket_email.proto`
+- [x] 1.2 Define `TicketEmailType` enum (`LOTTERY_INFO`, `LOTTERY_RESULT`) in `entity/v1/ticket_email.proto`
+- [x] 1.3 Define `TicketEmail` message with all fields (id, user_id, event_id, email_type, raw_body, parsed_data, payment_deadline, lottery_start, lottery_end, application_url) in `entity/v1/ticket_email.proto`
+- [x] 1.4 Define `TicketEmailService` with `CreateTicketEmail` and `UpdateTicketEmail` RPCs in `rpc/ticket_email/v1/ticket_email_service.proto`
+- [x] 1.5 Define request/response messages for both RPCs (CreateTicketEmailRequest accepts raw_body, email_type, repeated event_ids; UpdateTicketEmailRequest accepts ticket_email_id and correctable fields)
+- [x] 1.6 Run `buf lint` and `buf format -w`, verify no breaking changes
+
+## 2. Database Migration (backend)
+
+- [x] 2.1 Create Atlas migration for `ticket_emails` table (id UUID PK, user_id FK, event_id FK, email_type SMALLINT, raw_body TEXT, parsed_data JSONB, payment_deadline TIMESTAMPTZ, lottery_start TIMESTAMPTZ, lottery_end TIMESTAMPTZ, application_url TEXT)
+- [x] 2.2 Add index on `(user_id, event_id)` for efficient lookups
+- [ ] 2.3 Apply migration locally and verify with `atlas migrate apply --env local`
+
+## 3. Backend Entity & Repository (backend)
+
+- [x] 3.1 Define `TicketEmail` entity struct and `TicketEmailType` constants in `internal/entity/ticket_email.go`
+- [x] 3.2 Define `TicketEmailRepository` interface (Create, Update, GetByID, ListByUserAndEvent)
+- [x] 3.3 Implement pgx-based `TicketEmailRepository`
+- [ ] 3.4 Write repository integration tests
+
+## 4. Gemini Client (backend)
+
+- [x] 4.1 Create `internal/gemini/parser.go` with `TicketEmailParser` interface
+- [x] 4.2 Implement Vertex AI Gemini Flash client with structured output (response schema defining lottery dates, payment deadline, win/loss status, payment status, application URL)
+- [x] 4.3 Define the Gemini prompt for Japanese ticket email parsing
+- [ ] 4.4 Write unit tests with mock Gemini responses
+
+## 5. Backend Service Handler (backend)
+
+- [x] 5.1 Implement `CreateTicketEmail` handler: validate input → call Gemini parser → persist TicketEmail records (one per event_id) → return parsed results
+- [x] 5.2 Implement `UpdateTicketEmail` handler: validate ownership → update TicketEmail record → upsert TicketJourney status based on email_type and parsed content
+- [x] 5.3 Wire `TicketEmailService` into DI graph (Google Wire)
+- [ ] 5.4 Write handler unit tests (mock repository + mock Gemini parser)
+
+## 6. Cloud Provisioning
+
+- [ ] 6.1 Verify Vertex AI API is enabled in GCP project
+- [ ] 6.2 Add Vertex AI permissions to backend service account IAM (if not already present)
+
+## 7. Frontend: PWA Share Target (frontend)
+
+- [x] 7.1 Add `share_target` entry to `manifest.webmanifest` (POST, multipart/form-data, title + text params)
+- [x] 7.2 Add Service Worker handler to intercept share target POST and redirect to import wizard route with shared data
+- [ ] 7.3 Verify share target works on Android via Chrome DevTools or physical device
+
+## 8. Frontend: Import Wizard Route (frontend)
+
+- [x] 8.1 Create `/import/ticket-email` route and view model
+- [x] 8.2 Implement Step 1: regex validation for ticket-related keywords
+- [x] 8.3 Implement Step 2-3: artist matching (search followed artists in email body) + artist dropdown selection
+- [x] 8.4 Implement Step 4: concert selection (filter dashboard by selected artist, multi-select)
+- [x] 8.5 Implement Step 5: email body display with edit capability
+- [x] 8.6 Implement Step 6: call `CreateTicketEmail` API and display parse results
+- [x] 8.7 Implement Step 7: parsed result review/correction + call `UpdateTicketEmail` API
+
+## 9. Frontend: RPC Client (frontend)
+
+- [x] 9.1 Create `ticket-email-service.ts` Connect-RPC client for `TicketEmailService`
+- [x] 9.2 Wire into DI container

--- a/proto/liverty_music/entity/v1/ticket_email.proto
+++ b/proto/liverty_music/entity/v1/ticket_email.proto
@@ -108,9 +108,9 @@ message TicketEmail {
 
   // lottery_result indicates whether the user won or lost the lottery.
   // Present only for LOTTERY_RESULT emails.
-  optional LotteryResult lottery_result = 11;
+  optional LotteryResult lottery_result = 11 [(buf.validate.field).enum.defined_only = true];
 
   // payment_status indicates whether payment has been completed.
   // Present only for LOTTERY_RESULT emails where the user won.
-  optional PaymentStatus payment_status = 12;
+  optional PaymentStatus payment_status = 12 [(buf.validate.field).enum.defined_only = true];
 }

--- a/proto/liverty_music/entity/v1/ticket_email.proto
+++ b/proto/liverty_music/entity/v1/ticket_email.proto
@@ -1,0 +1,116 @@
+syntax = "proto3";
+
+// Package liverty_music.entity.v1 defines core business entities for the Liverty Music platform.
+package liverty_music.entity.v1;
+
+import "buf/validate/validate.proto";
+import "google/api/field_behavior.proto";
+import "google/protobuf/struct.proto";
+import "google/protobuf/timestamp.proto";
+import "liverty_music/entity/v1/ticket.proto";
+import "liverty_music/entity/v1/user.proto";
+
+option go_package = "github.com/liverty-music/specification/gen/go/liverty_music/entity/v1;entityv1";
+
+// TicketEmailId uniquely identifies a single imported ticket email record.
+// It wraps a UUID string to provide type safety and prevent accidental misuse of raw identifiers.
+message TicketEmailId {
+  // value is the UUID that uniquely identifies this ticket email across the platform.
+  string value = 1 [(buf.validate.field).string.uuid = true];
+}
+
+// TicketEmailType classifies the kind of ticket-related email that was imported.
+// Each type determines which fields are expected to be present after parsing
+// and which TicketJourney status transition to apply upon confirmation.
+enum TicketEmailType {
+  // Default value; must not be used in API requests.
+  TICKET_EMAIL_TYPE_UNSPECIFIED = 0;
+
+  // A lottery announcement email containing ticket sales dates and an application URL.
+  // Importing this type sets TicketJourney status to TRACKING upon confirmation.
+  TICKET_EMAIL_TYPE_LOTTERY_INFO = 1;
+
+  // A lottery result notification email indicating win/loss and payment details.
+  // Importing this type sets TicketJourney status to UNPAID, PAID, or LOST upon confirmation.
+  TICKET_EMAIL_TYPE_LOTTERY_RESULT = 2;
+}
+
+// LotteryResult indicates whether the user won or lost a ticket lottery.
+// Used within parsed data from lottery result emails.
+enum LotteryResult {
+  // Default value; must not be used in API requests.
+  LOTTERY_RESULT_UNSPECIFIED = 0;
+
+  // The user won the ticket lottery (当選).
+  LOTTERY_RESULT_WON = 1;
+
+  // The user lost the ticket lottery (落選).
+  LOTTERY_RESULT_LOST = 2;
+}
+
+// PaymentStatus indicates the payment state for a won lottery ticket.
+// Used within parsed data from lottery result emails.
+enum PaymentStatus {
+  // Default value; must not be used in API requests.
+  PAYMENT_STATUS_UNSPECIFIED = 0;
+
+  // Payment is pending — the user must pay before the deadline (入金待ち).
+  PAYMENT_STATUS_UNPAID = 1;
+
+  // Payment has been completed — typically via automatic credit card charge (支払済).
+  PAYMENT_STATUS_PAID = 2;
+}
+
+// TicketEmail represents a ticket-related email imported by a user via PWA Share Target.
+// Each record stores the raw email body, structured data extracted by Gemini Flash,
+// and is linked to a specific user and event. Multiple emails may be imported for
+// the same event (e.g., lottery announcement followed by result notification).
+message TicketEmail {
+  // id is the unique identifier for this ticket email record.
+  TicketEmailId id = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // user_id identifies the fan who imported this email.
+  UserId user_id = 2 [(buf.validate.field).required = true];
+
+  // event_id identifies the event this email is associated with.
+  EventId event_id = 3 [(buf.validate.field).required = true];
+
+  // email_type classifies the kind of ticket email (lottery info or lottery result).
+  TicketEmailType email_type = 4 [
+    (buf.validate.field).required = true,
+    (buf.validate.field).enum.defined_only = true
+  ];
+
+  // raw_body is the email text as provided (and optionally redacted) by the user.
+  // This is the text that was parsed by Gemini Flash.
+  string raw_body = 5 [(buf.validate.field).string.min_len = 1];
+
+  // parsed_data stores the structured output from Gemini Flash parsing.
+  // The schema varies by email_type but is preserved as a JSON object
+  // for flexibility and auditability.
+  google.protobuf.Struct parsed_data = 6 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // payment_deadline is the date by which the user must complete payment.
+  // Present only for LOTTERY_RESULT emails where the user won with pending payment.
+  optional google.protobuf.Timestamp payment_deadline = 7;
+
+  // lottery_start is the start date/time of the lottery application period.
+  // Present only for LOTTERY_INFO emails.
+  optional google.protobuf.Timestamp lottery_start = 8;
+
+  // lottery_end is the end date/time of the lottery application period.
+  // Present only for LOTTERY_INFO emails.
+  optional google.protobuf.Timestamp lottery_end = 9;
+
+  // application_url is the URL where the user can apply for the ticket lottery.
+  // Present only for LOTTERY_INFO emails.
+  optional string application_url = 10;
+
+  // lottery_result indicates whether the user won or lost the lottery.
+  // Present only for LOTTERY_RESULT emails.
+  optional LotteryResult lottery_result = 11;
+
+  // payment_status indicates whether payment has been completed.
+  // Present only for LOTTERY_RESULT emails where the user won.
+  optional PaymentStatus payment_status = 12;
+}

--- a/proto/liverty_music/rpc/ticket_email/v1/ticket_email_service.proto
+++ b/proto/liverty_music/rpc/ticket_email/v1/ticket_email_service.proto
@@ -89,10 +89,10 @@ message UpdateTicketEmailRequest {
   optional string application_url = 5;
 
   // Corrected lottery result. If set, overrides the parsed value.
-  optional liverty_music.entity.v1.LotteryResult lottery_result = 6;
+  optional liverty_music.entity.v1.LotteryResult lottery_result = 6 [(buf.validate.field).enum.defined_only = true];
 
   // Corrected payment status. If set, overrides the parsed value.
-  optional liverty_music.entity.v1.PaymentStatus payment_status = 7;
+  optional liverty_music.entity.v1.PaymentStatus payment_status = 7 [(buf.validate.field).enum.defined_only = true];
 }
 
 // UpdateTicketEmailResponse contains the updated ticket email record.

--- a/proto/liverty_music/rpc/ticket_email/v1/ticket_email_service.proto
+++ b/proto/liverty_music/rpc/ticket_email/v1/ticket_email_service.proto
@@ -1,0 +1,102 @@
+syntax = "proto3";
+
+// Package liverty_music.rpc.ticket_email.v1 provides the TicketEmailService
+// for importing and managing ticket-related emails parsed by Gemini Flash.
+package liverty_music.rpc.ticket_email.v1;
+
+import "buf/validate/validate.proto";
+import "google/protobuf/timestamp.proto";
+import "liverty_music/entity/v1/ticket.proto";
+import "liverty_music/entity/v1/ticket_email.proto";
+
+option go_package = "github.com/liverty-music/specification/gen/go/liverty_music/rpc/ticket_email/v1;ticketemailv1";
+
+// TicketEmailService manages the import and confirmation of ticket-related emails.
+// Users share emails from their Gmail app via PWA Share Target. The service parses
+// the unstructured email text using Gemini Flash, persists the results, and upon
+// user confirmation updates the associated TicketJourney statuses.
+//
+// The flow is two-step:
+//  1. CreateTicketEmail: parse + persist (user reviews the parsed output)
+//  2. UpdateTicketEmail: user confirms/corrects → TicketJourney status updated
+service TicketEmailService {
+  // CreateTicketEmail parses a shared email body using Gemini Flash, persists the
+  // raw email and parsed results, and returns the created records for user review.
+  // One TicketEmail record is created per event_id provided.
+  //
+  // The user_id is derived from the authentication context.
+  //
+  // Possible errors:
+  //  - INVALID_ARGUMENT: Missing or invalid fields (empty body, invalid email_type,
+  //    no event_ids, malformed event_id).
+  //  - INTERNAL: Gemini Flash parsing failed or returned unparseable results.
+  //  - UNAUTHENTICATED: The user identity could not be verified.
+  rpc CreateTicketEmail(CreateTicketEmailRequest) returns (CreateTicketEmailResponse);
+
+  // UpdateTicketEmail applies user corrections to a previously created ticket email
+  // record and triggers TicketJourney status updates based on the confirmed data.
+  //
+  // Status transitions by email_type:
+  //  - LOTTERY_INFO   → TRACKING
+  //  - LOTTERY_RESULT → UNPAID (won, payment pending)
+  //                   → PAID   (won, payment completed)
+  //                   → LOST   (lost)
+  //
+  // Possible errors:
+  //  - NOT_FOUND: The ticket_email_id does not exist or belongs to another user.
+  //  - INVALID_ARGUMENT: Missing or invalid fields.
+  //  - UNAUTHENTICATED: The user identity could not be verified.
+  rpc UpdateTicketEmail(UpdateTicketEmailRequest) returns (UpdateTicketEmailResponse);
+}
+
+// CreateTicketEmailRequest contains the email text and metadata for parsing.
+message CreateTicketEmailRequest {
+  // Required. The email body text as shared from Gmail (optionally redacted by the user).
+  string raw_body = 1 [(buf.validate.field).string.min_len = 1];
+
+  // Required. The type of ticket email being imported.
+  liverty_music.entity.v1.TicketEmailType email_type = 2 [
+    (buf.validate.field).required = true,
+    (buf.validate.field).enum.defined_only = true
+  ];
+
+  // Required. One or more event IDs to associate this email with.
+  // One TicketEmail record is created per event_id.
+  repeated liverty_music.entity.v1.EventId event_ids = 3 [(buf.validate.field).repeated.min_items = 1];
+}
+
+// CreateTicketEmailResponse contains the created ticket email records with parsed data.
+message CreateTicketEmailResponse {
+  // The created ticket email records, one per event_id in the request.
+  repeated liverty_music.entity.v1.TicketEmail ticket_emails = 1;
+}
+
+// UpdateTicketEmailRequest contains user corrections for a previously created ticket email.
+message UpdateTicketEmailRequest {
+  // Required. The ticket email record to update.
+  liverty_music.entity.v1.TicketEmailId ticket_email_id = 1 [(buf.validate.field).required = true];
+
+  // Corrected payment deadline. If set, overrides the parsed value.
+  optional google.protobuf.Timestamp payment_deadline = 2;
+
+  // Corrected lottery application start date. If set, overrides the parsed value.
+  optional google.protobuf.Timestamp lottery_start = 3;
+
+  // Corrected lottery application end date. If set, overrides the parsed value.
+  optional google.protobuf.Timestamp lottery_end = 4;
+
+  // Corrected application URL. If set, overrides the parsed value.
+  optional string application_url = 5;
+
+  // Corrected lottery result. If set, overrides the parsed value.
+  optional liverty_music.entity.v1.LotteryResult lottery_result = 6;
+
+  // Corrected payment status. If set, overrides the parsed value.
+  optional liverty_music.entity.v1.PaymentStatus payment_status = 7;
+}
+
+// UpdateTicketEmailResponse contains the updated ticket email record.
+message UpdateTicketEmailResponse {
+  // The updated ticket email record reflecting the confirmed data.
+  liverty_music.entity.v1.TicketEmail ticket_email = 1;
+}


### PR DESCRIPTION
## Related Issue

Closes #294

## Summary of Changes

Add protobuf definitions and OpenSpec artifacts for the ticket email import feature, which enables users to share ticket-related emails from Gmail on Android into the Liverty Music PWA via Share Target.

**Proto definitions:**
- `TicketEmailId` wrapper message with UUID validation
- `TicketEmailType`, `LotteryResult`, `PaymentStatus` enums
- `TicketEmail` entity with parsed fields (lottery dates, application URL, win/loss, payment status)
- `TicketEmailService` with two-step RPC flow: `CreateTicketEmail` (parse + persist) and `UpdateTicketEmail` (confirm/correct + TicketJourney status update)

**OpenSpec artifacts:**
- Proposal, design, specs (ticket-email-import + ticket-journey delta), and implementation tasks

## Self-Checklist

- [x] I have linked the related issue.
- [x] I have updated the relevant documentation (e.g., `README.md`) if needed.
- [x] I have run `buf lint` and `buf format` locally and all checks have passed.
- [x] My proto definitions follow the project's style guidelines and validation rules.
- [x] Breaking changes have been justified and documented if applicable.