### PR TITLE
chore(openspec): add entity-test-coverage spec and archive changes

### DIFF
--- a/openspec/changes/archive/2026-03-19-frontend-entity-logic/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-19-frontend-entity-logic/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-19

--- a/openspec/changes/archive/2026-03-19-frontend-entity-logic/design.md
+++ b/openspec/changes/archive/2026-03-19-frontend-entity-logic/design.md
@@ -1,0 +1,76 @@
+## Context
+
+The frontend `entities/` layer was introduced to centralize type definitions mirroring the Go backend's `entity` package. Currently, `artist.ts` is the only entity file with pure functions (`bestLogoUrl`, `bestBackgroundUrl`); the rest are type-only. Business logic lives in framework-coupled services, routes, and state reducers, making it untestable without Aurelia DI or store setup.
+
+The Go backend's `internal/entity/` contains rich domain logic (hype notification eligibility, proximity classification, concert grouping, validation). The frontend should follow the same pattern for its domain rules.
+
+Current adapter layer structure:
+```
+src/adapter/
+  rpc/client/    ← UseCase → proto (outbound)
+  rpc/mapper/    ← proto → Entity (inbound)
+  storage/       ← Entity ↔ localStorage
+```
+
+Presentation-derived pure logic (artist color hashing, hype display metadata) is scattered across components and routes with no consistent home.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Extract pure business logic from services/state/routes/components into `entities/` as framework-free, independently testable pure functions
+- Establish `adapter/view/` as the canonical location for entity-to-view-model transformations shared across multiple components
+- Achieve architectural consistency with the Go backend's entity layer pattern
+- Enable unit testing of domain rules without Aurelia DI, store, or DOM dependencies
+
+**Non-Goals:**
+- Refactoring the adapter/rpc layer (mapper and client structure stays as-is)
+- Moving single-component-specific presentation logic (e.g., `getStageParams` stays in `dna-orb/`)
+- Creating entity classes with methods (stay with interfaces + pure functions to match existing pattern)
+- Changing any runtime behavior — this is a structural refactor only
+
+## Decisions
+
+### 1. Pure functions alongside interfaces (not classes)
+
+The existing `artist.ts` pattern uses `export interface Artist` + `export function bestLogoUrl(artist)`. All entity files will follow this same pattern: interfaces for data shape, exported pure functions for business logic.
+
+**Alternative considered**: Entity classes with methods (e.g., `concert.isHypeMatched(lane)`). Rejected because the codebase already uses plain objects from proto mappers, and wrapping them in class instances would add unnecessary construction overhead and change the data flow pattern.
+
+### 2. `adapter/view/` for shared presentation logic
+
+Presentation-derived pure functions that are referenced by 2+ components go in `adapter/view/`. This follows Clean Architecture's Interface Adapters layer — `adapter/` already contains `rpc/` (inbound) and `storage/` (persistence), so `view/` (outbound to UI) is the natural extension.
+
+**Alternative considered**: Top-level `presentation/` directory. Rejected because the adapter layer already has precedent for non-RPC adapters (`adapter/storage/`), and `adapter/view/` maintains consistency with Clean Architecture's layer model where the Go backend also places its mappers in `adapter/`.
+
+**Boundary rule**: If a pure function is only used by one component, it stays colocated with that component. It moves to `adapter/view/` only when shared.
+
+### 3. Entity file organization: one file per domain concept
+
+Each entity file owns the types AND logic for its domain concept:
+- `concert.ts` — Concert interface + `isHypeMatched()` + hype/lane ordering constants
+- `follow.ts` — FollowedArtist/Hype types + `hasFollow()` dedup check
+- `user.ts` — User/UserHome types + `codeToHome()` + `displayName()`
+- `entry.ts` — MerklePath type + `bytesToDecimal()` + `uuidToFieldElement()`
+- `onboarding.ts` (new) — OnboardingStep enum + STEP_ORDER + `stepIndex()` + predicates
+
+**Alternative considered**: Separate `entities/concert-rules.ts` for logic vs `entities/concert.ts` for types. Rejected as over-separation — the Go backend keeps both in the same file (e.g., `concert.go` has both struct and methods).
+
+### 4. Location logic stays with User entity
+
+`codeToHome()`, `displayName()`, and the prefecture data currently in `constants/iso3166.ts` are domain knowledge about the `UserHome` entity. They move to `entities/user.ts` (or a new `entities/location.ts` if the file grows too large).
+
+`constants/iso3166.ts` will remain as the data source (prefecture records, region groups, quick-select cities) since these are reference data, not business logic. Only the pure functions (`codeToHome`, `displayName`, `translationKey`) move.
+
+### 5. Reducer delegates to entity functions
+
+The Redux reducer (`state/reducer.ts`) currently implements duplicate-follow prevention inline. After extraction, it will call `hasFollow(state.guest.follows, artistId)` from `entities/follow.ts`. The reducer remains the state mutation point, but the business rule lives in the entity.
+
+Same pattern for `middleware.ts` step migration: delegates to `normalizeStep()` from `entities/onboarding.ts`.
+
+## Risks / Trade-offs
+
+**[Circular import risk]** Entity files must not import from services, state, or components. Since entities are the innermost layer, this is enforced by convention. → Mitigation: Biome lint rule or ESLint `import/no-restricted-paths` can enforce this boundary if needed.
+
+**[Moving `iso3166.ts` functions]** Components that currently import from `constants/iso3166.ts` will need import path updates. → Mitigation: Re-export from `constants/iso3166.ts` during transition, remove re-exports in a follow-up.
+
+**[Test file placement]** Entity tests should live alongside entity files (e.g., `entities/concert.spec.ts`). This is a new pattern for the frontend — current tests are in `__tests__/` or colocated with components. → Mitigation: Follow the colocated pattern already used in the project; Vitest supports any `*.spec.ts` location.

