### PR TITLE
docs(openspec): add sbt test hardening and formal verification changes

### DIFF
--- a/openspec/changes/sbt-formal-verification/.openspec.yaml
+++ b/openspec/changes/sbt-formal-verification/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-19

--- a/openspec/changes/sbt-formal-verification/design.md
+++ b/openspec/changes/sbt-formal-verification/design.md
@@ -1,0 +1,53 @@
+## Context
+
+Phase 1 (sbt-test-hardening) の完了を前提とする。Phase 1 完了時点で、TicketSBT は approve/setApprovalForAll の override、網羅的な unit test、fuzz test、Slither CI、ガス回帰検出を備えた状態になっている。Phase 2 では「テストが十分か」と「全入力で安全か」を証明するレイヤーを追加する。
+
+## Goals / Non-Goals
+
+**Goals:**
+- Halmos で「transferFrom/approve は全入力で revert する」「MINTER_ROLE なしでは mint 不可」を数学的に証明する
+- Foundry invariant テストで、ランダムなトランザクションシーケンス後も SBT 不変条件が保たれることを検証する
+- Aderyn を Slither と併用し、検出パターンの網を広げる
+- vertigo-rs で mutation テストを実行し、テストスイートが変異を見逃さないことを確認する
+- forge coverage で行/ブランチカバレッジを可視化する
+
+**Non-Goals:**
+- Certora Prover の導入（CVL の学習コストが小さいコントラクトに見合わない）
+- Echidna / Medusa の導入（Foundry invariant + Halmos で十分）
+- mainnet デプロイ（別 change で管理）
+- 競争的監査（Sherlock/Code4rena）の実施
+
+## Decisions
+
+### D1: Halmos テストの構造
+
+**選択:** `test/halmos/` ディレクトリに `TicketSBT.halmos.t.sol` として分離。関数名は `check_` prefix（Halmos 規約）。
+
+**理由:** Halmos テストは Foundry の `forge test` では実行されない（`check_` prefix）。分離することで CI ジョブを独立させ、Halmos の遅い実行が通常テストをブロックしない。
+
+**代替案:** 同一ファイルに混在 → 不採用。可読性とCI分離の観点で分離が優れる。
+
+### D2: Invariant テストの Handler パターン
+
+**選択:** `test/invariant/` に Handler コントラクトを配置。Handler が mint のみ呼べるよう制約し、ghost variable で mint 済み tokenId リストを管理。
+
+**理由:** Foundry の invariant テストは Handler 経由でコントラクトを操作する。Handler が現実的な操作に絞ることで、意味のある状態遷移のみ探索する。ghost variable でテスト側の期待値を追跡する。
+
+### D3: Aderyn の CI 統合方式
+
+**選択:** Slither ジョブと並列に `aderyn` ジョブを追加。Aderyn は markdown レポートを出力し、PR コメントとしてアップロード。
+
+**理由:** Slither と異なる AST ベースの解析を行い、補完的な発見が期待できる。Rust 製で高速。
+
+### D4: Mutation テストの実行タイミング
+
+**選択:** CI の weekly スケジュールまたは手動トリガー。PR ごとの自動実行はしない。
+
+**理由:** vertigo-rs はテストスイート全体を変異数 × 実行するため遅い。小さいコントラクトでも数分かかる。PR ごとに実行するとフィードバックループが遅くなる。
+
+## Risks / Trade-offs
+
+- **[Risk] Halmos が OZ の複雑な内部ロジックでタイムアウト** → Mitigation: `--loop-bound` や `--solver-timeout` を調整。OZ の ERC721 は広く使われており Halmos での実績あり。
+- **[Risk] vertigo-rs が Foundry の最新版と非互換** → Mitigation: 互換性を事前に確認。問題があれば Gambit + 手動実行にフォールバック。
+- **[Risk] Aderyn の false positive が多い** → Mitigation: `.aderyn.toml` で除外設定。初回実行時にトリアージ。
+- **[Risk] Phase 1 が未完了のまま Phase 2 に着手** → Mitigation: Phase 2 の tasks は Phase 1 完了を前提条件として明記。

