### PR TITLE
docs(proto): document ListTop tag/country priority logic

### DIFF
--- a/openspec/changes/archive/2026-03-22-locale-aware-discovery/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-22-locale-aware-discovery/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-22

--- a/openspec/changes/archive/2026-03-22-locale-aware-discovery/design.md
+++ b/openspec/changes/archive/2026-03-22-locale-aware-discovery/design.md
@@ -1,0 +1,62 @@
+## Context
+
+The Discovery page (used in both onboarding and the Discover tab) calls `ArtistService.ListTop` with a hardcoded `country = 'Japan'`. This means non-Japanese users see Japan-centric results. Additionally, when a genre tag is selected, the backend delegates to Last.fm's `tag.getTopArtists` endpoint, which has no country parameter — results are always global for that genre.
+
+The user's home area (`UserHomeSelector`) is only presented on the Dashboard (Step 3), after Discovery (Step 1). During onboarding discovery, there is no user home to reference.
+
+The browser's `Intl.DateTimeFormat().resolvedOptions().timeZone` API returns the OS timezone synchronously without requiring any permission prompt. This can be mapped to a country name for the `ListTop` call.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Dynamically detect the user's country from browser timezone and use it for `ListTop` calls
+- Remove all hardcoded `'Japan'` country values from the Discovery page
+- Document the `tag` vs `country` priority logic in the `ListTopRequest` proto comments
+- Graceful fallback to global chart when country cannot be determined
+
+**Non-Goals:**
+- Combining tag + country filtering (Last.fm API does not support this)
+- Using `navigator.geolocation` (requires permission prompt, async)
+- Moving `UserHomeSelector` earlier in the onboarding flow
+- Backend changes (already accepts dynamic country)
+
+## Decisions
+
+### 1. Country detection via `Intl.DateTimeFormat().resolvedOptions().timeZone`
+
+Use the IANA timezone identifier to infer the user's country. This is synchronous, requires no permission, and is available in all modern browsers.
+
+**Alternatives considered:**
+- `navigator.language` — Returns language preference, not location. `en` doesn't imply a country.
+- `navigator.geolocation` — Requires permission prompt, async, overkill for country-level granularity.
+- Move `UserHomeSelector` before Discovery — Adds onboarding friction for a problem solvable without user interaction.
+
+### 2. Static timezone-to-country mapping table
+
+Maintain a curated mapping of IANA timezone → ISO 3166-1 country name (as Last.fm expects). The table covers major timezones (~40 entries for countries with active Last.fm data). Unknown timezones fall back to empty string → global chart.
+
+**Alternatives considered:**
+- Full IANA database (~400+ entries) — Over-engineered. Most timezones map to countries with negligible Last.fm data.
+- Third-party library (e.g., `countries-and-timezones`) — Unnecessary dependency for a simple lookup table.
+
+### 3. Genre selection returns global results (by design)
+
+When a genre chip is tapped, `tag.getTopArtists` returns global results for that genre. This is a Last.fm API limitation, not a bug. The proto comments will document this explicitly so callers understand the behavior.
+
+When the genre is deselected, the system reverts to `geo.getTopArtists` with the detected country.
+
+### 4. Proto comment clarification (no wire changes)
+
+Update `ListTopRequest` field comments and the `ListTop` RPC comment to document the data-source priority:
+1. `tag` set → `tag.getTopArtists` (global, country ignored)
+2. `tag` empty, `country` set → `geo.getTopArtists` (regional)
+3. Both empty → `chart.getTopArtists` (global)
+
+This is a comment-only change — no breaking changes, no field additions.
+
+## Risks / Trade-offs
+
+- **Timezone ≠ location**: VPN users or users with misconfigured OS timezone get wrong country → Acceptable. Fallback is global chart, not broken behavior.
+- **Sparse mapping table**: Countries not in the mapping get global results → Better than hardcoded Japan for everyone. Table can be expanded incrementally.
+- **Genre results are global**: Users may expect "Rock in Japan" but get "Rock globally" → Document in UI or accept as-is. Last.fm API constraint.
+- **Cache interaction**: Backend caches by `country+tag+limit`. Changing from hardcoded `'Japan'` to dynamic countries increases cache cardinality → Minimal impact; cache is in-memory and short-lived.

