### PR TITLE
docs(openspec): archive fix-gemini-alert-duplication

### DIFF
--- a/openspec/changes/archive/2026-03-21-fix-gemini-alert-duplication/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-21-fix-gemini-alert-duplication/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-21

--- a/openspec/changes/archive/2026-03-21-fix-gemini-alert-duplication/design.md
+++ b/openspec/changes/archive/2026-03-21-fix-gemini-alert-duplication/design.md
@@ -1,0 +1,41 @@
+## Context
+
+The Gemini concert searcher (`internal/infrastructure/gcp/gemini/searcher.go`) logs at ERROR when the API call fails, and the calling usecase (`internal/usecase/concert_uc.go`) also logs at ERROR when the search fails. Both logs match the `severity="ERROR"` filter in the Cloud Monitoring alert policy.
+
+Cloud Monitoring's `conditionMatchedLog` with `labelExtractors` creates separate incidents when extracted label values differ. The infrastructure-layer log has `jsonPayload.error` as a plain string (no `.code` sub-field), while the usecase-layer log has `jsonPayload.error.code` as a structured field. This causes `error_code` to extract differently (empty vs `"unauthenticated"`), resulting in two incidents from one failure.
+
+Separately, GKE Workload Identity token refresh can intermittently produce HTTP 401 errors. The current `isRetryable` function treats 401 as permanent, so the backoff loop exits immediately instead of retrying.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Eliminate duplicate alert incidents caused by multi-layer ERROR logging of the same failure.
+- Make transient WI credential failures recoverable via the existing retry mechanism.
+
+**Non-Goals:**
+- Changing the Cloud Monitoring alert policy configuration or `labelExtractors`.
+- Changing log structure or fields.
+- Addressing other error types or retry behaviors.
+
+## Decisions
+
+### 1. Demote infrastructure-layer log to WARN
+
+**Change**: `searcher.go:227` — `s.logger.Error(...)` → `s.logger.Warn(...)`
+
+**Rationale**: The infrastructure layer provides detailed context (model version, artist, official site) which is valuable for debugging but should not independently trigger alerts. The usecase layer is the appropriate place for ERROR-level logging because it has the full business context (artist_id) and wraps the error with `apperr` which populates `error.code`.
+
+**Alternative considered**: Filter the alert policy by `jsonPayload.msg` to only match usecase-layer messages. Rejected because it couples the alert policy to specific log message strings, making it fragile.
+
+### 2. Add HTTP 401 to `isRetryable`
+
+**Change**: Add `http.StatusUnauthorized` (401) to the switch in `errors.go:isRetryable`.
+
+**Rationale**: WI token refresh failures are transient (typically resolve within seconds). The existing backoff configuration (1s initial, 2x multiplier, max 10s, 3 tries) is well-suited to handle this. A 401 from Vertex AI in a GKE environment with Workload Identity is almost always a transient credential issue, not a genuine authorization failure.
+
+**Alternative considered**: Only retry 401 when a specific error detail (`CREDENTIALS_MISSING`) is present. Rejected because the `genai.APIError` type only exposes the HTTP status code, not the detailed error reason. Parsing the error message string would be fragile.
+
+## Risks / Trade-offs
+
+- **[Risk] Retrying genuine 401 errors**: If the service account truly lacks `aiplatform.user` permissions, the retry will fail 3 times before giving up (adding ~7s latency). → **Mitigation**: The 3-retry cap with exponential backoff limits the blast radius. Genuine permission errors will still surface as ERROR in the usecase layer after retries are exhausted.
+- **[Risk] WARN logs are less visible**: Operators may miss infrastructure-level details when triaging. → **Mitigation**: The usecase-layer ERROR log includes the full wrapped error with cause chain. Cloud Logging correlation via `trace_id` allows finding the WARN log for additional context.

--- a/openspec/changes/archive/2026-03-21-fix-gemini-alert-duplication/proposal.md
+++ b/openspec/changes/archive/2026-03-21-fix-gemini-alert-duplication/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+The Gemini concert search logs the same error at ERROR level in two layers (infrastructure and usecase), causing Cloud Monitoring to create duplicate alert incidents from a single failure. Additionally, `isRetryable` does not cover HTTP 401, so transient Workload Identity token refresh failures are treated as permanent errors instead of being retried.
+
+## What Changes
+
+- Demote the infrastructure-layer log (`gemini model call failed` in `searcher.go`) from ERROR to WARN so that only the usecase-layer log (`background concert search failed` in `concert_uc.go`) triggers alerts.
+- Add HTTP 401 (Unauthorized) to `isRetryable` in `errors.go` so that transient WI credential failures are retried with exponential backoff.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `app-error-log-alerting`: No spec-level requirement changes. The alerting policy and its `severity="ERROR"` filter remain the same. The change is purely in which application code emits ERROR vs WARN logs.
+
+## Impact
+
+- **backend** (`internal/infrastructure/gcp/gemini/searcher.go`): Log level change from ERROR to WARN.
+- **backend** (`internal/infrastructure/gcp/gemini/errors.go`): `isRetryable` function updated to include 401.
+- **Alerting behavior**: Duplicate incidents from a single Gemini failure will no longer occur because only one ERROR log line (from the usecase layer) will be emitted per failure.

--- a/openspec/changes/archive/2026-03-21-fix-gemini-alert-duplication/specs/app-error-log-alerting/spec.md
+++ b/openspec/changes/archive/2026-03-21-fix-gemini-alert-duplication/specs/app-error-log-alerting/spec.md
@@ -1,0 +1,1 @@
+No spec-level requirement changes. The existing alerting requirements (severity="ERROR" filter, notification rate limiting, label extractors) remain unchanged. This change only modifies which application code emits ERROR vs WARN logs.

--- a/openspec/changes/archive/2026-03-21-fix-gemini-alert-duplication/tasks.md
+++ b/openspec/changes/archive/2026-03-21-fix-gemini-alert-duplication/tasks.md
@@ -1,0 +1,12 @@
+## 1. Demote infrastructure-layer log level
+
+- [x] 1.1 Change `s.logger.Error` to `s.logger.Warn` at `internal/infrastructure/gcp/gemini/searcher.go:227`
+
+## 2. Add HTTP 401 to retry list
+
+- [x] 2.1 Add `http.StatusUnauthorized` to the `isRetryable` switch in `internal/infrastructure/gcp/gemini/errors.go`
+- [x] 2.2 Add test case for 401 in `isRetryable` unit tests
+
+## 3. Verify
+
+- [x] 3.1 Run `make check` to confirm lint and tests pass


### PR DESCRIPTION
## Summary

- Archive the completed `fix-gemini-alert-duplication` change artifacts (proposal, design, specs, tasks)

## Context

This change demoted the Gemini infrastructure-layer error log from ERROR to WARN and added HTTP 401 to `isRetryable`. No spec-level requirement changes were needed. Implementation was merged in backend PR liverty-music/backend#238.

## Test plan

- [x] Documentation-only change (archived OpenSpec artifacts)
