### PR TITLE
feat(user): add ResendEmailVerification RPC for email verification flow

### DIFF
--- a/openspec/changes/email-verification/.openspec.yaml
+++ b/openspec/changes/email-verification/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-21

--- a/openspec/changes/email-verification/design.md
+++ b/openspec/changes/email-verification/design.md
@@ -1,0 +1,83 @@
+## Context
+
+Users register via Passkey on Zitadel's Hosted Login UI. Currently, a Zitadel Action (`autoVerifyEmail`) marks every user's email as verified at creation time, so no verification email is ever sent. Testing confirmed that removing this Action does NOT block the Passkey OIDC flow — users sign up normally with `email: not verified`. However, Zitadel does not auto-send verification emails for Passkey registrations (unlike password-based flows), so the backend must explicitly trigger them.
+
+The backend currently has no Zitadel API client — it only validates JWTs via `lestrrat-go/jwx`. The `zitadel-go/v3` SDK and a Machine User service account are needed for API calls.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Users receive a verification email after signing up
+- Email verification does not block the signup/login flow
+- Users can resend the verification email from the Settings page
+- `email_verified` JWT claim reflects real verification state
+- Backend authenticates to Zitadel API via Private Key JWT (asymmetric, secure for future ticket sales)
+
+**Non-Goals:**
+- Custom verification UI — Zitadel's hosted verification page handles code entry
+- Custom `urlTemplate` for verification links — use Zitadel's default
+- Feature gating based on `email_verified` status (future work for ticket sales)
+- Email change flow — only initial verification for now
+
+## Decisions
+
+### 1. Remove `autoVerifyEmail` Action
+
+The `autoVerifyEmail` Action and its `PRE_CREATION` trigger are deleted from cloud-provisioning. The `auto-verify-email.js` script file is also removed. Users are created with `email: not verified`.
+
+The `addEmailClaim` Action and its `PRE_ACCESS_TOKEN_CREATION` trigger remain unchanged. The `email_verified` claim will now reflect the real Zitadel verification state.
+
+**Alternative considered:** Keep the Action but add a POST_CREATION trigger to re-send verification. Rejected because this creates contradictory state (verified then immediately unverified) and adds unnecessary complexity.
+
+### 2. Private Key JWT for Machine User authentication
+
+A Zitadel Machine User is provisioned via Pulumi with a Private Key JWT credential. The private key JSON file is stored in GCP Secret Manager and mounted into the backend pod via External Secrets Operator (ESO).
+
+**Why Private Key JWT over Client Credentials:** Asymmetric authentication — the private key never leaves the backend, Zitadel only stores the public key. If Zitadel's database is compromised, the credential cannot be used to impersonate the service account. This is the recommended approach for services handling financial transactions (future ticket sales).
+
+**Why not PAT:** Static tokens cannot be scoped, have no expiry negotiation, and are a single point of compromise.
+
+### 3. NATS `USER.created` event for async verification trigger
+
+User creation in `UserUseCase.Create()` publishes a `USER.created` event to NATS JetStream after successful database persistence. The `userUseCase` struct receives a `message.Publisher` (Watermill) injection, following the existing pattern in `concertCreationUseCase`, `concertUseCase`, and `artistUseCase`. A subject constant `entity.SubjectUserCreated` is defined in `internal/entity/`.
+
+A consumer subscribes to this event and calls `POST /v2/users/{externalId}/email/send` via the `zitadel-go` SDK.
+
+**Why NATS over synchronous call in UseCase:**
+- Email verification failure should never block user creation
+- JetStream provides automatic retry with backoff on transient failures
+- Follows existing patterns (CONCERT, VENUE, ARTIST streams)
+- Clear separation of concerns — user creation logic stays focused
+
+**Stream configuration** follows the existing pattern: `USER.*` subjects, 7-day retention, file storage, 2-minute deduplication window.
+
+### 4. Resend verification via backend RPC proxy
+
+A new RPC method `ResendEmailVerification` is added to the existing `UserService`. The handler extracts the authenticated user's `external_id` from JWT claims and calls `POST /v2/users/{externalId}/email/resend` via the `zitadel-go` SDK.
+
+**Why proxy through backend instead of frontend calling Zitadel directly:**
+- Frontend does not have Zitadel Admin API credentials
+- Backend can enforce rate limiting and authorization
+- Consistent with the pattern of all external API calls going through backend
+
+### 5. Zitadel API client as infrastructure component
+
+The `zitadel-go` client is initialized in both DI entrypoints:
+- `internal/di/provider.go` (API server) — for the `ResendEmailVerification` RPC handler
+- `internal/di/consumer.go` (event consumer) — for the `USER.created` event handler
+
+It uses `client.DefaultServiceUserAuthentication()` with the private key JSON file path. The client is injected into the consumer and the UserService handler via an `EmailVerifier` interface defined in `internal/usecase/`.
+
+**Configuration additions to `pkg/config/config.go`:**
+- `ZitadelMachineKeyPath` — path to the machine key JSON file (mounted from Secret Manager via `ZITADEL_MACHINE_KEY_PATH`). Added to both `ServerConfig` and `ConsumerConfig`.
+- Zitadel domain reuses existing `JWT.Issuer` (no new field needed)
+
+## Risks / Trade-offs
+
+**[Risk] Machine User key rotation** → Private keys should be rotated periodically. Mitigation: Pulumi can generate a new key and update Secret Manager; ESO syncs to the pod. The old key is revoked in Zitadel. This is a manual but infrequent operation.
+
+**[Risk] SMTP delivery failure is silent to the user** → If Postmark fails to deliver, the user simply doesn't receive the email. Mitigation: Resend button on Settings page. Future: monitor Postmark delivery webhooks.
+
+**[Risk] Zitadel rate limits on email/send** → High signup volume could hit rate limits. Mitigation: NATS consumer processes events sequentially with backoff. Current user volumes are low.
+
+**[Risk] `email_verified` claim changes mid-session** → After a user verifies their email, the JWT `email_verified` claim updates on the next token refresh, not immediately. Mitigation: Acceptable UX — the Settings page can re-fetch verification status from the backend if needed.

