### PR TITLE
docs(openspec): archive completed changes and relocate misplaced change

### DIFF
--- a/openspec/changes/archive/2026-03-21-fix-discovery-bubble-content/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-21-fix-discovery-bubble-content/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-19

--- a/openspec/changes/archive/2026-03-21-fix-discovery-bubble-content/design.md
+++ b/openspec/changes/archive/2026-03-21-fix-discovery-bubble-content/design.md
@@ -1,0 +1,55 @@
+## Context
+
+The `DnaOrbCanvas` component contains image loading code (`preloadImages`, `imageCache`, `renderBubble` image drawing) that predates the `artist-image-ui` change which explicitly marked bubble images as a Non-Goal. This dead code causes two user-visible bugs:
+
+1. **Console errors**: fanart.tv URLs loaded via `new Image()` with `crossOrigin='anonymous'` fail (404, CORS, broken links), producing mass `ERR_FAILED` / network errors in the console.
+2. **Off-center text**: When image load fails, `img.complete` is `true` but `naturalWidth` is 0. The text position condition (`img?.complete ? y + r * 0.5 : y`) shifts the name downward even though no image renders (the draw condition checks `img?.complete && img.naturalWidth > 0`).
+
+Current bubble rendering: gradient background + attempted image + single-line text + outline.
+Target bubble rendering: gradient background + adaptive multi-line centered text + outline.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Remove all image loading/caching/rendering from bubble and absorption code
+- Display artist name only, centered horizontally and vertically in each bubble
+- Scale font size inversely with name length relative to bubble radius
+- Wrap long names across multiple lines to avoid overflow
+
+**Non-Goals:**
+- Changing bubble gradient colors, outline, or physics behavior
+- Modifying the `bestLogoUrl` helper itself (other components use it)
+- Adding text truncation with ellipsis (prefer wrapping)
+- Changing absorption animation visuals beyond removing the unused `imageUrl` parameter
+
+## Decisions
+
+### 1. Remove image infrastructure entirely from DnaOrbCanvas
+
+Delete `imageCache`, `preloadImages()`, all `bestLogoUrl` calls in `dna-orb-canvas.ts`, and the image drawing block in `renderBubble()`. Remove the `imageUrl` field from `AbsorptionAnimation` interface and `startAbsorption()` parameter.
+
+**Why**: This code is dead by spec (Non-Goal in artist-image-ui). Removing it eliminates both bugs at the source rather than patching around them.
+
+### 2. Adaptive font sizing based on bubble radius and character count
+
+Use a simple formula: `baseFontSize = radius * 0.38`, then scale down proportionally if the text width exceeds the available diameter. Canvas `measureText()` provides the width measurement.
+
+**Why**: Bubbles have varying radii (30-45px). A fixed font size doesn't work. Scaling from the radius ensures proportionality, and `measureText()` is already available in the 2D context with no performance cost.
+
+### 3. Word-wrap via manual line splitting
+
+Split the artist name into words. Greedily fit words per line using `measureText()`. If a single word exceeds the bubble width, reduce font size further. Render each line offset from center by `lineHeight * (lineIndex - (totalLines - 1) / 2)`.
+
+**Why**: Canvas 2D has no built-in word wrap. Manual splitting with greedy fit is simple, deterministic, and handles the common cases (1-3 word names, occasional long single words like "BABYMETAL" or "Aerosmith").
+
+### 4. Text vertical centering always at bubble center
+
+Always position text at `y` (bubble center). Remove the conditional `y + r * 0.5` offset entirely since there's no image to make room for.
+
+**Why**: Directly fixes the off-center bug. With no image, the text should always be vertically centered.
+
+## Risks / Trade-offs
+
+**[Very long artist names]** — Names exceeding ~30 characters at minimum font size may still be hard to read at small bubble radii (30px). Acceptable because this is a rare edge case and the bubble tap still works as a discovery mechanism even if the name is small.
+
+**[CJK character wrapping]** — Word-based splitting doesn't work for CJK names without spaces (e.g., Japanese artist names). For now, character-level overflow reduction handles this acceptably. Can be revisited if CJK artist discovery becomes a priority.

--- a/openspec/changes/archive/2026-03-21-fix-discovery-bubble-content/proposal.md
+++ b/openspec/changes/archive/2026-03-21-fix-discovery-bubble-content/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+Discovery page bubbles load artist images from fanart.tv via `bestLogoUrl()`, causing mass image loading errors in the browser console. The `artist-image-ui` change (2026-03-17) explicitly marked "DNA Orb / discovery bubble images" as a Non-Goal, but the image loading code was never removed. Additionally, when images fail to load (`img.complete=true`, `naturalWidth=0`), the artist name text position shifts downward due to an inconsistent condition check, causing off-center layout.
+
+## What Changes
+
+- Remove all image loading, caching, and rendering from `DnaOrbCanvas` bubble rendering
+- Redefine bubble content as artist name only, centered within the bubble
+- Add adaptive font sizing and line wrapping for artist names based on bubble radius and name length
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `artist-discovery-dna-orb-ui`: Add explicit "Bubble Content Display" requirement defining that bubbles show artist name only (no images), with adaptive font sizing and line wrapping
+
+## Impact
+
+- `frontend/src/components/dna-orb/dna-orb-canvas.ts`: Remove `preloadImages`, `imageCache`, image rendering in `renderBubble`, `bestLogoUrl` import. Rewrite text rendering with adaptive sizing and wrapping.
+- `frontend/src/components/dna-orb/absorption-animator.ts`: Remove `logoUrl` parameter from `startAbsorption` if it references image data.
+- No backend or proto changes required.

--- a/openspec/changes/archive/2026-03-21-fix-discovery-bubble-content/specs/artist-discovery-dna-orb-ui/spec.md
+++ b/openspec/changes/archive/2026-03-21-fix-discovery-bubble-content/specs/artist-discovery-dna-orb-ui/spec.md
@@ -1,0 +1,24 @@
+## ADDED Requirements
+
+### Requirement: Bubble Content Display
+
+Each bubble SHALL display the artist's name as its sole visual content, centered within the bubble area. No images SHALL be loaded or rendered inside bubbles.
+
+#### Scenario: Artist name centered in bubble
+
+- **WHEN** artist bubbles are rendered on the canvas
+- **THEN** each bubble SHALL display the artist's name centered horizontally and vertically within the bubble
+- **AND** the bubble SHALL NOT load or display any image (no fanart, no logo, no thumbnail)
+
+#### Scenario: Font size adapts to name length
+
+- **WHEN** the artist's name is rendered inside a bubble
+- **THEN** the font size SHALL scale based on the bubble radius (base size proportional to radius)
+- **AND** if the rendered text width exceeds the available bubble diameter, the font size SHALL be reduced to fit
+
+#### Scenario: Long names wrap to multiple lines
+
+- **WHEN** the artist's name contains multiple words and the full name exceeds the bubble width at the current font size
+- **THEN** the name SHALL wrap to multiple lines using word boundaries
+- **AND** all lines SHALL be vertically centered as a group within the bubble
+- **AND** each line SHALL be horizontally centered

