### PR TITLE
feat!(rpc): make SearchNewConcerts synchronous, remove polling

### DIFF
--- a/openspec/changes/sync-concert-search/.openspec.yaml
+++ b/openspec/changes/sync-concert-search/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-22

--- a/openspec/changes/sync-concert-search/design.md
+++ b/openspec/changes/sync-concert-search/design.md
@@ -1,0 +1,70 @@
+## Context
+
+The concert search pipeline uses an async fire-and-forget pattern: the RPC returns immediately, a background goroutine calls Gemini, and the frontend polls `ListSearchStatuses` every 2 seconds with a 15-second per-artist timeout. When users follow many artists quickly, the Gemini calls queue up and most artists exceed the frontend timeout, causing the onboarding coach mark to never appear.
+
+The backend already has a synchronous `SearchNewConcerts` usecase method used by the CronJob. The RPC handler wraps it in `AsyncSearchNewConcerts` (a goroutine). Removing this wrapper and returning concerts directly simplifies the entire pipeline.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Eliminate polling: frontend awaits SearchNewConcerts and gets concerts in the response
+- Delete all polling infrastructure (backend + frontend, ~650 lines total)
+- Fix Dockerfile log level override
+- Keep the 24h search_log cache guard to avoid redundant Gemini calls
+
+**Non-Goals:**
+- Batching multiple artists into a single streaming RPC (unary per artist is sufficient)
+- Changing the search_log table schema (just stop using `ListByArtistIDs`)
+- Modifying the CronJob (already uses sync SearchNewConcerts)
+
+## Decisions
+
+### 1. Unary sync RPC, not server-side streaming
+
+**Choice**: Keep `SearchNewConcerts` as unary RPC, make it synchronous (block until Gemini completes), return `repeated Concert concerts` in the response.
+
+**Alternatives considered**:
+- Server-side streaming for multiple artists → unnecessary complexity; frontend follows one artist at a time
+- Keep async + increase timeout → band-aid; polling adds 6+ RPCs per artist
+
+**Rationale**: The simplest possible change. One RPC call per artist, one response with concerts. No polling state machine.
+
+### 2. 60-second context timeout
+
+**Choice**: Apply `context.WithTimeout(ctx, 60*time.Second)` in the usecase layer's `SearchNewConcerts`. The RPC handler passes context through without additional timeout.
+
+**Rationale**: Gemini calls take 8-15 seconds typically. 60 seconds provides ample buffer for retries (3 attempts with backoff). Gateway/LB timeouts should be >= 60s (verify).
+
+### 3. Return discovered concerts, not persisted concerts
+
+**Choice**: `SearchNewConcerts` returns the concerts it discovers and persists in this call. The response includes only newly discovered concerts (after deduplication), not all existing concerts for the artist.
+
+**Rationale**: The frontend only needs to know "were concerts found?" for the coach mark. Returning discovered concerts avoids an extra `List` RPC.
+
+### 4. SearchNewConcerts return type change
+
+**Choice**: Change the Go usecase method signature from `error` to `([]*entity.Concert, error)`. The handler maps entity concerts to proto concerts for the response.
+
+### 5. Delete ListSearchStatuses entirely
+
+**Choice**: Remove the RPC, handler, usecase method, mapper, proto messages, and enum. No deprecation period.
+
+**Rationale**: Only consumer is the frontend polling loop. Both sides deploy together in the same change. No external consumers.
+
+### 6. Keep search_log for deduplication
+
+**Choice**: Keep `SearchLogRepository` with `GetByArtistID`, `Upsert`, `UpdateStatus`, `Delete`. Remove only `ListByArtistIDs` (used exclusively by ListSearchStatuses).
+
+**Rationale**: The 24h TTL cache guard prevents redundant Gemini API calls. Removing it would waste API quota.
+
+### 7. Fix Dockerfile log level
+
+**Choice**: Remove `ARG VITE_LOG_LEVEL` and `ENV VITE_LOG_LEVEL=${VITE_LOG_LEVEL}` from Dockerfile. The `.env` file's `VITE_LOG_LEVEL=debug` flows through `COPY . .` and Vite reads it automatically.
+
+**Rationale**: The `ENV` line overrides `.env` with an empty string when CI doesn't pass `--build-arg`. Removing it is the simplest fix.
+
+## Risks / Trade-offs
+
+- **[Gateway timeout]** 60s RPC requires gateway/LB to allow long requests. Verify GKE Gateway timeout config (default is usually 30s) → may need to set `timeout` annotation on the HTTPRoute
+- **[Breaking proto change]** Removing RPCs and messages is a breaking change. Since BSR consumers (backend + frontend) deploy together, coordinate via dependency order: specification PR → release → backend + frontend PRs
+- **[UX during long search]** Frontend blocks on `await searchNewConcerts` for up to 60s per artist. The bubble absorption animation provides immediate feedback, but no progress indicator for the Gemini search. Consider adding a subtle loading state in a follow-up change

