### PR TITLE
docs(specs): sync and archive fix-onboarding-follow-pipeline

### DIFF
--- a/openspec/changes/archive/2026-03-22-fix-onboarding-follow-pipeline/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-22-fix-onboarding-follow-pipeline/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-22

--- a/openspec/changes/archive/2026-03-22-fix-onboarding-follow-pipeline/design.md
+++ b/openspec/changes/archive/2026-03-22-fix-onboarding-follow-pipeline/design.md
@@ -1,0 +1,58 @@
+## Context
+
+The onboarding flow's concert search pipeline is completely broken. After a user follows an artist, `SearchNewConcerts` triggers a background Gemini API call that fails with 401 CREDENTIALS_MISSING. The root cause is that `provider.go` passes `&http.Client{Timeout: 60*time.Second}` to `NewConcertSearcher`, which prevents the genai SDK from configuring ADC-based authentication. Additionally, debugging was difficult because `dev.liverty-music.app` uses a production build with log level `warn`, hiding all INFO logs.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Gemini API calls authenticate correctly via WIF-based ADC
+- Maintain 60-second timeout for concert search operations
+- Allow log level to be configured per deployment environment (dev=debug, prod=info)
+
+**Non-Goals:**
+- Reworking the concert search retry strategy (existing 3-retry approach is adequate)
+- Adding user-facing notification UI for `SEARCH_STATUS_FAILED` (separate change)
+- Fixing `EmailParser` (already passes `nil`, works correctly)
+
+## Decisions
+
+### 1. Pass `nil` for HTTPClient — let the SDK manage ADC
+
+**Choice**: Pass `nil` to `NewConcertSearcher` so the genai SDK constructs an ADC-authenticated HTTP client internally.
+
+**Alternatives considered**:
+- A) Build ADC transport manually with `golang.org/x/oauth2/google` — unnecessary complexity, SDK does the same internally
+- B) Pass authenticated client via `option.WithHTTPClient` — genai SDK uses `ClientConfig.HTTPClient`, not the `option` pattern; manual construction is discouraged
+
+**Rationale**: Google Cloud Go SDK best practice is to not pass custom HTTP clients. The SDK manages credential refresh and transport configuration correctly.
+
+### 2. Use `context.WithTimeout` for timeout control
+
+**Choice**: Apply `context.WithTimeout(ctx, 60*time.Second)` at the `ConcertSearcher.Search()` call site in the usecase layer.
+
+**Rationale**: Recommended by Google Cloud Go SDK documentation. Per-call `context.WithTimeout` provides fine-grained control with proper cancellation propagation, unlike `http.Client.Timeout` which applies globally.
+
+### 3. Keep the `httpClient` parameter for testing
+
+**Choice**: Maintain the `NewConcertSearcher(ctx, cfg, httpClient, logger)` signature. Pass `nil` in production, `httptest.Server` clients in tests.
+
+**Rationale**: Existing unit tests (`searcher_test.go`, `retry_test.go`) rely on `httptest.Server`. No reason to break this pattern.
+
+### 4. Control log level via `VITE_LOG_LEVEL` environment variable
+
+**Choice**: Read `import.meta.env.VITE_LOG_LEVEL` at startup with fallback to `import.meta.env.DEV`.
+
+```
+VITE_LOG_LEVEL=debug  → LogLevel.debug  (dev environment)
+VITE_LOG_LEVEL=info   → LogLevel.info   (prod environment)
+unset + DEV=true      → LogLevel.debug  (local development)
+unset + DEV=false     → LogLevel.warn   (fallback)
+```
+
+**Rationale**: `import.meta.env.DEV` is a build-time flag, making it impossible to run the same production build with different log levels across environments. `VITE_LOG_LEVEL` is embedded at build time via Vite's env system, but `.env` and Dockerfile `ARG` allow per-environment control.
+
+## Risks / Trade-offs
+
+- **[Test compatibility]** Keeping `httpClient` parameter means zero impact on existing tests → low risk
+- **[genai SDK updates]** Default client construction may change in major SDK versions → monitor on upgrade
+- **[Build-time log level]** `VITE_LOG_LEVEL` is embedded at build time, requiring a rebuild to change → acceptable; runtime control can be added separately if needed