--- a/openspec/changes/sbt-formal-verification/proposal.md
+++ b/openspec/changes/sbt-formal-verification/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+Phase 1 (sbt-test-hardening) でテストの穴を塞ぎ Slither を導入した後、mainnet デプロイ前に更に高い保証レベルが必要。Fuzz テストは「ランダムなサンプル」でしかなく、「全ての入力で安全」を証明できない。Halmos による形式検証で SBT の不変条件を数学的に証明し、Invariant テストで状態遷移全体を網羅し、Mutation テストでテストスイート自体の品質を客観的に測定する。
+
+## What Changes
+
+- Halmos によるシンボリック実行テストを追加し、SBT の全不変条件を全入力空間で証明
+- Foundry invariant テスト（Handler パターン）を追加し、ランダムなトランザクションシーケンスに対する不変条件を検証
+- Aderyn 静的解析を CI に追加し、Slither と併用してセカンドオピニオンを提供
+- vertigo-rs による mutation テストを実行し、テストスイートの品質を定量化
+- `forge coverage` による lcov レポートを CI に追加
+
+## Capabilities
+
+### New Capabilities
+
+- `sbt-formal-verification`: Halmos シンボリック実行による SBT 不変条件の網羅的証明と Foundry invariant テスト
+- `sbt-quality-assurance`: Aderyn 静的解析、mutation テスト（vertigo-rs）、カバレッジレポートによるテスト品質の定量化と CI 統合
+
+### Modified Capabilities
+
+(none)
+
+## Impact
+
+- `backend/contracts/test/`: Halmos 用テストファイル、invariant テスト用 Handler コントラクトの新規追加
+- `.github/workflows/test.yml`: Halmos ジョブ、Aderyn ジョブ、coverage ジョブの追加
+- `backend/contracts/foundry.toml`: invariant テスト設定の追加
+- 開発依存: `halmos` (pip), `aderyn` (cargo/npm), `vertigo-rs` (cargo)

--- a/openspec/changes/sbt-formal-verification/specs/sbt-formal-verification/spec.md
+++ b/openspec/changes/sbt-formal-verification/specs/sbt-formal-verification/spec.md
@@ -1,0 +1,60 @@
+## ADDED Requirements
+
+### Requirement: Halmos symbolic proof of transfer immutability
+Halmos SHALL prove that all ERC-721 transfer and approval functions revert for ALL possible inputs, not just fuzzed samples.
+
+#### Scenario: transferFrom reverts for all inputs
+- **WHEN** Halmos symbolically executes `transferFrom(from, to, tokenId)` for all possible `(from, to, tokenId)`
+- **THEN** the execution MUST always revert
+
+#### Scenario: safeTransferFrom reverts for all inputs
+- **WHEN** Halmos symbolically executes both overloads of `safeTransferFrom` for all possible inputs
+- **THEN** the execution MUST always revert
+
+#### Scenario: approve reverts for all inputs
+- **WHEN** Halmos symbolically executes `approve(spender, tokenId)` for all possible `(spender, tokenId)`
+- **THEN** the execution MUST always revert
+
+#### Scenario: setApprovalForAll reverts for all inputs
+- **WHEN** Halmos symbolically executes `setApprovalForAll(operator, approved)` for all possible `(operator, approved)`
+- **THEN** the execution MUST always revert
+
+### Requirement: Halmos symbolic proof of access control
+Halmos SHALL prove that only addresses with MINTER_ROLE can successfully call `mint`.
+
+#### Scenario: Unauthorized mint reverts for all callers
+- **WHEN** Halmos symbolically executes `mint(recipient, tokenId)` from any address without MINTER_ROLE
+- **THEN** the execution MUST always revert
+
+### Requirement: Halmos symbolic proof of locked status
+Halmos SHALL prove that `locked()` returns `true` for every minted token.
+
+#### Scenario: locked returns true for all minted tokens
+- **WHEN** a token is minted and Halmos symbolically executes `locked(tokenId)`
+- **THEN** the result MUST be `true`
+
+### Requirement: Foundry invariant tests with Handler pattern
+Foundry invariant tests SHALL verify that SBT invariants hold after any random sequence of contract operations.
+
+#### Scenario: No token is ever transferred
+- **WHEN** the fuzzer executes a random sequence of contract calls (mint, approve, transfer attempts)
+- **THEN** `ownerOf(tokenId)` for every minted token MUST equal the original recipient
+
+#### Scenario: Minted token count matches balanceOf sum
+- **WHEN** the fuzzer executes a random sequence of mint operations
+- **THEN** the total number of minted tokens MUST equal the sum of `balanceOf` across all recipients tracked by the Handler
+
+#### Scenario: All minted tokens are locked
+- **WHEN** the fuzzer executes a random sequence of contract calls
+- **THEN** `locked(tokenId)` MUST return `true` for every minted token tracked by the Handler
+
+### Requirement: Halmos CI integration
+Halmos proofs SHALL run as a separate CI job on PRs targeting main.
+
+#### Scenario: Halmos job runs on PR to main
+- **WHEN** a PR targeting main modifies contract files
+- **THEN** the `halmos` CI job MUST execute and all `check_` functions MUST pass
+
+#### Scenario: Halmos failure blocks merge
+- **WHEN** a Halmos proof fails (counterexample found)
+- **THEN** the CI job MUST fail and block the PR from merging