--- a/openspec/changes/archive/2026-03-19-frontend-entity-logic/proposal.md
+++ b/openspec/changes/archive/2026-03-19-frontend-entity-logic/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+Business logic in the frontend is scattered across services, routes, and components, making it difficult to unit test without framework dependencies. The Go backend already follows Clean Architecture with a rich `entity` package containing pure domain logic. The frontend `entities/` layer currently holds only type definitions (except `artist.ts`), while business rules like hype matching, onboarding step progression, and follow deduplication live in framework-coupled code. Extracting these into `entities/` and establishing `adapter/view/` for presentation-layer pure logic will align the frontend with the backend's architecture and dramatically improve testability.
+
+## What Changes
+
+- Extract pure business rules from `services/`, `routes/`, `components/`, and `state/` into `entities/` as framework-free pure functions
+- Create `adapter/view/` directory for UI-derived pure logic (entity-to-view-model transformations) that is referenced by multiple components
+- Move domain constants and predicates (hype ordering, onboarding steps, location code parsing) into their corresponding entity files
+- Move binary/crypto conversion utilities into `entities/entry.ts` alongside `MerklePath`
+- Relocate `OnboardingStep` enum, step ordering, and predicates from `onboarding-service.ts` into a new `entities/onboarding.ts`
+- Keep single-component-specific presentation logic colocated (e.g., `getStageParams` stays in `dna-orb/`)
+
+## Capabilities
+
+### New Capabilities
+- `frontend-entity-business-logic`: Pure business logic functions extracted into `entities/` — hype matching, follow deduplication, onboarding step progression, location code parsing, and Merkle path conversions
+- `frontend-view-adapter`: `adapter/view/` layer for entity-to-view-model pure functions shared across multiple components — artist color derivation, hype display metadata
+
+### Modified Capabilities
+- `frontend-entity-layer`: Entity files gain pure functions alongside existing type definitions, extending the pattern established by `artist.ts` (which already has `bestLogoUrl`, `bestBackgroundUrl`)
+
+## Impact
+
+- **Frontend `entities/`**: `concert.ts`, `follow.ts`, `user.ts`, `entry.ts` gain exported pure functions; new `onboarding.ts` created
+- **Frontend `adapter/view/`**: New directory with `artist-color.ts`, `hype-display.ts`
+- **Frontend `services/`**: `dashboard-service.ts`, `onboarding-service.ts`, `proof-service.ts` lose inline logic, import from entities instead
+- **Frontend `state/`**: `reducer.ts` delegates duplicate-follow check to `follow.ts`; `middleware.ts` delegates step migration to `onboarding.ts`
+- **Frontend `components/`**: `color-generator.ts` moves to `adapter/view/artist-color.ts`; `my-artists-route.ts` imports `HYPE_TIERS` from `adapter/view/`
+- **No API, proto, or backend changes required**

