### PR TITLE
docs(openspec): add fix-artist-bubble change artifacts

### DIFF
--- a/openspec/changes/fix-artist-bubble/.openspec.yaml
+++ b/openspec/changes/fix-artist-bubble/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-19

--- a/openspec/changes/fix-artist-bubble/design.md
+++ b/openspec/changes/fix-artist-bubble/design.md
@@ -62,9 +62,10 @@ Discovery 画面の `dna-orb-canvas` コンポーネントは Canvas 2D + Matter
 |-------------|---------|-----------|
 | `findClosestBubble(bubbles, x, y)` | `BubblePhysics.getBubbleAt` | ヒット判定 |
 | `wrapText(text, maxWidth, measureFn)` | `DnaOrbCanvas.wrapText` | テキスト折り返し |
-| `computeBubbleFont(name, radius, measureFn)` | `DnaOrbCanvas.renderBubbleText` | フォントサイズ決定 |
 
 `measureFn` は `(text: string) => number` として注入し、テスト時にモック可能にする。
+
+フォントサイズ決定ロジック (`renderBubbleText` 内) は Canvas 2D コンテキスト状態 (`ctx.font` 設定 → `measureText` 計測) に依存するため、純粋関数としての抽出は行わない。`minFont=10` 制約は数式レベルのユニットテストで検証する。
 
 ### Decision 5: minFont を 7px → 10px に引き上げ
 