--- a/openspec/changes/sbt-formal-verification/specs/sbt-quality-assurance/spec.md
+++ b/openspec/changes/sbt-formal-verification/specs/sbt-quality-assurance/spec.md
@@ -1,0 +1,34 @@
+## ADDED Requirements
+
+### Requirement: Aderyn static analysis in CI
+Aderyn SHALL run as a CI job alongside Slither to provide a second-opinion static analysis.
+
+#### Scenario: Aderyn runs on contract changes
+- **WHEN** a push or PR modifies contract source files
+- **THEN** the `aderyn` CI job MUST execute and analyze all contract source files
+
+#### Scenario: Aderyn findings are reported
+- **WHEN** Aderyn detects findings
+- **THEN** results MUST be output as a markdown report and uploaded as a CI artifact
+
+### Requirement: Mutation testing with vertigo-rs
+vertigo-rs SHALL be used to measure the quality of the test suite by generating mutants and checking if tests catch them.
+
+#### Scenario: Mutation testing runs on schedule
+- **WHEN** the weekly CI schedule triggers or a manual dispatch is executed
+- **THEN** vertigo-rs MUST generate mutants of TicketSBT.sol and run the test suite against each
+
+#### Scenario: Surviving mutants are reported
+- **WHEN** mutation testing completes
+- **THEN** any surviving mutants (mutations not caught by tests) MUST be reported with file location and mutation type
+
+### Requirement: Code coverage reporting
+`forge coverage` SHALL generate lcov reports and make them available in CI.
+
+#### Scenario: Coverage report generated on PR
+- **WHEN** a PR modifies contract files
+- **THEN** `forge coverage --report lcov` MUST execute and the lcov report MUST be uploaded as a CI artifact
+
+#### Scenario: Coverage tracks line and branch metrics
+- **WHEN** the coverage report is generated
+- **THEN** it MUST include both line coverage and branch coverage for all source files in `contracts/src/`

