### PR TITLE
docs(spec): add Ethereum address validation requirement and archive consolidate-validation

### DIFF
--- a/openspec/changes/archive/2026-03-27-consolidate-validation/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-27-consolidate-validation/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-26

--- a/openspec/changes/archive/2026-03-27-consolidate-validation/design.md
+++ b/openspec/changes/archive/2026-03-27-consolidate-validation/design.md
@@ -1,0 +1,130 @@
+## Context
+
+The backend has three layers of input validation:
+
+1. **Protovalidate interceptor** (`connectrpc.com/validate`) — validates all request messages against `buf.validate` annotations before handlers execute. Already registered as the innermost interceptor.
+2. **Handler (adapter) layer** — ~35 manual checks (nil guards, empty string, enum map lookups) that duplicate protovalidate rules.
+3. **Usecase layer** — ~49 parameter guards, of which ~30 duplicate proto validation, ~11 check JWT-derived `userID`, and ~8 are domain invariants.
+
+Additionally, handlers inconsistently pass either external IDs (`claims.Sub`) or internal UUIDs to usecases, leaking IdP concerns into the domain layer.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Establish a single validation boundary: protovalidate interceptor for proto-derived fields, handler helper for JWT-derived identity.
+- Usecases trust all inputs unconditionally — zero validation guards.
+- All usecases receive internal user UUID, never external ID.
+- Reduce handler boilerplate to: extract identity → map proto to domain → delegate to usecase.
+
+**Non-Goals:**
+- Changing proto `buf.validate` annotations (already comprehensive).
+- Modifying entity-layer domain invariants (`Home.Validate()`, Ethereum address regex, ZKP verification).
+- Changing the interceptor chain ordering or adding new interceptors.
+- Refactoring the mapper package beyond the new helper function.
+
+## Decisions
+
+### D1: Remove all handler input validation
+
+**Decision:** Delete every manual nil/empty/enum check in handler files.
+
+**Rationale:** The protovalidate interceptor runs before handlers and enforces identical constraints via `buf.validate` annotations. These checks are unreachable dead code. Audit confirmed all 35 handler checks have corresponding proto annotations.
+
+**Alternative considered:** Keep checks as defense-in-depth.
+**Rejected because:** Double validation creates maintenance drift risk — when a proto annotation changes, the handler check silently diverges. The interceptor is the authoritative boundary.
+
+### D2: Remove all usecase input validation
+
+**Decision:** Delete every `InvalidArgument` guard in usecase files, including `userID == ""` checks.
+
+**Rationale:** If the policy is "usecases trust inputs", there should be no exceptions. Selective checking (e.g., only `userID`) is worse than no checking because it implies a contract that other parameters are validated elsewhere while `userID` is not — which is misleading once the handler guarantees it.
+
+**Where validation remains:**
+- `entity.Home.Validate()` — cross-field domain invariant (country-level1 prefix). Called by `user_uc.UpdateHome` and `user_uc.Create`.
+- `entity.ParseZKPPublicSignals()` / `signals.VerifyEventID()` — cryptographic verification, not input validation.
+- `ticket_uc.validateMintParams` Ethereum address regex — domain constraint not expressible in proto. **This stays but moves to entity layer** as `entity.ValidateEthereumAddress(addr string) error`.
+
+**Alternative considered:** Keep usecase guards for JWT-derived values only.
+**Rejected because:** Inconsistent policy. Handler already guarantees non-empty `userID` via `GetExternalUserID` + `GetByExternalID` (which returns `NotFound` for unknown users).
+
+### D3: Introduce `GetExternalUserID(ctx)` helper
+
+**Decision:** Add a single function in `mapper/user.go`:
+
+```go
+func GetExternalUserID(ctx context.Context) (string, error) {
+    claims, ok := auth.GetClaims(ctx)
+    if !ok || claims == nil {
+        return "", connect.NewError(connect.CodeUnauthenticated,
+            errors.New("authentication required"))
+    }
+    if claims.Sub == "" {
+        return "", connect.NewError(connect.CodeUnauthenticated,
+            errors.New("token missing subject claim"))
+    }
+    return claims.Sub, nil
+}
+```
+
+**Rationale:** Consolidates claims extraction + empty-sub guard into one call. Returns `Unauthenticated` (not `InvalidArgument`) because an empty `Sub` is a token integrity issue. Existing `GetClaimsFromContext` remains available for handlers that need full claims (e.g., `Create` which uses `Email` and `Name`).
+
+### D4: Unify handler identity pattern to internal UUID
+
+**Decision:** All handlers resolve `claims.Sub` → internal `User.ID` before calling usecases.
+
+Current state:
+- **Pattern A** (follow, concert): pass `claims.Sub` (external ID) directly to usecase.
+- **Pattern B** (ticket, ticket_journey, ticket_email, push_notification): resolve to internal UUID first.
+
+After change: all use Pattern B.
+
+**Rationale:** The domain layer should not know about IdP identifiers. `claims.Sub` is a transport concern. Internal UUID is the domain identity.
+
+**Affected usecases and repositories:**
+- `follow_uc.Follow(userID, artistID)` — `userID` changes from external ID to internal UUID.
+- `follow_uc.Unfollow(userID, artistID)` — same.
+- `follow_uc.SetHype(userID, artistID, hype)` — same.
+- `follow_uc.ListFollowed(userID)` — same.
+- `concert_uc.ListByFollower(externalUserID)` — parameter becomes internal UUID.
+- `concert_uc.ListByFollowerGrouped(externalUserID)` — same.
+- Follow and concert repositories update queries from `external_id` to `user_id` (internal UUID).
+
+**Migration note:** The follow DB table currently stores `external_user_id`. This column will be migrated to `user_id` referencing the `users` table. Concert queries that join through follow → user will also be updated.
+
+### D5: Simplify enum mapping in handlers
+
+**Decision:** Remove `ok` guard from enum map lookups. After interceptor guarantees `defined_only`, the map lookup always succeeds for valid proto enum values.
+
+```go
+// Before
+status, ok := mapper.TicketJourneyStatusFromProto[req.Msg.Status]
+if !ok {
+    return nil, connect.NewError(connect.CodeInvalidArgument, ...)
+}
+
+// After
+status := mapper.TicketJourneyStatusFromProto[req.Msg.Status]
+```
+
+**Risk:** If a new proto enum value is added but the Go mapper map is not updated, the lookup returns zero-value silently.
+**Mitigation:** Mapper tests already cover all enum values. CI catches missing mappings.
+
+### D6: Move Ethereum address validation to entity layer
+
+**Decision:** Extract `ethAddressRe` regex from `ticket_uc.validateMintParams` to `entity.ValidateEthereumAddress(addr string) error`.
+
+**Rationale:** This is a domain invariant (what constitutes a valid Ethereum address), not input validation. It belongs alongside `Home.Validate()` in the entity layer. The usecase calls it as a business rule check, not as parameter guard.
+
+## Risks / Trade-offs
+
+**[Risk] Usecase called from non-handler context with bad inputs**
+→ Currently all usecases are only called from handlers. If a future CLI or batch job calls usecases directly, it bypasses protovalidate. Mitigation: document in usecase package godoc that callers must provide validated inputs. This is the standard Clean Architecture contract — usecases define the interface, callers satisfy preconditions.
+
+**[Risk] Follow DB migration (external_id → user_id)**
+→ Requires Atlas migration to rename/replace column and backfill data. Mitigation: migration runs via Atlas operator before new code deploys (sync wave ordering). Backfill joins `users.external_id` to resolve internal UUIDs.
+
+**[Risk] Enum zero-value after mapper lookup (D5)**
+→ If mapper map is incomplete, handler passes zero-value to usecase silently. Mitigation: existing mapper unit tests enumerate all proto enum values. Add a compile-time exhaustiveness check if Go supports it (or generator-based approach).
+
+**[Trade-off] More DB lookups in follow/concert handlers**
+→ Resolving `claims.Sub` → `User.ID` adds one `GetByExternalID` call per request where there was none before. These handlers previously avoided the lookup. Impact: one indexed query per request (~1ms). Acceptable for architectural consistency.

