### PR TITLE
docs(openspec): add harden-test-infrastructure change artifacts

### DIFF
--- a/openspec/changes/harden-test-infrastructure/.openspec.yaml
+++ b/openspec/changes/harden-test-infrastructure/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-26

--- a/openspec/changes/harden-test-infrastructure/design.md
+++ b/openspec/changes/harden-test-infrastructure/design.md
@@ -1,0 +1,423 @@
+## Context
+
+During the concert-highway CE extraction (PR #298), five distinct CI failures cascaded from structural weaknesses in the test infrastructure:
+
+1. **`document is not defined`** — vitest's jsdom teardown conflicted with a manually-created JSDOM instance in `test/setup.ts`, leaving stale `globalThis.document` references
+2. **CE height: 0** — Custom Elements default to `display: inline`, breaking grid/flex height propagation. No integration test detected this before E2E.
+3. **Selector breakage** — `.concert-scroll` moved inside a CE, breaking 4 E2E tests relying on that CSS class
+4. **`promise.bind` comment nodes** — Aurelia's template directives inject comment nodes that break parent-child layout chains. No unit/integration test existed for this.
+5. **`page.evaluate()` workarounds** — 13+ E2E test sites bypass Playwright's locator API via JS dispatch due to page-help overlay interception and popover top-layer blocking
+
+The companion `refine-frontend-testing` change (PR #360) addresses unit test quality (createFixture adoption, infra bug fixes). This change targets the **structural causes** that make refactoring unsafe.
+
+**Key documentation references:**
+
+| Topic | Source |
+|-------|--------|
+| Vitest environment lifecycle | https://vitest.dev/guide/environment.html |
+| Vitest per-file environments | https://vitest.dev/guide/environment.html#environments-for-specific-files |
+| Vitest projects feature | https://vitest.dev/guide/#projects-support |
+| Vitest mocking modules | https://vitest.dev/guide/mocking.html |
+| Vitest common errors | https://vitest.dev/guide/common-errors.html |
+| Aurelia createFixture | https://docs.aurelia.io/developer-guides/overview/testing-components |
+| Aurelia fluent API | https://docs.aurelia.io/developer-guides/overview/fluent-api |
+| Aurelia DI mocking | https://docs.aurelia.io/developer-guides/overview/mocks-spies |
+| Playwright locators best practices | https://playwright.dev/docs/locators |
+| Playwright test isolation | https://playwright.dev/docs/browser-contexts |
+
+## Goals / Non-Goals
+
+**Goals:**
+- Eliminate dual jsdom management so vitest teardown is deterministic
+- Contain Aurelia template `<import>` module graph expansion to prevent cascading `vi.mock()` requirements
+- Introduce `data-testid` selector strategy for E2E resilience
+- Remove `page.evaluate()` JS dispatch workarounds by fixing application-layer issues
+- Add CE composition integration tests (parent + child CE layout verification)
+- Add dashboard-route integration test (most complex, currently untested route)
+- Evaluate and adopt vitest environment optimization (happy-dom, per-file env, projects)
+
+**Non-Goals:**
+- Rewriting existing passing tests (additive only)
+- Changing component source code beyond what's needed for testability (data-testid attributes, pointer-events fixes)
+- Achieving 100% E2E selector migration in one pass (incremental, critical paths first)
+- Adding new E2E test scenarios (stabilize existing ones)
+
+## Decisions
+
+### Decision 1: Unify jsdom management — let vitest own the environment
+
+**Choice:** Remove the manual `new JSDOM(...)` and `Object.assign(globalThis, ...)` from `test/setup.ts`. Let vitest's `environment: 'jsdom'` be the single source of truth. Keep only `BrowserPlatform` initialization and fixture cleanup hooks. Disable Node.js 25's built-in Web Storage via `--no-experimental-webstorage` so jsdom can provide its own working implementation.
+
+**Rationale (per [Vitest Environment docs](https://vitest.dev/guide/environment.html)):**
+Vitest manages environment lifecycle automatically — setup before tests, teardown after. Creating a second JSDOM instance causes:
+- Two `window` objects (vitest's and the manual one)
+- `globalThis.document` pointing to the manual JSDOM, but vitest tearing down its own
+- After teardown, Aurelia module resolution still references the stale manual JSDOM globals
+
+**Node.js 25+ localStorage conflict (discovered during implementation):**
+Node.js 25 unflagged `--experimental-webstorage` ([nodejs/node#57666](https://github.com/nodejs/node/pull/57666)), providing `globalThis.localStorage` as an empty proxy object where `.getItem`, `.setItem`, `.clear()` are all `undefined`. jsdom detects this existing property and skips its own Web Storage polyfill. This is tracked in [vitest-dev/vitest#8757](https://github.com/vitest-dev/vitest/issues/8757), [happy-dom#1950](https://github.com/capricorn86/happy-dom/issues/1950), and [nodejs/node#60303](https://github.com/nodejs/node/issues/60303).
+
+**Fix:** Add `--no-experimental-webstorage` to vitest's fork worker `execArgv`. This removes Node's broken localStorage entirely, letting jsdom provide its own working Web Storage implementation.
+
+```typescript
+// vitest.config.ts — disable Node.js 25+ built-in Web Storage
+poolOptions: {
+  forks: {
+    execArgv: ['--no-experimental-webstorage'],
+  },
+},
+```
+
+```typescript
+// BEFORE: test/setup.ts (PROBLEMATIC — dual jsdom)
+import { JSDOM } from 'jsdom'
+const jsdom = new JSDOM('<!DOCTYPE html><html><body></body></html>', {
+  url: 'http://localhost',
+})
+const { window } = jsdom
+Object.assign(globalThis, {
+  window, document: window.document, navigator: window.navigator,
+  Node: window.Node, HTMLElement: window.HTMLElement,
+  localStorage: window.localStorage, // ...
+})
+
+// AFTER: test/setup.ts (vitest owns jsdom, Node.js webstorage disabled)
+import { BrowserPlatform } from '@aurelia/platform-browser'
+import { type IFixture, onFixtureCreated, setPlatform } from '@aurelia/testing'
+import { beforeAll, afterEach } from 'vitest'
+
+function bootstrapTestEnv() {
+  const platform = new BrowserPlatform(window as unknown as Window & typeof globalThis)
+  setPlatform(platform)
+  BrowserPlatform.set(globalThis, platform)
+}
+
+const fixtures: IFixture<object>[] = []
+beforeAll(() => {
+  bootstrapTestEnv()
+  onFixtureCreated((fixture) => fixtures.push(fixture))
+})
+
+afterEach(async () => {
+  await Promise.all(
+    fixtures.map((f) => {
+      const result = f.stop?.(true) ?? (f as any).tearDown?.()
+      return result?.catch?.(() => {}) ?? Promise.resolve()
+    }),
+  )
+  fixtures.length = 0
+})
+```
+
+**Verification:** After this change:
+- `jsdom` SHALL NOT appear in `test/setup.ts` imports
+- `--localstorage-file` warning SHALL NOT appear in test output
+- `localStorage.clear()` SHALL work in all test files
+
+**Alternative considered:** MemoryStorage polyfill in `test/setup.ts`.
+**Why rejected:** Polyfill shadows jsdom's implementation, adding maintenance burden. The `--no-experimental-webstorage` flag is the vitest community's recommended workaround ([vitest#8757](https://github.com/vitest-dev/vitest/issues/8757)) and will be removable once Node.js stabilizes Web Storage behavior.
+
+**Alternative considered:** Switch to `environment: 'node'` and keep manual JSDOM.
+**Why rejected:** Per vitest docs, `jsdom` environment provides proper lifecycle management. Fighting the framework's environment system is the root cause of the timing bugs.
+
+### Decision 2: Contain template module graph via global CE registration + import guards
+
+**Choice:** Establish a convention that all shared CEs are registered globally in `main.ts` (already partially done) and templates use CE tag names directly without `<import from="...">`. For tests, import the CE class directly — never via a route module.
+
+**Rationale (per [Vitest Mocking Modules](https://vitest.dev/guide/mocking.html#how-it-works)):**
+Vitest transforms `import` statements and evaluates modules eagerly. Aurelia's convention-based `.ts` → `.html` auto-resolution means importing a route module triggers:
+
+```
+app-shell.ts
+  └── @route({ component: import('./dashboard-route') })
+       └── dashboard-route.ts → dashboard-route.html (convention)
+            └── <import from="concert-highway">
+                 └── concert-highway.ts → concert-highway.html
+                      └── <import from="event-card">
+                           └── event-card.ts → resolve(INode) → document 💥
+```
+
+**The containment strategy has three pillars:**
+
+**Pillar A: Global CE registration (already in place)**
+All shared CEs registered in `main.ts`. Templates use `<concert-highway>` without `<import>`.
+
+**Pillar B: Test import isolation**
+Tests import the target CE directly, not through parent routes:
+```typescript
+// GOOD: Direct import — no module chain
+import { ConcertHighway } from '../../src/components/live-highway/concert-highway'
+
+// BAD: Import via route — triggers entire template chain
+import { DashboardRoute } from '../../src/routes/dashboard/dashboard-route'
+```
+
+**Pillar C: vi.mock() for HTML templates when route-level tests are needed**
+For route-level tests that must import the route module, mock the HTML template to prevent Aurelia's convention from loading child templates:
+
+```typescript
+// Per Vitest docs: vi.mock() is hoisted to top of file
+vi.mock('../../src/routes/dashboard/dashboard-route.html', () => ({
+  default: '<div></div>'  // minimal template, no <import> chains
+}))
+```
+
+**Alternative considered:** Use vitest `server.deps.inline` to control which modules are transformed.
+**Why rejected:** `server.deps.inline` controls external dependency transformation, not internal module resolution. The chain expansion is within the project's own source files.
+
+### Decision 3: Adopt data-testid attributes for E2E selector stability
+
+**Choice:** Add `data-testid` attributes to all elements that are targeted by E2E tests. Migrate critical E2E selectors from CSS classes to `data-testid`.
+
+**Rationale (per [Playwright Locators docs](https://playwright.dev/docs/locators#locate-by-test-id)):**
+Playwright explicitly recommends `data-testid` for test stability:
+> "Test IDs are the most resilient locator strategy. [...] Since test IDs are dedicated to testing, they won't break when you refactor CSS or change text content."
+
+```html
+<!-- BEFORE: CSS class selector (breaks on refactor) -->
+<ol class="concert-scroll date-group-list">
+
+<!-- AFTER: data-testid (stable across refactors) -->
+<ol class="concert-scroll date-group-list" data-testid="concert-scroll">
+```
+
+```typescript
+// BEFORE: Fragile CSS class selector
+const scroll = page.locator('.concert-scroll')
+
+// AFTER: Stable test ID selector
+const scroll = page.getByTestId('concert-scroll')
+```
+
+**Scope — Phase 1 critical selectors to migrate:**
+
+| Current Selector | Component | data-testid |
+|-----------------|-----------|-------------|
+| `.concert-scroll` | concert-highway | `concert-scroll` |
+| `[data-live-card]` | event-card | (already stable) |
+| `.journey-badge` | event-card | `journey-badge` |
+| `.sheet-journey` | event-detail-sheet | `sheet-journey` |
+| `.journey-btn` | event-detail-sheet | `journey-btn` |
+| `.journey-remove-btn` | event-detail-sheet | `journey-remove-btn` |
+| `.loading-text` | dashboard-route | `dashboard-loading` |
+| `.welcome-preview` | welcome-route | `welcome-preview` |
+
+**Convention:** `data-testid` values use kebab-case matching the component/semantic purpose, not CSS class names. Only add to elements actually used in E2E tests — not every element.
+
+### Decision 4: Fix application-layer issues causing page.evaluate() workarounds
+
+**Choice:** Fix the root causes in application code rather than keeping test workarounds.
+
+**Issue A: page-help dismiss-zone intercepts pointer events**
+
+The `page-help` component creates a full-viewport dismiss zone that captures all click events. E2E tests must use `page.evaluate(() => el.click())` to bypass it.
+
+**Fix:** Add `pointer-events: none` to the dismiss zone when the help overlay is not actively shown, and use `pointer-events: auto` only when visible:
+
+```css
+/* page-help.css */
+.dismiss-zone {
+  pointer-events: none;  /* default: transparent to clicks */
+}
+
+.dismiss-zone[data-active="true"] {
+  pointer-events: auto;  /* only intercept when help is shown */
+}
+```
+
+**Issue B: Popover top-layer blocks Playwright hit-testing**
+
+Popover elements in the top layer intercept Playwright's actionability checks even when visually non-overlapping due to top-layer stacking.
+
+**Fix:** Ensure popovers are closed (removed from top layer) before E2E assertions on elements behind them. In serial mode tests, add explicit popover dismiss before each interaction:
+
+```typescript
+// In E2E beforeEach for serial tests
+await page.evaluate(() => {
+  document.querySelectorAll('[popover]').forEach(el => {
+    try { (el as HTMLElement).hidePopover() } catch {}
+  })
+})
+```
+
+**Issue C: visually-hidden radio inputs**
+
+Radio inputs with `class="visually-hidden"` are not clickable by Playwright (zero bounding box).
+
+**Fix per [Playwright docs](https://playwright.dev/docs/actionability#visible):** Use `force: true` on the label click, or use Playwright's `page.getByLabel()` which clicks the associated label:
+
+```typescript
+// BEFORE: JS dispatch workaround
+await page.evaluate(() => {
+  const radio = document.querySelector('input[type="radio"]')
+  radio.dispatchEvent(new Event('change', { bubbles: true }))
+})
+
+// AFTER: Click the visible label
+await page.getByLabel('日本語').click()
+```
+
+### Decision 5: CE composition integration tests via createFixture
+
+**Choice:** Create integration tests that mount parent CE containing child CEs to verify layout propagation, using `createFixture` from `@aurelia/testing`.
+
+**Rationale (per [Aurelia Testing Components](https://docs.aurelia.io/developer-guides/overview/testing-components)):**
+The official docs recommend testing "view and view-model together." For CE composition, this means mounting the parent with its child CEs registered:
+
+```typescript
+import { createFixture, Registration } from '@aurelia/testing'
+import { ConcertHighway } from '../../src/components/live-highway/concert-highway'
+import { EventCard } from '../../src/components/event-card/event-card'
+
+it('concert-highway renders with non-zero height when dateGroups provided', async () => {
+  const fixture = await createFixture
+    .component(class App {
+      dateGroups = [mockDateGroup]
+    })
+    .html`<div style="display:grid; grid-template-rows: auto 1fr; height:500px">
+      <concert-highway date-groups.bind="dateGroups"></concert-highway>
+    </div>`
+    .deps(ConcertHighway, EventCard)
+    .build()
+    .started
+
+  const ce = fixture.getBy('concert-highway')
+  expect(ce.offsetHeight).toBeGreaterThan(0)
+
+  await fixture.stop(true)
+})
+```
+
+**Key composition scenarios to test:**
+1. `dashboard-route` + `concert-highway` — grid height propagation
+2. `welcome-route` + `concert-highway` — scroll-snap overflow containment
+3. `concert-highway` + `event-card` — subgrid lane alignment
+
+**JSDOM limitation:** `offsetHeight` and computed styles may not fully replicate browser layout. Tests should verify DOM structure and CSS class/attribute presence. For pixel-accurate layout, E2E remains necessary — but composition tests catch structural issues (missing elements, broken bindings, incorrect display modes).
+
+### Decision 6: Dashboard-route integration test
+
+**Choice:** Create `test/routes/dashboard-route.fixture.spec.ts` using `createFixture` with all 3 service mocks.
+
+**Rationale:** Dashboard-route is the most complex route component with:
+- `IConcertService`, `IFollowServiceClient`, `ITicketJourneyService` (3 service injections)
+- `isLoading` / `loadError` / `dateGroups` / `needsRegion` / `showCelebration` (5 state flags)
+- 6 child CEs in its template
+
+The previous `dashboard-route.spec.ts` was deleted during PR #298 due to Unhandled Rejection from the module chain explosion. With Decision 2's containment strategy, it can be safely reintroduced:
+
+```typescript
+// Mock the HTML template to prevent child CE chain loading
+vi.mock('../../src/routes/dashboard/dashboard-route.html', () => ({
+  default: `
+    <p if.bind="isLoading" data-testid="dashboard-loading">Loading</p>
+    <div if.bind="!isLoading && !loadError && dateGroups.length > 0"
+         data-testid="concert-content">Content</div>
+  `
+}))
+
+import { DashboardRoute } from '../../src/routes/dashboard/dashboard-route'
+
+it('shows loading state initially', async () => {
+  const mockConcertService = { listWithProximity: vi.fn().mockResolvedValue({ groups: [] }) }
+
+  const fixture = await createFixture
+    .component(DashboardRoute)
+    .html`<dashboard-route></dashboard-route>`
+    .deps(
+      Registration.instance(IConcertService, mockConcertService),
+      Registration.instance(IFollowServiceClient, mockFollowService),
+      Registration.instance(ITicketJourneyService, mockJourneyService),
+    )
+    .build()
+    .started
+
+  // isLoading should be false after attached() completes
+  expect(mockConcertService.listWithProximity).toHaveBeenCalled()
+  await fixture.stop(true)
+})
+```
+
+### Decision 7: Evaluate vitest environment optimization
+
+**Choice:** Evaluate and adopt optimizations in phases.
+
+**Phase A: Per-file environment annotations (immediate)**
+
+Per [Vitest docs](https://vitest.dev/guide/environment.html#environments-for-specific-files), use control comments to run pure logic tests in `node` environment:
+
+```typescript
+// test/adapter/rpc/mapper/artist-mapper.spec.ts
+// @vitest-environment node
+
+import { describe, it, expect } from 'vitest'
+// ... pure mapping logic tests, no DOM needed
+```
+
+This avoids jsdom initialization overhead for ~30 test files that don't need DOM.
+
+**Phase B: happy-dom evaluation (spike)**
+
+Per vitest docs: "happy-dom is considered to be faster than jsdom, but lacks some API."
+
+Run benchmark:
+```bash
+# Compare test execution time
+time npx vitest run --environment jsdom
+time npx vitest run --environment happy-dom
+```
+
+Evaluate:
+- Does Aurelia's `BrowserPlatform` work with happy-dom?
+- Do `createFixture` tests pass with happy-dom?
+- What's the speed improvement?
+
+**Phase C: vitest projects (future consideration)**
+
+Per [Vitest Projects docs](https://vitest.dev/guide/#projects-support):
+```typescript
+// vitest.config.ts
+export default defineConfig({
+  test: {
+    projects: [
+      {
+        test: {
+          name: 'unit',
+          environment: 'node',
+          include: ['test/adapter/**', 'test/entities/**', 'test/services/**'],
+        },
+      },
+      {
+        test: {
+          name: 'integration',
+          environment: 'jsdom',  // or happy-dom
+          include: ['test/components/**', 'test/routes/**', 'test/smoke/**'],
+          setupFiles: ['./test/setup.ts'],
+        },
+      },
+    ],
+  },
+})
+```
+
+This is a larger refactor and may be deferred if Phase A + B yield sufficient improvement.
+
+## Risks / Trade-offs
+
+### [Risk] Removing manual JSDOM breaks tests that depend on specific JSDOM configuration
+**Mitigation:** The current manual JSDOM uses `url: 'http://localhost'` — vitest's jsdom environment defaults to the same. Run full test suite after change to verify. If specific JSDOM options are needed, they can be passed via `environmentOptions.jsdom` in `vitest.config.ts` per [Vitest docs](https://vitest.dev/guide/environment.html).
+
+### [Risk] data-testid attributes add maintenance burden to templates
+**Mitigation:** Only add to elements actually used in E2E tests (~15-20 elements total). The attribute is inert and doesn't affect rendering or accessibility. Convention: `data-testid` is only added when an E2E test references the element.
+
+### [Risk] Template HTML mocking (Decision 2, Pillar C) may mask template binding errors
+**Mitigation:** Template mocking is only used for route-level tests where the goal is testing ViewModel logic. Template binding correctness is verified by the `createFixture` component integration tests from `refine-frontend-testing` (PR #360). The two approaches are complementary.
+
+### [Risk] happy-dom may not support all APIs used by Aurelia
+**Mitigation:** This is explicitly a spike/evaluation, not a commitment. If happy-dom fails, jsdom remains the default. Per vitest docs, per-file `// @vitest-environment jsdom` can override for specific files that need full jsdom.
+
+### [Trade-off] page-help pointer-events fix changes visible behavior
+**Accepted:** The dismiss-zone should be transparent when the help overlay is not shown. The current behavior (always intercepting) is a bug, not a feature. Users are not affected because the overlay is invisible when inactive.
+
+### [Trade-off] Two CE testing patterns coexist (composition + unit)
+**Accepted:** CE composition tests verify parent-child layout. CE unit tests (from `refine-frontend-testing`) verify individual component logic. Both are needed — this is the same unit/integration split recommended by the Aurelia docs.

--- a/openspec/changes/harden-test-infrastructure/design.md
+++ b/openspec/changes/harden-test-infrastructure/design.md
@@ -197,7 +197,7 @@ const scroll = page.getByTestId('concert-scroll')
 | `[data-live-card]` | event-card | (already stable) |
 | `.journey-badge` | event-card | `journey-badge` |
 | `.sheet-journey` | event-detail-sheet | `sheet-journey` |
-| `.journey-btn` | event-detail-sheet | `journey-btn` |
+| `.journey-btn` | event-detail-sheet | `journey-btn` (static; combine with `[data-journey-status]` for specificity) |
 | `.journey-remove-btn` | event-detail-sheet | `journey-remove-btn` |
 | `.loading-text` | dashboard-route | `dashboard-loading` |
 | `.welcome-preview` | welcome-route | `welcome-preview` |
@@ -206,30 +206,13 @@ const scroll = page.getByTestId('concert-scroll')
 
 ### Decision 4: Fix application-layer issues causing page.evaluate() workarounds
 
-**Choice:** Fix the root causes in application code rather than keeping test workarounds.
+**Choice:** Address the root causes of JS dispatch workarounds in E2E tests.
 
-**Issue A: page-help dismiss-zone intercepts pointer events**
+**Issue A: Popover top-layer blocks Playwright hit-testing (actual root cause)**
 
-The `page-help` component creates a full-viewport dismiss zone that captures all click events. E2E tests must use `page.evaluate(() => el.click())` to bypass it.
+Initial hypothesis was that `page-help` had a `.dismiss-zone` element intercepting pointer events. **Investigation during implementation revealed this was incorrect** — `page-help` uses `<bottom-sheet>` which renders as a popover in the top layer. In serial-mode E2E tests, popovers from prior tests can remain open and intercept Playwright's actionability checks.
 
-**Fix:** Add `pointer-events: none` to the dismiss zone when the help overlay is not actively shown, and use `pointer-events: auto` only when visible:
-
-```css
-/* page-help.css */
-.dismiss-zone {
-  pointer-events: none;  /* default: transparent to clicks */
-}
-
-.dismiss-zone[data-active="true"] {
-  pointer-events: auto;  /* only intercept when help is shown */
-}
-```
-
-**Issue B: Popover top-layer blocks Playwright hit-testing**
-
-Popover elements in the top layer intercept Playwright's actionability checks even when visually non-overlapping due to top-layer stacking.
-
-**Fix:** Ensure popovers are closed (removed from top layer) before E2E assertions on elements behind them. In serial mode tests, add explicit popover dismiss before each interaction:
+**Fix:** Add explicit popover cleanup in serial-mode `beforeEach` to close lingering popovers, then use native Playwright `click()`:
 
 ```typescript
 // In E2E beforeEach for serial tests
@@ -238,24 +221,22 @@ await page.evaluate(() => {
     try { (el as HTMLElement).hidePopover() } catch {}
   })
 })
+
+// Now native Playwright click works
+await page.locator('[data-live-card]').first().click()
 ```
 
-**Issue C: visually-hidden radio inputs**
+**Issue B: visually-hidden radio inputs (JS dispatch is correct)**
 
-Radio inputs with `class="visually-hidden"` are not clickable by Playwright (zero bounding box).
+Initial hypothesis was to replace JS dispatch with `page.getByLabel()`. **Investigation revealed this is not feasible** — Aurelia's `change.trigger` binding fires only on native `change` events, not on `click`. The hype radio labels contain only visual dots (`<span class="hype-dot">`) with no readable text, so `page.getByLabel()` cannot target them.
 
-**Fix per [Playwright docs](https://playwright.dev/docs/actionability#visible):** Use `force: true` on the label click, or use Playwright's `page.getByLabel()` which clicks the associated label:
+**Conclusion:** JS dispatch via `dispatchEvent(new Event('change', { bubbles: true }))` is the **correct approach** for Aurelia `change.trigger` bindings on visually-hidden inputs without readable label text. These are not workarounds — they are the appropriate interaction pattern.
 
-```typescript
-// BEFORE: JS dispatch workaround
-await page.evaluate(() => {
-  const radio = document.querySelector('input[type="radio"]')
-  radio.dispatchEvent(new Event('change', { bubbles: true }))
-})
-
-// AFTER: Click the visible label
-await page.getByLabel('日本語').click()
-```
+**Remaining JS dispatch sites (audit results):**
+- 2 hype radio dispatches — correct (Aurelia `change.trigger`)
+- 4 journey button clicks — pending native click validation after popover cleanup
+- 3 nav tab clicks — pending investigation (may be related to popover interception)
+- 2 event card clicks in other specs — pending popover cleanup propagation
 
 ### Decision 5: CE composition integration tests via createFixture
 

--- a/openspec/changes/harden-test-infrastructure/proposal.md
+++ b/openspec/changes/harden-test-infrastructure/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+The `refine-frontend-testing` change (PR #360) addresses unit test layer improvements (createFixture adoption, infra bug fixes, test isolation) but leaves unresolved the **structural root causes** that caused cascading CI failures during the concert-highway CE extraction (PR #298). Specifically: dual jsdom management in `test/setup.ts` causing `document is not defined` errors, Aurelia template import chains triggering uncontrolled module graph expansion in vitest, fragile CSS-class-based E2E selectors breaking on refactors, and pervasive `page.evaluate()` JS dispatch workarounds bypassing Playwright's auto-wait. These issues will recur on every non-trivial component refactoring unless the test infrastructure itself is hardened.
+
+## What Changes
+
+- **Resolve dual jsdom management**: Eliminate the manual `new JSDOM()` + `Object.assign(globalThis, ...)` in `test/setup.ts` that conflicts with vitest's built-in `environment: 'jsdom'`. Align with vitest's environment lifecycle so teardown ordering is deterministic.
+- **Contain Aurelia template module graph expansion**: Establish a strategy to prevent `<import from="...">` in `.html` templates from causing vitest to recursively load the entire component dependency tree. Introduce global CE registration guidelines and `vi.mock()` containment patterns.
+- **Introduce data-testid E2E selector strategy**: Migrate critical E2E selectors from CSS classes (`.concert-scroll`, `.journey-badge`) to stable `data-testid` attributes on components, reducing selector breakage on refactors.
+- **Eliminate page.evaluate() JS dispatch workarounds**: Fix the application-layer issues (page-help dismiss-zone interception, popover top-layer blocking, visually-hidden form controls) that force E2E tests to bypass Playwright's native locator API.
+- **Add CE composition integration tests**: Create `createFixture`-based tests that mount parent+child CE combinations to catch layout propagation issues (display:inline default, grid/flex chain breaks) before E2E.
+- **Add dashboard-route integration test**: Cover the most complex route component (3 service injections, 5 state flags, 6 child CEs) which currently has zero test coverage after the previous spec was deleted.
+- **Evaluate vitest environment optimization**: Assess `happy-dom` vs `jsdom`, per-file environment annotations, and vitest `projects` feature to separate unit (node) from integration (dom) tests for faster CI.
+
+## Capabilities
+
+### New Capabilities
+
+_(none)_
+
+### Modified Capabilities
+
+- `frontend-testing`: Resolve dual jsdom management, contain template module graph expansion, add CE composition tests, add dashboard-route tests, optimize vitest environment configuration
+- `layout-assertions`: Introduce data-testid selector strategy, eliminate page.evaluate() JS dispatch workarounds in E2E tests
+
+## Impact
+
+- **frontend repo**: `test/setup.ts` (jsdom alignment), `vitest.config.ts` (environment optimization), `src/components/**/*.html` (data-testid attributes), `src/components/page-help/` (dismiss-zone pointer-events fix), `e2e/**/*.spec.ts` (selector migration, JS dispatch removal), new test files for CE composition and dashboard-route
+- **No API or dependency changes**: All changes are internal to the frontend repo
+- **No breaking changes**: Existing tests continue to work; changes are additive or fix silent bugs
+- **CI**: Faster test execution from environment optimization; more stable E2E from selector hardening

--- a/openspec/changes/harden-test-infrastructure/specs/frontend-testing/spec.md
+++ b/openspec/changes/harden-test-infrastructure/specs/frontend-testing/spec.md
@@ -1,0 +1,123 @@
+## MODIFIED Requirements
+
+### Requirement: Test infrastructure provides shared mock factories
+The test suite SHALL provide reusable mock factories for commonly used DI dependencies (`ILogger`, `IAuthService`, `IRouter`, RPC service clients) in `test/helpers/`.
+
+#### Scenario: Creating a mock logger
+- **WHEN** a test imports `createMockLogger` from `test/helpers/mock-logger`
+- **THEN** it SHALL return an object implementing `ILogger` with all methods as Vitest spies (`debug`, `info`, `warn`, `error`, `scopeTo`)
+
+#### Scenario: Creating a mock auth service
+- **WHEN** a test imports `createMockAuth` from `test/helpers/mock-auth`
+- **THEN** it SHALL return an object implementing `IAuthService` with configurable `isAuthenticated`, `user`, and spy methods for `signIn`, `signOut`, `signUp`, `handleCallback`
+
+#### Scenario: Creating a test DI container
+- **WHEN** a test calls `createTestContainer` with mock registrations
+- **THEN** it SHALL return an Aurelia `IContainer` with the provided mocks registered and `ILogger` pre-registered
+
+#### Scenario: Creating a composition fixture helper
+- **WHEN** a test calls `createCompositionFixture` with a parent CE, child CE deps, and mock services
+- **THEN** it SHALL return a `createFixture` instance with all CEs registered and services mocked via `Registration.instance()`
+
+## ADDED Requirements
+
+### Requirement: Vitest environment is managed by vitest, not manually
+The `test/setup.ts` file SHALL NOT create its own JSDOM instance. Vitest's `environment: 'jsdom'` (configured in `vitest.config.ts`) SHALL be the single source of truth for the DOM environment.
+
+#### Scenario: setup.ts does not import jsdom
+- **WHEN** `test/setup.ts` is loaded
+- **THEN** it SHALL NOT import from `jsdom` package
+- **AND** it SHALL NOT call `new JSDOM()`
+- **AND** it SHALL NOT assign to `globalThis.window`, `globalThis.document`, or `globalThis.navigator`
+
+#### Scenario: setup.ts initializes only Aurelia platform bridge
+- **WHEN** `test/setup.ts` is loaded
+- **THEN** it SHALL call `new BrowserPlatform(window)` using vitest's environment-provided `window`
+- **AND** it SHALL call `setPlatform()` and `BrowserPlatform.set()` per [Aurelia testing docs](https://docs.aurelia.io/developer-guides/overview)
+
+#### Scenario: Fixture cleanup uses vitest-managed environment
+- **WHEN** a test that created fixtures completes
+- **THEN** fixture `stop(true)` SHALL execute while vitest's jsdom is still active (no stale `document` reference)
+
+### Requirement: Aurelia template module graph is contained in tests
+Test files SHALL NOT trigger recursive Aurelia template resolution chains that load untested component dependencies.
+
+#### Scenario: Direct CE import for component tests
+- **WHEN** a test targets a specific custom element (e.g., `ConcertHighway`)
+- **THEN** the test SHALL import the CE class directly from its source file (e.g., `src/components/live-highway/concert-highway`)
+- **AND** it SHALL NOT import via a parent route module that would trigger template chain resolution
+
+#### Scenario: HTML template mock for route-level tests
+- **WHEN** a test targets a route component's ViewModel logic (e.g., `DashboardRoute`)
+- **THEN** the test SHALL mock the route's HTML template via `vi.mock('...route.html', () => ({ default: '<minimal-template>' }))` per [Vitest module mocking docs](https://vitest.dev/guide/mocking.html)
+- **AND** the mock template SHALL NOT contain `<import from="...">` directives
+
+#### Scenario: No cascading document reference errors
+- **WHEN** any test file is executed by vitest
+- **THEN** it SHALL NOT produce `ReferenceError: document is not defined` from transitive Aurelia template imports
+
+### Requirement: CE composition integration tests verify layout propagation
+Integration tests SHALL verify that custom elements render with correct layout when composed inside parent containers, using `createFixture` from `@aurelia/testing` per [Aurelia Testing Components docs](https://docs.aurelia.io/developer-guides/overview/testing-components).
+
+#### Scenario: ConcertHighway renders with non-zero height in grid parent
+- **WHEN** `ConcertHighway` is rendered via `createFixture` inside a CSS Grid container with `dateGroups` bound
+- **THEN** the `concert-highway` element SHALL be present in the DOM
+- **AND** it SHALL contain date separator elements and lane grid elements matching the provided dateGroups
+
+#### Scenario: ConcertHighway with EventCard child CEs
+- **WHEN** `ConcertHighway` is rendered with `EventCard` registered as a dependency
+- **THEN** `event-card` elements SHALL be present in the DOM for each event in the dateGroups
+
+#### Scenario: ConcertHighway in readonly mode
+- **WHEN** `ConcertHighway` is rendered with `is-readonly="true"`
+- **THEN** clicking an `event-card` SHALL NOT dispatch an `event-selected` custom event
+
+#### Scenario: ConcertHighway beam index map
+- **WHEN** `ConcertHighway` is rendered with dateGroups containing events where `matched` is `true`
+- **THEN** `component.beamIndexMap` SHALL contain entries mapping each matched event ID to a beam index
+
+### Requirement: Dashboard-route has integration tests
+The `DashboardRoute` component SHALL have `createFixture`-based integration tests verifying state management and service interaction.
+
+#### Scenario: Loading state on initial render
+- **WHEN** `DashboardRoute` is rendered via `createFixture` with mocked services
+- **THEN** the `loadData()` method SHALL call `concertService.listWithProximity`
+
+#### Scenario: Error state when service fails
+- **WHEN** the concert service rejects with an error
+- **THEN** `loadError` SHALL be truthy
+- **AND** the template SHALL render the error state (not the concert highway)
+
+#### Scenario: Empty state when no concerts exist
+- **WHEN** the concert service resolves with zero groups
+- **THEN** `dateGroups` SHALL be empty
+- **AND** the template SHALL render the empty state placeholder
+
+#### Scenario: Concert data populates dateGroups
+- **WHEN** the concert service resolves with proximity groups
+- **THEN** `dateGroups` SHALL contain the mapped groups
+- **AND** the template SHALL render the concert highway (not loading or error state)
+
+#### Scenario: needsRegion blurs concert highway
+- **WHEN** no home region is set (needsRegion is true)
+- **THEN** the concert-highway element SHALL have `data-blurred="true"`
+
+### Requirement: Per-file vitest environment annotations optimize execution
+Test files that do not require DOM access SHALL declare `// @vitest-environment node` to skip jsdom initialization per [Vitest environment docs](https://vitest.dev/guide/environment.html#environments-for-specific-files).
+
+#### Scenario: Mapper tests run in node environment
+- **WHEN** a mapper test file (e.g., `test/adapter/rpc/mapper/artist-mapper.spec.ts`) is executed
+- **THEN** it SHALL contain `// @vitest-environment node` at the top
+- **AND** it SHALL execute without jsdom overhead
+
+#### Scenario: Entity tests run in node environment
+- **WHEN** an entity test file (e.g., `src/entities/artist.spec.ts`) is executed
+- **THEN** it SHALL contain `// @vitest-environment node` at the top
+
+#### Scenario: Service tests without DOM dependency run in node environment
+- **WHEN** a service test that only tests pure logic (no DOM, no Aurelia lifecycle) is executed
+- **THEN** it SHALL contain `// @vitest-environment node` at the top
+
+#### Scenario: Component and route tests remain in jsdom environment
+- **WHEN** a test file uses `createFixture`, `BrowserPlatform`, or DOM APIs
+- **THEN** it SHALL NOT declare `// @vitest-environment node` (inherits jsdom from config)

--- a/openspec/changes/harden-test-infrastructure/specs/layout-assertions/spec.md
+++ b/openspec/changes/harden-test-infrastructure/specs/layout-assertions/spec.md
@@ -1,0 +1,64 @@
+## ADDED Requirements
+
+### Requirement: E2E selectors use data-testid for stability
+All E2E test selectors for elements that are subject to refactoring SHALL use `data-testid` attributes instead of CSS class selectors, per [Playwright locator best practices](https://playwright.dev/docs/locators#locate-by-test-id).
+
+#### Scenario: Concert highway scroll container uses data-testid
+- **WHEN** an E2E test targets the concert scroll container
+- **THEN** it SHALL use `page.getByTestId('concert-scroll')` instead of `page.locator('.concert-scroll')`
+
+#### Scenario: Journey badge uses data-testid
+- **WHEN** an E2E test targets a ticket journey badge on an event card
+- **THEN** it SHALL use `page.getByTestId('journey-badge')` instead of `page.locator('.journey-badge')`
+
+#### Scenario: Detail sheet journey section uses data-testid
+- **WHEN** an E2E test targets the journey section in the event detail sheet
+- **THEN** it SHALL use `page.getByTestId('sheet-journey')` instead of `page.locator('.sheet-journey')`
+
+#### Scenario: Journey status buttons use data-testid with status qualifier
+- **WHEN** an E2E test targets a specific journey status button
+- **THEN** it SHALL use `page.getByTestId('journey-btn-tracking')` (combining testid with status) instead of `.journey-btn[data-journey-status="tracking"]`
+
+#### Scenario: Dashboard loading indicator uses data-testid
+- **WHEN** an E2E test targets the dashboard loading text
+- **THEN** it SHALL use `page.getByTestId('dashboard-loading')` instead of `page.locator('.loading-text')`
+
+#### Scenario: Welcome preview section uses data-testid
+- **WHEN** an E2E test targets the welcome page preview section
+- **THEN** it SHALL use `page.getByTestId('welcome-preview')` instead of `page.locator('.welcome-preview')`
+
+#### Scenario: data-testid attributes are present in component templates
+- **WHEN** a component template contains an element targeted by E2E tests
+- **THEN** the element SHALL have a `data-testid` attribute with a kebab-case value matching its semantic purpose
+
+### Requirement: E2E tests use Playwright native locator API without JS dispatch workarounds
+E2E tests SHALL use Playwright's native locator API (`click()`, `fill()`, `check()`) instead of `page.evaluate()` for user interactions, per [Playwright actionability docs](https://playwright.dev/docs/actionability).
+
+#### Scenario: page-help dismiss-zone does not intercept clicks when inactive
+- **WHEN** the page-help overlay is not actively shown
+- **THEN** the dismiss-zone element SHALL have `pointer-events: none`
+- **AND** Playwright `click()` on elements behind it SHALL succeed without JS dispatch
+
+#### Scenario: page-help dismiss-zone intercepts clicks when active
+- **WHEN** the page-help overlay is actively shown (data-active="true")
+- **THEN** the dismiss-zone element SHALL have `pointer-events: auto`
+
+#### Scenario: Popover elements are dismissed before serial test interactions
+- **WHEN** a serial-mode E2E test begins a new interaction after a prior test opened a popover
+- **THEN** the test setup SHALL close any open popovers before performing actions
+- **AND** subsequent Playwright `click()` calls SHALL succeed without JS dispatch
+
+#### Scenario: Visually-hidden radio inputs are clickable via labels
+- **WHEN** an E2E test needs to select a radio option with a visually-hidden input
+- **THEN** it SHALL use `page.getByLabel('label text').click()` per [Playwright getByLabel docs](https://playwright.dev/docs/locators#locate-by-label)
+- **AND** it SHALL NOT use `page.evaluate()` to dispatch synthetic events
+
+#### Scenario: Event card clicks use native Playwright click
+- **WHEN** an E2E test clicks an event card to open the detail sheet
+- **THEN** it SHALL use `page.getByTestId('live-card').first().click()` or equivalent Playwright locator
+- **AND** it SHALL NOT use `page.evaluate(() => el.click())`
+
+#### Scenario: Journey button clicks use native Playwright click
+- **WHEN** an E2E test clicks a journey status button inside the detail sheet
+- **THEN** it SHALL use `page.getByTestId('journey-btn-tracking').click()` or equivalent
+- **AND** it SHALL NOT use `page.evaluate(() => btn.click())`

--- a/openspec/changes/harden-test-infrastructure/specs/layout-assertions/spec.md
+++ b/openspec/changes/harden-test-infrastructure/specs/layout-assertions/spec.md
@@ -35,31 +35,24 @@ All E2E test selectors for elements that are subject to refactoring SHALL use `d
 ### Requirement: E2E tests use Playwright native locator API without JS dispatch workarounds
 E2E tests SHALL use Playwright's native locator API (`click()`, `fill()`, `check()`) instead of `page.evaluate()` for user interactions, per [Playwright actionability docs](https://playwright.dev/docs/actionability).
 
-#### Scenario: page-help dismiss-zone does not intercept clicks when inactive
-- **WHEN** the page-help overlay is not actively shown
-- **THEN** the dismiss-zone element SHALL have `pointer-events: none`
-- **AND** Playwright `click()` on elements behind it SHALL succeed without JS dispatch
-
-#### Scenario: page-help dismiss-zone intercepts clicks when active
-- **WHEN** the page-help overlay is actively shown (data-active="true")
-- **THEN** the dismiss-zone element SHALL have `pointer-events: auto`
-
 #### Scenario: Popover elements are dismissed before serial test interactions
 - **WHEN** a serial-mode E2E test begins a new interaction after a prior test opened a popover
-- **THEN** the test setup SHALL close any open popovers before performing actions
+- **THEN** the test setup SHALL close any open popovers via `hidePopover()` before performing actions
 - **AND** subsequent Playwright `click()` calls SHALL succeed without JS dispatch
 
 #### Scenario: Visually-hidden radio inputs are clickable via labels
-- **WHEN** an E2E test needs to select a radio option with a visually-hidden input
+- **WHEN** an E2E test needs to select a radio option with a visually-hidden input whose label has readable text and does not use an event-sensitive binding (e.g. Aurelia `change.trigger`)
 - **THEN** it SHALL use `page.getByLabel('label text').click()` per [Playwright getByLabel docs](https://playwright.dev/docs/locators#locate-by-label)
 - **AND** it SHALL NOT use `page.evaluate()` to dispatch synthetic events
+- **WHEN** the input has no readable label text or requires a native `change` event (e.g. Aurelia `change.trigger` binding)
+- **THEN** it SHALL use `page.evaluate(() => el.dispatchEvent(new Event('change', { bubbles: true })))` — this is correct behavior, not a workaround (see Design Decision 4)
 
 #### Scenario: Event card clicks use native Playwright click
-- **WHEN** an E2E test clicks an event card to open the detail sheet
-- **THEN** it SHALL use `page.getByTestId('live-card').first().click()` or equivalent Playwright locator
+- **WHEN** an E2E test clicks an event card to open the detail sheet and popovers have been cleaned up
+- **THEN** it SHALL use `page.locator('[data-live-card]').first().click()` or equivalent Playwright locator
 - **AND** it SHALL NOT use `page.evaluate(() => el.click())`
 
 #### Scenario: Journey button clicks use native Playwright click
 - **WHEN** an E2E test clicks a journey status button inside the detail sheet
-- **THEN** it SHALL use `page.getByTestId('journey-btn-tracking').click()` or equivalent
+- **THEN** it SHALL use `page.locator('[data-testid="journey-btn"][data-journey-status="tracking"]').click()` or equivalent
 - **AND** it SHALL NOT use `page.evaluate(() => btn.click())`

--- a/openspec/changes/harden-test-infrastructure/specs/layout-assertions/spec.md
+++ b/openspec/changes/harden-test-infrastructure/specs/layout-assertions/spec.md
@@ -17,7 +17,8 @@ All E2E test selectors for elements that are subject to refactoring SHALL use `d
 
 #### Scenario: Journey status buttons use data-testid with status qualifier
 - **WHEN** an E2E test targets a specific journey status button
-- **THEN** it SHALL use `page.getByTestId('journey-btn-tracking')` (combining testid with status) instead of `.journey-btn[data-journey-status="tracking"]`
+- **THEN** it SHALL use `[data-testid="journey-btn"][data-journey-status="tracking"]` (static testid combined with existing status attribute) instead of `.journey-btn[data-journey-status="tracking"]`
+- **AND** the template SHALL use static `data-testid="journey-btn"` (not dynamic interpolation, per `lint-no-data-interpolation` rule)
 
 #### Scenario: Dashboard loading indicator uses data-testid
 - **WHEN** an E2E test targets the dashboard loading text

--- a/openspec/changes/harden-test-infrastructure/tasks.md
+++ b/openspec/changes/harden-test-infrastructure/tasks.md
@@ -1,0 +1,82 @@
+## 1. Unify jsdom management (Design Decision 1)
+
+- [x] 1.1 Remove `import { JSDOM } from 'jsdom'` and manual JSDOM instance creation from `test/setup.ts`
+- [x] 1.2 Remove `Object.assign(globalThis, { window, document, navigator, ... })` from `test/setup.ts`
+- [x] 1.3 Verify `BrowserPlatform` initialization uses vitest's environment-provided `window` (no import needed)
+- [x] 1.4 Run full test suite (`make test`) and verify no `document is not defined` errors
+- [x] 1.5 If any tests fail due to missing globals, add them via `vitest.config.ts` `environmentOptions.jsdom` instead of manual assignment — Node.js 25 provides non-functional localStorage stub; added MemoryStorage polyfill in setup.ts + defensive stop/tearDown fallback for fixture cleanup
+
+## 2. Contain Aurelia template module graph (Design Decision 2)
+
+- [x] 2.1 Audit all `<import from="...">` usages in `.html` templates — list which CEs are already globally registered vs only imported per-template
+- [x] 2.2 Move remaining shared CEs to global registration in `main.ts` — added ConcertHighway, EventDetailSheet, UserHomeSelector, InlineError, CelebrationOverlay, SignupPromptBanner
+- [x] 2.3 Remove `<import from="...">` directives from dashboard-route.html (8 imports), welcome-route.html (1), my-artists-route.html (2), settings-route.html (1), discovery-route.html (1 page-help)
+- [x] 2.4 Verify `app-shell.spec.ts` — removed `dashboard-route.html` vi.mock() (no longer needed since template has no `<import>` chains)
+- [ ] 2.5 Document the convention in `docs/testing-strategy.md`: "Tests import CE classes directly, never via parent route modules" — deferred to task 11.5
+
+## 3. CE composition integration tests (Design Decision 5)
+
+- [x] 3.1 Create `test/helpers/mock-date-groups.ts` — reusable makeConcert/makeDateGroup factories for composition tests
+- [x] 3.2 Create `test/components/live-highway/concert-highway.composition.spec.ts` — test ConcertHighway + EventCard rendering with mock dateGroups, verify DOM structure (date separators, lane grid, event cards)
+- [x] 3.3 Add test: ConcertHighway in readonly mode — verify event-selected is not dispatched on click
+- [x] 3.4 Add test: ConcertHighway beam index map — verify beamIndexMap contains entries for matched events
+- [x] 3.5 Add test: ConcertHighway detaching cleanup — verify scroll listener removal and rAF cancellation
+
+## 4. Dashboard-route integration test (Design Decision 6)
+
+- [x] 4.1-4.6 Skipped — existing `test/routes/dashboard-route.spec.ts` already covers ViewModel logic with 15 DI unit tests (loadData, loading, onHomeSelected, celebration, detaching). Fixture-based template test deferred as template rendering is validated by E2E.
+
+## 5. data-testid selector introduction (Design Decision 3)
+
+- [ ] 5.1 Add `data-testid="concert-scroll"` to concert-highway.html `<ol class="concert-scroll">`
+- [ ] 5.2 Add `data-testid="journey-badge"` to event-card.html journey badge element
+- [ ] 5.3 Add `data-testid="sheet-journey"` to event-detail-sheet.html journey section
+- [ ] 5.4 Add `data-testid="journey-btn-{status}"` to event-detail-sheet.html journey buttons (use repeat.for variable)
+- [ ] 5.5 Add `data-testid="journey-remove-btn"` to event-detail-sheet.html remove button
+- [ ] 5.6 Add `data-testid="dashboard-loading"` to dashboard-route.html loading text
+- [ ] 5.7 Add `data-testid="welcome-preview"` to welcome-route.html preview section
+
+## 6. Migrate E2E selectors to data-testid
+
+- [ ] 6.1 Update `e2e/layout/dashboard.layout.spec.ts` — replace `.concert-scroll` selectors with `getByTestId`
+- [ ] 6.2 Update `e2e/layout/ticket-journey.layout.spec.ts` — replace `.journey-badge`, `.sheet-journey`, `.journey-btn`, `.journey-remove-btn` selectors with `getByTestId`
+- [ ] 6.3 Update `e2e/dashboard-lane-classification.spec.ts` — replace `.concert-scroll` selectors with `getByTestId`
+- [ ] 6.4 Update `e2e/onboarding-flow.spec.ts` — replace `.welcome-preview` and `.loading-text` selectors with `getByTestId`
+- [ ] 6.5 Configure Playwright `testIdAttribute` in `playwright.config.mjs` if default `data-testid` needs customization
+
+## 7. Fix page-help dismiss-zone pointer-events (Design Decision 4A)
+
+- [x] 7.1-7.4 Skipped — investigation revealed page-help uses `<bottom-sheet>` (no dismiss-zone element). The JS dispatch workarounds were caused by popover top-layer interception in serial mode, not page-help.
+
+## 8. Fix popover and visually-hidden interaction issues (Design Decision 4B, 4C)
+
+- [x] 8.1 Add popover cleanup to serial-mode E2E test `beforeEach` — close all open popovers before each test. Replace event card JS dispatch with native Playwright `click()`.
+- [x] 8.2 Skipped — hype radio uses Aurelia `change.trigger` binding which requires `dispatchEvent(new Event('change'))`. Labels have no readable text. JS dispatch is the correct approach here.
+- [ ] 8.3 Replace journey button JS dispatch clicks with native Playwright `click()` — deferred pending E2E CI validation of popover cleanup
+- [ ] 8.4 Replace remaining JS dispatch clicks in detail-sheet-dismiss.spec.ts and onboarding-flow.spec.ts — deferred pending E2E validation
+- [x] 8.5 Audit complete: 11 `page.evaluate(() => el.click())` sites remaining. 2 are hype radio (correct), 4 are journey buttons (pending popover cleanup validation), 3 are nav tab clicks, 2 are event card clicks in other specs.
+
+## 9. Per-file vitest environment optimization (Design Decision 7A)
+
+- [x] 9.1 Add `// @vitest-environment node` to 4 mapper test files, 5 entity test files, 3 view adapter files, 1 physics file
+- [x] 9.2 Add `// @vitest-environment node` to pure service/component files: prompt-coordinator, bubble-pool, stage-effects, absorption-animator, detect-country
+- [x] 9.3 Guard `test/setup.ts` BrowserPlatform init with `typeof window !== 'undefined'` check + dynamic imports
+- [x] 9.4 Run `npx vitest run` — 76 files, 809 tests, 0 failures
+- [x] 9.5 Execution time: 37.38s → 22.90s (38.7% faster)
+
+## 10. happy-dom evaluation spike (Design Decision 7B)
+
+- [x] 10.1 Installed happy-dom as dev dependency (spike only, reverted)
+- [x] 10.2 All 809 tests pass with happy-dom. 4 Uncaught Exceptions from Canvas `measureText` in dna-orb-canvas (happy-dom lacks full Canvas API)
+- [x] 10.3 BrowserPlatform initialization works with happy-dom's window
+- [x] 10.4 createFixture tests pass with happy-dom
+- [x] 10.5 Benchmark: jsdom 24.67s → happy-dom 16.68s (32.4% faster, environment time 50% faster)
+- [x] 10.6 Decision: happy-dom viable but deferred. Canvas API limitation requires per-file `// @vitest-environment jsdom` on dna-orb-canvas.spec.ts. Adoption recommended in separate PR with `dna-orb-canvas` jsdom fallback.
+
+## 11. Validation and cleanup
+
+- [x] 11.1 CI passed for all 3 PRs (#302, #303, #304): lint, test, E2E, smoke, security
+- [x] 11.2 E2E tests pass with data-testid selectors and popover cleanup
+- [x] 11.3 Audit: 11 `page.evaluate(() => el.click())` remain — 2 hype radio (correct, Aurelia change.trigger), 4 journey buttons (pending native click validation), 3 nav tabs, 2 event cards in other specs
+- [x] 11.4 Verified: zero `new JSDOM()` calls in test infrastructure
+- [ ] 11.5 Update `docs/testing-strategy.md` — deferred to follow-up PR

--- a/openspec/changes/harden-test-infrastructure/tasks.md
+++ b/openspec/changes/harden-test-infrastructure/tasks.md
@@ -4,7 +4,7 @@
 - [x] 1.2 Remove `Object.assign(globalThis, { window, document, navigator, ... })` from `test/setup.ts`
 - [x] 1.3 Verify `BrowserPlatform` initialization uses vitest's environment-provided `window` (no import needed)
 - [x] 1.4 Run full test suite (`make test`) and verify no `document is not defined` errors
-- [x] 1.5 If any tests fail due to missing globals, add them via `vitest.config.ts` `environmentOptions.jsdom` instead of manual assignment — Node.js 25 provides non-functional localStorage stub; added MemoryStorage polyfill in setup.ts + defensive stop/tearDown fallback for fixture cleanup
+- [x] 1.5 Node.js 25 provides non-functional localStorage stub ([vitest#8757](https://github.com/vitest-dev/vitest/issues/8757)). Fixed via `poolOptions.forks.execArgv: ['--no-experimental-webstorage']` in vitest.config.ts — disables Node's built-in localStorage so jsdom provides its own working implementation. Also added defensive stop/tearDown fallback for fixture cleanup.
 
 ## 2. Contain Aurelia template module graph (Design Decision 2)
 
@@ -28,21 +28,21 @@
 
 ## 5. data-testid selector introduction (Design Decision 3)
 
-- [ ] 5.1 Add `data-testid="concert-scroll"` to concert-highway.html `<ol class="concert-scroll">`
-- [ ] 5.2 Add `data-testid="journey-badge"` to event-card.html journey badge element
-- [ ] 5.3 Add `data-testid="sheet-journey"` to event-detail-sheet.html journey section
-- [ ] 5.4 Add `data-testid="journey-btn-{status}"` to event-detail-sheet.html journey buttons (use repeat.for variable)
-- [ ] 5.5 Add `data-testid="journey-remove-btn"` to event-detail-sheet.html remove button
-- [ ] 5.6 Add `data-testid="dashboard-loading"` to dashboard-route.html loading text
-- [ ] 5.7 Add `data-testid="welcome-preview"` to welcome-route.html preview section
+- [x] 5.1 Add `data-testid="concert-scroll"` to concert-highway.html
+- [x] 5.2 Add `data-testid="journey-badge"` to event-card.html
+- [x] 5.3 Add `data-testid="sheet-journey"` to event-detail-sheet.html
+- [x] 5.4 Add static `data-testid="journey-btn"` to event-detail-sheet.html journey buttons — dynamic `journey-btn-${s}` rejected by `lint-no-data-interpolation` rule; use `[data-testid="journey-btn"][data-journey-status="X"]` for specificity
+- [x] 5.5 Add `data-testid="journey-remove-btn"` to event-detail-sheet.html
+- [x] 5.6 Add `data-testid="dashboard-loading"` to dashboard-route.html
+- [x] 5.7 Add `data-testid="welcome-preview"` to welcome-route.html
 
 ## 6. Migrate E2E selectors to data-testid
 
-- [ ] 6.1 Update `e2e/layout/dashboard.layout.spec.ts` — replace `.concert-scroll` selectors with `getByTestId`
-- [ ] 6.2 Update `e2e/layout/ticket-journey.layout.spec.ts` — replace `.journey-badge`, `.sheet-journey`, `.journey-btn`, `.journey-remove-btn` selectors with `getByTestId`
-- [ ] 6.3 Update `e2e/dashboard-lane-classification.spec.ts` — replace `.concert-scroll` selectors with `getByTestId`
-- [ ] 6.4 Update `e2e/onboarding-flow.spec.ts` — replace `.welcome-preview` and `.loading-text` selectors with `getByTestId`
-- [ ] 6.5 Configure Playwright `testIdAttribute` in `playwright.config.mjs` if default `data-testid` needs customization
+- [x] 6.1 Update `e2e/layout/dashboard.layout.spec.ts` — replaced `.concert-scroll` with `[data-testid="concert-scroll"]`
+- [x] 6.2 Update `e2e/layout/ticket-journey.layout.spec.ts` — replaced `.journey-badge`, `.sheet-journey`, `.journey-btn`, `.journey-remove-btn` selectors with `[data-testid]` equivalents
+- [x] 6.3 `e2e/dashboard-lane-classification.spec.ts` — no targeted selectors found, no changes needed
+- [x] 6.4 Update `e2e/onboarding-flow.spec.ts` — replaced `.welcome-preview` with `[data-testid="welcome-preview"]`
+- [x] 6.5 Playwright default `data-testid` attribute works without customization
 
 ## 7. Fix page-help dismiss-zone pointer-events (Design Decision 4A)
 

--- a/openspec/changes/harden-test-infrastructure/tasks.md
+++ b/openspec/changes/harden-test-infrastructure/tasks.md
@@ -48,7 +48,7 @@
 
 - [x] 7.1-7.4 Skipped — investigation revealed page-help uses `<bottom-sheet>` (no dismiss-zone element). The JS dispatch workarounds were caused by popover top-layer interception in serial mode, not page-help.
 
-## 8. Fix popover and visually-hidden interaction issues (Design Decision 4B, 4C)
+## 8. Fix popover and visually-hidden interaction issues (Design Decision 4A, 4B)
 
 - [x] 8.1 Add popover cleanup to serial-mode E2E test `beforeEach` — close all open popovers before each test. Replace event card JS dispatch with native Playwright `click()`.
 - [x] 8.2 Skipped — hype radio uses Aurelia `change.trigger` binding which requires `dispatchEvent(new Event('change'))`. Labels have no readable text. JS dispatch is the correct approach here.


### PR DESCRIPTION
## Summary

- Add OpenSpec change artifacts (proposal, design, specs, tasks) for hardening the frontend test infrastructure
- Documents 7 design decisions with references to Vitest, Aurelia, Playwright, and Node.js official documentation
- Covers: jsdom unification, Node.js 25 localStorage fix, template module graph containment, CE composition tests, data-testid selectors, per-file vitest environment optimization, happy-dom evaluation
- Tracks implementation progress across 3 frontend PRs (#302 merged, #303 merged, #304 CI passing)

## Test plan

- [ ] Verify change artifacts render correctly on GitHub
- [ ] No proto changes — buf lint/breaking checks should pass trivially
