### PR TITLE
docs(spec): update frontend-route-guard spec and archive nav-bar-onboarding-nav-fix

### DIFF
--- a/openspec/changes/archive/2026-03-26-nav-bar-onboarding-nav-fix/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-26-nav-bar-onboarding-nav-fix/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-26

--- a/openspec/changes/archive/2026-03-26-nav-bar-onboarding-nav-fix/design.md
+++ b/openspec/changes/archive/2026-03-26-nav-bar-onboarding-nav-fix/design.md
@@ -1,0 +1,63 @@
+## Context
+
+`AuthHook.canLoad()` guards every route transition. For unauthenticated users in onboarding, it compares `stepIndex(currentStep) >= stepIndex(routeStep)` to decide whether to allow navigation. There is a special bypass for `routeStep === 'dashboard' && spotlightActive`, but once the 2-second coach-mark timer fires and `deactivateSpotlight()` is called, that bypass is no longer available.
+
+The result: a user who has met the dashboard-unlock condition (≥5 follows or ≥3 artists with concerts) but didn't tap the coach mark during its 2-second window cannot navigate to `/dashboard` via the nav bar. The AuthHook silently redirects them back to `/discovery`.
+
+The existing `frontend-onboarding-flow` spec already states "the user MAY tap the Dashboard icon at any time (including after the spotlight fades)", so this is an implementation gap, not a requirements gap.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Allow an unauthenticated user who has met the progression condition to navigate to `/dashboard` via the nav bar, even after the coach mark has faded.
+- Keep the progression condition authoritative in `OnboardingService`, not in `AuthHook`.
+- Preserve testability: the condition check must be injectable / mockable without DOM or timer state.
+
+**Non-Goals:**
+- Auto-navigating to dashboard when the condition is met (pull model, not push).
+- Changing the coach-mark fade duration or UX.
+- Any backend changes.
+
+## Decisions
+
+### D1: Add `readyForDashboard` getter to `OnboardingService` — inject counts via a single method
+
+**Decision**: `DiscoveryRoute` calls `onboarding.setDiscoveryCounts(followed, concerts)` via two `@watch` decorators (one per count). `OnboardingService.readyForDashboard` computes the result from those stored values. A single method rather than two separate setters keeps the update atomic and the call sites uniform.
+
+**Why this over alternatives:**
+
+| Alternative | Problem |
+|---|---|
+| AuthHook reads counts directly from FollowServiceClient + ConcertService | AuthHook gains discovery-domain knowledge; harder to unit-test in isolation |
+| Pass counts as arguments to a method on OnboardingService | Caller must know the thresholds; leaks domain logic out of the service |
+| Duplicate the condition in AuthHook | Two sources of truth; diverge over time |
+
+**Trade-off**: `OnboardingService` now holds two counters that are only meaningful during the discovery step. They will be `0` at all other steps but are harmless.
+
+### D2: AuthHook check order — `readyForDashboard` sits inside the existing Priority 2 block
+
+The new condition is inserted between the existing `stepIndex` check and the `spotlightActive` check:
+
+```
+Priority 2 (isOnboarding):
+  1. stepIndex(currentStep) >= stepIndex(routeStep)  → allow (existing)
+  2. readyForDashboard && routeStep === 'dashboard'   → advance step + allow (new)
+  3. spotlightActive && routeStep === 'dashboard'     → advance step + allow (existing, now redundant but kept for clarity)
+  4. fallthrough → redirect to current step's route
+```
+
+Keeping the `spotlightActive` check as a separate branch (instead of merging with `readyForDashboard`) makes each case explicit and independently testable.
+
+### D3: Step advancement happens in AuthHook, not in DiscoveryRoute
+
+When the condition passes via `readyForDashboard`, `AuthHook` calls `onboarding.setStep('dashboard')` — same as the existing `spotlightActive` branch. This keeps all step-advancement-on-navigation logic in one place.
+
+## Risks / Trade-offs
+
+- **`OnboardingService` counter staleness**: If `DiscoveryRoute` detaches before counts are reset, stale counts remain. Mitigation: `DiscoveryRoute.detaching()` resets `onboarding.setDiscoveryCounts(0, 0)` (or equivalent).
+- **Double-advancement**: If `spotlightActive` is somehow still `true` when `readyForDashboard` is also `true`, both checks fire in sequence but `setStep` is idempotent (same value), so no harm.
+- **Future threshold changes**: The progression thresholds live in `discovery-route.ts` (constants `TUTORIAL_FOLLOW_TARGET`, `TUTORIAL_TOTAL_FOLLOW_TARGET`). `readyForDashboard` in `OnboardingService` checks raw counts, not the thresholds — so the counts passed by `DiscoveryRoute` must be pre-filtered (pass the *boolean* result, or pass raw counts alongside the threshold constants). Passing raw counts with constants kept in `OnboardingService` is the cleanest; this is captured as an open question.
+
+## Open Questions
+
+- **Q1** ~~Open~~ **Resolved**: `OnboardingService` owns the threshold constants (`DASHBOARD_FOLLOW_TARGET = 5`, `DASHBOARD_CONCERT_TARGET = 3`) and accepts raw counts via `setDiscoveryCounts`. This keeps the condition fully unit-testable in `onboarding-service.spec.ts` without importing discovery-domain constants. `readyForDashboard` computes the result internally.

