### PR TITLE
docs(openspec): update state-management spec for DI service architecture

### DIFF
--- a/openspec/changes/archive/2026-03-21-migrate-state-to-di/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-21-migrate-state-to-di/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-20

--- a/openspec/changes/archive/2026-03-21-migrate-state-to-di/design.md
+++ b/openspec/changes/archive/2026-03-21-migrate-state-to-di/design.md
@@ -1,0 +1,85 @@
+## Context
+
+The frontend currently uses `@aurelia/state` (Redux-style) for onboarding and guest data. The state shape is simple — an onboarding step string, a spotlight config, an array of guest follows, and a nullable home string. Despite this simplicity, the architecture requires actions, a reducer, middleware, a store interface, and facade services. Routes and components inconsistently access state through both facades and direct `resolveStore()` calls.
+
+Aurelia 2 provides native fine-grained reactivity via `@observable`, `@computed`, and automatic property observation in templates. These primitives make the Redux layer redundant for this use case.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Eliminate `@aurelia/state` and the `src/state/` directory entirely
+- Consolidate state into two `@singleton` services: `OnboardingService` and `GuestService`
+- Use Aurelia native `@observable` for persistence side-effects via `propertyChanged` callbacks
+- Enforce a single access path: DI interfaces (`IOnboardingService`, `IGuestService`)
+- Simplify `guest-storage.ts` to POJO-only serialization (drop legacy format support)
+
+**Non-Goals:**
+- Introducing `signal-polyfill` or TC39 Signals — Aurelia native observation is sufficient
+- Changing the localStorage key names or breaking the current POJO format
+- Refactoring services beyond state management (e.g., `AuthService`, `LastfmService`)
+- Adding new features or capabilities
+
+## Decisions
+
+### 1. Two domain services instead of one monolithic store
+
+Split the single `AppState` into `OnboardingService` (onboarding step + spotlight) and `GuestService` (follows + home). Each service owns its state and persistence.
+
+**Why**: These two domains have no cross-cutting logic. The only interaction is `GuestDataMergeService` which reads guest data and then completes onboarding — this is orchestration, not shared state. Separate services enable independent testing and clearer ownership.
+
+**Alternative considered**: Single `AppStateService` mirroring the current `AppState` shape. Rejected because it would recreate the monolith without the Redux ceremony.
+
+### 2. Direct property mutation, not immutable updates
+
+Services mutate `@observable` properties directly (e.g., `this.step = newStep`). For arrays, use `push()` / `splice()` which Aurelia intercepts natively.
+
+**Why**: Aurelia's observation system is designed for mutation. Immutable replacement (spread patterns) is a React/Redux idiom that adds allocation overhead without benefit here. Aurelia's array observation intercepts mutation methods and triggers binding updates automatically.
+
+### 3. `propertyChanged` callbacks for persistence
+
+Each service persists its own state via `@observable` + `propertyChanged` convention:
+
+```
+OnboardingService:
+  @observable step = loadStep()  → stepChanged() → localStorage.setItem('onboardingStep', step)
+
+GuestService:
+  follows = loadFollows()        → explicit save after mutation
+  @observable home = loadHome()  → homeChanged() → localStorage set/remove
+```
+
+**Hydration via field initializers**: State is hydrated at field initialization time (e.g., `@observable step = loadStep()`), NOT in the constructor. This prevents `propertyChanged` from firing during hydration — the callback only fires when the value changes from the initial value.
+
+**Why over a central PersistenceService**: Only 3 fields are persisted. Distributing persistence into each service keeps the logic co-located with the state it persists. A central service would add indirection for no gain.
+
+**Array persistence caveat**: `@observable` on an array fires `propertyChanged` only on reference change (reassignment), not on `push()`/`splice()`. The service methods that mutate `follows` will call a private `persistFollows()` method explicitly after mutation. `clearAll()` uses `splice(0)` to preserve the array reference rather than reassignment.
+
+**`@observable` only for persisted properties**: Spotlight properties (`spotlightTarget`, `spotlightMessage`, `spotlightRadius`, `spotlightActive`) do NOT need `@observable` — they have no persistence side-effects. Aurelia's template binding auto-observes plain properties.
+
+### 4. Existing DI interface pattern preserved
+
+`OnboardingService` already uses `DI.createInterface<IOnboardingService>()`. This pattern is preserved. `LocalArtistClient` is renamed to `GuestService` with a new `IGuestService` interface, following the same pattern. `GuestService` exposes `followedCount` getter and `listFollowed()` projection for existing consumers. The legacy `getHome()` method is removed — `home` is a public `@observable` property accessed directly.
+
+### 5. guest-storage.ts simplified to save/load functions
+
+The current 160-line file with 3 legacy format parsers becomes ~30 lines:
+- `saveFollows(follows: GuestFollow[]): void` — `JSON.stringify` + `localStorage.setItem`
+- `loadFollows(): GuestFollow[]` — `localStorage.getItem` + `JSON.parse` + type guard
+- `saveHome(code: string | null): void`
+- `loadHome(): string | null`
+
+Legacy formats (VO-wrapped, `artistId` key, snake_case fanart) are removed. This is safe because the app is pre-release.
+
+### 6. GuestFollow type moves from state/app-state.ts to entities
+
+`GuestFollow` is a domain type (an artist paired with a nullable home). It belongs in `src/entities/`, not in the now-deleted `src/state/app-state.ts`.
+
+## Risks / Trade-offs
+
+**[Array observation gap]** → Aurelia auto-observes array mutation methods in templates (`repeat.for`), but `@observable` `Changed` callback does not fire on `push()`/`splice()`. Persistence after array mutation must be called explicitly in each service method. Mitigation: each method that mutates `follows` ends with `this.persistFollows()`.
+
+**[Getter reactivity in templates]** → Current services expose getters like `get followedCount()`. In Aurelia, plain getters are observed by default in templates but have no caching. For cheap computations (`.length`) this is fine. If expensive getters are needed in the future, add `@computed`. Mitigation: none needed now — current getters are trivial.
+
+**[Test migration]** → Existing reducer and middleware tests become obsolete. New tests will exercise service methods directly, which is simpler. Mitigation: delete old tests, write new service-level tests as part of the task list. Service tests focus on business logic; persistence correctness is covered by storage module unit tests.
+
+**[Spotlight complexity]** → `OnboardingService` owns both step management and spotlight (coach mark) state (5 properties + 2 callbacks). These are separate concerns but currently coupled. If spotlight grows in complexity, extract to a dedicated `SpotlightService`. This is explicitly out of scope for this change.

