### PR TITLE
docs(openspec): add fix-onboarding-dashboard-bugs change artifacts

### DIFF
--- a/openspec/changes/fix-onboarding-dashboard-bugs/.openspec.yaml
+++ b/openspec/changes/fix-onboarding-dashboard-bugs/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-26

--- a/openspec/changes/fix-onboarding-dashboard-bugs/design.md
+++ b/openspec/changes/fix-onboarding-dashboard-bugs/design.md
@@ -1,0 +1,72 @@
+## Context
+
+The onboarding flow on the dashboard has three interacting bugs:
+
+1. **Incorrect auto-open**: `PageHelp.attached()` auto-opens the help bottom-sheet on ALL pages during onboarding, but the spec only defines auto-open for Discovery and My Artists. On Dashboard, page-help should only display the `?` icon (manual open). The unconditional auto-open during celebration produces a dark, unreadable screen with two overlapping overlays.
+
+2. **Positioning**: The `<page-help>` component is placed at the bottom of the dashboard template (outside the page header), causing the `?` icon to appear at the bottom-left. Additionally, discovery has no `<page-help>` at all despite the spec requiring it. Only my-artists correctly places page-help inside `<page-header>`.
+
+3. **Orchestration inversion**: `loading()` sets `showCelebration = true` immediately, which prevents `attached()` from calling `startLaneIntro()` (guarded by `!showCelebration`). After celebration dismiss, there is no code to trigger lane intro. The result: lane intro never executes, and users are stuck without guidance.
+
+The existing specs clearly define the correct order: lane intro (HOME → NEAR → AWAY) → celebration → free exploration. The code needs to match this.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Fix the orchestration so lane intro runs before celebration (matching the spec)
+- Limit page-help auto-open to Discovery and My Artists only (matching the spec)
+- Unify `<page-help>` placement: all onboarding pages use `<page-header>` with page-help inside its slot
+- Add regression tests that fail against the current bugs and pass after fixes
+
+**Non-Goals:**
+- Redesigning the onboarding flow or adding new steps
+- Changing the page-help content or styling
+- Modifying the celebration overlay animation
+
+## Decisions
+
+### D1: Restrict page-help auto-open to spec-defined pages
+
+**Decision**: Add an `autoOpenPages` allowlist (`['discovery', 'my-artists']`) inside `PageHelp.attached()`. Only pages in the allowlist trigger auto-open. Dashboard page-help shows the `?` icon only — manual open.
+
+**Why not a `suppress` bindable?** The spec clearly defines which pages auto-open. This is a property of the page-help component's own logic, not something the parent should control. An allowlist is simpler, self-documenting, and doesn't require plumbing from each route.
+
+### D2: Remove premature `showCelebration` from `loading()`, trigger after lane intro
+
+**Decision**: `loading()` no longer sets `showCelebration = true`. Instead, `completeLaneIntro()` (called after AWAY phase tap) sets `showCelebration = true`. The `attached()` method always calls `startLaneIntro()` when the step is DASHBOARD.
+
+**Flow after fix:**
+```
+loading()
+  └─ set needsRegion, loadData()
+
+attached()
+  └─ isOnboardingStepDashboard → startLaneIntro()
+       └─ HOME → NEAR → AWAY (tap-to-advance)
+       └─ completeLaneIntro() → showCelebration = true
+            └─ onCelebrationOpen() → setStep(MY_ARTISTS)
+            └─ onCelebrationDismissed() → free exploration
+```
+
+**Alternative considered**: Keep `showCelebration` in `loading()` but call `startLaneIntro()` in `onCelebrationDismissed()`. Rejected — contradicts the spec which says celebration is AFTER lane intro, not before.
+
+### D3: Unify page-help placement inside `<page-header>` on all pages
+
+**Decision**: All onboarding pages (dashboard, discovery, my-artists) use `<page-header>` with `<page-help>` inside its `<au-slot>`. The `<page-header>` component uses `display: flex` with `h1 { flex: 1 }`, so slot content is automatically right-aligned.
+
+- **dashboard**: Add `<page-header>` above the stage header. Title TBD (e.g., `nav.home` or similar existing i18n key). Place `<page-help page="dashboard">` inside.
+- **discovery**: Add `<page-header>` above the search bar. Place `<page-help page="discovery">` inside.
+- **my-artists**: Already correct — no changes needed.
+
+### D4: Test-first approach
+
+**Decision**: Write failing unit tests first that detect the bugs, then implement fixes. This ensures:
+- Bugs are reproducible
+- Fixes are verified by the same tests passing
+- Future regressions are caught
+
+## Risks / Trade-offs
+
+- **[Risk] Lane intro depends on data being loaded** → `startLaneIntro()` already awaits `dataPromise`, so this is handled. If data fetch fails, lane intro is skipped and celebration shows directly (per spec).
+- **[Risk] `celebrationShown` localStorage flag prevents re-testing** → Tests clear localStorage between runs.
+- **[Risk] Dashboard `<page-header>` changes visual layout** → The header is minimal (flex row with title + slot). Visual impact is small and consistent with other pages.

