### PR TITLE
docs: update specs for onboarding UX refinements

### DIFF
--- a/openspec/changes/archive/2026-03-23-refine-onboarding-ux/design.md
+++ b/openspec/changes/archive/2026-03-23-refine-onboarding-ux/design.md
@@ -1,0 +1,136 @@
+## Design Decisions
+
+### D1: Bottom Sheet CSS Selector Fix — Safe-by-Default Pattern
+
+**Decision:** Fix the CSS selector to match Aurelia's boolean attribute output.
+
+**Context:** Aurelia's `data-dismissable.bind="dismissable"` outputs `data-dismissable="false"` when the value is `false` — the attribute is always present with a string value. The CSS selector `:not([data-dismissable])` checks for attribute absence, which never matches.
+
+**Approach:** Use explicit value matching:
+
+```css
+/* Before (broken): checks attribute absence */
+.scroll-area:not([data-dismissable]) .dismiss-zone { ... }
+
+/* After: checks attribute value */
+.scroll-area:not([data-dismissable="true"]) .dismiss-zone { ... }
+```
+
+**Alternative considered — safe-by-default inversion:** Default dismiss-zone to `scroll-snap-align: none` and only enable on `[data-dismissable="true"]`. Rejected because the `initial-snap` animation pattern relies on `--_snap-align` custom property toggling via `@keyframes`, and inverting the default would require reworking the animation. The minimal selector fix is sufficient and preserves the existing animation design.
+
+**Alternative considered — revert to `if.bind="dismissable"`:** Rejected because dismiss-zone must remain in DOM for the `initial-snap` CSS animation pattern to work. This pattern eliminates the JS `scrollTo` + `requestAnimationFrame` hack that was needed previously (see commit `15a2538`).
+
+### D2: Coach Mark Tooltip — Transparent Background
+
+**Decision:** Remove the tooltip's solid background and drop-shadow.
+
+**Context:** The coach mark overlay already darkens the viewport to 70% opacity. Adding a solid `--color-surface-overlay` background to the tooltip creates two dark layers stacked, which feels visually heavy. The handwritten font (`Klee One`) works better as text floating directly on the dark overlay — lighter and more natural.
+
+**Changes:**
+- `.coach-mark-tooltip`: `background: transparent`, `filter: none`
+- The existing `color: var(--color-white)` and `font-family: var(--coach-font-handwritten)` remain unchanged
+
+### D3: Welcome Page Language Toggle
+
+**Decision:** Add a minimal language switcher below the CTA buttons on the Welcome page.
+
+**Context:** Language switching currently requires navigating to Settings, which is only accessible after authentication. The welcome page is the first touchpoint — if the language is wrong, the user cannot fix it.
+
+**Implementation:**
+- Extract `selectLanguage(lang)` logic from `settings-route.ts` into a shared function (e.g., `changeLocale(i18n, lang)` in a utility module)
+- Add two language buttons (EN / JA) in the welcome template footer, below the Log In button
+- Current language is highlighted with a distinct style (bold or underline)
+- Uses same persistence mechanism: `localStorage.setItem('language', lang)` + `i18n.setLocale(lang)`
+
+### D4: Bottom Sheet Spec Update — Architecture Alignment
+
+**Decision:** Update the `bottom-sheet-ce` spec to reflect the current implementation architecture.
+
+**Context:** The spec still describes the `15a2538` architecture (dialog as popover host and scroll container). The current implementation (`72c768a`) separates popover (CE host) from scroll (`.scroll-area` div). The spec's DOM structure scenario, non-dismissable scenario, and scroll-driven animation scenario need updating.
+
+**Key spec changes:**
+- DOM structure: `<bottom-sheet popover> > .scroll-area > .dismiss-zone + .sheet-body`
+- Non-dismissable: dismiss-zone always in DOM, CSS controls `scroll-snap-align` via `data-dismissable` attribute value
+- `scrollTo` + `requestAnimationFrame` replaced by `initial-snap` CSS animation
+- Scroll-timeline on `.scroll-area` (not on dialog)
+- Semantic improvement: `.sheet-body` uses `<section>` element
+
+## Architecture Diagram
+
+```
+Bottom Sheet Component (after fix)
+====================================
+
+<bottom-sheet popover="manual" role="dialog" aria-label="...">
+│  ← CE host: popover API, opacity transition, ::backdrop
+│  ← @starting-style handles display:none → block transition
+│
+├── <div class="scroll-area" data-dismissable="false">
+│   │  ← scroll-snap container, initial-snap animation
+│   │  ← scroll-timeline: --sheet-scroll
+│   │
+│   ├── <div class="dismiss-zone" aria-hidden="true">
+│   │      ← block-size: 100dvh (swipe target)
+│   │      ← scroll-snap-align: none  ← CSS disables when
+│   │         not data-dismissable="true"
+│   │
+│   └── <section class="sheet-body">
+│          ← scroll-snap-align: end (always active)
+│          ← browser snaps here on open ✓
+│          ├── <div class="handle-bar">
+│          └── <au-slot>  ← projected content
+
+
+Selector fix:
+  .scroll-area:not([data-dismissable="true"]) .dismiss-zone {
+      scroll-snap-align: none;   ← dismiss-zone snap disabled
+      pointer-events: none;      ← no interaction
+  }
+
+  Result: only .sheet-body has active snap → browser snaps to sheet ✓
+```
+
+## Onboarding Flow After Changes
+
+```
+┌─────────────────────────────────┐
+│         LIVERTY MUSIC           │
+│                                 │
+│  Never miss a live show         │
+│  from the bands you love.       │
+│                                 │
+│  ┌───────────────────────┐      │
+│  │    Get Started         │      │
+│  └───────────────────────┘      │
+│  ┌───────────────────────┐      │
+│  │    Log In              │      │
+│  └───────────────────────┘      │
+│                                 │
+│         EN  ·  日本語            │  ← NEW: language toggle
+└─────────────────────────────────┘
+         │
+         ▼ Get Started
+┌─────────────────────────────────┐
+│  Discovery (DNA Orb)            │
+│  Follow 3+ artists              │
+│                                 │
+│  Coach mark spotlight on Home:  │
+│  ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ │
+│  ░                             ░│
+│  ░  Check out your             ░│ ← CHANGED: no bg, text only
+│  ░  timetable!                 ░│    on dark overlay
+│  ░  ╔════════╗                 ░│
+│  ░  ║  Home  ║                 ░│
+│  ░  ╚════════╝                 ░│
+│  ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ │
+└─────────────────────────────────┘
+         │
+         ▼ Tap Home
+┌─────────────────────────────────┐
+│  Dashboard                      │
+│  1. Celebration overlay (2.5s)  │
+│  2. User Home Selector opens ✓  │ ← FIXED: sheet body visible
+│  3. Lane intro sequence         │
+│  4. My Artists spotlight        │
+└─────────────────────────────────┘
+```

