### PR TITLE
docs(openspec): add gemini-retry-timeout-fix change artifacts

### DIFF
--- a/openspec/changes/gemini-retry-timeout-fix/.openspec.yaml
+++ b/openspec/changes/gemini-retry-timeout-fix/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-23

--- a/openspec/changes/gemini-retry-timeout-fix/design.md
+++ b/openspec/changes/gemini-retry-timeout-fix/design.md
@@ -1,0 +1,133 @@
+## Context
+
+SearchNewConcerts RPC は Gemini API (gemini-3-flash-preview + Google Search grounding) を呼び出す。
+実測の Gemini 応答時間は 25-110 秒だが、現在のタイムアウトチェーンは以下の通り：
+
+```
+Frontend (timeout なし)
+  → GKE Gateway  GCPBackendPolicy.timeoutSec = 60s
+    → http.TimeoutHandler = 60s (SERVER_HANDLER_TIMEOUT)
+      → backoff.Retry (ctx 継承, MaxTries=3)
+        → genai.GenerateContent(ctx) ← 60s で ctx 失効 → 504
+```
+
+問題点:
+1. Gemini の応答時間 (25-110s) に対して Gateway/Handler timeout (60s) が不足
+2. `isRetryable` が Google 公式推奨の 408, 500, 502, 504 を含んでいない
+3. リトライ時に親 ctx の deadline を共有 → 2回目以降は残り時間が足りない
+4. client cancel (画面遷移) で Gemini call が中断される
+
+## Goals / Non-Goals
+
+**Goals:**
+- Gemini API 呼び出しが 120 秒以内に完了できる十分な timeout を確保する
+- Google 公式リトライ戦略に準拠したエラーリトライを実装する
+- ConcertService の timeout を他 RPC から分離し、軽量 RPC への影響を回避する
+- client cancel でも Gemini call を中断しない（1 回目から独立 context）
+- Gateway → Handler → Gemini の timeout チェーン全体の整合性を確保する
+
+**Non-Goals:**
+- SearchNewConcerts の非同期化（将来検討）
+- Gemini モデルの変更（gemini-3-flash-preview → GA モデル）
+- Frontend 側の timeout 設定（現状 Connect-Web はデフォルト timeout なしで問題なし）
+
+## Decisions
+
+### 1. Gemini API 呼び出しの context を親 RPC から切り離す
+
+**決定**: 1 回目の API コールから `context.WithoutCancel(parentCtx)` + `context.WithTimeout(..., 120s)` で新しい context を作成する。
+
+**理由**:
+- client cancel（画面遷移等）で Gemini call を止めたくない
+- リトライごとに独立した 120 秒の deadline を確保する
+- `context.WithoutCancel` により trace_id/span_id は維持される
+
+```go
+backoff.Retry(parentCtx, func() ([]*entity.ScrapedConcert, error) {
+    reqCtx, cancel := context.WithTimeout(
+        context.WithoutCancel(parentCtx), 120*time.Second)
+    defer cancel()
+    resp, err := s.client.Models.GenerateContent(reqCtx, ...)
+    ...
+}, ...)
+```
+
+**代替案**: `context.Background()` を使う → trace 情報が失われるため却下。
+
+### 2. isRetryable を Google 公式推奨に合わせる
+
+**決定**: 以下のコードを retryable に追加する。
+
+| Code | 現状 | 変更後 | 理由 |
+|------|------|--------|------|
+| 408 | - | Retry | Request Timeout (公式推奨) |
+| 429 | Retry | Retry | そのまま |
+| 500 | - | Retry | Internal Server Error (公式推奨) |
+| 502 | - | Retry | Bad Gateway (公式推奨) |
+| 503 | Retry | Retry | そのまま |
+| 504 | **Not retry** | **Retry** | DEADLINE_EXCEEDED (公式推奨、context 独立化で有効) |
+
+504 を retryable にする根拠: 現状コメントの「retrying wastes 15-25s per attempt」は親 ctx の deadline 残量が不足していたため。context を独立化すれば各リトライが 120s のフレッシュな deadline を持ち、504 のリトライが有効になる。
+
+### 3. backoff パラメータの調整
+
+**決定**:
+- `MaxInterval`: 10s → 60s（Google 推奨に合わせる）
+- `MaxTries`: 3 のまま（十分なリトライ回数）
+
+### 4. ConcertService 専用の HandlerTimeout 分離
+
+**決定**: ConcertService のパスにのみ 120s の `http.TimeoutHandler` を適用し、他の RPC は 60s のまま。
+
+**実装方法**: `connect.go` の mux 構成で ConcertService のパスだけ別の TimeoutHandler でラップする。
+
+```go
+// ConcertService: 120s (Gemini API + grounding の応答時間を考慮)
+concertPath, concertHandler := concertHandlerFunc(handlerOpts...)
+protectedMux.Handle(concertPath,
+    http.TimeoutHandler(concertHandler, concertTimeout, ""))
+
+// Other services: default timeout
+for _, hf := range otherHandlerFuncs {
+    path, handler := hf(handlerOpts...)
+    protectedMux.Handle(path, handler)
+}
+
+// Root mux に default timeout を適用
+rootHandler := http.TimeoutHandler(rootMux, defaultTimeout, "")
+```
+
+### 5. Timeout チェーンの整合性
+
+変更後のタイムアウトチェーン:
+
+```
+Frontend (timeout なし — Connect-Web デフォルト)
+  → GKE Gateway  GCPBackendPolicy.timeoutSec = 150s  (← 60s から変更)
+    → http.TimeoutHandler = 120s (ConcertService 専用)
+      → backoff.Retry (parentCtx, MaxTries=3)
+        → context.WithTimeout(WithoutCancel(parentCtx), 120s)
+          → genai.GenerateContent(reqCtx)
+
+各レイヤーのバッファ:
+  Gateway (150s) > Handler (120s) > Gemini timeout (120s/回)
+  ※リトライ含む最大所要時間: 120s + backoff(1s) + 120s + backoff(2s) + 120s = ~363s
+  ※ただし Handler 120s で全体が打ち切られるため、実質 1回目のみ 120s で完了する必要がある
+```
+
+**重要**: Handler の 120s timeout は RPC 全体にかかる。リトライ 3 回 × 120s = 360s は Handler の 120s に収まらない。そのため:
+- Gemini context timeout (120s) は Handler timeout と同値
+- 1 回目が失敗した場合、2 回目以降は Handler の残り時間で制約される
+- ただし Gemini context は `WithoutCancel` なので、Handler timeout 後もバックグラウンドで完了する（レスポンスはクライアントに返せないが、search log の更新は行われる）
+
+**GCPBackendPolicy の timeoutSec**: Gateway timeout は Handler timeout より大きくする必要がある。120s + バッファ = 150s に設定。
+
+### 6. configmap コメントの更新
+
+`SERVER_HANDLER_TIMEOUT` のコメントを実測値に合わせて更新する。
+
+## Risks / Trade-offs
+
+- **[Risk] Handler 120s でも Gemini が完了しない場合がある** → Mitigation: backoff で最大 3 回リトライ。それでも失敗なら graceful degradation（空結果返却）。CronJob 経由では deadline なしで動作するため、最終的にはバッチで補完される。
+- **[Risk] `context.WithoutCancel` により、RPC cancel 後も Gemini リクエストが残る** → Mitigation: backoff.Retry の parentCtx は cancel を受け取るため、次のリトライは開始されない。進行中の Gemini コールのみバックグラウンドで完了する（最大 120s）。
+- **[Trade-off] Gateway timeout を 150s にすることでスロークライアントが長時間接続を保持する** → 許容範囲: SearchNewConcerts は低頻度（フォロー時のみ）のため負荷は限定的。

