### PR TITLE
docs(openspec): archive fix-error-log-noise and sync spec

### DIFF
--- a/openspec/changes/archive/2026-03-26-fix-error-log-noise/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-26-fix-error-log-noise/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-26

--- a/openspec/changes/archive/2026-03-26-fix-error-log-noise/design.md
+++ b/openspec/changes/archive/2026-03-26-fix-error-log-noise/design.md
@@ -1,0 +1,45 @@
+## Context
+
+Cloud Monitoring の ERROR ログアラートが以下の理由でノイズを発生させている：
+
+1. **Gemini HTTP 499 の誤分類**: `gemini.toAppErr` の switch に HTTP 499 (Client Cancelled) が含まれず、`codes.Unknown`（server error）にフォールバックしている
+2. **DB レイヤーの過剰なエラー分類**: `rdb.toAppErr` が未知のエラー（`context.Canceled` 含む）をすべて `codes.Internal` でラップし、usecase レイヤーでのエラー種別判定を不可能にしている
+3. **slog デフォルトハンドラー未設定**: NATS 接続リトライが default slog (TextHandler → stderr) に出力され、GKE が stderr を `severity=ERROR` に昇格している
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Gemini HTTP 499 を client error として正しく分類する
+- infrastructure レイヤーがエラーの種別を隠蔽しないようにする（エラー分類は interceptor の責務）
+- NATS 接続リトライログの false positive を解消する
+
+**Non-Goals:**
+
+- Gemini API の `DEADLINE_EXCEEDED` / `invalid JSON` エラー自体の解決（別 change で対応）
+- アラートポリシーの条件やフィルターの変更
+- `go-apperr` パッケージの変更
+
+## Decisions
+
+### Decision 1: Gemini HTTP 499 を `codes.Canceled` にマッピング
+
+**選択**: `gemini/errors.go` の `toAppErr` switch に `case 499: code = codes.Canceled` を追加。
+
+**理由**: HTTP 499 は Nginx 由来の非標準コードで「クライアントがリクエストをキャンセルした」を意味する。Gemini API がこのコードを返す場合、サーバーの不具合ではないため `codes.Unknown`（server error）ではなく `codes.Canceled`（client error）が適切。`codes.Canceled` は `IsServerError() = false` なので interceptor が ERROR ログを出力しない。
+
+### Decision 2: `rdb.toAppErr` の default fallback を `fmt.Errorf` に変更
+
+**選択**: 未知のエラーは `codes.Internal` の AppErr にラップせず、`fmt.Errorf` でコンテキスト文字列のみ付与して返す。
+
+**理由**: infrastructure レイヤーがエラーを AppErr にラップすると、元のエラー型（`context.Canceled` 等）が `errors.Is` で検出不可能になる。エラーの最終分類とクライアント向け隠蔽は interceptor の責務。infrastructure レイヤーは既知の DB エラー（pgx/pgconn）のみ AppErr にマッピングし、それ以外は透過的に返すべき。
+
+### Decision 3: `slog.SetDefault()` を DI 初期化直後に呼ぶ
+
+**選択**: 各 DI 初期化関数（`InitializeApp`, `InitializeConsumerApp`, `InitializeJobApp`）で `provideLogger` 後に `slog.SetDefault(logger.Slog())` を呼び、グローバル slog ハンドラーを JSON フォーマットに設定する。
+
+**理由**: `messaging/streams.go` の `connectWithRetry` は標準 `slog` パッケージを直接使用しており、custom logger のインスタンスを受け取らない。`slog.SetDefault()` を呼ぶことで、すべての標準 slog 呼び出しが JSON handler を使用し、GKE が severity フィールドを正しく解釈する。
+
+## Risks / Trade-offs
+
+- **`rdb.toAppErr` default 変更の影響**: 未知のエラーが AppErr ではなく素のエラーとして interceptor に到達するため、interceptor の "unhandled error" パスで `connect.CodeUnknown` として処理される。クライアントへのレスポンスコードは同じ（Unknown）だが、ログメッセージが "server error occurred" から "unhandled error occurred" に変わる。

--- a/openspec/changes/archive/2026-03-26-fix-error-log-noise/proposal.md
+++ b/openspec/changes/archive/2026-03-26-fix-error-log-noise/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+Cloud Monitoring の ERROR ログアラートが、サーバー起因ではないエラー（Gemini 499 キャンセル）や、誤分類されたログ（NATS リトライの INFO/WARN が stderr 経由で ERROR に昇格）で発火しており、アラートの信頼性が低下している。また DB レイヤーが未知のエラーを一律 `codes.Internal` にラップしており、上位レイヤーでのエラー種別判定を妨げている。
+
+## What Changes
+
+- **Gemini HTTP 499 のコード分類を修正**: `gemini.toAppErr` で HTTP 499 (Client Cancelled) を `codes.Unknown` ではなく `codes.Canceled` にマッピングする。
+- **DB レイヤーのエラー隠蔽を除去**: `rdb.toAppErr` の default `codes.Internal` ラッピングを削除し、未知のエラーは `fmt.Errorf` でコンテキスト付与のみ行う。これにより usecase レイヤーで `context.Canceled` 等の判定が可能になる。
+- **slog デフォルトハンドラーを JSON に設定**: `provideLogger` 後に `slog.SetDefault()` を呼び、NATS リトライログが stderr テキスト経由で ERROR に誤分類される問題を解消する。
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `app-error-log-alerting`: ERROR ログアラートのノイズ低減。Gemini HTTP 499 が ERROR として記録されなくなり、NATS リトライの false positive が解消される。
+
+## Impact
+
+- **backend** (`gemini/errors.go`): HTTP 499 マッピング変更
+- **backend** (`rdb/errors.go`): default `codes.Internal` を `fmt.Errorf` に変更
+- **backend** (`di/provider.go`, `di/consumer.go`, `di/job.go`): `slog.SetDefault()` 追加
+- **Cloud Monitoring**: アラートポリシー自体の変更なし。ログ側の severity が正しくなることでノイズが減る