--- a/openspec/changes/sync-concert-search/proposal.md
+++ b/openspec/changes/sync-concert-search/proposal.md
@@ -1,0 +1,35 @@
+## Why
+
+The onboarding follow flow is broken because the frontend's concert search polling times out (15s) before the backend's Gemini API completes (~8-60s for multiple artists). The async fire-and-forget + polling architecture adds unnecessary complexity — 6+ RPC calls per artist with fragile timeout logic. A synchronous SearchNewConcerts that waits for Gemini and returns concerts directly eliminates polling entirely, making the system simpler and more reliable.
+
+Additionally, the frontend's `VITE_LOG_LEVEL` Dockerfile ARG overrides `.env` with an empty string, keeping the log level at `warn` on the dev environment despite the previous fix.
+
+## What Changes
+
+- **BREAKING**: `SearchNewConcerts` RPC changes from async (fire-and-forget, empty response) to sync (blocks until Gemini completes, returns concerts). Timeout is 60s via context.
+- **BREAKING**: Remove `ListSearchStatuses` RPC entirely — no longer needed without polling.
+- **BREAKING**: Remove `SearchStatus` enum, `ArtistSearchStatus`, `ListSearchStatusesRequest/Response` messages from proto.
+- **Proto**: Unreserve field 1 on `SearchNewConcertsResponse` and add `repeated Concert concerts = 1`.
+- **Backend**: Delete `AsyncSearchNewConcerts`, polling infrastructure, `SearchStatusValue` enum, status mapper. Simplify `SearchLogRepository` (remove `ListByArtistIDs`, keep `GetByArtistID` for 24h cache guard).
+- **Frontend**: Delete entire polling infrastructure (~250 lines) from `ConcertService`. Replace `searchAndTrack()` with direct `await searchNewConcerts()`. Delete `listSearchStatuses` RPC client method.
+- **Frontend**: Remove `ARG/ENV VITE_LOG_LEVEL` from Dockerfile to let `.env` value flow through correctly.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `concert-search`: SearchNewConcerts becomes synchronous, returns concerts, removes ListSearchStatuses
+- `follow-triggered-search`: Frontend replaces polling with direct await on SearchNewConcerts
+- `frontend-onboarding-flow`: Coach mark logic unchanged but concert discovery trigger simplified
+- `frontend-observability`: Fix Dockerfile log level override
+
+## Impact
+
+- **Proto** (`concert_service.proto`): Breaking change — removed RPCs and messages require a new major version or coordinated rollout
+- **Backend**: `concert_handler.go`, `concert_uc.go`, `search_status.go` (delete), `mapper/search_status.go` (delete), `provider.go`, tests
+- **Frontend**: `concert-service.ts`, `concert-client.ts`, `discovery-route.ts`, `Dockerfile`, tests, e2e mocks
+- **CronJob**: No impact — already uses sync `SearchNewConcerts` directly

