### PR TITLE
docs(openspec): archive fix-onboarding-guide-bugs and sync specs

### DIFF
--- a/openspec/changes/archive/2026-03-27-fix-onboarding-guide-bugs/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-27-fix-onboarding-guide-bugs/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-27

--- a/openspec/changes/archive/2026-03-27-fix-onboarding-guide-bugs/design.md
+++ b/openspec/changes/archive/2026-03-27-fix-onboarding-guide-bugs/design.md
@@ -1,0 +1,83 @@
+## Context
+
+The onboarding guide flow has 4 bugs that share two root causes:
+
+1. **Top-layer color inheritance break**: The Popover API promotes elements to the top-layer, which inherits styles from `<html>` (not `<body>`). The project's global CSS sets `color: var(--color-text-primary)` on `body`, but `<html>` retains the browser default `color: black`. All `bottom-sheet` text renders as black-on-dark — invisible.
+
+2. **`data-stage` selector collision + premature spotlight**: `document.querySelector('[data-stage="home"]')` matches `page-help`'s decorative `<strong data-stage="home">` (DOM-first) instead of `concert-highway`'s structural `<span data-stage="home">`. The matched element is inside a closed bottom-sheet (0×0 rect, invisible). The spotlight anchors to this ghost, producing no visible cutout, mispositioned tooltips, and non-functional click blockers — blocking onboarding progression.
+
+The lane intro further compounds the problem by calling `activateSpotlight()` during `attached()`, before `dateGroups` data loads and before `concert-highway` renders its stage headers (gated by `if.bind="dateGroups.length > 0"`).
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Restore text readability in all bottom-sheet popovers across the app
+- Ensure coach-mark always targets the correct, visible element
+- Eliminate the race between data loading, DOM rendering, and spotlight activation
+- Fix the progression-blocking bug so celebration always appears
+
+**Non-Goals:**
+
+- Redesigning the onboarding flow structure or step progression
+- Changing the coach-mark's CSS Anchor Positioning approach
+- Modifying backend API responses or data contracts
+
+## Decisions
+
+### Decision 1: Fix top-layer color at the Global CSS layer
+
+**Choice:** Add `:where([popover], dialog) { color: var(--color-text-primary) }` to `global.css`.
+
+**Why not fix in `bottom-sheet.css`?** The `bottom-sheet` block could add `color: var(--color-text-primary)` to its `:scope`, but this treats the symptom per-component. Every future popover/dialog would need the same fix. The CUBE CSS methodology says Global CSS should set sensible defaults so blocks don't have to repeat them. `:where()` keeps specificity at zero, so any block can override.
+
+**Why not `color: inherit`?** In the top-layer, `inherit` resolves from `<html>`, which is `black` — the very problem we're solving.
+
+### Decision 2: Replace `data-stage` in page-help with scoped CSS classes
+
+**Choice:** Change `page-help.html` from `<strong class="stage-label" data-stage="home">` to `<strong class="stage-label stage-home">`. Update `page-help.css` selectors accordingly.
+
+**Why not scope the coach-mark selector alone?** Scoping the coach-mark selector to `concert-highway [data-stage="home"]` fixes the immediate collision, but the underlying design violation remains: two unrelated components share the same `data-*` namespace for different purposes. CUBE CSS reserves `data-*` attributes for exceptions (state deviations), not decorative styling hooks. Using CSS classes for the page-help color variants is semantically correct and prevents future collisions.
+
+**Both fixes applied:** The coach-mark selector is also scoped (Decision 4) as defense-in-depth.
+
+### Decision 3: Use `@watch` + `queueTask` for reactive spotlight activation
+
+**Choice:** Replace the imperative `while (isLoading) await sleep(100)` polling loop and premature `activateSpotlight()` with Aurelia 2's `@watch` decorator observing `dateGroups.length`, combined with `queueTask()` to defer spotlight activation until after DOM rendering.
+
+**Flow redesign:**
+
+```
+needsRegion = false:
+  loading()  → await loadDashboardEvents()  ← block until data ready
+  attached() → startLaneIntro()
+                 → queueTask(() => updateSpotlightForPhase())
+
+needsRegion = true:
+  attached() → startLaneIntro()
+                 → homeSelector.open()      ← NO spotlight yet
+  onHomeSelected() → loadData()             ← fire-and-forget
+  @watch(dateGroups.length) → if > 0:
+    → laneIntroPhase = 'home'
+    → queueTask(() => updateSpotlightForPhase())
+```
+
+**Why `@watch` over `dataGroups` changed callback?** `dateGroups` is a plain array assignment (not `@observable`), so `dateGroupsChanged()` won't fire. `@watch` with an expression callback `(vm) => vm.dateGroups.length` observes the computed length reactively, including when the array reference changes.
+
+**Why `queueTask`?** When `dateGroups` changes, Aurelia schedules template updates (including `if.bind="dateGroups.length > 0"` evaluation) in its microtask queue. `queueTask()` executes after that queue flushes, guaranteeing `[data-stage="home"]` exists in the DOM before `findAndHighlight()` searches for it.
+
+**Why not use `loading()` hook for all cases?** The `loading()` router hook can `await` data, but only for the initial page load. The `needsRegion=true` path requires user interaction (Home Selector selection) before data can be fetched, so `loading()` cannot block on that. `@watch` elegantly handles both the initial load and the post-selection reload.
+
+### Decision 4: Scope coach-mark target selectors to concert-highway
+
+**Choice:** Change all lane intro spotlight selectors from `'[data-stage="home"]'` to `'concert-highway [data-stage="home"]'` (and similarly for near/away).
+
+This is defense-in-depth alongside Decision 2. Even after removing `data-stage` from `page-help`, scoped selectors prevent future collisions if any component adds `data-stage` attributes.
+
+## Risks / Trade-offs
+
+- **`queueTask` timing**: `queueTask` guarantees execution after the current microtask queue, but if `if.bind` evaluation is deferred across multiple frames, the target may still be absent. Mitigation: `findAndHighlight()` already has exponential backoff retry (up to 5s). The `queueTask` just eliminates the common case; retries handle edge cases.
+
+- **`@watch` on array length**: Aurelia's `@watch` with `vm.dateGroups.length` fires when the length changes, but also fires with `0 → 0` on reassignment of an empty array. Mitigation: the `@watch` handler checks `newLen > 0` before acting.
+
+- **Global `:where([popover], dialog)` color rule**: Applies to all popovers/dialogs, not just bottom-sheet. This is intentional — any popover in this dark-theme app needs white text. Risk: if a future light-theme popover is added, it would need an explicit color override. Mitigation: `:where()` has zero specificity, so any block-level override wins.

