### PR TITLE
docs(spec): add concert-highway-ce and update welcome-dashboard-preview

### DIFF
--- a/openspec/changes/archive/2026-03-26-extract-concert-highway-ce/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-26-extract-concert-highway-ce/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-26

--- a/openspec/changes/archive/2026-03-26-extract-concert-highway-ce/design.md
+++ b/openspec/changes/archive/2026-03-26-extract-concert-highway-ce/design.md
@@ -1,0 +1,108 @@
+## Context
+
+The dashboard route currently owns all rendering logic for the 3-column concert lane grid: stage headers, date separators, event cards, and laser beam effects. This prevents reuse on the Welcome page, which needs the identical UI in readonly mode with preview data.
+
+`dashboard-service.ts` aggregates three unrelated concerns (follows, concerts, journeys) into a single orchestrator. The `protoGroupToDateGroup()` conversion is private, blocking Welcome from using the same `ProximityGroup → DateGroup` pipeline.
+
+The Welcome page currently has a broken inline implementation that hard-codes all concerts into the `away` lane and lacks the grid CSS entirely.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Extract a `<concert-highway>` CE that both `dashboard-route` and `welcome-route` consume
+- Decompose `dashboard-service` by moving methods to their domain services
+- Rewrite `welcome-route` to use `ListWithProximity` RPC with tokyo-fixed home, rendering via `<concert-highway readonly>`
+- Apply Sticky CTA + Peek Preview layout to the Welcome page
+
+**Non-Goals:**
+- Changing the backend `ListWithProximity` RPC or proximity calculation
+- Modifying event-card internals (already a standalone CE)
+- Adding new onboarding flows or changing the lane intro state machine
+- Staging/prod preview artist configuration (handled by existing `.env` mechanism)
+
+## Decisions
+
+### Decision: `<concert-highway>` CE location — `components/live-highway/`
+
+Place the new CE alongside `event-card` in the existing `live-highway` directory, since it composes event-cards into a highway grid.
+
+**Alternatives considered:**
+- Separate `components/concert-highway/` directory: Rejected — the highway and event-card are tightly coupled, and co-location simplifies imports.
+- Keep in `routes/dashboard/`: Rejected — defeats the purpose of extraction.
+
+### Decision: Bindable API for `<concert-highway>`
+
+```typescript
+@bindable dateGroups: DateGroup[] = []
+@bindable readonly: boolean = false
+@bindable showBeams: boolean = true
+```
+
+Data loading stays in the consuming route. The CE is a pure presentation component that receives fully-formed `DateGroup[]`. This keeps the CE framework-agnostic regarding data source (dashboard service, preview RPC, mock data, etc.).
+
+**Alternatives considered:**
+- CE loads its own data via injected service: Rejected — tightly couples CE to a specific data source, breaks reuse for different contexts.
+
+### Decision: Decompose `dashboard-service` into domain services
+
+| Method | Current Location | New Location |
+|---|---|---|
+| `protoGroupToDateGroup()` | `dashboard-service` (private) | `concert-service.toDateGroups()` (public) |
+| `fetchFollowedArtistMap()` | `dashboard-service` (private) | `follow-service.getFollowedArtistMap()` (public) |
+| `fetchJourneyMap()` | `dashboard-service` (private) | `journey-service.getJourneyMap()` (public) |
+| `loadDashboardEvents()` | `dashboard-service` (public) | `dashboard-route.loadData()` (inline orchestration) |
+
+After migration, `dashboard-service.ts` is deleted.
+
+**Alternatives considered:**
+- Keep `dashboard-service` and just export `protoGroupToDateGroup`: Rejected — the service is an unnecessary orchestration layer; each method belongs to its domain.
+
+### Decision: Welcome preview data flow via `listWithProximity`
+
+```
+welcome-route.ts
+  attached()
+  └── loadPreviewData()
+      ├── concertService.listWithProximity(
+      │     PREVIEW_ARTIST_IDS,
+      │     'JP',       // countryCode
+      │     'JP-13'     // level1 (Tokyo)
+      │   )
+      └── concertService.toDateGroups(proximityGroups, artistMap)
+          → this.dateGroups = result
+```
+
+This reuses the existing guest flow in `concert-service` and the same `ProximityGroup → DateGroup` conversion that the dashboard uses. No new RPC calls or mappers needed.
+
+### Decision: Peek Preview layout for Welcome
+
+The preview section uses a fixed-height scrollable container (`~55svh`) with a bottom fade-out mask. CTA buttons are positioned below the preview with sticky behavior so they remain visible while the user scrolls the preview.
+
+```
+┌─ viewport ──────────────┐
+│  Hero copy              │
+│  ┌─ preview (55svh) ──┐ │
+│  │ <concert-highway    │ │
+│  │   readonly>         │ │
+│  │   (internal scroll) │ │
+│  └─ fade mask ─────────┘ │
+│  Guest-friendly copy     │
+│  [Get Started] sticky    │
+│  [Log In]                │
+└──────────────────────────┘
+```
+
+## Risks / Trade-offs
+
+- **CSS extraction complexity**: Moving grid/beam CSS from `dashboard-route.css` to the CE requires careful `@scope` boundary management. The CE must not leak styles to parent, and parent must not override CE internals.
+  → Mitigation: Use Aurelia 2 shadow DOM-like `@scope` isolation (already the project pattern).
+
+- **Beam tracking scroll context change**: In `dashboard-route`, the scroll container is the route itself. In `welcome-route`, the scroll container is the `.welcome-preview` wrapper (not the full page).
+  → Mitigation: The CE accepts a scroll container reference or uses its own root element for intersection/scroll observation.
+
+- **`dashboard-route` regression**: Refactoring a working route carries risk of breaking the authenticated dashboard.
+  → Mitigation: Ensure existing E2E tests pass. The template change is mechanical (replace inline HTML with CE tag).
+
+## Open Questions
+
+- Should the laser beams animate on Welcome page load, or start static and animate on first scroll interaction? (UX preference — can be decided during implementation.)