--- a/openspec/changes/archive/2026-03-22-fix-onboarding-follow-pipeline/proposal.md
+++ b/openspec/changes/archive/2026-03-22-fix-onboarding-follow-pipeline/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+Users report that the onboarding follow flow has "no response" after tapping artist bubbles. Investigation revealed that follow itself works correctly, but the downstream concert search pipeline is completely broken due to two issues:
+
+1. **Backend**: The `ConcertSearcher` Gemini API call fails with 401 CREDENTIALS_MISSING because a bare `http.Client` is passed, bypassing ADC (Application Default Credentials).
+2. **Frontend**: `dev.liverty-music.app` uses a production build where the log level is hardcoded to `warn`, suppressing all INFO-level logs from FollowService and ConcertService, making the issue invisible to developers.
+
+## What Changes
+
+- **Backend**: Stop passing a custom `http.Client` to `NewConcertSearcher`. Use `nil` to let the genai SDK manage ADC authentication. Apply timeout via `context.WithTimeout` at the call site instead.
+- **Frontend**: Make the log level configurable via the `VITE_LOG_LEVEL` environment variable instead of relying on Vite's build-mode flag (`import.meta.env.DEV`). Default to `debug` for dev, `info` for prod.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `auto-concert-discovery`: Use SDK-managed ADC authentication for Gemini API calls in concert search
+- `frontend-observability`: Make log level configurable per deployment environment
+
+## Impact
+
+- **backend**: `internal/di/provider.go` — change `httpClient` argument from `&http.Client{Timeout: 60s}` to `nil`
+- **backend**: `internal/usecase/concert_uc.go` — apply `context.WithTimeout` at the Gemini search call site
+- **frontend**: `src/main.ts` — resolve log level from `VITE_LOG_LEVEL` environment variable
+- **frontend**: `.env` / `Dockerfile` — add `VITE_LOG_LEVEL` configuration

--- a/openspec/changes/archive/2026-03-22-fix-onboarding-follow-pipeline/specs/auto-concert-discovery/spec.md
+++ b/openspec/changes/archive/2026-03-22-fix-onboarding-follow-pipeline/specs/auto-concert-discovery/spec.md
@@ -1,0 +1,17 @@
+## MODIFIED Requirements
+
+### Requirement: Job-Specific Dependency Injection
+
+The CronJob SHALL use a lightweight DI initializer that provisions only the dependencies required for batch processing, without starting an HTTP server.
+
+#### Scenario: Job initialization
+
+- **WHEN** the concert discovery job starts
+- **THEN** it SHALL initialize config, logger, database, repositories, Gemini searcher, and ConcertUseCase
+- **AND** the Gemini searcher SHALL be initialized with `HTTPClient: nil` to use SDK-managed ADC authentication
+- **AND** it SHALL NOT initialize HTTP server, RPC handlers, auth interceptors, or in-memory caches
+
+#### Scenario: Graceful resource cleanup
+
+- **WHEN** the job completes (success or circuit break)
+- **THEN** it SHALL close all initialized resources (database connections, telemetry)