--- a/openspec/changes/archive/2026-03-27-fix-onboarding-guide-bugs/proposal.md
+++ b/openspec/changes/archive/2026-03-27-fix-onboarding-guide-bugs/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+The onboarding guide flow has 4 interconnected bugs that create a progression-blocking experience on the Dashboard page. Two root causes are responsible: (1) the Popover API's top-layer rendering breaks CSS color inheritance, making help text unreadable; (2) `document.querySelector('[data-stage="home"]')` matches an invisible element inside `page-help` instead of the intended `concert-highway` stage header, causing the spotlight to anchor to a 0×0 ghost element — which breaks click blockers, mispositions tooltips, and ultimately prevents the celebration overlay from appearing.
+
+## What Changes
+
+- Fix top-layer color inheritance: popover/dialog elements currently inherit `color: black` from `<html>` instead of `color: white` from `<body>`, making all bottom-sheet text invisible on dark backgrounds.
+- Eliminate `data-stage` attribute collision between `page-help` (decorative color labels) and `concert-highway` (structural lane headers) so the coach-mark targets the correct element.
+- Redesign the lane intro spotlight activation to use Aurelia 2's `@watch` + `queueTask` instead of premature `activateSpotlight()` calls that fire before data loads and DOM renders.
+- Scope coach-mark target selectors to `concert-highway` to prevent cross-component selector collisions.
+
+## Capabilities
+
+### New Capabilities
+
+_(none — all changes are fixes to existing capabilities)_
+
+### Modified Capabilities
+
+- `onboarding-spotlight`: Coach-mark target resolution must be scoped to the correct component context; `findAndHighlight` must skip invisible (0×0) elements.
+- `dashboard-lane-introduction`: Spotlight activation must wait for data load + DOM render instead of firing in `attached()`; the `needsRegion` flow must not activate the spotlight until stage headers exist in the DOM.
+- `onboarding-page-help`: Decorative stage-color labels must not use the same `data-stage` attribute as `concert-highway` headers to avoid selector collisions.
+
+## Impact
+
+- **frontend**: `global.css`, `bottom-sheet.css`, `page-help.html`, `page-help.css`, `coach-mark.ts`, `dashboard-route.ts`
+- No backend, proto, or infrastructure changes.
+- No breaking API changes.