--- a/openspec/changes/archive/2026-03-23-refine-onboarding-ux/proposal.md
+++ b/openspec/changes/archive/2026-03-23-refine-onboarding-ux/proposal.md
@@ -1,0 +1,34 @@
+## Why
+
+The post-signup onboarding flow has three UX issues that together degrade first-run experience:
+
+1. **Language switcher inaccessible before sign-up.** The only language toggle lives in Settings, which requires authentication. Users whose browser locale doesn't match their preferred language have no way to switch before completing onboarding.
+
+2. **Coach mark tooltip has opaque background on dark overlay.** The spotlight darkens the viewport to 70% black, but the tooltip uses a solid `--color-surface-overlay` fill. This creates visual weight redundancy — two dark layers stacked — making the tooltip feel heavy and disconnected from the spotlight rather than floating naturally on the overlay.
+
+3. **Bottom sheet invisible when `dismissable=false` (progression blocker).** After the celebration overlay completes on the Dashboard, the User Home Selector bottom sheet opens but its content is not visible. The user sees a dark screen with no interactive elements. Root cause: CSS selector `:not([data-dismissable])` checks for attribute *absence*, but Aurelia outputs `data-dismissable="false"` (attribute *present* with string value), so the dismiss-zone's scroll-snap is never disabled — the browser snaps to the empty dismiss-zone instead of the sheet body.
+
+## What Changes
+
+- **Frontend (welcome-route)**: Add a language toggle below the CTA buttons. Extract the language switching logic from Settings into a reusable utility.
+- **Frontend (coach-mark)**: Remove the tooltip's solid background and drop-shadow. The handwritten font (`Klee One`) text renders directly on the dark overlay.
+- **Frontend (bottom-sheet)**: Fix the CSS selector to match Aurelia's boolean attribute output. Change from `:not([data-dismissable])` to `:not([data-dismissable="true"])` so dismiss-zone snap is correctly disabled when `dismissable=false`.
+- **Specification (bottom-sheet-ce)**: Update spec to reflect the current architecture (popover on CE host, scroll-area separation) and the dismiss-zone CSS-controlled snap behavior.
+
+## Capabilities
+
+### New Capabilities
+
+- `landing-page`: Language switcher on the Welcome page for unauthenticated users.
+
+### Modified Capabilities
+
+- `bottom-sheet-ce`: DOM structure updated to reflect CE host popover architecture; non-dismissable scenario updated to describe CSS-controlled dismiss-zone snap (always in DOM, snap disabled via CSS attribute selector).
+- `onboarding-spotlight`: Tooltip visual treatment changed from solid background to transparent.
+- `frontend-i18n`: Language switching extracted to a shared utility; available on Welcome page in addition to Settings.
+
+## Impact
+
+- **frontend only** — no backend, proto, or infrastructure changes required.
+- **No breaking changes** — all changes are visual/behavioral fixes within existing components.
+- The bottom-sheet fix affects all consumers using `dismissable.bind="false"` (user-home-selector, tickets-route, error-banner).