--- a/openspec/changes/archive/2026-03-26-fix-error-log-noise/specs/app-error-log-alerting/spec.md
+++ b/openspec/changes/archive/2026-03-26-fix-error-log-noise/specs/app-error-log-alerting/spec.md
@@ -1,0 +1,58 @@
+## ADDED Requirements
+
+### Requirement: Gemini client-cancelled errors classified as client error
+
+The Gemini infrastructure layer SHALL classify HTTP 499 (Client Cancelled) responses as `codes.Canceled` instead of `codes.Unknown`. This ensures the error handling interceptor treats it as a client error and does not log it at ERROR level.
+
+#### Scenario: Gemini API returns HTTP 499
+
+- **WHEN** the Gemini API returns HTTP status 499 (Client Cancelled)
+- **THEN** the error SHALL be classified as `codes.Canceled` (client error)
+- **AND** the error handling interceptor SHALL NOT log it at ERROR level
+
+#### Scenario: Server-side deadline exceeded is still logged
+
+- **WHEN** the server's handler timeout expires (context.DeadlineExceeded)
+- **THEN** the error SHALL continue to be logged at ERROR level
+- **AND** the error SHALL be classified as `codes.DeadlineExceeded` (server error)
+
+### Requirement: Infrastructure layer preserves original error types
+
+The database infrastructure layer (`rdb.toAppErr`) SHALL NOT wrap unknown errors as `codes.Internal` AppErr. For errors that do not match any known database error pattern (pgx, pgconn), the layer SHALL wrap the error with `fmt.Errorf` to add context while preserving the original error chain.
+
+This ensures that usecase and interceptor layers can inspect the original error type using `errors.Is` and `errors.As`.
+
+#### Scenario: context.Canceled from database query
+
+- **WHEN** a database query returns `context.Canceled`
+- **THEN** `rdb.toAppErr` SHALL wrap it with `fmt.Errorf` preserving the original error
+- **AND** `errors.Is(err, context.Canceled)` on the wrapped error SHALL return true
+
+#### Scenario: Known pgx error is still mapped to AppErr
+
+- **WHEN** a database query returns `pgx.ErrNoRows`
+- **THEN** `rdb.toAppErr` SHALL wrap it as `codes.NotFound` AppErr (unchanged behavior)
+
+#### Scenario: PostgreSQL constraint violation is still mapped to AppErr
+
+- **WHEN** a database query returns a PostgreSQL unique violation (23505)
+- **THEN** `rdb.toAppErr` SHALL wrap it as `codes.AlreadyExists` AppErr (unchanged behavior)
+
+### Requirement: Standard slog output uses structured JSON format
+
+All log output from the Go standard `slog` package SHALL use the application's configured structured logging format (JSON) by setting `slog.SetDefault()` after logger initialization.
+
+This prevents the GKE logging agent from misclassifying INFO/WARN logs written to stderr as ERROR severity.
+
+#### Scenario: NATS connection retry logged as INFO/WARN
+
+- **WHEN** the NATS client retries a connection during startup
+- **AND** the retry log is emitted via the standard `slog` package
+- **THEN** the log entry SHALL be written in JSON format with the correct `severity` field
+- **AND** GKE Cloud Logging SHALL classify it according to the `severity` field (INFO or WARN), not as ERROR
+
+#### Scenario: NATS connection established after retry
+
+- **WHEN** the NATS client successfully connects after retries
+- **AND** emits an INFO log via the standard `slog` package
+- **THEN** the log entry SHALL appear as `severity=INFO` in Cloud Logging (not ERROR)