--- a/openspec/changes/archive/2026-03-26-nav-bar-onboarding-nav-fix/proposal.md
+++ b/openspec/changes/archive/2026-03-26-nav-bar-onboarding-nav-fix/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+After the discovery coach mark fades (2-second auto-dismiss), the `AuthHook` blocks navigation to `/dashboard` because `onboardingStep` is still `'discovery'` and `spotlightActive` is `false`. Tapping any nav bar icon while in this state silently redirects back to discovery, violating the existing spec requirement that "the user MAY tap the Dashboard icon at any time (including after the spotlight fades)."
+
+## What Changes
+
+- Add `readyForDashboard: boolean` computed getter to `OnboardingService` — returns `true` when step is `'discovery'` and the progression condition is met (≥5 follows OR ≥3 artists with concerts).
+- Update `AuthHook` to allow dashboard navigation when `onboarding.readyForDashboard` is `true`, and advance the step to `'dashboard'` at that point.
+- Add the missing guard scenario to `frontend-route-guard` spec so the rule is explicit and testable.
+
+## Capabilities
+
+### New Capabilities
+
+_None._
+
+### Modified Capabilities
+
+- `frontend-route-guard`: Add scenario — unauthenticated user in `'discovery'` step who has met the progression condition SHALL be allowed to navigate to `/dashboard` via the nav bar, and the system SHALL advance `onboardingStep` to `'dashboard'` at that point.
+
+## Impact
+
+- **`src/services/onboarding-service.ts`** — new `readyForDashboard` getter (depends on `IFollowServiceClient` and `IConcertService` counts, or accepts them as an argument for testability).
+- **`src/hooks/auth-hook.ts`** — one additional condition in Priority 2 branch.
+- **`src/routes/discovery/discovery-route.ts`** — wires follow/concert counts into `OnboardingService` (or passes them to a new method).
+- No proto changes, no backend changes, no BSR release needed.

--- a/openspec/changes/archive/2026-03-26-nav-bar-onboarding-nav-fix/specs/frontend-route-guard/spec.md
+++ b/openspec/changes/archive/2026-03-26-nav-bar-onboarding-nav-fix/specs/frontend-route-guard/spec.md
@@ -1,4 +1,4 @@
-## Requirements
+## MODIFIED Requirements
 
 ### Requirement: Global Auth Hook
 
@@ -62,6 +62,8 @@ The system SHALL provide a global authentication lifecycle hook that checks the 
 - **AND** the system SHALL display a "Login required" toast notification
 - **AND** the landing page SHALL display [Get Started] and [Login]
 
+## ADDED Requirements
+
 ### Requirement: Onboarding Dashboard Readiness
 
 `OnboardingService` SHALL expose a `readyForDashboard` computed property that encapsulates the dashboard-unlock condition for unauthenticated users in the discovery step.