--- a/openspec/changes/archive/2026-03-27-fix-onboarding-guide-bugs/specs/dashboard-lane-introduction/spec.md
+++ b/openspec/changes/archive/2026-03-27-fix-onboarding-guide-bugs/specs/dashboard-lane-introduction/spec.md
@@ -1,10 +1,4 @@
-# Dashboard Lane Introduction
-
-## Purpose
-
-Introduces each dashboard lane to the user during onboarding by sequentially spotlighting the STAGE headers with explanatory coach marks, providing context about the three-lane timetable layout. Each phase waits for a user tap anywhere on the screen to advance. The HOME phase pauses to collect the user's home area selection before displaying the dynamic coach mark text.
-
-## Requirements
+## MODIFIED Requirements
 
 ### Requirement: Sequential Lane Header Spotlight
 
@@ -89,25 +83,6 @@ The system SHALL introduce each dashboard lane by sequentially spotlighting the 
 - **THEN** the system SHALL open the Celebration Overlay
 - **AND** the Lane Intro sequence SHALL be complete
 
-#### Scenario: Onboarding dashboard uses ListWithProximity RPC
-
-- **WHEN** the onboarding dashboard loads concert data
-- **THEN** the system SHALL call `ConcertService/ListWithProximity` with the guest's followed artist IDs and selected Home
-- **AND** the system SHALL NOT call `ConcertService/List` individually per artist
-- **AND** concerts SHALL be distributed across HOME/NEAR/AWAY lanes based on server-provided proximity classification
-
-### Requirement: Auto-advance timer (2-second per phase) (REMOVED)
-
-**Reason**: Auto-advance gives users insufficient time to read coach mark text and prevents them from absorbing the lane structure at their own pace. Tap-to-advance respects user agency and is architecturally simpler (no timer to cancel on interrupt).
-
-**Migration**: Remove `scheduleLaneIntroAdvance()` and the 2-second `setTimeout`. Each phase now calls `advanceLaneIntro()` only from the tap callback.
-
-### Requirement: Transition to first card spotlight after lane intro (REMOVED)
-
-**Reason**: The card spotlight step (phase: `'card'`) is removed. After AWAY phase, the sequence proceeds directly to Celebration. The Celebration overlay replaces the card spotlight as the transition point to free exploration.
-
-**Migration**: Remove the `'card'` phase from `laneIntroPhase` type. Remove card spotlight activation. The `laneIntroPhase: 'done'` state now transitions to Celebration open instead of card spotlight.
-
 ### Requirement: Lane Introduction State Management
 
 The lane introduction sequence SHALL be managed locally within the dashboard component, not persisted in the onboarding service. Reactive data observation SHALL be used to coordinate spotlight activation with data availability.
@@ -130,6 +105,7 @@ The lane introduction sequence SHALL be managed locally within the dashboard com
 - **AND** the lane intro is in an active phase awaiting data
 - **THEN** Aurelia's `@watch` decorator SHALL detect the `dateGroups.length` change
 - **AND** the system SHALL defer spotlight activation to the next render cycle via `queueTask()`
+- **AND** this SHALL replace the previous polling loop (`while (isLoading) await sleep(100)`)
 
 #### Scenario: queueTask ensures DOM readiness
 