--- a/openspec/changes/archive/2026-03-26-fix-error-log-noise/tasks.md
+++ b/openspec/changes/archive/2026-03-26-fix-error-log-noise/tasks.md
@@ -1,0 +1,18 @@
+## 1. backend: Gemini HTTP 499 のコード分類を修正
+
+- [x] 1.1 `gemini/errors.go` の `toAppErr` switch に `case 499: code = codes.Canceled` を追加
+- [x] 1.2 `gemini/errors_internal_test.go` に HTTP 499 と context.Canceled のマッピングテストを追加
+
+## 2. backend: DB レイヤーのエラー隠蔽を除去
+
+- [x] 2.1 `rdb/errors.go` の default fallback を `codes.Internal` AppErr から `fmt.Errorf` に変更
+
+## 3. backend: slog デフォルトハンドラーを JSON に設定
+
+- [x] 3.1 `di/provider.go` の `InitializeApp` で `provideLogger` 後に `slog.SetDefault(logger.Slog())` を呼ぶ
+- [x] 3.2 `di/consumer.go` の `InitializeConsumerApp` で `provideLogger` 後に `slog.SetDefault(logger.Slog())` を呼ぶ
+- [x] 3.3 `di/job.go` の `InitializeJobApp` で `provideLogger` 後に `slog.SetDefault(logger.Slog())` を呼ぶ
+
+## 4. 検証
+
+- [x] 4.1 `make check` を実行し、lint + テストが通ることを確認

--- a/openspec/specs/app-error-log-alerting/spec.md
+++ b/openspec/specs/app-error-log-alerting/spec.md
@@ -174,3 +174,60 @@ Google Chat Notification Channels are created and managed by Pulumi as `gcp.moni
 - **AND** the Slack Notification Channel SHALL be referenced by its channel ID from Pulumi ESC
 - **AND** the Google Chat Notification Channel SHALL be created with its space_id from Pulumi ESC
 - **AND** all Alert Policies SHALL include both Slack and Google Chat notification channels
+
+### Requirement: Gemini client-cancelled errors classified as client error
+
+The Gemini infrastructure layer SHALL classify HTTP 499 (Client Cancelled) responses as `codes.Canceled` instead of `codes.Unknown`. This ensures the error handling interceptor treats it as a client error and does not log it at ERROR level.
+
+#### Scenario: Gemini API returns HTTP 499
+
+- **WHEN** the Gemini API returns HTTP status 499 (Client Cancelled)
+- **THEN** the error SHALL be classified as `codes.Canceled` (client error)
+- **AND** the error handling interceptor SHALL NOT log it at ERROR level
+
+#### Scenario: Server-side deadline exceeded is still logged
+
+- **WHEN** the server's handler timeout expires (context.DeadlineExceeded)
+- **THEN** the error SHALL continue to be logged at ERROR level
+- **AND** the error SHALL be classified as `codes.DeadlineExceeded` (server error)
+
+### Requirement: Infrastructure layer preserves original error types
+
+The database infrastructure layer (`rdb.toAppErr`) SHALL NOT wrap unknown errors as `codes.Internal` AppErr. For errors that do not match any known database error pattern (pgx, pgconn), the layer SHALL wrap the error with `fmt.Errorf` to add context while preserving the original error chain.
+
+This ensures that usecase and interceptor layers can inspect the original error type using `errors.Is` and `errors.As`.
+
+#### Scenario: context.Canceled from database query
+
+- **WHEN** a database query returns `context.Canceled`
+- **THEN** `rdb.toAppErr` SHALL wrap it with `fmt.Errorf` preserving the original error
+- **AND** `errors.Is(err, context.Canceled)` on the wrapped error SHALL return true
+
+#### Scenario: Known pgx error is still mapped to AppErr
+
+- **WHEN** a database query returns `pgx.ErrNoRows`
+- **THEN** `rdb.toAppErr` SHALL wrap it as `codes.NotFound` AppErr (unchanged behavior)
+
+#### Scenario: PostgreSQL constraint violation is still mapped to AppErr
+
+- **WHEN** a database query returns a PostgreSQL unique violation (23505)
+- **THEN** `rdb.toAppErr` SHALL wrap it as `codes.AlreadyExists` AppErr (unchanged behavior)
+
+### Requirement: Standard slog output uses structured JSON format
+
+All log output from the Go standard `slog` package SHALL use the application's configured structured logging format (JSON) by setting `slog.SetDefault()` after logger initialization.
+
+This prevents the GKE logging agent from misclassifying INFO/WARN logs written to stderr as ERROR severity.
+
+#### Scenario: NATS connection retry logged as INFO/WARN
+
+- **WHEN** the NATS client retries a connection during startup
+- **AND** the retry log is emitted via the standard `slog` package
+- **THEN** the log entry SHALL be written in JSON format with the correct `severity` field
+- **AND** GKE Cloud Logging SHALL classify it according to the `severity` field (INFO or WARN), not as ERROR
+
+#### Scenario: NATS connection established after retry
+
+- **WHEN** the NATS client successfully connects after retries
+- **AND** emits an INFO log via the standard `slog` package
+- **THEN** the log entry SHALL appear as `severity=INFO` in Cloud Logging (not ERROR)


### PR DESCRIPTION
## Summary

- Archive fix-error-log-noise change artifacts
- Sync app-error-log-alerting spec with 3 new requirements:
  - Gemini HTTP 499 classified as client error
  - Infrastructure layer preserves original error types
  - Standard slog output uses structured JSON format

## Test plan

- [x] Delta specs synced to main spec
- [x] Archive directory created at correct date path
