### PR TITLE
docs(openspec): add fix-dev-regressions change and update bottom-sheet spec

### DIFF
--- a/openspec/changes/fix-dev-regressions/.openspec.yaml
+++ b/openspec/changes/fix-dev-regressions/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-21

--- a/openspec/changes/fix-dev-regressions/design.md
+++ b/openspec/changes/fix-dev-regressions/design.md
@@ -1,0 +1,103 @@
+## Context
+
+Three bugs in the dev environment traced to distinct root causes:
+
+1. **TicketJourney RPC failure**: `vite.config.ts` has resolve aliases that redirect BSR-generated `TicketJourneyService` imports to `tmp/ticket-journey-stub.js` — a stub with `methods: {}`. The stub was added before the BSR release (specification v0.28.0) and never removed. `createClient()` returns an empty object, causing `this.client.setStatus is not a function`.
+
+2. **Push notification UUID mismatch**: `PushNotificationHandler.Subscribe` passes the Zitadel `sub` claim (numeric ID `365016846690184714`) directly as `user_id` to the database. The `push_subscriptions.user_id` column is `UUID NOT NULL REFERENCES users(id)`. Other handlers (TicketHandler, UserHandler) correctly resolve via `userRepo.GetByExternalID()`.
+
+3. **Bottom-sheet dismiss broken**: `onBackdropClick` uses `closest('.sheet-page')` to filter clicks, but `.sheet-page` has `min-block-size: 100dvh` — so the transparent area above the sheet body is inside `.sheet-page`, causing the guard to always return early. The overall implementation is overly complex with 3 dismiss paths and JS-driven backdrop opacity.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Fix all three bugs so dev environment works correctly
+- Simplify bottom-sheet to use modern CSS (Scroll-Driven Animations for backdrop opacity) and reduce JS surface area
+- Remove `.sheet-page` wrapper and `onBackdropClick` hack from bottom-sheet
+
+**Non-Goals:**
+- Adding touch-drag dismiss gesture (future enhancement)
+- Changing the bottom-sheet's visual design or layout
+- Modifying the PushNotification proto definition
+
+## Decisions
+
+### Decision 1: Remove Vite aliases (TicketJourney fix)
+
+Remove the 3 resolve aliases from `vite.config.ts` and delete `tmp/ticket-journey-stub.js`. The BSR-generated code in `node_modules/@buf/liverty-music_schema.connectrpc_es` already contains the correct `TicketJourneyService` with all methods.
+
+**Alternative considered**: Update the stub to include proper methods. Rejected — the real generated code is already installed; the alias is simply masking it.
+
+### Decision 2: Add UserRepository to PushNotificationHandler (push notification fix)
+
+Follow the established pattern from `TicketHandler` and `UserHandler`:
+
+```
+auth.GetUserID(ctx)  →  Zitadel sub claim (numeric string)
+                     →  userRepo.GetByExternalID(ctx, externalID)
+                     →  user.ID (UUIDv7)
+                     →  pass to use case
+```
+
+Add `UserRepository` as a dependency to `PushNotificationHandler` and resolve the internal UUID before calling `pushUseCase.Subscribe()`. Update DI wiring in `internal/di/`.
+
+**Alternative considered**: Convert at the use-case layer. Rejected — the handler layer is where auth context is resolved in all other handlers; consistency matters.
+
+### Decision 3: Simplify bottom-sheet DOM — merge scroll-wrapper into dialog
+
+**Current DOM** (5 elements, 4 levels deep):
+```
+dialog[popover] > div.scroll-wrapper > div.dismiss-zone + section.sheet-page > div.sheet-body > au-slot
+```
+
+**New DOM** (3 elements, 2 levels deep):
+```
+dialog[popover="auto"] > div.dismiss-zone + div.sheet-body > au-slot
+```
+
+The `dialog` element itself becomes the scroll-snap container (`overflow-y: auto`, `scroll-snap-type: y mandatory`). The intermediate `div.scroll-wrapper` and `section.sheet-page` are both eliminated.
+
+**Key insight — light dismiss backdrop click does not work, but ESC does**: `popover="auto"` light dismiss via backdrop click requires clicks on `::backdrop` (outside the popover). The dialog is `inset: 0` (full-viewport) as a scroll container, so `::backdrop` has no clickable area — backdrop click dismiss is structurally impossible. However, `popover="auto"` still provides ESC key dismiss via the browser standard, which is simpler than manually handling `keydown` events with `popover="manual"`. The `toggle` event fired on ESC dismiss is used to sync the `open` state.
+
+Changes:
+- Remove `div.scroll-wrapper` — dialog itself is the scroll-snap container with `overflow-y: auto; scroll-snap-type: y mandatory; scrollbar-width: none`
+- Remove `section.sheet-page` wrapper — `.sheet-body` is a direct child of `dialog` with `scroll-snap-align: end`
+- Remove `onBackdropClick` method and `click.trigger` — no transparent click target ambiguity exists
+- Remove `onScroll` method and `scroll.trigger` — replace JS-driven `--_backdrop-opacity` with CSS Scroll-Driven Animations using `scroll-timeline` on `dialog` and `animation-timeline` on `dialog::backdrop`
+- Keep `popover="auto"` for dismissable mode — ESC key dismiss is handled by the browser; `onToggle` detects the toggle event and dispatches `sheet-closed`
+- Keep `dismissableChanged` — switches between `popover="auto"` (dismissable) and `popover="manual"` (non-dismissable)
+- Keep `onScrollEnd` + `scrollend.trigger` for scroll-snap dismiss detection
+- Keep `dismissable` bindable — controls whether dismiss-zone is rendered and `onScrollEnd` fires
+
+**Scroll-Driven Animation for backdrop opacity:**
+```css
+dialog {
+  scroll-timeline: --sheet-scroll block;
+}
+
+dialog::backdrop {
+  animation: backdrop-fade linear both;
+  animation-timeline: --sheet-scroll;
+}
+
+@keyframes backdrop-fade {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+```
+
+If `::backdrop` cannot receive `animation-timeline` from the dialog's `scroll-timeline`, fall back to static opacity (progressive enhancement).
+
+**Alternative considered**: Use `popover="manual"` unconditionally + manual `keydown` handler for ESC. Rejected — `popover="auto"` provides ESC dismiss for free via browser standard, eliminating the need for `addEventListener('keydown')` registration/cleanup. Simpler code.
+
+**Alternative considered**: Use touch events for swipe dismiss instead of scroll-snap. Rejected — scroll-snap provides native inertia scrolling and snap behavior; touch event reimplementation is more code and worse UX.
+
+## Risks / Trade-offs
+
+- **Scroll-Driven Animations on `::backdrop`**: If `::backdrop` cannot receive `animation-timeline` from the dialog's `scroll-timeline`, the backdrop opacity will be static. Dismiss functionality is unaffected. Mitigation: test in Chrome DevTools during implementation; if it doesn't work, use static `opacity: 1`.
+
+- **No light dismiss**: Users cannot close the sheet by tapping the backdrop. Scroll-down swipe is the only dismiss mechanism. This matches native iOS/Android bottom-sheet behavior where backdrop tap is optional and swipe-down is primary.
+
+- **PushNotificationHandler DI change**: Adding `UserRepository` changes the constructor signature and requires updating Wire providers. Low risk — follows the exact pattern of existing handlers.
+
+- **Bottom-sheet consumer impact**: All consumers bind via `open`, `dismissable`, `sheet-closed`, and `au-slot`. None of these change. The internal DOM restructuring is transparent to consumers.