--- a/openspec/changes/fix-onboarding-dashboard-bugs/proposal.md
+++ b/openspec/changes/fix-onboarding-dashboard-bugs/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+Onboarding flow on the dashboard page has three interacting bugs that create a broken first-time user experience: (1) page-help bottom-sheet auto-opens simultaneously with the celebration overlay, producing a dark, unreadable screen, (2) the `?` help icon appears at the bottom-left of the page instead of inside the page header, and (3) tapping the celebration overlay does not start the lane introduction coach-mark sequence, leaving the user stuck with no guidance.
+
+## What Changes
+
+- **Fix page-help auto-open race condition**: `PageHelp.attached()` must not auto-open when celebration overlay or lane intro is active. Defer auto-open until celebration is dismissed.
+- **Fix `?` icon positioning on dashboard**: Move `<page-help>` inside the dashboard page header (matching the pattern used in my-artists-route).
+- **Fix lane intro not starting after celebration**: The `loading()` method sets `showCelebration = true` before `attached()` runs, which causes `startLaneIntro()` to be skipped. After celebration is dismissed, lane intro must be triggered.
+- **Add regression tests**: Unit tests for `PageHelp` auto-open gating and `DashboardRoute` onboarding orchestration. E2E test for the full onboarding-to-dashboard flow.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `onboarding-page-help`: Auto-open must be suppressed while celebration overlay or lane intro is active
+- `onboarding-celebration`: Celebration dismiss must trigger lane intro sequence instead of entering free exploration directly
+- `dashboard-lane-introduction`: Lane intro must start after celebration dismiss when arriving from discovery during onboarding
+
+## Impact
+
+- `src/components/page-help/page-help.ts` — auto-open gating logic
+- `src/routes/dashboard/dashboard-route.ts` — onboarding orchestration order
+- `src/routes/dashboard/dashboard-route.html` — page-help placement in template
+- New/updated test files in `src/components/page-help/` and `src/routes/dashboard/`

--- a/openspec/changes/fix-onboarding-dashboard-bugs/proposal.md
+++ b/openspec/changes/fix-onboarding-dashboard-bugs/proposal.md
@@ -4,7 +4,7 @@ Onboarding flow on the dashboard page has three interacting bugs that create a b
 
 ## What Changes
 
-- **Fix page-help auto-open race condition**: `PageHelp.attached()` must not auto-open when celebration overlay or lane intro is active. Defer auto-open until celebration is dismissed.
+- **Fix page-help auto-open scope**: `PageHelp.attached()` must only auto-open on Discovery and My Artists. Dashboard is permanently excluded via an `autoOpenPages` allowlist — no auto-open at all on Dashboard (not deferred, permanently excluded).
 - **Fix `?` icon positioning on dashboard**: Move `<page-help>` inside the dashboard page header (matching the pattern used in my-artists-route).
 - **Fix lane intro not starting after celebration**: The `loading()` method sets `showCelebration = true` before `attached()` runs, which causes `startLaneIntro()` to be skipped. After celebration is dismissed, lane intro must be triggered.
 - **Add regression tests**: Unit tests for `PageHelp` auto-open gating and `DashboardRoute` onboarding orchestration. E2E test for the full onboarding-to-dashboard flow.
@@ -17,9 +17,9 @@ Onboarding flow on the dashboard page has three interacting bugs that create a b
 
 ### Modified Capabilities
 
-- `onboarding-page-help`: Auto-open must be suppressed while celebration overlay or lane intro is active
-- `onboarding-celebration`: Celebration dismiss must trigger lane intro sequence instead of entering free exploration directly
-- `dashboard-lane-introduction`: Lane intro must start after celebration dismiss when arriving from discovery during onboarding
+- `onboarding-page-help`: Dashboard page SHALL NOT auto-open the help sheet; auto-open is restricted to Discovery and My Artists via an `autoOpenPages` allowlist
+- `onboarding-celebration`: Celebration MUST NOT appear before lane intro; it appears only after `completeLaneIntro()` is called (AWAY phase tap)
+- `dashboard-lane-introduction`: Lane intro runs immediately on Dashboard attach; `completeLaneIntro()` (after AWAY tap) triggers celebration — not the other way around
 
 ## Impact
 