--- a/openspec/changes/archive/2026-03-19-frontend-entity-logic/specs/frontend-entity-business-logic/spec.md
+++ b/openspec/changes/archive/2026-03-19-frontend-entity-logic/specs/frontend-entity-business-logic/spec.md
@@ -1,0 +1,194 @@
+## ADDED Requirements
+
+### Requirement: Hype-lane matching
+
+The `entities/concert.ts` file SHALL export an `isHypeMatched(hype: HypeLevel, lane: LaneType): boolean` pure function that determines whether a user's hype level qualifies a concert for display in a given proximity lane. The matching rule is: a hype level matches a lane if the hype's ordinal value is greater than or equal to the lane's ordinal value, where the ordering is `watch=0 < home=1 < nearby=2 < away=3` for hype and `home=1 < nearby=2 < away=3` for lanes.
+
+#### Scenario: Away hype matches all lanes
+
+- **WHEN** `isHypeMatched('away', 'home')` is called
+- **THEN** it returns `true`
+
+#### Scenario: Home hype matches home lane only
+
+- **WHEN** `isHypeMatched('home', 'home')` is called
+- **THEN** it returns `true`
+
+#### Scenario: Home hype does not match nearby lane
+
+- **WHEN** `isHypeMatched('home', 'nearby')` is called
+- **THEN** it returns `false`
+
+#### Scenario: Watch hype matches no lanes
+
+- **WHEN** `isHypeMatched('watch', 'home')` is called
+- **THEN** it returns `false`
+
+#### Scenario: Nearby hype matches home and nearby
+
+- **WHEN** `isHypeMatched('nearby', 'home')` and `isHypeMatched('nearby', 'nearby')` are called
+- **THEN** both return `true`
+
+#### Scenario: Nearby hype does not match away
+
+- **WHEN** `isHypeMatched('nearby', 'away')` is called
+- **THEN** it returns `false`
+
+---
+
+### Requirement: Follow deduplication check
+
+The `entities/follow.ts` file SHALL export a `hasFollow(follows: ReadonlyArray<{ artist: { id: string } }>, artistId: string): boolean` pure function that returns `true` if any element in the array has a matching artist ID. This function enforces the business invariant that a user cannot follow the same artist twice.
+
+#### Scenario: Artist already followed
+
+- **WHEN** `hasFollow([{ artist: { id: 'a1' } }], 'a1')` is called
+- **THEN** it returns `true`
+
+#### Scenario: Artist not followed
+
+- **WHEN** `hasFollow([{ artist: { id: 'a1' } }], 'a2')` is called
+- **THEN** it returns `false`
+
+#### Scenario: Empty follow list
+
+- **WHEN** `hasFollow([], 'a1')` is called
+- **THEN** it returns `false`
+
+---
+
+### Requirement: Onboarding step progression
+
+The `entities/onboarding.ts` file SHALL export:
+1. An `OnboardingStep` constant object with values: `lp`, `discovery`, `dashboard`, `detail`, `my-artists`, `completed`.
+2. A `STEP_ORDER` array defining the canonical progression order.
+3. A `stepIndex(step: OnboardingStepValue): number` pure function returning the ordinal position of a step in `STEP_ORDER`.
+4. An `isOnboarding(step: OnboardingStepValue): boolean` pure function returning `true` for steps `discovery`, `dashboard`, `detail`, `my-artists`.
+5. An `isCompleted(step: OnboardingStepValue): boolean` pure function returning `true` only for `completed`.
+
+#### Scenario: stepIndex returns correct ordinal
+
+- **WHEN** `stepIndex('discovery')` is called
+- **THEN** it returns `1`
+
+#### Scenario: stepIndex for first step
+
+- **WHEN** `stepIndex('lp')` is called
+- **THEN** it returns `0`
+
+#### Scenario: isOnboarding for active step
+
+- **WHEN** `isOnboarding('dashboard')` is called
+- **THEN** it returns `true`
+
+#### Scenario: isOnboarding for terminal steps
+
+- **WHEN** `isOnboarding('lp')` and `isOnboarding('completed')` are called
+- **THEN** both return `false`
+
+#### Scenario: isCompleted for completed step
+
+- **WHEN** `isCompleted('completed')` is called
+- **THEN** it returns `true`
+
+#### Scenario: isCompleted for non-completed step
+
+- **WHEN** `isCompleted('dashboard')` is called
+- **THEN** it returns `false`
+
+---
+
+### Requirement: Onboarding step normalization
+
+The `entities/onboarding.ts` file SHALL export a `normalizeStep(raw: string): OnboardingStepValue` pure function that converts a raw string (potentially a legacy numeric step index) into a valid `OnboardingStepValue`. If the raw value is a legacy numeric index (`'0'`-`'7'`), it SHALL be mapped to the corresponding step. If the raw value is already a valid step string, it SHALL be returned as-is. If the raw value is unrecognized, it SHALL return `'lp'` as the fallback.
+
+#### Scenario: Legacy numeric step '1' maps to discovery
+
+- **WHEN** `normalizeStep('1')` is called
+- **THEN** it returns `'discovery'`
+
+#### Scenario: Legacy numeric step '7' maps to completed
+
+- **WHEN** `normalizeStep('7')` is called
+- **THEN** it returns `'completed'`
+
+#### Scenario: Valid string step passes through
+
+- **WHEN** `normalizeStep('dashboard')` is called
+- **THEN** it returns `'dashboard'`
+
+#### Scenario: Unknown value falls back to lp
+
+- **WHEN** `normalizeStep('invalid')` is called
+- **THEN** it returns `'lp'`
+
+---
+
+### Requirement: Location code decomposition
+
+The `entities/user.ts` file SHALL export a `codeToHome(code: string): { countryCode: string; level1: string }` pure function that decomposes an ISO 3166-2 subdivision code into a structured home object. The country code SHALL be extracted from the first two characters of the input.
+
+#### Scenario: Japanese prefecture code
+
+- **WHEN** `codeToHome('JP-13')` is called
+- **THEN** it returns `{ countryCode: 'JP', level1: 'JP-13' }`
+
+#### Scenario: US state code
+
+- **WHEN** `codeToHome('US-CA')` is called
+- **THEN** it returns `{ countryCode: 'US', level1: 'US-CA' }`
+
+---
+
+### Requirement: Location display name
+
+The `entities/user.ts` file SHALL export a `displayName(code: string, lang?: 'ja' | 'en'): string` pure function that returns the human-readable name for an ISO 3166-2 code. If no entry is found for the code, the code itself SHALL be returned. The default language SHALL be `'ja'`.
+
+#### Scenario: Known Japanese prefecture in Japanese
+
+- **WHEN** `displayName('JP-13')` is called
+- **THEN** it returns `'東京都'`
+
+#### Scenario: Known Japanese prefecture in English
+
+- **WHEN** `displayName('JP-13', 'en')` is called
+- **THEN** it returns `'Tokyo'`
+
+#### Scenario: Unknown code returns code as fallback
+
+- **WHEN** `displayName('XX-99')` is called
+- **THEN** it returns `'XX-99'`
+
+---
+
+### Requirement: Merkle path binary conversions
+
+The `entities/entry.ts` file SHALL export pure conversion functions for Merkle proof data:
+1. `bytesToHex(bytes: Uint8Array): string` — converts bytes to lowercase hex string.
+2. `bytesToDecimal(bytes: Uint8Array): string` — converts bytes to decimal string via hex intermediate.
+3. `uuidToFieldElement(uuid: string): string` — strips hyphens from a UUID and converts the hex to a decimal string.
+
+#### Scenario: bytesToHex converts bytes
+
+- **WHEN** `bytesToHex(new Uint8Array([0x0a, 0xff]))` is called
+- **THEN** it returns `'0aff'`
+
+#### Scenario: bytesToHex empty input
+
+- **WHEN** `bytesToHex(new Uint8Array([]))` is called
+- **THEN** it returns `''`
+
+#### Scenario: bytesToDecimal converts to decimal string
+
+- **WHEN** `bytesToDecimal(new Uint8Array([0x01, 0x00]))` is called
+- **THEN** it returns `'256'`
+
+#### Scenario: bytesToDecimal empty input returns zero
+
+- **WHEN** `bytesToDecimal(new Uint8Array([]))` is called
+- **THEN** it returns `'0'`
+
+#### Scenario: uuidToFieldElement strips hyphens
+
+- **WHEN** `uuidToFieldElement('550e8400-e29b-41d4-a716-446655440000')` is called
+- **THEN** it returns the decimal representation of `0x550e8400e29b41d4a716446655440000`