--- a/openspec/changes/email-verification/proposal.md
+++ b/openspec/changes/email-verification/proposal.md
@@ -1,0 +1,34 @@
+## Why
+
+Users who sign up via the Passkey flow currently have their email auto-verified by a Zitadel Action (`autoVerifyEmail`), meaning they never actually confirm ownership of their email address. Email verification is required for future ticket sales and builds user trust. Testing confirmed that removing the auto-verify Action does NOT block the Passkey OIDC flow — users can sign up and log in without email verification. However, Zitadel does not automatically send verification emails for Passkey registrations, so the backend must explicitly trigger verification via the Zitadel API.
+
+## What Changes
+
+- **Remove** the `autoVerifyEmail` Zitadel Action and its trigger (cloud-provisioning)
+- **Add** a Zitadel Machine User (service account) with Private Key JWT credentials for backend-to-Zitadel API communication (cloud-provisioning)
+- **Add** `zitadel-go/v3` SDK integration in backend to call Zitadel Admin APIs
+- **Add** a `USER.created` NATS/JetStream event published on user provisioning (backend)
+- **Add** a consumer that listens to `USER.created` and triggers email verification via `POST /v2/users/{userId}/email/send` (backend)
+- **Add** a resend verification email RPC endpoint in backend, proxying to Zitadel's `POST /v2/users/{userId}/email/resend`
+- **Add** email verification status display and resend button on the Settings page (frontend)
+- **Update** the `identity-management` spec to replace auto-verify with the new verification flow
+
+## Capabilities
+
+### New Capabilities
+
+- `email-verification`: Covers the end-to-end email verification flow — triggering verification on user creation, resending verification emails, and displaying verification status in the UI.
+- `zitadel-service-account`: Covers the Zitadel Machine User provisioning, Private Key JWT credential management, and GCP Secret Manager integration for backend-to-Zitadel API authentication.
+
+### Modified Capabilities
+
+- `identity-management`: The "Auto-Verify Email on Self-Registration" requirement is removed. Users are now created with unverified email, and verification happens asynchronously via backend.
+- `email-provider`: No requirement changes — SMTP configuration remains the same. The email-provider capability already covers Postmark SMTP delivery, which this change relies on.
+
+## Impact
+
+- **cloud-provisioning**: Remove `autoVerifyEmail` Action/Trigger, add Machine User + key + IAM role, store key in Secret Manager
+- **backend**: New dependency on `zitadel-go/v3`, new NATS stream (`USER`), new consumer, new RPC endpoint for resend, new configuration for Zitadel API client
+- **frontend**: Settings page UI changes (verification status + resend button)
+- **Zitadel**: `addEmailClaim` Action's `email_verified` claim will now reflect real verification state instead of always being `true`
+- **Proto**: New RPC method for resending verification email (in UserService or new service)