--- a/openspec/changes/archive/2026-03-23-refine-onboarding-ux/specs/bottom-sheet-ce.md
+++ b/openspec/changes/archive/2026-03-23-refine-onboarding-ux/specs/bottom-sheet-ce.md
@@ -1,0 +1,64 @@
+## CHANGED Requirements
+
+### Requirement: DOM Structure (CHANGED)
+
+The bottom sheet DOM SHALL separate popover responsibility from scroll responsibility.
+
+#### Scenario: DOM structure
+- **WHEN** the sheet is rendered
+- **THEN** the CE host element (`<bottom-sheet>`) SHALL be the popover host via `host.setAttribute('popover', ...)`
+- **AND** the CE host SHALL have `role="dialog"` and `aria-label` set programmatically
+- **AND** the internal DOM SHALL be `.scroll-area > .dismiss-zone + section.sheet-body`
+- **AND** `.scroll-area` SHALL be the scroll-snap container (`overflow-y: auto`, `scroll-snap-type: y mandatory`)
+- **AND** `.sheet-body` SHALL be a `<section>` element (semantic content container)
+
+### Requirement: Non-Dismissable Mode (CHANGED)
+
+When `dismissable` is `false`, the dismiss zone SHALL remain in the DOM but its scroll-snap behavior SHALL be disabled via CSS.
+
+#### Scenario: Non-dismissable sheet opens to sheet body
+- **WHEN** `dismissable` is `false`
+- **THEN** the CE SHALL use `popover="manual"`
+- **AND** `.dismiss-zone` SHALL remain in the DOM with `aria-hidden="true"`
+- **AND** `.scroll-area` SHALL have `data-dismissable="false"`
+- **AND** CSS SHALL set `.dismiss-zone` to `scroll-snap-align: none` and `pointer-events: none` via `.scroll-area:not([data-dismissable="true"]) .dismiss-zone`
+- **AND** the browser SHALL snap to `.sheet-body` (the only active snap target) on open
+- **AND** ESC key SHALL NOT close the sheet
+
+#### Scenario: Dismissable sheet enables dismiss zone snap
+- **WHEN** `dismissable` is `true` (default)
+- **THEN** `.scroll-area` SHALL have `data-dismissable="true"`
+- **AND** `.dismiss-zone` SHALL have `scroll-snap-align: var(--_snap-align, start)`
+- **AND** swiping down SHALL scroll toward the dismiss zone, triggering close on `scrollend`
+
+### Requirement: Initial Snap Animation (NEW)
+
+The scroll-area SHALL use a CSS `initial-snap` animation to ensure the sheet body is the initial snap target on open, regardless of dismiss-zone presence.
+
+#### Scenario: Sheet opens snapped to body
+- **WHEN** `showPopover()` is called on the CE host
+- **THEN** `.scroll-area` SHALL run an `initial-snap` animation (`0.01s`, `backwards` fill)
+- **AND** during the animation, `--_snap-align` SHALL be `none`, disabling dismiss-zone snap
+- **AND** after the animation completes, dismiss-zone snap SHALL restore to its CSS-determined value
+- **AND** no JavaScript `scrollTo()` or `requestAnimationFrame` SHALL be required
+
+### Requirement: Basic Open/Close (CHANGED)
+
+#### Scenario: Open via bindable
+- **WHEN** `open` is set to `true`
+- **THEN** the CE SHALL call `showPopover()` on the CE host element (not an internal dialog)
+- **AND** the sheet body SHALL be visible at the bottom of the viewport via CSS scroll-snap (no JS scroll required)
+
+#### Scenario: Close via bindable
+- **WHEN** `open` is set to `false`
+- **THEN** the CE SHALL call `hidePopover()` on the CE host element
+- **AND** the sheet SHALL animate out via CSS opacity transition
+
+### Requirement: Semantic Host Element (NEW)
+
+The CE host SHALL have `role="dialog"` set programmatically in `attached()`, providing dialog semantics without requiring an internal `<dialog>` element.
+
+#### Scenario: Host has dialog role
+- **WHEN** the CE is attached to the DOM
+- **THEN** `host.setAttribute('role', 'dialog')` SHALL be called
+- **AND** `host.setAttribute('aria-label', ...)` SHALL be called with the `ariaLabel` bindable value