--- a/openspec/changes/fix-dev-regressions/proposal.md
+++ b/openspec/changes/fix-dev-regressions/proposal.md
@@ -16,7 +16,7 @@ _(none)_
 
 ### Modified Capabilities
 
-- `bottom-sheet-ce`: Replace JS-driven backdrop opacity with CSS Scroll-Driven Animations; remove `onBackdropClick` and `.sheet-page` wrapper; simplify DOM to dialog > scroll-wrapper > dismiss-zone + sheet-body
+- `bottom-sheet-ce`: Replace JS-driven backdrop opacity with CSS Scroll-Driven Animations; remove `onBackdropClick`, `.scroll-wrapper`, and `.sheet-page` wrapper; simplify DOM to dialog > dismiss-zone + sheet-body
 
 ## Impact
 

--- a/openspec/changes/fix-dev-regressions/proposal.md
+++ b/openspec/changes/fix-dev-regressions/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+Three bugs are visible on the dev environment (dev.liverty-music.app) as of 2026-03-21: TicketJourney RPC calls fail because Vite aliases override generated BSR code with an empty stub, push notification subscribe fails due to a Zitadel-to-UUID type mismatch in the backend, and the bottom-sheet's scroll-down and backdrop-tap dismiss mechanisms are broken. The bottom-sheet's implementation is also overly complex with three competing dismiss paths and JS-driven backdrop opacity — this should be simplified using modern CSS (Scroll-Driven Animations) and the Popover API's native light dismiss.
+
+## What Changes
+
+- **Frontend**: Remove stale Vite resolve aliases for TicketJourneyService stub in `vite.config.ts` and delete `tmp/ticket-journey-stub.js`
+- **Backend**: Add `GetByExternalID` user lookup in `PushNotificationHandler.Subscribe` to convert Zitadel numeric ID to internal UUID before database insert
+- **Frontend**: Simplify `<bottom-sheet>` custom element — remove `.sheet-page` wrapper and `onBackdropClick` JS hack, replace JS-driven `onScroll` backdrop opacity with CSS Scroll-Driven Animations, keep `popover="auto"` light dismiss as-is
+
+## Capabilities
+
+### New Capabilities
+
+_(none)_
+
+### Modified Capabilities
+
+- `bottom-sheet-ce`: Replace JS-driven backdrop opacity with CSS Scroll-Driven Animations; remove `onBackdropClick` and `.sheet-page` wrapper; simplify DOM to dialog > scroll-wrapper > dismiss-zone + sheet-body
+
+## Impact
+
+- **Frontend `vite.config.ts`**: Remove 3 resolve alias entries + delete stub file
+- **Frontend `src/components/bottom-sheet/`**: Rewrite .ts, .html, .css (fewer lines overall)
+- **Backend `internal/adapter/rpc/push_notification_handler.go`**: Add UserRepository dependency, wire via DI
+- **Backend `internal/usecase/push_notification_uc.go`**: No change (receives correct UUID)
+- **Backend `internal/di/`**: Update Wire provider set for PushNotificationHandler