--- a/openspec/changes/gemini-retry-timeout-fix/proposal.md
+++ b/openspec/changes/gemini-retry-timeout-fix/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+SearchNewConcerts RPC が Gemini API (gemini-3-flash-preview + Google Search grounding) を呼び出す際、504 DEADLINE_EXCEEDED が頻発してアラートが発生している。根本原因は 2 つ: (1) Gemini + grounding の実測応答時間（25-110秒）に対して Handler timeout（60秒）が不足、(2) Google 公式リトライ戦略に対してリトライ対象エラーコードが不足（504, 500, 502, 408 が欠落）。
+
+## What Changes
+
+- Gemini API 呼び出しの context を親 RPC から切り離し、リトライごとに `context.Background()` ベースで 120 秒 timeout の新 context を作成する（client cancel でも Gemini call を止めない）
+- `isRetryable` に Google 公式推奨のエラーコード (408, 500, 502, 504) を追加する
+- backoff の `MaxInterval` を 10 秒 → 60 秒に引き上げる
+- ConcertService の RPC に対してのみ HandlerTimeout を 120 秒に分離する（他の軽量 RPC への影響を回避）
+- API Gateway (GKE Gateway) の ConcertService 向けルートの timeout を 120 秒以上に設定する
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `http-retry`: Gemini API 呼び出しのリトライ戦略を Google 公式推奨に合わせ、context 管理とタイムアウトを修正
+- `concert-service`: ConcertService RPC の timeout を他サービスから分離して 120 秒に設定
+
+## Impact
+
+- **backend**: `internal/infrastructure/gcp/gemini/errors.go` — isRetryable 拡大
+- **backend**: `internal/infrastructure/gcp/gemini/searcher.go` — context 作成ロジック、backoff パラメータ変更
+- **backend**: `internal/infrastructure/server/connect.go` — ConcertService 向け HandlerTimeout 分離
+- **backend**: `pkg/config/config.go` — ConcertService 用 timeout 設定の追加（必要に応じて）
+- **cloud-provisioning**: `k8s/namespaces/backend/base/server/configmap.env` — configmap コメント更新
+- **cloud-provisioning**: GKE Gateway HTTPRoute — ConcertService パスの timeout 設定

