### PR TITLE
docs(openspec): add refine-consumer-shutdown change artifacts

### DIFF
--- a/openspec/changes/refine-consumer-shutdown/.openspec.yaml
+++ b/openspec/changes/refine-consumer-shutdown/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-26

--- a/openspec/changes/refine-consumer-shutdown/design.md
+++ b/openspec/changes/refine-consumer-shutdown/design.md
@@ -1,0 +1,113 @@
+## Context
+
+The backend has four entry points sharing a common `pkg/shutdown` package that orchestrates five-phase teardown (Drain → Flush → External → Observe → Datastore). The API server is well-integrated: its `ConnectServer` is registered in Drain phase, ensuring in-flight requests complete before downstream resources close.
+
+The consumer and CronJob entry points have gaps in this integration, identified through code analysis:
+
+1. **Consumer**: Watermill `Router.Run(ctx)` reacts to context cancellation asynchronously. On SIGTERM, `<-ctx.Done()` fires in the `select`, `run()` returns immediately, and `defer shutdown.Shutdown()` begins closing publisher/DB while the Router is still draining in-flight message handlers.
+2. **Consumer**: HealthServer goroutine starts before DI, but is only registered in shutdown after DI succeeds. DI failure leaks the goroutine.
+3. **All entry points**: `defer` block accesses `app.ShutdownTimeout` — a nil dereference when DI fails and `app` is nil.
+
+### Watermill Router Close Semantics
+
+Key findings from Watermill v1.5.1 source analysis:
+
+- `Router.Close()` is idempotent (guarded by `r.closed` bool + mutex)
+- `Router.Run(ctx)` spawns a watcher that calls `Close()` on context cancellation
+- `Run()` blocks until `Close()` completes (waits on `closedCh`)
+- `Close()` calls `waitForHandlers()` which waits for all `runningHandlersWg` to drain
+- Each handler closes its own subscriber and publisher on shutdown — but `AddNoPublisherHandler` (used by all consumer handlers via `AddConsumerHandler`) has no publisher to close
+- The top-level publisher (registered in Flush phase) is **not** closed by Router
+
+## Goals / Non-Goals
+
+**Goals:**
+- Ensure consumer shutdown phases execute only after all in-flight message handlers complete
+- Prevent HealthServer goroutine leak on DI failure
+- Prevent nil-pointer panic on DI failure across all entry points
+- Maintain the existing phased shutdown contract (Drain → Flush → External → Observe → Datastore)
+
+**Non-Goals:**
+- Refactoring the shutdown package itself (global registry, `sync.Once` pattern)
+- Adding shutdown integration tests (separate effort)
+- Changing AckAsync behavior (existing ack semantics are correct for throughput)
+- Modifying CronJob loop interruption patterns (already correct)
+
+## Decisions
+
+### D1: Wait for Router completion before shutdown phases
+
+**Approach**: Restructure `cmd/consumer/main.go` so that `Router.Run(ctx)` completion is awaited **before** `shutdown.Shutdown()` runs.
+
+Current flow (broken):
+```
+SIGTERM
+  → ctx cancelled
+  → select picks <-ctx.Done() immediately
+  → return nil → defer shutdown.Shutdown() starts
+  → Router still closing in background (race!)
+```
+
+New flow:
+```
+SIGTERM
+  → ctx cancelled
+  → select picks <-ctx.Done()
+  → log shutdown signal
+  → wait for Router.Run() to return via <-errChan  ← NEW
+  → return nil → defer shutdown.Shutdown() starts
+  → all handlers already drained, safe to close publisher/DB
+```
+
+Concretely, after `<-ctx.Done()` fires, we drain `errChan` to ensure `Router.Run()` has fully returned (and internally completed `Close()`). This mirrors the API server's pattern where `ConnectServer.Shutdown()` in Drain phase waits for in-flight requests.
+
+**Why not register Router in Drain phase?** While `Router.Close()` is idempotent and the second call would block until the first completes, it creates a subtle dependency: shutdown correctness depends on the Watermill internal mutex behavior. Waiting for `Run()` to return is explicit, easier to reason about, and doesn't couple shutdown phases to library internals.
+
+### D2: Defer HealthServer close unconditionally
+
+**Approach**: Add `defer healthSrv.Close()` immediately after starting the goroutine, before DI initialization. This ensures cleanup on any exit path.
+
+```go
+healthSrv := server.NewHealthServer(":8081")
+go func() { ... healthSrv.Start() ... }()
+defer healthSrv.Close()  // ← always runs, even on DI failure
+
+app, err := di.InitializeConsumerApp(ctx)
+// ...
+shutdown.AddDrainPhase(healthSrv)  // Drain phase calls Close() again — idempotent
+```
+
+`HealthServer.Close()` calls `http.Server.Shutdown()`, which is safe to call multiple times. The Drain phase registration still works because Shutdown is idempotent — the second call returns immediately.
+
+### D3: Guard against nil app in defer across all entry points
+
+**Approach**: Use a fallback timeout constant when `app` is nil.
+
+```go
+const fallbackShutdownTimeout = 10 * time.Second
+
+defer func() {
+    timeout := fallbackShutdownTimeout
+    if app != nil {
+        timeout = app.ShutdownTimeout
+    }
+    ctx, cancel := context.WithTimeout(context.Background(), timeout)
+    defer cancel()
+    if err := shutdown.Shutdown(ctx); err != nil {
+        // Use bootLogger since app.Logger may also be nil
+        bootLogger.Error(context.Background(), "error during shutdown", err)
+    }
+}()
+```
+
+This applies to all four entry points: `cmd/api/main.go`, `cmd/consumer/main.go`, `cmd/job/concert-discovery/main.go`, `cmd/job/artist-image-sync/main.go`.
+
+**Why not skip shutdown entirely when app is nil?** Because partial DI initialization may have already opened resources (e.g., DB connection created before a later step fails). `shutdown.Shutdown()` with no registered closers is a no-op, so calling it is always safe.
+
+## Risks / Trade-offs
+
+**[Risk] Router.Run() hangs indefinitely** → Mitigated by Watermill's `CloseTimeout` config (defaults to 0 = no timeout). If a handler blocks forever, the consumer process would be SIGKILLed by K8s after `terminationGracePeriodSeconds`. Consider setting `RouterConfig.CloseTimeout` to align with the K8s budget in a follow-up.
+
+**[Risk] Double-close of HealthServer** → `http.Server.Shutdown()` is documented as safe to call on an already-shut-down server. The defer close and Drain phase close are both safe.
+
+**[Trade-off] Fallback timeout is a hardcoded constant** → Acceptable because the DI-failure path is an error recovery scenario where config is unavailable. 10s is generous for closing partially-initialized resources.

