### PR TITLE
docs(spec): update page-help spec for always-visible icon and visual readability

### DIFF
--- a/openspec/changes/archive/2026-03-27-improve-help-sheet/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-27-improve-help-sheet/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-27

--- a/openspec/changes/archive/2026-03-27-improve-help-sheet/design.md
+++ b/openspec/changes/archive/2026-03-27-improve-help-sheet/design.md
@@ -1,0 +1,80 @@
+## Context
+
+The `page-help` component provides contextual help via a bottom-sheet triggered by a `?` icon in the page header. Currently it is gated by `if.bind="isOnboarding"` in each route template, making it invisible after onboarding completes. The help content suffers from two issues: a rendering bug where all three page sections display simultaneously (the `<if condition.bind>` conditional is not filtering correctly), and poor visual contrast between the sheet surface and the app background.
+
+Key files:
+- `src/components/page-help/page-help.{ts,html,css}` — component logic, template, styles
+- `src/components/bottom-sheet/bottom-sheet.css` — sheet surface styling
+- `src/routes/{discovery,dashboard,my-artists}/*-route.html` — route integration
+- `src/locales/{en,ja}/translation.json` — i18n content under `pageHelp.*`
+- `src/styles/tokens.css` — design tokens
+
+## Goals / Non-Goals
+
+**Goals:**
+- Make the help `?` icon always accessible on Discovery, Dashboard, and My Artists pages
+- Fix the conditional rendering so only the active page's help content is shown
+- Revise help text per page to serve as a concise reference for both onboarding and returning users
+- Improve sheet readability using existing design tokens
+
+**Non-Goals:**
+- Adding help to pages beyond Discovery, Dashboard, My Artists
+- Illustrated or animated help content
+- Changing the bottom-sheet primitive itself (scroll-snap, popover API, dismiss behavior)
+- Adding follow-count display or progress indicators to help (these belong in persistent page UI)
+
+## Decisions
+
+### 1. Remove `isOnboarding` gate from route templates, keep auto-open logic in TS
+
+Remove `if.bind="isOnboarding"` from `<page-help>` in the three route templates. The component always renders, but auto-open still only fires during onboarding (the `attached()` check in `page-help.ts` already gates on `this.onboarding.isOnboarding`).
+
+**Why**: Simplest change — one attribute removal per route. No new state management needed.
+
+### 2. Fix conditional rendering with `switch`/`case` pattern
+
+Replace the three separate `<if condition.bind="page === '...'">` blocks with Aurelia's `switch`/`case` template controller on the `page` bindable. This ensures mutual exclusivity and avoids the current bug where multiple `<if>` blocks may all evaluate.
+
+**Alternative considered**: Debug why `<if condition.bind>` renders all sections. Rejected because `switch`/`case` is semantically correct for mutually exclusive content and prevents recurrence.
+
+### 3. Apply existing tokens for visual improvement
+
+| Element | Current | Change |
+|---------|---------|--------|
+| Sheet background | `--color-surface-raised` (oklch 22%) | `--color-surface-overlay` (oklch 26%) |
+| Help title font | `--font-body` (inherited) | `--font-display` (Righteous) |
+| Muted text | `opacity: 0.7` | `color: var(--color-text-secondary)` (oklch 82%) |
+| Dashboard stage labels | plain white text | `color: var(--color-stage-home/near/away)` per label |
+
+All tokens already exist in `tokens.css`. No new tokens needed.
+
+**Where to apply**: Sheet background is controlled via a `--sheet-bg` CSS custom property added to `bottom-sheet.css` (with a fallback of `--color-surface-raised`). `page-help.css` sets `--sheet-bg: var(--color-surface-overlay)` scoped to `bottom-sheet` within the `page-help` component. This approach ensures the handle bar and content area share the same background, preventing a visual step between them. Stage colors apply only to the Dashboard help section via `data-stage` attribute selectors.
+
+**Why not override on `.page-help-content` directly**: Setting `background` only on the slotted content element (`.page-help-content`) would leave the `.handle-bar` inside `bottom-sheet`'s `.sheet-body` rendering in the old `--color-surface-raised` color, creating a visible band above the content area.
+
+### 4. Content structure per page
+
+**Discovery:**
+- Tap bubbles to follow
+- Unfollow from My Artists page
+- Genre tabs and search bar available
+
+**Dashboard:**
+- Three stages (HOME/NEAR/AWAY) with stage-colored labels
+- Card tap opens concert detail
+
+**My Artists:**
+- Four Hype levels with notification scope
+- Dot tap to change level
+- Practical tip: "Start with Home for artists you're curious about"
+
+Content that is explicitly excluded:
+- Follow count (not help's responsibility)
+- Account registration note (handled by `signup-prompt-banner`)
+- Swipe gestures (not applicable to current UI)
+
+## Risks / Trade-offs
+
+- [Always-visible `?` button may confuse non-onboarding users who don't need help] → Acceptable: the button is small and non-intrusive. Users who don't need it will ignore it. Users who do need it will find it.
+- [Sheet background change affects all bottom-sheet usages if applied globally] → Mitigated: `--sheet-bg` custom property defaults to `--color-surface-raised`, so all other bottom-sheet usages are unaffected. Only `page-help` overrides it.
+- [`switch`/`case` requires Aurelia 2 template controller support] → Already available in Aurelia 2. Verify syntax in implementation.

--- a/openspec/changes/archive/2026-03-27-improve-help-sheet/proposal.md
+++ b/openspec/changes/archive/2026-03-27-improve-help-sheet/proposal.md
@@ -1,0 +1,37 @@
+## Why
+
+The page help sheet has two problems: poor readability due to insufficient contrast between the sheet background and the app surface, and content that doesn't match each page's context well enough to serve as a useful reference. Additionally, help is currently only accessible during onboarding — users who complete onboarding lose access to the `?` button entirely.
+
+## What Changes
+
+- Remove the `isOnboarding` gate on the `<page-help>` component so the `?` icon is always visible in the page header (Discovery, Dashboard, My Artists)
+- Auto-open behavior remains onboarding-only (no change to localStorage-based first-visit logic)
+- Fix the `<if condition.bind>` rendering bug that displays all page sections simultaneously instead of only the active page's content
+- Revise help content per page to serve as a concise reference (not a tutorial):
+  - **Discovery**: tap to follow, unfollow from My Artists, genre tabs and search bar
+  - **Dashboard**: three-stage model (HOME/NEAR/AWAY) with stage colors, card tap for detail
+  - **My Artists**: four Hype levels with notification scope, dot-tap interaction, practical tip ("start with Home")
+- Remove content that belongs to other UI surfaces:
+  - Follow count display (belongs in persistent UI, not help)
+  - Account registration note (handled by signup-prompt-banner)
+- Apply existing design tokens to improve readability:
+  - Use `--color-surface-overlay` for a lighter sheet background
+  - Apply `--color-stage-*` tokens to Dashboard stage labels
+  - Replace `opacity: 0.7` text with `--color-text-secondary` for proper contrast
+  - Use `--font-display` for help titles
+
+## Capabilities
+
+### New Capabilities
+
+_(none)_
+
+### Modified Capabilities
+
+- `onboarding-page-help`: Help icon becomes always-accessible (not gated by onboarding state). Content requirements updated per page. Visual design requirements added.
+
+## Impact
+
+- **Frontend only** — `page-help` component (TS, HTML, CSS), `bottom-sheet` CSS, i18n files (en/ja)
+- **Route templates** — `discovery-route.html`, `dashboard-route.html`, `my-artists-route.html` (remove `if.bind="isOnboarding"` from `<page-help>`)
+- **No backend or protobuf changes**

--- a/openspec/changes/archive/2026-03-27-improve-help-sheet/specs/onboarding-page-help/spec.md
+++ b/openspec/changes/archive/2026-03-27-improve-help-sheet/specs/onboarding-page-help/spec.md
@@ -1,0 +1,90 @@
+## MODIFIED Requirements
+
+### Requirement: Persistent Help Icon in Onboarding Pages
+
+The system SHALL display a persistent `?` help icon in the top-right area of the Discovery, Dashboard, and My Artists page headers for all users, regardless of onboarding state.
+
+#### Scenario: Help icon is visible during onboarding
+
+- **WHEN** the user is on the Discovery, Dashboard, or My Artists page during onboarding
+- **THEN** a `?` icon button SHALL be visible in the page header
+- **AND** the button SHALL have `aria-label="ヘルプを表示"` for accessibility
+
+#### Scenario: Help icon is visible after onboarding
+
+- **WHEN** the user is on the Discovery, Dashboard, or My Artists page after completing onboarding
+- **THEN** the `?` icon button SHALL still be visible in the page header
+- **AND** tapping it SHALL open the help bottom-sheet
+
+### Requirement: Page-specific Help Content
+
+The help bottom-sheet SHALL display content specific to the current page only. Content for other pages SHALL NOT be rendered.
+
+#### Scenario: Discovery help content
+
+- **WHEN** the help bottom-sheet opens on the Discovery page
+- **THEN** the sheet SHALL display guidance explaining that tapping artist bubbles follows them
+- **AND** the sheet SHALL state that unfollowing is done from the My Artists page
+- **AND** the sheet SHALL mention genre tabs and the search bar as discovery methods
+
+#### Scenario: Dashboard help content
+
+- **WHEN** the help bottom-sheet opens on the Dashboard page
+- **THEN** the sheet SHALL display an explanation of the HOME / NEAR / AWAY stage structure
+- **AND** each stage label SHALL be styled with its corresponding stage color token (`--color-stage-home`, `--color-stage-near`, `--color-stage-away`)
+- **AND** the sheet SHALL explain that tapping a concert card shows details
+
+#### Scenario: My Artists help content
+
+- **WHEN** the help bottom-sheet opens on the My Artists page
+- **THEN** the sheet SHALL display the four Hype levels with notification scope:
+  - Watch — no notifications
+  - Home — notifications for concerts in home area
+  - Nearby — notifications for nearby concerts too
+  - Away — notifications for all concerts nationwide
+- **AND** the sheet SHALL explain that tapping a dot changes the Hype level
+- **AND** the sheet SHALL include a practical tip recommending Home as a starting level for artists the user is curious about
+
+#### Scenario: Only active page content is rendered
+
+- **WHEN** the help bottom-sheet opens on any page
+- **THEN** only the content for the current page SHALL be displayed
+- **AND** content for other pages SHALL NOT be rendered
+
+## ADDED Requirements
+
+### Requirement: Help sheet visual readability
+
+The help bottom-sheet SHALL use design tokens that provide sufficient contrast and visual hierarchy.
+
+#### Scenario: Sheet background contrast
+
+- **WHEN** the help bottom-sheet is open
+- **THEN** the sheet content area SHALL use `--color-surface-overlay` as background color
+- **AND** the background SHALL be visually distinct from the app's base surface (`--color-surface-base`)
+
+#### Scenario: Title typography
+
+- **WHEN** the help bottom-sheet displays a title
+- **THEN** the title SHALL use `--font-display` font family
+- **AND** the title SHALL be visually distinct from body text
+
+#### Scenario: Muted text contrast
+
+- **WHEN** the help sheet displays secondary or note text
+- **THEN** the text SHALL use `color: var(--color-text-secondary)` instead of opacity reduction
+- **AND** the text SHALL meet readable contrast against the sheet background
+
+## REMOVED Requirements
+
+### Requirement: Discovery follow progress in help
+
+**Reason**: Follow count display is not help content. If needed, it belongs in the persistent page UI (e.g., Discovery header or bubble area).
+
+**Migration**: Remove `followedCount` bindable from `page-help` component. Remove `pageHelp.discovery.followedCount` from i18n files.
+
+### Requirement: Account registration note in My Artists help
+
+**Reason**: Account registration prompts are the responsibility of the `signup-prompt-banner` component, which already displays contextually after onboarding.
+
+**Migration**: Remove `pageHelp.myArtists.accountNote` from i18n files. Remove the corresponding `<p>` element from the My Artists help section template.

--- a/openspec/changes/archive/2026-03-27-improve-help-sheet/tasks.md
+++ b/openspec/changes/archive/2026-03-27-improve-help-sheet/tasks.md
@@ -1,0 +1,24 @@
+## 1. Fix Rendering and Accessibility
+
+- [x] 1.1 Replace three `<if condition.bind>` blocks in `page-help.html` with `switch`/`case` on the `page` bindable to ensure mutual exclusivity
+- [x] 1.2 Remove `if.bind="isOnboarding"` from `<page-help>` in `discovery-route.html`, `dashboard-route.html`, and `my-artists-route.html`
+- [x] 1.3 Remove `followedCount` bindable from `page-help.ts` and the `followed-count.bind` attribute from `discovery-route.html`
+
+## 2. Update Help Content
+
+- [x] 2.1 Update Discovery help content in `page-help.html`: tap to follow, unfollow from My Artists, genre tabs and search bar
+- [x] 2.2 Update Dashboard help content in `page-help.html`: three stages with stage-colored labels, card tap for detail
+- [x] 2.3 Update My Artists help content in `page-help.html`: four Hype levels with notification scope, dot-tap interaction, practical tip for Home level
+- [x] 2.4 Update Japanese i18n strings in `locales/ja/translation.json` under `pageHelp.*` — remove `followedCount`, `accountNote`; add new keys for updated content
+- [x] 2.5 Update English i18n strings in `locales/en/translation.json` under `pageHelp.*` — same changes as Japanese
+
+## 3. Improve Visual Readability
+
+- [x] 3.1 Override sheet background in `page-help.css`: set `background: var(--color-surface-overlay)` on `.page-help-content`
+- [x] 3.2 Apply `font-family: var(--font-display)` to `.page-help-title`
+- [x] 3.3 Replace `opacity: 0.7` on `.page-help-note` and `.page-help-count` with `color: var(--color-text-secondary)`
+- [x] 3.4 Add stage-colored label styling for Dashboard help using `--color-stage-home`, `--color-stage-near`, `--color-stage-away`
+
+## 4. Update Tests
+
+- [x] 4.1 Update `page-help.spec.ts`: remove `followedCount` tests, add test for always-visible `?` icon (not gated by onboarding), verify `switch`/`case` renders only active page content

--- a/openspec/specs/onboarding-page-help/spec.md
+++ b/openspec/specs/onboarding-page-help/spec.md
@@ -2,17 +2,17 @@
 
 ## Purpose
 
-Provides persistent, page-specific help content during onboarding via a help icon and bottom-sheet. Auto-opens on first visit to each page to deliver contextual guidance without blocking the user's flow.
+Provides persistent, page-specific help content via a help icon and bottom-sheet on the Discovery, Dashboard, and My Artists pages. Auto-opens on first visit to each page during onboarding to deliver contextual guidance without blocking the user's flow. The help icon remains accessible after onboarding completes so users can revisit guidance at any time.
 
 ## Requirements
 
 ### Requirement: Persistent Help Icon in Onboarding Pages
 
-The system SHALL display a persistent `?` help icon in the top-right area of the Discovery, Dashboard, and My Artists pages during onboarding.
+The system SHALL display a persistent `?` help icon in the top-right area of the Discovery, Dashboard, and My Artists pages for all users regardless of onboarding state.
 
 #### Scenario: Help icon is always visible
 
-- **WHEN** the user is on the Discovery, Dashboard, or My Artists page during onboarding
+- **WHEN** the user is on the Discovery, Dashboard, or My Artists page
 - **THEN** a `?` icon button SHALL be visible in the top-right corner of the page header
 - **AND** the button SHALL have `aria-label="ヘルプを表示"` for accessibility
 
@@ -42,30 +42,43 @@ The system SHALL automatically open the help bottom-sheet on the user's first vi
 
 ### Requirement: Page-specific Help Content
 
-The help bottom-sheet SHALL display page-specific guide content when opened.
+The help bottom-sheet SHALL display page-specific guide content when opened. Only the active page's content SHALL be rendered (mutually exclusive, enforced via `switch.bind` on the `page` bindable).
 
 #### Scenario: Discovery help content
 
 - **WHEN** the help bottom-sheet opens on the Discovery page
 - **THEN** the sheet SHALL display guidance explaining that tapping artist bubbles follows them
-- **AND** the sheet SHALL note that followed artists can be managed from the My Artists page
-- **AND** the sheet SHALL include the current follow progress (e.g., "3 / 5 フォロー済み")
+- **AND** the sheet SHALL explain that followed artists can be unfollowed from the My Artists page
+- **AND** the sheet SHALL mention that genre tabs and the search bar are available for browsing
 
 #### Scenario: Dashboard help content
 
 - **WHEN** the help bottom-sheet opens on the Dashboard page
-- **THEN** the sheet SHALL display an explanation of the HOME / NEAR / AWAY lane structure
-- **AND** the sheet SHALL explain how the hype level setting determines which lanes show notifications
+- **THEN** the sheet SHALL display an explanation of the three stage lanes: HOME, NEAR, and AWAY
+- **AND** each stage label SHALL be rendered in its corresponding stage color (`--color-stage-home`, `--color-stage-near`, `--color-stage-away`)
+- **AND** the sheet SHALL explain that tapping a concert card opens the concert detail
 
 #### Scenario: My Artists help content
 
 - **WHEN** the help bottom-sheet opens on the My Artists page
-- **THEN** the sheet SHALL display the hype level explanation:
+- **THEN** the sheet SHALL display the four Hype level explanations with notification scope:
   - Watch — 通知なし
   - Home — 居住エリアのライブを通知
   - Nearby — 近くのライブも通知
   - Away — 全国のライブを通知
-- **AND** the sheet SHALL note that an account is required to receive notifications
+- **AND** the sheet SHALL explain that tapping the dot icon changes an artist's Hype level
+- **AND** the sheet SHALL include a practical tip recommending Home level for artists the user is curious about
+
+### Requirement: Help sheet visual readability
+
+The help bottom-sheet SHALL use design tokens that ensure clear visual distinction from the app surface.
+
+#### Scenario: Sheet background, title font, and muted text rendering
+
+- **WHEN** the help bottom-sheet is displayed
+- **THEN** the sheet background SHALL use `var(--color-surface-overlay)` so the sheet is visually elevated above the page surface
+- **AND** help section titles SHALL use `font-family: var(--font-display)`
+- **AND** secondary text (notes, tips) SHALL use `color: var(--color-text-secondary)` instead of reduced opacity
 
 ### Requirement: Help seen flags cleared on onboarding reset
 


### PR DESCRIPTION
## Summary

Update the onboarding-page-help spec to reflect the help sheet improvements implemented in liverty-music/frontend#300.

### Changes

- **Always-visible icon**: Help icon is now available to all users, not only during onboarding
- **Page content updates**: Discovery mentions genre tabs and search bar; Dashboard describes stage lane colors; My Artists includes Hype practical tip and dot-tap interaction
- **Visual readability requirement**: New requirement section for `--color-surface-overlay` background, `--font-display` titles, and `--color-text-secondary` for muted text
- **Removed**: Follow count display requirement, account registration note
- **Archive**: Completed change archived at `openspec/changes/archive/2026-03-27-improve-help-sheet/`

Refs: #300
