### PR TITLE
docs(openspec): add fix-my-artists-onboarding-ux change

### DIFF
--- a/openspec/changes/fix-my-artists-onboarding-ux/.openspec.yaml
+++ b/openspec/changes/fix-my-artists-onboarding-ux/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-19

--- a/openspec/changes/fix-my-artists-onboarding-ux/design.md
+++ b/openspec/changes/fix-my-artists-onboarding-ux/design.md
@@ -1,0 +1,59 @@
+## Context
+
+Onboarding Step 5 (My Artists) is the final interactive step before completing onboarding. The user is a guest (unauthenticated) who has followed artists during discovery. The page displays those artists with hype sliders. The intended flow: spotlight highlights the slider area → user taps a hype dot → onboarding completes → redirect to welcome.
+
+Currently, `HypeInlineSlider.selectHype()` contains business logic (auth gate, event branching) that belongs in the parent route. Since the user is a guest, `hype-signup-prompt` fires instead of `hype-changed`, and the onboarding completion handler never executes. This is a progression-blocking bug caused by a responsibility violation — a UI component should not own authentication or onboarding logic.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Refactor `HypeInlineSlider` into a pure presentation component (zero methods, zero event dispatch)
+- Move all business logic (auth check, onboarding completion, signup prompt, RPC calls) to the parent route
+- Correct the spotlight target to cover the interactive area (artist list with sliders)
+- Fix visual regressions: slider track alignment, default hype value
+
+**Non-Goals:**
+- Persisting the signup-prompt-banner state across navigation (becomes irrelevant once onboarding completes correctly)
+- Changing the hype-notification-dialog or signup flow for non-onboarding guests
+
+## Decisions
+
+### 1. Pure Presentation Slider with twoWay Binding
+
+Remove all methods (`selectHype`), all business-logic bindables (`isAuthenticated`, `isOnboarding`), and all custom event dispatch (`INode` dependency) from the slider. The slider becomes data-only: three bindables (`artistId`, `hypeColor`, `hype`) and a static `stops` array.
+
+The `hype` bindable uses `BindingMode.twoWay`. When the user clicks a radio, Aurelia's `checked.bind` updates `hype`, which pushes to the parent's `artist.hype` via two-way binding. The native `change` event bubbles through the light DOM to the parent.
+
+The parent handles the `change` event with all business logic. If the selection is rejected (unauthenticated, onboarding), the parent reverts `artist.hype = prev`, which pushes back via two-way binding. Programmatic changes do not trigger `change` events (native DOM behavior), so no infinite loop.
+
+**Alternative considered**: Controlled component with `preventDefault()` + `hype-select` CustomEvent. Rejected as unnecessarily complex — requires a method and event dispatch in the slider when Aurelia's binding + native DOM events achieve the same result with zero component code.
+
+**Alternative considered**: `isOnboarding` bypass flag. Rejected because the slider still owns business logic and violates single responsibility.
+
+### 2. Parent Route Handles All Business Logic via `change` Event
+
+`MyArtistsRoute.onHypeInput()` receives the native `change` event and branches using a `prevHypes` Map to track previous values:
+
+| Condition | Action |
+|-----------|--------|
+| `isOnboardingStepMyArtists` | Revert hype → deactivate spotlight → `setStep(COMPLETED)` → navigate to LP |
+| `!isAuthenticated` | Revert hype → show notification dialog (signup prompt) |
+| `isAuthenticated` | Accept → update `prevHypes` → `SetHype` RPC with retry |
+
+### 3. Spotlight target: `.artist-list` instead of `[data-hype-header]`
+
+The hype-legend header is a passive reference element. The interactive target is the artist list containing hype sliders. Using `.artist-list` makes the spotlight cutout cover the actual tap target area.
+
+### 4. CSS logical properties for track centering
+
+Use `inset-block-start: 50%; translate: 0 -50%` for vertical centering. The project enforces logical properties via stylelint (`csstools/use-logical`).
+
+### 5. Default hype `'watch'` for guest follows
+
+`'watch'` (observation level) is the lowest hype tier and the correct default for newly followed artists. `'away'` was a bug — it's the highest intensity tier.
+
+## Risks / Trade-offs
+
+- **[Risk] twoWay binding + revert pattern** → Reverts are safe because programmatic changes to radio checked state do not fire native `change` events. No infinite loop risk.
+- **[Risk] `prevHypes` Map adds state tracking** → Minimal overhead. Initialized once in `loading()`, updated only on successful authenticated changes.
+- **[Risk] Spotlight over `.artist-list` is a larger area** → The larger spotlight correctly matches the interactive region. Click-blockers and target-interceptor already handle arbitrary-sized targets.