--- a/openspec/changes/archive/2026-03-19-frontend-entity-logic/specs/frontend-entity-layer/spec.md
+++ b/openspec/changes/archive/2026-03-19-frontend-entity-logic/specs/frontend-entity-layer/spec.md
@@ -1,0 +1,56 @@
+## MODIFIED Requirements
+
+### Requirement: Artist entity
+The frontend SHALL use the BSR-generated proto `Artist` class from `@buf/liverty-music_schema.bufbuild_es/liverty_music/entity/v1/artist_pb.js` as the canonical artist representation across all layers (services, state, components). Custom interfaces (`ArtistBubble`, `GuestFollow`) that duplicate Artist fields SHALL be removed. The `src/entities/artist.ts` file SHALL re-export the proto `Artist` type and provide helper functions for common field access patterns (e.g., best logo URL extraction).
+
+The `entities/artist.ts` file SHALL export `bestLogoUrl(artist)` and `bestBackgroundUrl(artist)` as pure functions. Artist color derivation functions (`artistHue`, `artistColor`, `artistHueFromColorProfile`) SHALL NOT be placed in `entities/artist.ts` but in `adapter/view/artist-color.ts`, as they are presentation-layer concerns.
+
+#### Scenario: Discovery service returns proto Artist
+- **WHEN** `ArtistServiceClient.listTop()`, `search()`, or `listSimilar()` is called
+- **THEN** the response SHALL return proto `Artist` objects directly, not mapped `ArtistBubble` interfaces
+
+#### Scenario: Artist with fanart preserved through discovery
+- **WHEN** an `Artist` proto is returned from ArtistService with `fanart.logoColorProfile` populated
+- **THEN** the `logoColorProfile` data SHALL be preserved on the `Artist` object without being stripped
+
+#### Scenario: Physics bubble composition
+- **WHEN** the discovery dna-orb needs physics properties (`x`, `y`, `radius`) for an artist
+- **THEN** it SHALL use a `PhysicsBubble` composition type `{ artist: Artist, x: number, y: number, radius: number }` instead of flattening artist fields into the physics type
+
+#### Scenario: Color functions not in entity
+- **WHEN** a component needs an artist color or hue
+- **THEN** it SHALL import from `adapter/view/artist-color` not from `entities/artist`
+
+### Requirement: Concert entity
+The `src/entities/concert.ts` file SHALL export a `Concert` interface that includes an `artist?: Artist` field (proto type) instead of separate `logoUrl`, `backgroundUrl`, and `logoColorProfile` fields. Components SHALL extract display-specific values from the `Artist` object.
+
+The `entities/concert.ts` file SHALL additionally export `isHypeMatched(hype, lane)`, `HypeLevel`, `LaneType`, and the ordering constants `HYPE_ORDER` and `LANE_ORDER` as pure domain logic alongside the type definitions.
+
+#### Scenario: Concert with artist fanart
+- **WHEN** a Concert is constructed from a proto concert and an artist map entry
+- **THEN** `concert.artist` SHALL contain the full proto `Artist` with `fanart` (including `logoColorProfile` when available)
+
+#### Scenario: Concert template accesses logo URL
+- **WHEN** an event-card template needs the logo URL
+- **THEN** it SHALL derive it from `concert.artist.fanart.hdMusicLogo?.value ?? concert.artist.fanart.musicLogo?.value`
+
+#### Scenario: Hype matching imported from entity
+- **WHEN** `dashboard-service.ts` needs to check hype matching
+- **THEN** it SHALL import `isHypeMatched` from `entities/concert` not define it locally
+
+### Requirement: FollowedArtist entity
+The `src/entities/follow.ts` file SHALL export a `FollowedArtist` interface containing the proto `Artist` object and a `Hype` value. The interface SHALL NOT flatten artist fields (`id`, `name`, `logoUrl`) into top-level properties. Components that need specific artist fields SHALL access them via `followedArtist.artist.name?.value` or equivalent accessors.
+
+The `entities/follow.ts` file SHALL additionally export a `hasFollow(follows, artistId)` pure function for deduplication checks. The `Hype` type and `FollowedArtist` interface SHALL remain in this file.
+
+#### Scenario: FollowedArtist from ListFollowed RPC
+- **WHEN** the follow service client receives a ListFollowed response
+- **THEN** it SHALL map each proto `FollowedArtist` to `{ artist: Artist, hype: Hype }` preserving the full `Artist` object including `fanart`
+
+#### Scenario: FollowedArtist during onboarding
+- **WHEN** the follow service client is called during onboarding (`isOnboarding === true`)
+- **THEN** it SHALL return `FollowedArtist` objects with the proto `Artist` from the guest state, including any `fanart` data that was available at follow time
+
+#### Scenario: Duplicate follow check uses entity function
+- **WHEN** the Redux reducer handles a `guest/follow` action
+- **THEN** it SHALL call `hasFollow()` from `entities/follow` to check for duplicates instead of inlining the check

