### PR TITLE
docs(spec): update concert gate and bubble pool specs for discovery fix

### DIFF
--- a/openspec/changes/archive/2026-03-19-fix-discovery-concert-gate/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-19-fix-discovery-concert-gate/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-19

--- a/openspec/changes/archive/2026-03-19-fix-discovery-concert-gate/design.md
+++ b/openspec/changes/archive/2026-03-19-fix-discovery-concert-gate/design.md
@@ -1,0 +1,68 @@
+## Context
+
+The discovery page has two bugs caused by a mismatch between the onboarding step order and the implementation:
+
+1. **Concert gate deadlock**: `verifyConcertData()` calls `listByFollower()`, which during onboarding delegates to `listWithProximity()`. This RPC requires `guest.home`, but home is set on the Dashboard (Step 3) — unreachable without passing the discovery gate (Step 1).
+2. **Reload state loss**: `FollowOrchestrator.followedArtists` initializes as `[]` and is never hydrated from the persisted store. After reload, `followedIds` is empty, so `BubblePool.dedup()` cannot filter out followed artists.
+
+The existing `ConcertService/List` RPC accepts only `artist_id` and returns concerts without auth or home. It is already used in `FollowOrchestrator.checkLiveEvents()`.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Break the circular dependency: discovery concert gate works without `guest.home`
+- Restore followed state on reload so bubbles exclude followed artists
+- Add test coverage for the discovery controllers that were untested
+
+**Non-Goals:**
+
+- Changing the onboarding step order (home selection stays on Dashboard)
+- Adding a new backend RPC — reuse existing `ConcertService/List`
+- Refactoring `ConcertServiceClient.listByFollower()` broadly — only change the verification path
+
+## Decisions
+
+### D1: Use `ConcertService/List` per-artist for concert existence check
+
+**Decision**: Replace the single `listByFollower()` call in `ConcertSearchTracker.verifyConcertData()` with parallel `ConcertService/List` calls for each followed artist.
+
+**Why**: `ConcertService/List` requires only `artist_id` — no auth, no home. It is already available in the frontend via `ConcertRpcClient.listConcerts()`.
+
+**Alternatives considered**:
+- *Add a new `ExistsConcerts` RPC*: Cleaner but requires proto change, BSR release cycle, and backend implementation for a gate that only fires once per session. Over-engineered for the use case.
+- *Remove the concert gate entirely*: Simpler but degrades UX — users would reach the dashboard with an empty timetable if no concerts were found.
+
+**Trade-off**: N+1 RPC calls (one per followed artist, typically 3–10). Acceptable because this runs once per session, the calls are parallel, and the response payloads are small.
+
+### D2: Introduce a dedicated `verifyConcertsExist` method on `ConcertSearchClient` interface
+
+**Decision**: Add a `verifyConcertsExist(artistIds: string[]): Promise<boolean>` method to the `ConcertSearchClient` interface used by `ConcertSearchTracker`. The implementation calls `ConcertService/List` per artist in parallel and returns `true` if any artist has ≥1 concert.
+
+**Why**: Keeps `ConcertSearchTracker` decoupled from the specifics of which RPC is called. The tracker only needs to know "do concerts exist?" — the service layer decides how to answer.
+
+### D3: Hydrate `FollowOrchestrator` from store in `DiscoveryRoute.loading()`
+
+**Decision**: In `DiscoveryRoute.loading()`, read `store.getState().guest.follows` and pass the artist list to `FollowOrchestrator` before calling `loadInitialArtists()`.
+
+**Why**: The store is already restored from localStorage by `loadPersistedState()` at app startup. The orchestrator just needs to be seeded from it. No new persistence mechanism required.
+
+**Approach**: Add a `hydrate(artists: Artist[])` method on `FollowOrchestrator` that sets `followedArtists` from an external source. Call it at the top of `loading()`.
+
+### D4: Unit tests for discovery controllers
+
+**Decision**: Add Vitest unit tests for `ConcertSearchTracker`, `FollowOrchestrator`, and `BubbleManager`. These are plain classes (not DI-registered) that accept interfaces — easy to test with stubs.
+
+**Why**: All three classes contain critical gate/filter logic with zero test coverage. The two bugs would have been caught by straightforward unit tests.
+
+### D5: Fix E2E test to not pre-seed `guest.home`
+
+**Decision**: Update the existing E2E coach mark test to remove `guest.home` from localStorage setup, validating that the coach mark works without home.
+
+**Why**: The current test masks the bug by pre-seeding home. After fixing the implementation, the test should reflect the real user flow.
+
+## Risks / Trade-offs
+
+- **N+1 `List` calls**: 3–10 parallel RPCs per session. Mitigated by small payload size and one-time execution. If artist count grows, a batched RPC could be added later.
+- **Race between hydrate and loadInitialArtists**: `hydrate()` must complete before `loadInitialArtists()` reads `followedIds`. Mitigated by calling them sequentially in `loading()` (synchronous hydrate, then async load).
+- **`ConcertService/List` returns full concert objects**: We only need a boolean "exists". Acceptable overhead for now; a lightweight `Exists` RPC is a non-goal.

