### PR TITLE
docs(openspec): archive id-resolution fixes and sync main spec

### DIFF
--- a/openspec/changes/archive/2026-03-21-fix-double-id-resolution/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-21-fix-double-id-resolution/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-21

--- a/openspec/changes/archive/2026-03-21-fix-double-id-resolution/design.md
+++ b/openspec/changes/archive/2026-03-21-fix-double-id-resolution/design.md
@@ -1,0 +1,50 @@
+## Context
+
+The codebase has two distinct patterns for ID resolution (external Zitadel sub → internal UUID):
+
+**Pattern A — UseCase-layer resolution** (pre-PR #246 pattern, used by `FollowUseCase`):
+```
+Handler receives claims.Sub → passes to UseCase → UseCase calls GetByExternalID internally
+```
+
+**Pattern B — Handler-layer resolution** (introduced in PR #246 for TicketJourney, TicketEmail):
+```
+Handler calls GetByExternalID → passes user.ID to UseCase → UseCase uses it directly
+```
+
+PR #246 incorrectly applied Pattern B to `FollowHandler` even though `FollowUseCase` already implements Pattern A via `resolveUserID()`. This caused double resolution: the handler passed `user.ID` (UUID) to `uc.ListFollowed`, which then called `GetByExternalID(user.ID)` — querying the `external_id` column with a UUID that was never stored there → `not_found`.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Fix `FollowService/ListFollowed`, `Follow`, `Unfollow`, `SetHype` returning `not_found`
+- Establish a clear rule: each use case uses exactly one pattern — never both
+
+**Non-Goals:**
+- Unifying all use cases to a single pattern (that is a larger refactor)
+- Changing `TicketJourneyUseCase` or `TicketEmailUseCase` (they correctly use Pattern B)
+
+## Decisions
+
+**Decision: Revert `FollowHandler` to pass `claims.Sub` directly to the use case.**
+
+`FollowUseCase.resolveUserID()` already owns ID resolution for all follow operations. The handler should not duplicate this. Pattern B (handler-layer resolution) is only appropriate when the use case has no internal resolution.
+
+Alternatives considered:
+- Remove `resolveUserID` from `FollowUseCase` and keep handler-layer resolution → would require touching the use case and all its tests; higher blast radius; Pattern B is less clean for use cases with multiple methods all needing resolution.
+- Add a rule to `resolveUserID` to detect UUID input and skip → fragile, no clear ownership.
+
+**Decision: `FollowHandler` does not hold a `userRepo` reference.**
+
+Since the handler no longer calls `GetByExternalID`, the `userRepo` dependency is not needed. Removing it makes the handler's dependency surface smaller and its tests simpler.
+
+## Risks / Trade-offs
+
+- [Risk] Other use cases may have the same double-resolution bug → Mitigation: audit `TicketJourneyUseCase` and `TicketEmailUseCase` to confirm they do NOT call `resolveUserID` internally (they don't — handler-layer resolution is the sole path for those).
+
+## Migration Plan
+
+1. Revert `follow_handler.go`: remove `userRepo`, pass `claims.Sub` to use case
+2. Update `di/provider.go`: remove `userRepo` from `NewFollowHandler`
+3. Update `follow_handler_test.go`: remove `MockUserRepository`, pass `claims.Sub` as userID in mock expectations
+4. Deploy — no DB migration needed

--- a/openspec/changes/archive/2026-03-21-fix-double-id-resolution/proposal.md
+++ b/openspec/changes/archive/2026-03-21-fix-double-id-resolution/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+`FollowUseCase` already resolves external ID → internal UUID via `resolveUserID()` internally, but PR #246 added a second resolution in `FollowHandler` before calling the use case. The handler now passes `user.ID` (internal UUID) to the use case, which then calls `GetByExternalID(user.ID)` — searching the `external_id` column with a UUID string that was never stored there. This causes `not_found` on every authenticated follow-related RPC call.
+
+## What Changes
+
+- Remove `userRepo.GetByExternalID` calls from `FollowHandler` methods (`Follow`, `Unfollow`, `ListFollowed`, `SetHype`)
+- Handler passes `claims.Sub` (external ID) directly to use case — the use case owns ID resolution
+- Confirm `TicketJourneyUseCase` and `TicketEmailUseCase` do NOT have internal `resolveUserID` — handler-layer resolution is correct for those
+- Update `FollowHandler` tests to reflect that `userRepo` is no longer injected into the handler
+
+## Capabilities
+
+### New Capabilities
+<!-- none -->
+
+### Modified Capabilities
+- `id-resolution`: Clarify that ID resolution responsibility belongs in the handler layer ONLY when the use case does not perform its own resolution internally. When the use case already resolves IDs (as `FollowUseCase` does), the handler must pass `claims.Sub` directly.
+
+## Impact
+
+- `backend/internal/adapter/rpc/follow_handler.go` — remove `userRepo` field and `GetByExternalID` calls
+- `backend/internal/adapter/rpc/follow_handler_test.go` — remove `MockUserRepository` from handler tests
+- `backend/internal/di/provider.go` — remove `userRepo` from `NewFollowHandler` call
+- No proto changes, no DB migrations

--- a/openspec/changes/archive/2026-03-21-fix-double-id-resolution/specs/id-resolution/spec.md
+++ b/openspec/changes/archive/2026-03-21-fix-double-id-resolution/specs/id-resolution/spec.md
@@ -1,0 +1,53 @@
+## MODIFIED Requirements
+
+### Requirement: RPC handlers resolve Zitadel external ID to internal UUID before database access
+All authenticated RPC handlers that write or query per-user rows in the database SHALL ensure that the JWT `sub` claim (Zitadel external ID) is resolved to the internal `users.id` UUID before any database access. The resolution SHALL occur at exactly one layer — either in the handler or in the use case — never both. Passing the raw JWT `sub` claim to a UUID column is prohibited.
+
+When the use case owns ID resolution internally (e.g., via a `resolveUserID` helper), the handler SHALL pass `claims.Sub` directly to the use case. When the use case accepts an internal UUID directly, the handler SHALL resolve `claims.Sub` to `users.id` before calling the use case.
+
+#### Scenario: Authenticated user calls FollowService/Follow
+- **WHEN** an authenticated user calls `FollowService/Follow`
+- **THEN** the handler passes `claims.Sub` to the use case, which resolves it to `users.id` internally and uses `users.id` for the `followed_artists.user_id` column
+
+#### Scenario: Authenticated user calls FollowService/Unfollow
+- **WHEN** an authenticated user calls `FollowService/Unfollow`
+- **THEN** the handler passes `claims.Sub` to the use case, which resolves it to `users.id` internally and uses `users.id` for the delete operation
+
+#### Scenario: Authenticated user calls FollowService/ListFollowed
+- **WHEN** an authenticated user calls `FollowService/ListFollowed`
+- **THEN** the handler passes `claims.Sub` to the use case, which resolves it to `users.id` and queries `followed_artists` with the internal UUID
+
+#### Scenario: Authenticated user calls FollowService/SetHype
+- **WHEN** an authenticated user calls `FollowService/SetHype`
+- **THEN** the handler passes `claims.Sub` to the use case, which resolves it to `users.id` and updates `followed_artists` with the internal UUID
+
+#### Scenario: Authenticated user calls TicketJourneyService/SetStatus
+- **WHEN** an authenticated user calls `TicketJourneyService/SetStatus`
+- **THEN** the handler resolves `claims.Sub` to `users.id` via `GetByExternalID` and writes to `ticket_journeys` with the internal UUID
+
+#### Scenario: Authenticated user calls TicketJourneyService/Delete
+- **WHEN** an authenticated user calls `TicketJourneyService/Delete`
+- **THEN** the handler resolves `claims.Sub` to `users.id` via `GetByExternalID` and deletes from `ticket_journeys` using the internal UUID
+
+#### Scenario: Authenticated user calls TicketJourneyService/ListByUser
+- **WHEN** an authenticated user calls `TicketJourneyService/ListByUser`
+- **THEN** the handler resolves `claims.Sub` to `users.id` via `GetByExternalID` and queries `ticket_journeys` with the internal UUID
+
+#### Scenario: Authenticated user calls TicketEmailService/CreateTicketEmail
+- **WHEN** an authenticated user calls `TicketEmailService/CreateTicketEmail`
+- **THEN** the handler resolves `claims.Sub` to `users.id` via `GetByExternalID` and writes to `ticket_emails` with the internal UUID
+
+#### Scenario: Authenticated user calls TicketEmailService/UpdateTicketEmail
+- **WHEN** an authenticated user calls `TicketEmailService/UpdateTicketEmail`
+- **THEN** the handler resolves `claims.Sub` to `users.id` via `GetByExternalID` and authorizes the update using the internal UUID
+
+#### Scenario: ID resolution occurs exactly once per request
+- **WHEN** any authenticated RPC is processed
+- **THEN** `GetByExternalID` is called exactly once — either in the handler or in the use case, not in both
+
+### Requirement: Handlers return NotFound when user record does not exist
+If `GetByExternalID` returns no user (e.g., user has a valid JWT but no record in `users`), the resolution layer SHALL return `CodeNotFound`.
+
+#### Scenario: Valid JWT but no user record
+- **WHEN** an authenticated request arrives but `GetByExternalID` finds no matching user
+- **THEN** the handler or use case returns `connect.CodeNotFound` with message "user not found"

--- a/openspec/changes/archive/2026-03-21-fix-double-id-resolution/tasks.md
+++ b/openspec/changes/archive/2026-03-21-fix-double-id-resolution/tasks.md
@@ -1,0 +1,28 @@
+## 1. Revert FollowHandler to pass claims.Sub to use case
+
+- [x] 1.1 Remove `userRepo entity.UserRepository` field from `FollowHandler` struct
+- [x] 1.2 Remove `userRepo entity.UserRepository` parameter from `NewFollowHandler`
+- [x] 1.3 In `Follow`: replace `userRepo.GetByExternalID` + `user.ID` with `claims.Sub` passed directly to use case
+- [x] 1.4 In `Unfollow`: same — pass `claims.Sub` directly to use case
+- [x] 1.5 In `ListFollowed`: same — pass `claims.Sub` directly to use case
+- [x] 1.6 In `SetHype`: same — pass `claims.Sub` directly to use case
+- [x] 1.7 Remove unused `entity` import from `follow_handler.go` if no longer needed
+
+## 2. Update DI wiring
+
+- [x] 2.1 Remove `userRepo` argument from `NewFollowHandler(...)` call in `di/provider.go`
+
+## 3. Update tests
+
+- [x] 3.1 Remove `entitymocks.MockUserRepository` from `follow_handler_test.go` (handler no longer holds userRepo)
+- [x] 3.2 Update `TestFollowHandler_Follow` success case: mock expects `uc.Follow(ctx, "ext-user-1", artistID)` (external ID, not UUID)
+- [x] 3.3 Update `TestFollowHandler_Unfollow` success case: mock expects `uc.Unfollow(ctx, "ext-user-1", artistID)`
+- [x] 3.4 Update `TestFollowHandler_ListFollowed` success case: mock expects `uc.ListFollowed(ctx, "ext-user-1")`
+- [x] 3.5 Update `TestFollowHandler_SetHype` success case: mock expects `uc.SetHype(ctx, "ext-user-1", artistID, ...)`
+- [x] 3.6 Remove "user not found" test cases from FollowHandler tests (handler no longer calls GetByExternalID)
+- [x] 3.7 Remove `followAuthedCtx` helper if it duplicates the ticket-journey helper (or keep for clarity)
+
+## 4. Verify and deploy
+
+- [x] 4.1 Run `make check` in backend repo
+- [ ] 4.2 Confirm `FollowService/ListFollowed` returns 200 after deploy

--- a/openspec/changes/archive/2026-03-21-fix-zitadel-id-resolution/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-21-fix-zitadel-id-resolution/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-21

--- a/openspec/changes/archive/2026-03-21-fix-zitadel-id-resolution/design.md
+++ b/openspec/changes/archive/2026-03-21-fix-zitadel-id-resolution/design.md
@@ -1,0 +1,47 @@
+## Context
+
+The backend uses Zitadel as the identity provider. Each Zitadel user has an `external_id` (the JWT `sub` claim, a numeric string such as `"365016846690184714"`). Internally, every row in `users` has a `id UUID` primary key that is distinct from the Zitadel ID.
+
+All tables that store per-user data (`followed_artists`, `ticket_journeys`, `ticket_emails`, `push_subscriptions`, `tickets`) define `user_id UUID NOT NULL REFERENCES users(id)`. The correct flow is:
+
+```
+JWT sub claim (external_id)
+  → userRepo.GetByExternalID(ctx, claims.Sub)
+  → user.ID  (internal UUID)
+  → passed to use case / repository
+```
+
+The fix was applied to `TicketHandler` (originally correct) and later to `PushNotificationHandler` (#239). `FollowHandler`, `TicketJourneyHandler`, and `TicketEmailHandler` still use `auth.GetUserID()` — which returns `claims.Sub` — and pass it directly to use cases that ultimately write or query against a UUID column.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Fix the `SQLSTATE 22P02` error in `FollowHandler`, `TicketJourneyHandler`, and `TicketEmailHandler`
+- Apply the same pattern established by `TicketHandler` and `PushNotificationHandler`
+- Add/update unit tests for all three handlers
+
+**Non-Goals:**
+- Changing the ID resolution strategy (e.g., caching, middleware-based resolution)
+- Modifying use case or repository interfaces
+- Any database schema or API changes
+
+## Decisions
+
+### Inject `UserRepository` into each handler (not the use case)
+
+The resolution of `external_id` → `internal UUID` is an **adapter-layer concern**: it bridges the identity-provider world (JWT) and the domain world (UUID). The use case should only receive domain identifiers. Injecting `UserRepository` at the handler level keeps this mapping at the correct layer boundary, consistent with the existing pattern in `TicketHandler`.
+
+Alternative considered: resolve in a shared middleware interceptor. Rejected because not all RPCs require user resolution (e.g., unauthenticated endpoints), and the current per-handler pattern avoids over-fetching for those cases.
+
+### Reuse `mapper.GetClaimsFromContext` + `userRepo.GetByExternalID`
+
+Both helpers already exist and are used in `TicketHandler`. No new abstractions are needed.
+
+### Return `CodeNotFound` when user is not found
+
+After signup the user record is created via `UserService/Create`. If `GetByExternalID` returns `nil` (user not yet created), the correct response is `CodeNotFound`, consistent with `TicketHandler` and `PushNotificationHandler`.
+
+## Risks / Trade-offs
+
+- **Extra DB lookup per request**: Each of the 9 affected handler methods now issues one additional `SELECT` to resolve the user. This is the same trade-off accepted for `TicketHandler` and `PushNotificationHandler`. Acceptable at current scale.
+- **DI wiring changes**: `di/provider.go` must be updated for all three handlers. Wire re-generation is needed.

--- a/openspec/changes/archive/2026-03-21-fix-zitadel-id-resolution/proposal.md
+++ b/openspec/changes/archive/2026-03-21-fix-zitadel-id-resolution/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+Multiple RPC handlers pass the Zitadel JWT `sub` claim (a numeric string like `"365016846690184714"`) directly as `user_id` to PostgreSQL, where the column type is `UUID`. This causes `SQLSTATE 22P02: invalid input syntax for type uuid` at runtime. The same bug was fixed in `PushNotificationHandler` (#239) and `TicketHandler`, but three handlers were missed: `FollowHandler`, `TicketJourneyHandler`, and `TicketEmailHandler`.
+
+## What Changes
+
+- `FollowHandler`: inject `UserRepository`, resolve `claims.Sub` → `user.ID` before calling use case (affects `Follow`, `Unfollow`, `ListFollowed`, `SetHype`)
+- `TicketJourneyHandler`: inject `UserRepository`, resolve `claims.Sub` → `user.ID` before calling use case (affects `SetStatus`, `Delete`, `ListByUser`)
+- `TicketEmailHandler`: inject `UserRepository`, resolve `claims.Sub` → `user.ID` before calling use case (affects `CreateTicketEmail`, `UpdateTicketEmail`)
+- `di/provider.go`: wire `UserRepository` into the three handlers above
+
+## Capabilities
+
+### New Capabilities
+
+_None._
+
+### Modified Capabilities
+
+_None._ This is a pure bug fix — no requirements change, only the implementation corrects a missing ID-resolution step.
+
+## Impact
+
+- **Backend handlers**: `follow_handler.go`, `ticket_journey_handler.go`, `ticket_email_handler.go`
+- **DI wiring**: `di/provider.go`
+- **Tests**: handler unit tests for the three affected files must be updated/added
+- **No API changes**: request/response shapes are unchanged
+- **No DB migration**: schema is unchanged

--- a/openspec/changes/archive/2026-03-21-fix-zitadel-id-resolution/specs/id-resolution/spec.md
+++ b/openspec/changes/archive/2026-03-21-fix-zitadel-id-resolution/specs/id-resolution/spec.md
@@ -1,0 +1,47 @@
+## ADDED Requirements
+
+### Requirement: RPC handlers resolve Zitadel external ID to internal UUID before database access
+All authenticated RPC handlers that write or query per-user rows in the database SHALL resolve the JWT `sub` claim (Zitadel external ID) to the internal `users.id` UUID before passing the user identifier to any use case or repository. Passing the raw JWT `sub` claim to a UUID column is prohibited.
+
+#### Scenario: Authenticated user calls FollowService/Follow
+- **WHEN** an authenticated user calls `FollowService/Follow`
+- **THEN** the handler resolves `claims.Sub` to `users.id` via `GetByExternalID` and uses `users.id` for the `followed_artists.user_id` column
+
+#### Scenario: Authenticated user calls FollowService/Unfollow
+- **WHEN** an authenticated user calls `FollowService/Unfollow`
+- **THEN** the handler resolves `claims.Sub` to `users.id` and uses `users.id` for the delete operation
+
+#### Scenario: Authenticated user calls FollowService/ListFollowed
+- **WHEN** an authenticated user calls `FollowService/ListFollowed`
+- **THEN** the handler resolves `claims.Sub` to `users.id` and queries `followed_artists` with the internal UUID
+
+#### Scenario: Authenticated user calls FollowService/SetHype
+- **WHEN** an authenticated user calls `FollowService/SetHype`
+- **THEN** the handler resolves `claims.Sub` to `users.id` and updates `followed_artists` with the internal UUID
+
+#### Scenario: Authenticated user calls TicketJourneyService/SetStatus
+- **WHEN** an authenticated user calls `TicketJourneyService/SetStatus`
+- **THEN** the handler resolves `claims.Sub` to `users.id` and writes to `ticket_journeys` with the internal UUID
+
+#### Scenario: Authenticated user calls TicketJourneyService/Delete
+- **WHEN** an authenticated user calls `TicketJourneyService/Delete`
+- **THEN** the handler resolves `claims.Sub` to `users.id` and deletes from `ticket_journeys` using the internal UUID
+
+#### Scenario: Authenticated user calls TicketJourneyService/ListByUser
+- **WHEN** an authenticated user calls `TicketJourneyService/ListByUser`
+- **THEN** the handler resolves `claims.Sub` to `users.id` and queries `ticket_journeys` with the internal UUID without a `22P02` error
+
+#### Scenario: Authenticated user calls TicketEmailService/CreateTicketEmail
+- **WHEN** an authenticated user calls `TicketEmailService/CreateTicketEmail`
+- **THEN** the handler resolves `claims.Sub` to `users.id` and writes to `ticket_emails` with the internal UUID
+
+#### Scenario: Authenticated user calls TicketEmailService/UpdateTicketEmail
+- **WHEN** an authenticated user calls `TicketEmailService/UpdateTicketEmail`
+- **THEN** the handler resolves `claims.Sub` to `users.id` and authorizes the update using the internal UUID
+
+### Requirement: Handlers return NotFound when user record does not exist
+If `GetByExternalID` returns no user (e.g., user has a valid JWT but no record in `users`), the handler SHALL return `CodeNotFound`.
+
+#### Scenario: Valid JWT but no user record
+- **WHEN** an authenticated request arrives but `GetByExternalID` finds no matching user
+- **THEN** the handler returns `connect.CodeNotFound` with message "user not found"

--- a/openspec/changes/archive/2026-03-21-fix-zitadel-id-resolution/tasks.md
+++ b/openspec/changes/archive/2026-03-21-fix-zitadel-id-resolution/tasks.md
@@ -1,0 +1,33 @@
+## 1. FollowHandler
+
+- [x] 1.1 Add `userRepo entity.UserRepository` field to `FollowHandler` struct and update `NewFollowHandler` constructor
+- [x] 1.2 Replace `auth.GetUserID` with `mapper.GetClaimsFromContext` + `userRepo.GetByExternalID` in `Follow`
+- [x] 1.3 Replace `auth.GetUserID` with `mapper.GetClaimsFromContext` + `userRepo.GetByExternalID` in `Unfollow`
+- [x] 1.4 Replace `auth.GetUserID` with `mapper.GetClaimsFromContext` + `userRepo.GetByExternalID` in `ListFollowed`
+- [x] 1.5 Replace `auth.GetUserID` with `mapper.GetClaimsFromContext` + `userRepo.GetByExternalID` in `SetHype`
+- [x] 1.6 Update `follow_handler_test.go` to inject a mock `UserRepository` and cover the ID-resolution path for all four methods
+
+## 2. TicketJourneyHandler
+
+- [x] 2.1 Add `userRepo entity.UserRepository` field to `TicketJourneyHandler` struct and update `NewTicketJourneyHandler` constructor
+- [x] 2.2 Replace `auth.GetUserID` with `mapper.GetClaimsFromContext` + `userRepo.GetByExternalID` in `SetStatus`
+- [x] 2.3 Replace `auth.GetUserID` with `mapper.GetClaimsFromContext` + `userRepo.GetByExternalID` in `Delete`
+- [x] 2.4 Replace `auth.GetUserID` with `mapper.GetClaimsFromContext` + `userRepo.GetByExternalID` in `ListByUser`
+- [x] 2.5 Update `ticket_journey_handler_test.go` to inject a mock `UserRepository` and cover the ID-resolution path for all three methods
+
+## 3. TicketEmailHandler
+
+- [x] 3.1 Add `userRepo entity.UserRepository` field to `TicketEmailHandler` struct and update `NewTicketEmailHandler` constructor
+- [x] 3.2 Replace `auth.GetUserID` with `mapper.GetClaimsFromContext` + `userRepo.GetByExternalID` in `CreateTicketEmail`
+- [x] 3.3 Replace `auth.GetUserID` with `mapper.GetClaimsFromContext` + `userRepo.GetByExternalID` in `UpdateTicketEmail`
+- [x] 3.4 Update `ticket_email_handler_test.go` to inject a mock `UserRepository` and cover the ID-resolution path for both methods
+
+## 4. DI Wiring
+
+- [x] 4.1 Update `di/provider.go` to pass `UserRepository` to `NewFollowHandler`, `NewTicketJourneyHandler`, and `NewTicketEmailHandler`
+- [x] 4.2 Run `wire` (or verify Wire auto-generation) to confirm the dependency graph compiles
+
+## 5. Verification
+
+- [x] 5.1 Run `make check` (lint + unit tests) and confirm all tests pass
+- [ ] 5.2 Manually verify `TicketJourneyService/ListByUser` no longer returns 400 after signup in the dev environment

--- a/openspec/changes/simplify-concert-search-flow/.openspec.yaml
+++ b/openspec/changes/simplify-concert-search-flow/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-21

--- a/openspec/changes/simplify-concert-search-flow/design.md
+++ b/openspec/changes/simplify-concert-search-flow/design.md
@@ -1,0 +1,96 @@
+## Context
+
+The discovery page currently uses a 5-layer call chain to determine when to show the Dashboard Coach Mark:
+
+```
+DiscoveryRoute → FollowOrchestrator → ConcertSearchTracker → ConcertServiceClient → RPC
+```
+
+`FollowOrchestrator` duplicates follow state that `FollowServiceClient` already manages. `ConcertSearchTracker` wraps polling logic that belongs in `ConcertServiceClient`. Both are page-scoped controllers that discard state on navigation — meaning Dashboard must re-fetch all concert data from scratch.
+
+The project has established a state management pattern (see `state-management` spec): singleton services own `@observable` state, hydrate from localStorage, and persist via `propertyChanged` callbacks. `GuestService` and `OnboardingService` already follow this pattern. `FollowServiceClient` and `ConcertServiceClient` do not yet — they are stateless RPC wrappers.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Fix the Coach Mark bug: display when 3+ followed artists have concerts, regardless of how many artists are followed or still searching.
+- Eliminate `FollowOrchestrator` and `ConcertSearchTracker` by absorbing their logic into singleton services.
+- Make concert search state survive navigation (service-owned, not page-scoped).
+- Reduce discovery page from 5 controllers to 3.
+
+**Non-Goals:**
+
+- Changing backend RPC APIs — this is frontend-only.
+- Replacing polling with WebSocket/SSE — the polling mechanism itself works fine, the problem is where it lives and how completion is evaluated.
+- Optimizing Dashboard loading with cached concert data — the service will hold the state, but Dashboard can adopt it incrementally.
+- Persisting `artistsWithConcerts` to localStorage — this is session-scoped ephemeral state, not worth persisting.
+
+## Decisions
+
+### Decision 1: `FollowServiceClient` becomes the follow state SSoT
+
+**Choice**: Add `@observable followedArtists: Artist[]` to `FollowServiceClient`. It hydrates from `GuestService.follows` (guest) or `listFollowed()` RPC (authenticated) and exposes `followedIds` / `followedCount` as derived getters.
+
+**Why not keep FollowOrchestrator**: It holds a `followedArtists` array that is a copy of what the service already knows. The optimistic-update + rollback pattern belongs in the service (where the RPC call happens), not in a page-scoped controller. The `BubblePool.remove()` / `BubblePool.add()` calls for rollback are UI concerns that stay in `DiscoveryRoute`.
+
+**Why not a new FollowStateService**: `FollowServiceClient` already has `follow()`, `unfollow()`, `listFollowed()` — adding state to it is natural, not a new abstraction.
+
+### Decision 2: `ConcertServiceClient` owns polling and `artistsWithConcerts`
+
+**Choice**: Add a `searchAndTrack(artistId)` method that encapsulates the full search lifecycle:
+
+```
+searchNewConcerts(artistId)     ← fire & forget to backend
+startPolling()                  ← setInterval if not running
+  pollSearchStatuses()          ← check pending artist statuses
+    on completed → listConcerts(artistId)
+      → has concerts → artistsWithConcerts.add(artistId)
+      → artistsWithConcerts.size >= target → stopPolling (early exit)
+    on timeout (15s) → mark done, skip listConcerts
+```
+
+**Why in the service, not a controller**: The polling is pure data-fetching logic with no UI dependencies. Moving it to the singleton service means: (a) state survives page navigation, (b) `DiscoveryRoute` becomes a thin event handler, (c) Dashboard or any future page can read `artistsWithConcerts`.
+
+**Why `Set<string>` not `number`**: A Set prevents double-counting if `searchAndTrack` is called twice for the same artist (e.g., page reload with pre-seeded follows). The count is derived via `.size`.
+
+### Decision 3: Per-artist concert check replaces batch verify
+
+**Choice**: When a search status becomes `completed`, immediately call `listConcerts(artistId)` for that single artist. If concerts exist, add to `artistsWithConcerts` and emit a snack callback. Remove `verifyConcertsExist()` entirely.
+
+**Why**: The current flow calls `verifyConcertsExist()` only after ALL searches complete, which is the root cause of the bug. Per-artist checking enables the "3 artists with concerts → Coach Mark" condition to trigger as soon as the third qualifying artist completes, regardless of others still pending.
+
+**Alternative considered — count from `listSearchStatuses` response**: The RPC returns status only (pending/completed/failed), not whether concerts were found. A new RPC field would require backend changes, which is out of scope.
+
+### Decision 4: Snack notification unified with search completion
+
+**Choice**: The "artist has upcoming events" snack is emitted as a side effect of the per-artist `listConcerts` check inside `searchAndTrack`. The caller provides a callback for snack display. `checkLiveEvents()` in `FollowOrchestrator` is removed.
+
+**Why**: Currently there are two separate `listConcerts` calls per artist — one in `checkLiveEvents` (immediate, optimistic) and one in `verifyConcertsExist` (deferred, batch). The new design makes exactly one `listConcerts` call per artist, at the right time (after backend search completes).
+
+### Decision 5: Coach Mark condition simplified
+
+**Choice**:
+
+```typescript
+get showDashboardCoachMark(): boolean {
+  return this.isOnboarding
+    && this.concertService.artistsWithConcertsCount >= TUTORIAL_FOLLOW_TARGET
+}
+```
+
+**Why**: The condition no longer depends on `followedCount` at all. It answers only the question that matters: "have we found enough artists with concerts?" This is immune to the race condition where followedCount grows faster than searches complete.
+
+### Decision 6: Polling lifecycle managed by AbortController
+
+**Choice**: `ConcertServiceClient.searchAndTrack()` accepts an `AbortSignal`. When the discovery page detaches, it aborts the signal, which stops polling and cancels in-flight RPCs. The service clears its interval but retains `artistsWithConcerts` state.
+
+**Why**: The service is a singleton that outlives the page. Polling must be tied to page lifecycle (no point polling after the user leaves discovery). But the accumulated state (`artistsWithConcerts`) should survive for Dashboard's benefit.
+
+## Risks / Trade-offs
+
+**[Risk] Service singleton holds polling state for a page-specific flow** → The polling is page-scoped via AbortSignal. The service only retains the result (`artistsWithConcerts`), not the polling mechanism. If the user returns to discovery, `searchAndTrack` re-checks and resumes polling for any new follows.
+
+**[Risk] `listConcerts` called once per completed artist instead of batch** → Slightly more RPC calls than the current batch `verifyConcertsExist`. However, the calls are spread over time (as each artist completes) rather than concentrated, so actual load is smoother. And it eliminates the redundant `checkLiveEvents` call, so total RPC count may decrease.
+
+**[Trade-off] Early polling stop at target count** → Once 3 artists with concerts are found, polling stops. Any remaining pending searches won't complete. This is acceptable because: (a) the Coach Mark goal is met, (b) the user is about to navigate to Dashboard which fetches fresh data via `listByFollower`, (c) the backend `SearchNewConcerts` fire-and-forget already ran — the data will be there for future requests regardless of frontend polling.

--- a/openspec/changes/simplify-concert-search-flow/proposal.md
+++ b/openspec/changes/simplify-concert-search-flow/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+The discovery page's concert search polling has a bug: the Coach Mark display condition requires **all** followed artists' searches to complete (`completedSearchCount >= followedCount`), but `followedCount` grows dynamically as the user keeps following. This creates a moving goalpost where the Coach Mark may never appear if the user follows artists faster than searches complete. The root cause is over-engineered orchestration — `FollowOrchestrator` and `ConcertSearchTracker` duplicate state and logic that should live in singleton services.
+
+## What Changes
+
+- **Fix Coach Mark condition**: Change from "all searches complete + any concert exists" to "3+ artists with concerts found" — matching the intended UX.
+- **Remove `FollowOrchestrator`**: Push follow state (`followedArtists`, `followedIds`, `followedCount`) into `FollowServiceClient` as `@observable` SSoT, consistent with the `GuestService` state management pattern.
+- **Remove `ConcertSearchTracker`**: Move polling logic (`searchNewConcerts` → `listSearchStatuses` → `listConcerts`) into `ConcertServiceClient`. The service tracks `artistsWithConcerts` as `@observable` state, reusable by Dashboard.
+- **Remove `verifyConcertsExist`**: Replace batch-verify-after-all-complete with per-artist `listConcerts` check on each search completion. Eliminates the redundant second round of API calls.
+- **Remove `checkLiveEvents`**: The snack notification ("this artist has upcoming events") is produced as a side effect of the per-artist completion check, eliminating the duplicate `listConcerts` call.
+
+## Capabilities
+
+### New Capabilities
+
+_(none)_
+
+### Modified Capabilities
+
+- `frontend-onboarding-flow`: Coach Mark condition changes from "all searches complete + concert exists" to "3+ artists with concerts found". Pre-seeded follow sync moves to service layer.
+- `state-management`: `FollowServiceClient` gains `@observable followedArtists` as SSoT. `ConcertServiceClient` gains `@observable artistsWithConcerts` state and `searchAndTrack()` polling method.
+
+## Impact
+
+- **Frontend only** — no backend or protobuf changes required.
+- **Files removed**: `follow-orchestrator.ts`, `concert-search-tracker.ts`
+- **Files modified**: `discovery-route.ts` (simplified), `follow-service-client.ts` (SSoT), `concert-service.ts` (polling + state)
+- **Files modified (minor)**: `bubble-manager.ts`, `genre-filter-controller.ts` (update references to follow state source)
+- **Dashboard**: Can leverage `concertService.artistsWithConcerts` for optimized loading indicators (optional, not required).

--- a/openspec/changes/simplify-concert-search-flow/specs/frontend-onboarding-flow/spec.md
+++ b/openspec/changes/simplify-concert-search-flow/specs/frontend-onboarding-flow/spec.md
@@ -1,0 +1,66 @@
+## MODIFIED Requirements
+
+### Requirement: Interactive Artist Discovery (Bubble Network UI)
+
+The system SHALL provide an engaging, gamified interface for users to discover and follow artists using Last.fm API data. During onboarding, followed artists are stored locally (not via backend RPC). The system SHALL trigger a background concert search for each followed artist and track which artists have concerts. The Coach Mark SHALL appear as soon as the concert-with-artists target is reached, independent of how many artists the user has followed or how many searches are still pending.
+
+#### Scenario: Guest user follows artist via bubble tap
+
+- **WHEN** a guest user (in onboarding) taps an artist bubble
+- **THEN** the system SHALL trigger the absorption animation
+- **AND** the system SHALL store the artist in `FollowServiceClient.followedArtists` (which delegates to `GuestService` for guest users)
+- **AND** the system SHALL call `ConcertServiceClient.searchAndTrack(artistId)` to initiate background search and polling
+- **AND** the system SHALL NOT call any backend RPC for the follow operation itself
+
+#### Scenario: Guest follow default hype level
+
+- **WHEN** a guest user (in onboarding) requests the list of followed artists via `listFollowed()`
+- **THEN** the system SHALL return each followed artist with hype level `'watch'` (observation tier)
+
+#### Scenario: Discover to Dashboard transition
+
+- **WHEN** a user is at Step `'discovery'`
+- **AND** `ConcertServiceClient.artistsWithConcertsCount` >= 3
+- **THEN** the system SHALL activate a coach mark spotlight on the Dashboard icon
+- **AND** when the user taps the Dashboard icon, the system SHALL advance `onboardingStep` to `'dashboard'`
+- **AND** the system SHALL navigate to `/dashboard`
+
+#### Scenario: Coach Mark appears immediately at target
+
+- **WHEN** a user has followed 5 artists
+- **AND** 3 artists' searches have completed with concerts found
+- **AND** 2 artists' searches are still pending
+- **THEN** the system SHALL display the Coach Mark immediately
+- **AND** the system SHALL NOT wait for the remaining 2 searches to complete
+
+#### Scenario: Coach Mark does not appear without enough concerts
+
+- **WHEN** a user has followed >= 3 artists
+- **AND** fewer than 3 artists have concerts found (regardless of search completion status)
+- **THEN** the system SHALL NOT display the Coach Mark
+
+#### Scenario: Pre-seeded follows on page reload
+
+- **WHEN** the discovery page loads during onboarding
+- **THEN** the system SHALL hydrate follows from `GuestService.follows` into `FollowServiceClient`
+- **AND** the system SHALL call `ConcertServiceClient.searchAndTrack()` for any artists not yet tracked
+
+#### Scenario: Snack notification on concert found
+
+- **WHEN** a followed artist's search completes with status `completed`
+- **AND** `listConcerts(artistId)` returns at least one concert
+- **THEN** the system SHALL display a snack notification indicating the artist has upcoming events
+
+## REMOVED Requirements
+
+### Requirement: FollowOrchestrator page-scoped controller
+
+**Reason**: Follow state management is absorbed into `FollowServiceClient` singleton. Optimistic update + rollback stays in `DiscoveryRoute` as UI-layer concern. `checkLiveEvents()` is replaced by the per-artist concert check in `ConcertServiceClient.searchAndTrack()`.
+
+**Migration**: Replace `this.follow.followArtist(artist)` with `this.followService.follow(artist)`. Move `pool.remove()` / rollback logic to `DiscoveryRoute` event handlers.
+
+### Requirement: ConcertSearchTracker page-scoped controller
+
+**Reason**: Polling logic and concert existence tracking are absorbed into `ConcertServiceClient` singleton via `searchAndTrack()`. The `allSearchesComplete` / `completedSearchCount` / `concertGroupCount` state is replaced by `artistsWithConcerts: Set<string>`.
+
+**Migration**: Replace `this.concertTracker.searchConcertsWithTimeout(id)` with `this.concertService.searchAndTrack(id)`. Replace `this.concertTracker.concertGroupCount > 0` with `this.concertService.artistsWithConcertsCount >= TUTORIAL_FOLLOW_TARGET`.

--- a/openspec/changes/simplify-concert-search-flow/specs/state-management/spec.md
+++ b/openspec/changes/simplify-concert-search-flow/specs/state-management/spec.md
@@ -1,0 +1,102 @@
+## ADDED Requirements
+
+### Requirement: FollowServiceClient as follow state SSoT
+
+The `FollowServiceClient` singleton SHALL own `followedArtists: Artist[]` as `@observable` state, serving as the single source of truth for followed artists across all pages. It SHALL expose `followedIds` (derived `ReadonlySet<string>`) and `followedCount` (derived `number`) getters. For guest users, mutations delegate to `GuestService` for localStorage persistence. For authenticated users, mutations call the backend RPC.
+
+#### Scenario: Hydrate from guest state
+
+- **WHEN** `FollowServiceClient` is asked to hydrate during onboarding
+- **THEN** it SHALL set `followedArtists` from `GuestService.follows` mapped to `Artist[]`
+- **AND** Aurelia templates bound to `followService.followedCount` SHALL update automatically
+
+#### Scenario: Follow an artist (guest)
+
+- **WHEN** `follow(artist)` is called and the user is not authenticated
+- **THEN** the system SHALL optimistically append the artist to `followedArtists`
+- **AND** the system SHALL call `GuestService.follow(artist)` for localStorage persistence
+- **AND** `followedIds` and `followedCount` SHALL reflect the new state immediately
+
+#### Scenario: Follow an artist (authenticated)
+
+- **WHEN** `follow(artist)` is called and the user is authenticated
+- **THEN** the system SHALL optimistically append the artist to `followedArtists`
+- **AND** the system SHALL call the backend Follow RPC
+- **AND** on RPC failure, the system SHALL rollback `followedArtists` to its previous state
+
+#### Scenario: Duplicate follow is no-op
+
+- **WHEN** `follow(artist)` is called with an artist whose `id` is already in `followedIds`
+- **THEN** `followedArtists` SHALL remain unchanged
+
+#### Scenario: followedIds derivation
+
+- **WHEN** `followedIds` is accessed
+- **THEN** it SHALL return a `ReadonlySet<string>` derived from current `followedArtists` IDs
+
+### Requirement: ConcertServiceClient concert search and tracking
+
+The `ConcertServiceClient` singleton SHALL provide a `searchAndTrack(artistId, signal, onConcertFound?)` method that encapsulates the full search lifecycle: initiate backend search, poll for completion, verify concerts on completion, and accumulate results in `artistsWithConcerts`. The service SHALL own `artistsWithConcerts: Set<string>` tracking which artists have confirmed concerts.
+
+#### Scenario: searchAndTrack initiates backend search
+
+- **WHEN** `searchAndTrack(artistId)` is called
+- **AND** the artist is not already tracked
+- **THEN** the system SHALL call `searchNewConcerts(artistId)` fire-and-forget
+- **AND** the system SHALL start polling via `setInterval` (2000ms) if not already running
+
+#### Scenario: searchAndTrack for already-tracked artist is no-op
+
+- **WHEN** `searchAndTrack(artistId)` is called for an artist already in the tracking map
+- **THEN** the system SHALL NOT initiate a new search or duplicate the tracking entry
+
+#### Scenario: Poll detects search completion
+
+- **WHEN** `listSearchStatuses` returns `completed` for an artist
+- **THEN** the system SHALL call `listConcerts(artistId)`
+- **AND** if concerts exist, the system SHALL add `artistId` to `artistsWithConcerts`
+- **AND** if an `onConcertFound` callback was provided, the system SHALL invoke it with the artist ID
+
+#### Scenario: Poll detects search failure
+
+- **WHEN** `listSearchStatuses` returns `failed` for an artist
+- **THEN** the system SHALL mark the artist as done without checking concerts
+- **AND** the system SHALL NOT add the artist to `artistsWithConcerts`
+
+#### Scenario: Per-artist timeout
+
+- **WHEN** an artist's search has been pending for >= 15 seconds
+- **THEN** the system SHALL mark the artist as done (timeout)
+- **AND** the system SHALL NOT call `listConcerts` for that artist
+
+#### Scenario: Early polling stop at target
+
+- **WHEN** `artistsWithConcerts.size` reaches the provided target count
+- **THEN** the system SHALL stop polling immediately via `clearInterval`
+- **AND** remaining pending searches SHALL be abandoned (backend searches continue independently)
+
+#### Scenario: All searches complete stops polling
+
+- **WHEN** all tracked artists have status `done` (completed, failed, or timed out)
+- **AND** `artistsWithConcerts.size` has not yet reached the target
+- **THEN** the system SHALL stop polling
+
+#### Scenario: AbortSignal cancels polling
+
+- **WHEN** the provided `AbortSignal` is aborted (e.g., page navigation)
+- **THEN** the system SHALL stop polling via `clearInterval`
+- **AND** the system SHALL cancel any in-flight RPC calls
+- **AND** the system SHALL retain `artistsWithConcerts` state (not clear it)
+
+#### Scenario: artistsWithConcertsCount getter
+
+- **WHEN** `artistsWithConcertsCount` is accessed
+- **THEN** it SHALL return `artistsWithConcerts.size`
+
+## REMOVED Requirements
+
+### Requirement: verifyConcertsExist batch check
+
+**Reason**: Replaced by per-artist `listConcerts` check on search completion inside `searchAndTrack()`. The batch approach required all searches to complete first, which caused the Coach Mark timing bug.
+
+**Migration**: Remove `verifyConcertsExist()` from `ConcertServiceClient`. Callers use `artistsWithConcertsCount` instead.

--- a/openspec/changes/simplify-concert-search-flow/tasks.md
+++ b/openspec/changes/simplify-concert-search-flow/tasks.md
@@ -1,0 +1,31 @@
+## 1. FollowServiceClient — SSoT for follow state
+
+- [x] 1.1 Add `@observable followedArtists: Artist[]` to `FollowServiceClient` with `followedIds` and `followedCount` derived getters
+- [x] 1.2 Add `hydrate(artists: Artist[])` method for onboarding page-load initialization from `GuestService.follows`
+- [x] 1.3 Move optimistic update + rollback logic into `follow()` method (guest delegates to `GuestService`, authenticated calls RPC with rollback on failure)
+
+## 2. ConcertServiceClient — polling and artistsWithConcerts state
+
+- [x] 2.1 Add `artistsWithConcerts: Set<string>` and `artistsWithConcertsCount` getter to `ConcertServiceClient`
+- [x] 2.2 Implement `searchAndTrack(artistId, signal, onConcertFound?)` — fire-and-forget `searchNewConcerts`, start polling, per-artist `listConcerts` on completion, add to set, early stop at target count
+- [x] 2.3 Add per-artist timeout (15s) and AbortSignal support for polling lifecycle
+- [x] 2.4 Remove `verifyConcertsExist()` method
+
+## 3. DiscoveryRoute — simplify to thin event handler
+
+- [x] 3.1 Replace `FollowOrchestrator` usage with direct `FollowServiceClient` calls + inline BubblePool UI operations (remove/add for rollback)
+- [x] 3.2 Replace `ConcertSearchTracker` usage with `concertService.searchAndTrack()` calls, passing snack callback for `onConcertFound`
+- [x] 3.3 Simplify `showDashboardCoachMark` to `isOnboarding && concertService.artistsWithConcertsCount >= TUTORIAL_FOLLOW_TARGET`
+- [x] 3.4 Update `loading()` to hydrate follows into `FollowServiceClient` and call `searchAndTrack` for pre-seeded follows
+- [x] 3.5 Update `BubbleManager` and `GenreFilterController` constructor references from `follow.followedIds` / `follow.followedArtists` to `followService` equivalents
+
+## 4. Cleanup
+
+- [x] 4.1 Delete `follow-orchestrator.ts`
+- [x] 4.2 Delete `concert-search-tracker.ts`
+- [x] 4.3 Remove `checkLiveEvents` call sites from `onArtistSelected` and `onFollowFromSearch`
+
+## 5. Verification
+
+- [x] 5.1 Run `make check` (lint + typecheck + unit tests) — passes (pre-existing TS error in user-client.ts unrelated to this change)
+- [ ] 5.2 Manual E2E: follow 3+ artists on discovery page, verify Coach Mark appears when 3rd artist with concerts is found (not after all searches complete)

--- a/openspec/specs/id-resolution/spec.md
+++ b/openspec/specs/id-resolution/spec.md
@@ -1,0 +1,59 @@
+# Capability: ID Resolution
+
+## Purpose
+
+Defines how authenticated RPC handlers resolve the Zitadel external ID (JWT `sub` claim) to the internal `users.id` UUID before any database access. This prevents raw external IDs from being passed to UUID columns and ensures consistent user identity across all services.
+
+## Requirements
+
+### Requirement: RPC handlers resolve Zitadel external ID to internal UUID before database access
+All authenticated RPC handlers that write or query per-user rows in the database SHALL ensure that the JWT `sub` claim (Zitadel external ID) is resolved to the internal `users.id` UUID before any database access. The resolution SHALL occur at exactly one layer — either in the handler or in the use case — never both. Passing the raw JWT `sub` claim to a UUID column is prohibited.
+
+When the use case owns ID resolution internally (e.g., via a `resolveUserID` helper), the handler SHALL pass `claims.Sub` directly to the use case. When the use case accepts an internal UUID directly, the handler SHALL resolve `claims.Sub` to `users.id` before calling the use case.
+
+#### Scenario: Authenticated user calls FollowService/Follow
+- **WHEN** an authenticated user calls `FollowService/Follow`
+- **THEN** the handler passes `claims.Sub` to the use case, which resolves it to `users.id` internally and uses `users.id` for the `followed_artists.user_id` column
+
+#### Scenario: Authenticated user calls FollowService/Unfollow
+- **WHEN** an authenticated user calls `FollowService/Unfollow`
+- **THEN** the handler passes `claims.Sub` to the use case, which resolves it to `users.id` internally and uses `users.id` for the delete operation
+
+#### Scenario: Authenticated user calls FollowService/ListFollowed
+- **WHEN** an authenticated user calls `FollowService/ListFollowed`
+- **THEN** the handler passes `claims.Sub` to the use case, which resolves it to `users.id` and queries `followed_artists` with the internal UUID
+
+#### Scenario: Authenticated user calls FollowService/SetHype
+- **WHEN** an authenticated user calls `FollowService/SetHype`
+- **THEN** the handler passes `claims.Sub` to the use case, which resolves it to `users.id` and updates `followed_artists` with the internal UUID
+
+#### Scenario: Authenticated user calls TicketJourneyService/SetStatus
+- **WHEN** an authenticated user calls `TicketJourneyService/SetStatus`
+- **THEN** the handler resolves `claims.Sub` to `users.id` via `GetByExternalID` and writes to `ticket_journeys` with the internal UUID
+
+#### Scenario: Authenticated user calls TicketJourneyService/Delete
+- **WHEN** an authenticated user calls `TicketJourneyService/Delete`
+- **THEN** the handler resolves `claims.Sub` to `users.id` via `GetByExternalID` and deletes from `ticket_journeys` using the internal UUID
+
+#### Scenario: Authenticated user calls TicketJourneyService/ListByUser
+- **WHEN** an authenticated user calls `TicketJourneyService/ListByUser`
+- **THEN** the handler resolves `claims.Sub` to `users.id` via `GetByExternalID` and queries `ticket_journeys` with the internal UUID
+
+#### Scenario: Authenticated user calls TicketEmailService/CreateTicketEmail
+- **WHEN** an authenticated user calls `TicketEmailService/CreateTicketEmail`
+- **THEN** the handler resolves `claims.Sub` to `users.id` via `GetByExternalID` and writes to `ticket_emails` with the internal UUID
+
+#### Scenario: Authenticated user calls TicketEmailService/UpdateTicketEmail
+- **WHEN** an authenticated user calls `TicketEmailService/UpdateTicketEmail`
+- **THEN** the handler resolves `claims.Sub` to `users.id` via `GetByExternalID` and authorizes the update using the internal UUID
+
+#### Scenario: ID resolution occurs exactly once per request
+- **WHEN** any authenticated RPC is processed
+- **THEN** `GetByExternalID` is called exactly once — either in the handler or in the use case, not in both
+
+### Requirement: Handlers return NotFound when user record does not exist
+If `GetByExternalID` returns no user (e.g., user has a valid JWT but no record in `users`), the resolution layer SHALL return `CodeNotFound`.
+
+#### Scenario: Valid JWT but no user record
+- **WHEN** an authenticated request arrives but `GetByExternalID` finds no matching user
+- **THEN** the handler or use case returns `connect.CodeNotFound` with message "user not found"


### PR DESCRIPTION
## Summary

- Archives completed OpenSpec changes: `fix-zitadel-id-resolution` (PR #246) and `fix-double-id-resolution` (PR #248)
- Adds new main spec `openspec/specs/id-resolution/spec.md` documenting the two-pattern ID resolution model
- Updates id-resolution spec to clarify that resolution must occur at exactly one layer (handler OR use case, never both)

## Changes

**New main spec — `openspec/specs/id-resolution/`**
- Documents Pattern A (use-case-layer resolution) for FollowService
- Documents Pattern B (handler-layer resolution) for TicketJourney and TicketEmail services
- Adds "ID resolution occurs exactly once per request" requirement
- Broadens NotFound requirement to cover both handler and use-case resolution layers

**Archived changes**
- `2026-03-21-fix-zitadel-id-resolution` — fixed raw Zitadel sub passed to UUID columns in TicketJourney/TicketEmail handlers (PR #246)
- `2026-03-21-fix-double-id-resolution` — fixed double GetByExternalID in FollowHandler caused by PR #246 (PR #248)

## Test plan

- [ ] Spec files render correctly
