### PR TITLE
docs(openspec): archive fix-gemini-search-timeout

### DIFF
--- a/openspec/changes/archive/2026-03-21-fix-gemini-search-timeout/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-21-fix-gemini-search-timeout/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-20

--- a/openspec/changes/archive/2026-03-21-fix-gemini-search-timeout/design.md
+++ b/openspec/changes/archive/2026-03-21-fix-gemini-search-timeout/design.md
@@ -38,7 +38,7 @@ Three issues compound:
 
 Pass `&http.Client{Timeout: 60 * time.Second}` to `NewConcertSearcher` in `provider.go` instead of `nil`.
 
-**Why 60s?** The Google Maps client already uses 10s. Gemini with Google Search Grounding involves web crawling and synthesis — 60s per attempt is generous but bounded. With 3 retry attempts and backoff, worst case is ~60+1+60+2+60 ≈ 183s, well within the 120s background timeout because the context cancellation will cut off retries early. Each individual attempt is bounded.
+**Why 60s?** The Google Maps client already uses 10s. Gemini with Google Search Grounding involves web crawling and synthesis — 60s per attempt is generous but bounded. With 3 retry attempts and backoff, the theoretical worst case is ~60+1+60+2+60 ≈ 183s, but the 120s background context will cancel retries before that point. Each individual attempt is bounded.
 
 **Alternative considered: per-attempt context deadline inside the retry loop.** This would work but adds complexity. The HTTP client timeout achieves the same goal more simply and is consistent with how the Maps client is configured.
 

--- a/openspec/changes/archive/2026-03-21-fix-gemini-search-timeout/design.md
+++ b/openspec/changes/archive/2026-03-21-fix-gemini-search-timeout/design.md
@@ -1,0 +1,59 @@
+## Context
+
+`AsyncSearchNewConcerts` creates a single 120s context that flows through the entire pipeline:
+
+```
+bgCtx (120s) ──▶ DB lookups ──▶ Gemini API (with retries) ──▶ DB status update
+                  ~100ms          ~60-120s consumed             💥 deadline exceeded
+```
+
+Three issues compound:
+1. The Gemini HTTP client is created with `nil` (no per-call timeout), so each API call can consume the entire remaining budget.
+2. `errInvalidJSON` is retried up to 3 times despite structured output mode being enabled — retrying produces the same truncation.
+3. `markSearchCompleted`/`markSearchFailed` use the same context, which may already be expired.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Ensure search log status updates (`markSearchCompleted`/`markSearchFailed`) always succeed regardless of Gemini API duration
+- Bound each Gemini API attempt to a reasonable timeout so one slow call doesn't consume the entire budget
+- Avoid futile retries when structured output mode produces invalid JSON (token limit exhaustion)
+
+**Non-Goals:**
+- Increasing `maxOutputTokens` (separate investigation — may be needed but is orthogonal)
+- Changing the retry strategy for genuine Gemini server errors (503, 504) — those remain retryable
+- NATS stderr logging (separate change)
+
+## Decisions
+
+### 1. Independent context for DB status updates
+
+`markSearchCompleted` and `markSearchFailed` will create a new `context.Background()` with a 5-second timeout instead of propagating the caller's context.
+
+**Why not just extend `backgroundSearchTimeout`?** Extending the timeout is a band-aid — if Gemini takes longer in the future, we hit the same problem. The DB update is a simple single-row UPDATE that should never need more than a few seconds regardless of what happened upstream.
+
+**Why `context.Background()` instead of `context.WithoutCancel(ctx)`?** The caller's context may already be cancelled. A fresh background context guarantees the update runs.
+
+### 2. Explicit HTTP client timeout for Gemini (60s)
+
+Pass `&http.Client{Timeout: 60 * time.Second}` to `NewConcertSearcher` in `provider.go` instead of `nil`.
+
+**Why 60s?** The Google Maps client already uses 10s. Gemini with Google Search Grounding involves web crawling and synthesis — 60s per attempt is generous but bounded. With 3 retry attempts and backoff, worst case is ~60+1+60+2+60 ≈ 183s, well within the 120s background timeout because the context cancellation will cut off retries early. Each individual attempt is bounded.
+
+**Alternative considered: per-attempt context deadline inside the retry loop.** This would work but adds complexity. The HTTP client timeout achieves the same goal more simply and is consistent with how the Maps client is configured.
+
+### 3. Treat `errInvalidJSON` as permanent error
+
+When `ResponseMIMEType: "application/json"` and `ResponseSchema` are configured, the Gemini API guarantees structured output. If the response is still invalid JSON, it means the output was truncated due to `maxOutputTokens` being exceeded. Retrying with the same prompt and token limit produces the same truncation.
+
+Change: wrap `errInvalidJSON` with `backoff.Permanent()` in `parseEvents`.
+
+**What about non-structured-output mode?** Currently all calls use structured output. If a future caller doesn't, the retry would still be pointless for the same prompt — the model's response length is deterministic for the same input.
+
+## Risks / Trade-offs
+
+**[Risk] 60s HTTP timeout may be too aggressive for complex artists with many tour dates** → Monitor Gemini response times after deployment. The 60s timeout can be adjusted via config if needed. Current logs show most successful calls complete in 10-30s.
+
+**[Risk] Permanent `errInvalidJSON` means no recovery for truncated responses** → This is intentional. The search log is marked as FAILED, and the CronJob retries on the next cycle (24h TTL). If truncation is systematic for certain artists, the fix is increasing `maxOutputTokens`, not retrying.
+
+**[Trade-off] Fresh `context.Background()` for DB updates bypasses any parent cancellation signals** → Acceptable because the update is fire-and-forget with a short 5s timeout. If the DB is down, it fails fast and logs the error.

