### PR TITLE
chore(openspec): archive fix-discovery-abort-handling

### DIFF
--- a/openspec/changes/archive/2026-03-23-fix-discovery-abort-handling/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-23-fix-discovery-abort-handling/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-23

--- a/openspec/changes/archive/2026-03-23-fix-discovery-abort-handling/design.md
+++ b/openspec/changes/archive/2026-03-23-fix-discovery-abort-handling/design.md
@@ -1,0 +1,56 @@
+## Context
+
+DiscoveryRoute で `searchConcertsForArtist()` は fire-and-forget パターンで呼ばれる。現在 `AbortController.signal` を RPC に渡しており、`detaching()` で `abort()` が呼ばれるとリクエストがキャンセルされる。
+
+サーバー側は意図的に Gemini API 呼び出しをキャンセルしない設計（Gemini の検索結果を無駄にしないため）。フロントエンドがリクエストをキャンセルしてもサーバーは処理を続行するため、abort は無意味かつノイズの原因になっている。
+
+## Goals / Non-Goals
+
+**Goals:**
+- ページ遷移時に `SearchNewConcerts` RPC をキャンセルしない
+- ページ遷移後の RPC 完了時、データ更新は実行するが UI 通知（Snack）はスキップする
+- AbortError / ConnectError(Canceled) を transport interceptor で error ログから除外する
+
+**Non-Goals:**
+- サーバー側の変更
+- AbortController 自体の削除（他の UI ガードで引き続き使用）
+- Gemini invalid JSON エラーの修正（別 change で対応）
+
+## Decisions
+
+### 1. `searchConcertsForArtist()` から signal を除去
+
+`discovery-route.ts` の `searchConcertsForArtist()` で `this.abortController.signal` を渡さないようにする。
+
+呼び出しチェーン全体:
+```
+discovery-route.ts  →  concert-service.ts  →  concert-client.ts  →  Connect transport
+  (signal除去)         (signal?: optional)     (signal?: optional)    (signalなし)
+```
+
+`concert-service.ts` と `concert-client.ts` の `signal?` パラメータはオプショナルなので、呼び出し側で渡さなければそのまま `undefined` として伝播する。変更は `discovery-route.ts` のみで済む。
+
+detach 後の振る舞い:
+- `addArtistWithConcerts()` → 実行する（データ整合性のため）
+- `ea.publish(new Snack(...))` → `abortController.signal.aborted` チェックでスキップ（既存のL308ガードがそのまま使える）
+
+### 2. transport interceptor の AbortError 除外
+
+`grpc-transport.ts` の2つの interceptor を修正:
+
+**loggingInterceptor:**
+- AbortError (`err.name === 'AbortError'`) → ログ出力しない（re-throw のみ）
+- ConnectError で code が `Canceled` → ログ出力しない
+- その他 → 現状通り `logger.error`
+
+**otelInterceptor:**
+- AbortError → `SpanStatusCode.OK` で終了（キャンセルは正常終了）
+- ConnectError(Canceled) → `SpanStatusCode.OK` で終了
+- その他 → 現状通り `SpanStatusCode.ERROR`
+
+理由: AbortError は `ConnectError` ではなく `DOMException` としてスローされるため、`instanceof ConnectError` の分岐には入らない。明示的に `err.name === 'AbortError'` でチェックする必要がある。
+
+## Risks / Trade-offs
+
+- **[Risk] RPC 完了後に unmount 済みコンポーネントの状態を更新する** → `addArtistWithConcerts` は singleton service のメソッドなのでコンポーネントのライフサイクルに依存しない。Snack は EventAggregator 経由で app-level のため問題なし。ただし `aborted` チェックでスキップするので Snack は表示されない
+- **[Risk] signal を渡さないことで、長時間ハングするリクエストをユーザーが止められない** → `SearchNewConcerts` はサーバー側でタイムアウト管理されており、クライアント側での中断は不要

--- a/openspec/changes/archive/2026-03-23-fix-discovery-abort-handling/proposal.md
+++ b/openspec/changes/archive/2026-03-23-fix-discovery-abort-handling/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+DiscoveryRoute からページ遷移すると、進行中の `SearchNewConcerts` RPC が `AbortController.abort()` でキャンセルされ、コンソールに `[ERR Transport] RPC error AbortError: signal is aborted without reason` が複数件表示される。サーバー側では意図的に Gemini API 呼び出しをキャンセルしないため、フロントエンドもキャンセルしないよう合わせる必要がある。また、AbortError が `logger.error` レベルで出力されており、本当のエラーとの区別がつきにくい。
+
+## What Changes
+
+- **DiscoveryRoute**: `searchConcertsForArtist()` で AbortSignal を RPC に渡さないよう変更。ページ遷移後もリクエストは完走するが、UI 更新（Snack 表示）はスキップする
+- **grpc-transport**: `loggingInterceptor` と `otelInterceptor` で AbortError / ConnectError(Canceled) を error レベルから除外し、デバッグログまたはスキップに変更
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+None. Implementation-level の変更のみで、仕様レベルの要件変更はなし。
+
+## Impact
+
+- **frontend** `src/routes/discovery/discovery-route.ts` — signal 引数の除去、detach 後の UI ガード調整
+- **frontend** `src/services/grpc-transport.ts` — interceptor のエラー分岐追加
+- ユーザー影響: コンソールノイズの削減。機能的な変更なし

--- a/openspec/changes/archive/2026-03-23-fix-discovery-abort-handling/tasks.md
+++ b/openspec/changes/archive/2026-03-23-fix-discovery-abort-handling/tasks.md
@@ -1,0 +1,14 @@
+## 1. DiscoveryRoute — signal 除去
+
+- [x] 1.1 `discovery-route.ts` の `searchConcertsForArtist()` で `this.abortController.signal` を RPC に渡さないよう変更
+- [x] 1.2 detach 後ガード: `abortController.signal.aborted` 時は `addArtistWithConcerts()` は実行し、Snack 表示のみスキップするよう調整
+- [x] 1.3 既存テスト `discovery-route.spec.ts` を更新（signal が渡されないことを反映）
+
+## 2. Transport interceptor — AbortError ログ抑制
+
+- [x] 2.1 `grpc-transport.ts` の `loggingInterceptor` で AbortError と ConnectError(Canceled) をログ出力しないよう分岐追加
+- [x] 2.2 `grpc-transport.ts` の `otelInterceptor` で AbortError と ConnectError(Canceled) を `SpanStatusCode.OK` で終了するよう変更
+
+## 3. 検証
+
+- [x] 3.1 `make check` (lint + test) パス確認


### PR DESCRIPTION
## Summary

Archives the `fix-discovery-abort-handling` OpenSpec change. Implementation was completed and merged in liverty-music/frontend#290.

- Stop passing `AbortSignal` to `SearchNewConcerts` RPC on route detach (server intentionally does not cancel Gemini API calls)
- Suppress `AbortError` / `ConnectError(Canceled)` from error logs and OTEL traces in transport interceptors