### PR TITLE
fix(specs): sync user-account-sync spec and archive fix-post-signup-issues

### DIFF
--- a/openspec/changes/archive/2026-03-21-fix-post-signup-issues/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-21-fix-post-signup-issues/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-21

--- a/openspec/changes/archive/2026-03-21-fix-post-signup-issues/design.md
+++ b/openspec/changes/archive/2026-03-21-fix-post-signup-issues/design.md
@@ -1,0 +1,56 @@
+## Context
+
+After onboarding and sign-up, the frontend console shows a red 404 error from `UserService/Get` for new users, a redundant second Get RPC after provisioning, a `TypeError: this.client.listByUser is not a function` from an outdated BSR dependency, flooding `isMatch()` debug logs from Aurelia Router, and visual issues on the My Artists hype slider (tap highlight flash, visible grid lines).
+
+The current `UserService/Get` returns `NOT_FOUND` for unregistered users. While semantically correct, this produces an unavoidable browser console error because `fetch()` logs all non-2xx responses. The `CreateResponse` already includes a `user` field, but the frontend discards it and makes an extra Get call.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Remove the redundant UserService/Get RPC after provisioning
+- Fix TicketJourneyService runtime error by updating BSR dependency
+- Reduce console noise from Aurelia Router debug logs in production
+- Remove mobile tap highlight and track grid lines from hype slider
+
+**Non-Goals:**
+- Changing hype dot glow/animation styling
+- Refactoring the overall auth callback flow
+- Adding new RPC methods or proto fields
+
+## Decisions
+
+### D1: Keep UserService/Get NOT_FOUND behavior
+
+**Decision**: `UserService/Get` continues to return `NOT_FOUND` when no user record exists. The 404 console error on new user sign-up is accepted as a cosmetic issue.
+
+**Rationale**: Changing the error contract is a breaking change across the proto/backend/frontend boundary. The 404 is only visible in the developer console and does not affect user experience. The frontend already handles it correctly via `ConnectError.NotFound` catch.
+
+### D2: Frontend create() returns User and caches it
+
+**Decision**: `UserRpcClient.create()` returns `User` from `CreateResponse.user`. `UserServiceClient.create()` sets `_current` from the returned value. The second `ensureLoaded()` call in `auth-callback-route.ts` is removed.
+
+**Rationale**: `CreateResponse` already includes the full `User` entity. The backend populates it through the entire chain (repository → usecase → handler → mapper). Discarding it and re-fetching is a wasted RPC call adding ~37ms latency to sign-up.
+
+### D3: Environment-aware LogLevel
+
+**Decision**: Set `LogLevel.debug` only when `import.meta.env.DEV` is true; use `LogLevel.warn` otherwise.
+
+**Rationale**: Aurelia Router emits many `DBG` level logs (e.g., `isMatch()` for every route candidate on each navigation). These are useful during development but flood the console and OTel sink in production. Vite's dead-code elimination ensures the debug sink code is tree-shaken in production builds.
+
+### D4: Tap highlight reset in @layer reset
+
+**Decision**: Add `-webkit-tap-highlight-color: transparent` to the universal reset selector in `reset.css` (`@layer reset`), not in the block-level component CSS.
+
+**Rationale**: CUBE CSS methodology — browser default resets belong in the reset layer. This applies globally to all interactive elements, which is correct since the app provides its own visual feedback for all tap targets.
+
+### D5: Remove hype track grid line
+
+**Decision**: Delete the `.hype-col:first-of-type > &::before` pseudo-element that draws the horizontal track line across hype columns.
+
+**Rationale**: The line is barely visible and adds visual noise. The hype dots themselves provide sufficient visual affordance for the slider interaction.
+
+## Risks / Trade-offs
+
+- **[D1 Console 404]** → Accepted: the 404 on `UserService/Get` for new users is a developer-only cosmetic issue. No user-facing impact.
+- **[D3 Log suppression]** → Trade-off: production logs below `warn` level will not appear in console or OTel. This is acceptable since `INF`/`DBG` level logs are for development. If production debugging is needed, the OTel collector can be configured independently.
+- **[D5 Track line removal]** → Low risk: purely cosmetic change with no functional impact.