--- a/openspec/changes/archive/2026-03-22-locale-aware-discovery/proposal.md
+++ b/openspec/changes/archive/2026-03-22-locale-aware-discovery/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+The Discovery page hardcodes `country = 'Japan'` when calling `ArtistService.ListTop`. Users outside Japan see Japanese regional top artists instead of artists relevant to their location. Additionally, when a genre tag is selected, the backend uses `tag.getTopArtists` (Last.fm) which has no country parameter — so results are always global regardless of the country value passed. The `ListTopRequest` proto comments do not document this priority logic, making it easy for callers to assume both fields work together.
+
+## What Changes
+
+- **Browser locale detection**: Infer the user's country from `Intl.DateTimeFormat().resolvedOptions().timeZone` (no permission prompt required) and use it as the default country for `ListTop` calls on the Discovery page.
+- **Remove hardcoded `'Japan'`**: Replace all hardcoded country values in `genre-filter-controller.ts`, `bubble-manager.ts`, and `discovery-route.ts` with the dynamically detected country.
+- **Fallback to global chart**: When timezone-to-country mapping fails (e.g., `"UTC"`, `"Etc/GMT+9"`), pass empty country to get global results.
+- **Document ListTop priority logic in proto**: Add comments to `ListTopRequest` clarifying that `tag` and `country` are mutually exclusive at the data-source level — when `tag` is set, country is ignored and results are global for that genre.
+
+## Capabilities
+
+### New Capabilities
+
+- `browser-locale-detection`: Timezone-based country detection utility for determining user's country from browser environment without requiring geolocation permission.
+
+### Modified Capabilities
+
+- `bubble-pool-lifecycle`: Initial pool load uses detected country instead of hardcoded `'Japan'`. Genre filtering behavior unchanged (global results by design).
+- `discover`: Genre filtering on Discover tab uses detected country for initial load; genre chip selection returns global genre results (documented behavior).
+
+## Impact
+
+- **Proto** (`artist_service.proto`): Comment-only change on `ListTopRequest` — no wire-breaking changes.
+- **Frontend** (`discovery-route.ts`, `genre-filter-controller.ts`, `bubble-manager.ts`): Replace hardcoded country with dynamic detection.
+- **Frontend** (new utility): Timezone-to-country mapping module.
+- **Backend**: No changes required — already accepts dynamic country parameter.
+- **Tests**: Frontend unit tests that mock `'Japan'` country need updating.

--- a/openspec/changes/archive/2026-03-22-locale-aware-discovery/specs/browser-locale-detection/spec.md
+++ b/openspec/changes/archive/2026-03-22-locale-aware-discovery/specs/browser-locale-detection/spec.md
@@ -1,0 +1,41 @@
+# Browser Locale Detection
+
+## Purpose
+
+Provides a utility to detect the user's country from browser environment data without requiring geolocation permission or user interaction. Used to personalize Discovery page results based on the user's inferred location.
+
+---
+
+## ADDED Requirements
+
+### Requirement: Timezone-based country detection
+The system SHALL detect the user's country from the browser's IANA timezone identifier using `Intl.DateTimeFormat().resolvedOptions().timeZone`.
+
+#### Scenario: Known timezone maps to a country
+- **WHEN** the browser reports a recognized IANA timezone (e.g., `"Asia/Tokyo"`)
+- **THEN** the system SHALL return the corresponding ISO 3166-1 country name (e.g., `"Japan"`)
+- **AND** the mapping SHALL be performed synchronously without user interaction
+
+#### Scenario: Unknown or generic timezone
+- **WHEN** the browser reports `"UTC"`, `"Etc/GMT+9"`, or an unmapped timezone
+- **THEN** the system SHALL return an empty string
+- **AND** the caller SHALL treat empty string as "no country detected" (global fallback)
+
+#### Scenario: API unavailable
+- **WHEN** `Intl.DateTimeFormat` is not available in the browser environment
+- **THEN** the system SHALL return an empty string without throwing an error
+
+### Requirement: Mapping table coverage
+The system SHALL maintain a static mapping table covering major IANA timezones for countries with meaningful Last.fm chart data.
+
+#### Scenario: Mapping table entries
+- **WHEN** the mapping table is consulted
+- **THEN** it SHALL include at minimum the following timezone-to-country mappings:
+  - `Asia/Tokyo` → `Japan`
+  - `America/New_York`, `America/Chicago`, `America/Denver`, `America/Los_Angeles` → `United States`
+  - `Europe/London` → `United Kingdom`
+  - `Europe/Berlin`, `Europe/Paris`, `Europe/Rome`, `Europe/Madrid` → their respective countries
+  - `Asia/Seoul` → `South Korea`
+  - `Australia/Sydney`, `Australia/Melbourne` → `Australia`
+  - `America/Toronto`, `America/Vancouver` → `Canada`
+  - `America/Sao_Paulo` → `Brazil`