--- a/openspec/changes/email-verification/specs/email-verification/spec.md
+++ b/openspec/changes/email-verification/specs/email-verification/spec.md
@@ -1,0 +1,108 @@
+# Email Verification
+
+## Purpose
+
+Defines the email verification flow for users who register via Passkey. Covers triggering verification emails on user creation, resending verification, and displaying verification status in the UI.
+
+## ADDED Requirements
+
+### Requirement: Trigger verification email on user creation
+
+The system SHALL publish a `USER.created` event to NATS JetStream when a user is successfully provisioned in the backend. A consumer SHALL subscribe to this event and call Zitadel's `POST /v2/users/{externalId}/email/send` API to trigger a verification email via the configured SMTP provider (Postmark).
+
+#### Scenario: New user signs up via Passkey
+
+- **WHEN** a new user completes Passkey registration and the backend provisions the user record
+- **THEN** the backend SHALL publish a `USER.created` event to the `USER` NATS JetStream stream
+- **AND** the consumer SHALL call Zitadel's email send API with the user's `external_id` (Zitadel user ID)
+- **AND** Zitadel SHALL send a verification email to the user's registered email address via Postmark
+
+#### Scenario: Zitadel API call fails transiently
+
+- **WHEN** the consumer calls Zitadel's email send API and receives a transient error (network timeout, 5xx)
+- **THEN** the NATS JetStream consumer SHALL retry the message with backoff
+- **AND** the user creation SHALL NOT be affected (already persisted)
+
+#### Scenario: User email is already verified
+
+- **WHEN** the consumer calls Zitadel's email send API for a user whose email is already verified
+- **THEN** the consumer SHALL handle the response gracefully (log and acknowledge the message)
+
+#### Scenario: Duplicate USER.created event
+
+- **WHEN** the consumer receives a duplicate `USER.created` event (e.g., NATS redelivery after ack timeout)
+- **THEN** the consumer SHALL call Zitadel's email send API
+- **AND** the operation SHALL be idempotent (re-sending a verification email has no adverse side effects)
+
+### Requirement: NATS USER stream
+
+The system SHALL define a `USER` JetStream stream capturing all `USER.*` subjects, following the existing stream pattern (CONCERT, VENUE, ARTIST).
+
+#### Scenario: Stream configuration
+
+- **WHEN** the backend starts and ensures JetStream streams
+- **THEN** a `USER` stream SHALL exist with subjects `USER.*`
+- **AND** retention SHALL be `LimitsPolicy` with 7-day max age
+- **AND** storage SHALL be `FileStorage` with 2-minute deduplication window
+
+### Requirement: Resend verification email via RPC
+
+The system SHALL provide an RPC method that allows authenticated users to resend the verification email for their own account. The backend SHALL proxy this request to Zitadel's `POST /v2/users/{userId}/email/resend` API.
+
+#### Scenario: User requests resend from Settings page
+
+- **WHEN** an authenticated user calls the resend verification RPC
+- **THEN** the backend SHALL extract the user's `external_id` from JWT claims
+- **AND** the backend SHALL call Zitadel's email resend API with the `external_id`
+- **AND** Zitadel SHALL send a new verification email to the user
+
+#### Scenario: User is already verified
+
+- **WHEN** an authenticated user whose email is already verified calls the resend verification RPC
+- **THEN** the backend SHALL return a `FailedPrecondition` error indicating the email is already verified
+
+#### Scenario: Rapid resend attempts
+
+- **WHEN** a user calls the resend verification RPC more than 3 times within 10 minutes
+- **THEN** the backend SHALL return a `ResourceExhausted` error
+
+#### Scenario: Unauthenticated request
+
+- **WHEN** an unauthenticated request calls the resend verification RPC
+- **THEN** the backend SHALL reject the request with an authentication error
+
+### Requirement: Verification status display on Settings page
+
+The frontend Settings page SHALL display the user's email verification status and provide a resend button for unverified users.
+
+#### Scenario: Unverified user views Settings
+
+- **WHEN** an authenticated user with an unverified email visits the Settings page
+- **THEN** the page SHALL display the user's email address
+- **AND** the page SHALL show a "not verified" indicator
+- **AND** a "Resend verification email" button SHALL be visible
+
+#### Scenario: Verified user views Settings
+
+- **WHEN** an authenticated user with a verified email visits the Settings page
+- **THEN** the page SHALL display the user's email address
+- **AND** the page SHALL show a "verified" indicator
+- **AND** the resend button SHALL NOT be visible
+
+#### Scenario: User clicks resend button
+
+- **WHEN** an unverified user clicks the "Resend verification email" button
+- **THEN** the frontend SHALL call the backend resend verification RPC
+- **AND** the button SHALL show a success confirmation on completion
+- **AND** the button SHALL be disabled temporarily to prevent rapid re-clicks
+
+### Requirement: Verification flow uses Zitadel hosted UI
+
+Email verification SHALL be handled entirely by Zitadel's hosted verification page. No custom verification UI is built. The verification email links to Zitadel's default verification URL.
+
+#### Scenario: User clicks verification link in email
+
+- **WHEN** a user clicks the verification link in the email
+- **THEN** the user SHALL be directed to Zitadel's hosted verification page
+- **AND** after entering the code, Zitadel SHALL mark the email as verified
+- **AND** the user SHALL be redirected back to the application