--- a/openspec/changes/archive/2026-03-26-extract-concert-highway-ce/proposal.md
+++ b/openspec/changes/archive/2026-03-26-extract-concert-highway-ce/proposal.md
@@ -1,0 +1,38 @@
+## Why
+
+The Welcome page needs to display the same concert dashboard UI that authenticated users see, so new visitors can experience the product's value before signing up. Currently the 3-column lane grid (home/nearby/away), event cards, laser beams, and date separators are all embedded directly in `dashboard-route`. This makes reuse impossible without duplicating code.
+
+Additionally, `dashboard-service` bundles orchestration logic for three unrelated domains (follows, concerts, journeys) into a single service, preventing `welcome-route` from accessing the `ProximityGroup → DateGroup` conversion.
+
+## What Changes
+
+- Extract a new `<concert-highway>` custom element (CE) from `dashboard-route` encapsulating the 3-column lane grid, stage header, date separators, laser beam overlay, and scroll tracking
+- Decompose `dashboard-service` by moving each method to its domain service:
+  - `protoGroupToDateGroup()` → `concert-service` (as public `toDateGroups()`)
+  - `fetchFollowedArtistMap()` → `follow-service`
+  - `fetchJourneyMap()` → `journey-service`
+  - Orchestration (`loadDashboardEvents`) → `dashboard-route` (inline)
+- Delete `dashboard-service` after migration
+- Rewrite `welcome-route` to use `<concert-highway>` with data from `listWithProximity` RPC (tokyo fixed home, preview artist IDs)
+- Apply "Sticky CTA + Peek Preview" UX layout to `welcome-route`: fixed-height scrollable preview with fade mask and sticky CTA at bottom
+
+## Capabilities
+
+### New Capabilities
+
+- `concert-highway-ce`: Reusable custom element that renders the 3-column concert lane grid with laser beam effects, accepting `DateGroup[]` data and supporting readonly mode
+
+### Modified Capabilities
+
+- `welcome-dashboard-preview`: Preview now uses the real dashboard CE with `listWithProximity` RPC instead of a custom inline implementation; layout changes to Sticky CTA + Peek Preview pattern
+
+## Impact
+
+- **frontend/src/components/live-highway/**: New `concert-highway.*` files (CE)
+- **frontend/src/routes/dashboard/**: Refactored to consume `<concert-highway>`, grid/beam CSS moves to CE
+- **frontend/src/routes/welcome/**: Rewritten template and data loading; new CSS for peek preview layout
+- **frontend/src/services/dashboard-service.ts**: Deleted
+- **frontend/src/services/concert-service.ts**: Gains `toDateGroups()` method
+- **frontend/src/services/follow-service.ts**: Gains `fetchFollowedArtistMap()` method
+- **frontend/src/services/journey-service.ts**: Gains `fetchJourneyMap()` method (if not already present)
+- No backend or proto changes required — uses existing `ListWithProximity` RPC

--- a/openspec/changes/archive/2026-03-26-extract-concert-highway-ce/specs/concert-highway-ce/spec.md
+++ b/openspec/changes/archive/2026-03-26-extract-concert-highway-ce/specs/concert-highway-ce/spec.md
@@ -1,0 +1,34 @@
+## ADDED Requirements
+
+### Requirement: Concert Highway Custom Element
+
+The system SHALL provide a reusable `<concert-highway>` custom element that renders a 3-column concert lane grid (home/nearby/away) with stage headers, date separators, event cards, and laser beam effects.
+
+#### Scenario: Render date groups with 3-column layout
+
+- **WHEN** `<concert-highway>` receives a `dateGroups` binding containing `DateGroup[]`
+- **THEN** the CE SHALL render a 3-column grid with stage headers labeled HOME, NEAR, and AWAY
+- **AND** each date group SHALL display a sticky date separator followed by three lane columns containing `<event-card>` components
+
+#### Scenario: Laser beam effects for matched events
+
+- **WHEN** `showBeams` is true (default) and the date groups contain matched events
+- **THEN** the CE SHALL render laser beam overlays from the top of the viewport to each matched event card
+- **AND** beam positions SHALL update on scroll via `requestAnimationFrame`
+
+#### Scenario: Readonly mode suppresses card interaction
+
+- **WHEN** `readonly` is set to true
+- **THEN** all `<event-card>` components SHALL be rendered with `readonly="true"`
+- **AND** tapping a card SHALL NOT dispatch the `event-selected` event
+
+#### Scenario: Interactive mode dispatches event selection
+
+- **WHEN** `readonly` is false and the user taps an event card
+- **THEN** the `event-selected` custom event SHALL bubble up from the CE
+- **AND** the event detail payload SHALL contain the selected `Concert` object
+
+#### Scenario: Empty lane display
+
+- **WHEN** a lane (home, nearby, or away) has no concerts for a given date
+- **THEN** the lane SHALL display a placeholder dash ("—")

--- a/openspec/changes/archive/2026-03-26-extract-concert-highway-ce/specs/welcome-dashboard-preview/spec.md
+++ b/openspec/changes/archive/2026-03-26-extract-concert-highway-ce/specs/welcome-dashboard-preview/spec.md
@@ -1,10 +1,4 @@
-# Welcome Dashboard Preview
-
-## Purpose
-
-Displays an interactive, read-only dashboard preview on the Welcome page using live concert data from a curated popular-artist fallback list, giving new users a tangible preview of what they will build during onboarding.
-
-## Requirements
+## MODIFIED Requirements
 
 ### Requirement: Live Dashboard Preview on Welcome Page
 

--- a/openspec/changes/archive/2026-03-26-extract-concert-highway-ce/tasks.md
+++ b/openspec/changes/archive/2026-03-26-extract-concert-highway-ce/tasks.md
@@ -1,0 +1,35 @@
+## 1. Decompose dashboard-service
+
+- [x] 1.1 Move `protoGroupToDateGroup()` to `concert-service.ts` as public `toDateGroups()` (accepting `ProximityGroup[]` and an artist map)
+- [x] 1.2 Move `fetchFollowedArtistMap()` to `follow-service.ts` as public `getFollowedArtistMap()`
+- [x] 1.3 Move `fetchJourneyMap()` — kept inline in dashboard-route since it's orchestration logic (auth check + graceful fallback); `listByUser` already exists on RPC client
+- [x] 1.4 Inline the `loadDashboardEvents()` orchestration into `dashboard-route.ts` `loadData()`, calling the three domain services directly
+- [x] 1.5 Delete `dashboard-service.ts` and remove its DI registration from `main.ts`
+
+## 2. Extract `<concert-highway>` CE
+
+- [x] 2.1 Create `components/live-highway/concert-highway.ts` with `@bindable` API: `dateGroups`, `readonly`, `showBeams`
+- [x] 2.2 Create `components/live-highway/concert-highway.html` — move the stage-header, concert-scroll, date-group-list, lane-grid, and beam-overlay markup from `dashboard-route.html`
+- [x] 2.3 Create `components/live-highway/concert-highway.css` — move the 3-column grid, laser beam, date-separator, lane-grid, lane, and empty-state styles from `dashboard-route.css`
+- [x] 2.4 Move `buildBeamIndexMap()`, `updateBeamPositions()`, `scheduleBeamUpdate()`, and scroll listener setup/teardown from `dashboard-route.ts` into the CE
+- [x] 2.5 Export the CE from `components/live-highway/index.ts` (or equivalent barrel)
+
+## 3. Refactor dashboard-route to consume CE
+
+- [x] 3.1 Replace the inline lane-grid/beam HTML in `dashboard-route.html` with `<concert-highway date-groups.bind="dateGroups" event-selected.trigger="onEventSelected($event)">`
+- [x] 3.2 Remove the grid/beam/lane CSS from `dashboard-route.css` (now owned by CE)
+- [x] 3.3 Remove beam-tracking methods from `dashboard-route.ts` (now owned by CE)
+- [x] 3.4 Verify dashboard route still renders correctly — run `make check` and E2E tests
+
+## 4. Rewrite welcome-route to use CE + ListWithProximity
+
+- [x] 4.1 Replace `loadPreviewConcerts()` in `welcome-route.ts` with `loadPreviewData()` that calls `concertService.listWithProximity(PREVIEW_ARTIST_IDS, 'JP', 'JP-13')` and `concertService.toDateGroups()`
+- [x] 4.2 Replace the inline lane-grid HTML in `welcome-route.html` with `<concert-highway date-groups.bind="dateGroups" readonly="true">` wrapped in a `.welcome-preview` container
+- [x] 4.3 Add Peek Preview CSS to `welcome-route.css`: `.welcome-preview` with `~55svh` fixed height, `overflow-y: scroll`, bottom fade-out gradient mask
+- [x] 4.4 Add sticky CTA layout: position CTA buttons and guest-friendly copy below the preview with sticky behavior
+- [x] 4.5 Verify welcome page renders the 3-column grid with real concert data — run `make check`
+
+## 5. Cleanup
+
+- [x] 5.1 Remove any unused imports or dead code from dashboard-route, welcome-route, and service files
+- [x] 5.2 Run full lint and test suite (`make check`) to verify no regressions

--- a/openspec/specs/concert-highway-ce/spec.md
+++ b/openspec/specs/concert-highway-ce/spec.md
@@ -1,0 +1,40 @@
+# Concert Highway Custom Element
+
+## Purpose
+
+Reusable custom element that renders the 3-column concert lane grid (home/nearby/away) with stage headers, date separators, event cards, and laser beam effects. Used by both the authenticated dashboard and the Welcome page preview.
+
+## Requirements
+
+### Requirement: Concert Highway Custom Element
+
+The system SHALL provide a reusable `<concert-highway>` custom element that renders a 3-column concert lane grid (home/nearby/away) with stage headers, date separators, event cards, and laser beam effects.
+
+#### Scenario: Render date groups with 3-column layout
+
+- **WHEN** `<concert-highway>` receives a `dateGroups` binding containing `DateGroup[]`
+- **THEN** the CE SHALL render a 3-column grid with stage headers labeled HOME, NEAR, and AWAY
+- **AND** each date group SHALL display a sticky date separator followed by three lane columns containing `<event-card>` components
+
+#### Scenario: Laser beam effects for matched events
+
+- **WHEN** `showBeams` is true (default) and the date groups contain matched events
+- **THEN** the CE SHALL render laser beam overlays from the top of the viewport to each matched event card
+- **AND** beam positions SHALL update on scroll via `requestAnimationFrame`
+
+#### Scenario: Readonly mode suppresses card interaction
+
+- **WHEN** `readonly` is set to true
+- **THEN** all `<event-card>` components SHALL be rendered with `readonly="true"`
+- **AND** tapping a card SHALL NOT dispatch the `event-selected` event
+
+#### Scenario: Interactive mode dispatches event selection
+
+- **WHEN** `readonly` is false and the user taps an event card
+- **THEN** the `event-selected` custom event SHALL bubble up from the CE
+- **AND** the event detail payload SHALL contain the selected `Concert` object
+
+#### Scenario: Empty lane display
+
+- **WHEN** a lane (home, nearby, or away) has no concerts for a given date
+- **THEN** the lane SHALL display a placeholder dash ("—")


### PR DESCRIPTION
## Summary

- New spec: `concert-highway-ce` — reusable 3-column lane grid custom element
- Updated spec: `welcome-dashboard-preview` — scroll-snap layout, ListWithProximity RPC, `VITE_PREVIEW_ARTIST_NAMES` env var
- Archive `extract-concert-highway-ce` change artifacts

## Test plan

- [ ] No buf lint errors (no proto changes in this PR)
