### PR TITLE
docs(spec): fix passion-level EN labels and archive change

### DIFF
--- a/openspec/changes/archive/2026-03-23-fix-hype-slider-visuals/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-23-fix-hype-slider-visuals/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-23

--- a/openspec/changes/archive/2026-03-23-fix-hype-slider-visuals/design.md
+++ b/openspec/changes/archive/2026-03-23-fix-hype-slider-visuals/design.md
@@ -1,0 +1,53 @@
+## Context
+
+The My Artists hype slider originally rendered a 2px horizontal track line connecting all 4 dots using a `::before` pseudo-element on `.hype-label` scoped to `.hype-col:first-of-type`. Commit `e64f6e8` removed this CSS block while targeting vertical grid lines, breaking the visual connection between dots. The `hype-inline-slider` spec explicitly requires "4 dot stops connected by a 2px track line".
+
+Separately, the `passion-level` spec's EN UI label for the Away tier was never updated from "Anywhere!" to "Away" after the `rename-hype-anywhere-to-away` change. The i18n implementation propagated this stale label.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Restore the horizontal track line connecting hype dots
+- Fix EN "Anywhere!" → "Away" in translation and spec
+- Replace hardcoded Japanese in `hype-display.ts` with i18n keys
+
+**Non-Goals:**
+- Redesigning the slider visual style
+- Changing the track line's appearance (color, width, position)
+- Investigating vertical grid line artifacts (current CSS has no explicit vertical borders)
+
+## Decisions
+
+### 1. Restore track line CSS with restructured nesting
+
+**Choice**: Re-insert the `::before` pseudo-element for the track line, but nest it inside `.hype-col` (not `.hype-label` as in the original) to avoid a browser limitation with `@scope` + CSS nesting.
+
+Original (before `e64f6e8`, nested inside `.hype-label`):
+```css
+.hype-col:first-of-type > &::before { ... }
+```
+
+Actual implementation (nested inside `.hype-col`):
+```css
+&:first-of-type > .hype-label::before { ... }
+```
+
+Both resolve to the same selector: `.hype-col:first-of-type > .hype-label::before`. However, when `&` refers to `.hype-label` and appears mid-selector inside `@scope`, Chromium silently drops the rule. Moving the nesting anchor to `.hype-col` (where `&` is at the start) avoids this.
+
+**Why**: The original CSS properties (position, dimensions, background) are unchanged — only the nesting structure differs. Verified visually with Playwright.
+
+### 2. Fix EN label to "Away" (not "Anywhere")
+
+**Choice**: Update `translation.json` EN `myArtists.table.away` to "Away" and update `passion-level/spec.md` tier table EN label to "Away".
+
+**Why**: The `rename-hype-anywhere-to-away` change (2026-03-11) established "Away" as the canonical EN label. The spec was not updated, causing the i18n implementation to use the stale "Anywhere!" label.
+
+### 3. Replace hardcoded Japanese in hype-display.ts with i18n keys
+
+**Choice**: Change `HYPE_TIERS` `labelKey` values from hardcoded Japanese strings to i18n translation keys (`myArtists.table.watch`, etc.).
+
+**Why**: The file was missed during the i18n migration in `6155baa`. Using keys ensures labels respect the user's locale setting.
+
+## Risks / Trade-offs
+
+- **hype-display.ts consumers**: Any code using `HYPE_TIERS[tier].labelKey` as a display string will now get an i18n key instead. Verified: the only consumer (`trHypeLabel`) was dead code and has been removed.