--- a/openspec/changes/archive/2026-03-21-fix-discovery-bubble-content/tasks.md
+++ b/openspec/changes/archive/2026-03-21-fix-discovery-bubble-content/tasks.md
@@ -1,0 +1,23 @@
+## 1. Remove image infrastructure from DnaOrbCanvas
+
+- [x] 1.1 Remove `imageCache` field, `preloadImages()` method, and `bestLogoUrl` import from `dna-orb-canvas.ts`
+- [x] 1.2 Remove all `preloadImages()` calls in `attached()`, `artistsChanged()`, `reloadBubbles()`, `spawnBubblesAt()`
+- [x] 1.3 Remove `this.imageCache.clear()` from `detaching()` and `reloadBubbles()`
+- [x] 1.4 Remove image drawing block in `renderBubble()` (lines 470-478: the `img?.complete && img.naturalWidth > 0` block)
+
+## 2. Remove image references from absorption animator
+
+- [x] 2.1 Remove `imageUrl` field from `AbsorptionAnimation` interface in `absorption-animator.ts`
+- [x] 2.2 Remove `imageUrl` parameter from `startAbsorption()` method signature
+- [x] 2.3 Update all `startAbsorption()` call sites in `dna-orb-canvas.ts` (in `handleInteraction` and `spawnAndAbsorb`) to remove the `logoUrl` argument
+
+## 3. Implement adaptive text rendering in renderBubble
+
+- [x] 3.1 Fix text vertical position: always use `y` (bubble center) instead of conditional `img?.complete ? y + r * 0.5 : y`
+- [x] 3.2 Implement word-wrap function: split artist name into words, greedily fit per line using `ctx.measureText()`, return array of lines
+- [x] 3.3 Implement adaptive font sizing: base size from `radius * 0.38`, reduce if widest line exceeds usable diameter (`radius * 1.6`)
+- [x] 3.4 Render multi-line text: draw each line offset from vertical center by `lineHeight * (lineIndex - (totalLines - 1) / 2)`
+
+## 4. Verify
+
+- [x] 4.1 Run `make check` in frontend to ensure lint and tests pass

--- a/openspec/changes/archive/2026-03-21-onboarding-guide-to-snack/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-21-onboarding-guide-to-snack/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-18

--- a/openspec/changes/archive/2026-03-21-onboarding-guide-to-snack/design.md
+++ b/openspec/changes/archive/2026-03-21-onboarding-guide-to-snack/design.md
@@ -1,0 +1,53 @@
+## Context
+
+The discover page currently uses a `<dialog popover="auto">` element with custom CSS to display a one-time onboarding guide. This component has poor visibility — the translucent gradient blends into the bubble canvas. Meanwhile, the app already has a mature `<snack-bar>` notification system with consistent styling, auto-dismiss, and fire-and-forget API via `IEventAggregator`.
+
+The snack-bar is used elsewhere (e.g., unfollow undo notifications in my-artists) and provides a well-tested, accessible notification pattern that users will already be familiar with by the time they reach other parts of the app.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Replace the custom onboarding popover with a snack-bar notification for visual consistency
+- Simplify `discovery-route` by removing ~50 lines of CSS, template markup, and ref/lifecycle logic
+- Maintain the same user experience: a brief instructional message shown once on discover entry during onboarding
+
+**Non-Goals:**
+- Modifying the snack-bar component itself (the existing API is sufficient)
+- Changing the onboarding flow progression (spotlight coach marks, step tracking)
+- Adding new snack-bar features (e.g., light-dismiss mode)
+
+## Decisions
+
+### 1. Use snack-bar (EventAggregator) instead of toast primitive
+
+**Decision**: Publish a `Snack` event in `attached()` rather than using the `<toast>` CE directly.
+
+**Why**: The `<toast>` CE is a low-level popover wrapper — using it would require reimplementing timer-based dismiss logic that snack-bar already provides. The onboarding guide is semantically a notification ("here's what to do"), which maps directly to snack-bar's purpose.
+
+**Alternative considered**: Using `<toast>` directly with manual timeout — rejected because it recreates snack-bar logic and diverges visually.
+
+### 2. Auto-dismiss with extended duration (5000 ms)
+
+**Decision**: Set `duration: 5000` on the Snack event instead of relying on light-dismiss.
+
+**Why**: The default 2500 ms is too short for first-time users to read the guide message. 5000 ms provides ample reading time. Auto-dismiss is preferable to light-dismiss because it removes the cognitive overhead of "dismiss this before interacting with bubbles" — users can start exploring immediately.
+
+### 3. Use `info` severity
+
+**Decision**: Use `severity: 'info'` for the onboarding snack.
+
+**Why**: The guide is informational, not a warning or error. The `info` severity provides the brand gradient styling (purple → blue) which aligns with the app's visual identity.
+
+### 4. No action button on the snack
+
+**Decision**: The onboarding snack has no action button — it is a passive, informational message.
+
+**Why**: The guide is a one-way notification. There is no meaningful action to take on the snack itself; the user's next action is to interact with the bubble canvas directly.
+
+## Risks / Trade-offs
+
+**[Position change: bottom → top]** → The snack-bar renders at the top of the viewport, while the current popover sits at the bottom center. This changes the visual flow but places the guide in a more conventional notification position that users expect. Acceptable trade-off for consistency.
+
+**[No light-dismiss]** → Users cannot tap to explicitly dismiss the snack. Mitigated by the 5000 ms auto-dismiss; the snack disappears before it becomes an obstacle. If needed in the future, a dismiss action could be added via `options.action`.
+
+**[No backdrop overlay]** → The current popover has a backdrop that dims the background, drawing attention. The snack-bar has no backdrop. Mitigated by the snack-bar's solid gradient background and top-positioned entry animation which naturally draws the eye.

--- a/openspec/changes/archive/2026-03-21-onboarding-guide-to-snack/proposal.md
+++ b/openspec/changes/archive/2026-03-21-onboarding-guide-to-snack/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+The onboarding popover guide on the discover page has poor visibility — its translucent gradient background blends into the bubble canvas, making it easy to miss. Replacing it with the existing snack-bar notification system unifies the visual language (tone & manner) across the app and leverages a proven, accessible notification pattern with better contrast and positioning.
+
+## What Changes
+
+- Remove the `<dialog popover="auto" class="onboarding-guide">` element from `discovery-route.html`
+- Remove the `onboardingGuide` ref, `showPopover()` call in `attached()`, and related template/CSS (~50 lines)
+- Publish a `Snack` event via `IEventAggregator` in `attached()` when `isOnboarding` is true, with a longer duration (4000–5000 ms) so users have time to read the message
+- The snack-bar's existing auto-dismiss replaces the popover's light-dismiss; no explicit tap is required to proceed to bubble interaction
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `onboarding-popover-guide`: Replace Popover API `<dialog>` with snack-bar notification. The guide message is now delivered as an `info`-severity snack instead of a standalone popover, changing dismiss behavior from light-dismiss to auto-dismiss.
+- `onboarding-guidance`: The discover page no longer renders a popover element for onboarding; guidance is handled by the global snack-bar component.
+
+## Impact
+
+- **Frontend only** — no backend, proto, or infrastructure changes
+- `discovery-route.ts` / `.html` / `.css`: Template simplification, CSS deletion
+- `snack-bar`: No changes needed (existing API supports this use case)
+- E2E test `onboarding-flow.spec.ts`: Update popover assertions to snack-bar assertions
+- Unit test `discovery-route.spec.ts`: Update `showPopover` mocks to `ea.publish(Snack)` assertions