--- a/openspec/changes/sbt-formal-verification/tasks.md
+++ b/openspec/changes/sbt-formal-verification/tasks.md
@@ -1,0 +1,57 @@
+## 0. Prerequisites
+
+- [ ] 0.1 Confirm Phase 1 (sbt-test-hardening) is fully complete and merged
+
+## 1. Halmos Setup & Proofs
+
+- [ ] 1.1 Add Halmos to dev dependencies (`pip install halmos`) and document in README
+- [ ] 1.2 Create `test/halmos/TicketSBT.halmos.t.sol` with Halmos test structure
+- [ ] 1.3 Implement `check_transferFromAlwaysReverts` — prove transferFrom reverts for all inputs
+- [ ] 1.4 Implement `check_safeTransferFromAlwaysReverts` — prove both safeTransferFrom overloads revert
+- [ ] 1.5 Implement `check_approveAlwaysReverts` — prove approve reverts for all inputs
+- [ ] 1.6 Implement `check_setApprovalForAllAlwaysReverts` — prove setApprovalForAll reverts
+- [ ] 1.7 Implement `check_unauthorizedMintReverts` — prove non-minter mint always reverts
+- [ ] 1.8 Implement `check_lockedAlwaysTrueForMinted` — prove locked() returns true for all minted tokens
+- [ ] 1.9 Run Halmos locally and verify all proofs pass
+
+## 2. Foundry Invariant Tests
+
+- [ ] 2.1 Create `test/invariant/Handler.sol` with bounded mint operations and ghost variables
+- [ ] 2.2 Create `test/invariant/TicketSBT.invariant.t.sol` with invariant test contract
+- [ ] 2.3 Implement `invariant_noTokenTransferred` — ownerOf never changes after mint
+- [ ] 2.4 Implement `invariant_allTokensLocked` — locked() is true for every minted token
+- [ ] 2.5 Implement `invariant_mintCountMatchesBalances` — total minted equals sum of balanceOf
+- [ ] 2.6 Configure `foundry.toml` with invariant test settings (runs, depth)
+- [ ] 2.7 Run invariant tests locally and verify all pass
+
+## 3. Aderyn Integration
+
+- [ ] 3.1 Install Aderyn and verify it runs against the project
+- [ ] 3.2 Add `aderyn` job to `.github/workflows/test.yml` parallel to Slither
+- [ ] 3.3 Create `.aderyn.toml` with project config and initial exclusions
+- [ ] 3.4 Triage initial Aderyn findings and exclude false positives
+
+## 4. Mutation Testing
+
+- [ ] 4.1 Install vertigo-rs and verify compatibility with current Foundry version
+- [ ] 4.2 Run vertigo-rs locally against TicketSBT and the full test suite
+- [ ] 4.3 Analyze surviving mutants and add missing tests if gaps are found
+- [ ] 4.4 Add weekly/manual-dispatch CI job for mutation testing
+
+## 5. Coverage Reporting
+
+- [ ] 5.1 Run `forge coverage --report lcov` locally and review results
+- [ ] 5.2 Add coverage job to CI that uploads lcov as artifact
+
+## 6. CI Integration
+
+- [ ] 6.1 Add Halmos CI job (PR to main trigger) to `.github/workflows/test.yml`
+- [ ] 6.2 Verify all new CI jobs (Halmos, Aderyn, coverage) run successfully
+- [ ] 6.3 Document the full security toolchain in contracts/README.md
+
+## 7. Verification
+
+- [ ] 7.1 Run full test suite locally: unit + fuzz + invariant + Halmos — all pass
+- [ ] 7.2 Run Slither + Aderyn locally — no unresolved high/medium findings
+- [ ] 7.3 Run mutation testing — zero or minimal surviving mutants
+- [ ] 7.4 Verify CI pipeline with all new jobs runs end-to-end

--- a/openspec/changes/sbt-test-hardening/.openspec.yaml
+++ b/openspec/changes/sbt-test-hardening/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-19