--- a/openspec/changes/email-verification/specs/identity-management/spec.md
+++ b/openspec/changes/email-verification/specs/identity-management/spec.md
@@ -1,0 +1,9 @@
+# Identity Management — Delta Spec
+
+## REMOVED Requirements
+
+### Requirement: Auto-Verify Email on Self-Registration
+
+**Reason**: Email verification is now handled asynchronously by the backend after user creation. The `autoVerifyEmail` Zitadel Action is no longer needed because testing confirmed that the Passkey OIDC flow does NOT block on unverified email. Users are created with `email: not verified` and receive a verification email triggered by the backend via Zitadel's API.
+
+**Migration**: Delete the `autoVerifyEmail` Action, its `PRE_CREATION` TriggerAction, and the `auto-verify-email.js` script from cloud-provisioning. No data migration is needed — existing verified users remain verified.

--- a/openspec/changes/email-verification/specs/zitadel-service-account/spec.md
+++ b/openspec/changes/email-verification/specs/zitadel-service-account/spec.md
@@ -1,0 +1,63 @@
+# Zitadel Service Account
+
+## Purpose
+
+Defines the Zitadel Machine User provisioning and Private Key JWT credential management for backend-to-Zitadel API communication.
+
+## ADDED Requirements
+
+### Requirement: Zitadel Machine User provisioned via Pulumi
+
+The infrastructure SHALL provision a Zitadel Machine User (service account) via Pulumi for the backend to authenticate against the Zitadel Management API.
+
+#### Scenario: Machine User creation
+
+- **WHEN** the Pulumi stack is applied
+- **THEN** a Zitadel Machine User SHALL exist with userName `backend-app`
+- **AND** the Machine User SHALL have `ACCESS_TOKEN_TYPE_JWT` as its access token type
+
+### Requirement: Private Key JWT credential
+
+The Machine User SHALL be configured with a Private Key for JWT-based authentication. The key JSON file SHALL be stored in GCP Secret Manager.
+
+#### Scenario: Key generation and storage
+
+- **WHEN** the Pulumi stack is applied
+- **THEN** a Machine Key SHALL be generated for the Machine User with type `KEY_TYPE_JSON`
+- **AND** the key JSON content SHALL be stored in GCP Secret Manager as a secret
+- **AND** the secret SHALL be named `zitadel-machine-key`
+
+#### Scenario: Key mounted to backend pod via ESO
+
+- **WHEN** the backend pod starts in GKE
+- **THEN** External Secrets Operator SHALL sync the key from GCP Secret Manager to a Kubernetes Secret
+- **AND** the key SHALL be mounted as a file at a configurable path in the backend container
+
+### Requirement: Machine User IAM permissions
+
+The Machine User SHALL be granted the minimum permissions required to send email verification codes.
+
+#### Scenario: Required permissions
+
+- **WHEN** the Machine User authenticates to the Zitadel API
+- **THEN** the Machine User SHALL be able to call `POST /v2/users/{userId}/email/send`
+- **AND** the Machine User SHALL be able to call `POST /v2/users/{userId}/email/resend`
+- **AND** the Machine User SHALL NOT have broader admin permissions
+
+### Requirement: Backend Zitadel API client configuration
+
+The backend SHALL be configured with the Zitadel instance domain and the path to the Machine User's private key JSON file.
+
+#### Scenario: Configuration via environment variables
+
+- **WHEN** the backend starts
+- **THEN** it SHALL read the Zitadel domain from the existing OIDC issuer configuration
+- **AND** it SHALL read the key file path from `ZITADEL_MACHINE_KEY_PATH`
+- **AND** it SHALL initialize the `zitadel-go/v3` client with `DefaultServiceUserAuthentication`
+
+#### Scenario: Missing key file in development
+
+- **WHEN** the backend starts in local development without a Zitadel key file configured
+- **THEN** the Zitadel API client SHALL be nil/disabled
+- **AND** the email verification consumer SHALL log a warning and skip processing
+- **AND** the resend RPC SHALL return an error indicating the feature is unavailable