--- a/openspec/changes/archive/2026-03-21-onboarding-guide-to-snack/specs/onboarding-guidance/spec.md
+++ b/openspec/changes/archive/2026-03-21-onboarding-guide-to-snack/specs/onboarding-guidance/spec.md
@@ -1,0 +1,34 @@
+## MODIFIED Requirements
+
+### Requirement: Onboarding guidance rendered within unified DiscoverPage
+The onboarding guidance SHALL be delivered as a snack-bar notification within the global `<snack-bar>` component, instead of as a Popover API element within `DiscoverPage`.
+
+#### Scenario: Onboarding user navigates to discover
+- **WHEN** `OnboardingService.isOnboarding` is `true` and the user navigates to `/discover`
+- **THEN** the onboarding snack notification SHALL be shown via `ea.publish(new Snack(...))`
+- **AND** the search bar and genre filter SHALL also be available
+- **AND** the discover page grid SHALL have 3 rows (`auto auto 1fr`), not 4
+
+#### Scenario: Normal user navigates to discover
+- **WHEN** `OnboardingService.isOnboarding` is `false` and the user navigates to `/discover`
+- **THEN** no onboarding notification SHALL appear
+- **AND** no CTA button SHALL be shown (bottom navigation provides transitions)
+
+#### Scenario: CTA button removed during onboarding
+- **REMOVED**: The "ダッシュボードを生成する" CTA button is removed from the discover page. The CTA is replaced by a coach mark spotlight on the nav-bar Dashboard icon (defined in `onboarding-tutorial` Step 1 completion).
+
+**Reason**: The nav-bar Dashboard icon spotlight teaches users about navigation while serving as the CTA. A separate button is redundant.
+**Migration**: Remove the `complete-button-wrapper` and `complete-button` elements from `discover-page.html`. CTA behavior is handled by the coach mark component targeting `[data-nav-dashboard]`.
+
+### Requirement: No z-index stacking in discovery page CSS
+The discovery page SHALL NOT use `z-index` for visual stacking. The snack-bar renders in the top layer automatically via Popover API; all other layer ordering SHALL be achieved through DOM source order.
+
+#### Scenario: Overlay elements paint above canvas
+- **WHEN** the discovery page renders
+- **THEN** the orb label SHALL paint above the canvas via DOM order
+- **AND** no CSS `z-index` property SHALL be present in the discovery page CSS
+
+#### Scenario: Snack notification renders in top layer
+- **WHEN** the onboarding snack is shown
+- **THEN** it SHALL render in the browser's top layer via the snack-bar's Popover API usage
+- **AND** no manual `z-index` management SHALL be needed

--- a/openspec/changes/archive/2026-03-21-onboarding-guide-to-snack/specs/onboarding-popover-guide/spec.md
+++ b/openspec/changes/archive/2026-03-21-onboarding-guide-to-snack/specs/onboarding-popover-guide/spec.md
@@ -1,0 +1,44 @@
+## MODIFIED Requirements
+
+### Requirement: Popover guide on discover page entry during onboarding
+The system SHALL display a one-time instructional snack notification when an onboarding user navigates to the discover page, using the existing snack-bar component with auto-dismiss behavior.
+
+#### Scenario: Snack notification appears on onboarding entry
+- **WHEN** `OnboardingService.isOnboarding` is `true` and the user navigates to `/discover`
+- **THEN** the system SHALL publish a `Snack` event via `IEventAggregator` in the `attached()` lifecycle
+- **AND** the snack SHALL have `severity: 'info'` and `duration: 5000`
+- **AND** the snack SHALL display the localized message from `discovery.popoverGuide`
+- **AND** the snack SHALL render at the top of the viewport via the global `<snack-bar>` component
+
+#### Scenario: Snack auto-dismisses after duration
+- **WHEN** the snack is visible and 5000 ms have elapsed
+- **THEN** the snack SHALL auto-dismiss via the snack-bar's built-in timer
+- **AND** no explicit user action SHALL be required to dismiss the notification
+
+#### Scenario: Non-onboarding user does not see snack
+- **WHEN** `OnboardingService.isOnboarding` is `false` and the user navigates to `/discover`
+- **THEN** no `Snack` event SHALL be published
+- **AND** no onboarding notification SHALL appear
+
+#### Scenario: Snack shown only once per page visit
+- **WHEN** the snack has been published and the user remains on `/discover`
+- **THEN** the snack SHALL NOT be published again during the same page visit
+- **AND** if the user navigates away and returns to `/discover` while still onboarding, the snack MAY appear again
+
+## REMOVED Requirements
+
+### Requirement: Popover dismissed via light-dismiss
+**Reason**: Replaced by snack-bar auto-dismiss. The snack-bar uses `popover="manual"` with timer-based dismissal instead of `popover="auto"` light-dismiss.
+**Migration**: Remove `<dialog popover="auto">` element and `.onboarding-guide` CSS from `discovery-route`. The snack-bar handles display and dismissal.
+
+### Requirement: Popover entry animation uses CSS only
+**Reason**: The snack-bar component provides its own entry/exit animations. Custom CSS animations for the popover guide are no longer needed.
+**Migration**: Remove `.onboarding-guide` CSS block (~50 lines including `@starting-style`, `:popover-open`, and backdrop rules) from `discovery-route.css`.
+
+### Requirement: Popover exit animation
+**Reason**: Handled by snack-bar's built-in exit transition.
+**Migration**: No action needed — removed with the `.onboarding-guide` CSS block.
+
+### Requirement: Respects prefers-reduced-motion
+**Reason**: The snack-bar component handles reduced-motion preferences in its own CSS.
+**Migration**: No action needed — the snack-bar's existing reduced-motion handling applies.

--- a/openspec/changes/archive/2026-03-21-onboarding-guide-to-snack/tasks.md
+++ b/openspec/changes/archive/2026-03-21-onboarding-guide-to-snack/tasks.md
@@ -1,0 +1,27 @@
+## 1. Template and ViewModel cleanup
+
+- [x] 1.1 Remove `<dialog popover="auto" class="onboarding-guide">` element from `discovery-route.html`
+- [x] 1.2 Remove `onboardingGuide` ref property from `discovery-route.ts`
+- [x] 1.3 Remove `showPopover()` call from `attached()` in `discovery-route.ts`
+- [x] 1.4 Inject `IEventAggregator` and `I18N` into `DiscoveryRoute` (if not already injected)
+- [x] 1.5 Publish `new Snack(this.i18n.tr('discovery.popoverGuide'), 'info', { duration: 5000 })` in `attached()` when `isOnboarding` is true
+
+## 2. CSS cleanup
+
+- [x] 2.1 Remove `.onboarding-guide` CSS block from `discovery-route.css` (including `@starting-style`, `:popover-open`, `::backdrop` rules)
+
+## 3. Unit tests
+
+- [x] 3.1 Remove `showPopover` mock tests from `discovery-route.spec.ts`
+- [x] 3.2 Add test: when onboarding, `attached()` publishes a `Snack` event with correct message, severity `info`, and duration `5000`
+- [x] 3.3 Add test: when not onboarding, `attached()` does not publish a `Snack` event
+
+## 4. E2E tests
+
+- [x] 4.1 Update `onboarding-flow.spec.ts` Step 1 assertions: replace `.onboarding-guide` popover checks with snack-bar `.snack-item` visibility assertions
+- [x] 4.2 Remove light-dismiss test (click-outside-to-close) — replaced by auto-dismiss behavior
+
+## 5. Verification
+
+- [x] 5.1 Run `make check` in frontend (lint + test)
+- [x] 5.2 Run `npx playwright test onboarding-flow` to verify E2E

--- a/openspec/changes/archive/2026-03-21-refactor-my-artists-table/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-21-refactor-my-artists-table/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-20

