### PR TITLE
docs: archive enforce-required-ci-checks change

### DIFF
--- a/openspec/changes/archive/2026-03-27-enforce-required-ci-checks/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-27-enforce-required-ci-checks/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-27

--- a/openspec/changes/archive/2026-03-27-enforce-required-ci-checks/design.md
+++ b/openspec/changes/archive/2026-03-27-enforce-required-ci-checks/design.md
@@ -1,0 +1,53 @@
+## Context
+
+GitHub branch protection for all liverty-music repositories is managed via Pulumi in `cloud-provisioning/src/index.ts`, using the `GitHubRepositoryComponent`. Branch protection is only applied in the `prod` Pulumi stack (`if (environment === 'prod')`).
+
+Current state of `requiredStatusCheckContexts`:
+
+| Repository | Current Value | CI Success Job Exists? |
+|---|---|---|
+| backend | `['CI Success']` | Yes |
+| frontend | `[]` | Yes |
+| specification | `['CI Success']` | Yes |
+| cloud-provisioning | `[]` | Yes |
+
+All four repos have a `CI Success` aggregation job (using `re-actors/alls-green`) that gates on all other CI jobs. Cloud-provisioning additionally has Pulumi-managed preview checks reported by the Pulumi GitHub App:
+- `liverty-music/dev - Update (preview)`
+- `liverty-music/prod - Update (preview)`
+
+## Goals / Non-Goals
+
+**Goals:**
+- Prevent merging PRs when CI checks fail, for frontend and cloud-provisioning repos.
+- Achieve consistency: all four repos require `CI Success` to merge.
+
+**Non-Goals:**
+- Changing CI workflows themselves (no new jobs, no workflow modifications).
+- Adding review approval requirements.
+- Changing `requireUpToDateBranch` settings (cloud-provisioning already has `true`).
+
+## Decisions
+
+### 1. Use `CI Success` as the single required GitHub Actions check (all repos)
+
+Every repo already has an `alls-green` aggregation job named `CI Success` that depends on all other CI jobs. Requiring only this one check is sufficient — if any upstream job (lint, test, e2e, etc.) fails, `CI Success` fails.
+
+**Alternative considered**: Listing individual jobs (e.g., `Lint`, `Test`, `E2E`). Rejected because it creates a maintenance burden — every time a CI job is added or renamed, branch protection must be updated.
+
+### 2. Do NOT add Pulumi preview as a required status check
+
+**Investigation result**: Pulumi preview checks (`liverty-music/{stack} - Update (preview)`) are only posted by the Pulumi GitHub App when `src/**` files change. For k8s-only PRs (PR #176 confirmed), these checks do not appear at all. GitHub treats a missing required check as permanently "pending", which would block merge indefinitely.
+
+**Decision**: Only require `CI Success` for cloud-provisioning. Pulumi preview checks remain informational — developers should verify them manually when Pulumi code changes.
+
+**Alternative considered**: Creating a CI workflow that conditionally reports a `Pulumi Preview` success when no `src/**` changes are detected. This adds complexity and is out of scope for this change. Can be revisited later if needed.
+
+## Risks / Trade-offs
+
+**[Risk] Pulumi preview failures are not enforced** → A developer could merge a PR with a failing Pulumi preview.
+
+→ **Mitigation**: Acceptable for now. Pulumi preview failures are visible on the PR. The `CI Success` check (which gates lint/typecheck) is the primary guard. Pulumi preview enforcement can be added later via a conditional CI job if needed.
+
+**[Risk] Prod stack deployment required** → Branch protection only applies from the prod Pulumi stack. Running `pulumi up -s prod` is required.
+
+→ **Mitigation**: Standard operational procedure. Preview first, then apply.

--- a/openspec/changes/archive/2026-03-27-enforce-required-ci-checks/proposal.md
+++ b/openspec/changes/archive/2026-03-27-enforce-required-ci-checks/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+Frontend and cloud-provisioning repositories allow merging PRs even when CI checks (lint, test) are failing. This is because their `requiredStatusCheckContexts` in Pulumi branch protection are set to empty arrays. Backend and specification already enforce `CI Success` as a required check, so there is an inconsistency across the organization.
+
+## What Changes
+
+- Set `requiredStatusCheckContexts: ['CI Success']` for the **frontend** repository so lint/test failures block merging.
+- Set `requiredStatusCheckContexts: ['CI Success']` for the **cloud-provisioning** repository so lint failures block merging. (Pulumi preview checks cannot be required because they only appear on `src/**` changes — k8s-only PRs would be permanently blocked.)
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+(none - this is a pure infrastructure/configuration change with no spec-level behavior impact)
+
+## Impact
+
+- **cloud-provisioning/src/index.ts**: Two lines changed (frontend and cloud-provisioning `requiredStatusCheckContexts` arrays).
+- **Deployment**: Requires `pulumi up` on the **prod** stack, since branch protection is only applied when `environment === 'prod'`.
+- **Developer workflow**: After this change, PRs to frontend and cloud-provisioning `main` branches will be blocked from merging until all required checks pass.

--- a/openspec/changes/archive/2026-03-27-enforce-required-ci-checks/specs/no-spec-changes.md
+++ b/openspec/changes/archive/2026-03-27-enforce-required-ci-checks/specs/no-spec-changes.md
@@ -1,0 +1,1 @@
+No capability-level specification changes. This is a pure infrastructure configuration change (Pulumi branch protection settings).

--- a/openspec/changes/archive/2026-03-27-enforce-required-ci-checks/tasks.md
+++ b/openspec/changes/archive/2026-03-27-enforce-required-ci-checks/tasks.md
@@ -1,0 +1,15 @@
+## 1. Update Pulumi Branch Protection Config
+
+- [x] 1.1 In `cloud-provisioning/src/index.ts`, set frontend `requiredStatusCheckContexts` to `['CI Success']`
+- [x] 1.2 In `cloud-provisioning/src/index.ts`, set cloud-provisioning `requiredStatusCheckContexts` to `['CI Success']`
+
+## 2. Verify & Deploy
+
+- [x] 2.1 Run `make check` in cloud-provisioning to ensure lint passes
+- [x] 2.2 Run `pulumi preview -s prod` to verify the branch protection changes
+- [x] 2.3 Run `pulumi up -s prod` to apply (requires user approval)
+
+## 3. Validate
+
+- [x] 3.1 Verified frontend branch protection: `CI Success` required (confirmed via GitHub API)
+- [x] 3.2 Verified cloud-provisioning branch protection: `CI Success` required + strict mode (confirmed via GitHub API)


### PR DESCRIPTION
## Summary

- Archive `enforce-required-ci-checks` OpenSpec change artifacts (proposal, design, tasks)
- Infrastructure-only change — no spec-level modifications

## Test plan

- [x] Archived change contains all completed artifacts