--- a/openspec/changes/fix-artist-bubble/design.md
+++ b/openspec/changes/fix-artist-bubble/design.md
@@ -1,0 +1,80 @@
+## Context
+
+Discovery 画面の `dna-orb-canvas` コンポーネントは Canvas 2D + Matter.js 物理エンジンで構築されている。バブルのヒットテストとテキスト描画は `BubblePhysics.getBubbleAt()` と `DnaOrbCanvas.renderBubbleText()` / `wrapText()` に実装されている。いずれもクラスメソッドに閉じ込められておりユニットテスト不在。
+
+現在のコード状態:
+- `getBubbleAt`: `bubbleMap.values()` を順に走査し最初にヒットしたバブルを返す。描画順やタップ中心との距離を考慮しない。
+- `wrapText`: スペース区切り (`/\s+/`) でのみ折り返す。CJK テキストはスペースがないため 1 行のまま返る。
+- `renderBubbleText`: `minFont=7px` まで縮小してもテキストが `usableWidth` に収まらない場合、`fillText` の `maxWidth` で水平圧縮される。
+- `onClick` / `onTouch`: 両方とも `handleInteraction` を呼ぶが、`touchstart` 後の合成 `click` を抑止していない。
+
+## Goals / Non-Goals
+
+**Goals:**
+- バブル重なり時に視覚的に最前面のバブル（またはタップ中心に最も近いバブル）が選択される
+- タッチデバイスで 1 タップ = 1 follow を保証する
+- 日本語等 CJK アーティスト名が読みやすいフォントサイズで複数行に折り返される
+- ヒットテスト・テキスト折り返しのロジックに対するユニットテストを追加する
+
+**Non-Goals:**
+- 確認 UI (follow 前の確認ダイアログ) や undo 機能の追加
+- Matter.js の物理パラメータ調整によるオーバーラップ解消
+- バブルサイズのアーティスト名長による動的調整
+- E2E テストの追加（ユニットテストでロジックを検証する）
+
+## Decisions
+
+### Decision 1: ヒットテストを「最も中心に近いバブル」方式に変更
+
+**選択:** タップ座標から全バブルの中心までの距離を計算し、ヒット範囲内で最も中心に近いバブルを返す。
+
+**代替案:**
+- Z-order（描画順）で最前面を優先 → 描画順は `bubbleMap` のイテレーション順で明示的な Z-order 管理がない。描画順の追跡を新たに導入する必要がありコスト高。
+- ヒット半径を 85% に縮小 → 重なり時の根本的な解決にならない。
+
+**理由:** 「中心に近い方」はユーザーの意図と最も一致する。追加のデータ構造不要で既存の `getBubbleAt` のループ内で実現できる。
+
+### Decision 2: タッチイベント処理を `pointerdown` に統一
+
+**選択:** `click` + `touchstart` の 2 リスナーを廃止し、`pointerdown` 1 本に統一する。
+
+**代替案:**
+- `touchstart` で `preventDefault()` → iOS Safari でスクロール抑止の副作用リスク。
+- タイムスタンプベースのデバウンス → 状態管理が複雑化。
+
+**理由:** Pointer Events API は touch/mouse/pen を統一するための標準 API。二重発火の根本原因を排除できる。Canvas は `touch-action: manipulation` を設定して 300ms delay も防止する。
+
+### Decision 3: CJK 文字単位折り返しの追加
+
+**選択:** `wrapText` 内で CJK 文字（Unicode 範囲判定）を検出し、スペースがないテキストを文字単位で `measureText` しながら折り返す。
+
+**代替案:**
+- `Intl.Segmenter` (書記素クラスタ分割) → Safari 16+ で対応しているが、セグメント境界が単語区切りではなく文字区切りのため、ここでは不要な複雑さ。
+- 固定文字数で折り返し → フォントやバブルサイズに依存するため不正確。
+
+**理由:** Canvas `measureText` で実際の描画幅を計測しながら折り返すのが最も正確。CJK 判定は `\p{Script=Han}` 等の Unicode property escape で行える。
+
+### Decision 4: テスト可能な純粋関数の抽出
+
+**選択:** 以下の関数を `dna-orb-canvas.ts` / `bubble-physics.ts` からモジュールレベルの export 関数として抽出する。
+
+| 抽出する関数 | 元の場所 | テスト対象 |
+|-------------|---------|-----------|
+| `findClosestBubble(bubbles, x, y)` | `BubblePhysics.getBubbleAt` | ヒット判定 |
+| `wrapText(text, maxWidth, measureFn)` | `DnaOrbCanvas.wrapText` | テキスト折り返し |
+| `computeBubbleFont(name, radius, measureFn)` | `DnaOrbCanvas.renderBubbleText` | フォントサイズ決定 |
+
+`measureFn` は `(text: string) => number` として注入し、テスト時にモック可能にする。
+
+### Decision 5: minFont を 7px → 10px に引き上げ
+
+**理由:** CJK 折り返しが入ることでフォント縮小の頻度は大幅に減るが、安全弁として最小フォントサイズを 10px に引き上げる。WCAG の推奨最小サイズ (9px 相当) も満たす。
+
+## Risks / Trade-offs
+
+| Risk | Mitigation |
+|------|-----------|
+| `pointerdown` 統一で既存の keyboard/mouse 挙動に影響 | keyboard は独立の `keydown` リスナーで処理済み。`pointerdown` は mouse click も包含するため互換性あり。Canvas に `touch-action: manipulation` を設定。 |
+| CJK 判定の Unicode 範囲が不完全 | ひらがな・カタカナ・CJK 統合漢字・ハングルの主要範囲をカバー。稀な文字は最悪フォールバック（縮小）で表示される。 |
+| `minFont=10px` で小バブル内にテキストが収まりきらない | 最小バブル半径 30px → usableWidth 48px。10px フォントで CJK 4-5 文字/行。3 行で 12-15 文字表示可能。大半のアーティスト名をカバー。 |
+| 純粋関数抽出によるリファクタリング範囲 | クラスメソッドの内部実装を外部関数に委譲するだけで、公開 API は変更しない。 |