--- a/openspec/changes/archive/2026-03-22-locale-aware-discovery/specs/bubble-pool-lifecycle/spec.md
+++ b/openspec/changes/archive/2026-03-22-locale-aware-discovery/specs/bubble-pool-lifecycle/spec.md
@@ -1,0 +1,18 @@
+## MODIFIED Requirements
+
+### Requirement: Bubble pool initialization based on followed-artist count
+The system SHALL initialize the bubble pool differently based on whether the user follows any artists. On page load, the system SHALL hydrate the follow state from the persisted store before initializing the pool.
+
+#### Scenario: No followed artists (Step 1-a)
+- **WHEN** the discovery page loads
+- **AND** the user follows zero artists (including after checking persisted guest state)
+- **THEN** the system SHALL detect the user's country via browser timezone detection
+- **AND** the system SHALL call `ArtistService.ListTop` with `limit=50` and the detected country
+- **AND** if country detection returns empty, the system SHALL pass an empty country (global chart fallback)
+- **AND** the system SHALL populate the bubble pool with the response artists
+
+#### Scenario: User has followed artists (Step 1-b)
+- **WHEN** the discovery page loads
+- **AND** the user follows one or more artists (including artists restored from persisted guest state)
+- **THEN** the system SHALL randomly select up to 5 followed artists as seeds
+- **AND** the system SHALL call `ArtistService.ListSimilar` for each seed in parallel with the limit evenly distributed to fill 50 total (e.g., 5 seeds × limit=10, 2 seeds × limit=25)

--- a/openspec/changes/archive/2026-03-22-locale-aware-discovery/specs/discover/spec.md
+++ b/openspec/changes/archive/2026-03-22-locale-aware-discovery/specs/discover/spec.md
@@ -1,0 +1,29 @@
+## MODIFIED Requirements
+
+### Requirement: Bubble UI Re-experience
+The system SHALL provide the onboarding Bubble UI as a reusable discovery experience on the Discover tab, with a simplified 3-row grid layout.
+
+#### Scenario: Default Bubble UI display
+- **WHEN** the Discover tab is opened
+- **THEN** the system SHALL display the physics-based artist Bubble UI (same as onboarding)
+- **AND** the DNA Orb SHALL be displayed at the bottom
+- **AND** tapping a bubble SHALL trigger the absorption animation and call `ArtistService.Follow`
+- **AND** the page grid SHALL use `grid-template-rows: auto auto 1fr` (search bar, genre chips, bubble area)
+
+#### Scenario: Genre filtering
+- **WHEN** the Bubble UI is displayed
+- **THEN** genre/tag chips SHALL be displayed above the bubble area (e.g., Rock, Pop, Anime, Jazz, Electronic, Hip-Hop)
+- **AND** tapping a genre chip SHALL regenerate bubbles with artists from that genre via `ArtistService.ListTop` with the selected tag
+- **AND** genre results SHALL be global (not country-filtered) due to Last.fm API constraints
+- **AND** the active genre chip SHALL be visually highlighted
+
+#### Scenario: Genre deselection reverts to regional results
+- **WHEN** a genre chip is active
+- **AND** the user taps the same genre chip again (deselection)
+- **THEN** the system SHALL regenerate bubbles using `ArtistService.ListTop` with the detected country and no tag
+- **AND** the system SHALL return to showing regional top artists
+
+#### Scenario: Already-followed artists
+- **WHEN** an artist bubble represents an already-followed artist
+- **THEN** the bubble SHALL be visually distinguished (e.g., dimmed, checkmark overlay)
+- **AND** tapping it SHALL NOT trigger a duplicate follow action