--- a/openspec/changes/archive/2026-03-23-fix-hype-slider-visuals/proposal.md
+++ b/openspec/changes/archive/2026-03-23-fix-hype-slider-visuals/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+Commit `e64f6e8` (2026-03-21) intended to remove the vertical grid lines between hype columns but accidentally also deleted the horizontal track line that connects hype dots. The track line is a spec requirement (`hype-inline-slider` spec: "4 dot stops connected by a 2px track line"). Additionally, the `passion-level` spec still lists the EN UI label for the Away tier as "Anywhere!" even though the `rename-hype-anywhere-to-away` change (2026-03-11) decided it should be "Away". The i18n implementation (`6155baa`) copied the stale spec label into `translation.json`.
+
+## What Changes
+
+- Restore the `::before` track line pseudo-element on `.hype-label` that was removed in `e64f6e8`, connecting all 4 hype dots with a 2px horizontal line
+- Fix EN translation `myArtists.table.away` from "Anywhere!" to "Away"
+- Update `hype-display.ts` `HYPE_TIERS` to use i18n keys instead of hardcoded Japanese strings
+- Verify that vertical grid lines between hype columns are not visible (no CSS changes expected — the original removal was correct for borders; the visible lines may be cell-gap artifacts)
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `passion-level`: Fix EN UI label for Away tier from "Anywhere!" to "Away" (aligns spec with the `rename-hype-anywhere-to-away` decision)
+- `hype-inline-slider`: No requirement change — restore implementation to match existing track line requirement
+
+## Impact
+
+- `frontend/src/routes/my-artists/my-artists-route.css` — restore track line CSS
+- `frontend/src/locales/en/translation.json` — fix Away label
+- `frontend/src/adapter/view/hype-display.ts` — replace hardcoded Japanese with i18n keys
+- `specification/openspec/specs/passion-level/spec.md` — fix EN label in tier table

--- a/openspec/changes/archive/2026-03-23-fix-hype-slider-visuals/specs/passion-level/spec.md
+++ b/openspec/changes/archive/2026-03-23-fix-hype-slider-visuals/specs/passion-level/spec.md
@@ -1,0 +1,33 @@
+## MODIFIED Requirements
+
+### Requirement: Passion Level Tiers
+
+The system SHALL support four hype level tiers for each followed artist, with emotion-based UI labels:
+
+| Tier | Proto Value | Emoji | UI Label (ja) | UI Label (en) | Notification Scope |
+|------|-------------|-------|----------------|----------------|-------------------|
+| Watch | HYPE_TYPE_WATCH | 👀 | チェック | Watch | None |
+| Home | HYPE_TYPE_HOME | 🔥 | 地元 | Home | Home area only |
+| Nearby | HYPE_TYPE_NEARBY | 🔥🔥 | 近くも | Nearby | Within 200km |
+| Away | HYPE_TYPE_AWAY | 🔥🔥🔥 | どこでも！ | Away | All concerts |
+
+All four tiers SHALL be selectable by authenticated users via the SetHype RPC. No tier SHALL be rejected by server-side validation.
+
+#### Scenario: Default hype level on follow
+
+- **WHEN** a user follows a new artist
+- **AND** the follow relationship is created
+- **THEN** the hype level SHALL default to Watch (HYPE_TYPE_WATCH)
+
+#### Scenario: UI labels use locale-appropriate phrasing
+
+- **WHEN** hype level labels are displayed in the UI (slider header, dialogs, settings)
+- **AND** the locale is Japanese
+- **THEN** the system SHALL use emotion-based labels (チェック/地元/近くも/どこでも！)
+- **WHEN** the locale is English
+- **THEN** the system SHALL use proximity-based labels (Watch/Home/Nearby/Away)
+
+#### Scenario: SetHype accepts all four tiers
+
+- **WHEN** an authenticated user calls SetHype with any of the four defined hype tiers (WATCH, HOME, NEARBY, AWAY)
+- **THEN** the system SHALL accept the request and persist the hype level