--- a/openspec/changes/archive/2026-03-21-migrate-state-to-di/proposal.md
+++ b/openspec/changes/archive/2026-03-21-migrate-state-to-di/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+The `@aurelia/state` Redux-style store adds unnecessary indirection for this application's simple state shape (onboarding step, guest follows, home area). Services act as thin facades that merely translate method calls into Action dispatches and `getState()` reads — a double-layered architecture with no benefit. Routes and components bypass the facade layer via direct `resolveStore()` calls, creating two competing access paths. Aurelia 2's native observation system (`@observable`, `@computed`, direct property binding) provides fine-grained reactivity without needing a separate store abstraction.
+
+## What Changes
+
+- **BREAKING**: Remove `@aurelia/state` dependency and the entire `src/state/` directory (actions, reducer, middleware, app-state, store-interface)
+- **BREAKING**: Remove `StateDefaultConfiguration` registration from `main.ts`
+- Replace `OnboardingService` thin facade with a self-contained `@singleton` service using `@observable` properties and `propertyChanged` callbacks for localStorage persistence
+- Replace `LocalArtistClient` thin facade with a self-contained `GuestService` using direct array mutation and `@observable` properties
+- Eliminate all `resolveStore()` / `store.dispatch()` / `store.getState()` calls from routes and components, replacing with `resolve(IOnboardingService)` / `resolve(IGuestService)` method calls
+- **BREAKING**: Simplify `adapter/storage/guest-storage.ts` by removing all legacy format support (VO wrapped, flat `artistId`, snake_case fanart) — POJO-only serialization
+- Remove `@aurelia/state` from `package.json`
+
+## Capabilities
+
+### New Capabilities
+
+_None — this is a refactoring of existing capabilities._
+
+### Modified Capabilities
+
+- `state-management`: Replace Redux-style store (actions, reducer, middleware, `IStore`) with DI-managed `@singleton` services using Aurelia native `@observable` / `@computed` for reactivity and `propertyChanged` callbacks for persistence
+
+## Impact
+
+- **Frontend code**: 16 files modified or deleted across `src/state/`, `src/services/`, `src/routes/`, `src/components/`, `src/adapter/storage/`, and `src/main.ts`
+- **Dependencies**: `@aurelia/state` removed from `package.json`
+- **localStorage**: Existing persisted data remains compatible (same keys, same POJO format for new writes). Legacy format reads are dropped — acceptable for pre-release
+- **Tests**: Existing unit tests for reducer and middleware become obsolete; replaced by service-level tests
+- **No backend or specification repo changes required** — this is a frontend-internal refactoring