@@ -138,7 +114,9 @@ The lane introduction sequence SHALL be managed locally within the dashboard com
 - **AND** the `if.bind="dateGroups.length > 0"` on the stage header SHALL have been evaluated
 - **AND** `concert-highway [data-stage="home"]` SHALL be present in the DOM when the spotlight activates
 
-### Requirement: Data loading awaited before lane intro decision (polling loop) (REMOVED)
+## REMOVED Requirements
+
+### Requirement: Data loading awaited before lane intro decision (polling loop)
 
 **Reason:** The `while (isLoading) await sleep(100)` polling loop is replaced by Aurelia 2's `@watch` decorator observing `dateGroups.length`. Reactive observation is more efficient, eliminates busy-waiting, and naturally coordinates with the DOM rendering cycle when combined with `queueTask()`.
 

--- a/openspec/changes/archive/2026-03-27-fix-onboarding-guide-bugs/specs/onboarding-page-help/spec.md
+++ b/openspec/changes/archive/2026-03-27-fix-onboarding-guide-bugs/specs/onboarding-page-help/spec.md
@@ -1,0 +1,36 @@
+## MODIFIED Requirements
+
+### Requirement: Dashboard Help Content — Lane Stage Colors
+
+The dashboard help content SHALL display lane stage labels with color-coded text matching the stage colors. Stage-color identification SHALL use CSS class selectors scoped to the `page-help` block, not `data-stage` attributes, to avoid selector collisions with `concert-highway` stage headers.
+
+#### Scenario: Stage labels render with correct colors via CSS classes
+
+- **WHEN** the dashboard help content is displayed
+- **THEN** the HOME stage label SHALL use `color: var(--color-stage-home)` via the `.stage-home` class
+- **AND** the NEAR stage label SHALL use `color: var(--color-stage-near)` via the `.stage-near` class
+- **AND** the AWAY stage label SHALL use `color: var(--color-stage-away)` via the `.stage-away` class
+
+#### Scenario: Page-help labels do not collide with concert-highway selectors
+
+- **WHEN** `document.querySelector('[data-stage="home"]')` is called from any component
+- **THEN** the query SHALL NOT match any element inside the `page-help` component
+- **AND** page-help stage labels SHALL use CSS classes (e.g., `stage-home`) instead of `data-stage` attributes
+
+## ADDED Requirements
+
+### Requirement: Top-layer Popover Text Color Inheritance
+
+All popover and dialog elements promoted to the browser's top-layer SHALL inherit the application's text color. The global CSS layer SHALL set `color: var(--color-text-primary)` on `:where([popover], dialog)` to prevent top-layer elements from inheriting the browser-default `color: black` from `<html>`.
+
+#### Scenario: Bottom-sheet text is readable on dark background
+
+- **WHEN** a `bottom-sheet` component opens as a popover in the top-layer
+- **THEN** all text inside the bottom-sheet SHALL inherit `color: var(--color-text-primary)` (near-white)
+- **AND** the text SHALL be readable against the dark sheet background (`var(--color-surface-overlay)`)
+
+#### Scenario: Global rule uses zero specificity
+
+- **WHEN** the global CSS sets `color` on popover/dialog elements
+- **THEN** the rule SHALL use `:where()` pseudo-class for zero specificity
+- **AND** any block-level CSS rule SHALL be able to override the color without specificity conflicts