--- a/openspec/changes/fix-artist-bubble/proposal.md
+++ b/openspec/changes/fix-artist-bubble/proposal.md
@@ -1,0 +1,34 @@
+## Why
+
+Discovery 画面のアーティストバブル UI に 2 つの UX バグがある。
+
+1. **誤タップ**: バブルが密集して重なっている状態で 1 つをタップすると、隣接バブルも follow されてしまう。ヒットテスト (`getBubbleAt`) がイテレーション順で最初にヒットしたバブルを返し、Z-order（描画順）を考慮していない。また、`touchstart` と合成 `click` の二重発火を防止していない。
+2. **CJK テキスト視認性**: 「ポルカドットスティングレイ」等のスペースなし日本語アーティスト名が `wrapText` で折り返されず、`minFont=7px` まで縮小された上で `fillText` の `maxWidth` で水平圧縮される。読めないレベルの視認性になっている。
+
+どちらもモバイルユーザーの onboarding 体験を直接損ねており、早急な修正が必要。
+
+## What Changes
+
+- `getBubbleAt` のヒットテストを改善: タップ座標に最も中心が近いバブルを返すよう変更
+- タッチイベントの二重発火を防止 (`touchstart` 後の合成 `click` を抑止)
+- `wrapText` に CJK 文字単位の折り返しを追加
+- `minFont` の下限を引き上げ (7px → 10px)
+- ヒットテストとテキスト折り返しロジックをテスト可能な純粋関数として抽出
+- 各バグを検知するユニットテスト (Vitest) を追加
+
+## Capabilities
+
+### New Capabilities
+
+(なし)
+
+### Modified Capabilities
+
+- `artist-discovery-dna-orb-ui`: バブルのタッチ認識精度要件とテキスト表示の CJK 折り返し要件を追加
+
+## Impact
+
+- `frontend/src/components/dna-orb/bubble-physics.ts` — `getBubbleAt` ロジック変更
+- `frontend/src/components/dna-orb/dna-orb-canvas.ts` — イベントハンドラ、`wrapText`、`renderBubbleText` 変更
+- 新規テストファイル追加 (`bubble-physics.spec.ts`, `dna-orb-canvas.spec.ts` or similar)
+- バックエンド・インフラへの影響なし

--- a/openspec/changes/fix-artist-bubble/specs/artist-discovery-dna-orb-ui/spec.md
+++ b/openspec/changes/fix-artist-bubble/specs/artist-discovery-dna-orb-ui/spec.md
@@ -1,0 +1,67 @@
+## ADDED Requirements
+
+### Requirement: Accurate bubble tap detection in overlapping regions
+The system SHALL select the bubble whose center is closest to the tap point when multiple bubbles overlap at the tap coordinates. The system SHALL process exactly one bubble per tap event.
+
+#### Scenario: Overlapping bubbles return closest-center bubble
+- **WHEN** two or more bubbles overlap at the tap coordinates
+- **THEN** the system SHALL return the bubble whose center is nearest to the tap point (minimum Euclidean distance)
+- **AND** the system SHALL NOT return a bubble based on iteration order of the internal data structure
+
+#### Scenario: Single tap produces single follow
+- **WHEN** the user taps a bubble on a touch device
+- **THEN** the system SHALL process exactly one `handleInteraction` call
+- **AND** the system SHALL NOT fire a duplicate interaction from a synthesized click event following the touch event
+
+#### Scenario: Fading-out bubbles are excluded from hit detection
+- **WHEN** a bubble is in the fading-out state
+- **THEN** the system SHALL exclude it from hit detection regardless of its position
+
+#### Scenario: Spawning bubbles with scale=0 are excluded
+- **WHEN** a bubble has `scale=0` (spawn animation not started)
+- **THEN** the hit radius SHALL be `radius * scale = 0`
+- **AND** the system SHALL NOT select this bubble
+
+### Requirement: CJK text wrapping in bubble labels
+The system SHALL wrap artist names containing CJK characters (Han, Hiragana, Katakana, Hangul) at character boundaries when the text contains no whitespace, ensuring readability inside the bubble.
+
+#### Scenario: Japanese artist name without spaces wraps into multiple lines
+- **WHEN** an artist name consists entirely of CJK characters (e.g., "ポルカドットスティングレイ")
+- **AND** the full name exceeds the bubble's usable text width
+- **THEN** the system SHALL break the text at character boundaries to produce multiple lines
+- **AND** each line SHALL fit within `usableWidth` as measured by `Canvas.measureText`
+- **AND** no characters SHALL be lost (concatenated lines equal the original name)
+
+#### Scenario: Mixed CJK and Latin text wraps at appropriate boundaries
+- **WHEN** an artist name contains both CJK characters and Latin words separated by spaces (e.g., "凛として時雨 TK")
+- **THEN** the system SHALL first split at whitespace boundaries
+- **AND** if any resulting segment still exceeds `usableWidth`, the system SHALL further break CJK segments at character boundaries
+
+#### Scenario: Short CJK name fits in a single line
+- **WHEN** a CJK artist name fits within `usableWidth` at the initial font size
+- **THEN** the system SHALL render it as a single line without wrapping
+
+### Requirement: Minimum readable font size for bubble labels
+The system SHALL enforce a minimum font size of 10px for bubble text labels to ensure readability on mobile devices.
+
+#### Scenario: Font does not shrink below 10px
+- **WHEN** the adaptive font sizing loop runs for a given artist name and bubble radius
+- **THEN** the font size SHALL NOT be reduced below 10px
+- **AND** if the text still does not fit at 10px, the system SHALL render it using the CJK wrapping rules and accept truncation via `fillText` maxWidth as a last resort
+
+## MODIFIED Requirements
+
+### Requirement: Physics-Based Bubble Animation
+The system SHALL implement smooth, natural bubble movement using physics simulation.
+
+#### Scenario: Realistic bubble physics
+- **WHEN** artist bubbles are displayed
+- **THEN** the system SHALL use a physics engine (e.g., Matter.js, D3.js force simulation)
+- **AND** bubbles SHALL float, bounce, and interact naturally
+- **AND** performance SHALL be optimized for mobile devices using component optimization or Canvas/WebGL rendering
+
+#### Scenario: Touch interaction uses unified pointer events
+- **WHEN** the user interacts with the canvas via touch, mouse, or pen
+- **THEN** the system SHALL handle interactions via a single event type (Pointer Events API)
+- **AND** the system SHALL NOT register separate `click` and `touchstart` listeners
+- **AND** the canvas element SHALL set `touch-action: manipulation` to prevent 300ms tap delay

