### PR TITLE
fix(proto): replace ticket.proto import with event.proto

### DIFF
--- a/proto/liverty_music/entity/v1/ticket_email.proto
+++ b/proto/liverty_music/entity/v1/ticket_email.proto
@@ -7,7 +7,7 @@ import "buf/validate/validate.proto";
 import "google/api/field_behavior.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/timestamp.proto";
-import "liverty_music/entity/v1/ticket.proto";
+import "liverty_music/entity/v1/event.proto";
 import "liverty_music/entity/v1/user.proto";
 
 option go_package = "github.com/liverty-music/specification/gen/go/liverty_music/entity/v1;entityv1";

--- a/proto/liverty_music/rpc/ticket_email/v1/ticket_email_service.proto
+++ b/proto/liverty_music/rpc/ticket_email/v1/ticket_email_service.proto
@@ -6,7 +6,7 @@ package liverty_music.rpc.ticket_email.v1;
 
 import "buf/validate/validate.proto";
 import "google/protobuf/timestamp.proto";
-import "liverty_music/entity/v1/ticket.proto";
+import "liverty_music/entity/v1/event.proto";
 import "liverty_music/entity/v1/ticket_email.proto";
 
 option go_package = "github.com/liverty-music/specification/gen/go/liverty_music/rpc/ticket_email/v1;ticketemailv1";


### PR DESCRIPTION
## Related Issue

Closes #294

## Summary of Changes

Fix BSR push failure caused by missing direct proto imports. Proto imports are not transitive — `ticket_email.proto` and `ticket_email_service.proto` both use `EventId` (defined in `event.proto`) but only imported `ticket.proto`. Replaced `ticket.proto` import with `event.proto` in both files.

## Self-Checklist

- [x] I have linked the related issue.
- [x] I have updated the relevant documentation (e.g., `README.md`) if needed.
- [x] I have run `buf lint` and `buf format` locally and all checks have passed.
- [x] My proto definitions follow the project's style guidelines and validation rules.
- [x] Breaking changes have been justified and documented if applicable.