--- a/openspec/changes/gemini-retry-timeout-fix/proposal.md
+++ b/openspec/changes/gemini-retry-timeout-fix/proposal.md
@@ -4,7 +4,7 @@ SearchNewConcerts RPC が Gemini API (gemini-3-flash-preview + Google Search gro
 
 ## What Changes
 
-- Gemini API 呼び出しの context を親 RPC から切り離し、リトライごとに `context.Background()` ベースで 120 秒 timeout の新 context を作成する（client cancel でも Gemini call を止めない）
+- Gemini API 呼び出しの context を親 RPC から切り離し、リトライごとに `context.WithoutCancel(parentCtx)` ベースで 120 秒 timeout の新 context を作成する（client cancel でも Gemini call を止めない）
 - `isRetryable` に Google 公式推奨のエラーコード (408, 500, 502, 504) を追加する
 - backoff の `MaxInterval` を 10 秒 → 60 秒に引き上げる
 - ConcertService の RPC に対してのみ HandlerTimeout を 120 秒に分離する（他の軽量 RPC への影響を回避）

--- a/openspec/changes/gemini-retry-timeout-fix/specs/concert-service/spec.md
+++ b/openspec/changes/gemini-retry-timeout-fix/specs/concert-service/spec.md
@@ -1,0 +1,25 @@
+## ADDED Requirements
+
+### Requirement: ConcertService handler timeout isolation
+The ConcertService RPC handlers SHALL have a dedicated handler timeout of 120 seconds, separate from the default handler timeout applied to other services. This accommodates the Gemini API + Google Search grounding response time (25-110 seconds).
+
+#### Scenario: SearchNewConcerts completes within 120 seconds
+- **WHEN** `SearchNewConcerts` is called and the Gemini API responds within 120 seconds
+- **THEN** the RPC SHALL return successfully with discovered concerts
+
+#### Scenario: SearchNewConcerts exceeds 120 seconds
+- **WHEN** `SearchNewConcerts` is called and the handler timeout of 120 seconds is exceeded
+- **THEN** the RPC SHALL return a deadline exceeded error to the client
+
+#### Scenario: Other services retain default timeout
+- **WHEN** an RPC on UserService or ArtistService is called
+- **THEN** the default handler timeout (60 seconds) SHALL apply
+- **AND** the ConcertService timeout SHALL NOT affect other services
+
+### Requirement: GKE Gateway timeout for ConcertService
+The GKE Gateway backend policy `timeoutSec` SHALL be set to 150 seconds to accommodate the ConcertService handler timeout (120 seconds) plus network overhead buffer.
+
+#### Scenario: Gateway timeout exceeds handler timeout
+- **WHEN** a request is routed through the GKE Gateway to the backend
+- **THEN** the Gateway timeout (150 seconds) SHALL be greater than the ConcertService handler timeout (120 seconds)
+- **AND** the Gateway SHALL NOT prematurely terminate ConcertService requests

--- a/openspec/changes/gemini-retry-timeout-fix/specs/http-retry/spec.md
+++ b/openspec/changes/gemini-retry-timeout-fix/specs/http-retry/spec.md
@@ -1,0 +1,69 @@
+## MODIFIED Requirements
+
+### Requirement: HTTP retry on transient errors
+The system SHALL automatically retry HTTP requests that fail with transient status codes (408 Request Timeout, 429 Too Many Requests, 500 Internal Server Error, 502 Bad Gateway, 503 Service Unavailable, 504 Gateway Timeout) using exponential backoff with jitter.
+
+#### Scenario: Retry on 408 request timeout
+- **WHEN** an external HTTP API returns 408 Request Timeout
+- **THEN** the system SHALL wait with exponential backoff and retry the request up to 3 times
+
+#### Scenario: Retry on 429 rate limit
+- **WHEN** an external HTTP API returns 429 Too Many Requests
+- **THEN** the system SHALL wait with exponential backoff and retry the request up to 3 times
+
+#### Scenario: Retry on 500 internal server error
+- **WHEN** an external HTTP API returns 500 Internal Server Error
+- **THEN** the system SHALL wait with exponential backoff and retry the request up to 3 times
+
+#### Scenario: Retry on 502 bad gateway
+- **WHEN** an external HTTP API returns 502 Bad Gateway
+- **THEN** the system SHALL wait with exponential backoff and retry the request up to 3 times
+
+#### Scenario: Retry on 503 service unavailable
+- **WHEN** an external HTTP API returns 503 Service Unavailable
+- **THEN** the system SHALL wait with exponential backoff and retry the request up to 3 times
+
+#### Scenario: Retry on 504 gateway timeout
+- **WHEN** an external HTTP API returns 504 Gateway Timeout
+- **THEN** the system SHALL wait with exponential backoff and retry the request up to 3 times
+
+#### Scenario: No retry on client errors
+- **WHEN** an external HTTP API returns a 4xx status code other than 408 or 429
+- **THEN** the system SHALL NOT retry and SHALL return the error immediately
+
+#### Scenario: All retries exhausted
+- **WHEN** all retry attempts are exhausted
+- **THEN** the system SHALL return the last error to the caller
+
+#### Scenario: All retries exhausted with transient errors only (graceful degradation)
+- **WHEN** all retry attempts are exhausted
+- **AND** all failures were transient errors (not permanent)
+- **THEN** the Gemini concert searcher SHALL log a warning and return empty results instead of an error
+- **AND** the CronJob batch process SHALL eventually discover the concerts on a subsequent run
+
+## ADDED Requirements
+
+### Requirement: Independent context per Gemini API retry
+The Gemini API caller SHALL create a new context for each API call attempt using `context.WithoutCancel` from the parent context, with a fixed 120-second timeout. This ensures each retry has a fresh deadline independent of the parent RPC deadline, and preserves trace propagation.
+
+#### Scenario: First attempt uses independent context
+- **WHEN** the Gemini API is called for the first time in a request
+- **THEN** the system SHALL create a new context derived from `context.WithoutCancel(parentCtx)` with a 120-second timeout
+- **AND** the parent context's trace_id and span_id SHALL be preserved in the new context
+
+#### Scenario: Retry uses fresh context
+- **WHEN** a retryable error occurs and a retry is attempted
+- **THEN** the system SHALL create a new context with a fresh 120-second timeout
+- **AND** the new context SHALL NOT share the deadline of the previous attempt
+
+#### Scenario: Client cancellation does not abort Gemini call
+- **WHEN** the parent RPC context is canceled (e.g., client navigates away)
+- **THEN** the in-progress Gemini API call SHALL continue to completion
+- **AND** the backoff retry loop SHALL stop (no further retry attempts)
+
+### Requirement: Backoff max interval aligned with Google recommendation
+The exponential backoff `MaxInterval` SHALL be set to 60 seconds, aligned with the Google Vertex AI retry strategy documentation.
+
+#### Scenario: Backoff interval capped at 60 seconds
+- **WHEN** the calculated exponential backoff exceeds 60 seconds
+- **THEN** the actual wait time SHALL be capped at 60 seconds

--- a/openspec/changes/gemini-retry-timeout-fix/tasks.md
+++ b/openspec/changes/gemini-retry-timeout-fix/tasks.md
@@ -1,0 +1,28 @@
+## 1. Backend: Retry Strategy
+
+- [x] 1.1 Update `isRetryable` in `internal/infrastructure/gcp/gemini/errors.go` to add 408, 500, 502, 504 as retryable status codes
+- [x] 1.2 Update `isRetryable` doc comment to reflect the new retry policy and reference Google's retry strategy documentation
+- [x] 1.3 Update backoff `MaxInterval` from 10s to 60s in `internal/infrastructure/gcp/gemini/searcher.go`
+
+## 2. Backend: Context Isolation
+
+- [x] 2.1 Modify `Search` method in `searcher.go` to create independent context per Gemini API call using `context.WithoutCancel(parentCtx)` + `context.WithTimeout(..., 120s)`
+- [x] 2.2 Extract Gemini timeout duration as a named constant (e.g., `geminiCallTimeout = 120 * time.Second`)
+- [x] 2.3 Update `backoff.Retry` to use the parent context for loop control while each attempt uses its own context
+
+## 3. Backend: ConcertService Handler Timeout Isolation
+
+- [x] 3.1 Add ConcertService-specific timeout config (or constant) for 120s handler timeout
+- [x] 3.2 Modify `NewConnectServer` in `internal/infrastructure/server/connect.go` to apply 120s `http.TimeoutHandler` only to ConcertService path, keeping default 60s for other services
+- [x] 3.3 Update `connect.go` function signature/DI wiring if ConcertService handler needs to be passed separately
+
+## 4. Cloud Provisioning: Timeout Chain
+
+- [x] 4.1 Update `GCPBackendPolicy` `timeoutSec` from 60 to 150 in `k8s/namespaces/backend/base/server/backend-policy.yaml`
+- [x] 4.2 Update `configmap.env` comment for `SERVER_HANDLER_TIMEOUT` to reflect actual Gemini response times (25-110s, not 16-25s)
+
+## 5. Tests
+
+- [x] 5.1 Update `isRetryable` unit tests to cover new retryable status codes (408, 500, 502, 504)
+- [x] 5.2 Add test for context isolation: verify `context.WithoutCancel` preserves trace but not deadline
+- [x] 5.3 Verify existing `searcher_test.go` passes with updated backoff and context changes


### PR DESCRIPTION
## Summary

- Add OpenSpec change artifacts for `gemini-retry-timeout-fix`: proposal, design, delta specs (http-retry, concert-service), and tasks

## Context

Documents the Gemini API retry strategy alignment and timeout chain fix. Delta specs modify `http-retry` (expanded retryable codes, independent context per retry, backoff max interval) and `concert-service` (handler timeout isolation, gateway timeout).

## Test plan

- [x] All artifacts pass `openspec status` validation

## Related PRs

- backend: liverty-music/backend#253
- cloud-provisioning: liverty-music/cloud-provisioning#175
