### PR TITLE
docs(openspec): add refine-frontend-testing change artifacts

### DIFF
--- a/openspec/changes/refine-frontend-testing/.openspec.yaml
+++ b/openspec/changes/refine-frontend-testing/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-26

--- a/openspec/changes/refine-frontend-testing/design.md
+++ b/openspec/changes/refine-frontend-testing/design.md
@@ -1,0 +1,343 @@
+## Context
+
+The frontend test suite was built with a "DI Unit tests as PRIMARY" strategy documented in `docs/testing-strategy.md`. This served the team well for rapid initial coverage, achieving ~55% statement coverage. However, a thorough review of the [Aurelia 2 official testing documentation](https://docs.aurelia.io/developer-guides/overview) reveals that the framework provides a rich integration testing API via `@aurelia/testing` that the project underutilizes.
+
+**Current state:**
+- 58+ unit test files, mostly DI container + method invocation pattern
+- `createFixture` used only in 1 smoke test file with tautological assertions (`expect(true).toBe(true)`)
+- `@aurelia/testing` provides 20+ fixture helper methods (assertText, trigger.click, getBy, etc.) — none actively used
+- `auth-service.ts` excluded from coverage due to module-level `window.location` access
+- Dead vitest config pattern (`src/*-page.ts`) matches no files
+- Template binding bugs (typos, broken expressions) only caught at E2E layer
+
+**Audit findings (infrastructure bugs):**
+- `test/setup.ts:50` — `forEach(async)` pattern silently breaks fixture cleanup (Promises not awaited)
+- `test/smoke/component-compile.spec.ts` — uses deprecated `tearDown()` instead of `stop(true)`
+- 2 test files missing `localStorage.clear()` in `afterEach` (state pollution between tests)
+- 5 test files have `vi.useRealTimers()` inside `it()` blocks instead of `afterEach` (timer state leak)
+- 3 mock helpers lack proper return types (untyped `any` instead of `Partial<IInterface>`)
+- `auth-service.spec.ts` accesses private members via `@ts-expect-error` instead of testing public API
+- Only 6% of components (2/33) have any `createFixture` test; 30% (10/33) have no test at all
+
+**Aurelia 2 Official Testing Documentation** (all pages referenced in this design):
+
+| Page | URL | Relevance |
+|------|-----|-----------|
+| Testing Overview | [developer-guides/overview](https://docs.aurelia.io/developer-guides/overview) | Platform setup, TestContext, core concepts |
+| Getting Started | [developer-guides/overview (Testing section)](https://docs.aurelia.io/developer-guides/overview) | bootstrapTestEnvironment, configuration |
+| Testing Components | [developer-guides/overview/testing-components](https://docs.aurelia.io/developer-guides/overview/testing-components) | createFixture patterns, DOM assertions, event testing |
+| Testing Attributes | [developer-guides/overview/testing-attributes](https://docs.aurelia.io/developer-guides/overview/testing-attributes) | Custom attribute testing via createFixture |
+| Testing Value Converters | [developer-guides/overview/testing-value-converters](https://docs.aurelia.io/developer-guides/overview/testing-value-converters) | Unit + integration test combination |
+| Working with the Fluent API | [developer-guides/overview/fluent-api](https://docs.aurelia.io/developer-guides/overview/fluent-api) | Builder pattern for createFixture |
+| Stubs, Mocks & Spies | [developer-guides/overview/mocks-spies](https://docs.aurelia.io/developer-guides/overview/mocks-spies) | DI mocking via Registration, spy patterns |
+| Advanced Testing Techniques | [developer-guides/overview/advanced-testing](https://docs.aurelia.io/developer-guides/overview/advanced-testing) | Async patterns, lifecycle, accessibility, drag-and-drop |
+| Outcome Recipes | [developer-guides/overview/outcome-recipes](https://docs.aurelia.io/developer-guides/overview/outcome-recipes) | API calls, router, form validation, component interaction, lifecycle hooks, real-world dependencies |
+| Quick Reference | [developer-guides/overview (Testing section)](https://docs.aurelia.io/developer-guides/overview) | API cheat sheet, troubleshooting |
+| Decision Trees | [developer-guides/overview (Testing section)](https://docs.aurelia.io/developer-guides/overview) | When to use which test approach |
+
+## Goals / Non-Goals
+
+**Goals:**
+- Fix critical test infrastructure bugs (forEach+async cleanup, deprecated tearDown, localStorage pollution, timer state leak)
+- Align the testing strategy with Aurelia 2 official documentation by adopting `createFixture` as a co-primary test approach
+- Add component integration tests for critical-path components that verify template bindings and DOM interactions
+- Upgrade smoke tests to use meaningful fixture assertions instead of tautologies
+- Improve mock helper type safety to prevent runtime type errors
+- Make `auth-service.ts` testable by refactoring away module-level browser global access
+- Clean up dead vitest configuration
+- Update `docs/testing-strategy.md` to reflect the new approach
+- Incrementally raise coverage thresholds
+
+**Non-Goals:**
+- Replacing all existing DI Unit tests with fixture tests (DI Unit tests remain valid for pure logic)
+- Adding new E2E tests (existing Playwright coverage is sufficient)
+- Refactoring component source code beyond what's needed for testability
+- Achieving 100% coverage
+
+## Decisions
+
+### Decision 1: Elevate `createFixture` to co-primary status
+
+**Choice:** `createFixture` integration tests become the **default for components** that have templates; DI Unit tests remain the default for services and pure logic.
+
+**Rationale (per official docs):**
+- [Testing Components](https://docs.aurelia.io/developer-guides/overview/testing-components): "Aurelia 2 uses integration testing that covers both the view and view model together"
+- [Outcome Recipes](https://docs.aurelia.io/developer-guides/overview/outcome-recipes): All 6 recipes use `createFixture`, including router testing, form validation, lifecycle hooks, and component interaction
+- [Advanced Testing](https://docs.aurelia.io/developer-guides/overview/advanced-testing): Fixture API provides specialized validators for text, HTML, attributes, classes, styles, and form values
+
+**Updated decision flow:**
+
+```
+Is it a pure function with no dependencies?
+├── YES → Pure Unit Test
+│
+└── NO → Is it a component with a template?
+         ├── YES → Component Integration Test (createFixture)    ★ CHANGED
+         │         Use: assertText, trigger.click, getBy, type()
+         │         DI mocking via Registration.instance() in deps
+         │
+         └── NO → Is it a service, interceptor, or guard?
+                  ├── YES → DI Unit Test (createTestContainer)
+                  │
+                  └── NO → E2E Test (Playwright)
+```
+
+**Alternative considered:** Keep DI Unit as primary for all modules, add fixture tests only for specific binding-heavy components.
+**Why rejected:** The official documentation explicitly recommends view+view-model integration testing as the standard approach. Limiting fixture tests to "specific cases" would perpetuate the gap.
+
+### Decision 2: Use the Fluent Builder API for new fixture tests
+
+**Choice:** All new `createFixture` tests use the fluent builder pattern.
+
+**Rationale (per [Fluent API docs](https://docs.aurelia.io/developer-guides/overview/fluent-api)):**
+
+```typescript
+// PREFERRED: Fluent builder (better type inference, readable)
+const fixture = await createFixture
+  .component(BottomNavBar)
+  .html`<bottom-nav-bar></bottom-nav-bar>`
+  .deps(
+    Registration.instance(IRouter, mockRouter),
+    Registration.instance(IAuthService, mockAuth),
+  )
+  .build()
+  .started
+
+// LEGACY: Single call (still valid but less readable)
+const { appHost } = createFixture(
+  '<bottom-nav-bar></bottom-nav-bar>',
+  class App {},
+  [BottomNavBar, Registration.instance(IRouter, mockRouter)]
+)
+```
+
+Benefits per docs: "better TypeScript support with proper type inference for components" and "template interpolation with tagged template literals."
+
+### Decision 3: Adopt official fixture assertion helpers
+
+**Choice:** Use `IFixture` assertion methods instead of raw DOM queries.
+
+**Rationale (per [Testing Components](https://docs.aurelia.io/developer-guides/overview/testing-components) and [Advanced Testing](https://docs.aurelia.io/developer-guides/overview/advanced-testing)):**
+
+| Official API | Replaces | Benefit |
+|---|---|---|
+| `fixture.assertText('selector', 'text')` | `expect(el.textContent).toBe(...)` | Null-safe, whitespace handling |
+| `fixture.assertAttr('sel', 'name', 'val')` | `expect(el.getAttribute(...)).toBe(...)` | Focused error messages |
+| `fixture.assertClass('sel', 'active')` | `expect(el.classList.contains(...)).toBe(true)` | Multi-class support |
+| `fixture.assertValue('input', 'val')` | `expect((el as HTMLInputElement).value).toBe(...)` | Type-safe |
+| `fixture.getBy('selector')` | `appHost.querySelector(...)` | Throws if 0 or >1 match |
+| `fixture.queryBy('selector')` | `appHost.querySelector(...)` | Explicit null return |
+| `fixture.trigger.click('button')` | Manual event dispatch | Full event init support |
+| `fixture.type('input', 'text')` | Manual value set + dispatchEvent | Triggers binding update |
+
+### Decision 4: Use `tasksSettled()` for reactive updates
+
+**Choice:** After mutating component state, always `await tasksSettled()` before DOM assertions.
+
+**Rationale (per [Outcome Recipes](https://docs.aurelia.io/developer-guides/overview/outcome-recipes) and [Quick Reference](https://docs.aurelia.io/developer-guides/overview)):**
+
+```typescript
+// Official pattern for async state changes
+component.items.push('new item')
+await tasksSettled()  // Wait for Aurelia to process the change queue
+fixture.assertText('.count', '4')
+```
+
+This replaces ad-hoc `await new Promise(r => setTimeout(r, 0))` or missing sync waits.
+
+### Decision 5: Refactor auth-service.ts with lazy initialization
+
+**Choice:** Move `UserManagerSettings` construction from module scope to a lazy getter inside `AuthService`.
+
+**Rationale (per [Stubs, Mocks & Spies](https://docs.aurelia.io/developer-guides/overview/mocks-spies)):**
+The official docs show all dependencies resolved via `resolve()` at class instantiation time, not at module parse time. The current module-level `window.location.origin` access violates this pattern and prevents both testing and coverage.
+
+```typescript
+// BEFORE: Module-level (untestable)
+const settings: UserManagerSettings = {
+  redirect_uri: `${window.location.origin}/auth/callback`,  // runs at import
+}
+
+// AFTER: Lazy initialization (testable)
+export class AuthService {
+  private _userManager: UserManager | undefined
+
+  private get userManager(): UserManager {
+    if (!this._userManager) {
+      this._userManager = new UserManager({
+        redirect_uri: `${window.location.origin}/auth/callback`,
+        // ... other settings
+      })
+      this.subscribeToEvents()
+    }
+    return this._userManager
+  }
+}
+```
+
+**Alternative considered:** DI-inject a config object from `main.ts`.
+**Why rejected:** More invasive change with breaking API. Lazy init is minimal and keeps the same public surface.
+
+### Decision 6: Upgrade smoke tests with real assertions
+
+**Choice:** Replace `expect(true).toBe(true)` with meaningful fixture assertions.
+
+**Rationale (per [Testing Components](https://docs.aurelia.io/developer-guides/overview/testing-components)):**
+
+```typescript
+// BEFORE: Proves nothing
+const { tearDown } = await createFixture('<svg-icon name="home"></svg-icon>', {}, [...]).started
+expect(true).toBe(true)
+await tearDown()
+
+// AFTER: Proves template compiled AND rendered correctly
+const fixture = await createFixture
+  .component(class App { iconName = 'home' })
+  .html`<svg-icon name.bind="iconName"></svg-icon>`
+  .deps(SvgIcon, ...sharedRegistrations)
+  .build()
+  .started
+
+fixture.assertAttr('svg-icon', 'data-icon', 'home')
+await fixture.stop(true)
+```
+
+### Decision 7: Test lifecycle hooks via `.started` and `stop(true)`
+
+**Choice:** Use the official lifecycle testing pattern from [Outcome Recipes - Recipe 5](https://docs.aurelia.io/developer-guides/overview/outcome-recipes).
+
+**Rationale:**
+```typescript
+// Official pattern: .started waits for all async lifecycle hooks
+const fixture = await createFixture
+  .component(DashboardRoute)
+  .html`<dashboard-route></dashboard-route>`
+  .deps(Registration.instance(IDashboardService, mockService))
+  .build()
+  .started  // ← binding(), bound(), attaching(), attached() all complete
+
+// Verify attached() side effects
+expect(mockService.loadData).toHaveBeenCalledOnce()
+
+// stop(true) triggers detaching() + unbinding()
+await fixture.stop(true)
+expect(mockService.cleanup).toHaveBeenCalledOnce()
+```
+
+### Decision 8: Mock services via Registration.instance() in fixture deps
+
+**Choice:** Use `Registration.instance()` as the 3rd parameter (or via `.deps()`) per [Stubs, Mocks & Spies](https://docs.aurelia.io/developer-guides/overview/mocks-spies).
+
+**Rationale:** This is the official Aurelia DI mocking pattern. It works for both `@inject` decorator and `resolve()` function patterns:
+
+```typescript
+const mockApi = { fetchData: vi.fn().mockResolvedValue([1, 2, 3]) }
+
+const fixture = await createFixture
+  .component(MyComponent)
+  .html`<my-component></my-component>`
+  .deps(
+    MyComponent,
+    Registration.instance(IApiService, mockApi),
+    Registration.instance(IRouter, createMockRouter()),
+  )
+  .build()
+  .started
+```
+
+Existing `test/helpers/mock-*.ts` factories remain valid — they produce the mock objects passed to `Registration.instance()`.
+
+### Decision 9: Value converter tests combine unit + integration
+
+**Choice:** Per [Testing Value Converters](https://docs.aurelia.io/developer-guides/overview/testing-value-converters), keep existing pure unit tests AND add fixture-based integration tests.
+
+**Rationale:** "Good tests cover a range of scenarios" — unit tests verify converter logic; fixture tests verify the converter works within an Aurelia view pipeline (`${value | converter}`).
+
+### Decision 10: Custom attribute tests use createFixture with style assertions
+
+**Choice:** Per [Testing Attributes](https://docs.aurelia.io/developer-guides/overview/testing-attributes), test custom attributes by rendering them on host elements and verifying DOM mutations.
+
+**Rationale:** Custom attributes modify element behavior/styling. The official pattern creates a fixture with the attribute applied, then asserts style/class/attribute changes:
+
+```typescript
+const fixture = await createFixture
+  .component(class App { color = 'blue' })
+  .html`<div tile-color="color.bind: color"></div>`
+  .deps(TileColorCustomAttribute)
+  .build()
+  .started
+
+fixture.assertStyles('div', { '--tile-color': 'blue' })
+```
+
+### Decision 11: Fix forEach+async fixture cleanup in setup.ts
+
+**Choice:** Replace `fixtures.forEach(async (f) => ...)` with `for...of` loop inside an `async` afterEach.
+
+**Rationale (per [Testing Components](https://docs.aurelia.io/developer-guides/overview/testing-components) — "Always call `stop(true)` for cleanup"):**
+
+`Array.forEach` does not await async callbacks — the Promises fire but are never awaited. This means fixture teardown races with the next test's setup, causing cross-test contamination.
+
+```typescript
+// BEFORE: Promises not awaited (BUG)
+afterEach(() => {
+  fixtures.forEach(async (f) => {
+    try { await f.stop(true) } catch { /* ignore */ }
+  })
+  fixtures.length = 0  // ← clears before stop() completes
+})
+
+// AFTER: Sequential cleanup with proper await
+afterEach(async () => {
+  await Promise.all(fixtures.map(f => f.stop(true).catch(() => {})))
+  fixtures.length = 0
+})
+```
+
+### Decision 12: Enforce afterEach hygiene across all test files
+
+**Choice:** All test files SHALL follow these `afterEach` rules per [Quick Reference](https://docs.aurelia.io/developer-guides/overview):
+
+1. `vi.restoreAllMocks()` — in every test suite that uses spies
+2. `vi.useRealTimers()` — in every suite that uses `vi.useFakeTimers()`, never inside `it()` blocks
+3. `localStorage.clear()` — in every suite that reads/writes localStorage
+4. `fixture.stop(true)` — in every suite that creates fixtures (or handled by global setup.ts hook)
+
+**Rationale:** The audit found 5 files with `vi.useRealTimers()` inside `it()` blocks (timer state leaks to subsequent tests) and 2 files missing `localStorage.clear()` in `afterEach` (state pollution). Per the official docs' troubleshooting section, these cause "property update delays" and "cleanup failures."
+
+**Files to fix:**
+- `test/services/pwa-install-service.spec.ts` — add `localStorage.clear()` to afterEach
+- `test/components/notification-prompt.spec.ts` — add `localStorage.clear()` to afterEach
+- `test/routes/discovery-route.spec.ts` — move `vi.useRealTimers()` to afterEach
+- `test/routes/my-artists-route.spec.ts` — move `vi.useRealTimers()` to afterEach
+- `test/services/connect-error-router.spec.ts` — move `vi.useRealTimers()` to afterEach
+- `test/components/dna-orb-canvas.spec.ts` — move `vi.useRealTimers()` to afterEach
+- `test/value-converters/date.spec.ts` — move `vi.useRealTimers()` to afterEach
+
+### Decision 13: Type-safe mock helpers
+
+**Choice:** All mock factories SHALL return `Partial<IInterface>` with explicit return types per [Stubs, Mocks & Spies](https://docs.aurelia.io/developer-guides/overview/mocks-spies).
+
+**Rationale:** Three mock helpers currently return untyped objects:
+- `mock-i18n.ts` — returns implicit `any`, should return `Partial<I18N>`
+- `mock-toast.ts` — returns implicit `any`, should return `Partial<IEventAggregator>` or typed toast interface
+- `mock-error-boundary.ts` — `currentError`/`errorHistory` are plain values instead of properly typed
+
+Untyped mocks silently allow incorrect mock shapes to pass TypeScript compilation, leading to runtime failures that are hard to debug.
+
+## Risks / Trade-offs
+
+### [Risk] Fixture tests are slower than DI Unit tests
+**Mitigation:** Only add fixture tests for components that benefit from template verification. Services and pure logic remain as DI Unit tests. The official docs note that `createFixture` creates an isolated mini-Aurelia context — it's lightweight compared to full app bootstrap.
+
+### [Risk] `auth-service.ts` lazy init could change timing behavior
+**Mitigation:** The `AuthService` is a singleton registered at app startup. The `ready` Promise already gates all consumers. Lazy init simply moves `UserManager` creation from module parse to first property access — consumers already await `ready` before using the service.
+
+### [Risk] Existing DI Unit tests may become redundant with fixture tests
+**Mitigation:** We explicitly do NOT replace existing passing tests. New fixture tests are additive, focusing on template binding verification that DI Unit tests cannot cover.
+
+### [Risk] JSDOM limitations may cause fixture test failures
+**Mitigation:** Some APIs (Canvas, `popover`, `showModal`) are not available in JSDOM. For components requiring these, retain the DI Unit test pattern with mocked `INode`. The [Advanced Testing](https://docs.aurelia.io/developer-guides/overview/advanced-testing) docs note that JSDOM is the standard environment; components with canvas dependencies are appropriately excluded.
+
+### [Trade-off] Two test patterns coexist
+**Accepted:** DI Unit tests for services/interceptors/guards + `createFixture` tests for components with templates. This is exactly the split the official docs recommend — each pattern serves a distinct purpose.

--- a/openspec/changes/refine-frontend-testing/proposal.md
+++ b/openspec/changes/refine-frontend-testing/proposal.md
@@ -1,0 +1,37 @@
+## Why
+
+The frontend test suite relies almost exclusively on DI Unit tests (`createTestContainer` + method calls), leaving `@aurelia/testing`'s `createFixture` API largely unused. The Aurelia 2 official documentation recommends integration tests that verify view and view-model together via `createFixture`, with rich DOM assertion helpers (`assertText`, `assertAttr`, `trigger.click`, `getBy`, etc.). This gap means template binding bugs (typos in `.bind` expressions, broken `if.bind`/`repeat.for`, missing event wiring) can only be caught at the E2E layer, which is slow and flaky.
+
+A comprehensive audit of existing tests revealed additional issues: a critical `forEach(async)` bug in the global test setup that silently breaks fixture cleanup, deprecated `tearDown()` calls instead of `stop(true)`, localStorage pollution between tests, `vi.useRealTimers()` placed inside `it()` blocks instead of `afterEach`, and untyped mock helpers. These issues compound the risk of flaky tests and reduce reliability as the test suite grows. Additionally, `auth-service.ts` is excluded from coverage due to module-level `window.location` access, and a dead vitest config pattern (`src/*-page.ts`) creates confusion.
+
+## What Changes
+
+- **Fix critical test infrastructure bugs**: `forEach(async)` in `test/setup.ts` that silently breaks fixture cleanup; deprecated `tearDown()` → `stop(true)`
+- **Adopt `createFixture`-based component integration tests** for critical-path components, using the official Aurelia testing patterns (fluent builder API, `assertText`, `trigger.click`, `tasksSettled()`)
+- **Upgrade smoke tests** from tautological `expect(true).toBe(true)` to meaningful DOM assertions
+- **Fix test isolation issues**: Add missing `localStorage.clear()` in `afterEach` (pwa-install-service, notification-prompt); move `vi.useRealTimers()` from `it()` blocks to `afterEach` (5 files)
+- **Improve mock helper type safety**: Add proper return types to `mock-i18n.ts`, `mock-toast.ts`, `mock-error-boundary.ts`
+- **Refactor `auth-service.ts`** to lazy-initialize `UserManager`, eliminating module-level `window.location` access and enabling coverage inclusion
+- **Remove dead vitest config** (`src/*-page.ts` exclusion pattern that matches no files)
+- **Update `docs/testing-strategy.md`** to align with Aurelia 2 official testing documentation, elevating `createFixture` from "template binding only" to a co-primary testing approach alongside DI Unit tests
+- **Add missing component tests** for untested critical-path components (welcome-route, bottom-nav-bar, snack-bar, user-home-selector, post-signup-dialog, error-banner, settings-route, import-ticket-email-route)
+- **Raise coverage thresholds** incrementally as new tests land (55% -> 65% target)
+
+## Capabilities
+
+### New Capabilities
+
+_(none — this change refines an existing capability)_
+
+### Modified Capabilities
+
+- `frontend-testing`: Fix test infrastructure bugs (forEach+async cleanup, deprecated tearDown, localStorage pollution, timer leak); elevate `createFixture` integration tests to co-primary status; add coverage for untested critical-path components; improve mock type safety; remove dead config; refactor auth-service for testability; align testing strategy with Aurelia 2 official documentation
+
+## Impact
+
+- **frontend repo**: `test/setup.ts` (critical cleanup fix); test files in `test/`, `test/helpers/`, `test/smoke/`; `src/services/auth-service.ts` (lazy init refactor); `vitest.config.ts` (remove dead pattern, raise thresholds); `docs/testing-strategy.md` (strategy update)
+- **Existing test files modified**: 7+ files for afterEach fixes (localStorage, timer cleanup, deprecated API replacement)
+- **Mock helpers**: 3 files updated for type safety (`mock-i18n.ts`, `mock-toast.ts`, `mock-error-boundary.ts`)
+- **No API or dependency changes**: All changes are internal to the frontend repo
+- **No breaking changes**: Existing DI Unit tests remain as-is; fixture tests are additive; infrastructure fixes only correct silent bugs
+- **CI**: Coverage thresholds will increase, requiring new tests to maintain green builds

--- a/openspec/changes/refine-frontend-testing/specs/frontend-testing/spec.md
+++ b/openspec/changes/refine-frontend-testing/specs/frontend-testing/spec.md
@@ -1,0 +1,260 @@
+## ADDED Requirements
+
+### Requirement: Global fixture cleanup awaits all stop() calls
+The `test/setup.ts` afterEach hook SHALL properly await fixture cleanup using `Promise.all` instead of `forEach(async)`.
+
+#### Scenario: Fixture cleanup completes before next test
+- **WHEN** a test creates one or more fixtures via `createFixture`
+- **THEN** the global `afterEach` hook SHALL await `Promise.all(fixtures.map(f => f.stop(true).catch(() => {})))` before clearing the fixtures array
+
+#### Scenario: Cleanup errors do not fail the test
+- **WHEN** a fixture's `stop(true)` throws an error during cleanup
+- **THEN** the error SHALL be caught silently and other fixtures SHALL still be cleaned up
+
+### Requirement: All afterEach hooks prevent test state pollution
+All test suites SHALL include proper cleanup in `afterEach` to prevent state leaking between tests.
+
+#### Scenario: localStorage is cleared after tests that use it
+- **WHEN** a test suite reads or writes `localStorage`
+- **THEN** `localStorage.clear()` SHALL be called in `afterEach`
+
+#### Scenario: Fake timers are restored in afterEach, not inside it()
+- **WHEN** a test suite uses `vi.useFakeTimers()`
+- **THEN** `vi.useRealTimers()` SHALL be called in `afterEach`, never inside individual `it()` blocks
+
+#### Scenario: Mock spies are restored in afterEach
+- **WHEN** a test suite creates mock spies
+- **THEN** `vi.restoreAllMocks()` SHALL be called in `afterEach`
+
+### Requirement: Mock helpers return typed Partial interfaces
+All mock factory functions in `test/helpers/mock-*.ts` SHALL return explicitly typed `Partial<IInterface>` with all method properties as `vi.fn()` spies.
+
+#### Scenario: mock-i18n returns typed interface
+- **WHEN** `createMockI18n()` is called
+- **THEN** it SHALL return `Partial<I18N>` with explicit return type annotation
+
+#### Scenario: mock-toast returns typed interface
+- **WHEN** `createMockToast()` is called
+- **THEN** it SHALL return a properly typed mock with explicit return type annotation
+
+#### Scenario: mock-error-boundary has all properties as spies or typed values
+- **WHEN** `createMockErrorBoundary()` is called
+- **THEN** `currentError` and `errorHistory` SHALL be properly typed (not plain `null`/`[]` without type context)
+
+### Requirement: No deprecated Aurelia testing APIs are used
+All test files SHALL use `stop(true)` instead of the deprecated `tearDown()` method.
+
+#### Scenario: Smoke tests use stop(true)
+- **WHEN** `test/smoke/component-compile.spec.ts` cleans up fixtures
+- **THEN** it SHALL call `stop(true)` instead of `tearDown()`
+
+#### Scenario: No tearDown() calls exist in the codebase
+- **WHEN** the test codebase is searched for `tearDown`
+- **THEN** zero usages SHALL be found (excluding comments and type imports)
+
+### Requirement: Component integration tests use createFixture with official assertion helpers
+All component integration tests SHALL use `createFixture` (fluent builder API) from `@aurelia/testing` and verify DOM output using the official fixture assertion methods (`assertText`, `assertAttr`, `assertClass`, `assertValue`, `getBy`, `queryBy`, `trigger.click`, `type`).
+
+#### Scenario: Fixture test verifies template binding
+- **WHEN** a component integration test is created for a component with bindable properties
+- **THEN** the test SHALL use `createFixture.component(X).html(Y).deps(Z).build().started` and verify rendered output with `fixture.assertText()` or `fixture.assertAttr()`
+
+#### Scenario: Fixture test uses trigger for user interaction
+- **WHEN** a component integration test verifies click or keyboard interaction
+- **THEN** the test SHALL use `fixture.trigger.click(selector)` or `fixture.trigger.keydown(selector, init)` instead of manually dispatching events
+
+#### Scenario: Fixture test uses type() for input simulation
+- **WHEN** a component integration test verifies text input binding
+- **THEN** the test SHALL use `fixture.type(selector, value)` which sets the value and dispatches an input event to trigger two-way binding
+
+#### Scenario: Fixture test awaits tasksSettled() after state mutation
+- **WHEN** a test mutates component state and then asserts DOM output
+- **THEN** the test SHALL call `await tasksSettled()` between the mutation and the assertion
+
+#### Scenario: Fixture test uses stop(true) for cleanup
+- **WHEN** a component integration test completes
+- **THEN** the test SHALL call `await fixture.stop(true)` (not the deprecated `tearDown()`) for proper cleanup
+
+### Requirement: Smoke tests use meaningful DOM assertions
+Smoke tests in `test/smoke/component-compile.spec.ts` SHALL replace tautological assertions with meaningful DOM verification using fixture assertion methods.
+
+#### Scenario: Smoke test verifies rendered element exists
+- **WHEN** a smoke test renders a component via `createFixture`
+- **THEN** it SHALL verify the component's root element exists using `fixture.getBy()` or `fixture.queryBy()` instead of `expect(true).toBe(true)`
+
+#### Scenario: Smoke test verifies basic attribute or text content
+- **WHEN** a smoke test renders a component with known default state
+- **THEN** it SHALL verify at least one meaningful attribute or text content using `fixture.assertAttr()` or `fixture.assertText()`
+
+### Requirement: Bottom nav bar has component integration tests
+The `BottomNavBar` component SHALL have integration tests verifying navigation item rendering and active state.
+
+#### Scenario: Nav items render for all routes
+- **WHEN** `BottomNavBar` is rendered via `createFixture`
+- **THEN** the DOM SHALL contain navigation items for all configured routes
+
+#### Scenario: Active route is highlighted
+- **WHEN** the router reports the current path as `/dashboard`
+- **THEN** the dashboard nav item SHALL have the active CSS class
+
+### Requirement: Snack bar has component integration tests
+The `SnackBar` component SHALL have integration tests verifying toast message display, auto-dismiss, and action callbacks.
+
+#### Scenario: Toast message is displayed
+- **WHEN** a toast message is triggered
+- **THEN** the snack bar DOM SHALL contain the message text
+
+#### Scenario: Auto-dismiss removes toast after duration
+- **WHEN** a toast with a configured duration is shown and the duration elapses (using fake timers)
+- **THEN** the toast element SHALL be removed from the DOM
+
+#### Scenario: Action callback is invoked on click
+- **WHEN** a toast with an action button is shown and the user clicks the action
+- **THEN** the action callback SHALL be invoked
+
+### Requirement: User home selector has component integration tests
+The `UserHomeSelector` component SHALL have integration tests verifying region/prefecture selection and persistence.
+
+#### Scenario: Region options are rendered
+- **WHEN** the selector is rendered
+- **THEN** the DOM SHALL contain selectable region options
+
+#### Scenario: Selection persists via service call
+- **WHEN** a user selects a region and prefecture
+- **THEN** the component SHALL call the user service to persist the selection
+
+### Requirement: Post-signup dialog has component integration tests
+The `PostSignupDialog` component SHALL have integration tests verifying the multi-step post-signup flow.
+
+#### Scenario: Dialog renders notification prompt step
+- **WHEN** the dialog is opened after signup
+- **THEN** the DOM SHALL display the notification permission prompt
+
+#### Scenario: Dialog advances to PWA install step
+- **WHEN** the user completes the notification step
+- **THEN** the dialog SHALL advance to the PWA install prompt step
+
+### Requirement: Error banner has component integration tests
+The `ErrorBanner` component SHALL have integration tests verifying error display, GitHub issue URL, and dismiss behavior.
+
+#### Scenario: Error message is displayed
+- **WHEN** the error boundary service has a current error
+- **THEN** the banner DOM SHALL display the error message
+
+#### Scenario: Dismiss clears the error
+- **WHEN** the user clicks the dismiss button
+- **THEN** the error boundary service's `dismiss()` method SHALL be called
+
+### Requirement: Settings route has component integration tests
+The `SettingsRoute` component SHALL have integration tests verifying conditional section rendering and language selection.
+
+#### Scenario: Language options are rendered via repeat.for
+- **WHEN** the settings route is rendered via `createFixture`
+- **THEN** the DOM SHALL contain language option elements for all configured locales
+
+#### Scenario: Email verification status is displayed conditionally
+- **WHEN** the user has a verified email
+- **THEN** the verified status indicator SHALL be visible and the verify button SHALL NOT be rendered
+
+#### Scenario: PWA install section shown only when installable
+- **WHEN** the PWA install service reports `canShow: true`
+- **THEN** the install section SHALL be visible in the DOM
+
+### Requirement: Import ticket email route has component integration tests
+The `ImportTicketEmailRoute` component SHALL have integration tests verifying multi-step wizard rendering and state transitions.
+
+#### Scenario: Initial step renders input form
+- **WHEN** the route is rendered in the initial step
+- **THEN** the DOM SHALL contain the email input form
+
+#### Scenario: Step advancement renders next step content
+- **WHEN** the user completes the current step
+- **THEN** the DOM SHALL transition to show the next step's content
+
+### Requirement: Concert highway CE has component integration tests
+The `ConcertHighway` component (extracted from dashboard-route) SHALL have integration tests verifying bindable rendering, beam index mapping, and lifecycle cleanup.
+
+#### Scenario: Date groups render lane grid
+- **WHEN** `ConcertHighway` is rendered via `createFixture` with dateGroups containing home/nearby/away events
+- **THEN** the DOM SHALL contain date header elements and event cards in three lane columns
+
+#### Scenario: Beam index map is built from matched events
+- **WHEN** dateGroups contain events with `matched: true`
+- **THEN** `beamIndexMap` SHALL contain entries for each matched event ID
+
+#### Scenario: Readonly mode disables interaction
+- **WHEN** `isReadonly` is set to `true`
+- **THEN** event cards SHALL NOT dispatch event-selected on click
+
+#### Scenario: Detaching cleans up scroll listener and cancels rAF
+- **WHEN** `detaching()` is called
+- **THEN** the scroll event listener SHALL be removed and any pending `requestAnimationFrame` SHALL be cancelled
+
+### Requirement: Welcome route has component integration tests
+The `WelcomeRoute` component SHALL have integration tests verifying auth guard behavior, preview data loading, language switching, and navigation.
+
+#### Scenario: Unauthenticated user sees welcome content
+- **WHEN** the welcome route is rendered with an unauthenticated auth mock
+- **THEN** the rendered DOM SHALL contain sign-in and sign-up call-to-action elements
+
+#### Scenario: canLoad redirects authenticated users
+- **WHEN** `canLoad` is called with an authenticated auth service mock
+- **THEN** it SHALL return a redirect path to the dashboard
+
+#### Scenario: Preview concert data loads on attached
+- **WHEN** the welcome route is attached
+- **THEN** it SHALL call `concertService.listWithProximity` and populate `dateGroups`
+
+#### Scenario: Language switching updates locale via @observable
+- **WHEN** `currentLocale` changes
+- **THEN** the `currentLocaleChanged` handler SHALL call `changeLocale` with the new locale
+
+### Requirement: Custom attribute tests use createFixture with style assertions
+All custom attribute tests SHALL use `createFixture` to render the attribute on a host element and verify DOM mutations using `fixture.assertStyles()` or `fixture.assertAttr()`.
+
+#### Scenario: tile-color attribute applies CSS custom property
+- **WHEN** a `tile-color` custom attribute is rendered with a bound color value
+- **THEN** `fixture.assertStyles('div', { '--tile-color': expectedColor })` SHALL pass
+
+### Requirement: Value converter tests include fixture integration tests
+Value converter test suites SHALL include at least one `createFixture` integration test verifying the converter works within an Aurelia view pipeline.
+
+#### Scenario: Date converter renders correctly in template
+- **WHEN** `createFixture` renders `${date | dateFormat}` with a known date value
+- **THEN** `fixture.assertText()` SHALL contain the expected formatted date string
+
+## MODIFIED Requirements
+
+### Requirement: Coverage reporting is configured
+Vitest SHALL be configured with V8 coverage reporting with raised thresholds reflecting the expanded test suite.
+
+#### Scenario: Running tests with coverage
+- **WHEN** `vitest --coverage` is executed
+- **THEN** a coverage report SHALL be generated showing statement, branch, and function coverage
+
+#### Scenario: Coverage thresholds enforce minimum levels
+- **WHEN** coverage falls below thresholds (statements: 65%, branches: 75%, functions: 65%, lines: 65%)
+- **THEN** the coverage check SHALL fail
+
+#### Scenario: Dead config patterns are removed
+- **WHEN** vitest coverage exclusion patterns are evaluated
+- **THEN** the pattern `src/*-page.ts` SHALL NOT be present (it matches no files)
+
+#### Scenario: auth-service.ts is included in coverage
+- **WHEN** vitest coverage exclusion patterns are evaluated
+- **THEN** `src/services/auth-service.ts` SHALL NOT be excluded (lazy init refactor enables coverage)
+
+### Requirement: Timer cleanup uses afterEach unconditionally
+All tests that use `vi.useFakeTimers()` SHALL restore real timers in `afterEach`, never inside individual `it()` blocks.
+
+#### Scenario: Fake timers restored after each test
+- **WHEN** a test suite uses `vi.useFakeTimers()` in `beforeEach`
+- **THEN** `vi.useRealTimers()` SHALL be called in `afterEach`
+
+#### Scenario: Mocks restored after each test
+- **WHEN** a test suite uses mock spies
+- **THEN** `vi.restoreAllMocks()` SHALL be called in `afterEach`
+
+#### Scenario: Fixture tests use stop(true) in afterEach
+- **WHEN** a test suite creates fixtures
+- **THEN** each fixture SHALL be stopped via `stop(true)` in `afterEach` or at the end of each test

--- a/openspec/changes/refine-frontend-testing/tasks.md
+++ b/openspec/changes/refine-frontend-testing/tasks.md
@@ -1,0 +1,72 @@
+## 1. Critical infrastructure fixes
+
+- [x] 1.1 Fix `test/setup.ts` afterEach: Replace `fixtures.forEach(async (f) => ...)` with `await Promise.all(fixtures.map(f => f.stop(true).catch(() => {})))` — the forEach+async pattern silently drops Promises
+- [x] 1.2 Fix `test/smoke/component-compile.spec.ts`: Replace deprecated `tearDown()` with `stop(true)`
+- [x] 1.3 Remove dead `"src/*-page.ts"` exclusion pattern from `vitest.config.ts` (matches no files)
+
+## 2. Test isolation fixes (afterEach hygiene)
+
+- [x] 2.1 Add `localStorage.clear()` to afterEach in `test/services/pwa-install-service.spec.ts`
+- [x] 2.2 Add `localStorage.clear()` to afterEach in `test/components/notification-prompt.spec.ts`
+- [x] 2.3 Move `vi.useRealTimers()` from `it()` blocks to `afterEach` in `test/routes/discovery-route.spec.ts` (already correct — skipped)
+- [x] 2.4 Move `vi.useRealTimers()` from `it()` blocks to `afterEach` in `test/routes/my-artists-route.spec.ts` (already correct — skipped)
+- [x] 2.5 Move `vi.useRealTimers()` from `it()` blocks to `afterEach` in `test/services/connect-error-router.spec.ts` (already correct — skipped)
+- [x] 2.6 Move `vi.useRealTimers()` from `it()` blocks to `afterEach` in `test/components/dna-orb-canvas.spec.ts` (already correct — skipped)
+- [x] 2.7 Move `vi.useRealTimers()` from `it()` blocks to `afterEach` in `test/value-converters/date.spec.ts` (already correct — skipped)
+
+## 3. Mock helper type safety improvements
+
+- [x] 3.1 Add explicit `Partial<I18N>` return type to `test/helpers/mock-i18n.ts` (already typed — skipped)
+- [x] 3.2 Add explicit typed return to `test/helpers/mock-toast.ts` (already typed — skipped)
+- [x] 3.3 Fix `test/helpers/mock-error-boundary.ts`: Properly type `currentError` and `errorHistory` properties (already typed — skipped)
+
+## 4. Auth service refactor for testability
+
+- [x] 4.1 Refactor `src/services/auth-service.ts` to lazy-initialize `UserManager` (move `UserManagerSettings` construction from module scope to a lazy getter)
+- [x] 4.2 Remove `src/services/auth-service.ts` from vitest coverage exclusion list
+- [x] 4.3 Add unit test for `AuthService` itself (test lazy init, `ready` promise, `signIn`/`signOut` delegation)
+- [x] 4.4 Refactor `test/auth-service.spec.ts` to test public API instead of private members via `@ts-expect-error`
+
+## 5. Update testing strategy documentation
+
+- [ ] 5.1 Update `docs/testing-strategy.md` Section 1 (Testing Architecture): Elevate `createFixture` to co-primary status alongside DI Unit, update the decision flow diagram per design.md Decision 1
+- [ ] 5.2 Update `docs/testing-strategy.md` Section 2 (Test Patterns): Add Pattern H for `createFixture` fluent builder with official assertion helpers (`assertText`, `assertAttr`, `trigger.click`, `type`, `tasksSettled`)
+- [ ] 5.3 Update `docs/testing-strategy.md` Section 6 (Anti-Patterns): Add entries for forEach+async cleanup, missing `tasksSettled()` after state mutation, using deprecated `tearDown()` instead of `stop(true)`, `vi.useRealTimers()` inside `it()` instead of `afterEach`
+- [ ] 5.4 Update `docs/testing-strategy.md` Section 8 (Key Decisions): Change `createFixture` row from "Template binding verification only" to "Co-primary for components with templates"
+- [ ] 5.5 Add new section to `docs/testing-strategy.md` referencing all Aurelia 2 official testing documentation pages (Overview, Testing Components, Testing Attributes, Testing Value Converters, Fluent API, Stubs Mocks & Spies, Advanced Testing Techniques, Outcome Recipes, Quick Reference, Decision Trees)
+
+## 6. Upgrade smoke tests
+
+- [ ] 6.1 Upgrade `test/smoke/component-compile.spec.ts`: Replace `expect(true).toBe(true)` with `fixture.getBy()` / `fixture.assertAttr()` assertions for SvgIcon, StatePlaceholder, BottomNavBar
+- [ ] 6.2 Migrate smoke tests to fluent builder API (`createFixture.component(X).html(Y).deps(Z).build()`)
+- [ ] 6.3 Add additional components to the smoke test suite (expand the `components` array with more globally-registered components)
+
+## 7. Custom attribute and value converter integration tests
+
+- [ ] 7.1 Add `createFixture` integration test for `tile-color` custom attribute using `fixture.assertStyles()`
+- [ ] 7.2 Add `createFixture` integration test for `dot-color` custom attribute using `fixture.assertStyles()`
+- [ ] 7.3 Add `createFixture` integration test for `DateValueConverter` using `fixture.assertText()` with `${date | dateFormat}` pipeline
+
+## 8. Critical-path component integration tests (Phase 1)
+
+- [ ] 8.1 Create `test/components/bottom-nav-bar.fixture.spec.ts`: Test nav item rendering and active state via `createFixture` with mocked `IRouter`
+- [ ] 8.2 Create `test/components/snack-bar.fixture.spec.ts`: Test toast display, auto-dismiss (fake timers + `tasksSettled`), and action callback via `fixture.trigger.click()`
+- [ ] 8.3 Create `test/components/error-banner.fixture.spec.ts`: Test error display, dismiss interaction via `fixture.trigger.click()`, and GitHub issue URL rendering
+- [ ] 8.4 Create `test/components/concert-highway.spec.ts`: Test ConcertHighway CE — dateGroups rendering, beam index map construction from matched events, readonly mode, detaching cleanup (scroll listener removal, rAF cancellation)
+
+## 9. Critical-path component integration tests (Phase 2)
+
+- [ ] 9.1 Create `test/routes/welcome-route.fixture.spec.ts`: Test rendered DOM for unauthenticated user (sign-in/sign-up CTAs), canLoad redirect, preview concert data loading via ConcertService, language switching via @observable currentLocale
+- [ ] 9.2 Create `test/components/user-home-selector.fixture.spec.ts`: Test region option rendering, selection interaction via `fixture.trigger.click()`, and service call verification
+- [ ] 9.3 Create `test/components/post-signup-dialog.fixture.spec.ts`: Test multi-step flow rendering (notification prompt -> PWA install), step advancement via `fixture.trigger.click()`
+
+## 10. Additional high-complexity component integration tests (Phase 3)
+
+- [ ] 10.1 Create `test/routes/settings-route.fixture.spec.ts`: Test language option rendering (repeat.for), email verification conditional, PWA install section visibility
+- [ ] 10.2 Create `test/routes/import-ticket-email-route.fixture.spec.ts`: Test multi-step wizard rendering, step advancement, input form presence
+
+## 11. Coverage threshold increase
+
+- [ ] 11.1 Run `vitest --coverage` and verify new tests increase coverage above current thresholds
+- [ ] 11.2 Raise coverage thresholds in `vitest.config.ts` (statements: 55->65%, functions: 54->65%, lines: 55->65%, branches: 75% maintained)
+- [ ] 11.3 Run `make check` to verify all linting and tests pass with new thresholds


### PR DESCRIPTION
## Summary

- Add OpenSpec change artifacts (proposal, design, spec, tasks) for refining the frontend test suite
- Elevates Aurelia 2 `createFixture` integration tests to co-primary status alongside DI Unit tests
- Documents critical infrastructure bug fixes: `forEach(async)` cleanup race, deprecated `tearDown()`, localStorage/timer state leaks
- Includes auth-service lazy-init refactor design for testability and coverage inclusion

## Test plan

- [ ] Verify change artifacts render correctly on GitHub
- [ ] Confirm proposal, design, spec, and tasks are internally consistent
- [ ] No proto changes — buf lint/breaking checks should pass trivially