--- a/openspec/changes/refine-consumer-shutdown/proposal.md
+++ b/openspec/changes/refine-consumer-shutdown/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+The API server has a robust graceful shutdown via the `shutdown` package with phased teardown, but the event consumer and CronJob entry points have gaps that can cause message loss, resource leaks, and panics during termination. These issues are latent — they only manifest under SIGTERM timing pressure on Kubernetes — making them hard to detect in normal operation but critical for production reliability.
+
+## What Changes
+
+- **Fix Router/shutdown race in consumer**: The Watermill Router is not registered in any shutdown phase. On SIGTERM, `Router.Run(ctx)` begins closing asynchronously while `shutdown.Shutdown()` proceeds to close the publisher and database in parallel. This creates a race where in-flight handlers may fail DB writes or lose acks (especially with `AckAsync: true`). The Router will be integrated into the Drain phase so it fully stops before downstream resources are closed.
+- **Fix HealthServer leak on DI failure**: The consumer starts a HealthServer goroutine before DI initialization. If DI fails, the HealthServer is never registered in shutdown and its goroutine leaks. A deferred close will be added immediately after starting the server.
+- **Fix nil-pointer panic on DI failure in all entry points**: When DI fails, `run()` returns an error but the deferred `shutdown.Shutdown()` accesses `app.ShutdownTimeout` — a nil dereference. All four entry points (api, consumer, concert-discovery, artist-image-sync) will be guarded against this.
+
+## Capabilities
+
+### New Capabilities
+
+(none — this is an infrastructure reliability fix)
+
+### Modified Capabilities
+
+(none — no spec-level behavior changes, only shutdown implementation)
+
+## Impact
+
+- **Backend entry points**: `cmd/api/main.go`, `cmd/consumer/main.go`, `cmd/job/concert-discovery/main.go`, `cmd/job/artist-image-sync/main.go`
+- **DI wiring**: `internal/di/consumer.go` (Router registration in Drain phase)
+- **Risk**: Low — changes are isolated to startup/shutdown paths and do not affect request handling or business logic
+- **Testing**: Existing unit tests + manual SIGTERM verification on local Docker