--- a/openspec/changes/email-verification/tasks.md
+++ b/openspec/changes/email-verification/tasks.md
@@ -1,0 +1,66 @@
+## 1. Cloud Provisioning — Remove autoVerifyEmail
+
+- [x] 1.1 Delete `autoVerifyEmail` Action, `PRE_CREATION` TriggerAction, and `auto-verify-email.js` script from `src/zitadel/components/token-action.ts` and `src/zitadel/scripts/`
+- [x] 1.2 Remove `autoVerifyEmailAction` and `preCreationTrigger` from `ActionsComponent` class outputs and public properties
+- [x] 1.3 Run `make check` and verify Pulumi preview shows only the expected deletions
+
+## 2. Cloud Provisioning — Zitadel Machine User
+
+- [x] 2.1 Create a `MachineUserComponent` in `src/zitadel/components/machine-user.ts` that provisions a `zitadel.MachineUser` named `backend-app` with `ACCESS_TOKEN_TYPE_JWT`
+- [x] 2.2 Generate a `zitadel.MachineKey` (`backend-app-key`) with `KEY_TYPE_JSON` for the Machine User
+- [x] 2.3 Grant the Machine User `ORG_USER_MANAGER` role via `zitadel.OrgMember`
+- [x] 2.4 Output the Machine Key `keyDetails` for storage in GCP Secret Manager (`zitadel-machine-key`)
+- [x] 2.5 Wire the `MachineUserComponent` into the `Zitadel` orchestrator class in `src/zitadel/index.ts`
+- [x] 2.6 Run `make check` and verify Pulumi preview
+
+## 3. Cloud Provisioning — K8s Secret Sync
+
+- [x] 3.1 Add an ExternalSecret resource to sync `zitadel-machine-key` from GCP Secret Manager to a K8s Secret
+- [x] 3.2 Mount the K8s Secret as a file volume in the backend Deployment manifest
+- [x] 3.3 Add `ZITADEL_MACHINE_KEY_PATH` environment variable to the backend container pointing to the mounted file
+- [x] 3.4 Render Kustomize overlays and verify manifests
+
+## 4. Specification — Proto Schema
+
+- [x] 4.1 Add `ResendEmailVerification` RPC method to `UserService` in `proto/liverty_music/rpc/user/v1/user_service.proto`
+- [x] 4.2 Define request/response messages for `ResendEmailVerification`
+- [x] 4.3 Run `buf lint` and `buf breaking` to validate
+
+## 5. Backend — Zitadel API Client
+
+- [ ] 5.1 Add `zitadel-go/v3` dependency via `go get`
+- [ ] 5.2 Add `ZitadelMachineKeyPath` field to both `ServerConfig` and `ConsumerConfig` in `pkg/config/config.go`
+- [ ] 5.3 Create Zitadel client initialization in `internal/infrastructure/zitadel/` using `client.DefaultServiceUserAuthentication`
+- [ ] 5.4 Define an `EmailVerifier` interface in `internal/usecase/` for sending and resending verification emails
+- [ ] 5.5 Implement the `EmailVerifier` interface in `internal/infrastructure/zitadel/`
+- [ ] 5.6 Wire the Zitadel client into DI in both `internal/di/provider.go` (API server) and `internal/di/consumer.go` (event consumer), handling nil case for local dev
+
+## 6. Backend — NATS USER Stream and Event
+
+- [ ] 6.1 Add `USER` stream configuration to `internal/infrastructure/messaging/streams.go`
+- [ ] 6.2 Define `entity.SubjectUserCreated` constant and `USER.created` event payload struct in `internal/entity/`
+- [ ] 6.3 Inject `message.Publisher` (Watermill) into `userUseCase` struct, following existing pattern in `concertCreationUseCase`
+- [ ] 6.4 Publish `USER.created` event in `UserUseCase.Create()` after successful database persistence
+- [ ] 6.5 Create consumer in `internal/adapter/event/user_consumer.go` that subscribes to `USER.created` and calls `EmailVerifier.SendVerification()`. Use `logging.Logger` for trace-ID-aware error logging (via `ctx` from `msg.Context()`)
+- [ ] 6.6 Wire the consumer into `internal/di/consumer.go` and register handler in the Watermill Router
+
+## 7. Backend — Resend Verification RPC
+
+- [ ] 7.1 Implement `ResendEmailVerification` handler in `internal/adapter/rpc/user_handler.go`
+- [ ] 7.2 Extract `external_id` from JWT claims and call `EmailVerifier.ResendVerification()`
+- [ ] 7.3 Return `codes.FailedPrecondition` when email is already verified
+- [ ] 7.4 Return `codes.ResourceExhausted` when rate limit exceeded (3 requests per 10 minutes per user)
+- [ ] 7.5 Write unit tests for the handler and use case logic
+
+## 8. Frontend — Settings Page
+
+- [ ] 8.1 Add email verification status display (verified/not verified indicator) to Settings page
+- [ ] 8.2 Add "Resend verification email" button visible only for unverified users
+- [ ] 8.3 Connect button to `ResendEmailVerification` RPC call
+- [ ] 8.4 Add success/error feedback and temporary disable on button click
+
+## 9. Integration Testing
+
+- [ ] 9.1 Test the full signup flow in dev environment: Passkey registration → user created with unverified email → verification email received
+- [ ] 9.2 Test resend from Settings page
+- [ ] 9.3 Test verification via Zitadel hosted UI → `email_verified` claim updates on next token refresh