--- a/openspec/changes/archive/2026-03-19-frontend-entity-logic/specs/frontend-view-adapter/spec.md
+++ b/openspec/changes/archive/2026-03-19-frontend-entity-logic/specs/frontend-view-adapter/spec.md
@@ -1,0 +1,58 @@
+## ADDED Requirements
+
+### Requirement: Artist color derivation
+
+The `adapter/view/artist-color.ts` file SHALL export pure functions for deriving deterministic colors from artist data:
+1. `artistHue(name: string): number` — computes a stable hue (0-359) from the artist name using a hash function.
+2. `artistColor(name: string): string` — returns an HSL color string with fixed saturation and lightness.
+3. `artistHueFromColorProfile(profile: LogoColorProfile | undefined, artistName: string): number` — returns the profile's `dominantHue` when `isChromatic` is true and `dominantHue` is defined, otherwise falls back to `artistHue(artistName)`.
+
+These functions SHALL NOT depend on any framework, DI container, or DOM API.
+
+#### Scenario: Same name produces same hue
+
+- **WHEN** `artistHue('Radiohead')` is called twice
+- **THEN** both calls return the same number
+
+#### Scenario: Hue is within valid range
+
+- **WHEN** `artistHue('any artist name')` is called
+- **THEN** the result is between 0 and 359 inclusive
+
+#### Scenario: artistColor returns HSL string
+
+- **WHEN** `artistColor('Radiohead')` is called
+- **THEN** it returns a string matching the pattern `hsl(<number>, <number>%, <number>%)`
+
+#### Scenario: Chromatic profile uses dominant hue
+
+- **WHEN** `artistHueFromColorProfile({ isChromatic: true, dominantHue: 120, dominantLightness: 50 }, 'Radiohead')` is called
+- **THEN** it returns `120`
+
+#### Scenario: Achromatic profile falls back to name hash
+
+- **WHEN** `artistHueFromColorProfile({ isChromatic: false, dominantHue: 120, dominantLightness: 50 }, 'Radiohead')` is called
+- **THEN** it returns the same value as `artistHue('Radiohead')`
+
+#### Scenario: Undefined profile falls back to name hash
+
+- **WHEN** `artistHueFromColorProfile(undefined, 'Radiohead')` is called
+- **THEN** it returns the same value as `artistHue('Radiohead')`
+
+---
+
+### Requirement: Hype display metadata
+
+The `adapter/view/hype-display.ts` file SHALL export a `HYPE_TIERS` constant mapping each `Hype` value to its display label key and icon string. The mapping SHALL cover all four hype values: `watch`, `home`, `nearby`, `away`.
+
+This constant SHALL NOT depend on any framework, DI container, or DOM API.
+
+#### Scenario: All hype values have entries
+
+- **WHEN** `HYPE_TIERS` is accessed
+- **THEN** it has entries for keys `'watch'`, `'home'`, `'nearby'`, `'away'`
+
+#### Scenario: Each entry has label and icon
+
+- **WHEN** `HYPE_TIERS['home']` is accessed
+- **THEN** it contains `labelKey` (non-empty string) and `icon` (non-empty string) properties

--- a/openspec/changes/archive/2026-03-19-frontend-entity-logic/tasks.md
+++ b/openspec/changes/archive/2026-03-19-frontend-entity-logic/tasks.md
@@ -1,0 +1,29 @@
+## 1. Entity layer: extract business logic
+
+- [x] 1.1 Add `isHypeMatched()`, `HYPE_ORDER`, `LANE_ORDER` to `entities/concert.ts`; remove from `services/dashboard-service.ts`; update imports in `dashboard-service.ts`
+- [x] 1.2 Add `hasFollow()` to `entities/follow.ts`; update `state/reducer.ts` to delegate duplicate check to `hasFollow()`
+- [x] 1.3 Create `entities/onboarding.ts` with `OnboardingStep`, `STEP_ORDER`, `stepIndex()`, `isOnboarding()`, `isCompleted()`, `normalizeStep()`; move from `services/onboarding-service.ts`; update imports in `onboarding-service.ts`, `state/app-state.ts`, `state/actions.ts`, `state/middleware.ts`
+- [x] 1.4 Move `codeToHome()`, `displayName()`, `translationKey()` from `constants/iso3166.ts` to `entities/user.ts`; add re-exports in `constants/iso3166.ts` for backward compatibility
+- [x] 1.5 Move `bytesToHex()`, `bytesToDecimal()`, `uuidToFieldElement()` from `services/proof-service.ts` to `entities/entry.ts`; update imports in `proof-service.ts`
+- [x] 1.6 Update `entities/index.ts` barrel exports with new functions and `onboarding.ts` types
+
+## 2. View adapter layer: presentation logic
+
+- [x] 2.1 Create `adapter/view/artist-color.ts` by moving `artistHue()`, `artistColor()`, `artistHueFromColorProfile()` from `components/live-highway/color-generator.ts`
+- [x] 2.2 Create `adapter/view/hype-display.ts` by moving `HYPE_TIERS` from `routes/my-artists/my-artists-route.ts`
+- [x] 2.3 Update all import sites: `dashboard-route.ts`, `event-card.ts`, `orb-renderer.ts`, `my-artists-route.ts`, `hype-inline-slider.ts` and any other files that import from the old locations
+- [x] 2.4 Delete `components/live-highway/color-generator.ts` after all imports are migrated
+
+## 3. Tests
+
+- [x] 3.1 Add unit tests for `isHypeMatched()` in `entities/concert.spec.ts`
+- [x] 3.2 Add unit tests for `hasFollow()` in `entities/follow.spec.ts`
+- [x] 3.3 Add unit tests for `stepIndex()`, `isOnboarding()`, `isCompleted()`, `normalizeStep()` in `entities/onboarding.spec.ts`
+- [x] 3.4 Add unit tests for `codeToHome()`, `displayName()` in `entities/user.spec.ts`
+- [x] 3.5 Add unit tests for `bytesToHex()`, `bytesToDecimal()`, `uuidToFieldElement()` in `entities/entry.spec.ts`
+- [x] 3.6 Add unit tests for `artistHue()`, `artistColor()`, `artistHueFromColorProfile()` in `adapter/view/artist-color.spec.ts`
+
+## 4. Verification
+
+- [x] 4.1 Run `make check` (lint + test) and fix any issues
+- [x] 4.2 Remove backward-compatibility re-exports from `constants/iso3166.ts` if no remaining direct importers — **deferred**: 6 files still import from `constants/iso3166.ts`; re-exports remain