--- a/openspec/changes/fix-dev-regressions/specs/bottom-sheet-ce/spec.md
+++ b/openspec/changes/fix-dev-regressions/specs/bottom-sheet-ce/spec.md
@@ -1,0 +1,43 @@
+## MODIFIED Requirements
+
+### Requirement: Bottom Sheet Custom Element
+The system SHALL provide a `<bottom-sheet>` custom element as the single dialog primitive for all overlay content, using the Popover API with CSS scroll-snap dismiss.
+
+#### Scenario: Scroll-snap dismiss
+- **WHEN** the sheet is open and `dismissable` is `true`
+- **THEN** a dismiss zone SHALL be rendered above the sheet content as a direct child of the `dialog` element
+- **AND** swiping down SHALL scroll to the dismiss zone, triggering close on `scrollend`
+- **AND** the `::backdrop` opacity SHALL track scroll progress via CSS Scroll-Driven Animations (`scroll-timeline` on `dialog`, `animation-timeline` on `dialog::backdrop`)
+- **AND** if the browser does not support Scroll-Driven Animations on `::backdrop`, the backdrop SHALL display at static full opacity as a fallback
+
+#### Scenario: DOM structure
+- **WHEN** the sheet is rendered
+- **THEN** the internal DOM SHALL be `dialog > .dismiss-zone + .sheet-body`
+- **AND** the `dialog` element itself SHALL be the scroll-snap container (`overflow-y: auto`, `scroll-snap-type: y mandatory`)
+- **AND** no intermediate `.scroll-wrapper` or `.sheet-page` wrapper SHALL exist
+
+#### Scenario: Non-dismissable mode
+- **WHEN** `dismissable` is `false`
+- **THEN** the CE SHALL use `popover="manual"`
+- **AND** the dismiss zone SHALL NOT be rendered
+- **AND** scroll-snap dismiss SHALL be disabled
+- **AND** ESC key SHALL NOT close the sheet
+
+#### Scenario: Dismissable mode with ESC dismiss
+- **WHEN** `dismissable` is `true` (default)
+- **THEN** the CE SHALL use `popover="auto"`
+- **AND** pressing Escape SHALL close the sheet via the browser's native popover light dismiss
+- **AND** the CE SHALL handle the `toggle` event to detect ESC dismiss and dispatch `sheet-closed`
+- **AND** backdrop click dismiss SHALL NOT function (the full-viewport dialog has no clickable `::backdrop` area)
+
+## REMOVED Requirements
+
+### Requirement: Bottom Sheet Custom Element
+
+#### Scenario: Backdrop click dismiss
+- **WHEN** the user clicks the transparent area above the sheet card
+- **THEN** the CE SHALL initiate a smooth scroll to the dismiss zone
+- **AND** the sheet SHALL close via the scroll-snap dismiss mechanism
+
+**Reason**: The `.sheet-page` wrapper that created the "transparent area above the sheet card" is removed. The `onBackdropClick` JS handler was the source of the dismiss regression bug. Backdrop click dismiss is also structurally impossible with the full-viewport dialog layout.
+**Migration**: No consumer changes required. Scroll-snap dismiss and ESC key dismiss remain as the dismiss mechanisms.