--- a/openspec/changes/archive/2026-03-19-fix-discovery-concert-gate/proposal.md
+++ b/openspec/changes/archive/2026-03-19-fix-discovery-concert-gate/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+The discovery page's concert data gate uses `ListWithProximity` to verify that concerts exist before showing the Dashboard coach mark. This RPC requires `guest.home`, but home is not set until the Dashboard step — creating a circular dependency that prevents the coach mark from ever appearing. Additionally, after a page reload, `FollowOrchestrator` does not restore followed artists from the store, causing already-followed artists to reappear as bubbles.
+
+## What Changes
+
+- Replace the `ListWithProximity` call in `verifyConcertData()` with per-artist `ConcertService/List` calls that require only `artist_id` (no home, no auth)
+- Hydrate `FollowOrchestrator.followedArtists` from the store's `guest.follows` on discovery page load, so reload correctly filters bubbles and populates `followedIds`
+- Add unit tests for `ConcertSearchTracker`, `FollowOrchestrator`, and `BubbleManager` to cover the gate logic and reload scenarios
+- Add E2E test for the discovery reload scenario and the no-home coach mark scenario
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `onboarding-tutorial`: Step 1 concert data verification SHALL use `ConcertService/List` (per-artist, no home required) instead of `ListWithProximity`
+- `bubble-pool-lifecycle`: On discovery page load, the bubble pool SHALL exclude artists already present in the persisted guest follow state
+
+## Impact
+
+- **Frontend**: `concert-search-tracker.ts`, `follow-orchestrator.ts`, `discovery-route.ts`, `concert-service.ts`
+- **Tests**: New unit test files for discovery controllers; updated E2E `onboarding-flow.spec.ts`
+- **Backend/Proto**: No changes — uses existing `ConcertService/List` RPC

--- a/openspec/changes/archive/2026-03-19-fix-discovery-concert-gate/specs/bubble-pool-lifecycle/spec.md
+++ b/openspec/changes/archive/2026-03-19-fix-discovery-concert-gate/specs/bubble-pool-lifecycle/spec.md
@@ -1,0 +1,59 @@
+## MODIFIED Requirements
+
+### Requirement: Bubble pool initialization based on followed-artist count
+
+The system SHALL initialize the bubble pool differently based on whether the user follows any artists. On page load, the system SHALL hydrate the follow state from the persisted store before initializing the pool.
+
+#### Scenario: No followed artists (Step 1-a)
+
+- **WHEN** the discovery page loads
+- **AND** the user follows zero artists (including after checking persisted guest state)
+- **THEN** the system SHALL call `ArtistService.ListTop` with `limit=50` and the user's country
+- **AND** the system SHALL populate the bubble pool with the response artists
+
+#### Scenario: User has followed artists (Step 1-b)
+
+- **WHEN** the discovery page loads
+- **AND** the user follows one or more artists (including artists restored from persisted guest state)
+- **THEN** the system SHALL randomly select up to 5 followed artists as seeds
+- **AND** the system SHALL call `ArtistService.ListSimilar` for each seed in parallel with the limit evenly distributed to fill 50 total (e.g., 5 seeds × limit=10, 2 seeds × limit=25)
+- **AND** the system SHALL populate the bubble pool with the combined results
+
+#### Scenario: Seed selection with fewer than 5 followed artists
+
+- **WHEN** the user follows fewer than 5 artists
+- **THEN** the system SHALL use all followed artists as seeds
+- **AND** the limit per seed SHALL be `floor(50 / followedCount)`
+
+#### Scenario: Follow state hydration on page reload
+
+- **WHEN** the discovery page loads during onboarding
+- **AND** `guest.followedArtists` exists in localStorage (restored into the store by `loadPersistedState()`)
+- **THEN** the system SHALL hydrate `FollowOrchestrator.followedArtists` from `store.getState().guest.follows` before initializing the bubble pool
+- **AND** the hydrated `followedIds` SHALL be used for deduplication during `loadInitialArtists()`
+- **AND** the hydrated followed artists SHALL be passed to `BubbleManager.loadInitialArtists()` as the `followedArtists` parameter
+
+### Requirement: Bubble pool deduplication
+
+The system SHALL remove duplicate and already-followed artists from the bubble pool. Follow state SHALL be provided externally via a `followedIds` parameter rather than tracked internally by the pool.
+
+#### Scenario: Deduplication on initial load (Step 2)
+
+- **WHEN** the bubble pool is populated from any source
+- **THEN** the caller SHALL provide a `followedIds: ReadonlySet<string>` parameter to the dedup method
+- **AND** the system SHALL remove artists that match any already-seen artist by name (case-insensitive), internal ID, or MBID
+- **AND** the system SHALL remove artists whose ID is in the provided `followedIds` set
+- **AND** the system SHALL cap the pool at a maximum of 50 bubbles
+
+#### Scenario: Deduplication after tap refill (Step 5)
+
+- **WHEN** similar artists are added to the pool after a tap
+- **THEN** the system SHALL apply the same deduplication rules as Step 2
+- **AND** the caller SHALL provide the current `followedIds` derived from the FollowOrchestrator
+- **AND** already-seen artists from prior fetches SHALL be excluded
+
+#### Scenario: Deduplication on genre reload
+
+- **WHEN** the genre filter reloads the bubble pool
+- **THEN** the caller SHALL provide the current `followedIds` derived from the followed artists list
+- **AND** the system SHALL apply the same deduplication rules as Step 2