--- a/openspec/changes/archive/2026-03-23-refine-onboarding-ux/specs/frontend-i18n.md
+++ b/openspec/changes/archive/2026-03-23-refine-onboarding-ux/specs/frontend-i18n.md
@@ -1,0 +1,11 @@
+## CHANGED Requirements
+
+### Requirement: Shared Language Switching Utility (NEW)
+
+The system SHALL provide a shared utility function for changing the active locale, usable from any component without duplicating logic.
+
+#### Scenario: Language switch from any component
+- **WHEN** any component needs to change the active locale
+- **THEN** it SHALL call a shared `changeLocale(i18n: I18N, lang: string)` function
+- **AND** the function SHALL call `i18n.setLocale(lang)` and `localStorage.setItem('language', lang)`
+- **AND** the Settings page and Welcome page SHALL both use this shared function

--- a/openspec/changes/archive/2026-03-23-refine-onboarding-ux/specs/landing-page.md
+++ b/openspec/changes/archive/2026-03-23-refine-onboarding-ux/specs/landing-page.md
@@ -1,0 +1,22 @@
+## ADDED Requirements
+
+### Requirement: Welcome Page Language Switcher
+
+The landing page SHALL provide a language toggle for unauthenticated users to switch between supported locales without requiring sign-in.
+
+#### Scenario: Language toggle visible on welcome page
+- **WHEN** an unauthenticated user visits the welcome page
+- **THEN** the system SHALL display a language toggle below the Log In button
+- **AND** the toggle SHALL show all supported languages (EN, JA)
+- **AND** the current active language SHALL be visually distinguished (e.g., bold or underline)
+
+#### Scenario: Switching language on welcome page
+- **WHEN** the user taps a language option
+- **THEN** the system SHALL call `i18n.setLocale(lang)` to update all translated strings immediately
+- **AND** the system SHALL persist the choice via `localStorage.setItem('language', lang)`
+- **AND** no page reload SHALL be required
+
+#### Scenario: Language preference persists across sessions
+- **WHEN** the user selects a language on the welcome page and later returns
+- **THEN** the i18next language detector SHALL read the persisted `language` key from localStorage
+- **AND** the application SHALL start in the previously selected language

--- a/openspec/changes/archive/2026-03-23-refine-onboarding-ux/specs/onboarding-spotlight.md
+++ b/openspec/changes/archive/2026-03-23-refine-onboarding-ux/specs/onboarding-spotlight.md
@@ -1,0 +1,13 @@
+## CHANGED Requirements
+
+### Requirement: Tooltip Visual Treatment (CHANGED)
+
+The coach mark tooltip SHALL render with a transparent background, allowing the handwritten text to float directly on the dark overlay.
+
+#### Scenario: Tooltip renders without solid background
+- **WHEN** the coach mark tooltip is displayed
+- **THEN** `.coach-mark-tooltip` SHALL have `background: transparent`
+- **AND** `.coach-mark-tooltip` SHALL have `filter: none` (no drop-shadow)
+- **AND** the tooltip text color SHALL remain `var(--color-white)`
+- **AND** the font SHALL remain `var(--coach-font-handwritten)` ("Klee One", cursive)
+- **AND** the tooltip SHALL be visually readable against the 70% black overlay