--- a/openspec/changes/archive/2026-03-21-migrate-state-to-di/specs/state-management/spec.md
+++ b/openspec/changes/archive/2026-03-21-migrate-state-to-di/specs/state-management/spec.md
@@ -1,3 +1,5 @@
+## ADDED Requirements
+
 ### Requirement: OnboardingService as singleton state owner
 
 The system SHALL provide an `OnboardingService` registered as `@singleton` via `DI.createInterface<IOnboardingService>()` that owns all onboarding state. Only properties requiring persistence side-effects (`step`) SHALL use `@observable`. Spotlight properties (`spotlightTarget`, `spotlightMessage`, `spotlightRadius`, `spotlightActive`) SHALL be plain class properties — Aurelia's template binding observes them automatically without `@observable`.
@@ -75,7 +77,7 @@ The system SHALL define `GuestFollow` as an interface in `src/entities/` contain
 
 ### Requirement: Service-level persistence via propertyChanged
 
-Each service SHALL persist its own state to localStorage using `@observable` `propertyChanged` callbacks (for scalar properties) or explicit persistence calls after array mutation. The system SHALL use these localStorage keys: `onboardingStep`, `guest.followedArtists`, `guest.home`.
+Each service SHALL persist its own state to localStorage using `@observable` `propertyChanged` callbacks (for scalar properties) or explicit persistence calls after array mutation. Persistence correctness SHALL be verified via `guest-storage.ts` and `onboarding-storage.ts` unit tests. Service-level tests SHALL focus on business logic (duplicate guard, clearAll, step transitions), not localStorage side-effects.
 
 #### Scenario: Onboarding step persisted on change
 
@@ -112,11 +114,6 @@ Each service SHALL hydrate its initial state from localStorage at field initiali
 - **THEN** `stepChanged()` and `homeChanged()` SHALL NOT fire during field initialization
 - **AND** no redundant localStorage writes SHALL occur
 
-#### Scenario: Invalid or unrecognized step in localStorage
-
-- **WHEN** `OnboardingService` is instantiated and localStorage contains an unrecognized step value
-- **THEN** it SHALL fall back to `'lp'` and overwrite localStorage
-
 ### Requirement: Simplified guest-storage POJO-only serialization
 
 The `adapter/storage/guest-storage.ts` module SHALL serialize and deserialize `GuestFollow[]` as plain JSON without legacy format support.