--- a/openspec/changes/archive/2026-03-19-fix-discovery-concert-gate/specs/onboarding-tutorial/spec.md
+++ b/openspec/changes/archive/2026-03-19-fix-discovery-concert-gate/specs/onboarding-tutorial/spec.md
@@ -1,0 +1,57 @@
+## MODIFIED Requirements
+
+### Requirement: Linear Step Progression
+
+The system SHALL enforce a strict linear progression through onboarding steps. Users SHALL NOT be able to skip steps or navigate freely during onboarding. Direct navigation via the bottom nav bar SHALL advance the step when the prerequisite conditions are met.
+
+#### Scenario: Step 1 - Artist Discovery completion with concert data gate
+
+- **WHEN** a user is at Step `'discovery'`
+- **AND** the user has followed 3 or more artists via bubble taps
+- **AND** the backend search status for all followed artists has reached `COMPLETED` or `FAILED` (verified via `ListSearchStatuses` polling), or the per-artist frontend polling deadline (15 seconds) has elapsed
+- **AND** at least one followed artist has concerts in the database (verified via `ConcertService/List` per artist)
+- **THEN** the system SHALL activate the continuous spotlight on the Dashboard icon in the bottom navigation bar (target: `[data-nav-dashboard]`)
+- **AND** the coach mark SHALL display the message: "タイムテーブルを見てみよう！"
+- **AND** when the user taps the Dashboard icon through the spotlight, the system SHALL advance `onboardingStep` to `'dashboard'`
+- **AND** the system SHALL navigate to the Dashboard (`/dashboard`)
+
+#### Scenario: Step 1 - Concert data verification after search completion
+
+- **WHEN** all followed artists have reached a terminal search state (`COMPLETED`, `FAILED`, or timed out)
+- **AND** the user has followed 3 or more artists
+- **THEN** the system SHALL call `ConcertService/List` for each followed artist in parallel to verify that concert data exists in the database
+- **AND** the system SHALL NOT require `guest.home` for this verification
+- **AND** if at least 1 artist has concerts, the system SHALL activate the Dashboard coach mark
+- **AND** if 0 artists have concerts, the system SHALL NOT activate the Dashboard coach mark and SHALL re-evaluate each time a new artist's search completes
+
+#### Scenario: Step 1 - Concert searches complete with no results
+
+- **WHEN** a user is at Step `'discovery'`
+- **AND** the user has followed 3 or more artists
+- **AND** all artists' search statuses have reached a terminal state
+- **AND** no followed artist has concerts (all `ConcertService/List` responses are empty)
+- **THEN** the system SHALL NOT activate the Dashboard coach mark
+- **AND** the system SHALL re-evaluate the concert data gate each time a new artist is followed and their search reaches a terminal state
+
+#### Scenario: Step 1 - Search status polling mechanism
+
+- **WHEN** a user follows an artist during onboarding
+- **THEN** the system SHALL fire the `SearchNewConcerts` RPC to initiate the backend search
+- **AND** the system SHALL NOT treat the RPC return as search completion (the RPC is fire-and-forget; the actual search runs asynchronously on the backend)
+- **AND** the system SHALL poll `ListSearchStatuses` every 2 seconds to detect when the backend search log transitions to `COMPLETED` or `FAILED`
+- **AND** the system SHALL batch all pending artist IDs into a single `ListSearchStatuses` call per poll cycle
+- **AND** the system SHALL enforce a 15-second per-artist polling deadline as a fallback timeout
+
+#### Scenario: Step 1 - Direct Home nav tap when coach mark is active
+
+- **WHEN** a user is at Step `'discovery'`
+- **AND** the coach mark spotlight on the Dashboard icon is active
+- **AND** the user taps the Home/Dashboard icon in the bottom nav bar (bypassing the coach mark overlay)
+- **THEN** the system SHALL advance `onboardingStep` to `'dashboard'`
+- **AND** the system SHALL navigate to `/dashboard`
+
+#### Scenario: Step 1 - Spotlight deactivation before navigation
+
+- **WHEN** a user is at Step `'discovery'`
+- **AND** the user taps the Dashboard coach mark
+- **THEN** the system SHALL deactivate the spotlight (`deactivateSpotlight()`) before navigating to `/dashboard`