--- a/openspec/changes/fix-my-artists-onboarding-ux/proposal.md
+++ b/openspec/changes/fix-my-artists-onboarding-ux/proposal.md
@@ -4,8 +4,8 @@ During onboarding Step 5 (My Artists), four UX bugs prevent the flow from comple
 
 ## What Changes
 
-- **Refactor hype slider to controlled component**: Remove all business logic (`selectHype`, `isAuthenticated`, `isOnboarding`) from `HypeInlineSlider`. The slider becomes a pure presentation component that dispatches `hype-select` on dot tap (with `preventDefault()` to block native radio change). The parent route decides whether to accept the selection.
-- **Move business logic to parent route**: `MyArtistsRoute` handles the `hype-select` event with three branches: onboarding → complete; unauthenticated → signup prompt; authenticated → optimistic update + RPC.
+- **Refactor hype slider to pure presentation component**: Remove all business logic (`selectHype`, `isAuthenticated`, `isOnboarding`) from `HypeInlineSlider`. The slider becomes a data-only component with twoWay binding on `hype`; user interaction updates the binding and the native `change` event bubbles to the parent.
+- **Move business logic to parent route**: `MyArtistsRoute` handles the native `change` event via `onHypeInput()` with three branches: onboarding → complete; unauthenticated → signup prompt; authenticated → optimistic update + RPC. Rejected selections are reverted by pushing the previous value back via twoWay binding.
 - **Spotlight target widened to artist list**: Change from `[data-hype-header]` (legend row only) to `.artist-list` (the interactive area).
 - **Hype slider track vertical centering**: Add `inset-block-start: 50%; translate: 0 -50%` to center the track line.
 - **Default hype level corrected**: Guest follows default from `'away'` → `'watch'`.
@@ -18,18 +18,18 @@ During onboarding Step 5 (My Artists), four UX bugs prevent the flow from comple
 
 ### Modified Capabilities
 
-- `hype-inline-slider`: Refactor to controlled component pattern. Remove auth/onboarding logic. Replace `hype-changed`/`hype-signup-prompt` events with single `hype-select` event. Fix track vertical alignment.
-- `onboarding-tutorial`: Step 5 spotlight target changes from `[data-hype-header]` to `.artist-list`. Step 5 completion handled by parent route reacting to `hype-select` event.
+- `hype-inline-slider`: Refactor to pure presentation component. Remove auth/onboarding logic. Replace `hype-changed`/`hype-signup-prompt` custom events with twoWay `hype` binding; native `change` event bubbles to parent. Fix track vertical alignment.
+- `onboarding-tutorial`: Step 5 spotlight target changes from `[data-hype-header]` to `.artist-list`. Step 5 completion handled by parent route via `onHypeInput()` reacting to native `change` event.
 - `frontend-onboarding-flow`: Guest follow default hype corrected from `'away'` to `'watch'`.
 
 ## Impact
 
 - **Frontend only** — no backend, proto, or infrastructure changes.
 - Files affected:
-  - `src/components/hype-inline-slider/hype-inline-slider.ts` — remove `selectHype`, `isAuthenticated`, `isOnboarding`; add `onSelect`
+  - `src/components/hype-inline-slider/hype-inline-slider.ts` — remove `selectHype`, `isAuthenticated`, `isOnboarding`; retain only data bindables
   - `src/components/hype-inline-slider/hype-inline-slider.html` — replace `click.trigger`
   - `src/components/hype-inline-slider/hype-inline-slider.css` — track centering fix
-  - `src/routes/my-artists/my-artists-route.ts` — replace `onHypeChanged` + `onHypeSignupPrompt` with `onHypeSelect`; spotlight target
+  - `src/routes/my-artists/my-artists-route.ts` — replace `onHypeChanged` + `onHypeSignupPrompt` with `onHypeInput`; spotlight target
   - `src/routes/my-artists/my-artists-route.html` — replace event bindings; remove `is-authenticated`/`is-onboarding`
   - `src/services/follow-service-client.ts` — default hype value
   - `test/routes/my-artists-route.spec.ts` — updated for new event flow

--- a/openspec/changes/fix-my-artists-onboarding-ux/proposal.md
+++ b/openspec/changes/fix-my-artists-onboarding-ux/proposal.md
@@ -1,0 +1,35 @@
+## Why
+
+During onboarding Step 5 (My Artists), four UX bugs prevent the flow from completing correctly. The root cause is a responsibility violation: `HypeInlineSlider` contains business logic (auth gate, event branching) that belongs in the parent route. Since the user is a guest, the auth gate blocks all dot taps, `hype-changed` never fires, and `setStep(COMPLETED)` is never reached — the user is permanently stuck. Secondary issues degrade the visual quality of the step (wrong spotlight target, misaligned slider track, incorrect default hype).
+
+## What Changes
+
+- **Refactor hype slider to controlled component**: Remove all business logic (`selectHype`, `isAuthenticated`, `isOnboarding`) from `HypeInlineSlider`. The slider becomes a pure presentation component that dispatches `hype-select` on dot tap (with `preventDefault()` to block native radio change). The parent route decides whether to accept the selection.
+- **Move business logic to parent route**: `MyArtistsRoute` handles the `hype-select` event with three branches: onboarding → complete; unauthenticated → signup prompt; authenticated → optimistic update + RPC.
+- **Spotlight target widened to artist list**: Change from `[data-hype-header]` (legend row only) to `.artist-list` (the interactive area).
+- **Hype slider track vertical centering**: Add `inset-block-start: 50%; translate: 0 -50%` to center the track line.
+- **Default hype level corrected**: Guest follows default from `'away'` → `'watch'`.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `hype-inline-slider`: Refactor to controlled component pattern. Remove auth/onboarding logic. Replace `hype-changed`/`hype-signup-prompt` events with single `hype-select` event. Fix track vertical alignment.
+- `onboarding-tutorial`: Step 5 spotlight target changes from `[data-hype-header]` to `.artist-list`. Step 5 completion handled by parent route reacting to `hype-select` event.
+- `frontend-onboarding-flow`: Guest follow default hype corrected from `'away'` to `'watch'`.
+
+## Impact
+
+- **Frontend only** — no backend, proto, or infrastructure changes.
+- Files affected:
+  - `src/components/hype-inline-slider/hype-inline-slider.ts` — remove `selectHype`, `isAuthenticated`, `isOnboarding`; add `onSelect`
+  - `src/components/hype-inline-slider/hype-inline-slider.html` — replace `click.trigger`
+  - `src/components/hype-inline-slider/hype-inline-slider.css` — track centering fix
+  - `src/routes/my-artists/my-artists-route.ts` — replace `onHypeChanged` + `onHypeSignupPrompt` with `onHypeSelect`; spotlight target
+  - `src/routes/my-artists/my-artists-route.html` — replace event bindings; remove `is-authenticated`/`is-onboarding`
+  - `src/services/follow-service-client.ts` — default hype value
+  - `test/routes/my-artists-route.spec.ts` — updated for new event flow