--- a/openspec/changes/archive/2026-03-27-consolidate-validation/proposal.md
+++ b/openspec/changes/archive/2026-03-27-consolidate-validation/proposal.md
@@ -1,0 +1,34 @@
+## Why
+
+Backend handler (adapter) and usecase layers contain ~80 manual input validation checks (nil guards, empty string checks, enum lookups) that duplicate what the protovalidate interceptor already enforces via `buf.validate` annotations. This redundancy obscures each layer's true responsibility, inflates code volume, and creates maintenance drift risk when proto schemas evolve. Additionally, the handler layer inconsistently passes either external IDs (`claims.Sub`) or internal UUIDs to usecases, leaking IdP concerns into the domain layer.
+
+## What Changes
+
+- **Remove all manual input validation from handler (adapter) layer** — ~35 checks for nil, empty string, and enum validity that the protovalidate interceptor already rejects before handlers execute.
+- **Remove all proto-derived input validation from usecase layer** — ~30 guards on fields that originate from validated proto messages. Usecases will trust all inputs.
+- **Remove all `userID == ""` guards from usecase layer** — these checked JWT-derived values; responsibility moves to a single handler helper.
+- **Introduce `GetExternalUserID(ctx)` helper** in the mapper package — consolidates claims extraction + empty-sub guard into one function returning `CodeUnauthenticated`.
+- **Unify handler identity pattern** — all handlers resolve `claims.Sub` → internal `User.ID` via `GetByExternalID()` before calling usecases. Follow and concert handlers currently pass external IDs directly; they will be aligned.
+- **Update follow/concert usecase + repository** to accept internal user UUID instead of external ID.
+- **Simplify enum mapping in handlers** — remove `ok` guard from map lookups (interceptor guarantees `defined_only`); convert to direct lookup.
+
+## Capabilities
+
+### New Capabilities
+
+(none — this is a refactoring change with no new user-facing capabilities)
+
+### Modified Capabilities
+
+- `entity-domain-logic`: Usecase layer contract changes — usecases no longer validate inputs, and all user-identifying parameters become internal UUIDs.
+
+## Impact
+
+- **backend/internal/adapter/rpc/**: All handler files modified (validation removal, identity pattern unification).
+- **backend/internal/adapter/rpc/mapper/**: New `GetExternalUserID` helper; existing `GetClaimsFromContext` remains for handlers needing full claims.
+- **backend/internal/usecase/**: All usecase files modified (validation removal, follow/concert signature changes).
+- **backend/internal/infrastructure/database/rdb/**: Follow and concert repository queries updated from external ID to internal UUID.
+- **backend/internal/entity/**: `Home.Validate()` retained — cross-field domain invariant not expressible in proto.
+- **Tests**: Handler and usecase tests updated to remove validation-specific test cases; follow/concert repository tests updated for internal ID.
+- **No proto schema changes** — `buf.validate` annotations already cover all removed checks.
+- **No API contract changes** — wire format unchanged; clients unaffected.

--- a/openspec/changes/archive/2026-03-27-consolidate-validation/specs/entity-domain-logic/spec.md
+++ b/openspec/changes/archive/2026-03-27-consolidate-validation/specs/entity-domain-logic/spec.md
@@ -1,0 +1,37 @@
+## ADDED Requirements
+
+### Requirement: Ethereum address validation
+
+The entity package SHALL provide a `ValidateEthereumAddress(addr string) error` function that validates an Ethereum address format.
+
+The function SHALL return nil when the address matches the pattern `^0x[0-9a-fA-F]{40}$`, and return an error otherwise.
+
+#### Scenario: Valid checksummed address
+
+- **WHEN** ValidateEthereumAddress receives "0x742d35Cc6634C0532925a3b844Bc9e7595f2bD18"
+- **THEN** it returns nil
+
+#### Scenario: Valid lowercase address
+
+- **WHEN** ValidateEthereumAddress receives "0x742d35cc6634c0532925a3b844bc9e7595f2bd18"
+- **THEN** it returns nil
+
+#### Scenario: Missing 0x prefix
+
+- **WHEN** ValidateEthereumAddress receives "742d35cc6634c0532925a3b844bc9e7595f2bd18"
+- **THEN** it returns an error mentioning "Ethereum address"
+
+#### Scenario: Too short
+
+- **WHEN** ValidateEthereumAddress receives "0x742d35cc"
+- **THEN** it returns an error mentioning "Ethereum address"
+
+#### Scenario: Empty string
+
+- **WHEN** ValidateEthereumAddress receives ""
+- **THEN** it returns an error mentioning "Ethereum address"
+
+#### Scenario: Invalid hex characters
+
+- **WHEN** ValidateEthereumAddress receives "0xZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ"
+- **THEN** it returns an error mentioning "Ethereum address"

--- a/openspec/changes/archive/2026-03-27-consolidate-validation/tasks.md
+++ b/openspec/changes/archive/2026-03-27-consolidate-validation/tasks.md
@@ -1,0 +1,60 @@
+## 1. Entity Layer
+
+- [x] 1.1 Add `entity.ValidateEthereumAddress(addr string) error` with `^0x[0-9a-fA-F]{40}$` regex and tests per spec scenarios
+- [x] 1.2 Remove `ethAddressRe` from `ticket_uc.go` and update `validateMintParams` to call `entity.ValidateEthereumAddress`
+
+## 2. Mapper Helper
+
+- [x] 2.1 Add `mapper.GetExternalUserID(ctx) (string, error)` that extracts `claims.Sub` with `Unauthenticated` error on missing/empty (D3)
+- [x] 2.2 Add tests for `GetExternalUserID`: missing claims, nil claims, empty Sub, valid Sub
+
+## 3. Follow/Concert Identity Unification (No DB Migration Needed)
+
+- [x] 3.1 ~~Generate Atlas migration~~ — DB already uses internal `user_id` UUID in `followed_artists` table. No migration needed.
+- [x] 3.2 ~~Update follow repository queries~~ — Repository already uses internal UUIDs. No change needed.
+- [x] 3.3 ~~Update concert repository queries~~ — Repository already uses internal UUIDs. No change needed.
+- [x] 3.4 ~~Update kustomization.yaml~~ — No migration file to add.
+- [x] 3.5 Remove `resolveUserID` calls from `follow_uc.go` — usecase will receive internal UUID directly from handler
+- [x] 3.6 Remove `resolveUserID` / `GetByExternalID` calls from `concert_uc.go` — `ListByFollower` receives internal UUID; `ListByFollowerGrouped` receives internal UUID + `*entity.Home`
+- [x] 3.7 Remove `userRepo` dependency from `followUseCase` struct (only used for `resolveUserID`)
+- [x] 3.8 Update `concert_uc.ListByFollowerGrouped` signature to accept `(ctx, userID string, home *entity.Home)` instead of external ID
+- [x] 3.9 Remove `usecase/auth.go` (`resolveUserID`) if no longer referenced
+- [x] 3.10 Update DI wiring in `internal/di/` to remove `userRepo` from `NewFollowUseCase`
+
+## 4. Handler Validation Removal
+
+- [x] 4.1 `user_handler.go`: Remove nil/empty checks (req nil, home nil). Keep mapper calls and usecase delegation only
+- [x] 4.2 `artist_handler.go`: Remove nil checks on name, artist_id, url fields
+- [x] 4.3 `follow_handler.go`: Remove artist_id nil checks. Remove hype enum `ok` guard (keep mapping). Switch from `claims.Sub` to `GetExternalUserID` → `GetByExternalID` → `user.ID`
+- [x] 4.4 `ticket_handler.go`: Remove req nil, event_id nil, ticket_id nil checks
+- [x] 4.5 `ticket_journey_handler.go`: Remove event_id nil checks and status enum `ok` guard
+- [x] 4.6 `ticket_email_handler.go`: Remove email_type enum `ok` guard, event_ids element nil check, ticket_email_id nil check
+- [x] 4.7 `entry_handler.go`: Remove req nil, event_id nil/empty, proof_json empty, public_signals_json empty checks
+- [x] 4.8 `push_notification_handler.go`: Remove endpoint/p256dh/auth empty string checks
+- [x] 4.9 `concert_handler.go`: Remove artist_id empty check. Switch `ListByFollower`/`ListByFollowerGrouped` from `claims.Sub` to `GetExternalUserID` → `GetByExternalID` → `user.ID`
+
+## 5. Usecase Validation Removal
+
+- [x] 5.1 `user_uc.go`: Remove `id == ""` and `home == nil` guards. Keep `home.Validate()` call
+- [x] 5.2 `artist_uc.go`: Remove MBID, Name, URL, artistID, query empty checks
+- [x] 5.3 `follow_uc.go`: Remove all `userID == "" || artistID == ""` guards. Update method signatures if parameter type changes
+- [x] 5.4 `concert_uc.go`: Remove artistID, externalUserID, artistIDs empty checks. Rename `externalUserID` params to `userID`
+- [x] 5.5 `ticket_uc.go`: Remove `validateMintParams` nil/empty guards except `entity.ValidateEthereumAddress` call. Remove `GetTicket` and `ListTicketsForUser` empty guards
+- [x] 5.6 `entry_uc.go`: Remove params nil, eventID/proofJSON/publicSignalsJSON empty guards. Remove `GetMerklePath`/`BuildMerkleTree` empty guards
+- [x] 5.7 `ticket_journey_uc.go`: Remove userID, eventID, status guards
+- [x] 5.8 `ticket_email_uc.go`: Remove userID, eventIDs, emailType, rawBody, ticketEmailID guards
+- [x] 5.9 `push_notification_uc.go`: Verify no guards to remove (confirmed none exist)
+
+## 6. Test Updates
+
+- [x] 6.1 Remove handler test cases that assert `InvalidArgument` for nil/empty/invalid-enum inputs (interceptor covers these)
+- [x] 6.2 Remove usecase test cases that assert `InvalidArgument` for empty parameter guards
+- [x] 6.3 Update follow/concert handler tests to mock `GetByExternalID` call (new dependency)
+- [x] 6.4 Update follow/concert usecase tests: change `userID` fixture values from external IDs to internal UUIDs
+- [x] 6.5 Update follow/concert repository tests: queries now use `user_id` column
+- [x] 6.6 Regenerate mocks if usecase/repository interfaces changed (`mockery`)
+
+## 7. Verification
+
+- [x] 7.1 Run `make check` (lint + test) to verify all changes pass
+- [x] 7.2 Run integration tests with local DB to verify follow/concert migration

--- a/openspec/specs/entity-domain-logic/spec.md
+++ b/openspec/specs/entity-domain-logic/spec.md
@@ -596,3 +596,41 @@ The method SHALL:
 
 - **WHEN** NewConcertNotificationPayload is called with artist.ID="artist-abc"
 - **THEN** the returned payload data map contains a key mapping to "artist-abc"
+
+---
+
+### Requirement: Ethereum address validation
+
+The entity package SHALL provide a `ValidateEthereumAddress(addr string) error` function that validates an Ethereum address format.
+
+The function SHALL return nil when the address matches the pattern `^0x[0-9a-fA-F]{40}$`, and return an error otherwise.
+
+#### Scenario: Valid checksummed address
+
+- **WHEN** ValidateEthereumAddress receives "0x742d35Cc6634C0532925a3b844Bc9e7595f2bD18"
+- **THEN** it returns nil
+
+#### Scenario: Valid lowercase address
+
+- **WHEN** ValidateEthereumAddress receives "0x742d35cc6634c0532925a3b844bc9e7595f2bd18"
+- **THEN** it returns nil
+
+#### Scenario: Missing 0x prefix
+
+- **WHEN** ValidateEthereumAddress receives "742d35cc6634c0532925a3b844bc9e7595f2bd18"
+- **THEN** it returns an error mentioning "Ethereum address"
+
+#### Scenario: Too short
+
+- **WHEN** ValidateEthereumAddress receives "0x742d35cc"
+- **THEN** it returns an error mentioning "Ethereum address"
+
+#### Scenario: Empty string
+
+- **WHEN** ValidateEthereumAddress receives ""
+- **THEN** it returns an error mentioning "Ethereum address"
+
+#### Scenario: Invalid hex characters
+
+- **WHEN** ValidateEthereumAddress receives "0xZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ"
+- **THEN** it returns an error mentioning "Ethereum address"


### PR DESCRIPTION
## Summary

Syncs the `entity-domain-logic` spec with the `Ethereum address validation` requirement added by the `consolidate-validation` change, and archives the completed change.

- Add `entity.ValidateEthereumAddress` requirement with 6 scenarios to `openspec/specs/entity-domain-logic/spec.md`
- Archive `consolidate-validation` change to `openspec/changes/archive/2026-03-27-consolidate-validation/`

No proto changes — this is spec documentation only.

## Test plan

- [x] Delta spec synced to main spec (`entity-domain-logic`)
- [x] Archive directory created at `openspec/changes/archive/2026-03-27-consolidate-validation/`