--- a/openspec/changes/archive/2026-03-21-fix-post-signup-issues/proposal.md
+++ b/openspec/changes/archive/2026-03-21-fix-post-signup-issues/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+Post-signup console logs reveal multiple issues degrading developer experience and user functionality: a 404 console error on initial UserService/Get for new users, a redundant Get RPC after user provisioning, an outdated BSR dependency causing TicketJourney runtime errors, excessive Aurelia Router debug logs flooding the console, mobile tap highlight on hype slider cells, and visible grid lines on the hype track.
+
+## What Changes
+
+- **Frontend**: Refactor `UserRpcClient.create()` to return the `User` from `CreateResponse.user` and cache it in `UserServiceClient._current`, removing the redundant second `ensureLoaded()` call after provisioning.
+- **Frontend**: Update BSR dependency `@buf/liverty-music_schema.connectrpc_es` to latest version to include `TicketJourneyService.ListByUser` method.
+- **Frontend**: Set `LogLevel` to environment-aware values (`debug` in dev, `warn` in prod) to suppress Aurelia Router internal `isMatch()` debug logs.
+- **Frontend**: Add `-webkit-tap-highlight-color: transparent` to `reset.css` (`@layer reset`) to remove mobile tap highlight on hype slider and all interactive elements.
+- **Frontend**: Remove the hype track `::before` pseudo-element grid line from `my-artists-route.css`.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `user-account-sync`: Create flow caches user from CreateResponse, removing redundant Get RPC after provisioning.
+
+## Impact
+
+- **backend**: `user_handler_test.go` — new unit tests for Get handler.
+- **frontend**: `user-client.ts`, `user-service.ts`, `auth-callback-route.ts` — create flow refactor.
+- **frontend**: `package.json` / `package-lock.json` — BSR dependency update.
+- **frontend**: `main.ts` — LogLevel configuration.
+- **frontend**: `reset.css` — tap highlight reset.
+- **frontend**: `my-artists-route.css` — track line removal.

--- a/openspec/changes/archive/2026-03-21-fix-post-signup-issues/specs/user-account-sync/spec.md
+++ b/openspec/changes/archive/2026-03-21-fix-post-signup-issues/specs/user-account-sync/spec.md
@@ -1,0 +1,29 @@
+## MODIFIED Requirements
+
+### Requirement: User Account Provisioning on Signup
+
+The system SHALL create a local user record in the application database when a user completes the onboarding tutorial and authenticates via Passkey. The provisioning is triggered by the guest data merge process at the end of the tutorial.
+
+#### Scenario: Successful signup provisioning from tutorial
+
+- **WHEN** a user completes Passkey authentication at tutorial Step 6
+- **THEN** the frontend SHALL call `UserService/Get` to check for an existing user record
+- **AND** if the backend returns `NOT_FOUND`, the frontend SHALL call the `Create` RPC with the user's `email` parameter
+- **AND** the backend SHALL extract `external_id` (from JWT `sub` claim) and `name` (from JWT `name` claim)
+- **AND** the backend SHALL create a new user record with `external_id`, `email`, and `name` persisted
+- **AND** the frontend SHALL cache the `User` entity from the `CreateResponse.user` field without making an additional `Get` RPC call
+- **AND** the frontend SHALL then proceed to sync guest data (follows, passion levels)
+
+#### Scenario: Successful provisioning from Login link
+
+- **WHEN** a returning user authenticates via the [Login] link on the LP
+- **AND** no local user record exists
+- **THEN** the frontend SHALL call the `Create` RPC with the user's `email` parameter
+- **AND** the backend SHALL create the user record as normal
+
+#### Scenario: Duplicate provisioning attempt
+
+- **WHEN** the `Create` RPC is called with an `external_id` that already exists in the database
+- **THEN** the system SHALL return `connect.CodeAlreadyExists`
+- **AND** the frontend SHALL handle this error gracefully (treat as success since the user already exists)
+- **AND** the guest data merge SHALL proceed normally