--- a/openspec/changes/archive/2026-03-23-fix-hype-slider-visuals/tasks.md
+++ b/openspec/changes/archive/2026-03-23-fix-hype-slider-visuals/tasks.md
@@ -1,0 +1,30 @@
+## 1. Restore hype dot track line
+
+- [x] 1.1 In `frontend/src/routes/my-artists/my-artists-route.css`, restore the `::before` pseudo-element inside `.hype-label` (after `min-block-size: 44px`) that was removed in `e64f6e8`:
+  ```css
+  .hype-col:first-of-type > &::before {
+      content: "";
+      pointer-events: none;
+      position: absolute;
+      inset-block-start: 50%;
+      inset-inline-start: 50%;
+      translate: 0 -50%;
+      inline-size: calc(3 * 100%);
+      block-size: 2px;
+      background: var(--color-border-subtle, oklch(100% 0 0deg / 10%));
+  }
+  ```
+
+## 2. Fix EN "Anywhere!" label
+
+- [x] 2.1 In `frontend/src/locales/en/translation.json`, change `myArtists.table.away` from `"Anywhere!"` to `"Away"`
+- [x] 2.2 In `frontend/src/adapter/view/hype-display.ts`, replace hardcoded Japanese `labelKey` values with i18n keys: `watch` → `myArtists.table.watch`, `home` → `myArtists.table.home`, `nearby` → `myArtists.table.nearby`, `away` → `myArtists.table.away`
+
+## 3. Update spec
+
+- [x] 3.1 In `specification/openspec/specs/passion-level/spec.md`, update the tier table EN label from "Anywhere!" to "Away" and "Just checking" to "Watch"
+
+## 4. Verify
+
+- [x] 4.1 Run `make check` in frontend to ensure lint and tests pass
+- [x] 4.2 Visual verification with Playwright: navigate to `/my-artists`, confirm track line is visible connecting dots, confirm no vertical grid lines between columns, confirm Away column header reads "Away" (not "Anywhere!")

--- a/openspec/specs/passion-level/spec.md
+++ b/openspec/specs/passion-level/spec.md
@@ -12,10 +12,10 @@ The system SHALL support four hype level tiers for each followed artist, with em
 
 | Tier | Proto Value | Emoji | UI Label (ja) | UI Label (en) | Notification Scope |
 |------|-------------|-------|----------------|----------------|-------------------|
-| Watch | HYPE_TYPE_WATCH | 👀 | チェック | Just checking | None |
-| Home | HYPE_TYPE_HOME | 🔥 | 地元 | Local shows | Home area only |
-| Nearby | HYPE_TYPE_NEARBY | 🔥🔥 | 近くも | Nearby too | Within 200km |
-| Away | HYPE_TYPE_AWAY | 🔥🔥🔥 | どこでも！ | Anywhere! | All concerts |
+| Watch | HYPE_TYPE_WATCH | 👀 | チェック | Watch | None |
+| Home | HYPE_TYPE_HOME | 🔥 | 地元 | Home | Home area only |
+| Nearby | HYPE_TYPE_NEARBY | 🔥🔥 | 近くも | Nearby | Within 200km |
+| Away | HYPE_TYPE_AWAY | 🔥🔥🔥 | どこでも！ | Away | All concerts |
 
 All four tiers SHALL be selectable by authenticated users via the SetHype RPC. No tier SHALL be rejected by server-side validation.
 
@@ -25,10 +25,13 @@ All four tiers SHALL be selectable by authenticated users via the SetHype RPC. N
 - **AND** the follow relationship is created
 - **THEN** the hype level SHALL default to Watch (HYPE_TYPE_WATCH)
 
-#### Scenario: UI labels use emotion-based phrasing
+#### Scenario: UI labels use locale-appropriate phrasing
 
 - **WHEN** hype level labels are displayed in the UI (slider header, dialogs, settings)
-- **THEN** the system SHALL use emotion-based labels (チェック/地元/近くも/どこでも！) instead of proximity-based labels (Watch/Home/NearBy/Away)
+- **AND** the locale is Japanese
+- **THEN** the system SHALL use emotion-based labels (チェック/地元/近くも/どこでも！)
+- **WHEN** the locale is English
+- **THEN** the system SHALL use proximity-based labels (Watch/Home/Nearby/Away)
 
 #### Scenario: SetHype accepts all four tiers
 


### PR DESCRIPTION
## Summary

- Fix `passion-level` spec EN UI labels: "Just checking" → "Watch", "Anywhere!" → "Away"
- Update scenario to distinguish locale-appropriate phrasing (EN uses proximity labels, JA uses emotion labels)
- Archive `fix-hype-slider-visuals` change artifacts

## Test plan

- [x] Spec content matches the implemented frontend behavior
- [x] Archive directory contains all artifacts (proposal, design, specs, tasks)