--- a/openspec/changes/archive/2026-03-19-frontend-entity-test-coverage/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-19-frontend-entity-test-coverage/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-19

--- a/openspec/changes/archive/2026-03-19-frontend-entity-test-coverage/design.md
+++ b/openspec/changes/archive/2026-03-19-frontend-entity-test-coverage/design.md
@@ -1,0 +1,37 @@
+## Context
+
+The `frontend-entity-logic` change extracted 13 pure functions and 2 constants across 7 modules into `entities/` and `adapter/view/`. Initial tests covered happy paths but left gaps in edge cases, boundary conditions, and one module (`translationKey`) with zero coverage. Since these functions form the contract layer that services and components depend on, comprehensive tests are essential before further development builds on them.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Achieve comprehensive branch coverage for every exported pure function in `entities/` and `adapter/view/`
+- Cover all boundary and edge cases identified in the gap analysis
+- Add missing test file for `adapter/view/hype-display.ts`
+- Add missing `translationKey()` tests in `entities/user.spec.ts`
+
+**Non-Goals:**
+- Testing framework-dependent code (services, components, state)
+- Changing production code (test-only change)
+- Achieving 100% line coverage on interface/type exports
+
+## Decisions
+
+### 1. Co-located spec files
+
+Tests remain co-located with source (`entities/*.spec.ts`, `adapter/view/*.spec.ts`) rather than in the `test/` directory. This matches the pattern established in `frontend-entity-logic` and keeps pure-function tests close to their implementations.
+
+**Alternative considered**: Moving to `test/entities/`. Rejected because co-location makes it easier to verify coverage at a glance and avoids deep relative import paths.
+
+### 2. Table-driven tests for combinatorial coverage
+
+Functions like `isHypeMatched` (4 hypes x 3 lanes = 12 combinations) and `normalizeStep` (all legacy numeric values + gaps) use `it.each` table-driven style to exhaustively cover the input space without verbose duplication.
+
+### 3. Structural assertion for constant completeness
+
+`HYPE_TIERS` and `HYPE_ORDER` / `LANE_ORDER` tests verify that every value of the union type has a corresponding entry. This catches silent breakage when a new enum value is added to the type but not to the constant.
+
+## Risks / Trade-offs
+
+- **Risk**: Tests could become brittle if they assert exact hash values for `artistHue`. → Mitigation: Assert range and determinism properties, not specific numbers.
+- **Risk**: `dominantHue === 0` boundary test may surface an actual bug in `artistHueFromColorProfile`. → Mitigation: If the `!= null` check is correct, the test documents that `0` is valid. If not, it exposes the bug early.

--- a/openspec/changes/archive/2026-03-19-frontend-entity-test-coverage/proposal.md
+++ b/openspec/changes/archive/2026-03-19-frontend-entity-test-coverage/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+The `frontend-entity-logic` change extracted pure business logic into `entities/` and `adapter/view/` layers but shipped with minimal happy-path tests. Several functions lack edge-case coverage, one module (`translationKey`) has zero tests, and `adapter/view/hype-display.ts` has no test file at all. Comprehensive tests are needed to lock down the contracts before downstream code builds on them.
+
+## What Changes
+
+- Add missing edge-case and boundary tests for all extracted entity functions (`concert`, `follow`, `onboarding`, `user`, `entry`)
+- Add missing function-level coverage for `translationKey()` in `entities/user.ts`
+- Add missing test file for `adapter/view/hype-display.ts`
+- Strengthen `adapter/view/artist-color.ts` tests with falsy-but-valid boundary cases (`dominantHue === 0`)
+- Verify `normalizeStep()` covers all legacy numeric mappings including gap values (`'2'`, `'6'`)
+
+## Capabilities
+
+### New Capabilities
+
+- `entity-test-coverage`: Comprehensive unit test suite for all pure functions in `entities/` and `adapter/view/` layers
+
+### Modified Capabilities
+
+- `frontend-entity-layer`: Test coverage requirement added for all exported pure functions
+- `frontend-testing`: Entity and view-adapter test conventions established
+
+## Impact
+
+- Test files: `entities/*.spec.ts`, `adapter/view/*.spec.ts`
+- No production code changes
+- Increases unit test count and branch coverage for the entity layer