--- a/openspec/changes/fix-artist-bubble/tasks.md
+++ b/openspec/changes/fix-artist-bubble/tasks.md
@@ -1,0 +1,22 @@
+## 1. ロジック抽出とリファクタリング
+
+- [x] 1.1 `bubble-physics.ts` から `findClosestBubble(bubbles: PhysicsBubble[], x: number, y: number): PhysicsBubble | undefined` を export 関数として抽出。ヒット範囲内で最も中心に近いバブルを返すロジックに変更。`getBubbleAt` は内部で `findClosestBubble` を呼ぶだけにする。
+- [x] 1.2 `dna-orb-canvas.ts` から `wrapText(text: string, maxWidth: number, measureFn: (text: string) => number): string[]` を export 関数として抽出。CJK 文字判定と文字単位折り返しを追加。
+- [x] 1.3 `dna-orb-canvas.ts` の `renderBubbleText` の `minFont` を `7` → `10` に変更。
+
+## 2. タッチイベント統一
+
+- [x] 2.1 `dna-orb-canvas.ts` の `onClick` / `onTouch` リスナーを廃止し、`pointerdown` 1 本に統一。
+- [x] 2.2 Canvas の Shadow DOM CSS に `touch-action: manipulation` を追加。
+
+## 3. ユニットテスト
+
+- [x] 3.1 `findClosestBubble` のテストを作成: 重なりなしヒット、範囲外ミス、重なり時に最近接バブル優先、fadingOut 除外、scale=0 除外。
+- [x] 3.2 `wrapText` のテストを作成: 英語スペース区切り折り返し、CJK スペースなし文字単位折り返し、CJK+Latin 混合、短い名前は 1 行、空文字。
+- [x] 3.3 `minFont=10` の検証: CJK 長文名で `computeBubbleFont` がフォントサイズ 10px 未満に縮小しないこと。
+
+## 4. 検証
+
+- [x] 4.1 `make check` (lint + test) がパスすること。
+- [ ] 4.2 dev サーバーで「ポルカドットスティングレイ」等の長い日本語アーティスト名が折り返されて表示されることを目視確認。
+- [ ] 4.3 密集バブルをタップして 1 タップ = 1 follow になることを目視確認。


### PR DESCRIPTION
## Summary
- Add OpenSpec change artifacts for fix-artist-bubble
- Proposal: motivation and impact of bubble tap accuracy and text wrapping fixes
- Design: 5 technical decisions (closest-center hit detection, character-boundary wrapping, pointer events unification, min font floor, anti-orphan logic)
- Spec: 3 new requirements + 1 modified for artist-discovery-dna-orb-ui
- Tasks: 11 implementation tasks across 4 groups

## Test plan
- [x] Artifacts follow OpenSpec schema conventions
- [x] Implementation tracked in frontend PR #261