@@ -89,48 +91,3 @@ The system SHALL provide a global authentication lifecycle hook that checks the 
 
 - **WHEN** `onboardingStep` is any value other than `'discovery'`
 - **THEN** `OnboardingService.readyForDashboard` SHALL return `false`
-
-## Test Cases
-
-### Unit Tests (Vitest)
-
-#### TC-RG-01: Onboarding user navigating to route without tutorialStep redirects silently
-
-- **Given** `isAuthenticated = false`, `onboardingStep = 1`
-- **When** navigating to a route without `data.tutorialStep` (e.g., Tickets)
-- **Then** AuthHook SHALL return a redirect to the current step's route
-- **And** no "Login required" toast SHALL be published to EventAggregator
-
-#### TC-RG-02: Onboarding user navigating to future step redirects to current step
-
-- **Given** `isAuthenticated = false`, `onboardingStep = 1`
-- **When** navigating to a route with `data.tutorialStep = 3`
-- **Then** AuthHook SHALL redirect to the Step 1 route (discover)
-- **And** no toast SHALL be published
-
-#### TC-RG-03: Non-onboarding unauthenticated user sees "Login required" toast
-
-- **Given** `isAuthenticated = false`, `onboardingStep = 0` (or unset)
-- **When** navigating to a protected route
-- **Then** AuthHook SHALL redirect to the landing page
-- **And** a "Login required" toast SHALL be published to EventAggregator
-
-#### TC-RG-04: Authenticated user passes through without restriction
-
-- **Given** `isAuthenticated = true`
-- **When** navigating to any route
-- **Then** AuthHook SHALL allow navigation (return `true`)
-
-#### TC-RG-05: Discovery-step user with readyForDashboard=true navigates to dashboard — allowed + step advanced
-
-- **Given** `isAuthenticated = false`, `onboardingStep = 'discovery'`, `readyForDashboard = true`
-- **When** navigating to `/dashboard`
-- **Then** AuthHook SHALL return `true`
-- **And** `onboarding.setStep('dashboard')` SHALL be called
-
-#### TC-RG-06: Discovery-step user with readyForDashboard=false navigates to dashboard — redirected
-
-- **Given** `isAuthenticated = false`, `onboardingStep = 'discovery'`, `readyForDashboard = false`
-- **When** navigating to `/dashboard`
-- **Then** AuthHook SHALL return a redirect to `/discovery`
-- **And** no step advancement SHALL occur

--- a/openspec/changes/archive/2026-03-26-nav-bar-onboarding-nav-fix/tasks.md
+++ b/openspec/changes/archive/2026-03-26-nav-bar-onboarding-nav-fix/tasks.md
@@ -1,0 +1,26 @@
+## 1. OnboardingService — readyForDashboard
+
+- [x] 1.1 Add threshold constants `DASHBOARD_FOLLOW_TARGET = 5` and `DASHBOARD_CONCERT_TARGET = 3` to `OnboardingService` (move from `discovery-route.ts`)
+- [x] 1.2 Add `followedCount: number` and `artistsWithConcertsCount: number` public properties (initialized to `0`) to `OnboardingService`
+- [x] 1.3 Add `setDiscoveryCounts(followed: number, concerts: number): void` method to update both counts
+- [x] 1.4 Add `readyForDashboard: boolean` computed getter — returns `true` only when `step === 'discovery'` AND (`followedCount >= DASHBOARD_FOLLOW_TARGET` OR `artistsWithConcertsCount >= DASHBOARD_CONCERT_TARGET`)
+- [x] 1.5 Write unit tests for `readyForDashboard` covering all 4 scenarios in the spec (follow threshold, concert threshold, below threshold, wrong step)
+
+## 2. DiscoveryRoute — wire counts into OnboardingService
+
+- [x] 2.1 Remove the local `TUTORIAL_FOLLOW_TARGET` and `TUTORIAL_TOTAL_FOLLOW_TARGET` constants (now owned by `OnboardingService`)
+- [x] 2.2 Add a `@watch` on `followedCount` and `concertService.artistsWithConcertsCount` to call `this.onboarding.setDiscoveryCounts(...)` whenever either changes
+- [x] 2.3 In `detaching()`, call `this.onboarding.setDiscoveryCounts(0, 0)` to reset counts when leaving the discovery page
+- [x] 2.4 In `loading()`, call `this.onboarding.setDiscoveryCounts(...)` once after hydration — `@watch` only fires on changes, not on the initial value, so an explicit sync is required when counts are already non-zero at component load time
+
+## 3. AuthHook — allow navigation when readyForDashboard
+
+- [x] 3.1 In the Priority 2 block (after the `stepIndex` check), add: if `routeStep === 'dashboard' && this.onboarding.readyForDashboard` → call `this.onboarding.setStep(OnboardingStep.DASHBOARD)` and return `true`
+- [x] 3.2 Write unit tests for the new AuthHook scenario (TC-RG-05: discovery-step user with readyForDashboard=true navigates to dashboard → allowed + step advanced)
+- [x] 3.3 Write unit test for the inverse (TC-RG-06: discovery-step user with readyForDashboard=false navigates to dashboard → redirected to discovery)
+
+## 4. Verification
+
+- [x] 4.1 Run `make check` in `frontend/` — all lint and unit tests pass
+- [x] 4.2 Manual smoke test: follow 5 artists → wait for coach mark to fade → tap Home nav → confirm navigation to dashboard succeeds
+- [x] 4.3 Manual smoke test: follow 4 artists (no concerts) → tap Home nav → confirm redirect back to discovery (guard still blocks when condition not met)