--- a/openspec/changes/fix-dev-regressions/tasks.md
+++ b/openspec/changes/fix-dev-regressions/tasks.md
@@ -1,0 +1,26 @@
+## 1. Fix TicketJourney RPC stub (frontend)
+
+- [x] 1.1 Remove 3 resolve aliases from `vite.config.ts` (ticket_journey_pb, ticket_pb, ticket_journey_service_connect)
+- [x] 1.2 Delete `tmp/ticket-journey-stub.js`
+- [x] 1.3 Verify `TicketJourneyService` methods resolve from BSR package (`npm run build` succeeds)
+
+## 2. Fix push notification UUID mismatch (backend)
+
+- [x] 2.1 Add `UserRepository` dependency to `PushNotificationHandler` struct and constructor
+- [x] 2.2 In `Subscribe`, resolve internal UUID via `userRepo.GetByExternalID(ctx, userID)` before passing to use case
+- [x] 2.3 Update DI wiring in `internal/di/` to provide `UserRepository` to `PushNotificationHandler`
+- [x] 2.4 Run `mockery` to regenerate mocks if interface changed
+- [x] 2.5 Run `make check` to verify lint + tests pass
+
+## 3. Simplify bottom-sheet CE (frontend)
+
+- [x] 3.1 Rewrite `bottom-sheet.html`: remove `div.scroll-wrapper` and `section.sheet-page`, make `dialog` the scroll-snap container with `.dismiss-zone` + `.sheet-body` as direct children, remove `click.trigger` and `scroll.trigger`
+- [x] 3.2 Rewrite `bottom-sheet.ts`: remove `onBackdropClick` and `onScroll`; keep `onToggle` for ESC dismiss detection, `dismissableChanged` for auto/manual switching, `openChanged` (showPopover + scrollTo on dialog), and `onScrollEnd`
+- [x] 3.3 Rewrite `bottom-sheet.css`: remove `.scroll-wrapper` and `.sheet-page` rules, move scroll-snap properties to `dialog`, add `scroll-timeline: --sheet-scroll block` on `dialog`, add `animation-timeline: --sheet-scroll` on `dialog::backdrop` with `@keyframes backdrop-fade`
+- [x] 3.4 Test Scroll-Driven Animation on `::backdrop` in Chrome DevTools — if unsupported, fall back to static opacity
+- [x] 3.5 Verify all bottom-sheet consumers render correctly (event-detail-sheet, tickets QR, user-home-selector, hype-notification-dialog, language selector, error-banner)
+- [x] 3.6 Run `make check` to verify lint + tests pass
+
+## 4. Update spec (specification)
+
+- [x] 4.1 Archive delta spec into `openspec/specs/bottom-sheet-ce/spec.md`

