### PR TITLE
docs(spec): add gemini response resilience requirement

### DIFF
--- a/openspec/changes/archive/2026-03-20-gemini-response-resilience/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-20-gemini-response-resilience/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-19

--- a/openspec/changes/archive/2026-03-20-gemini-response-resilience/design.md
+++ b/openspec/changes/archive/2026-03-20-gemini-response-resilience/design.md
@@ -1,0 +1,86 @@
+## Context
+
+The concert search feature calls Gemini API with Grounding (Web Search) to discover upcoming concerts for an artist. The response is expected as JSON matching our `EventsResponse` struct. In production, we observed repeated `unexpected end of JSON input` errors where Gemini returned `finish_reason: STOP` but the JSON text was truncated. The current code only guards against `FinishReasonMaxTokens` and treats all other parse failures as ERROR — triggering alerts that are not actionable.
+
+Key file: `internal/infrastructure/gcp/gemini/searcher.go`
+
+- `searchConcerts()` (L207–L273): API call with backoff retry, response validation, delegates to `parseEvents`
+- `parseEvents()` (L276–L330): Strips markdown fences, JSON unmarshals into `EventsResponse`
+
+## Goals / Non-Goals
+
+**Goals:**
+- Gracefully handle incomplete/invalid Gemini responses without triggering ERROR alerts
+- Retry transient Gemini response issues (truncated JSON, non-STOP finish reasons) within the existing backoff loop
+- Improve observability: log truncated raw response text at WARN level for post-incident analysis
+- Reserve ERROR level for genuine structural issues (valid JSON that doesn't match schema)
+
+**Non-Goals:**
+- Fixing the Gemini API's truncation behavior (external dependency)
+- Fixing `AppErr.LogValue()` loss through `fmt.Errorf` wrapping (tracked in pannpers/go-apperr#5)
+- Changing the retry backoff configuration (intervals, max tries)
+- Adding structured error response to the RPC caller (async fire-and-forget flow)
+
+## Decisions
+
+### 1. FinishReason whitelist (not blacklist)
+
+**Decision**: Only allow `FinishReasonStop` and empty string (streaming in-progress) to proceed to JSON parsing. All other values → retryable error inside the backoff loop.
+
+**Why**: There are 14+ FinishReason values and new ones are added over time. A blacklist approach would silently pass unknown new reasons. Whitelisting is safer — any new unexpected reason triggers a retry and WARN log, making it visible.
+
+**Alternative considered**: Blacklist specific known-bad reasons (MaxTokens, Safety, Recitation, etc). Rejected because it requires maintenance as the SDK evolves.
+
+### 2. Restructure backoff loop to include response validation
+
+**Decision**: Move FinishReason check and `json.Valid()` check into the `backoff.Retry` callback. The callback returns a parsed `[]*entity.ScrapedConcert` (not `*genai.GenerateContentResponse`), so validation failures trigger retries.
+
+**Why**: Truncated JSON from Gemini is transient — the same query often succeeds on retry. Keeping validation inside the retry loop handles this automatically without additional retry infrastructure.
+
+```
+backoff.Retry callback:
+  1. GenerateContent() → API error → retry if retryable (existing)
+  2. Response received → FinishReason not in whitelist → retry (NEW)
+  3. Response received → json.Valid() fails → retry (NEW)
+  4. json.Unmarshal succeeds → return parsed results
+  5. json.Unmarshal fails (valid JSON, wrong structure) → permanent error (NEW)
+```
+
+**Alternative considered**: Separate retry loop around `parseEvents` only. Rejected because it would duplicate backoff configuration and the transient issue originates from the API call itself.
+
+### 3. json.Valid() pre-check with truncated raw text logging
+
+**Decision**: Before `json.Unmarshal`, check `json.Valid()`. On failure, log WARN with:
+- Truncated raw text (first 1000 characters)
+- Total raw text length
+- All existing context attrs (artist, model, usage metadata)
+
+Then return as retryable error within the backoff loop.
+
+**Why**: `json.Unmarshal` failure on invalid JSON is indistinguishable from structural mismatch. By pre-checking validity, we can:
+- Log the actual broken response for diagnosis (the key missing data today)
+- Classify it correctly as transient (retryable) vs structural (permanent)
+- Truncate at 1000 chars to stay within Cloud Logging's entry size limits while providing enough context
+
+**Alternative considered**: Log full raw text. Rejected due to Cloud Logging 256KB entry limit and potential for very large Gemini responses.
+
+### 4. Error severity reclassification
+
+**Decision**:
+
+| Scenario | Current | New | Rationale |
+|---|---|---|---|
+| Non-STOP FinishReason | ERROR (via toAppErr) | WARN (retry exhausted) | External API behavior, not actionable |
+| Invalid JSON from Gemini | ERROR (Unmarshal fail) | WARN (retry exhausted) | External API behavior, not actionable |
+| Valid JSON, wrong structure | ERROR | ERROR (permanent) | Likely a code bug or schema change — actionable |
+| Gemini API call failure | ERROR | ERROR (unchanged) | Network/auth issues — actionable |
+
+After all retries are exhausted for transient issues, log WARN and return `nil, nil` (empty results). The caller treats this as "no concerts found" — acceptable degradation.
+
+## Risks / Trade-offs
+
+**[Increased API cost from retries]** → Retries are bounded by existing `MaxTries(3)`. At worst, 2 extra API calls per search. Concert search volume is low (triggered by first-follow and daily cron), so cost impact is negligible.
+
+**[Silent data loss on persistent Gemini issues]** → If Gemini consistently returns truncated JSON for a specific artist, we'll silently return empty results instead of erroring. Mitigation: WARN logs remain visible in Cloud Logging for monitoring. The search log status is marked as "completed" with 0 results, which is distinguishable from "never searched".
+
+**[Retry delay increases user-perceived latency]** → Concert search is async (fire-and-forget from RPC). The user gets an immediate response; results appear later. Retry delay is invisible to the user.

--- a/openspec/changes/archive/2026-03-20-gemini-response-resilience/proposal.md
+++ b/openspec/changes/archive/2026-03-20-gemini-response-resilience/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+The Gemini API (with Grounding/Web Search) intermittently returns truncated JSON responses while reporting `finish_reason: STOP`. This triggers ERROR-level alerts that are not actionable — the root cause is external API instability, not a bug in our code. Additionally, the current error path loses diagnostic context (raw response text) due to `fmt.Errorf` wrapping, making root cause analysis difficult when issues do occur.
+
+## What Changes
+
+- Add a FinishReason whitelist check: only `STOP` (and unspecified for streaming) proceeds to JSON parsing; all other reasons are logged as WARN and treated as empty results.
+- Add `json.Valid()` pre-check before `json.Unmarshal`: invalid JSON is logged as WARN with truncated raw text and response length, then treated as empty results.
+- Move JSON parse failure retry into the existing `backoff.Retry` loop around `GenerateContent`, so transient Gemini response issues trigger automatic retries.
+- Downgrade external-API-caused failures from ERROR to WARN, reserving ERROR for structural mismatches (valid JSON that doesn't match our schema — indicating a code bug).
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `auto-concert-discovery`: Add resilience requirements for handling incomplete or invalid Gemini API responses during concert search.
+
+## Impact
+
+- **Backend**: `internal/infrastructure/gcp/gemini/searcher.go` — primary changes to `searchConcerts` and `parseEvents` methods.
+- **Alerting**: Reduces false-positive ERROR alerts from the "Server ERROR Log" policy. Only genuine structural mismatches will trigger ERROR alerts going forward.
+- **Observability**: Improved WARN-level logging with raw response text (truncated) and response length for post-incident analysis.

--- a/openspec/changes/archive/2026-03-20-gemini-response-resilience/specs/auto-concert-discovery/spec.md
+++ b/openspec/changes/archive/2026-03-20-gemini-response-resilience/specs/auto-concert-discovery/spec.md
@@ -1,0 +1,33 @@
+## ADDED Requirements
+
+### Requirement: Gemini Response Resilience
+
+The concert search SHALL gracefully handle incomplete or invalid responses from the Gemini API by validating response completeness before JSON parsing, retrying transient failures, and classifying errors by severity.
+
+#### Scenario: FinishReason is not STOP
+
+- **WHEN** the Gemini API returns a response with a `FinishReason` other than `STOP` or empty string
+- **THEN** the system SHALL treat this as a retryable transient error
+- **AND** retry the API call within the existing backoff loop (up to max retries)
+- **AND** if all retries are exhausted, log a WARN with the `FinishReason` value and response metadata
+- **AND** return empty results (no error propagated to caller)
+
+#### Scenario: Gemini returns invalid JSON with FinishReason STOP
+
+- **WHEN** the Gemini API returns `FinishReason: STOP` but the response text is not valid JSON
+- **THEN** the system SHALL treat this as a retryable transient error
+- **AND** log a WARN with the first 1000 characters of the raw response text and total response length
+- **AND** retry the API call within the existing backoff loop
+- **AND** if all retries are exhausted, return empty results (no error propagated to caller)
+
+#### Scenario: Valid JSON with unexpected structure
+
+- **WHEN** the Gemini API returns valid JSON that does not match the expected `EventsResponse` schema
+- **THEN** the system SHALL treat this as a permanent (non-retryable) ERROR
+- **AND** log an ERROR with the response text
+
+#### Scenario: Successful response after transient retry
+
+- **WHEN** the Gemini API returns an invalid response on the first attempt but a valid response on a subsequent retry
+- **THEN** the system SHALL parse the valid response normally
+- **AND** return the discovered concerts

--- a/openspec/changes/archive/2026-03-20-gemini-response-resilience/tasks.md
+++ b/openspec/changes/archive/2026-03-20-gemini-response-resilience/tasks.md
@@ -1,0 +1,23 @@
+## 1. Restructure backoff loop to return parsed results
+
+- [x] 1.1 Change `backoff.Retry` callback return type from `*genai.GenerateContentResponse` to `[]*entity.ScrapedConcert` — move response validation and parsing logic inside the callback
+- [x] 1.2 Add FinishReason whitelist check inside callback: only `FinishReasonStop` and `""` proceed; all others return retryable error with WARN log
+- [x] 1.3 Remove the standalone `FinishReasonMaxTokens` check (L265–L271) — now covered by the whitelist
+
+## 2. Add json.Valid() pre-check in parseEvents
+
+- [x] 2.1 Add `json.Valid([]byte(text))` check before `json.Unmarshal` in `parseEvents`
+- [x] 2.2 On invalid JSON: log WARN with truncated raw text (first 1000 chars), total `len(rawText)`, and context attrs; return retryable error
+- [x] 2.3 On `json.Unmarshal` failure (valid JSON, wrong structure): return `backoff.Permanent` error at ERROR level
+
+## 3. Error severity reclassification
+
+- [x] 3.1 Ensure exhausted retries for transient issues (non-STOP finish reason, invalid JSON) result in WARN log + `return nil, nil` (not ERROR)
+- [x] 3.2 Ensure structural mismatch (`json.Unmarshal` failure on valid JSON) remains ERROR via `backoff.Permanent`
+
+## 4. Tests
+
+- [x] 4.1 Add unit test: non-STOP FinishReason triggers retry and returns nil on exhaustion
+- [x] 4.2 Add unit test: invalid JSON triggers retry and logs WARN with truncated raw text on exhaustion
+- [x] 4.3 Add unit test: valid JSON with wrong structure returns permanent ERROR (no retry)
+- [x] 4.4 Add unit test: transient failure on first attempt, success on retry returns parsed results

--- a/openspec/specs/auto-concert-discovery/spec.md
+++ b/openspec/specs/auto-concert-discovery/spec.md
@@ -71,3 +71,35 @@ The CronJob SHALL use a lightweight DI initializer that provisions only the depe
 
 - **WHEN** the job completes (success or circuit break)
 - **THEN** it SHALL close all initialized resources (database connections, telemetry)
+
+### Requirement: Gemini Response Resilience
+
+The concert search SHALL gracefully handle incomplete or invalid responses from the Gemini API by validating response completeness before JSON parsing, retrying transient failures, and classifying errors by severity.
+
+#### Scenario: FinishReason is not STOP
+
+- **WHEN** the Gemini API returns a response with a `FinishReason` other than `STOP` or empty string
+- **THEN** the system SHALL treat this as a retryable transient error
+- **AND** retry the API call within the existing backoff loop (up to max retries)
+- **AND** if all retries are exhausted, log a WARN with the `FinishReason` value and response metadata
+- **AND** return empty results (no error propagated to caller)
+
+#### Scenario: Gemini returns invalid JSON with FinishReason STOP
+
+- **WHEN** the Gemini API returns `FinishReason: STOP` but the response text is not valid JSON
+- **THEN** the system SHALL treat this as a retryable transient error
+- **AND** log a WARN with the first 1000 characters of the raw response text and total response length
+- **AND** retry the API call within the existing backoff loop
+- **AND** if all retries are exhausted, return empty results (no error propagated to caller)
+
+#### Scenario: Valid JSON with unexpected structure
+
+- **WHEN** the Gemini API returns valid JSON that does not match the expected `EventsResponse` schema
+- **THEN** the system SHALL treat this as a permanent (non-retryable) ERROR
+- **AND** log an ERROR with the response text
+
+#### Scenario: Successful response after transient retry
+
+- **WHEN** the Gemini API returns an invalid response on the first attempt but a valid response on a subsequent retry
+- **THEN** the system SHALL parse the valid response normally
+- **AND** return the discovered concerts


### PR DESCRIPTION
## Summary

- Add "Gemini Response Resilience" requirement to auto-concert-discovery spec with 4 scenarios (FinishReason whitelist, invalid JSON retry, structural mismatch permanent error, transient retry recovery)
- Archive the gemini-response-resilience OpenSpec change

## Test plan

- [ ] Verify spec formatting renders correctly
- [ ] Confirm archive directory structure is correct