--- a/openspec/changes/sbt-test-hardening/design.md
+++ b/openspec/changes/sbt-test-hardening/design.md
@@ -1,0 +1,55 @@
+## Context
+
+TicketSBT は ERC-721 + ERC-5192 Soulbound Token で、OpenZeppelin の ERC721 と AccessControl を継承している。Base Sepolia にデプロイ済み（`0x7C50bdF2E5d6B81F71868d5B6B59B5B3EC2F06fa`）。現在のテストは 7 件で基本機能をカバーするが、SBT としての完全性（approve ブロック、全 transfer パスの遮断）やエッジケース、ロール管理のテストが不足している。CI は `forge test -vvv` のみで、静的解析やガス監視は未導入。
+
+## Goals / Non-Goals
+
+**Goals:**
+- テストカバレッジの穴を特定・網羅し、全ての SBT 不変条件をテストで保証する
+- approve / setApprovalForAll を override して revert させ、SBT の意味論的完全性を担保する
+- Slither 静的解析を CI に組み込み、既知脆弱性パターンを自動検出する
+- forge snapshot でガスベースラインを確立し、回帰を検知する
+- Foundry fuzz テストで、ランダム入力に対する堅牢性を検証する
+
+**Non-Goals:**
+- Invariant テスト（Handler パターン設計が必要 → Phase 2）
+- Halmos による形式検証（→ Phase 2）
+- Mutation テスト（テストスイート完成後に実施 → Phase 2）
+- Aderyn の導入（Slither で Phase 1 は十分 → Phase 2）
+- mainnet デプロイ
+
+## Decisions
+
+### D1: approve / setApprovalForAll を override して revert させる
+
+**選択:** コントラクト側で `approve` と `setApprovalForAll` を override し、無条件に revert させる。
+
+**理由:** SBT は転送不可であるため、approve が成功すること自体が意味論的に矛盾する。transferFrom が revert するため実害はないが、ユーザーがガスを無駄に消費し、外部ツール（マーケットプレイス等）が approve 成功を「転送可能」と誤解するリスクがある。
+
+**代替案:** テストだけで「approve しても transfer できない」ことを検証する → 不採用。根本原因（approve が通ること）を解消すべき。
+
+### D2: Slither を CI に追加する方法
+
+**選択:** `crytic/slither-action` GitHub Action を `test.yml` の contracts パスフィルタ配下に新規ジョブとして追加。forge-test ジョブと並列実行。
+
+**理由:** 公式 Action があり、Foundry プロジェクトを自動認識する。セットアップコストが最小。
+
+**代替案:** ローカル実行のみ → 不採用。CI で自動実行しないと漏れが発生する。
+
+### D3: fuzz-runs の設定値
+
+**選択:** CI では `--fuzz-runs 10000`、foundry.toml のデフォルトは `256`（ローカル開発用）のまま。
+
+**理由:** コミュニティ推奨は CI で 10000 以上。ローカルは速度重視で 256 のまま。CI 側でのみ override する。
+
+### D4: テスト構造
+
+**選択:** 既存の `TicketSBT.t.sol` にテストを追加する（新規ファイルは作らない）。
+
+**理由:** コントラクトが 1 つで小さいため、テストを分割するメリットがない。セクションコメントで整理する。
+
+## Risks / Trade-offs
+
+- **[Risk] approve override が既存デプロイに影響** → Mitigation: Base Sepolia のコントラクトは immutable。新しいコントラクトとして再デプロイが必要。Phase 1 ではコード変更のみ行い、再デプロイは別途判断。
+- **[Risk] Slither の false positive** → Mitigation: `.slither.config.json` でプロジェクト固有の除外ルールを設定。初回実行時に結果をトリアージし、false positive は明示的に除外。
+- **[Risk] fuzz-runs 10000 で CI が遅くなる** → Mitigation: 現在のコントラクトは小さいため 10000 runs でも数秒で完了する見込み。CI timeout 10 分以内に収まることを確認。

--- a/openspec/changes/sbt-test-hardening/proposal.md
+++ b/openspec/changes/sbt-test-hardening/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+TicketSBT コントラクトは Base Sepolia にデプロイ済みだが、既存テストは 7 件のみで、approve/setApprovalForAll のブロック検証、3引数 safeTransferFrom、二重 mint、address(0) mint、supportsInterface、ロール管理といった重要な観点が未テスト。mainnet デプロイ前にテストの穴を塞ぎ、静的解析による自動脆弱性検出を CI に組み込む必要がある。
+
+## What Changes
+
+- TicketSBT のテストケースを大幅に追加（approve ブロック、エッジケース、fuzz テスト、supportsInterface、AccessControl ロール管理）
+- Foundry fuzz テスト (`testFuzz_` prefix) を導入し、ランダム入力での堅牢性を検証
+- Slither 静的解析を CI ワークフローに追加（GitHub Action: `crytic/slither-action`）
+- `forge snapshot` によるガスベースライン作成と CI でのガス回帰検出
+- approve / setApprovalForAll を override して revert させるかの設計判断と、必要に応じた実装
+
+## Capabilities
+
+### New Capabilities
+
+- `sbt-test-coverage`: TicketSBT コントラクトのテストカバレッジ強化（unit test 追加、fuzz test 導入、エッジケース網羅）
+- `sbt-static-analysis`: Slither による Solidity 静的解析の CI 統合とガス回帰検出
+
+### Modified Capabilities
+
+(none)
+
+## Impact
+
+- `backend/contracts/test/TicketSBT.t.sol`: テストケース大幅追加
+- `backend/contracts/src/TicketSBT.sol`: approve/setApprovalForAll の override 追加の可能性
+- `.github/workflows/test.yml`: Slither ジョブ追加、forge test の fuzz-runs 増加、forge snapshot ステップ追加
+- `backend/contracts/.gas-snapshot`: 新規ファイル（git 管理）