--- a/openspec/specs/bottom-sheet-ce/spec.md
+++ b/openspec/specs/bottom-sheet-ce/spec.md
@@ -18,31 +18,35 @@ The system SHALL provide a `<bottom-sheet>` custom element as the single dialog 
 
 #### Scenario: Scroll-snap dismiss
 - **WHEN** the sheet is open and `dismissable` is `true`
-- **THEN** a dismiss zone SHALL be rendered above the sheet content as a scroll-snap target
+- **THEN** a dismiss zone SHALL be rendered above the sheet content as a direct child of the `dialog` element
 - **AND** swiping down SHALL scroll to the dismiss zone, triggering close on `scrollend`
-- **AND** the `::backdrop` opacity SHALL track scroll progress in real-time via a CSS custom property
+- **AND** the `::backdrop` opacity SHALL track scroll progress via CSS Scroll-Driven Animations (`scroll-timeline` on `dialog`, `animation-timeline` on `dialog::backdrop`)
+- **AND** if the browser does not support Scroll-Driven Animations on `::backdrop`, the backdrop SHALL display at static full opacity as a fallback
+
+#### Scenario: DOM structure
+- **WHEN** the sheet is rendered
+- **THEN** the internal DOM SHALL be `dialog > .dismiss-zone + .sheet-body`
+- **AND** the `dialog` element itself SHALL be the scroll-snap container (`overflow-y: auto`, `scroll-snap-type: y mandatory`)
+- **AND** no intermediate `.scroll-wrapper` or `.sheet-page` wrapper SHALL exist
 
 #### Scenario: Non-dismissable mode
 - **WHEN** `dismissable` is `false`
-- **THEN** the CE SHALL use `popover="manual"` instead of `popover="auto"`
+- **THEN** the CE SHALL use `popover="manual"`
 - **AND** the dismiss zone SHALL NOT be rendered
-- **AND** light dismiss (Escape, click-outside) SHALL be disabled
+- **AND** scroll-snap dismiss SHALL be disabled
+- **AND** ESC key SHALL NOT close the sheet
 
-#### Scenario: Dismissable mode with light dismiss
+#### Scenario: Dismissable mode with ESC dismiss
 - **WHEN** `dismissable` is `true` (default)
 - **THEN** the CE SHALL use `popover="auto"`
-- **AND** pressing Escape, clicking outside, or Android back gesture SHALL close the sheet
-- **AND** the CE SHALL handle the `toggle` event to detect light dismiss and dispatch `sheet-closed`
+- **AND** pressing Escape SHALL close the sheet via the browser's native popover light dismiss
+- **AND** the CE SHALL handle the `toggle` event to detect ESC dismiss and dispatch `sheet-closed`
+- **AND** backdrop click dismiss SHALL NOT function (the full-viewport dialog has no clickable `::backdrop` area)
 
 #### Scenario: Sheet closed event
-- **WHEN** the sheet is closed by any mechanism (light dismiss, scroll-snap, programmatic)
+- **WHEN** the sheet is closed by any mechanism (ESC dismiss, scroll-snap, programmatic)
 - **THEN** the CE SHALL dispatch a `sheet-closed` CustomEvent with `bubbles: true`
 - **AND** the parent component SHALL respond by setting `open` to `false`
-
-#### Scenario: Backdrop click dismiss
-- **WHEN** the user clicks the transparent area above the sheet card
-- **THEN** the CE SHALL initiate a smooth scroll to the dismiss zone
-- **AND** the sheet SHALL close via the scroll-snap dismiss mechanism
 
 #### Scenario: Handle bar rendering
 - **WHEN** the sheet is open


### PR DESCRIPTION
## Summary

- Add `fix-dev-regressions` OpenSpec change artifacts (proposal, design, delta specs, tasks)
- Update `bottom-sheet-ce` spec: simplified DOM structure (`dialog` as scroll-snap container), Scroll-Driven Animations for backdrop opacity, `popover="auto"` for ESC dismiss, removed backdrop click dismiss scenario

## Test plan

- [ ] `buf lint` passes
- [ ] OpenSpec artifacts are well-formed