--- a/openspec/changes/sync-concert-search/specs/concert-search/spec.md
+++ b/openspec/changes/sync-concert-search/specs/concert-search/spec.md
@@ -1,0 +1,54 @@
+## MODIFIED Requirements
+
+### Requirement: Search Concerts by Artist
+
+System must provide a way to search for future concerts of a specific artist using generative AI grounding. The system SHALL check the search log before calling the external API and skip the call if a recent search exists. The extracted concert data SHALL include the venue's administrative area (`admin_area`) when it can be determined with confidence. The `SearchNewConcerts` RPC SHALL be accessible without authentication to support guest onboarding flows. The RPC SHALL block until the search completes and return discovered concerts in the response.
+
+#### Scenario: Successful Search
+
+- **WHEN** `SearchNewConcerts` is called for an existing artist
+- **AND** no search log exists or the last search was more than 24 hours ago
+- **THEN** the system MUST call the external search API synchronously (blocking until completion)
+- **AND** return discovered concerts in the `SearchNewConcertsResponse.concerts` field
+- **AND** each concert includes title, listed venue name, date, and optionally start time and `admin_area`
+- **AND** results exclude concerts that are already stored in the database
+
+#### Scenario: Skip search when recently searched
+
+- **WHEN** `SearchNewConcerts` is called for an artist
+- **AND** a search log exists with `searched_at` within the last 24 hours
+- **THEN** the system MUST NOT call the external search API
+- **AND** return an empty `concerts` list
+
+#### Scenario: Filter Past Events
+
+- **WHEN** the search results include events with dates in the past
+- **THEN** the system MUST filter them out and only return future events
+
+#### Scenario: No Results
+
+- **WHEN** no upcoming concerts are found for the artist
+- **THEN** the system MUST return an empty `concerts` list without error
+
+#### Scenario: Missing Artist ID
+
+- **WHEN** an `artist_id` is not provided
+- **THEN** the system MUST return an `INVALID_ARGUMENT` error
+
+#### Scenario: Unauthenticated access
+
+- **WHEN** `SearchNewConcerts` is called without a bearer token
+- **THEN** the system SHALL process the request normally (public procedure)
+- **AND** the search log cache SHALL prevent abuse by skipping external API calls for recently searched artists
+
+#### Scenario: Search timeout
+
+- **WHEN** the external search API does not respond within 60 seconds
+- **THEN** the system SHALL return a deadline exceeded error
+- **AND** the search log SHALL be marked as failed
+
+## REMOVED Requirements
+
+### Requirement: ListSearchStatuses RPC
+**Reason**: Polling is no longer needed. SearchNewConcerts now blocks until completion and returns concerts directly.
+**Migration**: Frontend removes all polling logic. Backend deletes ListSearchStatuses handler, usecase method, mapper, and related proto messages (ListSearchStatusesRequest, ListSearchStatusesResponse, ArtistSearchStatus, SearchStatus enum).

--- a/openspec/changes/sync-concert-search/specs/follow-triggered-search/spec.md
+++ b/openspec/changes/sync-concert-search/specs/follow-triggered-search/spec.md
@@ -1,0 +1,17 @@
+## MODIFIED Requirements
+
+### Requirement: Trigger concert search on first follow
+When a user follows an artist and no search log exists for that artist, the system SHALL launch a concert search via `SearchNewConcerts`. The search runs synchronously within the follow goroutine context.
+
+#### Scenario: First follow triggers search
+- **WHEN** a user follows an artist that has no entry in the search log
+- **THEN** the system SHALL call `SearchNewConcerts(artistID)` in a background goroutine
+- **AND** the search SHALL block until the Gemini API completes (synchronous)
+
+#### Scenario: Subsequent follow skips search
+- **WHEN** a user follows an artist that already has a search log entry
+- **THEN** the system SHALL NOT trigger a search
+
+#### Scenario: Already-following is treated as no-op
+- **WHEN** a user follows an artist they already follow (ErrAlreadyExists)
+- **THEN** the system SHALL return success without checking the search log or triggering search

--- a/openspec/changes/sync-concert-search/specs/frontend-observability/spec.md
+++ b/openspec/changes/sync-concert-search/specs/frontend-observability/spec.md
@@ -1,0 +1,11 @@
+## MODIFIED Requirements
+
+### Requirement: ILogger OpenTelemetry Sink
+The system SHALL provide a custom `ISink` implementation that bridges Aurelia 2's `ILogger` to OpenTelemetry spans.
+
+#### Scenario: Multiple sinks are registered
+- **WHEN** the application is configured
+- **THEN** `LoggerConfiguration` SHALL register both `ConsoleSink` and `OtelLogSink`
+- **AND** all log events SHALL be emitted to both sinks
+- **AND** the log level SHALL be determined by the `VITE_LOG_LEVEL` environment variable
+- **AND** the Dockerfile SHALL NOT set `ENV VITE_LOG_LEVEL` to avoid overriding the `.env` file value with an empty string