--- a/openspec/changes/archive/2026-03-21-fix-gemini-search-timeout/proposal.md
+++ b/openspec/changes/archive/2026-03-21-fix-gemini-search-timeout/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+The background concert search (`AsyncSearchNewConcerts`) shares a single 120-second context across the entire Gemini API call chain and the subsequent DB status update. When Gemini responds slowly or returns truncated JSON (triggering retries with exponential backoff), the context deadline is exhausted before `markSearchCompleted` can update the search log. This leaves search logs stuck in PENDING status, causing users to see stale "searching…" indicators and blocking subsequent searches until the 3-minute self-healing timeout expires.
+
+A secondary issue is that `errInvalidJSON` (truncated Gemini response) is treated as a transient/retryable error. Since `ResponseMIMEType: "application/json"` and `ResponseSchema` are already configured, a truncated response from Gemini indicates an output token limit issue — retrying the same request produces the same truncation, wasting time and contributing to the deadline exhaustion.
+
+## What Changes
+
+- **Decouple DB update context from Gemini context**: `markSearchCompleted` and `markSearchFailed` will use an independent short-lived context (e.g., 5s) instead of the shared background context, ensuring status updates succeed even when Gemini consumes most of the deadline.
+- **Add per-call timeout to Gemini HTTP client**: Pass an `http.Client` with an explicit timeout (e.g., 60s) to `NewConcertSearcher` instead of `nil`, bounding each Gemini API attempt.
+- **Treat `errInvalidJSON` as a permanent error**: Since structured output mode (`ResponseMIMEType` + `ResponseSchema`) is enabled, invalid JSON indicates a systemic issue (likely `maxOutputTokens` exhaustion). Retrying is futile — fail fast and mark the search as failed.
+
+## Capabilities
+
+### New Capabilities
+
+_None — this is a bug fix within existing capabilities._
+
+### Modified Capabilities
+
+_None — no spec-level requirement changes. The behavior contract (search → update status) remains the same; only the implementation's timeout and retry strategy changes._
+
+## Impact
+
+- **Backend only**: `internal/usecase/concert_uc.go`, `internal/infrastructure/gcp/gemini/searcher.go`, `internal/di/provider.go`
+- **No API changes**: No proto, RPC, or DB schema changes
+- **No breaking changes**: External behavior is unchanged — searches that previously timed out will now fail faster and update status correctly

--- a/openspec/changes/archive/2026-03-21-fix-gemini-search-timeout/specs/README.md
+++ b/openspec/changes/archive/2026-03-21-fix-gemini-search-timeout/specs/README.md
@@ -1,0 +1,2 @@
+No spec changes required for this fix. This is a backend-only implementation change
+that does not alter any external behavior contracts.

--- a/openspec/changes/archive/2026-03-21-fix-gemini-search-timeout/tasks.md
+++ b/openspec/changes/archive/2026-03-21-fix-gemini-search-timeout/tasks.md
@@ -1,0 +1,17 @@
+## 1. Decouple DB status update context
+
+- [x] 1.1 In `concert_uc.go`, modify `markSearchCompleted` and `markSearchFailed` to create a fresh `context.WithTimeout(context.Background(), 5*time.Second)` instead of using the caller's context
+- [x] 1.2 Update existing tests in `concert_uc_test.go` to verify status update succeeds even when the parent context is cancelled
+
+## 2. Add Gemini HTTP client timeout
+
+- [x] 2.1 In `provider.go`, pass `&http.Client{Timeout: 60 * time.Second}` to `gemini.NewConcertSearcher` instead of `nil`
+
+## 3. Treat invalid JSON as permanent error
+
+- [x] 3.1 In `searcher.go` `parseEvents`, wrap `errInvalidJSON` return with `backoff.Permanent()` so truncated JSON responses are not retried
+- [x] 3.2 Update `searcher_test.go` to verify that invalid JSON causes immediate failure (no retry) and that the error is permanent
+
+## 4. Verification
+
+- [x] 4.1 Run `make check` (lint + tests) to confirm all changes pass


### PR DESCRIPTION
## Summary

- Archive OpenSpec change artifacts (proposal, design, tasks) for the Gemini search context deadline fix
- No proto or spec changes — backend-only implementation fix

## Test plan

- [x] No proto files changed — buf lint/format/breaking not applicable
- [x] Backend PR merged: liverty-music/backend#237