--- a/openspec/changes/fix-my-artists-onboarding-ux/specs/frontend-onboarding-flow/spec.md
+++ b/openspec/changes/fix-my-artists-onboarding-ux/specs/frontend-onboarding-flow/spec.md
@@ -1,0 +1,19 @@
+## MODIFIED Requirements
+
+### Requirement: Interactive Artist Discovery (Bubble Network UI)
+
+The system SHALL provide an engaging, gamified interface for users to discover and follow artists using Last.fm API data. During onboarding, followed artists are stored locally (not via backend RPC). Additionally, the system SHALL trigger a background concert search for each followed artist to pre-populate concert data for the Dashboard.
+
+#### Scenario: Guest follow default hype level
+
+- **WHEN** a guest user (in onboarding) requests the list of followed artists via `listFollowed()`
+- **THEN** the system SHALL return each followed artist with hype level `'watch'` (observation tier)
+- **AND** the system SHALL NOT return `'away'` or any other default hype level
+
+#### Scenario: Guest user follows artist via bubble tap
+
+- **WHEN** a guest user (in onboarding) taps an artist bubble
+- **THEN** the system SHALL trigger the absorption animation
+- **AND** the system SHALL store the artist in the `guest.follows` state slice via Store dispatch
+- **AND** the system SHALL NOT call any backend RPC for the follow operation itself
+- **AND** the system SHALL call `ConcertService/SearchNewConcerts` fire-and-forget in the background