--- a/openspec/changes/sync-concert-search/specs/frontend-onboarding-flow/spec.md
+++ b/openspec/changes/sync-concert-search/specs/frontend-onboarding-flow/spec.md
@@ -1,0 +1,46 @@
+## MODIFIED Requirements
+
+### Requirement: Interactive Artist Discovery (Bubble Network UI)
+
+The system SHALL provide an engaging, gamified interface for users to discover and follow artists using Last.fm API data. During onboarding, followed artists are stored locally (not via backend RPC). The system SHALL call `SearchNewConcerts` for each followed artist and track which artists have concerts. The Coach Mark SHALL appear as soon as the concert-with-artists target is reached.
+
+#### Scenario: Guest user follows artist via bubble tap
+
+- **WHEN** a guest user (in onboarding) taps an artist bubble
+- **THEN** the system SHALL trigger the absorption animation
+- **AND** the system SHALL store the artist in `FollowServiceClient.followedArtists` (which delegates to `GuestService` for guest users)
+- **AND** the system SHALL call `searchNewConcerts(artistId)` and await the response (blocking until Gemini completes)
+- **AND** if the response contains concerts, add the artist to `artistsWithConcerts`
+- **AND** the system SHALL NOT call any backend RPC for the follow operation itself
+
+#### Scenario: Guest follow default hype level
+
+- **WHEN** a guest user (in onboarding) requests the list of followed artists via `listFollowed()`
+- **THEN** the system SHALL return each followed artist with hype level `'watch'` (observation tier)
+
+#### Scenario: Discover to Dashboard transition
+
+- **WHEN** a user is at Step `'discovery'`
+- **AND** `ConcertServiceClient.artistsWithConcertsCount` >= 3
+- **THEN** the system SHALL activate a coach mark spotlight on the Dashboard icon
+- **AND** when the user taps the Dashboard icon, the system SHALL advance `onboardingStep` to `'dashboard'`
+- **AND** the system SHALL navigate to `/dashboard`
+
+#### Scenario: Snack notification on concert found
+
+- **WHEN** `searchNewConcerts(artistId)` returns a non-empty concerts list
+- **THEN** the system SHALL display a snack notification indicating the artist has upcoming events
+
+#### Scenario: Pre-seeded follows on page reload
+
+- **WHEN** the discovery page loads during onboarding
+- **THEN** the system SHALL hydrate follows from `GuestService.follows` into `FollowServiceClient`
+- **AND** the system SHALL call `searchNewConcerts()` for each hydrated artist (concurrently)
+- **AND** update `artistsWithConcerts` as each call completes
+
+#### Scenario: Search failure does not block follow
+
+- **WHEN** `searchNewConcerts(artistId)` fails or times out
+- **THEN** the system SHALL log the error
+- **AND** the follow operation itself SHALL remain successful
+- **AND** the artist SHALL NOT be added to `artistsWithConcerts`