--- a/openspec/changes/archive/2026-03-22-locale-aware-discovery/tasks.md
+++ b/openspec/changes/archive/2026-03-22-locale-aware-discovery/tasks.md
@@ -1,0 +1,23 @@
+## 1. Proto Documentation
+
+- [x] 1.1 Update `ListTop` RPC comment to document data-source priority logic (tag → geo → chart)
+- [x] 1.2 Update `ListTopRequest.country` field comment to note it is ignored when `tag` is set
+- [x] 1.3 Update `ListTopRequest.tag` field comment to note results are global when tag is specified
+
+## 2. Browser Locale Detection Utility
+
+- [x] 2.1 Create timezone-to-country mapping module in `frontend/src/util/` with IANA timezone → ISO 3166-1 country name table
+- [x] 2.2 Export a `detectCountryFromTimezone()` function that returns country name or empty string
+- [x] 2.3 Write unit tests for known timezones, unknown timezones, and `Intl` API unavailability
+
+## 3. Discovery Page Integration
+
+- [x] 3.1 Remove hardcoded `'Japan'` from `bubble-manager.ts` — use `detectCountryFromTimezone()` for `private country`
+- [x] 3.2 Remove hardcoded `'Japan'` default from `genre-filter-controller.ts` `reloadWithTag()` — use detected country
+- [x] 3.3 Remove hardcoded `'Japan'` from `discovery-route.ts` `loading()` — use detected country
+- [x] 3.4 Update unit tests in `discovery-route.spec.ts` to mock timezone detection instead of hardcoded `'Japan'`
+
+## 4. Verification
+
+- [x] 4.1 Run `make check` in frontend to verify lint and tests pass
+- [x] 4.2 Run `buf lint` and `buf breaking` in specification to verify proto changes

--- a/openspec/specs/browser-locale-detection/spec.md
+++ b/openspec/specs/browser-locale-detection/spec.md
@@ -1,0 +1,41 @@
+# Browser Locale Detection
+
+## Purpose
+
+Provides a utility to detect the user's country from browser environment data without requiring geolocation permission or user interaction. Used to personalize Discovery page results based on the user's inferred location.
+
+---
+
+## Requirements
+
+### Requirement: Timezone-based country detection
+The system SHALL detect the user's country from the browser's IANA timezone identifier using `Intl.DateTimeFormat().resolvedOptions().timeZone`.
+
+#### Scenario: Known timezone maps to a country
+- **WHEN** the browser reports a recognized IANA timezone (e.g., `"Asia/Tokyo"`)
+- **THEN** the system SHALL return the corresponding ISO 3166-1 country name (e.g., `"Japan"`)
+- **AND** the mapping SHALL be performed synchronously without user interaction
+
+#### Scenario: Unknown or generic timezone
+- **WHEN** the browser reports `"UTC"`, `"Etc/GMT+9"`, or an unmapped timezone
+- **THEN** the system SHALL return an empty string
+- **AND** the caller SHALL treat empty string as "no country detected" (global fallback)
+
+#### Scenario: API unavailable
+- **WHEN** `Intl.DateTimeFormat` is not available in the browser environment
+- **THEN** the system SHALL return an empty string without throwing an error
+
+### Requirement: Mapping table coverage
+The system SHALL maintain a static mapping table covering major IANA timezones for countries with meaningful Last.fm chart data.
+
+#### Scenario: Mapping table entries
+- **WHEN** the mapping table is consulted
+- **THEN** it SHALL include at minimum the following timezone-to-country mappings:
+  - `Asia/Tokyo` → `Japan`
+  - `America/New_York`, `America/Chicago`, `America/Denver`, `America/Los_Angeles` → `United States`
+  - `Europe/London` → `United Kingdom`
+  - `Europe/Berlin`, `Europe/Paris`, `Europe/Rome`, `Europe/Madrid` → their respective countries
+  - `Asia/Seoul` → `South Korea`
+  - `Australia/Sydney`, `Australia/Melbourne` → `Australia`
+  - `America/Toronto`, `America/Vancouver` → `Canada`
+  - `America/Sao_Paulo` → `Brazil`

--- a/openspec/specs/bubble-pool-lifecycle/spec.md
+++ b/openspec/specs/bubble-pool-lifecycle/spec.md
@@ -20,7 +20,9 @@ The system SHALL initialize the bubble pool differently based on whether the use
 #### Scenario: No followed artists (Step 1-a)
 - **WHEN** the discovery page loads
 - **AND** the user follows zero artists (including after checking persisted guest state)
-- **THEN** the system SHALL call `ArtistService.ListTop` with `limit=50` and the user's country
+- **THEN** the system SHALL detect the user's country via browser timezone detection
+- **AND** the system SHALL call `ArtistService.ListTop` with `limit=50` and the detected country
+- **AND** if country detection returns empty, the system SHALL pass an empty country (global chart fallback)
 - **AND** the system SHALL populate the bubble pool with the response artists
 
 #### Scenario: User has followed artists (Step 1-b)