--- a/openspec/changes/archive/2026-03-21-fix-post-signup-issues/tasks.md
+++ b/openspec/changes/archive/2026-03-21-fix-post-signup-issues/tasks.md
@@ -1,0 +1,23 @@
+## 1. Proto & Backend: UserService/Get empty response
+
+- [x] ~~1.1-1.3 Backend empty response for Get~~ — Reverted: keeping NOT_FOUND behavior
+- [x] 1.4 Add backend unit tests for Get handler (found + not-found cases)
+
+## 2. Frontend: Create flow refactor
+
+- [x] 2.1 Update `UserRpcClient.create()` in `user-client.ts` to return `User | undefined` from `CreateResponse.user`
+- [x] 2.2 Update `UserServiceClient.create()` in `user-service.ts` to cache the returned user in `_current`
+- [x] 2.3 Remove redundant second `ensureLoaded()` call in `auth-callback-route.ts` after provisioning (Create now caches the user)
+
+## 3. Frontend: BSR dependency update
+
+- [x] 3.1 Run `npm update @buf/liverty-music_schema.connectrpc_es @buf/liverty-music_schema.bufbuild_es` to pull latest BSR-generated code containing `TicketJourneyService.ListByUser`
+
+## 4. Frontend: Console noise reduction
+
+- [x] 4.1 Update `LoggerConfiguration` in `main.ts` to use `LogLevel.debug` in dev and `LogLevel.warn` in prod
+
+## 5. Frontend: Hype slider visual fixes
+
+- [x] 5.1 Add `-webkit-tap-highlight-color: transparent` to the universal reset selector in `reset.css` (`@layer reset`)
+- [x] 5.2 Remove the `.hype-col:first-of-type > &::before` track line pseudo-element from `my-artists-route.css`

--- a/openspec/specs/user-account-sync/spec.md
+++ b/openspec/specs/user-account-sync/spec.md
@@ -7,9 +7,11 @@ The system SHALL create a local user record in the application database when a u
 #### Scenario: Successful signup provisioning from tutorial
 
 - **WHEN** a user completes Passkey authentication at tutorial Step 6
-- **THEN** the frontend SHALL call the `Create` RPC with the user's `email` parameter
+- **THEN** the frontend SHALL call `UserService/Get` to check for an existing user record
+- **AND** if the backend returns `NOT_FOUND`, the frontend SHALL call the `Create` RPC with the user's `email` parameter
 - **AND** the backend SHALL extract `external_id` (from JWT `sub` claim) and `name` (from JWT `name` claim)
 - **AND** the backend SHALL create a new user record with `external_id`, `email`, and `name` persisted
+- **AND** the frontend SHALL cache the `User` entity from the `CreateResponse.user` field without making an additional `Get` RPC call
 - **AND** the frontend SHALL then proceed to sync guest data (follows, passion levels)
 
 #### Scenario: Successful provisioning from Login link

--- a/openspec/specs/user-account-sync/spec.md
+++ b/openspec/specs/user-account-sync/spec.md
@@ -17,13 +17,15 @@ The system SHALL create a local user record in the application database when a u
 #### Scenario: Successful provisioning from Login link
 
 - **WHEN** a returning user authenticates via the [Login] link on the LP
-- **AND** no local user record exists
-- **THEN** the frontend SHALL call the `Create` RPC with the user's `email` parameter
+- **THEN** the frontend SHALL call `UserService/Get` to check for an existing user record
+- **AND** if the backend returns `NOT_FOUND`, the frontend SHALL call the `Create` RPC with the user's `email` parameter
 - **AND** the backend SHALL create the user record as normal
+- **AND** the frontend SHALL cache the `User` entity from the `CreateResponse.user` field without making an additional `Get` RPC call
 
 #### Scenario: Duplicate provisioning attempt
 
 - **WHEN** the `Create` RPC is called with an `external_id` that already exists in the database
 - **THEN** the system SHALL return `connect.CodeAlreadyExists`
 - **AND** the frontend SHALL handle this error gracefully (treat as success since the user already exists)
+- **AND** the frontend SHALL call `UserService/Get` to retrieve and cache the existing `User` entity
 - **AND** the guest data merge SHALL proceed normally


### PR DESCRIPTION
## Summary

- Updates `user-account-sync` spec to reflect the implemented behavior: frontend caches the `User` entity from `CreateResponse` without making a second `Get` RPC call after provisioning.
- Archives the `fix-post-signup-issues` OpenSpec change (proposal, design, delta specs, tasks) now that all tasks are complete and verified.

## Test plan

- [ ] Verify `openspec/specs/user-account-sync/spec.md` matches the implemented auth-callback behavior
- [ ] Verify archive directory exists at `openspec/changes/archive/2026-03-21-fix-post-signup-issues/`