--- a/openspec/changes/sync-concert-search/tasks.md
+++ b/openspec/changes/sync-concert-search/tasks.md
@@ -1,0 +1,57 @@
+## 1. Proto: SearchNewConcerts sync + remove polling
+
+- [x] 1.1 Update `SearchNewConcertsResponse`: unreserve field 1, add `repeated Concert concerts = 1`
+- [x] 1.2 Update `SearchNewConcerts` RPC comment: remove "asynchronous", document sync behavior and 60s timeout
+- [x] 1.3 Delete `ListSearchStatuses` RPC definition
+- [x] 1.4 Delete `ListSearchStatusesRequest`, `ListSearchStatusesResponse`, `ArtistSearchStatus` messages
+- [x] 1.5 Delete `SearchStatus` enum
+- [x] 1.6 Run `buf lint` and `buf breaking` (expect breaking — label PR with `buf skip breaking`)
+
+## 2. Backend: Sync SearchNewConcerts + delete polling
+
+- [ ] 2.1 Change `SearchNewConcerts` usecase return type from `error` to `([]*entity.Concert, error)` — return discovered concerts after persist
+- [ ] 2.2 Update `SearchNewConcerts` handler: call sync usecase directly (not `AsyncSearchNewConcerts`), map `[]entity.Concert` to proto, populate response
+- [ ] 2.3 Delete `AsyncSearchNewConcerts` interface method and implementation
+- [ ] 2.4 Delete `backgroundSearchTimeout` constant
+- [ ] 2.5 Delete `ListSearchStatuses` handler method
+- [ ] 2.6 Delete `ListSearchStatuses` usecase interface method and implementation
+- [ ] 2.7 Delete `internal/usecase/search_status.go` file (SearchStatusValue enum)
+- [ ] 2.8 Delete `internal/adapter/rpc/mapper/search_status.go` file
+- [ ] 2.9 Delete `SearchLogRepository.ListByArtistIDs` method (entity interface + rdb implementation)
+- [ ] 2.10 Remove `ListSearchStatuses` from public procedures in `provider.go`
+- [ ] 2.11 Run `mockery` to regenerate mocks
+- [ ] 2.12 Delete handler tests: `TestConcertHandler_SearchNewConcerts` (old async), `TestConcertHandler_ListSearchStatuses`
+- [ ] 2.13 Write new handler test: `TestConcertHandler_SearchNewConcerts` (sync, concerts in response)
+- [ ] 2.14 Delete usecase test: `TestConcertUseCase_AsyncSearchNewConcerts`
+- [ ] 2.15 Update usecase test: `TestConcertUseCase_SearchNewConcerts` — expect `([]*entity.Concert, error)` return
+- [ ] 2.16 Delete `search_log_repo_test.go` `TestSearchLogRepository_ListByArtistIDs` test
+- [ ] 2.17 Run `make check`
+
+## 3. Frontend: Remove polling, await SearchNewConcerts
+
+- [ ] 3.1 Update `concert-client.ts`: `searchNewConcerts` returns `ProtoConcert[]` from response
+- [ ] 3.2 Delete from `concert-client.ts`: `listSearchStatuses()` method, `ArtistSearchStatus` import
+- [ ] 3.3 Delete from `concert-service.ts`: polling infrastructure (searchAndTrack, pollSearchStatuses, startPollingIfNeeded, stopPolling, markDone, getPendingArtistIds, checkArtistConcerts, onConcertFoundCallback, searchStatus Map, searchStartTimes Map, pollIntervalId, pollAbortSignal, pollTargetCount, POLL_INTERVAL_MS, PER_ARTIST_TIMEOUT_MS, SearchStatusResult, protoStatusToString)
+- [ ] 3.4 Add to `concert-service.ts`: simple `searchNewConcerts(artistId, signal)` method that calls RPC and returns concerts
+- [ ] 3.5 Keep `concert-service.ts`: `artistsWithConcerts` Set, `artistsWithConcertsCount` getter, `stopTracking()` (rename or remove if unused)
+- [ ] 3.6 Update `discovery-route.ts`: replace `searchAndTrack()` calls with `await concertService.searchNewConcerts()` + inline `artistsWithConcerts.add()` + snack notification
+- [ ] 3.7 Delete `discovery-route.ts`: `onConcertFound()` method, `concertService.stopTracking()` call in detaching
+- [ ] 3.8 Update tests: `concert-service.spec.ts` — delete listSearchStatuses suite, update searchNewConcerts suite
+- [ ] 3.9 Update tests: `discovery-route.spec.ts` — replace searchAndTrack expectations with searchNewConcerts await
+- [ ] 3.10 Update tests: mock helpers — remove searchAndTrack, stopTracking from mock
+- [ ] 3.11 Update e2e: `onboarding-flow.spec.ts` — delete ListSearchStatuses mock, update SearchNewConcerts mock to return concerts
+- [ ] 3.12 Run `make check`
+
+## 4. Frontend: Fix Dockerfile log level
+
+- [ ] 4.1 Remove `ARG VITE_LOG_LEVEL` and `ENV VITE_LOG_LEVEL=${VITE_LOG_LEVEL}` from Dockerfile
+- [ ] 4.2 Verify `.env` has `VITE_LOG_LEVEL=debug`
+
+## 5. Verification
+
+- [ ] 5.1 Deploy specification (create Release for BSR)
+- [ ] 5.2 Update backend deps (`go get buf.build/...`), deploy backend
+- [ ] 5.3 Update frontend deps (`npm install`), deploy frontend
+- [ ] 5.4 Verify onboarding: follow artist → SearchNewConcerts blocks → concerts returned → snack notification
+- [ ] 5.5 Verify coach mark appears after 3 artists with concerts
+- [ ] 5.6 Verify browser console shows INFO-level logs on dev.liverty-music.app