--- a/openspec/changes/fix-my-artists-onboarding-ux/specs/hype-inline-slider/spec.md
+++ b/openspec/changes/fix-my-artists-onboarding-ux/specs/hype-inline-slider/spec.md
@@ -1,0 +1,81 @@
+## MODIFIED Requirements
+
+### Requirement: Inline Dot Slider
+
+Each artist row in the My Artists list view SHALL include a 4-stop discrete dot slider for hype level selection, enabling 1-tap changes without opening a bottom sheet.
+
+The slider component SHALL be a pure presentation component with zero business logic. It SHALL expose `hype` as a `twoWay` bindable and render the active dot accordingly. The slider SHALL NOT contain authentication, onboarding, persistence, or event dispatch logic.
+
+The slider SHALL use native HTML `<fieldset>` with a visually hidden `<legend>` as the group container. Each hype stop SHALL be a `<label>` wrapping a native `<input type="radio">` (visually hidden) and a visual dot `<span>`. The radio inputs SHALL use Aurelia 2's `model.bind`/`checked.bind` pattern with two-way binding on `hype`. When the user taps a dot, the radio's native behavior updates `hype` via Aurelia binding, which pushes to the parent's data via `twoWay` mode. The native `change` event bubbles through the light DOM to the parent, which decides whether to accept or revert the change.
+
+#### Scenario: Slider renders on each artist row
+
+- **WHEN** an artist row renders in list view
+- **THEN** the row SHALL display the artist name (left-aligned, truncated with ellipsis) and the dot slider (right-aligned) on the same row
+- **AND** the slider SHALL display 4 dot stops connected by a 2px track line
+- **AND** the active dot SHALL be 14px diameter; inactive dots SHALL be 8px diameter
+- **AND** each dot SHALL have a minimum 44x44px transparent tap target area
+
+#### Scenario: User taps a dot
+
+- **WHEN** a user taps any dot on a slider
+- **THEN** the radio's native `checked` state SHALL update via Aurelia's `checked.bind`
+- **AND** the `twoWay` binding SHALL push the new value to the parent's bound property
+- **AND** the native `change` event SHALL bubble through the custom element boundary
+- **AND** the parent SHALL handle the `change` event to apply business logic
+
+#### Scenario: Parent accepts hype selection
+
+- **WHEN** the parent does NOT revert the bound property after a `change` event
+- **THEN** the slider SHALL remain at the new position (already updated by native radio behavior)
+
+#### Scenario: Parent reverts hype selection
+
+- **WHEN** the parent reverts the bound property (e.g., `artist.hype = prevValue`) after a `change` event
+- **THEN** the `twoWay` binding SHALL push the reverted value back to the slider
+- **AND** the slider SHALL return to the previous dot position
+- **AND** the programmatic update SHALL NOT trigger another `change` event (native DOM behavior)
+
+#### Scenario: Active dot reflects hype tier CSS effects
+
+- **WHEN** the slider renders with a specific hype level selected
+- **THEN** the active dot SHALL apply CSS glow effects based on the `HypeType` enum value:
+  - WATCH (1): `1px solid white/10` border, no glow
+  - HOME (2): artist-color border at 40% opacity, `box-shadow: 0 0 8px` at 30% opacity
+  - NEARBY (3): artist-color `2px solid` border, `box-shadow: 0 0 16px` at 50% opacity, gentle pulse animation
+  - AWAY (4): animated gradient border, layered glow (`0 0 24px` at 60% + `0 0 48px` at 20%), strong pulse animation
+- **AND** the CSS `data-level` attribute SHALL use `HypeType` enum values (1, 2, 3, 4)
+- **AND** the artist color SHALL be derived from the existing deterministic color generator
+
+#### Scenario: Reduced motion preference
+
+- **WHEN** the user has `prefers-reduced-motion: reduce` enabled
+- **THEN** all pulse and gradient rotation animations on active dots SHALL be disabled
+- **AND** static border and glow styles SHALL remain visible
+
+#### Scenario: Native radio input semantics
+
+- **WHEN** the slider renders
+- **THEN** the container SHALL be a `<fieldset>` with a visually hidden `<legend>` reading "Hype level"
+- **AND** each stop SHALL be a `<label>` containing a visually hidden `<input type="radio">` and a visual dot `<span>`
+- **AND** all radio inputs SHALL share a `name` attribute scoped to the artist (e.g., `hype-{artistId}`)
+- **AND** the selected radio SHALL be `checked` via Aurelia's `model.bind`/`checked.bind` pattern
+
+## REMOVED Requirements
+
+### Requirement: Slider-level authentication gate
+
+**Reason**: Authentication, onboarding, and signup-prompt logic are business concerns that belong in the parent route, not in a presentation component. The slider has no methods and dispatches no custom events. The parent listens for the native `change` event and applies all business logic.
+**Migration**: Remove `selectHype()` method, `isAuthenticated` bindable, and `isOnboarding` bindable. Remove `INode` dependency (no custom event dispatch). Remove `click.trigger` from radio inputs. Change `hype` bindable to `twoWay` mode. Parent listens for native `change` event via `change.trigger` on the `<hype-inline-slider>` element.
+
+## ADDED Requirements
+
+### Requirement: Slider Track Vertical Centering
+
+The slider track line SHALL be vertically centered within the slider grid cell using CSS logical properties.
+
+#### Scenario: Track is vertically centered
+
+- **WHEN** the slider renders
+- **THEN** the `.hype-slider-track` element SHALL use `inset-block-start: 50%` and `translate: 0 -50%` to center vertically within the grid row
+- **AND** the track SHALL remain centered across viewport sizes