--- a/openspec/changes/archive/2026-03-23-refine-onboarding-ux/tasks.md
+++ b/openspec/changes/archive/2026-03-23-refine-onboarding-ux/tasks.md
@@ -1,0 +1,97 @@
+## Tasks
+
+### Task 1: Fix bottom-sheet CSS selector for dismissable=false ✓
+
+**Repo:** frontend
+**Files:** `src/components/bottom-sheet/bottom-sheet.css`
+
+Change the CSS selector from `:not([data-dismissable])` to `:not([data-dismissable="true"])` so that Aurelia's `data-dismissable="false"` output correctly disables dismiss-zone scroll-snap.
+
+```css
+/* Before */
+.scroll-area:not([data-dismissable]) .dismiss-zone {
+
+/* After */
+.scroll-area:not([data-dismissable="true"]) .dismiss-zone {
+```
+
+**Verification:** Open the dashboard as a new onboarding user. After celebration overlay, the User Home Selector bottom sheet must be visible with its content at the bottom of the viewport.
+
+---
+
+### Task 2: Add semantic improvements to bottom-sheet ✓
+
+**Repo:** frontend
+**Files:** `src/components/bottom-sheet/bottom-sheet.html`, `src/components/bottom-sheet/bottom-sheet.ts`, `src/components/bottom-sheet/bottom-sheet.css`
+
+- Change `.sheet-body` from `<div>` to `<section>`
+- Add `host.setAttribute('role', 'dialog')` in `attached()`
+- Update CSS selector from `.sheet-body` div references if any
+
+---
+
+### Task 3: Remove coach-mark tooltip solid background ✓
+
+**Repo:** frontend
+**Files:** `src/components/coach-mark/coach-mark.css`
+
+Change `.coach-mark-tooltip`:
+- `background: var(--color-surface-overlay)` → `background: transparent`
+- `filter: drop-shadow(...)` → `filter: none`
+
+**Verification:** Activate a coach mark spotlight. The tooltip text should float directly on the dark overlay without a visible background box.
+
+---
+
+### Task 4: Add language switcher to welcome page ✓
+
+**Repo:** frontend
+**Files:**
+- `src/util/change-locale.ts` (new — shared utility)
+- `src/routes/welcome/welcome-route.ts`
+- `src/routes/welcome/welcome-route.html`
+- `src/routes/welcome/welcome-route.css`
+- `src/routes/settings/settings-route.ts` (refactor to use shared utility)
+- `src/locales/ja/translation.json` (add keys if needed)
+- `src/locales/en/translation.json` (add keys if needed)
+
+1. Create `changeLocale(i18n, lang)` utility function
+2. Refactor Settings to use the shared utility
+3. Add language toggle buttons to welcome template (below Log In)
+4. Style the toggle with the current language highlighted
+
+---
+
+### Task 5: Update bottom-sheet-ce spec ✓
+
+**Repo:** specification
+**Files:** `openspec/specs/bottom-sheet-ce/spec.md`
+
+Merge the changes from `openspec/changes/refine-onboarding-ux/specs/bottom-sheet-ce.md` into the main spec. Update:
+- DOM structure scenario (CE host popover, scroll-area, section.sheet-body)
+- Non-dismissable scenario (CSS-controlled dismiss-zone snap)
+- Remove `scrollTo` + `requestAnimationFrame` references
+- Add initial-snap animation requirement
+
+---
+
+### Task 6: Update related specs ✓
+
+**Repo:** specification
+**Files:**
+- `openspec/specs/onboarding-spotlight/spec.md`
+- `openspec/specs/landing-page/spec.md`
+- `openspec/specs/frontend-i18n/spec.md`
+
+Merge the spec changes from this change's specs/ directory into the main specs.
+
+---
+
+### Task 7: Update bottom-sheet tests ✓
+
+**Repo:** frontend
+**Files:** `test/components/bottom-sheet.spec.ts`
+
+Update or add test cases:
+- Verify `role="dialog"` is set on host in `attached()`
+- Verify that existing dismiss-zone DOM presence tests still pass (dismiss-zone remains in DOM for both true and false)

--- a/openspec/specs/bottom-sheet-ce/spec.md
+++ b/openspec/specs/bottom-sheet-ce/spec.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-Provides a `<bottom-sheet>` custom element as the single dialog primitive for all overlay content, using the Popover API with CSS scroll-snap dismiss.
+Provides a `<bottom-sheet>` custom element as the single dialog primitive for all overlay content, using the Popover API on the CE host element with CSS scroll-snap dismiss via an internal scroll container.
 
 ## Requirements
 