--- a/openspec/changes/archive/2026-03-21-refactor-my-artists-table/design.md
+++ b/openspec/changes/archive/2026-03-21-refactor-my-artists-table/design.md
@@ -1,0 +1,89 @@
+## Context
+
+The My Artists page currently renders artist hype settings as `<ul>/<li>` rows with a detached `<header class="hype-legend">` acting as a column header row. The two structures stay aligned only by sharing an identical `grid-template-columns: 2fr repeat(4, 1fr)` definition across three separate scopes (legend, row-content, hype-inline-slider). This is fragile and semantically incorrect.
+
+The `hype-inline-slider` custom element wraps a `<fieldset>` that is used simultaneously as a CSS Grid container and a `position: relative` containing block for the decorative track line. Browser UA stylesheets apply an internal top padding to `<fieldset>` elements to accommodate `<legend>` placement — this cannot be fully reset with CSS — causing `inset-block-start: 50%` on the track element to resolve against the wrong height, producing the visible vertical offset bug.
+
+The swipe-to-dismiss pattern uses `scroll-snap-type: x mandatory` on each `<li>`. This is incompatible with `<table><tr>` layout and is being removed in favour of an explicit delete `<button>` — a more discoverable and accessible interaction.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Replace `<ul>/<li>` + detached legend with a semantically correct `<fieldset>`-wrapped `<table>`
+- Move `<thead>` column headers to where they belong, eliminating the legend/header sync problem
+- Eliminate the `hype-slider-track` vertical offset bug by removing the `<fieldset>`-as-grid-container anti-pattern
+- Preserve identical dot slider visuals (size, glow, pulse animation, 44px tap targets)
+- Replace swipe-to-dismiss with a `<button>` delete action in the last `<td>` of each row
+- Preserve Undo toast behaviour unchanged
+- Preserve View Transition row removal animation (`view-transition-name` on `<tr>`)
+- Delete `hype-inline-slider` component entirely
+
+**Non-Goals:**
+- No changes to hype RPC calls or backend
+- No changes to onboarding spotlight targeting logic (target selector will change — see Risks)
+- No Grid (Festival) view changes
+- No new animations or visual redesign beyond parity with current dot style
+
+## Decisions
+
+### D1: `<fieldset>` wraps the entire `<table>`, not individual rows
+
+**Decision**: One `<fieldset>` with `<legend class="visually-hidden">My Artists</legend>` wraps the whole `<table>`. Radio inputs within `<td>` cells share `name="hype-{artistId}"` for grouping.
+
+**Why**: The memo.md pattern (notification settings) maps directly — `<fieldset>` labels the overall setting group; `<thead>/<th scope="col">` labels the columns; `<th scope="row">` labels each artist. This gives screen readers full row/column context automatically without any additional ARIA.
+
+**Alternative considered**: One `<fieldset>` per artist row (wrapping the 4 radios). Rejected — this would nest `<fieldset>` inside `<td>`, which is valid HTML but loses the column-header association that `<table>` provides for free.
+
+### D2: `hype-inline-slider` component is deleted, not kept as a thin wrapper
+
+**Decision**: The component is deleted. Dot markup (`<label>/<input type="radio">/<span class="hype-dot">`) moves directly into each `<td>` in `my-artists-route.html`. Dot CSS moves into `my-artists-route.css`.
+
+**Why**: The component's only job was to render 4 radio stops with a track line and dots. Inside a `<table>`, the `<td>` is the natural container — the component wrapper adds complexity with no benefit.
+
+**Alternative considered**: Keep `hype-inline-slider` and render it inside `<td>`. Rejected — the fieldset/grid container issues would persist and the track alignment problem only moves, not disappears.
+
+### D3: Track line rendered via `<td>::before` pseudo-element on hype cells
+
+**Decision**: The decorative 2px track line is rendered as `::before` on each hype `<td>` (`.hype-col`), positioned absolutely from the dot center (`inset-inline-start: 50%`) with `inline-size: 100%`. This creates a chain of segments connecting adjacent dots. `z-index` keeps the line below the dot.
+
+**Why**: `<tr>` pseudo-elements (`::before`/`::after`) have unreliable behaviour in the table anonymous-box structure — browsers may generate anonymous table cells around them, causing layout artifacts. `<td>` is a reliable `position: relative` containing block. `inset-block-start: 50%` resolves against the `<td>` height (not a `<fieldset>` UA-padded height), so vertical centering is exact.
+
+**Alternative considered**: Track line as `<tr>::after` spanning hype columns. Rejected — `<tr>` pseudo-elements are placed inside table anonymous box structure and can produce unreliable containing blocks across browsers.
+
+### D4: Delete action as `<button>` in final `<td>`, always visible
+
+**Decision**: Each `<tr>` ends with a `<td class="artist-remove-col">` containing `<button type="button" aria-label="Remove {name}" click.trigger="unfollowArtist(artist)">`. The button is always visible (icon only, subtle colour until hover/focus).
+
+**Why**: Swipe-to-dismiss has zero discoverability and is inaccessible to keyboard and AT users. An always-visible button solves both problems. The Undo toast (5s) already provides the safety net — no confirmation dialog needed.
+
+**Alternative considered**: Keep swipe-to-dismiss alongside the button. Rejected — maintaining two deletion paths adds complexity and `scroll-snap` is incompatible with `<tr>`.
+
+### D5: `<tbody><tr>` carries `view-transition-name`
+
+**Decision**: `view-transition-name` is set via inline style `css="--_vt-name: artist-${artist.artist.id}"` on `<tr>`, and `view-transition-name: var(--_vt-name)` in CSS — identical to the current `<li>` pattern.
+
+**Why**: View Transitions work on any element, not just `<li>`. The `startViewTransition` wrapper in `executeDismiss` remains unchanged.
+
+## Risks / Trade-offs
+
+- **Onboarding spotlight target changes** → The spotlight currently targets `.artist-list` (the `<ul>`). After this change, the equivalent is the `<table>` or `<tbody>`. The selector in `my-artists-route.ts` `activateSpotlight()` call must be updated. Low risk — single call site.
+
+- **`<tr>` as `position: relative`** → CSS spec historically did not guarantee `position: relative` on `<tr>` creates a containing block. Modern browsers (Chrome 85+, Firefox 80+, Safari 16+) all support it. Given the PWA's minimum browser targets, this is safe.
+
+- **`<table>` styling constraints** → `border-radius` on `<tr>` requires `border-collapse: separate` on `<table>`. The current card-style row borders need to move from `<li>` to `<tr>` with appropriate `border-spacing`.
+
+- **`display: contents` on `<fieldset>` not needed** → Since `<fieldset>` wraps `<table>` (not acting as the grid container), the UA padding quirk does not apply. No `display: contents` workaround required.
+
+## Migration Plan
+
+1. Delete `src/components/hype-inline-slider/` (3 files)
+2. Rewrite `my-artists-route.html` with the new `<fieldset>/<table>` structure
+3. Rewrite `my-artists-route.css` — remove scroll-snap/dismiss styles, add table styles and dot CSS (moved from hype-inline-slider)
+4. Update `my-artists-route.ts` — remove scroll-snap dismiss logic (`checkDismiss`, `executeDismiss`, `dismissingIds`); update `activateSpotlight` target selector
+5. Update `openspec/specs/my-artists/spec.md` and `openspec/specs/hype-inline-slider/spec.md`
+
+Rollback: revert the 3 changed files and restore the deleted component. No DB or API changes to roll back.
+
+## Open Questions
+
+_(none — all decisions resolved in exploration)_