--- a/openspec/changes/fix-onboarding-dashboard-bugs/specs/dashboard-lane-introduction/spec.md
+++ b/openspec/changes/fix-onboarding-dashboard-bugs/specs/dashboard-lane-introduction/spec.md
@@ -1,0 +1,30 @@
+## MODIFIED Requirements
+
+### Requirement: Sequential Lane Header Spotlight
+
+The system SHALL introduce each dashboard lane by sequentially spotlighting the STAGE headers with explanatory coach marks. Each phase waits for a user tap to advance. The HOME phase pauses to collect the user's 居住エリア selection before displaying the dynamic coach mark text.
+
+#### Scenario: Lane introduction begins after Dashboard load
+
+- **WHEN** the user is at Step `'dashboard'`
+- **AND** the Dashboard page loads
+- **AND** `ConcertService/ListWithProximity` has returned 1 or more date groups
+- **THEN** the system SHALL begin the lane introduction sequence
+- **AND** the lane intro SHALL start regardless of `showCelebration` state (celebration is not set until lane intro completes)
+- **AND** scrolling SHALL be disabled during the entire sequence
+- **AND** blocker divs SHALL be active
+
+#### Scenario: Lane introduction skipped when no concert data
+
+- **WHEN** the Dashboard page loads
+- **AND** `ConcertService/ListWithProximity` has returned 0 date groups
+- **THEN** the system SHALL NOT begin the lane introduction sequence
+- **AND** the system SHALL proceed directly to the Celebration Overlay
+- **AND** the system SHALL log a warning: "No concert data available, skipping lane intro"
+
+#### Scenario: Transition to Celebration after AWAY phase
+
+- **WHEN** the AWAY phase tap is received
+- **THEN** the system SHALL call `completeLaneIntro()`
+- **AND** `completeLaneIntro()` SHALL set `showCelebration = true`
+- **AND** `showCelebration` SHALL NOT be set in `loading()` or any earlier lifecycle hook

--- a/openspec/changes/fix-onboarding-dashboard-bugs/specs/onboarding-celebration/spec.md
+++ b/openspec/changes/fix-onboarding-dashboard-bugs/specs/onboarding-celebration/spec.md
@@ -1,0 +1,42 @@
+## MODIFIED Requirements
+
+### Requirement: Celebration Overlay on Dashboard — Repositioned After Lane Intro
+
+The system SHALL display the Celebration Overlay after the Lane Intro sequence completes, not before. Opening the Celebration Overlay SHALL advance `onboardingStep` from `'dashboard'` to `'my-artists'`. The overlay is dismissed by a tap anywhere on the screen.
+
+#### Scenario: Celebration overlay appears after Lane Intro
+
+- **WHEN** the Lane Intro AWAY phase tap is received
+- **THEN** the system SHALL open the Celebration Overlay
+- **AND** opening the overlay SHALL advance `onboardingStep` to `'my-artists'`
+- **AND** the overlay SHALL display "あなただけのタイムテーブルが完成しました！"
+- **AND** the overlay SHALL display a secondary message: "自由にタイムテーブルを触ってみよう"
+- **AND** the overlay SHALL play confetti/particle animation
+
+#### Scenario: Celebration dismissed by tap
+
+- **WHEN** the user taps anywhere on the Celebration Overlay
+- **THEN** the overlay SHALL fade out over 400ms
+- **AND** blocker divs SHALL be deactivated
+- **AND** scroll lock SHALL be released
+- **AND** the user SHALL enter free exploration mode on the Dashboard
+
+#### Scenario: Celebration MUST NOT appear before lane intro
+
+- **WHEN** the Dashboard page loads during onboarding at step DASHBOARD
+- **THEN** the system SHALL NOT set `showCelebration = true` in `loading()`
+- **AND** the system SHALL start the lane intro sequence first
+- **AND** `showCelebration` SHALL only become `true` after `completeLaneIntro()` is called
+
+#### Scenario: Celebration does not replay
+
+- **WHEN** the user has already seen the Celebration Overlay during this onboarding session
+- **AND** the user returns to the Dashboard
+- **THEN** the system SHALL NOT display the Celebration Overlay again
+
+#### Scenario: Reduced motion preference
+
+- **WHEN** the user has `prefers-reduced-motion: reduce` enabled
+- **THEN** the confetti/particle animation SHALL be skipped
+- **AND** the overlay SHALL appear instantly and remain until tapped
+- **AND** the overlay SHALL disappear instantly (no fade) on tap