--- a/openspec/changes/sbt-test-hardening/specs/sbt-static-analysis/spec.md
+++ b/openspec/changes/sbt-test-hardening/specs/sbt-static-analysis/spec.md
@@ -1,0 +1,34 @@
+## ADDED Requirements
+
+### Requirement: Slither static analysis in CI
+The CI pipeline SHALL run Slither static analysis on every push/PR that modifies contract files. Analysis results MUST be reviewed and false positives explicitly excluded.
+
+#### Scenario: Slither runs on contract changes
+- **WHEN** a push or PR modifies files matching `contracts/src/**`, `contracts/test/**`, or `contracts/foundry.toml`
+- **THEN** the `slither` CI job MUST execute and analyze all contract source files
+
+#### Scenario: Slither blocks merge on findings
+- **WHEN** Slither detects a vulnerability that is not in the exclusion list
+- **THEN** the CI job MUST fail and block the PR from merging
+
+#### Scenario: False positives are explicitly excluded
+- **WHEN** a Slither finding is triaged as a false positive
+- **THEN** it MUST be excluded via `.slither.config.json` with a comment explaining why
+
+### Requirement: Gas regression detection
+The CI pipeline SHALL track gas usage via `forge snapshot` and detect regressions.
+
+#### Scenario: Gas snapshot baseline exists in git
+- **WHEN** the contracts are built
+- **THEN** a `.gas-snapshot` file MUST exist in the `contracts/` directory and be tracked in git
+
+#### Scenario: Gas regression fails CI
+- **WHEN** a code change causes gas usage to increase beyond the baseline
+- **THEN** `forge snapshot --check` MUST fail the CI job
+
+### Requirement: Increased fuzz depth in CI
+The CI pipeline SHALL run fuzz tests with a higher iteration count than local development defaults.
+
+#### Scenario: CI runs fuzz tests with 10000 iterations
+- **WHEN** the `forge-test` CI job executes
+- **THEN** it MUST use `--fuzz-runs 10000` (not the default 256)