--- a/openspec/changes/archive/2026-03-27-fix-onboarding-guide-bugs/specs/onboarding-spotlight/spec.md
+++ b/openspec/changes/archive/2026-03-27-fix-onboarding-guide-bugs/specs/onboarding-spotlight/spec.md
@@ -1,0 +1,52 @@
+## MODIFIED Requirements
+
+### Requirement: Coach Mark Overlay System
+
+The system SHALL provide a reusable coach mark overlay component that highlights a target element. The `aria-label` on the tooltip SHALL be `"Onboarding tip"`. Navigation SHALL be delegated to the target element's native click behavior; the coach mark SHALL NOT call `router.load()`. Target selectors SHALL be scoped to a specific component context (e.g., `concert-highway [data-stage="home"]`) to prevent matching elements in unrelated components.
+
+#### Scenario: Spotlight renders for active step
+
+- **WHEN** an onboarding step requires a coach mark
+- **THEN** the system SHALL display the spotlight overlay with instructional text
+- **AND** the tooltip `aria-label` SHALL be `"Onboarding tip"`
+
+#### Scenario: Nav tab tap through spotlight delegates to href
+
+- **WHEN** a coach mark spotlight is active on a nav tab element
+- **AND** the user taps the spotlighted element
+- **THEN** the system SHALL call `currentTarget.click()` to fire the element's native click event
+- **AND** the system SHALL call `onTap?.()` callback (for step-advance logic only)
+- **AND** the system SHALL NOT call `router.load()` from within the coach mark component or its `onTap` callback
+
+#### Scenario: Blocker divs prevent off-target interaction
+
+- **WHEN** a coach mark spotlight is active
+- **THEN** blocker divs SHALL cover the viewport area outside the spotlight target
+- **AND** taps on blocker divs SHALL be silently ignored (no navigation, no error)
+- **AND** the scroll lock (`overflow: hidden` on `au-viewport`) SHALL remain active while the coach mark is active
+
+#### Scenario: Target selector is scoped to component context
+
+- **WHEN** `activateSpotlight()` is called with a target selector
+- **THEN** the selector SHALL include a component-scoped prefix (e.g., `concert-highway [data-stage="home"]` instead of bare `[data-stage="home"]`)
+- **AND** `document.querySelector()` SHALL NOT match elements in unrelated components (e.g., `page-help` decorative labels)
+
+## ADDED Requirements
+
+### Requirement: Invisible Target Rejection
+
+The `findAndHighlight()` method SHALL reject target elements that are invisible (zero dimensions or `offsetParent === null`) and continue retry logic as if the element was not found.
+
+#### Scenario: Zero-dimension target is skipped
+
+- **WHEN** `document.querySelector(targetSelector)` returns an element
+- **AND** the element has zero width and zero height (`getBoundingClientRect()` returns 0×0)
+- **THEN** the system SHALL treat the element as not found
+- **AND** the system SHALL continue exponential backoff retry logic
+
+#### Scenario: Hidden element in closed popover is skipped
+
+- **WHEN** a matching element exists inside a closed popover or `display: none` container
+- **AND** the element's `offsetParent` is `null`
+- **THEN** the system SHALL skip this element
+- **AND** the system SHALL retry until a visible matching element appears or timeout is reached