--- a/openspec/changes/archive/2026-03-22-fix-onboarding-follow-pipeline/specs/frontend-observability/spec.md
+++ b/openspec/changes/archive/2026-03-22-fix-onboarding-follow-pipeline/specs/frontend-observability/spec.md
@@ -1,0 +1,35 @@
+## MODIFIED Requirements
+
+### Requirement: ILogger OpenTelemetry Sink
+The system SHALL provide a custom `ISink` implementation that bridges Aurelia 2's `ILogger` to OpenTelemetry spans.
+
+#### Scenario: Error-level log creates OTEL span
+- **WHEN** a component or service calls `logger.error()` or `logger.fatal()`
+- **THEN** the `OtelLogSink` SHALL create an OTEL span with the log message
+- **AND** the span SHALL include attributes: `log.scope` (the logger's scope name), `log.severity`, and any additional log data
+- **AND** if the log includes an Error object, the sink SHALL call `span.recordException()`
+
+#### Scenario: Non-error logs are ignored by OTEL sink
+- **WHEN** a component or service calls `logger.info()`, `logger.debug()`, `logger.warn()`, or `logger.trace()`
+- **THEN** the `OtelLogSink` SHALL NOT create an OTEL span
+- **AND** these logs SHALL still be handled by the `ConsoleSink`
+
+#### Scenario: Multiple sinks are registered
+- **WHEN** the application is configured
+- **THEN** `LoggerConfiguration` SHALL register both `ConsoleSink` and `OtelLogSink`
+- **AND** all log events SHALL be emitted to both sinks
+- **AND** the log level SHALL be determined by the `VITE_LOG_LEVEL` environment variable
+
+#### Scenario: Log level controlled by environment variable
+- **WHEN** `VITE_LOG_LEVEL` is set to a valid level (trace, debug, info, warn, error)
+- **THEN** the `LoggerConfiguration` level SHALL match the specified level
+
+#### Scenario: Log level fallback when unset in development
+- **WHEN** `VITE_LOG_LEVEL` is not set
+- **AND** the build mode is development (`import.meta.env.DEV === true`)
+- **THEN** the `LoggerConfiguration` level SHALL be `LogLevel.debug`
+
+#### Scenario: Log level fallback when unset in production
+- **WHEN** `VITE_LOG_LEVEL` is not set
+- **AND** the build mode is production (`import.meta.env.DEV === false`)
+- **THEN** the `LoggerConfiguration` level SHALL be `LogLevel.warn`

--- a/openspec/changes/archive/2026-03-22-fix-onboarding-follow-pipeline/tasks.md
+++ b/openspec/changes/archive/2026-03-22-fix-onboarding-follow-pipeline/tasks.md
@@ -1,0 +1,19 @@
+## 1. Backend: Fix Gemini ADC Authentication
+
+- [x] 1.1 Change `httpClient` argument in `internal/di/provider.go` from `&http.Client{Timeout: 60*time.Second}` to `nil`
+- [x] 1.2 Verify `internal/di/job.go` already passes `nil` (confirmed)
+- [x] 1.3 Apply `context.WithTimeout(ctx, 60*time.Second)` at the `Search()` call site in `internal/usecase/concert_uc.go`
+- [x] 1.4 Run `make check` to verify tests and lint pass
+
+## 2. Frontend: Environment-Configurable Log Level
+
+- [x] 2.1 Update `src/main.ts` `LoggerConfiguration` to resolve level from `VITE_LOG_LEVEL` env var
+- [x] 2.2 Add `VITE_LOG_LEVEL=debug` to `.env` (dev environment default)
+- [x] 2.3 Add `ARG VITE_LOG_LEVEL` to `Dockerfile` for CI build-arg override
+- [x] 2.4 Run `make check` to verify tests and lint pass (pre-existing issues only, no regressions from this change)
+
+## 3. Verification
+
+- [x] 3.1 Deploy backend to dev and verify Gemini API calls succeed (200 OK) in backend logs
+- [x] 3.2 Deploy frontend to dev and verify INFO-level logs appear in browser console
+- [x] 3.3 Verify full onboarding flow: follow → concert search → snack notification

--- a/openspec/specs/auto-concert-discovery/spec.md
+++ b/openspec/specs/auto-concert-discovery/spec.md
@@ -65,6 +65,7 @@ The CronJob SHALL use a lightweight DI initializer that provisions only the depe
 
 - **WHEN** the concert discovery job starts
 - **THEN** it SHALL initialize config, logger, database, repositories, Gemini searcher, and ConcertUseCase
+- **AND** the Gemini searcher SHALL be initialized with `HTTPClient: nil` to use SDK-managed ADC authentication
 - **AND** it SHALL NOT initialize HTTP server, RPC handlers, auth interceptors, or in-memory caches
 
 #### Scenario: Graceful resource cleanup

--- a/openspec/specs/frontend-observability/spec.md
+++ b/openspec/specs/frontend-observability/spec.md
@@ -71,3 +71,18 @@ The system SHALL provide a custom `ISink` implementation that bridges Aurelia 2'
 - **WHEN** the application is configured
 - **THEN** `LoggerConfiguration` SHALL register both `ConsoleSink` and `OtelLogSink`
 - **AND** all log events SHALL be emitted to both sinks
+- **AND** the log level SHALL be determined by the `VITE_LOG_LEVEL` environment variable
+
+#### Scenario: Log level controlled by environment variable
+- **WHEN** `VITE_LOG_LEVEL` is set to a valid level (trace, debug, info, warn, error)
+- **THEN** the `LoggerConfiguration` level SHALL match the specified level
+
+#### Scenario: Log level fallback when unset in development
+- **WHEN** `VITE_LOG_LEVEL` is not set
+- **AND** the build mode is development (`import.meta.env.DEV === true`)
+- **THEN** the `LoggerConfiguration` level SHALL be `LogLevel.debug`
+
+#### Scenario: Log level fallback when unset in production
+- **WHEN** `VITE_LOG_LEVEL` is not set
+- **AND** the build mode is production (`import.meta.env.DEV === false`)
+- **THEN** the `LoggerConfiguration` level SHALL be `LogLevel.warn`


### PR DESCRIPTION
## Summary

- Sync delta specs from `fix-onboarding-follow-pipeline` change to main specs
- Archive the completed change

## Spec Changes

### auto-concert-discovery
- **MODIFIED** "Job-Specific Dependency Injection": added ADC authentication requirement to job initialization scenario

### frontend-observability
- **MODIFIED** "ILogger OpenTelemetry Sink": added `VITE_LOG_LEVEL` environment variable control with 3 new scenarios (env var, dev fallback, prod fallback)

## Test plan

- [x] Spec content matches implemented behavior (verified via deployment testing)
- [x] No breaking changes to proto definitions