@@ -11,46 +11,55 @@ The system SHALL provide a `<bottom-sheet>` custom element as the single dialog 
 
 #### Scenario: Basic open/close via bindable
 - **WHEN** `<bottom-sheet open.bind="isOpen">` has `open` set to `true`
-- **THEN** the CE SHALL call `showPopover()` on the internal `<dialog>` element
-- **AND** the CE SHALL defer `scrollTo({ top: scrollHeight })` by one animation frame (`requestAnimationFrame`) to ensure the browser has completed top-layer layout before programmatic scroll
-- **AND** the sheet-body SHALL be visible at the bottom of the viewport after the deferred scroll
+- **THEN** the CE SHALL call `showPopover()` on the CE host element (via `resolve(INode)`)
+- **AND** the sheet-body SHALL be visible at the bottom of the viewport via CSS `initial-snap` animation (no JS `scrollTo` required)
 - **WHEN** `open` is set to `false`
-- **THEN** the CE SHALL call `hidePopover()` and the sheet SHALL animate out
-
-#### Scenario: Scroll-snap dismiss
-- **WHEN** the sheet is open and `dismissable` is `true`
-- **THEN** a dismiss zone SHALL be rendered above the sheet content as a direct child of the `dialog` element
-- **AND** swiping down (physical gesture: finger moves downward, scrollTop decreases) SHALL scroll toward the dismiss zone at the top, triggering close on `scrollend`
-- **AND** the `::backdrop` opacity SHALL track scroll progress via CSS Scroll-Driven Animations (`scroll-timeline` on `dialog`, `animation-timeline` on `dialog::backdrop`)
-- **AND** if the browser does not support Scroll-Driven Animations on `::backdrop`, the backdrop SHALL display at static full opacity as a fallback
+- **THEN** the CE SHALL call `hidePopover()` on the CE host element and the sheet SHALL animate out
 
 #### Scenario: DOM structure
 - **WHEN** the sheet is rendered
-- **THEN** the internal DOM SHALL be `dialog > .dismiss-zone + .sheet-body`
-- **AND** the `.dismiss-zone` SHALL be the first child (`scroll-snap-align: start`) at the top of the scroll container
-- **AND** the `.sheet-body` SHALL be the last child (`scroll-snap-align: end`) at the bottom of the scroll container
-- **AND** the `dialog` element itself SHALL be the scroll-snap container (`overflow-y: auto`, `scroll-snap-type: y mandatory`)
-- **AND** no intermediate `.scroll-wrapper` or `.sheet-page` wrapper SHALL exist
+- **THEN** the CE host element (`<bottom-sheet>`) SHALL be the popover host with `popover` attribute set programmatically
+- **AND** the CE host SHALL have `role="dialog"` set in `attached()`
+- **AND** the internal DOM SHALL be `.scroll-area > .dismiss-zone + section.sheet-body`
+- **AND** `.scroll-area` SHALL be a `<div>` element serving as the scroll-snap container (`overflow-y: auto`, `scroll-snap-type: y mandatory`)
+- **AND** `.sheet-body` SHALL be a `<section>` element (semantic content container)
+- **AND** the `::backdrop` pseudo-element SHALL belong to the CE host (popover host)
+
+#### Scenario: Initial snap animation
+- **WHEN** the popover opens (`showPopover()` on CE host)
+- **THEN** `.scroll-area` SHALL run an `initial-snap` CSS animation (`0.01s`, `animation-fill-mode: backwards`)
+- **AND** during the animation, `--_snap-align` SHALL be `none`, disabling dismiss-zone's scroll-snap-align
+- **AND** `.sheet-body` (`scroll-snap-align: end`) SHALL be the only active snap target
+- **AND** the browser SHALL snap to `.sheet-body` on open
+- **AND** after the animation completes, dismiss-zone snap SHALL restore to its CSS-determined value
+- **AND** no JavaScript `scrollTo()` or `requestAnimationFrame` SHALL be required
+
+#### Scenario: Scroll-snap dismiss
+- **WHEN** the sheet is open and `dismissable` is `true`
+- **THEN** `.scroll-area` SHALL have `data-dismissable="true"`
+- **AND** the dismiss zone SHALL have `scroll-snap-align: var(--_snap-align, start)` (active after initial-snap animation)
+- **AND** swiping down (physical gesture: finger moves downward, scrollTop decreases) SHALL scroll toward the dismiss zone at the top, triggering close on `scrollend`
 
 #### Scenario: Swipe-down dismiss detection
 - **WHEN** the user swipes down (finger moves downward), decreasing scrollTop toward the dismiss zone