--- a/openspec/specs/frontend-route-guard/spec.md
+++ b/openspec/specs/frontend-route-guard/spec.md
@@ -134,3 +134,31 @@ The system SHALL provide a global authentication lifecycle hook that checks the 
 - **When** navigating to `/dashboard`
 - **Then** AuthHook SHALL return a redirect to `/discovery`
 - **And** no step advancement SHALL occur
+
+#### TC-RG-07: readyForDashboard is true when follow count threshold is met
+
+- **Given** `onboardingStep = 'discovery'`
+- **And** `followedCount = 5` (≥ DASHBOARD_FOLLOW_TARGET)
+- **When** `OnboardingService.readyForDashboard` is evaluated
+- **Then** it SHALL return `true`
+
+#### TC-RG-08: readyForDashboard is true when concert artist threshold is met
+
+- **Given** `onboardingStep = 'discovery'`
+- **And** `artistsWithConcertsCount = 3` (≥ DASHBOARD_CONCERT_TARGET)
+- **When** `OnboardingService.readyForDashboard` is evaluated
+- **Then** it SHALL return `true`
+
+#### TC-RG-09: readyForDashboard is false when both counts are below threshold
+
+- **Given** `onboardingStep = 'discovery'`
+- **And** `followedCount < 5` AND `artistsWithConcertsCount < 3`
+- **When** `OnboardingService.readyForDashboard` is evaluated
+- **Then** it SHALL return `false`
+
+#### TC-RG-10: readyForDashboard is false when step is not discovery
+
+- **Given** `onboardingStep` is any value other than `'discovery'`
+- **And** `followedCount` and `artistsWithConcertsCount` exceed their respective thresholds
+- **When** `OnboardingService.readyForDashboard` is evaluated
+- **Then** it SHALL return `false`


### PR DESCRIPTION
## Summary

- Update `openspec/specs/frontend-route-guard/spec.md` with requirements and test cases from the `nav-bar-onboarding-nav-fix` change:
  - Two new scenarios under "Global Auth Hook": discovery-step user who has met the progression condition navigates to dashboard (allowed), and the inverse (redirect)
  - New requirement "Onboarding Dashboard Readiness" with 4 scenarios covering the `readyForDashboard` computed property
  - TC-RG-05 and TC-RG-06 added to the unit test cases section
- Archive `nav-bar-onboarding-nav-fix` change artifacts to `openspec/changes/archive/2026-03-26-nav-bar-onboarding-nav-fix/`

## Test plan

- [x] Spec file promoted from stale delta format to canonical `## Requirements` structure
- [x] Frontend implementation PR: liverty-music/frontend#297 (all CI green)