--- a/openspec/changes/sbt-test-hardening/specs/sbt-test-coverage/spec.md
+++ b/openspec/changes/sbt-test-hardening/specs/sbt-test-coverage/spec.md
@@ -1,0 +1,101 @@
+## ADDED Requirements
+
+### Requirement: approve and setApprovalForAll MUST revert
+TicketSBT SHALL override `approve` and `setApprovalForAll` to revert unconditionally. SBT tokens are non-transferable, so approval operations are semantically invalid and MUST be blocked at the contract level.
+
+#### Scenario: approve reverts for any caller
+- **WHEN** any address calls `approve(spender, tokenId)` on a minted token
+- **THEN** the transaction MUST revert with message "SBT: Ticket transfer is prohibited"
+
+#### Scenario: setApprovalForAll reverts for any caller
+- **WHEN** any address calls `setApprovalForAll(operator, approved)`
+- **THEN** the transaction MUST revert with message "SBT: Ticket transfer is prohibited"
+
+### Requirement: All transfer paths MUST revert
+All ERC-721 transfer functions SHALL revert unconditionally, including both overloads of `safeTransferFrom`.
+
+#### Scenario: 3-argument safeTransferFrom reverts
+- **WHEN** token owner calls `safeTransferFrom(from, to, tokenId)` (3-argument version)
+- **THEN** the transaction MUST revert with message "SBT: Ticket transfer is prohibited"
+
+#### Scenario: 4-argument safeTransferFrom reverts
+- **WHEN** token owner calls `safeTransferFrom(from, to, tokenId, data)` (4-argument version)
+- **THEN** the transaction MUST revert with message "SBT: Ticket transfer is prohibited"
+
+#### Scenario: transferFrom reverts
+- **WHEN** token owner calls `transferFrom(from, to, tokenId)`
+- **THEN** the transaction MUST revert with message "SBT: Ticket transfer is prohibited"
+
+### Requirement: Duplicate mint MUST revert
+The contract SHALL revert when attempting to mint a token with an already-used tokenId.
+
+#### Scenario: Minting with existing tokenId fails
+- **WHEN** minter calls `mint(recipient, tokenId)` with a tokenId that has already been minted
+- **THEN** the transaction MUST revert
+
+### Requirement: Mint to zero address MUST revert
+The contract SHALL revert when attempting to mint a token to `address(0)`.
+
+#### Scenario: Minting to address(0) fails
+- **WHEN** minter calls `mint(address(0), tokenId)`
+- **THEN** the transaction MUST revert
+
+### Requirement: ERC-165 supportsInterface correctness
+The contract SHALL correctly report support for ERC-721, ERC-5192, and AccessControl interfaces via `supportsInterface`.
+
+#### Scenario: Reports ERC-721 support
+- **WHEN** `supportsInterface` is called with ERC-721 interfaceId (`0x80ac58cd`)
+- **THEN** it MUST return `true`
+
+#### Scenario: Reports ERC-5192 support
+- **WHEN** `supportsInterface` is called with ERC-5192 interfaceId
+- **THEN** it MUST return `true`
+
+#### Scenario: Reports AccessControl support
+- **WHEN** `supportsInterface` is called with IAccessControl interfaceId
+- **THEN** it MUST return `true`
+
+#### Scenario: Returns false for unsupported interface
+- **WHEN** `supportsInterface` is called with an unsupported interfaceId (`0xffffffff`)
+- **THEN** it MUST return `false`
+
+### Requirement: AccessControl role management
+Admin SHALL be able to grant and revoke MINTER_ROLE. Non-admin addresses SHALL NOT be able to grant roles. A revoked minter SHALL NOT be able to mint.
+
+#### Scenario: Admin grants MINTER_ROLE
+- **WHEN** admin calls `grantRole(MINTER_ROLE, newMinter)`
+- **THEN** `hasRole(MINTER_ROLE, newMinter)` MUST return `true`
+
+#### Scenario: Admin revokes MINTER_ROLE
+- **WHEN** admin calls `revokeRole(MINTER_ROLE, minter)`
+- **THEN** `hasRole(MINTER_ROLE, minter)` MUST return `false`
+
+#### Scenario: Revoked minter cannot mint
+- **WHEN** admin revokes MINTER_ROLE from minter, and the former minter calls `mint(recipient, tokenId)`
+- **THEN** the transaction MUST revert
+
+#### Scenario: Non-admin cannot grant roles
+- **WHEN** a non-admin address calls `grantRole(MINTER_ROLE, other)`
+- **THEN** the transaction MUST revert
+
+### Requirement: Constructor initializes correct state
+The contract SHALL set name, symbol, and roles correctly at deployment.
+
+#### Scenario: Name and symbol are correct
+- **WHEN** the contract is deployed
+- **THEN** `name()` MUST return "Liverty Music Ticket" and `symbol()` MUST return "LMTKT"
+
+#### Scenario: Admin has both roles
+- **WHEN** the contract is deployed with `admin` address
+- **THEN** `hasRole(DEFAULT_ADMIN_ROLE, admin)` and `hasRole(MINTER_ROLE, admin)` MUST both return `true`
+
+### Requirement: Fuzz testing for mint and access control
+The contract SHALL be tested with fuzz inputs to verify robustness against arbitrary tokenIds, recipient addresses, and unauthorized callers.
+
+#### Scenario: Fuzz mint with arbitrary tokenId
+- **WHEN** minter calls `mint(recipient, tokenId)` with any valid `uint256 tokenId` and non-zero `recipient`
+- **THEN** `ownerOf(tokenId)` MUST return `recipient`
+
+#### Scenario: Fuzz unauthorized mint with arbitrary caller
+- **WHEN** an arbitrary address without MINTER_ROLE calls `mint(recipient, tokenId)`
+- **THEN** the transaction MUST revert