--- a/openspec/changes/archive/2026-03-21-refactor-my-artists-table/proposal.md
+++ b/openspec/changes/archive/2026-03-21-refactor-my-artists-table/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+The My Artists list view uses a `<ul>/<li>` structure with a separate sticky header (`hype-legend`) to represent what is fundamentally tabular data: artists (rows) × hype levels (columns) × radio selection (cells). This mismatch forces a fragile 3-layer CSS grid synchronisation to keep column alignment, introduces broken semantics (`<section>` without heading, `<header>` as a flex wrapper, `<div>` for an interactive dismiss action), and causes a persistent layout bug where the `hype-slider-track` is vertically offset due to `<fieldset>` UA stylesheet quirks. Replacing the structure with a semantic `<table>` wrapped in a `<fieldset>` resolves all of these issues at once.
+
+## What Changes
+
+- Replace `<ul class="artist-list">` + `<header class="hype-legend">` with a `<fieldset>`-wrapped `<table>` where `<thead>` carries the hype-level column headers and each `<tbody><tr>` is one artist row
+- Remove the `hype-inline-slider` custom element; dot radio inputs move directly into table `<td>` cells, keeping identical visual style (dot glows, pulse animation, 44px tap targets)
+- Remove swipe-to-dismiss (`scroll-snap-type`, `dismiss-end`, `checkDismiss`, `executeDismiss`, `dismissingIds`); replace with an explicit `<button>` in the final `<td>` of each row — Undo toast behaviour is preserved unchanged
+- Fix `<section class="artist-row-content">` → `<div>` (layout wrapper, not a thematic region)
+- Fix `<header class="artist-identity">` → `<div>` (not introductory content)
+- Fix `<div class="dismiss-end">` → `<button type="button" aria-label="…">` (interactive element must be a button)
+- **BREAKING**: `hype-inline-slider` component is deleted; any other consumer must migrate to the table cell pattern or a standalone radio group
+
+## Capabilities
+
+### New Capabilities
+
+_(none — this is a refactor of existing UI)_
+
+### Modified Capabilities
+
+- `my-artists`: Row layout changes from scroll-snap `<li>` to `<tr>`; swipe-to-dismiss removed; delete button added to row
+- `hype-inline-slider`: Component deleted; dot slider visual moved into `my-artists` table cells
+
+## Impact
+
+- **Deleted files**: `src/components/hype-inline-slider/` (3 files: `.ts`, `.html`, `.css`)
+- **Modified files**: `src/routes/my-artists/my-artists-route.html`, `my-artists-route.css`, `my-artists-route.ts`
+- **Spec updates**: `openspec/specs/my-artists/spec.md`, `openspec/specs/hype-inline-slider/spec.md`
+- **No backend changes** — hype RPC calls remain identical
+- **No routing changes**

--- a/openspec/changes/archive/2026-03-21-refactor-my-artists-table/specs/hype-inline-slider/spec.md
+++ b/openspec/changes/archive/2026-03-21-refactor-my-artists-table/specs/hype-inline-slider/spec.md
@@ -1,0 +1,19 @@
+## REMOVED Requirements
+
+### Requirement: Sticky Header Legend
+
+**Reason**: The detached `<header class="hype-legend">` + shared `grid-template-columns` sync pattern is replaced by a proper `<thead>` with `<th scope="col">` elements inside the `<table>`. Column alignment is guaranteed structurally by the table layout engine, not by duplicated CSS grid definitions.
+
+**Migration**: Remove `<header class="hype-legend">` from `my-artists-route.html`. Remove `.hype-legend` and `.hype-legend-item` CSS rules. Hype column labels move to `<th scope="col">` in `<thead>`.
+
+### Requirement: Inline Dot Slider
+
+**Reason**: The `hype-inline-slider` custom element is deleted. Its visual output (dot radio stops, track line, glow effects) is now rendered directly in the `<table>` cells of `my-artists-route.html`. The `<fieldset>/<legend>` pattern for grouping radio inputs is superseded by `<table>` column/row headers which provide the same semantic association automatically.
+
+**Migration**: Delete `src/components/hype-inline-slider/hype-inline-slider.ts`, `.html`, and `.css`. Move `.hype-slider-dot` styles and `@keyframes dot-pulse` to `my-artists-route.css`. The `<fieldset>` now wraps the entire table (see `my-artists` spec).
+
+### Requirement: Slider dot positions align with header columns
+
+**Reason**: Column alignment is now inherent to `<table>` layout. No CSS grid synchronisation is needed.
+
+**Migration**: Remove `grid-template-columns: 2fr repeat(4, 1fr)` from `hype-inline-slider`, `artist-row-content`, and `hype-legend`. Table column widths handle alignment automatically.