--- a/openspec/changes/fix-onboarding-dashboard-bugs/specs/onboarding-page-help/spec.md
+++ b/openspec/changes/fix-onboarding-dashboard-bugs/specs/onboarding-page-help/spec.md
@@ -1,0 +1,42 @@
+## MODIFIED Requirements
+
+### Requirement: Auto-open on First Page Visit
+
+The system SHALL automatically open the help bottom-sheet on the user's first visit to Discovery and My Artists pages during onboarding. The Dashboard page SHALL NOT auto-open the help sheet.
+
+#### Scenario: First visit to Discovery during onboarding
+
+- **WHEN** the user arrives at the Discovery page for the first time during onboarding
+- **AND** `localStorage['liverty:onboarding:helpSeen:discovery']` is not set
+- **THEN** the help bottom-sheet SHALL open automatically
+- **AND** the system SHALL set `localStorage['liverty:onboarding:helpSeen:discovery']` to `'1'`
+
+#### Scenario: First visit to My Artists during onboarding
+
+- **WHEN** the user arrives at the My Artists page for the first time during onboarding
+- **AND** `localStorage['liverty:onboarding:helpSeen:my-artists']` is not set
+- **THEN** the help bottom-sheet SHALL open automatically
+- **AND** the system SHALL set `localStorage['liverty:onboarding:helpSeen:my-artists']` to `'1'`
+
+#### Scenario: Dashboard does NOT auto-open
+
+- **WHEN** the user arrives at the Dashboard page during onboarding
+- **THEN** the help bottom-sheet SHALL NOT open automatically
+- **AND** the user MAY open it manually by tapping the `?` icon
+
+#### Scenario: Subsequent visits do not auto-open
+
+- **WHEN** the user visits a page where `localStorage['liverty:onboarding:helpSeen:<page>']` is already set
+- **THEN** the help bottom-sheet SHALL NOT open automatically
+- **AND** the user MAY open it manually by tapping the `?` icon
+
+### Requirement: Persistent Help Icon in Onboarding Pages
+
+The system SHALL display a persistent `?` help icon in the top-right area of the Discovery, Dashboard, and My Artists pages during onboarding. The icon SHALL be placed inside a `<page-header>` component on all pages.
+
+#### Scenario: Help icon is always visible
+
+- **WHEN** the user is on the Discovery, Dashboard, or My Artists page during onboarding
+- **THEN** a `?` icon button SHALL be visible in the top-right corner of the page header
+- **AND** the button SHALL have `aria-label="ヘルプを表示"` for accessibility
+- **AND** the `<page-help>` component SHALL be placed inside the `<page-header>` `<au-slot>` on all pages

--- a/openspec/changes/fix-onboarding-dashboard-bugs/tasks.md
+++ b/openspec/changes/fix-onboarding-dashboard-bugs/tasks.md
@@ -1,0 +1,31 @@
+## 1. Regression Tests (test-first)
+
+- [x] 1.1 Add unit test: `PageHelp.attached()` auto-opens for discovery/my-artists
+- [x] 1.2 Add unit test: `PageHelp.attached()` does NOT auto-open for dashboard
+- [x] 1.3 Add unit test: `DashboardRoute.loading()` does NOT set `showCelebration=true` prematurely
+- [x] 1.4 Add unit test: `DashboardRoute.attached()` calls `startLaneIntro()` when step is DASHBOARD (not blocked by celebration)
+- [x] 1.5 Add unit test: `completeLaneIntro()` sets `showCelebration=true` after AWAY phase
+- [x] 1.6 Run tests to confirm they fail against current code
+
+## 2. Fix PageHelp auto-open
+
+- [x] 2.1 Add auto-open allowlist (`['discovery', 'my-artists']`) to `PageHelp.attached()` — dashboard excluded
+- [x] 2.2 Update tests to reflect allowlist approach (no `suppress` bindable)
+
+## 3. Fix Dashboard orchestration order
+
+- [x] 3.1 Remove `showCelebration = true` from `loading()` — celebration is set only by `completeLaneIntro()`
+- [x] 3.2 Update `attached()` to always call `startLaneIntro()` when step is DASHBOARD (remove `!showCelebration` guard)
+- [x] 3.3 Move `celebrationShown = true` from `loading()` to `completeLaneIntro()`
+- [x] 3.4 Verify `onCelebrationDismissed()` does not need changes
+
+## 4. Unify page-help placement inside `<page-header>`
+
+- [x] 4.1 Add `<page-header>` + `<page-help>` to dashboard-route.html (inside header, before stage-header)
+- [x] 4.2 Add `<page-header>` + `<page-help>` to discovery-route.html (above search bar)
+- [x] 4.3 Verify my-artists already correct — no changes needed
+
+## 5. Verify all fixes
+
+- [x] 5.1 Run `make check` to confirm all regression tests pass (829 tests, 0 failures)
+- [x] 5.2 Run `make lint` to confirm no linting issues (pre-existing `lint-no-div-role-status` in celebration-overlay only)


### PR DESCRIPTION
## Summary

- Add OpenSpec change artifacts for `fix-onboarding-dashboard-bugs`: proposal, design, spec deltas (onboarding-page-help, onboarding-celebration, dashboard-lane-introduction), and completed tasks
- Implementation: liverty-music/frontend#299 (merged)

close: #296

## Test plan

- [ ] No proto changes — buf lint/breaking not affected
