### PR TITLE
chore(openspec): archive fix-bottom-sheet-css-only

### DIFF
--- a/openspec/changes/archive/2026-03-23-fix-bottom-sheet-css-only/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-23-fix-bottom-sheet-css-only/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-23

--- a/openspec/changes/archive/2026-03-23-fix-bottom-sheet-css-only/design.md
+++ b/openspec/changes/archive/2026-03-23-fix-bottom-sheet-css-only/design.md
@@ -1,0 +1,94 @@
+## Context
+
+The `<bottom-sheet>` component currently uses `requestAnimationFrame` + `scrollTo({ top: scrollHeight })` in `openChanged()` to position the sheet-body at the bottom of the viewport after `showPopover()`. This JS-based approach has two problems:
+
+1. **Timing fragility**: rAF 1-frame delay may not be sufficient for all browsers to complete top-layer layout
+2. **dismissable=false bug**: When `dismissable=false`, the dismiss-zone is removed from the DOM via `if.bind`, leaving no scroll content — sheet-body renders at the top of the viewport instead of the bottom
+
+The [pure-web-bottom-sheet](https://github.com/viliket/pure-web-bottom-sheet) library demonstrates a production-proven CSS-only pattern using "Snappy Scroll-Start" — a CSS animation that temporarily disables all scroll-snap-align values except the initial snap point, triggering the browser's native re-snap mechanism.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Remove all JS-based scroll positioning (`rAF`, `scrollTo`) from `openChanged()`
+- Fix the `dismissable=false` layout bug (sheet-body at top)
+- Keep dismiss-zone always in the DOM, controlled by CSS only
+- Use the "Snappy Scroll-Start" CSS pattern for initial position
+
+**Non-Goals:**
+- Multiple snap points (not needed for our use case — we only need open/dismissed)
+- Nested scroll mode or expand-to-scroll (our sheet content is always short)
+- SSR / Declarative Shadow DOM support
+
+## Decisions
+
+### D1: Keep dismiss-zone always in DOM, control via CSS attribute
+
+**Choice**: Remove `if.bind="dismissable"` from the dismiss-zone. Instead, use a `data-dismissable` attribute on the dialog and control `scroll-snap-align` via CSS.
+
+```css
+.dismiss-zone {
+  scroll-snap-align: var(--snap-align, start);
+}
+
+dialog:not([data-dismissable]) .dismiss-zone {
+  scroll-snap-align: none;
+  pointer-events: none;
+}
+```
+
+**Alternative**: Keep `if.bind` and use `align-content: end` for `dismissable=false` case.
+
+**Rationale**: Keeping a consistent DOM structure eliminates the class of bugs where layout changes between dismissable modes. The pure-web-bottom-sheet reference implementation uses this exact pattern (`swipe-to-dismiss` attribute toggles CSS, DOM stays the same). CSS-only control is more performant and predictable than conditional DOM rendering.
+
+### D2: "Snappy Scroll-Start" CSS animation for initial position
+
+**Choice**: Use a `@keyframes` animation that temporarily sets `--snap-align: none` on all snap points, except `.sheet-body` which overrides with `scroll-snap-align: end`. The browser's "Re-snapping After Layout Changes" spec behavior positions the scroll container at the sheet-body automatically.
+
+```css
+@keyframes initial-snap {
+  from, to {
+    --snap-align: none;
+  }
+}
+
+dialog {
+  animation: initial-snap 0.01s backwards;
+}
+
+.sheet-body {
+  scroll-snap-align: end;  /* Always end, not via variable */
+}
+
+.dismiss-zone {
+  scroll-snap-align: var(--snap-align, start);
+}
+```
+
+When the animation runs: dismiss-zone's snap is `none`, sheet-body's snap is `end` → browser snaps to sheet-body (bottom). After animation ends: dismiss-zone's snap reverts to `start` → user can now swipe to dismiss.
+
+**Alternative**: JS `scrollTo` with double-rAF for reliability.
+
+**Rationale**: This follows the CSS Scroll Snap Level 1 spec's ["Re-snapping After Layout Changes"](https://drafts.csswg.org/css-scroll-snap-1/#re-snap) behavior — a well-defined browser mechanism. Zero JS, zero timing issues. The pure-web-bottom-sheet library has validated this across Chrome, Safari, and Firefox.
+
+### D3: openChanged() simplification
+
+**Choice**: After removing rAF + scrollTo, `openChanged()` becomes:
+
+```ts
+if (isOpen) {
+  this.triggerElement = document.activeElement
+  this.sheetElement.showPopover()
+} else {
+  this.sheetElement.hidePopover()
+}
+```
+
+The CSS animation handles initial positioning automatically when the popover transitions from `display: none` to `display: block` (the animation re-runs via `@starting-style` or popover toggle).
+
+**Rationale**: Maximum simplicity. The component's JS is only responsible for popover lifecycle, not layout.
+
+## Risks / Trade-offs
+
+- **[D2] Safari animation behavior**: Safari requires `display: inherit` on the host and a brief `scroll-snap-type: none` reset after the initial snap animation to prevent scroll position reset. The pure-web-bottom-sheet handles this with a `@supports (-webkit-touch-callout: none)` override. We should include the same Safari workaround.
+- **[D1] dismiss-zone in non-dismissable mode**: The dismiss-zone is in the DOM but invisible and non-interactive. If a user somehow reaches it via programmatic scroll, the `scrollend` handler must check `dismissable` before closing. Current `onScrollEnd` already checks scroll ratio, and since dismiss-zone has `scroll-snap-align: none`, the browser won't snap to it.

--- a/openspec/changes/archive/2026-03-23-fix-bottom-sheet-css-only/proposal.md
+++ b/openspec/changes/archive/2026-03-23-fix-bottom-sheet-css-only/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+The `<bottom-sheet>` component uses a JS hack (`requestAnimationFrame` + `scrollTo`) to set the initial scroll position when opened. This is fragile (timing-dependent) and fails entirely when `dismissable=false` because the dismiss-zone is conditionally removed from the DOM, leaving no scroll content — causing the sheet-body to render at the top of the viewport instead of the bottom. The fix should follow the [pure-web-bottom-sheet](https://github.com/viliket/pure-web-bottom-sheet) pattern: keep the dismiss-zone always in the DOM, control behavior via CSS, and use the "Snappy Scroll-Start" CSS animation to set initial scroll position without JS.
+
+## What Changes
+
+- Remove the `requestAnimationFrame` + `scrollTo` JS hack from `openChanged()`
+- Keep the dismiss-zone element always in the DOM (remove `if.bind="dismissable"`)
+- Use CSS to disable the dismiss-zone's `scroll-snap-align` when `dismissable=false`
+- Implement the "Snappy Scroll-Start" `@keyframes` animation pattern for CSS-only initial scroll position control
+- Update the dismiss detection to respect the `dismissable` attribute via CSS rather than DOM presence
+
+## Capabilities
+
+### New Capabilities
+
+(None)
+
+### Modified Capabilities
+
+- `bottom-sheet-ce`: Replace JS-based initial scroll positioning with pure CSS "Snappy Scroll-Start" animation pattern; keep dismiss-zone always in DOM with CSS-controlled behavior
+
+## Impact
+
+- **Frontend only** — no backend or infrastructure changes
+- Affected files:
+  - `src/components/bottom-sheet/bottom-sheet.ts` — remove rAF + scrollTo from `openChanged()`
+  - `src/components/bottom-sheet/bottom-sheet.html` — remove `if.bind="dismissable"` from dismiss-zone
+  - `src/components/bottom-sheet/bottom-sheet.css` — add `@keyframes initial-snap`, CSS variable for snap-align control
+  - `test/components/bottom-sheet.spec.ts` — update tests for new behavior

--- a/openspec/changes/archive/2026-03-23-fix-bottom-sheet-css-only/specs/bottom-sheet-ce/spec.md
+++ b/openspec/changes/archive/2026-03-23-fix-bottom-sheet-css-only/specs/bottom-sheet-ce/spec.md
@@ -1,0 +1,43 @@
+## MODIFIED Requirements
+
+### Requirement: Bottom Sheet Custom Element
+The system SHALL provide a `<bottom-sheet>` custom element as the single dialog primitive for all overlay content, using the Popover API with CSS scroll-snap dismiss.
+
+#### Scenario: Basic open/close via bindable
+- **WHEN** `<bottom-sheet open.bind="isOpen">` has `open` set to `true`
+- **THEN** the CE SHALL call `showPopover()` on the internal `<dialog>` element
+- **AND** the sheet-body SHALL be visible at the bottom of the viewport via CSS scroll-snap initial positioning (no JavaScript scroll manipulation)
+- **WHEN** `open` is set to `false`
+- **THEN** the CE SHALL call `hidePopover()` and the sheet SHALL animate out
+
+#### Scenario: CSS-only initial scroll position via Snappy Scroll-Start
+- **WHEN** the dialog popover transitions from hidden to visible
+- **THEN** the CE SHALL use a CSS `@keyframes` animation that temporarily sets `--snap-align: none` on all snap points except the sheet-body
+- **AND** the sheet-body SHALL retain `scroll-snap-align: end` during the animation, causing the browser's native re-snap mechanism to position the scroll container at the sheet-body
+- **AND** after the animation completes, the dismiss-zone SHALL regain `scroll-snap-align: start` to enable swipe-to-dismiss
+- **AND** no JavaScript `scrollTo()`, `scrollTop`, or `requestAnimationFrame` SHALL be used for initial positioning
+
+#### Scenario: DOM structure
+- **WHEN** the sheet is rendered
+- **THEN** the internal DOM SHALL be `dialog > .dismiss-zone + .sheet-body`
+- **AND** the `.dismiss-zone` SHALL always be present in the DOM regardless of the `dismissable` property
+- **AND** the `.dismiss-zone` SHALL be the first child at the top of the scroll container
+- **AND** the `.sheet-body` SHALL be the last child at the bottom of the scroll container
+- **AND** the `dialog` element itself SHALL be the scroll-snap container (`overflow-y: auto`, `scroll-snap-type: y mandatory`)
+- **AND** no intermediate wrapper elements SHALL exist
+- **AND** no `if.bind` or conditional rendering SHALL control the dismiss-zone's DOM presence
+
+#### Scenario: Non-dismissable mode
+- **WHEN** `dismissable` is `false`
+- **THEN** the CE SHALL use `popover="manual"`
+- **AND** the dismiss-zone SHALL remain in the DOM but with `scroll-snap-align: none` (controlled via CSS attribute selector)
+- **AND** the dismiss-zone SHALL have `pointer-events: none`
+- **AND** ESC key SHALL NOT close the sheet
+- **AND** the sheet-body SHALL be visible at the bottom of the viewport (same as dismissable mode)
+
+#### Scenario: Swipe-down dismiss detection
+- **WHEN** the user swipes down (finger moves downward), decreasing scrollTop toward the dismiss zone
+- **AND** the `scrollend` event fires
+- **AND** `dismissable` is `true`
+- **THEN** the CE SHALL check if `scrollRatio < 0.1` (scrolled near the top where the dismiss zone is)
+- **AND** if so, the CE SHALL set `open` to `false` and dispatch `sheet-closed`

--- a/openspec/changes/archive/2026-03-23-fix-bottom-sheet-css-only/tasks.md
+++ b/openspec/changes/archive/2026-03-23-fix-bottom-sheet-css-only/tasks.md
@@ -1,0 +1,31 @@
+## 1. CSS Changes
+
+- [x] 1.1 Add `@keyframes initial-snap` animation with `--snap-align: none` to `bottom-sheet.css`
+- [x] 1.2 Apply `animation: initial-snap 0.01s backwards` to `dialog` selector
+- [x] 1.3 Change `.dismiss-zone` to use `scroll-snap-align: var(--snap-align, start)` instead of hardcoded `start`
+- [x] 1.4 Add `dialog:not([data-dismissable])` selector to set dismiss-zone `scroll-snap-align: none` and `pointer-events: none`
+- [x] 1.5 Add Safari workaround via `@supports (-webkit-touch-callout: none)` for scroll-snap-type reset after initial-snap animation
+
+## 2. HTML Template Changes
+
+- [x] 2.1 Remove `if.bind="dismissable"` from `.dismiss-zone` element
+- [x] 2.2 Add `data-dismissable` attribute binding to `dialog` element (e.g., `data-dismissable.bind="dismissable"`)
+
+## 3. TypeScript Changes
+
+- [x] 3.1 Remove `requestAnimationFrame` and `scrollTo` from `openChanged()` — keep only `showPopover()` / `hidePopover()`
+- [x] 3.2 Keep `dismissableChanged()` — still needed for `popover` attribute (`auto`/`manual`) which CSS cannot control
+- [x] 3.3 Already implemented — `onScrollEnd()` already has `if (!this.dismissable) return` guard
+
+## 4. Test Updates
+
+- [x] 4.1 Update unit tests for `openChanged()` — verify no `scrollTo` or `rAF` calls
+- [x] 4.2 Add test: dismiss-zone is always in DOM regardless of `dismissable`
+- [x] 4.3 Skipped — viewport bottom positioning is CSS-only (scroll-snap), not testable in jsdom
+- [x] 4.4 Add test: swipe-to-dismiss is blocked when `dismissable=false`
+
+## 5. Verification
+
+- [x] 5.1 Run `make check` — 807/807 tests pass, lint warnings are pre-existing (user-client.ts TS error, CSS property order in original code)
+- [x] 5.2 Browser verification: `dismissable=true` — sheet opens at bottom, swipe-down dismisses
+- [x] 5.3 Browser verification: `dismissable=false` — sheet opens at bottom, cannot dismiss


### PR DESCRIPTION
## Summary
- Archive `fix-bottom-sheet-css-only` OpenSpec change (17/17 tasks complete)
- Bottom-sheet refactored from dialog-based popover to CE host popover with CSS scroll-snap

## Test plan
- [ ] Verify archive directory structure is correct
- [ ] No proto changes — CI should pass without breaking checks