--- a/openspec/changes/archive/2026-03-21-refactor-my-artists-table/specs/my-artists/spec.md
+++ b/openspec/changes/archive/2026-03-21-refactor-my-artists-table/specs/my-artists/spec.md
@@ -1,0 +1,91 @@
+## MODIFIED Requirements
+
+### Requirement: Artist List Row
+
+The My Artists list view SHALL render artist hype settings as a semantic HTML table wrapped in a `<fieldset>`. Each artist is a `<tr>` in the `<tbody>`; hype level columns are defined by `<th scope="col">` in the `<thead>`. The `<fieldset>` groups the entire table as a single form control group with a visually hidden `<legend>`.
+
+#### Scenario: Table structure renders correctly
+
+- **WHEN** the My Artists page renders in list view with at least one followed artist
+- **THEN** the system SHALL render a `<fieldset>` containing a `<table>`
+- **AND** the `<fieldset>` SHALL have a visually hidden `<legend>` that names the group
+- **AND** the `<thead>` SHALL contain one `<tr>` with column headers: artist name, 👀 チェック, 🔥 地元, 🔥🔥 近くも, 🔥🔥🔥 どこでも！, and a visually hidden "Remove" column header
+- **AND** each `<th scope="col">` in `<thead>` SHALL be sticky at the top of the scroll container with `backdrop-filter: blur(8px)`
+
+#### Scenario: Artist row layout
+
+- **WHEN** an artist row is rendered in list view
+- **THEN** the row SHALL be a `<tr>` with a `<th scope="row">` for the artist name and four `<td>` cells for hype level radio inputs
+- **AND** the artist name SHALL include a decorative color indicator dot (aria-hidden) and truncate with ellipsis if it exceeds available space
+- **AND** a final `<td>` SHALL contain a delete button for that artist
+- **AND** the row SHALL carry a `view-transition-name` via CSS custom property for animated removal
+
+#### Scenario: Dot radio input renders per hype cell
+
+- **WHEN** a hype `<td>` renders
+- **THEN** the cell SHALL contain a `<label>` wrapping a visually hidden `<input type="radio">` and a visible `<span class="hype-dot">`
+- **AND** all four radio inputs in a row SHALL share the same `name` attribute scoped to the artist ID
+- **AND** the active dot SHALL be 14px; inactive dots SHALL be 8px
+- **AND** each dot SHALL have a minimum 44×44px transparent tap target
+
+#### Scenario: Dot visual reflects hype tier
+
+- **WHEN** the slider renders with a specific hype level selected
+- **THEN** the active dot SHALL apply CSS effects based on hype level:
+  - watch: `1px solid white/10` border, no glow
+  - home: artist-color border at 40% opacity, `box-shadow: 0 0 8px` at 30%
+  - nearby: artist-color `2px solid` border, `box-shadow: 0 0 16px` at 50%, gentle pulse animation
+  - away: animated border, layered glow (`0 0 24px` at 60% + `0 0 48px` at 20%), strong pulse animation
+- **AND** the artist color SHALL be applied via `--_dot-color` CSS custom property on the `<tr>`
+
+#### Scenario: Decorative track line renders between dots
+
+- **WHEN** an artist row renders
+- **THEN** a 2px horizontal track line SHALL be visible connecting the four dot positions
+- **AND** the track line SHALL be vertically centered in the row
+- **AND** the track line SHALL be rendered as a CSS `::before` pseudo-element on each hype `<td>` (`.hype-col`), chaining from the dot center to the next cell
+
+#### Scenario: Reduced motion preference
+
+- **WHEN** the user has `prefers-reduced-motion: reduce` enabled
+- **THEN** all pulse animations on active dots SHALL be disabled
+- **AND** static border and glow styles SHALL remain visible
+
+#### Scenario: Delete button unfollows artist
+
+- **WHEN** the user taps the delete button in an artist row
+- **THEN** the system SHALL optimistically remove the artist from the list
+- **AND** if the View Transitions API is available, the remaining rows SHALL animate smoothly to fill the gap
+- **AND** the system SHALL display an Undo snack with a 5-second timeout
+- **AND** if the user taps Undo within 5 seconds, the artist SHALL be re-inserted at their original position
+- **AND** if the Undo snack dismisses without Undo, the system SHALL commit the unfollow via RPC with 1 retry
+
+#### Scenario: Unfollow button is accessible
+
+- **WHEN** an unfollow button renders in an artist row
+- **THEN** it SHALL be a `<button type="button">` element
+- **AND** it SHALL carry an i18n `aria-label` that includes the artist name (e.g., "Unfollow Suchmos")
+- **AND** the trash icon inside SHALL have `aria-hidden="true"`
+
+#### Scenario: Onboarding completes on hype interaction
+
+- **WHEN** the user is on the MY_ARTISTS onboarding step and taps a hype dot
+- **THEN** the system SHALL revert the hype change (no mutation)
+- **AND** SHALL deactivate the spotlight
+- **AND** SHALL advance onboarding to COMPLETED
+- **AND** SHALL stay on the My Artists page (no navigation)
+- **AND** the signup prompt banner SHALL remain visible for unauthenticated users
+
+## REMOVED Requirements
+
+### Requirement: Artist List Row (swipe-to-dismiss)
+
+**Reason**: The scroll-snap swipe-to-dismiss interaction has zero discoverability, is inaccessible to keyboard and AT users, and is incompatible with `<table><tr>` layout. The Undo toast provides the same safety net. Replaced by an explicit delete button in the row.
+
+**Migration**: Remove `scroll-snap-type: x mandatory` from rows. Remove `checkDismiss`, `executeDismiss`, and `dismissingIds` from `my-artists-route.ts`. Remove `.dismiss-end` element and styles.
+
+### Requirement: Hype slider replaces passion icon
+
+**Reason**: The `hype-inline-slider` custom element is deleted. Dot radio inputs are now rendered directly in `<td>` cells within the table structure. The visual style is preserved.
+
+**Migration**: Remove `<import>` of `hype-inline-slider` from `my-artists-route.html`. Delete `src/components/hype-inline-slider/` directory.

--- a/openspec/changes/archive/2026-03-21-refactor-my-artists-table/tasks.md
+++ b/openspec/changes/archive/2026-03-21-refactor-my-artists-table/tasks.md
@@ -1,0 +1,50 @@
+## 1. Delete hype-inline-slider component
+
+- [x] 1.1 Delete `src/components/hype-inline-slider/hype-inline-slider.ts`
+- [x] 1.2 Delete `src/components/hype-inline-slider/hype-inline-slider.html`
+- [x] 1.3 Delete `src/components/hype-inline-slider/hype-inline-slider.css`
+
+## 2. Rewrite my-artists-route.html
+
+- [x] 2.1 Remove `<import>` of `hype-inline-slider`
+- [x] 2.2 Replace `<header class="hype-legend">` + `<ul class="artist-list">` with `<fieldset>` wrapping a `<table>`
+- [x] 2.3 Add `<legend class="visually-hidden">` inside `<fieldset>`
+- [x] 2.4 Build `<thead>` with sticky `<tr>` containing `<th scope="col">` for: artist name, 👀 チェック, 🔥 地元, 🔥🔥 近くも, 🔥🔥🔥 どこでも！, and visually-hidden "Remove" column
+- [x] 2.5 Build `<tbody>` with `repeat.for` on `<tr>` — carry `css="--_vt-name: ...;  --_dot-color: ..."` on `<tr>`
+- [x] 2.6 Add `<th scope="row">` with color indicator dot (`aria-hidden="true"`) and artist name (ellipsis truncation)
+- [x] 2.7 Add four hype `<td>` cells each containing `<label>` → visually hidden `<input type="radio">` + `<span class="hype-dot" data-active.bind data-level.bind>`
+- [x] 2.8 Add delete `<td>` containing `<button type="button" aria-label.bind click.trigger="unfollowArtist(artist)">` with `<svg-icon name="trash" aria-hidden="true">`
+- [x] 2.9 Wire `change.trigger="onHypeInput(artist)"` on the radio inputs
+
+## 3. Rewrite my-artists-route.css
+
+- [x] 3.1 Remove `.hype-legend`, `.hype-legend-item` rules
+- [x] 3.2 Remove `.artist-list`, `.artist-row`, `.artist-row-content`, `.artist-identity`, `.artist-row-indicator`, `.artist-row-name`, `.dismiss-end` rules
+- [x] 3.3 Remove `scroll-snap` related CSS
+- [x] 3.4 Add `<fieldset>` reset styles (border, padding, margin)
+- [x] 3.5 Add `<table>` styles: `border-collapse: separate`, `border-spacing`, scroll container
+- [x] 3.6 Add sticky `<thead>` styles with `backdrop-filter: blur(8px)`
+- [x] 3.7 Style `<th scope="row">` (artist name cell: flex, indicator dot, ellipsis)
+- [x] 3.8 Style hype `<td>` cells (centered, min tap area)
+- [x] 3.9 Move `.hype-slider-dot` base styles, `data-active`/`data-level` dot variant styles, and `@keyframes dot-pulse` from `hype-inline-slider.css` into `@layer block` (under `@scope (my-artists-route)`) — variant styles are nested inside `.hype-dot { &[data-active]... }` which keeps them in block layer; `cube/data-attr-naming` only permits `data-state`/`data-variant`/`data-theme` in exception layer
+- [x] 3.10 Add `<td>::before` track line on `.hype-col` cells: `position: absolute; inset-block-start: 50%; inset-inline-start: 50%; inline-size: 100%; block-size: 2px; z-index: 0` — creates a chain of segments connecting adjacent dots (see D3)
+- [x] 3.11 Add delete button styles (icon-only, subtle until hover/focus)
+- [x] 3.12 Add `view-transition-name: var(--_vt-name)` on `<tr>`
+
+## 4. Update my-artists-route.ts
+
+- [x] 4.1 Remove `checkDismiss` method
+- [x] 4.2 Remove `executeDismiss` method
+- [x] 4.3 Remove `dismissingIds` Set field
+- [x] 4.4 Make `unfollowArtist` public (currently private, now called from template button)
+- [x] 4.5 Update `activateSpotlight` target selector from `.artist-list` to the new table target (e.g. `[data-artist-rows]` attribute on `<tbody>`)
+
+## 5. Verify onboarding spotlight target
+
+- [x] 5.1 Add `data-artist-rows` attribute to `<tbody>` in the template
+- [ ] 5.2 Confirm spotlight correctly highlights all artist rows (not the thead) in the dev environment
+
+## 6. Lint and tests
+
+- [x] 6.1 Run `make lint` and fix any issues
+- [x] 6.2 Run `make test` and fix any broken tests