--- a/proto/liverty_music/rpc/concert/v1/concert_service.proto
+++ b/proto/liverty_music/rpc/concert/v1/concert_service.proto
@@ -34,22 +34,16 @@ service ConcertService {
   //   or exceeds the maximum number of artist IDs (50).
   rpc ListWithProximity(ListWithProximityRequest) returns (ListWithProximityResponse);
 
-  // SearchNewConcerts triggers an asynchronous discovery process for new concerts.
-  // It enqueues a background search job and returns immediately. The actual search
-  // runs asynchronously with a 120-second timeout and publishes a
-  // concert.discovered.v1 event for downstream consumers.
+  // SearchNewConcerts discovers new concerts for a given artist using generative AI.
+  // The call blocks until the search completes (up to 60 seconds) and returns any
+  // newly discovered concerts. If a recent search exists (within 24 hours), the
+  // external API call is skipped and an empty list is returned.
   //
   // Possible errors:
   // - INVALID_ARGUMENT: The artist ID is missing or invalid.
   // - NOT_FOUND: The specified artist does not exist.
+  // - DEADLINE_EXCEEDED: The search did not complete within the timeout.
   rpc SearchNewConcerts(SearchNewConcertsRequest) returns (SearchNewConcertsResponse);
-
-  // ListSearchStatuses returns the current search status for one or more artists.
-  // Use this to poll for completion after calling SearchNewConcerts.
-  //
-  // Possible errors:
-  // - INVALID_ARGUMENT: The artist IDs list is empty or contains invalid IDs.
-  rpc ListSearchStatuses(ListSearchStatusesRequest) returns (ListSearchStatusesResponse);
 }
 
 // ListRequest is the request for retrieving concerts associated with a specific artist.
@@ -128,46 +122,10 @@ message SearchNewConcertsRequest {
   entity.v1.ArtistId artist_id = 1 [(buf.validate.field).required = true];
 }
 
-// SearchNewConcertsResponse is intentionally empty. Concert persistence happens
-// asynchronously via event-driven consumers after the discovery process publishes
-// a concert.discovered.v1 event.
+// SearchNewConcertsResponse contains the concerts discovered by the search.
+// The list includes only newly discovered concerts (after deduplication against
+// existing data). An empty list indicates no new concerts were found.
 message SearchNewConcertsResponse {
-  reserved 1;
-  reserved "concerts";
-}
-
-// ListSearchStatusesRequest specifies the artists whose search status is queried.
-message ListSearchStatusesRequest {
-  // Required. The artist identifiers to query search status for.
-  repeated entity.v1.ArtistId artist_ids = 1 [(buf.validate.field).repeated.min_items = 1];
-}
-
-// ListSearchStatusesResponse contains the search status for each requested artist.
-message ListSearchStatusesResponse {
-  // The search status for each requested artist.
-  repeated ArtistSearchStatus statuses = 1;
-}
-
-// ArtistSearchStatus represents the current search status for a single artist.
-message ArtistSearchStatus {
-  // The artist identifier.
-  entity.v1.ArtistId artist_id = 1;
-
-  // The current search status.
-  SearchStatus status = 2;
-}
-
-// SearchStatus indicates the state of a concert search job for an artist.
-enum SearchStatus {
-  // Default value. No search log exists for this artist.
-  SEARCH_STATUS_UNSPECIFIED = 0;
-
-  // A search is currently in progress.
-  SEARCH_STATUS_PENDING = 1;
-
-  // The search completed successfully.
-  SEARCH_STATUS_COMPLETED = 2;
-
-  // The search failed after all retries.
-  SEARCH_STATUS_FAILED = 3;
+  // The newly discovered concerts for the requested artist.
+  repeated entity.v1.Concert concerts = 1;
 }


### PR DESCRIPTION
## Summary

- **BREAKING**: Make `SearchNewConcerts` synchronous — blocks until Gemini completes, returns discovered concerts in response
- **BREAKING**: Remove `ListSearchStatuses` RPC, `SearchStatus` enum, and related messages (polling no longer needed)
- Unreserve field 1 on `SearchNewConcertsResponse` and add `repeated Concert concerts = 1`

## Context

The async fire-and-forget + polling architecture for concert search is broken in the onboarding flow. The frontend polls with a 15-second per-artist timeout, but when users follow many artists, the Gemini API processes them sequentially (8-60s total), causing most searches to timeout silently. Making the RPC synchronous eliminates polling entirely — one call, one response with concerts.

## Test plan

- [x] `buf lint` passes
- [x] `buf breaking` detects expected breaking changes (label PR with `buf skip breaking`)
- [ ] Backend and frontend PRs will follow after BSR gen completes