-- **AND** the `scrollend` event fires
+- **AND** the `scrollend` event fires on `.scroll-area`
 - **THEN** the CE SHALL check if `scrollRatio < 0.1` (scrolled near the top where the dismiss zone is)
 - **AND** if so, the CE SHALL set `open` to `false` and dispatch `sheet-closed`
 
 #### Scenario: Non-dismissable mode
 - **WHEN** `dismissable` is `false`
-- **THEN** the CE SHALL use `popover="manual"`
-- **AND** the dismiss zone SHALL NOT be rendered
-- **AND** scroll-snap dismiss SHALL be disabled
+- **THEN** the CE SHALL use `popover="manual"` on the CE host
+- **AND** `.scroll-area` SHALL have `data-dismissable="false"`
+- **AND** the dismiss zone SHALL remain in the DOM with `aria-hidden="true"` (required for `initial-snap` animation pattern)
+- **AND** CSS SHALL set `.dismiss-zone` to `scroll-snap-align: none` and `pointer-events: none` via `.scroll-area:not([data-dismissable="true"]) .dismiss-zone`
+- **AND** `.sheet-body` SHALL be the only active snap target, ensuring the sheet body is visible on open
 - **AND** ESC key SHALL NOT close the sheet
 
 #### Scenario: Dismissable mode with ESC dismiss
 - **WHEN** `dismissable` is `true` (default)
-- **THEN** the CE SHALL use `popover="auto"`
+- **THEN** the CE SHALL use `popover="auto"` on the CE host
 - **AND** pressing Escape SHALL close the sheet via the browser's native popover light dismiss
-- **AND** the CE SHALL handle the `toggle` event to detect ESC dismiss and dispatch `sheet-closed`
-- **AND** backdrop click dismiss SHALL NOT function (the full-viewport dialog has no clickable `::backdrop` area)
+- **AND** the CE SHALL handle the `toggle` event on the CE host to detect ESC dismiss and dispatch `sheet-closed`
 
 #### Scenario: Sheet closed event
 - **WHEN** the sheet is closed by any mechanism (ESC dismiss, scroll-snap, programmatic)
@@ -64,7 +73,7 @@ The system SHALL provide a `<bottom-sheet>` custom element as the single dialog 
 
 #### Scenario: Sheet body structure
 - **WHEN** the sheet is rendered
-- **THEN** the sheet body SHALL have `border-radius: var(--radius-sheet)` on top corners
+- **THEN** the sheet body (`<section>`) SHALL have `border-radius: var(--radius-sheet)` on top corners
 - **AND** background SHALL be `var(--color-surface-raised)`
 - **AND** box-shadow SHALL be `var(--shadow-sheet)`
 - **AND** `max-block-size` SHALL be `90dvh`
@@ -76,7 +85,7 @@ The system SHALL provide a `<bottom-sheet>` custom element as the single dialog 
 
 #### Scenario: Focus management
 - **WHEN** the sheet opens
-- **THEN** the sheet `<dialog>` element SHALL receive focus
+- **THEN** the CE host element SHALL receive focus via `showPopover()`
 - **WHEN** the sheet closes
 - **THEN** focus SHALL return to the element that was focused before the sheet opened
 
@@ -87,9 +96,10 @@ The system SHALL provide a `<bottom-sheet>` custom element as the single dialog 
 
 #### Scenario: Reduced motion
 - **WHEN** `prefers-reduced-motion: reduce` is active
-- **THEN** all transition durations SHALL be reduced to `var(--transition-fast)`
+- **THEN** all transition durations SHALL be reduced to `var(--_duration-reduced)`
 
 #### Scenario: Detach cleanup
 - **WHEN** the CE is detached from the DOM while the sheet is open
-- **THEN** all event listeners (popstate, toggle) SHALL be removed
+- **THEN** all event listeners (toggle) SHALL be removed from the CE host
+- **AND** `hidePopover()` SHALL be called on the CE host
 - **AND** no memory leaks SHALL occur