--- a/openspec/changes/archive/2026-03-19-frontend-entity-test-coverage/specs/entity-test-coverage/spec.md
+++ b/openspec/changes/archive/2026-03-19-frontend-entity-test-coverage/specs/entity-test-coverage/spec.md
@@ -1,0 +1,105 @@
+## ADDED Requirements
+
+### Requirement: isHypeMatched exhaustive coverage
+`isHypeMatched(hype, lane)` SHALL be tested for all 12 combinations of HypeLevel x LaneType using table-driven tests.
+
+#### Scenario: Full matrix via it.each
+- **WHEN** every (hype, lane) pair is evaluated
+- **THEN** results match the rule `HYPE_ORDER[hype] >= LANE_ORDER[lane]`
+
+### Requirement: hasFollow boundary cases
+`hasFollow()` SHALL be tested for multi-element lists and duplicate artist IDs.
+
+#### Scenario: Artist found among multiple follows
+- **WHEN** follows contains 3 entries and the target is the last one
+- **THEN** returns true
+
+#### Scenario: Duplicate artist IDs in list
+- **WHEN** follows contains two entries with the same artist ID
+- **THEN** returns true
+
+### Requirement: normalizeStep full legacy mapping
+`normalizeStep()` SHALL be tested for every key in the legacy numeric migration table plus gap values.
+
+#### Scenario: All mapped numeric values
+- **WHEN** input is `'0'`, `'1'`, `'3'`, `'4'`, `'5'`, or `'7'`
+- **THEN** returns the corresponding OnboardingStepValue
+
+#### Scenario: Unmapped numeric gap values
+- **WHEN** input is `'2'` or `'6'`
+- **THEN** returns `'lp'` (fallback)
+
+### Requirement: translationKey coverage
+`translationKey()` SHALL have dedicated tests covering known codes and unknown codes.
+
+#### Scenario: Known prefecture code
+- **WHEN** code is `'JP-13'`
+- **THEN** returns `'tokyo'`
+
+#### Scenario: Unknown code fallback
+- **WHEN** code is `'XX-99'`
+- **THEN** returns `'XX-99'`
+
+### Requirement: codeToHome boundary cases
+`codeToHome()` SHALL be tested for short input strings.
+
+#### Scenario: Code shorter than 3 characters
+- **WHEN** code is `'JP'` (no hyphen or subdivision)
+- **THEN** returns `{ countryCode: 'JP', level1: 'JP' }` without throwing
+
+### Requirement: bytesToHex zero-padding
+`bytesToHex()` SHALL verify that single-digit hex values are zero-padded.
+
+#### Scenario: Leading zero byte
+- **WHEN** input is `[0x00]`
+- **THEN** returns `'00'`
+
+### Requirement: bytesToDecimal multi-byte
+`bytesToDecimal()` SHALL be tested with 3+ byte inputs.
+
+#### Scenario: Three-byte input
+- **WHEN** input is `[0x01, 0x00, 0x00]`
+- **THEN** returns `'65536'`
+
+### Requirement: uuidToFieldElement robustness
+`uuidToFieldElement()` SHALL handle already-stripped and non-standard inputs.
+
+#### Scenario: UUID without hyphens
+- **WHEN** input is `'550e8400e29b41d4a716446655440000'`
+- **THEN** returns the same decimal as the hyphenated form
+
+### Requirement: artistHue empty string
+`artistHue()` SHALL handle empty string input without throwing.
+
+#### Scenario: Empty string input
+- **WHEN** name is `''`
+- **THEN** returns a number in 0-359 range
+
+### Requirement: artistHueFromColorProfile dominantHue zero
+`artistHueFromColorProfile()` SHALL treat `dominantHue === 0` as valid chromatic, not as falsy fallback.
+
+#### Scenario: Chromatic profile with hue 0 (red)
+- **WHEN** profile is `{ isChromatic: true, dominantHue: 0, dominantLightness: 50 }`
+- **THEN** returns `0` (not the name-hash fallback)
+
+### Requirement: HYPE_TIERS completeness
+`HYPE_TIERS` SHALL have an entry for every value of the `Hype` union type.
+
+#### Scenario: All hype values present
+- **WHEN** checking keys of `HYPE_TIERS`
+- **THEN** keys include `'watch'`, `'home'`, `'nearby'`, `'away'`
+
+#### Scenario: Each entry has labelKey and icon
+- **WHEN** iterating all entries
+- **THEN** every entry has non-empty `labelKey` and non-empty `icon`
+
+### Requirement: HYPE_ORDER and LANE_ORDER completeness
+Exported order constants SHALL cover every value of their respective union types.
+
+#### Scenario: HYPE_ORDER keys match HypeLevel
+- **WHEN** checking keys of `HYPE_ORDER`
+- **THEN** keys are exactly `['watch', 'home', 'nearby', 'away']`
+
+#### Scenario: LANE_ORDER keys match LaneType
+- **WHEN** checking keys of `LANE_ORDER`
+- **THEN** keys are exactly `['home', 'nearby', 'away']`

--- a/openspec/changes/archive/2026-03-19-frontend-entity-test-coverage/tasks.md
+++ b/openspec/changes/archive/2026-03-19-frontend-entity-test-coverage/tasks.md
@@ -1,0 +1,16 @@
+## 1. Entity layer tests
+
+- [x] 1.1 `concert.spec.ts`: Add `HYPE_ORDER` / `LANE_ORDER` completeness tests; convert `isHypeMatched` to `it.each` table-driven style covering all 12 combinations
+- [x] 1.2 `follow.spec.ts`: Add multi-element list test and duplicate artist ID test
+- [x] 1.3 `onboarding.spec.ts`: Add `normalizeStep` tests for all legacy numeric keys (`'3'`, `'4'`, `'5'`) and gap values (`'2'`, `'6'`)
+- [x] 1.4 `user.spec.ts`: Add `translationKey()` tests (known code, unknown fallback); add `codeToHome()` short-input boundary test
+- [x] 1.5 `entry.spec.ts`: Add `bytesToHex` zero-padding test (`0x00`); `bytesToDecimal` 3-byte test; `uuidToFieldElement` hyphen-free input test
+
+## 2. View adapter tests
+
+- [x] 2.1 `artist-color.spec.ts`: Add `artistHue` empty-string test; add `artistHueFromColorProfile` `dominantHue === 0` boundary test
+- [x] 2.2 Create `hype-display.spec.ts`: Completeness test (all Hype keys present), each entry has non-empty `labelKey` and `icon`
+
+## 3. Verification
+
+- [x] 3.1 Run `make check` and fix any issues