--- a/openspec/changes/fix-onboarding-progression-bugs/.openspec.yaml
+++ b/openspec/changes/fix-onboarding-progression-bugs/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-19

--- a/openspec/changes/fix-onboarding-progression-bugs/design.md
+++ b/openspec/changes/fix-onboarding-progression-bugs/design.md
@@ -1,0 +1,89 @@
+## Context
+
+The onboarding flow on dev (`dev.liverty-music.app`) has three bugs discovered during manual testing:
+
+1. `ConcertService/ListWithProximity` returns 401 for guest users because it is missing from the backend auth interceptor's public method whitelist — despite the concert-service spec explicitly stating it does not require authentication.
+2. On the My Artists page, the coach mark's click-blocker layer covers the hype sliders, making it impossible for the user to interact with them and complete onboarding. The `activateSpotlight` call omits the `onTap` callback.
+3. The deployed BSR package (`@buf/liverty-music_schema.connectrpc_es`) is stale — `TicketJourneyService.listByUser` exists in the proto definition but is missing at runtime, causing a `TypeError`.
+
+Current auth whitelist in `backend/internal/di/provider.go`:
+```
+ArtistService/ListTop, ListSimilar, Search
+ConcertService/List, SearchNewConcerts, ListSearchStatuses
+```
+`ConcertService/ListWithProximity` is absent.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Guest onboarding users can fetch proximity-grouped concerts without authentication
+- My Artists onboarding step allows hype slider interaction to complete the flow
+- BSR package is up-to-date so `TicketJourneyRpcClient.listByUser` works at runtime
+
+**Non-Goals:**
+- Changing the coach mark component's general architecture
+- Adding new onboarding steps or modifying the step order
+- Fixing the lane introduction UX when concert data is legitimately empty
+
+## Decisions
+
+### D1: Add `ListWithProximity` to public procedures whitelist
+
+Add one entry to the `publicProcedures` map in `backend/internal/di/provider.go`:
+
+```go
+"/" + concertconnect.ConcertServiceName + "/ListWithProximity": true,
+```
+
+**Why**: The spec already defines this as a public RPC. The handler comment says "Authentication is not required." This is a missing configuration, not a design gap.
+
+**Alternative considered**: Making the frontend pass a guest token or service account credential during onboarding. Rejected — adds unnecessary complexity when the RPC is designed to be public.
+
+### D2: Dismiss coach mark on tap, then let user interact with sliders
+
+On the My Artists onboarding step, provide an `onTap` callback to `activateSpotlight` that deactivates the spotlight. This reveals the hype sliders underneath, which the user can then interact with to complete onboarding via the existing `onHypeChanged` handler.
+
+```
+Step 5: My Artists
+┌────────────────────────┐     ┌────────────────────────┐     ┌────────────────────────┐
+│ Coach mark active       │     │ Sliders accessible      │     │ Onboarding complete     │
+│ [data-hype-header] lit  │────▶│ User adjusts hype       │────▶│ deactivateSpotlight()  │
+│ "熱量を上げておこう"     │ tap │ onHypeChanged fires     │     │ setStep(COMPLETED)      │
+└────────────────────────┘     └────────────────────────┘     └────────────────────────┘
+```
+
+In `my-artists-route.ts`, change from:
+```typescript
+this.onboarding.activateSpotlight(
+  '[data-hype-header]',
+  '絶対に見逃したくないアーティストの熱量を上げておこう',
+)
+```
+To:
+```typescript
+this.onboarding.activateSpotlight(
+  '[data-hype-header]',
+  '絶対に見逃したくないアーティストの熱量を上げておこう',
+  () => this.onboarding.deactivateSpotlight(),
+)
+```
+
+**Why**: Minimal change. Reuses the existing `onTap` callback mechanism and `deactivateSpotlight()`. The user taps the spotlight target (hype header) → spotlight dismisses → sliders become interactive → hype change completes onboarding.
+
+**Alternative considered**: Modifying `onBlockerClick()` to support a dismissal callback so tapping anywhere outside the target also dismisses. This would require changing the coach-mark component API. Could be a follow-up improvement but is not needed to unblock the flow — tapping the highlighted target is the natural action.
+
+### D3: Update BSR package via `npm install`
+
+Run `npm install` in the frontend to pull the latest BSR package version that includes the `TicketJourneyService.listByUser` RPC. Then redeploy.
+
+**Why**: The lock file references commit `72ea9d75f704` (March 19) but the installed version is `019227fea01d` (March 18). A fresh install resolves to the latest version matching the semver range in `package.json`.
+
+## Risks / Trade-offs
+
+- **[Risk] Coach mark tap target may be small on mobile** → The `[data-hype-header]` element is a sticky header spanning full width, so it should be easy to tap. If users still struggle, a follow-up can add `onBlockerClick` dismissal.
+- **[Risk] BSR package version drift** → After `npm install`, the lock file will update. CI must rebuild with the new lock file. Low risk since this is a dev environment fix.
+- **[Risk] Other public RPCs may also be missing from whitelist** → Out of scope for this change, but worth auditing. The `ListWithProximity` omission was introduced when the RPC was added in a recent PR.
+
+## Open Questions
+
+(none — all decisions are straightforward implementation fixes)

--- a/openspec/changes/fix-onboarding-progression-bugs/proposal.md
+++ b/openspec/changes/fix-onboarding-progression-bugs/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+The onboarding flow on dev has three bugs that together create a progression-blocking experience. After selecting a Home area, `ConcertService/ListWithProximity` returns 401 because the backend auth interceptor does not whitelist this public RPC. With no concert data, the lane introduction is skipped entirely, jumping the user straight to the My Artists spotlight. On the My Artists page, the coach mark's click-blocker covers the hype sliders that the user must interact with to complete onboarding — creating a deadlock where no tap can advance the flow. A secondary warning (`TicketJourneyRpcClient.listByUser is not a function`) indicates the deployed BSR package is stale.
+
+## What Changes
+
+- **Backend**: Add `ConcertService/ListWithProximity` to the auth interceptor's public-method whitelist so unauthenticated onboarding users can fetch concert data.
+- **Frontend**: Fix the My Artists coach mark so the user can interact with hype sliders while the spotlight is active — either by providing an `onTap` dismissal callback, by opening a click-through window over the artist list area, or both.
+- **Frontend**: Update the BSR package (`@buf/liverty-music_schema.connectrpc_es`) to resolve the `listByUser` runtime TypeError.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `concert-service`: `ListWithProximity` is specified as public but the backend auth interceptor blocks it — implementation must match the existing spec requirement.
+- `onboarding-spotlight`: The click-blocker layer must allow interaction with elements below the spotlight target when the onboarding step expects sub-target interaction (hype sliders on My Artists).
+
+## Impact
+
+- **backend**: Auth interceptor configuration (public method whitelist) — no proto changes needed.
+- **frontend**: Coach mark component CSS/logic for click-through on My Artists step; BSR dependency update in `package.json` / `package-lock.json`.
+- **No breaking changes**. No spec-level requirement changes — the existing specs already describe the correct behavior; this change fixes implementation gaps.