@@ -28,7 +30,6 @@ The system SHALL initialize the bubble pool differently based on whether the use
 - **AND** the user follows one or more artists (including artists restored from persisted guest state)
 - **THEN** the system SHALL randomly select up to 5 followed artists as seeds
 - **AND** the system SHALL call `ArtistService.ListSimilar` for each seed in parallel with the limit evenly distributed to fill 50 total (e.g., 5 seeds × limit=10, 2 seeds × limit=25)
-- **AND** the system SHALL populate the bubble pool with the combined results
 
 #### Scenario: Seed selection with fewer than 5 followed artists
 - **WHEN** the user follows fewer than 5 artists

--- a/openspec/specs/discover/spec.md
+++ b/openspec/specs/discover/spec.md
@@ -19,8 +19,15 @@ The system SHALL provide the onboarding Bubble UI as a reusable discovery experi
 #### Scenario: Genre filtering
 - **WHEN** the Bubble UI is displayed
 - **THEN** genre/tag chips SHALL be displayed above the bubble area (e.g., Rock, Pop, Anime, Jazz, Electronic, Hip-Hop)
-- **AND** tapping a genre chip SHALL regenerate bubbles with artists from that genre
+- **AND** tapping a genre chip SHALL regenerate bubbles with artists from that genre via `ArtistService.ListTop` with the selected tag
+- **AND** genre results SHALL be global (not country-filtered) due to Last.fm API constraints
 - **AND** the active genre chip SHALL be visually highlighted
+
+#### Scenario: Genre deselection reverts to regional results
+- **WHEN** a genre chip is active
+- **AND** the user taps the same genre chip again (deselection)
+- **THEN** the system SHALL regenerate bubbles using `ArtistService.ListTop` with the detected country and no tag
+- **AND** the system SHALL return to showing regional top artists
 
 #### Scenario: Already-followed artists
 - **WHEN** an artist bubble represents an already-followed artist

--- a/proto/liverty_music/rpc/artist/v1/artist_service.proto
+++ b/proto/liverty_music/rpc/artist/v1/artist_service.proto
@@ -55,10 +55,15 @@ service ArtistService {
   // - NOT_FOUND: The specified seed artist could not be found or has no recommendations.
   rpc ListSimilar(ListSimilarRequest) returns (ListSimilarResponse);
 
-  // ListTop retrieves globally or regionally popular artists.
+  // ListTop retrieves popular artists from one of three data sources,
+  // selected by the following priority:
+  //
+  //   1. tag is set       → tag-based global chart (country is ignored)
+  //   2. country is set   → region-based chart
+  //   3. both empty       → global chart
   //
   // Possible errors:
-  // - INVALID_ARGUMENT: The specified country code is invalid.
+  // - INVALID_ARGUMENT: The specified country name is invalid.
   rpc ListTop(ListTopRequest) returns (ListTopResponse);
 }
 
@@ -141,11 +146,14 @@ message ListSimilarResponse {
 // ListTopRequest specifies the parameters for retrieving popular artists.
 message ListTopRequest {
   // Optional. ISO 3166-1 country name (e.g., "Japan").
-  // If empty, the system returns a global chart.
+  // Used for region-based charts. Ignored when tag is set.
+  // If both country and tag are empty, the system returns a global chart.
   string country = 1;
 
-  // Optional. Filter top artists by genre or tag (e.g., "rock", "pop", "anime").
-  // When empty, returns top artists across all genres.
+  // Optional. Genre or tag filter (e.g., "rock", "pop", "anime").
+  // When set, returns a global genre chart — country is ignored because
+  // the upstream data source does not support combined tag + country filtering.
+  // When empty, returns top artists across all genres (regional or global).
   string tag = 2 [(buf.validate.field).string.max_len = 50];
 
   // Optional. Maximum number of top artists to return.


### PR DESCRIPTION
## Summary

- Document ListTop RPC data-source priority logic (tag → geo → chart) in proto comments
- Clarify that `country` is ignored when `tag` is set due to Last.fm API constraints
- Add `browser-locale-detection` spec and update `bubble-pool-lifecycle` / `discover` specs
- Archive `locale-aware-discovery` OpenSpec change

No wire-breaking changes — comment-only updates to `artist_service.proto`.

close: #325