--- a/openspec/changes/archive/2026-03-19-fix-discovery-concert-gate/tasks.md
+++ b/openspec/changes/archive/2026-03-19-fix-discovery-concert-gate/tasks.md
@@ -1,0 +1,21 @@
+## 1. Fix concert data gate (remove home dependency)
+
+- [x] 1.1 Add `verifyConcertsExist(artistIds: string[]): Promise<boolean>` to `ConcertSearchClient` interface in `concert-search-tracker.ts`
+- [x] 1.2 Implement `verifyConcertsExist` in `ConcertServiceClient` (`concert-service.ts`): call `ConcertService/List` per artist in parallel, return `true` if any has ≥1 concert
+- [x] 1.3 Replace `listByFollower()` call in `ConcertSearchTracker.verifyConcertData()` with `verifyConcertsExist()` and set `concertGroupCount` based on the boolean result
+
+## 2. Hydrate follow state on reload
+
+- [x] 2.1 Add `hydrate(artists: Artist[]): void` method to `FollowOrchestrator` that sets `followedArtists` from external source
+- [x] 2.2 In `DiscoveryRoute.loading()`, read `store.getState().guest.follows` during onboarding and call `follow.hydrate()` before `loadInitialArtists()`
+
+## 3. Unit tests
+
+- [x] 3.1 Create `concert-search-tracker.spec.ts`: test `verifyConcertData` calls `verifyConcertsExist` (no home needed), test gate with 0 concerts returns false, test gate with ≥1 concert returns true, test `syncPreSeeded` starts polling for pre-seeded artists
+- [x] 3.2 Create `follow-orchestrator.spec.ts`: test `hydrate` populates `followedIds`, test `followArtist` adds to `followedIds`, test optimistic rollback restores state
+- [x] 3.3 Create `bubble-manager.spec.ts`: test `loadInitialArtists` excludes followed artists via `followedIds`, test with pre-hydrated follows filters correctly
+
+## 4. E2E tests
+
+- [x] 4.1 Update `onboarding-flow.spec.ts` "Spotlight is visible" test: remove `guest.home` from localStorage setup, verify coach mark appears without home
+- [x] 4.2 Add E2E test: discovery page reload with pre-seeded follows — verify followed artists do not appear as bubbles

--- a/openspec/specs/bubble-pool-lifecycle/spec.md
+++ b/openspec/specs/bubble-pool-lifecycle/spec.md
@@ -15,17 +15,17 @@ This capability defines the lifecycle management of the artist bubble pool on th
 ## Requirements
 
 ### Requirement: Bubble pool initialization based on followed-artist count
-The system SHALL initialize the bubble pool differently based on whether the user follows any artists.
+The system SHALL initialize the bubble pool differently based on whether the user follows any artists. On page load, the system SHALL hydrate the follow state from the persisted store before initializing the pool.
 
 #### Scenario: No followed artists (Step 1-a)
 - **WHEN** the discovery page loads
-- **AND** the user follows zero artists
+- **AND** the user follows zero artists (including after checking persisted guest state)
 - **THEN** the system SHALL call `ArtistService.ListTop` with `limit=50` and the user's country
 - **AND** the system SHALL populate the bubble pool with the response artists
 
 #### Scenario: User has followed artists (Step 1-b)
 - **WHEN** the discovery page loads
-- **AND** the user follows one or more artists
+- **AND** the user follows one or more artists (including artists restored from persisted guest state)
 - **THEN** the system SHALL randomly select up to 5 followed artists as seeds
 - **AND** the system SHALL call `ArtistService.ListSimilar` for each seed in parallel with the limit evenly distributed to fill 50 total (e.g., 5 seeds × limit=10, 2 seeds × limit=25)
 - **AND** the system SHALL populate the bubble pool with the combined results
