### PR TITLE
docs(spec): document bottom-sheet 100dvh sizing and D4 design decision

### DIFF
--- a/openspec/changes/fix-onboarding-progression-bugs/design.md
+++ b/openspec/changes/fix-onboarding-progression-bugs/design.md
@@ -84,6 +84,28 @@ Run `npm install` in the frontend to pull the latest BSR package version that in
 - **[Risk] BSR package version drift** → After `npm install`, the lock file will update. CI must rebuild with the new lock file. Low risk since this is a dev environment fix.
 - **[Risk] Other public RPCs may also be missing from whitelist** → Out of scope for this change, but worth auditing. The `ListWithProximity` omission was introduced when the RPC was added in a recent PR.
 
+### D4: Fix scroll-area `block-size` percentage resolution in popover top-layer
+
+The bottom-sheet component's `.scroll-area` uses `block-size: 100%` to fill the popover host. However, inside the popover top-layer, percentage block-size does not resolve against the CE host's fixed-position height — instead, the scroll-area expands to fit its content (dismiss-zone + sheet-body). When `scrollHeight === clientHeight`, no overflow occurs, scroll-snap cannot function, and the sheet-body is positioned off-screen at the bottom of the scroll container with no way to reach it.
+
+**Root cause timeline:**
+
+| Commit | Architecture | scroll-area sizing | Status |
+|--------|-------------|-------------------|--------|
+| `6a995e4` | `<dialog popover>` > `.scroll-wrapper` > `.sheet-page` | `block-size: 100dvh` on `.scroll-wrapper` | Working |
+| `8d905f3` | `<dialog popover>` is the scroll container | `position: fixed; inset: 0` on dialog (implicit sizing) | Working |
+| `72c768a` | `<bottom-sheet popover>` > `.scroll-area` | `block-size: 100%` on `.scroll-area` | **Broken** — percentage resolve fails |
+
+**Fix:** Change `.scroll-area { block-size: 100% }` → `block-size: 100dvh`.
+
+- `100dvh` matches the popover host's viewport-filling size deterministically
+- Restores the original sizing strategy from `6a995e4` (`.scroll-wrapper` used `100dvh`)
+- Playwright-verified: `100dvh` produces `scrollHeight (1287) > clientHeight (1093)`, scroll-snap engages, `scrollTop: 194` (snapped to sheet-body)
+
+**Why not other approaches:**
+- `position: absolute; inset: 0` on `.scroll-area` — would work but adds unnecessary positioning complexity to a scroll container
+- JS `scrollTo` fallback — was the approach in `15a2538`, eliminated by `72c768a` in favor of CSS-only scroll-snap; re-introducing it would be a regression in design direction
+
 ## Open Questions
 
 (none — all decisions are straightforward implementation fixes)

--- a/openspec/changes/fix-onboarding-progression-bugs/tasks.md
+++ b/openspec/changes/fix-onboarding-progression-bugs/tasks.md
@@ -14,8 +14,14 @@
 - [x] 3.2 Verify `TicketJourneyService.listByUser` exists in the updated `node_modules/@buf/liverty-music_schema.connectrpc_es` JS file
 - [ ] 3.3 Commit updated `package-lock.json` (pending commit)
 
-## 4. Verification
+## 4. Frontend: Fix bottom-sheet scroll-area height in popover top-layer
 
-- [x] 4.1 Run `make check` in backend
-- [x] 4.2 Run `make check` in frontend
-- [ ] 4.3 Deploy to dev and run full onboarding flow end-to-end: discovery → dashboard (lane intro with concert data) → my-artists (spotlight tap → hype slider → complete)
+- [x] 4.1 In `frontend/src/components/bottom-sheet/bottom-sheet.css`, change `.scroll-area { block-size: 100% }` to `block-size: 100dvh`
+- [x] 4.2 Update bottom-sheet-ce spec to document `100dvh` sizing requirement
+- [x] 4.3 Run `make check` in frontend
+
+## 5. Verification
+
+- [x] 5.1 Run `make check` in backend
+- [x] 5.2 Run `make check` in frontend
+- [ ] 5.3 Deploy to dev and run full onboarding flow end-to-end: discovery → dashboard (lane intro with concert data) → my-artists (spotlight tap → hype slider → complete)

--- a/openspec/specs/bottom-sheet-ce/spec.md
+++ b/openspec/specs/bottom-sheet-ce/spec.md
@@ -21,7 +21,8 @@ The system SHALL provide a `<bottom-sheet>` custom element as the single dialog 
 - **THEN** the CE host element (`<bottom-sheet>`) SHALL be the popover host with `popover` attribute set programmatically
 - **AND** the CE host SHALL have `role="dialog"` set in `attached()`
 - **AND** the internal DOM SHALL be `.scroll-area > .dismiss-zone + section.sheet-body`
-- **AND** `.scroll-area` SHALL be a `<div>` element serving as the scroll-snap container (`overflow-y: auto`, `scroll-snap-type: y mandatory`)
+- **AND** `.scroll-area` SHALL be a `<div>` element serving as the scroll-snap container (`overflow-y: auto`, `scroll-snap-type: y mandatory`, `block-size: 100dvh`)
+- **NOTE** `.scroll-area` MUST use `100dvh` (not `100%`) because percentage block-size does not resolve against the CE host's fixed-position height inside the popover top-layer — the scroll container would expand to content size, preventing overflow and disabling scroll-snap
 - **AND** `.sheet-body` SHALL be a `<section>` element (semantic content container)
 - **AND** the `::backdrop` pseudo-element SHALL belong to the CE host (popover host)
 


### PR DESCRIPTION
## Summary

- Document `D4` design decision: why `block-size: 100dvh` is required on `.scroll-area` inside the popover top-layer (percentage resolution fails against CE host's fixed-position height)
- Update `bottom-sheet-ce` spec to require `block-size: 100dvh` on `.scroll-area` with explanatory NOTE
- Mark tasks 4.1–4.3 complete in `fix-onboarding-progression-bugs` change

## Context

This is a documentation-only PR. The implementation fix (`bottom-sheet.css: 100% → 100dvh`) was shipped in liverty-music/frontend#291.

close: #268