--- a/openspec/specs/frontend-i18n/spec.md
+++ b/openspec/specs/frontend-i18n/spec.md
@@ -97,3 +97,14 @@ The system SHALL re-render all translated strings when the active locale changes
 - **THEN** all `t`-bound template strings SHALL immediately update to the new locale
 - **AND** the `language` key in localStorage SHALL be updated
 - **AND** date/number formatters SHALL use the new locale for subsequent renders
+
+---
+
+### Requirement: Shared Language Switching Utility
+The system SHALL provide a shared utility function for changing the active locale, usable from any component without duplicating logic.
+
+#### Scenario: Language switch from any component
+- **WHEN** any component needs to change the active locale
+- **THEN** it SHALL call a shared `changeLocale(i18n: I18N, lang: string)` function
+- **AND** the function SHALL call `i18n.setLocale(lang)` and `localStorage.setItem('language', lang)`
+- **AND** the Settings page and Welcome page SHALL both use this shared function

--- a/openspec/specs/landing-page/spec.md
+++ b/openspec/specs/landing-page/spec.md
@@ -47,3 +47,24 @@ The system SHALL redirect already-authenticated users away from the landing page
 - **THEN** the system SHALL display the landing page with an error toast: "Could not determine account status. Please try signing in again."
 - **AND** the system SHALL NOT crash to a white screen
 - **AND** the system SHALL allow the user to manually navigate via the Log In button
+
+### Requirement: Welcome Page Language Switcher
+
+The landing page SHALL provide a language toggle for unauthenticated users to switch between supported locales without requiring sign-in.
+
+#### Scenario: Language toggle visible on welcome page
+- **WHEN** an unauthenticated user visits the welcome page
+- **THEN** the system SHALL display a language toggle below the Log In button
+- **AND** the toggle SHALL show all supported languages (EN, JA)
+- **AND** the current active language SHALL be visually distinguished (e.g., bold or underline)
+
+#### Scenario: Switching language on welcome page
+- **WHEN** the user taps a language option
+- **THEN** the system SHALL call `i18n.setLocale(lang)` to update all translated strings immediately
+- **AND** the system SHALL persist the choice via `localStorage.setItem('language', lang)`
+- **AND** no page reload SHALL be required
+
+#### Scenario: Language preference persists across sessions
+- **WHEN** the user selects a language on the welcome page and later returns
+- **THEN** the i18next language detector SHALL read the persisted `language` key from localStorage
+- **AND** the application SHALL start in the previously selected language

--- a/openspec/specs/onboarding-spotlight/spec.md
+++ b/openspec/specs/onboarding-spotlight/spec.md
@@ -185,6 +185,19 @@ The coach mark tooltip SHALL be positioned using CSS Anchor Positioning relative
 - **AND** the tooltip SHALL use `position-area: block-end` as the default placement
 - **AND** the tooltip SHALL use `position-try-fallbacks: flip-block, flip-inline` for overflow handling
 
+### Requirement: Tooltip Visual Treatment
+
+The coach mark tooltip SHALL render with a transparent background, allowing the handwritten text to float directly on the dark overlay.
+
+#### Scenario: Tooltip renders without solid background
+
+- **WHEN** the coach mark tooltip is displayed
+- **THEN** `.coach-mark-tooltip` SHALL have `background: transparent`
+- **AND** `.coach-mark-tooltip` SHALL have `filter: none` (no drop-shadow)
+- **AND** the tooltip text color SHALL remain `var(--color-white)`
+- **AND** the font SHALL remain `var(--coach-font-handwritten)` ("Klee One", cursive)
+- **AND** the tooltip SHALL be visually readable against the 70% black overlay
+
 ### Requirement: Inline SVG Directional Arrow
 
 The tooltip SHALL include a hand-drawn style directional arrow rendered as inline SVG. No external image assets (`<img>`, `.png`, `.svg` files) SHALL be used. The arrow SHALL visually connect the tooltip to the spotlight target.


### PR DESCRIPTION
## Summary

- Update `bottom-sheet-ce` spec to reflect CE host popover architecture, initial-snap animation, and CSS-controlled dismiss-zone
- Add tooltip transparent background requirement to `onboarding-spotlight` spec
- Add welcome page language switcher to `landing-page` and `frontend-i18n` specs
- Archive `refine-onboarding-ux` change (7/7 tasks complete)

## Test plan

- [x] Specs align with frontend implementation (PR liverty-music/frontend#289)