@@ -34,6 +34,13 @@ The system SHALL initialize the bubble pool differently based on whether the use
 - **WHEN** the user follows fewer than 5 artists
 - **THEN** the system SHALL use all followed artists as seeds
 - **AND** the limit per seed SHALL be `floor(50 / followedCount)`
+
+#### Scenario: Follow state hydration on page reload
+- **WHEN** the discovery page loads during onboarding
+- **AND** `guest.followedArtists` exists in localStorage (restored into the store by `loadPersistedState()`)
+- **THEN** the system SHALL hydrate `FollowOrchestrator.followedArtists` from `store.getState().guest.follows` before initializing the bubble pool
+- **AND** the hydrated `followedIds` SHALL be used for deduplication during `loadInitialArtists()`
+- **AND** the hydrated followed artists SHALL be passed to `BubbleManager.loadInitialArtists()` as the `followedArtists` parameter
 
 ---
 

--- a/openspec/specs/onboarding-tutorial/spec.md
+++ b/openspec/specs/onboarding-tutorial/spec.md
@@ -16,7 +16,7 @@ The system SHALL enforce a strict linear progression through onboarding steps. U
 - **WHEN** a user is at Step `'discovery'`
 - **AND** the user has followed 3 or more artists via bubble taps
 - **AND** the backend search status for all followed artists has reached `COMPLETED` or `FAILED` (verified via `ListSearchStatuses` polling), or the per-artist frontend polling deadline (15 seconds) has elapsed
-- **AND** `ListWithProximity` returns at least 1 proximity group for the followed artists
+- **AND** at least one followed artist has concerts in the database (verified via `ConcertService/List` per artist)
 - **THEN** the system SHALL activate the continuous spotlight on the Dashboard icon in the bottom navigation bar (target: `[data-nav-dashboard]`)
 - **AND** the coach mark SHALL display the message: "タイムテーブルを見てみよう！"
 - **AND** when the user taps the Dashboard icon through the spotlight, the system SHALL advance `onboardingStep` to `'dashboard'`
@@ -35,16 +35,17 @@ The system SHALL enforce a strict linear progression through onboarding steps. U
 
 - **WHEN** all followed artists have reached a terminal search state (`COMPLETED`, `FAILED`, or timed out)
 - **AND** the user has followed 3 or more artists
-- **THEN** the system SHALL call `ListWithProximity` to verify that concert data exists in the database
-- **AND** if at least 1 proximity group is returned, the system SHALL activate the Dashboard coach mark
-- **AND** if 0 proximity groups are returned, the system SHALL NOT activate the Dashboard coach mark and SHALL re-evaluate each time a new artist's search completes
+- **THEN** the system SHALL call `ConcertService/List` for each followed artist in parallel to verify that concert data exists in the database
+- **AND** the system SHALL NOT require `guest.home` for this verification
+- **AND** if at least 1 artist has concerts, the system SHALL activate the Dashboard coach mark
+- **AND** if 0 artists have concerts, the system SHALL NOT activate the Dashboard coach mark and SHALL re-evaluate each time a new artist's search completes
 
 #### Scenario: Step 1 - Concert searches complete with no results
 
 - **WHEN** a user is at Step `'discovery'`
 - **AND** the user has followed 3 or more artists
 - **AND** all artists' search statuses have reached a terminal state
-- **AND** `ListWithProximity` returns 0 proximity groups
+- **AND** no followed artist has concerts (all `ConcertService/List` responses are empty)
 - **THEN** the system SHALL NOT activate the Dashboard coach mark
 - **AND** the system SHALL re-evaluate the concert data gate each time a new artist is followed and their search reaches a terminal state
 


### PR DESCRIPTION
## Related Issue

Closes #301

## Summary of Changes

Update main specs to reflect the frontend fix that removed the guest.home dependency from the discovery concert data gate:

- **onboarding-tutorial**: Replace ListWithProximity references with ConcertService/List per artist in 3 scenarios (concert gate activation, verification, no-results)
- **bubble-pool-lifecycle**: Add follow state hydration on page reload scenario, update initialization requirement to include persisted store hydration

Also archives the fix-discovery-concert-gate change (10/10 tasks complete, delta specs synced).

No proto changes in this PR.

## Self-Checklist

- [x] I have linked the related issue.
- [x] I have updated the relevant documentation (e.g., README.md) if needed.
- [x] I have run buf lint and buf format locally and all checks have passed.
- [x] My proto definitions follow the project's style guidelines and validation rules.
- [x] Breaking changes have been justified and documented if applicable.