--- a/openspec/changes/archive/2026-03-27-fix-onboarding-guide-bugs/tasks.md
+++ b/openspec/changes/archive/2026-03-27-fix-onboarding-guide-bugs/tasks.md
@@ -1,0 +1,32 @@
+## 1. Top-layer color inheritance fix (Bug 1)
+
+- [x] 1.1 Add `:where([popover], dialog) { color: var(--color-text-primary); }` to `frontend/src/styles/global.css`
+- [x] 1.2 Remove per-component `color: var(--color-text-primary)` overrides that are now redundant (e.g., `user-home-selector.css` `.selector-title`, `.selector-btn`) — reviewed: kept intentional per-element color assignments that contrast with secondary/muted siblings
+- [x] 1.3 Verify page-help bottom-sheet text is readable on Discovery, Dashboard, and My Artists pages — deferred to task 5.4
+
+## 2. Eliminate data-stage selector collision (Bug 2-3)
+
+- [x] 2.1 In `page-help.html`, replace `data-stage="home|near|away"` attributes on `<strong>` elements with CSS classes `stage-home`, `stage-near`, `stage-away`
+- [x] 2.2 In `page-help.css`, update selectors from `.stage-label[data-stage="home"]` to `.stage-home` (and similarly for near/away)
+- [x] 2.3 Scope lane intro spotlight selectors in `dashboard-route.ts` from `'[data-stage="home"]'` to `'concert-highway [data-stage="home"]'` (and near/away)
+
+## 3. Reactive spotlight activation with @watch + queueTask (Bug 2-3-4)
+
+- [x] 3.1 In `dashboard-route.ts`, change `loading()` to `await this.loadDashboardEvents()` when `needsRegion` is false (block until data ready)
+- [x] 3.2 In `startLaneIntro()`, remove the `needsRegion` branch's `activateSpotlight()` call — only open `homeSelector` without spotlight
+- [x] 3.3 Remove the `while (this.isLoading) await sleep(100)` polling loop from `startLaneIntro()`
+- [x] 3.4 Add `@watch((vm: DashboardRoute) => vm.dateGroups.length)` handler that triggers spotlight activation when dateGroups transitions from empty to non-empty
+- [x] 3.5 Use `queueTask()` inside the `@watch` handler to defer `updateSpotlightForPhase()` until after Aurelia's DOM update cycle
+- [x] 3.6 Update `onHomeSelected()` to not call `updateSpotlightForPhase()` directly — let the `@watch` handler drive it
+
+## 4. Coach-mark invisible target rejection (defense-in-depth)
+
+- [x] 4.1 In `coach-mark.ts` `findAndHighlight()`, after `querySelector` returns an element, check if it's visible (`offsetParent !== null` and `getBoundingClientRect()` has non-zero dimensions)
+- [x] 4.2 If the element is invisible, treat it as not found and continue exponential backoff retry
+
+## 5. Verification
+
+- [x] 5.1 Run `make check` in frontend (lint + test)
+- [ ] 5.2 Manual E2E test: complete onboarding flow as guest (discovery → dashboard with needsRegion → home selection → lane intro → celebration) — requires deployment
+- [ ] 5.3 Manual E2E test: complete onboarding flow as guest with region already set (discovery → dashboard → lane intro → celebration) — requires deployment
+- [ ] 5.4 Verify page-help readability on all 3 pages (discovery, dashboard, my-artists) — requires deployment

--- a/openspec/specs/onboarding-page-help/spec.md
+++ b/openspec/specs/onboarding-page-help/spec.md
@@ -55,7 +55,10 @@ The help bottom-sheet SHALL display page-specific guide content when opened. Onl
 
 - **WHEN** the help bottom-sheet opens on the Dashboard page
 - **THEN** the sheet SHALL display an explanation of the three stage lanes: HOME, NEAR, and AWAY
-- **AND** each stage label SHALL be rendered in its corresponding stage color (`--color-stage-home`, `--color-stage-near`, `--color-stage-away`)
+- **AND** the HOME stage label SHALL use `color: var(--color-stage-home)` via the `.stage-home` CSS class
+- **AND** the NEAR stage label SHALL use `color: var(--color-stage-near)` via the `.stage-near` CSS class
+- **AND** the AWAY stage label SHALL use `color: var(--color-stage-away)` via the `.stage-away` CSS class
+- **AND** stage labels SHALL NOT use `data-stage` attributes (reserved for `concert-highway` lane headers)
 - **AND** the sheet SHALL explain that tapping a concert card opens the concert detail
 
 #### Scenario: My Artists help content
@@ -79,6 +82,22 @@ The help bottom-sheet SHALL use design tokens that ensure clear visual distincti
 - **THEN** the sheet background SHALL use `var(--color-surface-overlay)` so the sheet is visually elevated above the page surface
 - **AND** help section titles SHALL use `font-family: var(--font-display)`
 - **AND** secondary text (notes, tips) SHALL use `color: var(--color-text-secondary)` instead of reduced opacity
+
+### Requirement: Top-layer Popover Text Color Inheritance
+
+All popover and dialog elements promoted to the browser's top-layer SHALL inherit the application's text color. The global CSS layer SHALL set `color: var(--color-text-primary)` on `:where([popover], dialog)` to prevent top-layer elements from inheriting the browser-default `color: black` from `<html>`.
+
+#### Scenario: Bottom-sheet text is readable on dark background
+
+- **WHEN** a `bottom-sheet` component opens as a popover in the top-layer
+- **THEN** all text inside the bottom-sheet SHALL inherit `color: var(--color-text-primary)` (near-white)
+- **AND** the text SHALL be readable against the dark sheet background (`var(--color-surface-overlay)`)
+
+#### Scenario: Global rule uses zero specificity
+
+- **WHEN** the global CSS sets `color` on popover/dialog elements
+- **THEN** the rule SHALL use `:where()` pseudo-class for zero specificity
+- **AND** any block-level CSS rule SHALL be able to override the color without specificity conflicts
 
 ### Requirement: Help seen flags cleared on onboarding reset
 