@@ -141,6 +138,17 @@ The `adapter/storage/guest-storage.ts` module SHALL serialize and deserialize `G
 - **WHEN** localStorage contains data in VO-wrapped format (`{ id: { value: "..." } }`), flat `artistId` format, or snake_case fanart fields
 - **THEN** `loadFollows()` SHALL NOT attempt to parse these formats and SHALL return entries only if they match the current POJO structure
 
+### Requirement: Single DI access path
+
+All routes and components SHALL access onboarding and guest state exclusively through `resolve(IOnboardingService)` and `resolve(IGuestService)`. Direct store resolution (`resolveStore()`, `resolve(IStore)`) SHALL NOT exist in the codebase.
+
+#### Scenario: No direct store access
+
+- **WHEN** the codebase is searched for `resolveStore`, `IStore`, or `@aurelia/state` imports
+- **THEN** zero results SHALL be found outside of test files
+
+## MODIFIED Requirements
+
 ### Requirement: OnboardingStep string values
 
 The system SHALL define `OnboardingStep` as a const object with string literal values representing each step by name.
@@ -163,11 +171,57 @@ The system SHALL define `OnboardingStep` as a const object with string literal v
 - **THEN** the system SHALL check membership in an `ONBOARDING_STEPS` Set containing `'discovery'`, `'dashboard'`, `'detail'`, `'my-artists'`
 - **AND** the system SHALL NOT use numeric range comparison
 
-### Requirement: Single DI access path
+### Requirement: Persistence middleware
 
-All routes and components SHALL access onboarding and guest state exclusively through `resolve(IOnboardingService)` and `resolve(IGuestService)`. Direct store resolution (`resolveStore()`, `resolve(IStore)`) SHALL NOT exist in the codebase.
+The system SHALL persist onboarding step, guest follows, and guest home to localStorage. The previous `After` middleware pattern is replaced by the "Service-level persistence via propertyChanged" requirement (see ADDED). This requirement retains only the contract of WHAT is persisted and under which localStorage keys.
 
-#### Scenario: No direct store access
+#### Scenario: Persisted keys unchanged
 
-- **WHEN** the codebase is searched for `resolveStore`, `IStore`, or `@aurelia/state` imports
-- **THEN** zero results SHALL be found outside of test files
+- **WHEN** state is persisted
+- **THEN** the system SHALL use the same localStorage keys as before: `onboardingStep`, `guest.followedArtists`, `guest.home`
+
+### Requirement: State hydration from localStorage
+
+The system SHALL hydrate initial state from localStorage, validating string step values. Hydration SHALL occur at field initialization time in each service, replacing the previous `loadPersistedState()` function.
+
+#### Scenario: Valid string step in localStorage
+
+- **WHEN** `OnboardingService` is instantiated and localStorage contains a recognized string step value
+- **THEN** the field initializer SHALL set `step` to that value
+
+#### Scenario: Invalid or unrecognized step in localStorage
+
+- **WHEN** `OnboardingService` is instantiated and localStorage contains an unrecognized step value
+- **THEN** it SHALL fall back to `'lp'` and overwrite localStorage
+
+## REMOVED Requirements
+
+### Requirement: AppState type definition
+
+**Reason**: Replaced by per-service state ownership. Onboarding state lives in `OnboardingService`, guest state in `GuestService`. No unified `AppState` interface is needed.
+
+**Migration**: Delete `src/state/app-state.ts`. Move `GuestFollow` type to `src/entities/`.
+
+### Requirement: Action type definition
+
+**Reason**: Actions are a Redux concept. State mutations are now direct method calls on services.
+
+**Migration**: Delete `src/state/actions.ts`.
+
+### Requirement: Reducer as pure function
+
+**Reason**: The reducer is replaced by service methods that directly mutate `@observable` properties. Business logic (e.g., duplicate follow guard) moves into service methods.
+
+**Migration**: Delete `src/state/reducer.ts`. Port business logic to service methods.
+
+### Requirement: Logging middleware via factory
+
+**Reason**: Logging is handled by each service using `ILogger.scopeTo()` in its methods, as services already do today.
+
+**Migration**: Delete logging middleware from `src/state/middleware.ts`.
+
+### Requirement: Store resolution requires active DI context
+
+**Reason**: `IStore` and `resolveStore()` are removed. Services are resolved via standard `resolve()` which already requires DI context.
+
+**Migration**: Delete `src/state/store-interface.ts`. Replace all `resolveStore()` calls with `resolve(IOnboardingService)` or `resolve(IGuestService)`.

--- a/openspec/changes/archive/2026-03-21-migrate-state-to-di/tasks.md
+++ b/openspec/changes/archive/2026-03-21-migrate-state-to-di/tasks.md
@@ -1,0 +1,35 @@
+## 1. Entity and Storage Foundation
+
+- [x] 1.1 Move `GuestFollow` interface from `src/state/app-state.ts` to `src/entities/follow.ts`
+- [x] 1.2 Simplify `src/adapter/storage/guest-storage.ts` — remove all legacy format support (VO-wrapped, `artistId` key, snake_case fanart), implement `saveFollows()`, `loadFollows()`, `saveHome()`, `loadHome()` as POJO-only functions that encapsulate localStorage access
+- [x] 1.3 Add `src/adapter/storage/onboarding-storage.ts` with `saveStep()` and `loadStep()` functions (encapsulate localStorage key and `normalizeStep` validation)
+
+## 2. Service Refactoring
+
+- [x] 2.1 Rewrite `OnboardingService` — remove `resolveStore()` dependency, add `@observable step` with `stepChanged()` callback for persistence, hydrate from `loadStep()` in constructor, keep existing DI interface and public API
+- [x] 2.2 Create `GuestService` (replacing `LocalArtistClient`) — own `follows` array and `@observable home`, hydrate from `loadFollows()`/`loadHome()` in constructor, call `saveFollows()`/`saveHome()` explicitly after mutations, register via `DI.createInterface<IGuestService>()`
+- [x] 2.3 Update `src/services/follow-service-client.ts` to use `IGuestService` instead of `ILocalArtistClient` / `resolveStore()`
+- [x] 2.4 Update `src/services/guest-data-merge-service.ts` to use `IGuestService` and `IOnboardingService` instead of store
+- [x] 2.5 Update `src/services/concert-service.ts` to use `IGuestService` instead of `resolveStore()`
+
+## 3. Route and Component Migration
+
+- [x] 3.1 Update `welcome-route.ts` — replace `resolveStore()` + dispatch with `resolve(IOnboardingService)` and `resolve(IGuestService)` method calls
+- [x] 3.2 Update `dashboard-route.ts` — replace `resolveStore()` + dispatch with service method calls
+- [x] 3.3 Update `discovery-route.ts` — replace `store.getState()` reads with `resolve(IGuestService)` property access
+- [x] 3.4 Update `auth-callback-route.ts` — replace `store.getState().guest.home` with `resolve(IGuestService).home`
+- [x] 3.5 Update `user-home-selector.ts` — replace `resolveStore()` + dispatch with `resolve(IGuestService).setHome()`
+
+## 4. Cleanup
+
+- [x] 4.1 Delete `src/state/` directory (actions.ts, reducer.ts, middleware.ts, app-state.ts, store-interface.ts)
+- [x] 4.2 Remove `StateDefaultConfiguration` registration and middleware setup from `src/main.ts`
+- [x] 4.3 Remove `@aurelia/state` from `package.json` and run `npm install`
+
+## 5. Tests
+
+- [x] 5.1 Delete obsolete reducer and middleware tests
+- [x] 5.2 Write unit tests for `OnboardingService` (hydration, step transitions, persistence, spotlight)
+- [x] 5.3 Write unit tests for `GuestService` (hydration, follow/unfollow, duplicate guard, home, clearAll, persistence)
+- [x] 5.4 Update `guest-storage.ts` tests to remove legacy format test cases and verify POJO-only behavior
+- [x] 5.5 Run `make check` (lint + test) to verify all changes pass

--- a/openspec/changes/archive/2026-03-21-migrate-state-to-di/tasks.md
+++ b/openspec/changes/archive/2026-03-21-migrate-state-to-di/tasks.md
@@ -6,8 +6,8 @@
 
 ## 2. Service Refactoring
 
-- [x] 2.1 Rewrite `OnboardingService` — remove `resolveStore()` dependency, add `@observable step` with `stepChanged()` callback for persistence, hydrate from `loadStep()` in constructor, keep existing DI interface and public API
-- [x] 2.2 Create `GuestService` (replacing `LocalArtistClient`) — own `follows` array and `@observable home`, hydrate from `loadFollows()`/`loadHome()` in constructor, call `saveFollows()`/`saveHome()` explicitly after mutations, register via `DI.createInterface<IGuestService>()`
+- [x] 2.1 Rewrite `OnboardingService` — remove `resolveStore()` dependency, add `@observable step` with `stepChanged()` callback for persistence, hydrate from `loadStep()` at field initialization time (e.g., `@observable step = loadStep()`), keep existing DI interface and public API
+- [x] 2.2 Create `GuestService` (replacing `LocalArtistClient`) — own `follows` array and `@observable home`, hydrate from `loadFollows()`/`loadHome()` at field initialization time (e.g., `follows = loadFollows()`, `@observable home = loadHome()`), call `saveFollows()`/`saveHome()` explicitly after mutations, register via `DI.createInterface<IGuestService>()`
 - [x] 2.3 Update `src/services/follow-service-client.ts` to use `IGuestService` instead of `ILocalArtistClient` / `resolveStore()`
 - [x] 2.4 Update `src/services/guest-data-merge-service.ts` to use `IGuestService` and `IOnboardingService` instead of store
 - [x] 2.5 Update `src/services/concert-service.ts` to use `IGuestService` instead of `resolveStore()`


### PR DESCRIPTION
## Summary

- Update `state-management` capability spec to reflect the new DI singleton service architecture (replacing Redux-style store)
- Archive the `migrate-state-to-di` change artifacts (proposal, design, specs, tasks)

## Context

The frontend PR #266 (`liverty-music/frontend`) replaces `@aurelia/state` with native Aurelia DI services. This PR updates the specification to match the implemented architecture.

## Test Plan

- [x] Spec accurately reflects implemented code (verified via `/opsx:verify`)
- [ ] No proto changes — buf lint/breaking not affected