--- a/openspec/changes/fix-my-artists-onboarding-ux/specs/onboarding-tutorial/spec.md
+++ b/openspec/changes/fix-my-artists-onboarding-ux/specs/onboarding-tutorial/spec.md
@@ -1,0 +1,22 @@
+## MODIFIED Requirements
+
+### Requirement: Linear Step Progression
+
+The system SHALL enforce a strict linear progression through onboarding steps. Users SHALL NOT be able to skip steps or navigate freely during onboarding. Direct navigation via the bottom nav bar SHALL advance the step when the prerequisite conditions are met.
+
+#### Scenario: Step 5 - Passion Level guidance
+
+- **WHEN** a user is at Step `'my-artists'`
+- **AND** followed artists have been loaded
+- **THEN** the spotlight SHALL highlight the `.artist-list` element (the list containing artist rows with hype sliders)
+- **AND** the coach mark SHALL display the message: "絶対に見逃したくないアーティストの熱量を上げておこう"
+
+#### Scenario: Step 5 - User taps a hype dot
+
+- **WHEN** a user is at Step `'my-artists'`
+- **AND** the user taps any hype dot on the inline slider
+- **THEN** the native `change` event SHALL bubble to `MyArtistsRoute`
+- **AND** the parent SHALL detect `isOnboardingStepMyArtists` and revert the hype change
+- **AND** the system SHALL deactivate the spotlight
+- **AND** the system SHALL advance `onboardingStep` to `'completed'`
+- **AND** the system SHALL navigate to the landing page

--- a/openspec/changes/fix-my-artists-onboarding-ux/tasks.md
+++ b/openspec/changes/fix-my-artists-onboarding-ux/tasks.md
@@ -1,0 +1,34 @@
+## 1. Refactor HypeInlineSlider to Pure Presentation
+
+- [x] 1.1 Remove `selectHype()` method, `isAuthenticated` bindable, `isOnboarding` bindable, and `INode` dependency from `hype-inline-slider.ts`
+- [x] 1.2 Change `hype` bindable to `BindingMode.twoWay`
+- [x] 1.3 Remove `click.trigger="selectHype(stop, $event)"` from `hype-inline-slider.html`
+
+## 2. Move Business Logic to MyArtistsRoute
+
+- [x] 2.1 Add `prevHypes: Map<string, Hype>` initialized in `loading()` after artist fetch
+- [x] 2.2 Replace `onHypeChanged` + `onHypeSignupPrompt` with single `onHypeInput(artist)` handler: onboarding → revert + complete; unauthenticated → revert + dialog; authenticated → accept + RPC
+- [x] 2.3 Update `my-artists-route.html`: replace `hype-changed.trigger` + `hype-signup-prompt.trigger` + `is-authenticated` + `is-onboarding` with `change.trigger="onHypeInput(artist)"`
+
+## 3. Spotlight Target
+
+- [x] 3.1 Change spotlight target from `'[data-hype-header]'` to `'.artist-list'` in `my-artists-route.ts`
+
+## 4. Slider Track Vertical Centering
+
+- [x] 4.1 Add `inset-block-start: 50%` and `translate: 0 -50%` to `.hype-slider-track` in `hype-inline-slider.css`
+
+## 5. Default Hype Level
+
+- [x] 5.1 Change guest follow default from `'away' as const` to `'watch' as const` in `follow-service-client.ts`
+
+## 6. Tests
+
+- [x] 6.1 Update `my-artists-route.spec.ts`: spotlight target, `onHypeInput` handler tests (onboarding / unauthenticated / authenticated branches)
+- [x] 6.2 Run `make check` — all pass
+
+## 7. Manual Verification
+
+- [ ] 7.1 Onboarding Step 5: tap hype dot → onboarding completes → redirect to LP
+- [ ] 7.2 Guest (post-onboarding): tap hype dot → slider reverts, signup dialog appears
+- [ ] 7.3 Authenticated: tap hype dot → slider moves, RPC fires


### PR DESCRIPTION
## Summary

- Add OpenSpec change artifacts for `fix-my-artists-onboarding-ux`: proposal, design, delta specs (hype-inline-slider, onboarding-tutorial, frontend-onboarding-flow), and tasks
- Documents the hype slider refactor to pure presentation + parent route business logic pattern
- Implementation PR merged: liverty-music/frontend#265

## Test plan

- [x] Artifacts are complete (11/14 tasks done, 3 are manual verification)
- [x] No proto changes — spec-only