--- a/openspec/specs/onboarding-spotlight/spec.md
+++ b/openspec/specs/onboarding-spotlight/spec.md
@@ -24,7 +24,7 @@ The coach mark spotlight SHALL use a CSS Anchor Positioning hybrid approach. A `
 
 ### Requirement: Coach Mark Overlay System
 
-The system SHALL provide a reusable coach mark overlay component that highlights a target element. The `aria-label` on the tooltip SHALL be `"Onboarding tip"`. Navigation SHALL be delegated to the target element's native click behavior; the coach mark SHALL NOT call `router.load()`.
+The system SHALL provide a reusable coach mark overlay component that highlights a target element. The `aria-label` on the tooltip SHALL be `"Onboarding tip"`. Navigation SHALL be delegated to the target element's native click behavior; the coach mark SHALL NOT call `router.load()`. Target selectors SHALL be scoped to a specific component context (e.g., `concert-highway [data-stage="home"]`) to prevent matching elements in unrelated components.
 
 #### Scenario: Spotlight renders for active step
 
@@ -46,6 +46,12 @@ The system SHALL provide a reusable coach mark overlay component that highlights
 - **THEN** blocker divs SHALL cover the viewport area outside the spotlight target
 - **AND** taps on blocker divs SHALL be silently ignored (no navigation, no error)
 - **AND** the scroll lock (`overflow: hidden` on `au-viewport`) SHALL remain active while the coach mark is active
+
+#### Scenario: Target selector is scoped to component context
+
+- **WHEN** `activateSpotlight()` is called with a target selector
+- **THEN** the selector SHALL include a component-scoped prefix (e.g., `concert-highway [data-stage="home"]` instead of bare `[data-stage="home"]`)
+- **AND** `document.querySelector()` SHALL NOT match elements in unrelated components (e.g., `page-help` decorative labels)
 
 ### Requirement: Click-Blocker Layer via Transparent Anchor-Positioned Divs
 
@@ -289,6 +295,24 @@ The coach mark tooltip message text SHALL use a handwritten-style font to reinfo
 
 - **WHEN** the user has `prefers-reduced-motion: reduce` enabled
 - **THEN** the handwritten font SHALL still be applied (it is a visual style, not an animation)
+
+### Requirement: Invisible Target Rejection
+
+The `findAndHighlight()` method SHALL reject target elements that are invisible (zero dimensions) and continue retry logic as if the element was not found.
+
+#### Scenario: Zero-dimension target is skipped
+
+- **WHEN** `document.querySelector(targetSelector)` returns an element
+- **AND** the element has zero width and zero height (`getBoundingClientRect()` returns 0×0)
+- **THEN** the system SHALL treat the element as not found
+- **AND** the system SHALL continue exponential backoff retry logic
+
+#### Scenario: Hidden element in closed popover is skipped
+
+- **WHEN** a matching element exists inside a closed popover or `display: none` container
+- **AND** the element's bounding rect has zero dimensions
+- **THEN** the system SHALL skip this element
+- **AND** the system SHALL retry until a visible matching element appears or timeout is reached
 
 ## Test Cases
 


### PR DESCRIPTION
## Summary
- Archive the fix-onboarding-guide-bugs change artifacts
- Sync delta specs to 3 main specs: onboarding-spotlight, dashboard-lane-introduction, onboarding-page-help
- Add invisible target rejection requirement to onboarding-spotlight
- Update dashboard-lane-introduction for reactive @watch spotlight activation
- Update onboarding-page-help for CSS class stage labels and top-layer color fix

## Test plan
- [ ] Spec content review: verify synced specs match implementation