--- a/openspec/specs/entity-test-coverage/spec.md
+++ b/openspec/specs/entity-test-coverage/spec.md
@@ -1,0 +1,105 @@
+## ADDED Requirements
+
+### Requirement: isHypeMatched exhaustive coverage
+`isHypeMatched(hype, lane)` SHALL be tested for all 12 combinations of HypeLevel x LaneType using table-driven tests.
+
+#### Scenario: Full matrix via it.each
+- **WHEN** every (hype, lane) pair is evaluated
+- **THEN** results match the rule `HYPE_ORDER[hype] >= LANE_ORDER[lane]`
+
+### Requirement: hasFollow boundary cases
+`hasFollow()` SHALL be tested for multi-element lists and duplicate artist IDs.
+
+#### Scenario: Artist found among multiple follows
+- **WHEN** follows contains 3 entries and the target is the last one
+- **THEN** returns true
+
+#### Scenario: Duplicate artist IDs in list
+- **WHEN** follows contains two entries with the same artist ID
+- **THEN** returns true
+
+### Requirement: normalizeStep full legacy mapping
+`normalizeStep()` SHALL be tested for every key in the legacy numeric migration table plus gap values.
+
+#### Scenario: All mapped numeric values
+- **WHEN** input is `'0'`, `'1'`, `'3'`, `'4'`, `'5'`, or `'7'`
+- **THEN** returns the corresponding OnboardingStepValue
+
+#### Scenario: Unmapped numeric gap values
+- **WHEN** input is `'2'` or `'6'`
+- **THEN** returns `'lp'` (fallback)
+
+### Requirement: translationKey coverage
+`translationKey()` SHALL have dedicated tests covering known codes and unknown codes.
+
+#### Scenario: Known prefecture code
+- **WHEN** code is `'JP-13'`
+- **THEN** returns `'tokyo'`
+
+#### Scenario: Unknown code fallback
+- **WHEN** code is `'XX-99'`
+- **THEN** returns `'XX-99'`
+
+### Requirement: codeToHome boundary cases
+`codeToHome()` SHALL be tested for short input strings.
+
+#### Scenario: Code shorter than 3 characters
+- **WHEN** code is `'JP'` (no hyphen or subdivision)
+- **THEN** returns `{ countryCode: 'JP', level1: 'JP' }` without throwing
+
+### Requirement: bytesToHex zero-padding
+`bytesToHex()` SHALL verify that single-digit hex values are zero-padded.
+
+#### Scenario: Leading zero byte
+- **WHEN** input is `[0x00]`
+- **THEN** returns `'00'`
+
+### Requirement: bytesToDecimal multi-byte
+`bytesToDecimal()` SHALL be tested with 3+ byte inputs.
+
+#### Scenario: Three-byte input
+- **WHEN** input is `[0x01, 0x00, 0x00]`
+- **THEN** returns `'65536'`
+
+### Requirement: uuidToFieldElement robustness
+`uuidToFieldElement()` SHALL handle already-stripped and non-standard inputs.
+
+#### Scenario: UUID without hyphens
+- **WHEN** input is `'550e8400e29b41d4a716446655440000'`
+- **THEN** returns the same decimal as the hyphenated form
+
+### Requirement: artistHue empty string
+`artistHue()` SHALL handle empty string input without throwing.
+
+#### Scenario: Empty string input
+- **WHEN** name is `''`
+- **THEN** returns a number in 0-359 range
+
+### Requirement: artistHueFromColorProfile dominantHue zero
+`artistHueFromColorProfile()` SHALL treat `dominantHue === 0` as valid chromatic, not as falsy fallback.
+
+#### Scenario: Chromatic profile with hue 0 (red)
+- **WHEN** profile is `{ isChromatic: true, dominantHue: 0, dominantLightness: 50 }`
+- **THEN** returns `0` (not the name-hash fallback)
+
+### Requirement: HYPE_TIERS completeness
+`HYPE_TIERS` SHALL have an entry for every value of the `Hype` union type.
+
+#### Scenario: All hype values present
+- **WHEN** checking keys of `HYPE_TIERS`
+- **THEN** keys include `'watch'`, `'home'`, `'nearby'`, `'away'`
+
+#### Scenario: Each entry has labelKey and icon
+- **WHEN** iterating all entries
+- **THEN** every entry has non-empty `labelKey` and non-empty `icon`
+
+### Requirement: HYPE_ORDER and LANE_ORDER completeness
+Exported order constants SHALL cover every value of their respective union types.
+
+#### Scenario: HYPE_ORDER keys match HypeLevel
+- **WHEN** checking keys of `HYPE_ORDER`
+- **THEN** keys are exactly `['watch', 'home', 'nearby', 'away']`
+
+#### Scenario: LANE_ORDER keys match LaneType
+- **WHEN** checking keys of `LANE_ORDER`
+- **THEN** keys are exactly `['home', 'nearby', 'away']`


### PR DESCRIPTION
## Related Issue

Closes #253

## Summary of Changes

Add the `entity-test-coverage` capability spec and archive two completed OpenSpec changes from the frontend entity extraction work.

**New spec:**
- `openspec/specs/entity-test-coverage/spec.md` — 13 requirements with 17 testable scenarios defining comprehensive test coverage for all pure functions in the frontend `entities/` and `adapter/view/` layers

**Archived changes:**
- `frontend-entity-logic` — entity layer extraction and view-adapter layer creation
- `frontend-entity-test-coverage` — comprehensive test suite for extracted functions

No proto changes in this PR.

## Self-Checklist

- [x] I have linked the related issue.
- [x] I have updated the relevant documentation (e.g., `README.md`) if needed.
- [x] I have run `buf lint` and `buf format` locally and all checks have passed.
- [x] My proto definitions follow the project's style guidelines and validation rules.
- [x] Breaking changes have been justified and documented if applicable.