--- a/openspec/changes/fix-onboarding-progression-bugs/specs/concert-service/spec.md
+++ b/openspec/changes/fix-onboarding-progression-bugs/specs/concert-service/spec.md
@@ -1,0 +1,48 @@
+## MODIFIED Requirements
+
+### Requirement: List Concerts with Proximity for Unauthenticated Users
+
+The system SHALL provide a public RPC `ListWithProximity` that accepts a list of artist IDs and a Home, returning concerts grouped by date and classified by proximity. This RPC does not require authentication and shares the same `GroupByDateAndProximity` logic as `ListByFollower`. The backend auth interceptor SHALL include `ListWithProximity` in its public method whitelist so that requests without a bearer token are accepted.
+
+#### Scenario: Unauthenticated guest calls ListWithProximity
+
+- **WHEN** `ListWithProximity` is called without an `Authorization` header (e.g., during onboarding as a guest user)
+- **THEN** the auth interceptor SHALL allow the request through without returning `UNAUTHENTICATED`
+- **AND** the RPC SHALL return proximity-grouped concerts normally
+
+#### Scenario: Successful proximity-grouped listing
+
+- **WHEN** `ListWithProximity` is called with one or more `artist_ids` and a valid `Home` (country_code + level_1)
+- **THEN** it SHALL return concerts grouped by date using `ProximityGroup` messages
+- **AND** each `ProximityGroup` SHALL contain concerts classified into `home`, `nearby`, and `away` fields based on `Concert.ProximityTo(home)`
+- **AND** each concert SHALL include a resolved `Venue` object with `name`, `admin_area`, and coordinates
+- **AND** each concert SHALL include `listed_venue_name` with the raw scraped venue name
+- **AND** groups SHALL be ordered by date ascending
+
+#### Scenario: Home centroid resolved server-side
+
+- **WHEN** `ListWithProximity` is called with `Home.level_1` (e.g., "JP-40")
+- **THEN** the backend SHALL resolve the centroid from `level_1` using `geo.ResolveCentroid()`
+- **AND** the resolved centroid SHALL be used for Haversine distance calculation in proximity classification
+
+#### Scenario: Empty artist list
+
+- **WHEN** `ListWithProximity` is called with an empty `artist_ids` list
+- **THEN** it SHALL return an `INVALID_ARGUMENT` error
+
+#### Scenario: No concerts found for any artist
+
+- **WHEN** `ListWithProximity` is called with valid artist IDs
+- **AND** no concerts exist for any of the specified artists
+- **THEN** it SHALL return an empty `groups` list without error
+
+#### Scenario: Artist ID validation limit
+
+- **WHEN** `ListWithProximity` is called with more than 50 artist IDs
+- **THEN** it SHALL return an `INVALID_ARGUMENT` error via protovalidate
+
+#### Scenario: Home with unsupported country code
+
+- **WHEN** `ListWithProximity` is called with a `Home` whose `level_1` has no known centroid
+- **THEN** the centroid SHALL be nil
+- **AND** all concerts SHALL be classified as `AWAY` (except those matching by `admin_area`)

--- a/openspec/changes/fix-onboarding-progression-bugs/specs/onboarding-spotlight/spec.md
+++ b/openspec/changes/fix-onboarding-progression-bugs/specs/onboarding-spotlight/spec.md
@@ -1,0 +1,42 @@
+## MODIFIED Requirements
+
+### Requirement: Click-Blocker Layer via Transparent Anchor-Positioned Divs
+
+The coach mark SHALL use four transparent click-blocker divs (top, right, bottom, left) positioned with CSS `anchor()` functions to block interactions outside the target element.
+
+#### Scenario: Clicks outside spotlight are blocked
+
+- **WHEN** the coach mark overlay is active
+- **AND** the user taps an area covered by a click-blocker div
+- **THEN** the tap SHALL be intercepted by the blocker (`pointer-events: auto`)
+- **AND** the tap SHALL NOT reach the underlying page content
+
+#### Scenario: Clicks inside spotlight reach the target
+
+- **WHEN** the coach mark overlay is active
+- **AND** the user taps inside the spotlight cutout area
+- **THEN** the tap SHALL pass through to the actual target element
+- **AND** the target element SHALL receive the click event natively
+
+#### Scenario: Target interceptor invokes onTap callback
+
+- **WHEN** the coach mark overlay is active with an `onTap` callback registered
+- **AND** the user taps the target interceptor overlay
+- **THEN** the `onTap` callback SHALL be invoked
+- **AND** the caller MAY use the callback to deactivate the spotlight (e.g., `deactivateSpotlight()`)
+
+#### Scenario: Click-blockers cover the entire viewport except target bounds
+
+- **WHEN** the coach mark overlay is active
+- **THEN** `.mask-top` SHALL cover from viewport top to `anchor(target top)`
+- **AND** `.mask-bottom` SHALL cover from `anchor(target bottom)` to viewport bottom
+- **AND** `.mask-left` SHALL cover from viewport left to `anchor(target left)`, between target top and bottom
+- **AND** `.mask-right` SHALL cover from `anchor(target right)` to viewport right, between target top and bottom
+
+#### Scenario: My Artists step provides onTap dismissal callback
+
+- **WHEN** the onboarding step is `my-artists`
+- **AND** `activateSpotlight` is called for the `[data-hype-header]` target
+- **THEN** an `onTap` callback SHALL be provided that calls `deactivateSpotlight()`
+- **AND** after the spotlight is dismissed, the hype sliders SHALL be interactive
+- **AND** the user SHALL be able to change a hype level to complete onboarding

--- a/openspec/changes/fix-onboarding-progression-bugs/tasks.md
+++ b/openspec/changes/fix-onboarding-progression-bugs/tasks.md
@@ -1,0 +1,21 @@
+## 1. Backend: Add ListWithProximity to public whitelist
+
+- [x] 1.1 Add `"/" + concertconnect.ConcertServiceName + "/ListWithProximity": true` to `publicProcedures` map in `backend/internal/di/provider.go`
+- [x] 1.2 Verify existing auth interceptor test covers public procedure bypass, add test case for ListWithProximity if missing
+
+## 2. Frontend: Fix My Artists coach mark dismissal
+
+- [x] 2.1 In `frontend/src/routes/my-artists/my-artists-route.ts`, add `onTap` callback to `activateSpotlight` that calls `this.onboarding.deactivateSpotlight()`
+- [ ] 2.2 Manually verify on dev: tap hype header spotlight → spotlight dismisses → hype slider is interactive → onboarding completes (post-deploy)
+
+## 3. Frontend: Update BSR package
+
+- [x] 3.1 Run `npm install` in `frontend/` to resolve latest BSR package version matching semver range
+- [x] 3.2 Verify `TicketJourneyService.listByUser` exists in the updated `node_modules/@buf/liverty-music_schema.connectrpc_es` JS file
+- [ ] 3.3 Commit updated `package-lock.json` (pending commit)
+
+## 4. Verification
+
+- [x] 4.1 Run `make check` in backend
+- [x] 4.2 Run `make check` in frontend
+- [ ] 4.3 Deploy to dev and run full onboarding flow end-to-end: discovery → dashboard (lane intro with concert data) → my-artists (spotlight tap → hype slider → complete)


### PR DESCRIPTION
## Summary

- Archive 3 completed OpenSpec changes: `refactor-my-artists-table`, `fix-discovery-bubble-content`, `onboarding-guide-to-snack`
- Relocate `refactor-my-artists-table` from frontend repo (created in wrong directory) to specification archive
- Track `fix-onboarding-progression-bugs` (7/10) as active change

close: #263