--- a/proto/liverty_music/rpc/user/v1/user_service.proto
+++ b/proto/liverty_music/rpc/user/v1/user_service.proto
@@ -43,6 +43,19 @@ service UserService {
   // - NOT_FOUND: No user record exists for the authenticated identity.
   // - UNAUTHENTICATED: The request lacks valid authentication credentials.
   rpc UpdateHome(UpdateHomeRequest) returns (UpdateHomeResponse);
+
+  // ResendEmailVerification triggers a new email verification message for the
+  // authenticated user via the identity provider (Zitadel).
+  //
+  // The user identity is extracted from the JWT context — clients do not
+  // provide it in the request.
+  //
+  // Possible errors:
+  // - FAILED_PRECONDITION: The user's email is already verified.
+  // - RESOURCE_EXHAUSTED: The user has exceeded the resend rate limit.
+  // - UNAUTHENTICATED: The request lacks valid authentication credentials.
+  // - UNAVAILABLE: The email verification service is not configured.
+  rpc ResendEmailVerification(ResendEmailVerificationRequest) returns (ResendEmailVerificationResponse);
 }
 
 // GetRequest is the request for retrieving the authenticated user's profile.
@@ -88,3 +101,12 @@ message UpdateHomeResponse {
   // The updated user entity with the new home area applied.
   entity.v1.User user = 1 [(buf.validate.field).required = true];
 }
+
+// ResendEmailVerificationRequest is the request for resending the email
+// verification message. The user identity is resolved from the JWT context —
+// no fields are required.
+message ResendEmailVerificationRequest {}
+
+// ResendEmailVerificationResponse is returned when the verification email has
+// been successfully queued for delivery.
+message ResendEmailVerificationResponse {}


### PR DESCRIPTION
## Summary

- Add ResendEmailVerification RPC to UserService in the proto schema, allowing authenticated users to request a new verification email via Zitadel. User identity is resolved from JWT context; errors include FAILED_PRECONDITION (already verified) and RESOURCE_EXHAUSTED (rate limited).
- Add openspec change artifacts (proposal, design, specs, tasks) documenting the end-to-end email verification flow: automatic verification trigger on user creation, resend capability, and frontend status display.

## Test plan

- [ ] Run buf lint and buf breaking to validate proto changes
- [ ] Review openspec artifacts for completeness and consistency
- [ ] Confirm downstream repos (backend, frontend) can consume the new RPC after BSR generation

Closes: #275