--- a/openspec/changes/sbt-test-hardening/tasks.md
+++ b/openspec/changes/sbt-test-hardening/tasks.md
@@ -1,0 +1,56 @@
+## 1. Contract Changes
+
+- [x] 1.1 Override `approve` in TicketSBT.sol to revert with "SBT: Ticket transfer is prohibited"
+- [x] 1.2 Override `setApprovalForAll` in TicketSBT.sol to revert with "SBT: Ticket transfer is prohibited"
+
+## 2. Test Additions — Approve & Transfer Blocking
+
+- [x] 2.1 Add test: `approve` reverts for token owner
+- [x] 2.2 Add test: `setApprovalForAll` reverts for token owner
+- [x] 2.3 Add test: 3-argument `safeTransferFrom` reverts
+
+## 3. Test Additions — Edge Cases
+
+- [x] 3.1 Add test: duplicate mint (same tokenId) reverts
+- [x] 3.2 Add test: mint to `address(0)` reverts
+
+## 4. Test Additions — supportsInterface (ERC-165)
+
+- [x] 4.1 Add test: returns true for ERC-721 interfaceId
+- [x] 4.2 Add test: returns true for ERC-5192 interfaceId
+- [x] 4.3 Add test: returns true for IAccessControl interfaceId
+- [x] 4.4 Add test: returns false for unsupported interfaceId (`0xffffffff`)
+
+## 5. Test Additions — AccessControl Role Management
+
+- [x] 5.1 Add test: admin grants MINTER_ROLE to new address
+- [x] 5.2 Add test: admin revokes MINTER_ROLE, revoked address cannot mint
+- [x] 5.3 Add test: non-admin cannot grant MINTER_ROLE
+
+## 6. Test Additions — Constructor Verification
+
+- [x] 6.1 Add test: `name()` returns "Liverty Music Ticket", `symbol()` returns "LMTKT"
+- [x] 6.2 Add test: deployer has DEFAULT_ADMIN_ROLE and MINTER_ROLE
+
+## 7. Fuzz Tests
+
+- [x] 7.1 Add `testFuzz_MintAnyTokenId(uint256 tokenId)` — mint succeeds for arbitrary tokenId
+- [x] 7.2 Add `testFuzz_UnauthorizedMintReverts(address caller)` — arbitrary non-minter cannot mint
+
+## 8. CI — Slither Integration
+
+- [x] 8.1 Add `slither` job to `.github/workflows/test.yml` under contracts path filter
+- [x] 8.2 Create `contracts/slither.config.json` with initial configuration
+- [x] 8.3 ~~Run Slither locally~~ → CI-only execution; triage findings on first CI run
+
+## 9. CI — Gas Snapshot & Fuzz Depth
+
+- [x] 9.1 Run `forge snapshot` to generate `contracts/.gas-snapshot` and commit to git
+- [x] 9.2 Add `forge snapshot --check` step to forge-test CI job
+- [x] 9.3 Update forge-test CI job to use `--fuzz-runs 10000`
+
+## 10. Verification
+
+- [x] 10.1 Run `forge test -vvv` locally — all 23 tests pass
+- [x] 10.2 ~~Run Slither locally~~ → CI-only; verify on first PR CI run
+- [ ] 10.3 Verify CI pipeline runs successfully with new jobs


### PR DESCRIPTION
## Summary

- Add `sbt-test-hardening` change (Phase 1): proposal, design, specs, and tasks for TicketSBT test coverage expansion, approve/setApprovalForAll override, Slither CI integration, gas snapshot, and fuzz depth increase
- Add `sbt-formal-verification` change (Phase 2): proposal, design, specs, and tasks for Halmos formal verification, Foundry invariant tests, Aderyn static analysis, mutation testing, and coverage reporting

## Test plan

- [x] `openspec status` confirms all artifacts complete for both changes
- [ ] CI passes