--- a/openspec/changes/refine-consumer-shutdown/specs/event-management/spec.md
+++ b/openspec/changes/refine-consumer-shutdown/specs/event-management/spec.md
@@ -1,0 +1,33 @@
+## ADDED Requirements
+
+### Requirement: Graceful shutdown ordering for event consumer
+
+The event consumer process SHALL complete all in-flight message handlers before closing downstream resources (publisher, database). The shutdown sequence SHALL follow the order: stop accepting new messages → drain in-flight handlers → flush publisher → close external clients → flush telemetry → close datastore.
+
+#### Scenario: SIGTERM during message processing
+- **WHEN** the consumer receives SIGTERM while handlers are processing messages
+- **THEN** the consumer SHALL wait for all in-flight handlers to complete before closing the publisher or database connection
+- **AND** successfully processed messages SHALL be acknowledged to the message broker
+
+#### Scenario: SIGTERM with no in-flight messages
+- **WHEN** the consumer receives SIGTERM with no messages being processed
+- **THEN** the consumer SHALL proceed through all shutdown phases and exit with code 0
+
+### Requirement: Consumer health server lifecycle independence
+
+The consumer health server SHALL be cleaned up on all exit paths, including DI initialization failure.
+
+#### Scenario: DI initialization failure
+- **WHEN** the consumer health server starts but DI initialization subsequently fails
+- **THEN** the health server SHALL be gracefully shut down before the process exits
+- **AND** the health server port SHALL be released
+
+### Requirement: Nil-safe shutdown on initialization failure
+
+All entry points (API server, event consumer, CronJobs) SHALL execute the shutdown sequence without panicking, even when application initialization fails partway through.
+
+#### Scenario: DI failure with partial resource initialization
+- **WHEN** DI initialization fails after some resources (e.g., database connection) have been created
+- **THEN** the shutdown sequence SHALL execute with a fallback timeout
+- **AND** the process SHALL NOT panic due to nil application references
+- **AND** any partially-initialized resources registered in the shutdown manager SHALL be closed

--- a/openspec/changes/refine-consumer-shutdown/tasks.md
+++ b/openspec/changes/refine-consumer-shutdown/tasks.md
@@ -1,0 +1,21 @@
+## 1. Consumer shutdown ordering (D1)
+
+- [x] 1.1 Refactor `cmd/consumer/main.go`: after `<-ctx.Done()`, drain `errChan` to wait for `Router.Run()` to complete before returning (ensures all in-flight handlers finish before shutdown phases execute)
+- [x] 1.2 Verify `Router.Run()` returns cleanly on context cancellation by reviewing the select/errChan interaction — ensure no goroutine leak or deadlock
+
+## 2. HealthServer lifecycle fix (D2)
+
+- [x] 2.1 Add `defer healthSrv.Close()` in `cmd/consumer/main.go` immediately after the `go healthSrv.Start()` goroutine, before DI initialization
+- [x] 2.2 Verify double-close safety: Drain phase calls `Close()` again via `shutdown.AddDrainPhase(healthSrv)` — confirm `http.Server.Shutdown()` is idempotent
+
+## 3. Nil-safe shutdown across all entry points (D3)
+
+- [x] 3.1 Add `fallbackShutdownTimeout` constant and nil-guard for `app` in `cmd/consumer/main.go` defer block; use `bootLogger` instead of `app.Logger` on the error path
+- [x] 3.2 Apply same nil-guard pattern to `cmd/api/main.go`
+- [x] 3.3 Apply same nil-guard pattern to `cmd/job/concert-discovery/main.go`
+- [x] 3.4 Apply same nil-guard pattern to `cmd/job/artist-image-sync/main.go`
+
+## 4. Validation
+
+- [x] 4.1 Run `make check` in backend repo to ensure all linting and tests pass
+- [x] 4.2 Manual smoke test: start consumer locally, send SIGTERM, verify shutdown log output shows phased teardown in correct order


### PR DESCRIPTION
## Summary

- Add OpenSpec change artifacts for `refine-consumer-shutdown`: proposal, design, specs (event-management delta), and implementation tasks
- Documents fixes for consumer/job graceful shutdown reliability: router/shutdown phase race, health server lifecycle, nil-safe shutdown on DI failure

## Test plan

- [x] Artifacts follow OpenSpec schema structure
- [x] Implementation completed in liverty-music/backend#264