### PR TITLE
docs(openspec): add observability specs and archive change

### DIFF
--- a/openspec/changes/archive/2026-03-27-enhance-backend-observability/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-27-enhance-backend-observability/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-27

--- a/openspec/changes/archive/2026-03-27-enhance-backend-observability/design.md
+++ b/openspec/changes/archive/2026-03-27-enhance-backend-observability/design.md
@@ -1,0 +1,138 @@
+## Context
+
+The backend service (Go, Connect-RPC) currently has two instrumentation layers:
+
+1. **RPC layer**: `otelconnect` interceptor auto-creates spans for every Connect-RPC call
+2. **Database layer**: Custom `TracedPool`/`TracedTx` wrappers create client spans for every SQL query with sqlcommenter traceparent injection
+
+Between these two layers, all business logic (usecases, external API calls, event publishing) is invisible. The SDK uses `AlwaysSample()` globally and has no Metrics signal. Six external HTTP clients pass `nil` for `*http.Client` in production, bypassing any transport-level instrumentation.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Full visibility into request latency breakdown: RPC → external API → business logic → DB
+- Metrics signal for operational alerting (latency histograms, error counters, pool gauges)
+- Production-safe sampling with environment-aware configuration
+- DB span compliance with OTel Semantic Conventions
+
+**Non-Goals:**
+- OTel Collector metrics pipeline configuration (cloud-provisioning scope)
+- Log-Trace correlation (already handled by `go-logging`)
+- Tier 3 instrumentation (cache hit/miss, rate limiter waits, background goroutines)
+- Frontend or consumer-specific observability beyond what flows through shared telemetry setup
+- Custom dashboards or alerting rules
+
+## Decisions
+
+### D1: External HTTP client instrumentation via `otelhttp.NewTransport()`
+
+**Decision**: Wrap each external HTTP client's transport with `otelhttp.NewTransport()` at the DI layer, rather than adding manual span creation inside each client.
+
+**Why**: Transport-level wrapping captures all HTTP calls uniformly (method, URL, status code, duration) without modifying client internals. Each client already accepts `*http.Client` — the DI layer just needs to construct it with an instrumented transport.
+
+**Client-specific patterns**:
+
+| Client | Transport Chain | Auth Handling |
+|--------|----------------|---------------|
+| Gemini (genai) | `DefaultTransport → otelhttp → authTransport` | `ClientConfig.UseDefaultCredentials()` layers ADC on top of provided HTTPClient |
+| Google Maps | `DefaultTransport → otelhttp → RetryTransport` | Manual `TokenSource` injection in request headers (unchanged) |
+| Last.fm | `DefaultTransport → otelhttp` | API key in query params (unchanged) |
+| MusicBrainz | `DefaultTransport → otelhttp` | User-Agent header (unchanged) |
+| fanart.tv / Logo Fetcher | `DefaultTransport → otelhttp` | API key in header (unchanged) |
+
+**Alternative considered**: Using per-method `tracer.Start()` inside each client. Rejected because it duplicates HTTP-level attributes that `otelhttp` captures automatically and requires changes to every client method.
+
+### D2: Gemini ADC integration with `UseDefaultCredentials()`
+
+**Decision**: Construct `genai.ClientConfig` with an `otelhttp`-wrapped `*http.Client`, then call `cc.UseDefaultCredentials()` to layer ADC authentication on top.
+
+**Why**: `UseDefaultCredentials()` (available since genai v1.34.0, current: v1.44.0) wraps whatever transport the provided HTTPClient has with an `authTransport`. This means:
+- `otelhttp` sees requests **before** auth headers are added (no credential leakage in span attributes)
+- ADC token refresh is handled transparently
+- Test code continues to pass custom `*http.Client` without calling `UseDefaultCredentials()`
+
+**Alternative considered**: `httptransport.AddAuthorizationMiddleware()` for manual credential setup. Rejected because `UseDefaultCredentials()` is simpler and officially supported by the genai SDK.
+
+### D3: Zitadel gRPC instrumentation via `otelgrpc` interceptors
+
+**Decision**: Pass `otelgrpc` unary and stream interceptors as gRPC dial options to the Zitadel client.
+
+**Why**: Zitadel uses gRPC (not HTTP). The `zitadel-go/v3` library accepts `zitadelconn.Option` which wraps gRPC dial options. Adding `grpc.WithStatsHandler(otelgrpc.NewClientHandler())` instruments all gRPC calls uniformly.
+
+### D4: UseCase spans limited to CPU-intensive logic only
+
+**Decision**: Add spans to exactly 3 methods where in-process computation is the primary time cost:
+
+1. **`BuildMerkleTree()`**: Cryptographic identity commitment (hash per ticket) + O(n log n) tree construction
+2. **`executeSearch()` → `FilterNew`**: O(n) deduplication with date comparisons and set construction
+3. **`persistArtists()`**: 5-pass map/array manipulation (collect MBIDs → build existing set → determine missing → batch create → merge preserving order)
+
+**Why**: After Phase 2 wraps all external API and DB calls with spans, only CPU-bound processing remains invisible. Adding spans to methods where external calls dominate (e.g., `MintTicket`, `VerifyEntry`, `CreateFromDiscovered`) would add noise without diagnostic value.
+
+### D5: `SetupTelemetry` expanded to `SetupObservability`
+
+**Decision**: Expand `pkg/telemetry/telemetry.go` to initialize both `TracerProvider` and `MeterProvider`, and return a unified closer that shuts down both.
+
+**Configuration additions to `TelemetryConfig`**:
+- `SamplerRatio float64` (`TELEMETRY_SAMPLER_RATIO`, default: `1.0`) — used with `ParentBased(TraceIDRatioBased(ratio))`
+- `Environment` derived from existing `BaseConfig.Environment`
+
+**Resource attributes added**:
+- `deployment.environment` (from `BaseConfig.Environment`)
+
+**Propagator**: Explicitly set `otel.SetTextMapPropagator(propagation.TraceContext{})` instead of relying on defaults.
+
+**Why unified**: Traces and metrics share the same resource, OTLP endpoint, and shutdown lifecycle. A single setup function avoids divergent configuration.
+
+### D6: Metrics instrument selection
+
+**Decision**: Introduce metrics incrementally, starting with the highest-signal instruments:
+
+| Instrument | Type | Purpose |
+|------------|------|---------|
+| `rpc.server.request.duration` | Histogram | RPC latency distribution (already captured by otelconnect — verify) |
+| `external_api.request.duration` | Histogram | External API call latency by service |
+| `external_api.request.total` | Counter | External API call count by service and status |
+| `blockchain.mint.duration` | Histogram | Ticket minting latency |
+| `blockchain.mint.total` | Counter | Mint count by outcome (success, retry, failure) |
+| `db.pool.active_connections` | ObservableGauge | pgxpool active connections (from `pool.Stat()`) |
+| `db.pool.idle_connections` | ObservableGauge | pgxpool idle connections |
+
+**Why these first**: RPC and external API durations surface the top latency contributors. Blockchain metrics catch mint failures. Pool gauges catch connection exhaustion. All can trigger alerts without building custom dashboards.
+
+**Alternative considered**: Full RED metrics (Rate, Errors, Duration) for every component. Rejected for initial scope — start with high-signal instruments and expand based on operational need.
+
+### D7: DB span Semantic Convention enrichment
+
+**Decision**: Add missing attributes to `TracedPool.startSpan()` and `TracedTx.startSpan()`:
+
+| Attribute | Source |
+|-----------|--------|
+| `db.collection.name` | Extract table name from SQL (after FROM/INTO/UPDATE/JOIN) |
+| `db.namespace` | From `DatabaseConfig` (database name), passed to `TracedPool` at construction |
+| `server.address` | From `DatabaseConfig.Host`, passed to `TracedPool` at construction |
+| `db.response.status_code` | Extract PG error code from `*pgconn.PgError` in `recordError()` |
+
+**Why**: These are conditionally required by OTel DB Semantic Conventions. `db.collection.name` enables filtering traces by table. `db.response.status_code` distinguishes constraint violations from connection errors.
+
+**Table name extraction**: Extend the existing `ExtractOperation()` function to also return the table name. Use a simple regex for common patterns (`FROM \w+`, `INTO \w+`, `UPDATE \w+`). Complex queries (CTEs, subqueries) may not match — that is acceptable as `db.collection.name` is optional.
+
+### D8: Context propagation fix in ConcertUseCase
+
+**Decision**: Replace `context.Background()` with `context.WithoutCancel(ctx)` in `markSearchCompleted()` and `markSearchFailed()`.
+
+**Why**: The design intent is to detach from the parent's deadline/cancellation (the search may time out but the status update must still run). `context.WithoutCancel(ctx)` preserves the trace context (trace_id, span_id) while removing the cancellation signal — exactly the needed semantics.
+
+## Risks / Trade-offs
+
+**[Span volume increase] → Mitigation: Sampler ratio**
+Adding otelhttp spans for all external API calls increases span volume significantly. The `ParentBased(TraceIDRatioBased)` sampler ensures only a configured percentage of traces are sampled in production. Development keeps `AlwaysSample()` via ratio `1.0`.
+
+**[Table name extraction fragility] → Mitigation: Graceful fallback**
+SQL parsing for `db.collection.name` uses simple regex, not a full SQL parser. Complex queries (CTEs, dynamic SQL) may not match. The attribute is simply omitted when extraction fails — no error, no incorrect data.
+
+**[Gemini UseDefaultCredentials() coupling] → Mitigation: Version pin awareness**
+`UseDefaultCredentials()` was added in genai v1.34.0. If the genai library is downgraded below this version, compilation fails immediately (not a silent regression). Current version is v1.44.0 with significant margin.
+
+**[Metrics exporter requires Collector pipeline] → Mitigation: Conditional export**
+Same pattern as traces: metrics exporter is only created when `OTLPEndpoint` is configured. Local development without a Collector runs without exporting metrics.

--- a/openspec/changes/archive/2026-03-27-enhance-backend-observability/proposal.md
+++ b/openspec/changes/archive/2026-03-27-enhance-backend-observability/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+The backend currently instruments only the RPC entry layer (otelconnect) and database queries (TracedPool), leaving the entire business logic layer and all external API calls as blind spots. When a request takes 5 seconds but DB queries account for only 50ms, there is no visibility into where the remaining time is spent. Additionally, the Metrics signal is completely absent, and the SDK configuration uses `AlwaysSample()` which is unsuitable for production traffic.
+
+## What Changes
+
+- Instrument all external HTTP clients (Gemini, Google Places, Last.fm, MusicBrainz, fanart.tv, Logo Fetcher) with `otelhttp.NewTransport()` and the Zitadel gRPC client with `otelgrpc`
+- Add UseCase-level spans for CPU-intensive in-process logic: Merkle tree construction, concert deduplication, and artist batch persistence
+- Introduce the Metrics signal: MeterProvider initialization, RPC/external API histograms, blockchain operation counters, and DB pool gauges
+- Enhance the OTel SDK setup: environment-aware sampler, additional resource attributes (`deployment.environment`), explicit `TextMapPropagator`, and `SpanLimits`
+- Enrich DB spans with missing Semantic Convention attributes: `db.collection.name`, `db.namespace`, `server.address`, `db.response.status_code`
+- Fix trace context loss in `ConcertUseCase` where `context.Background()` severs parent traces for search status updates
+
+## Capabilities
+
+### New Capabilities
+
+- `backend-otel-instrumentation`: Covers external HTTP/gRPC client tracing, UseCase-level span placement, and Metrics signal introduction for the backend service
+- `otel-sdk-configuration`: Covers OTel SDK initialization enhancements including sampler strategy, resource attributes, propagator setup, MeterProvider, and span limits
+
+### Modified Capabilities
+
+- `db-trace-correlation`: Add missing DB Semantic Convention attributes (`db.collection.name`, `db.namespace`, `server.address`, `db.response.status_code`) to TracedPool and TracedTx spans
+
+## Impact
+
+- **backend repo**: `pkg/telemetry/`, `internal/infrastructure/` (all external clients), `internal/usecase/` (3 methods), `internal/infrastructure/database/rdb/` (TracedPool/TracedTx), `internal/di/` (DI wiring for instrumented clients)
+- **Dependencies**: Add `go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp`, `go.opentelemetry.io/otel/sdk/metric`, `go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp`, `go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc`
+- **Config**: New environment variable for sampler ratio (e.g., `TELEMETRY_SAMPLER_RATIO`); `deployment.environment` resource attribute derived from existing config
+- **OTel Collector**: Needs metrics pipeline added (OTLP metrics receiver → Cloud Monitoring exporter) — out of scope for this change but a prerequisite for metrics visibility

--- a/openspec/changes/archive/2026-03-27-enhance-backend-observability/specs/backend-otel-instrumentation/spec.md
+++ b/openspec/changes/archive/2026-03-27-enhance-backend-observability/specs/backend-otel-instrumentation/spec.md
@@ -1,0 +1,96 @@
+# Backend OTel Instrumentation
+
+## Purpose
+
+Defines the requirements for tracing external HTTP/gRPC client calls, adding UseCase-level spans for CPU-intensive business logic, and introducing application-level metrics in the backend service.
+
+## ADDED Requirements
+
+### Requirement: External HTTP client tracing via otelhttp transport
+The system SHALL instrument all outbound HTTP clients with `otelhttp.NewTransport()` at the DI layer, creating automatic spans for every HTTP request with standard attributes (method, URL, status code, duration).
+
+#### Scenario: Gemini API call creates an HTTP client span
+- **WHEN** the ConcertSearcher calls the Gemini Vertex AI API
+- **THEN** an OTel span SHALL be created with kind `Client`
+- **AND** the span SHALL have standard HTTP attributes (`http.request.method`, `url.full`, `http.response.status_code`)
+- **AND** the Gemini client SHALL use `ClientConfig.UseDefaultCredentials()` to layer ADC authentication on top of the otelhttp-wrapped transport
+- **AND** the otelhttp span SHALL NOT contain authorization headers in its attributes
+
+#### Scenario: Google Maps Places API call creates an HTTP client span
+- **WHEN** the Google Maps client calls the Places API
+- **THEN** an OTel span SHALL be created with kind `Client`
+- **AND** the existing `RetryTransport` SHALL be chained after `otelhttp.NewTransport()` (otelhttp outermost)
+
+#### Scenario: Last.fm API call creates an HTTP client span
+- **WHEN** the Last.fm client makes an API request
+- **THEN** an OTel span SHALL be created with kind `Client`
+- **AND** the span SHALL capture the full request duration including any throttle wait time
+
+#### Scenario: MusicBrainz API call creates an HTTP client span
+- **WHEN** the MusicBrainz client makes an API request
+- **THEN** an OTel span SHALL be created with kind `Client`
+
+#### Scenario: fanart.tv API call creates an HTTP client span
+- **WHEN** the fanart.tv client or LogoFetcher makes an HTTP request
+- **THEN** an OTel span SHALL be created with kind `Client`
+
+---
+
+### Requirement: Zitadel gRPC client tracing via otelgrpc
+The system SHALL instrument the Zitadel gRPC client with `otelgrpc` stats handler, creating automatic spans for every gRPC call.
+
+#### Scenario: Zitadel email verification call creates a gRPC client span
+- **WHEN** the EmailVerifier sends a verification email via the Zitadel gRPC API
+- **THEN** an OTel span SHALL be created with kind `Client`
+- **AND** the span SHALL have standard RPC attributes (`rpc.system`, `rpc.method`, `rpc.grpc.status_code`)
+
+---
+
+### Requirement: UseCase spans for CPU-intensive business logic
+The system SHALL create OTel spans for in-process operations where CPU-bound computation is the primary time cost, limited to methods where external API and DB spans do not cover the processing time.
+
+#### Scenario: Merkle tree construction creates a span
+- **WHEN** `BuildMerkleTree()` computes identity commitments and constructs the Merkle tree
+- **THEN** an OTel span SHALL be created with name `BuildMerkleTree`
+- **AND** the span SHALL have attribute `merkle.leaf_count` set to the number of tickets processed
+
+#### Scenario: Concert deduplication creates a span
+- **WHEN** `executeSearch()` calls `FilterNew` to deduplicate scraped concerts against existing ones
+- **THEN** an OTel span SHALL be created with name `FilterNewConcerts`
+- **AND** the span SHALL have attributes `filter.scraped_count` and `filter.new_count`
+
+#### Scenario: Artist batch persistence creates a span
+- **WHEN** `persistArtists()` performs the multi-pass deduplication and merge operation
+- **THEN** an OTel span SHALL be created with name `PersistArtists`
+- **AND** the span SHALL have attributes `persist.input_count` and `persist.created_count`
+
+---
+
+### Requirement: Application metrics
+The system SHALL expose application-level metrics via the OTel Metrics API, exported through OTLP to the OTel Collector.
+
+#### Scenario: External API call duration is recorded as a histogram
+- **WHEN** an external HTTP client completes a request
+- **THEN** `otelhttp` SHALL automatically record `http.client.request.duration` histogram
+- **AND** the metric SHALL include attributes for the target service name and response status
+
+#### Scenario: Blockchain mint operations record duration and count
+- **WHEN** a ticket mint operation completes (success or failure)
+- **THEN** the system SHALL record `blockchain.mint.duration` histogram with the total duration including retries
+- **AND** the system SHALL increment `blockchain.mint.total` counter with attribute `outcome` (success, retry_exhausted, error)
+
+#### Scenario: Database connection pool gauges are observable
+- **WHEN** the metrics export interval fires
+- **THEN** the system SHALL report `db.pool.active_connections` gauge from `pgxpool.Pool.Stat().AcquiredConns()`
+- **AND** the system SHALL report `db.pool.idle_connections` gauge from `pgxpool.Pool.Stat().IdleConns()`
+
+---
+
+### Requirement: Trace context preservation in deferred operations
+The system SHALL preserve trace context when executing deferred status updates that must outlive the parent request's cancellation.
+
+#### Scenario: Concert search status update preserves trace context
+- **WHEN** `markSearchCompleted()` or `markSearchFailed()` runs after the search completes or times out
+- **THEN** the function SHALL use `context.WithoutCancel(ctx)` instead of `context.Background()`
+- **AND** the resulting DB span SHALL be a child of the original search trace
+- **AND** the cancellation signal from the parent context SHALL NOT propagate to the status update

--- a/openspec/changes/archive/2026-03-27-enhance-backend-observability/specs/db-trace-correlation/spec.md
+++ b/openspec/changes/archive/2026-03-27-enhance-backend-observability/specs/db-trace-correlation/spec.md
@@ -1,0 +1,40 @@
+# Database Trace Correlation
+
+## MODIFIED Requirements
+
+### Requirement: OTel span creation for database queries
+The system SHALL create an OpenTelemetry child span for every database query executed through the connection pool, capturing the SQL operation, query text, execution duration, and additional Semantic Convention attributes including table name, database namespace, server address, and PostgreSQL error codes.
+
+#### Scenario: SELECT query creates a client span
+- **WHEN** a repository method executes a SELECT query via the pool wrapper
+- **THEN** an OTel span SHALL be created with kind `Client`
+- **AND** the span name SHALL be the SQL operation name (e.g., `SELECT`)
+- **AND** the span SHALL have attribute `db.system` set to `postgresql`
+- **AND** the span SHALL have attribute `db.query.text` set to the original SQL text (without injected comments)
+- **AND** the span SHALL have attribute `db.operation.name` set to the extracted operation
+- **AND** the span SHALL have attribute `db.collection.name` set to the primary table name extracted from the SQL (e.g., `concerts` from `SELECT ... FROM concerts`)
+- **AND** the span SHALL have attribute `db.namespace` set to the database name
+- **AND** the span SHALL have attribute `server.address` set to the database host
+
+#### Scenario: INSERT query creates a client span
+- **WHEN** a repository method executes an INSERT query via the pool wrapper
+- **THEN** an OTel span SHALL be created with span name `INSERT`
+- **AND** the span SHALL have attribute `db.collection.name` set to the target table name (e.g., `artists` from `INSERT INTO artists`)
+- **AND** the span SHALL record the duration of the query execution
+
+#### Scenario: Query execution error records PostgreSQL error code
+- **WHEN** a database query fails with a `*pgconn.PgError`
+- **THEN** the span SHALL record the error
+- **AND** the span status SHALL be set to `Error`
+- **AND** the span SHALL have attribute `db.response.status_code` set to the PostgreSQL error code (e.g., `23505` for unique violation)
+
+#### Scenario: Query execution error without PgError
+- **WHEN** a database query fails with a non-PostgreSQL error (e.g., context cancellation)
+- **THEN** the span SHALL record the error
+- **AND** the span status SHALL be set to `Error`
+- **AND** the `db.response.status_code` attribute SHALL NOT be set
+
+#### Scenario: Table name extraction fails gracefully
+- **WHEN** a query uses complex SQL (CTEs, subqueries, dynamic SQL) where table name extraction is not possible
+- **THEN** the `db.collection.name` attribute SHALL be omitted
+- **AND** no error SHALL be recorded for the extraction failure

--- a/openspec/changes/archive/2026-03-27-enhance-backend-observability/specs/otel-sdk-configuration/spec.md
+++ b/openspec/changes/archive/2026-03-27-enhance-backend-observability/specs/otel-sdk-configuration/spec.md
@@ -1,0 +1,58 @@
+# OTel SDK Configuration
+
+## Purpose
+
+Defines the requirements for the OpenTelemetry SDK initialization in the backend service, covering TracerProvider, MeterProvider, resource attributes, sampler strategy, and propagator setup.
+
+## ADDED Requirements
+
+### Requirement: Environment-aware trace sampling
+The system SHALL use a `ParentBased(TraceIDRatioBased)` sampler configured via the `TELEMETRY_SAMPLER_RATIO` environment variable, defaulting to `1.0` (sample all).
+
+#### Scenario: Production uses ratio-based sampling
+- **WHEN** `TELEMETRY_SAMPLER_RATIO` is set to `0.1`
+- **THEN** the TracerProvider SHALL sample approximately 10% of new root traces
+- **AND** child spans SHALL inherit the parent's sampling decision
+
+#### Scenario: Development samples all traces
+- **WHEN** `TELEMETRY_SAMPLER_RATIO` is not set or set to `1.0`
+- **THEN** the TracerProvider SHALL sample 100% of traces (equivalent to `AlwaysSample()`)
+
+---
+
+### Requirement: Enriched resource attributes
+The system SHALL configure the OTel Resource with `deployment.environment` in addition to the existing `service.name` and `service.version`.
+
+#### Scenario: Resource includes deployment environment
+- **WHEN** the telemetry SDK is initialized
+- **THEN** the Resource SHALL include attribute `deployment.environment` derived from the `ENVIRONMENT` config value (e.g., `local`, `development`, `staging`, `production`)
+
+---
+
+### Requirement: Explicit text map propagator
+The system SHALL explicitly configure `propagation.TraceContext{}` as the global text map propagator.
+
+#### Scenario: W3C TraceContext propagator is set
+- **WHEN** the telemetry SDK is initialized
+- **THEN** `otel.SetTextMapPropagator(propagation.TraceContext{})` SHALL be called
+- **AND** cross-service trace context propagation SHALL use W3C TraceContext format
+
+---
+
+### Requirement: MeterProvider initialization
+The system SHALL initialize an OTel MeterProvider alongside the TracerProvider, sharing the same Resource and OTLP endpoint.
+
+#### Scenario: MeterProvider exports metrics via OTLP
+- **WHEN** `TELEMETRY_OTLP_ENDPOINT` is configured
+- **THEN** the MeterProvider SHALL be created with an OTLP HTTP metric exporter targeting the same endpoint
+- **AND** the MeterProvider SHALL use the same Resource as the TracerProvider
+- **AND** the global MeterProvider SHALL be set via `otel.SetMeterProvider()`
+
+#### Scenario: MeterProvider is created without exporter when endpoint is not configured
+- **WHEN** `TELEMETRY_OTLP_ENDPOINT` is not configured
+- **THEN** the MeterProvider SHALL be created without an exporter (metrics recorded but not exported)
+
+#### Scenario: MeterProvider is shut down during graceful shutdown
+- **WHEN** the application receives a shutdown signal
+- **THEN** the MeterProvider SHALL be shut down in the Observe phase alongside the TracerProvider
+- **AND** pending metric data SHALL be flushed before shutdown completes

--- a/openspec/changes/archive/2026-03-27-enhance-backend-observability/tasks.md
+++ b/openspec/changes/archive/2026-03-27-enhance-backend-observability/tasks.md
@@ -1,0 +1,45 @@
+## 1. SDK Foundation (otel-sdk-configuration)
+
+- [x] 1.1 Add `SamplerRatio float64` field to `TelemetryConfig` with envconfig tag `TELEMETRY_SAMPLER_RATIO` and default `1.0`
+- [x] 1.2 Expand `SetupTelemetry` to accept `environment string` parameter and add `deployment.environment` resource attribute
+- [x] 1.3 Replace `trace.AlwaysSample()` with `trace.ParentBased(trace.TraceIDRatioBased(ratio))`
+- [x] 1.4 Add `otel.SetTextMapPropagator(propagation.TraceContext{})` call in setup
+- [x] 1.5 Initialize MeterProvider with OTLP HTTP metric exporter (conditional on OTLPEndpoint), set global via `otel.SetMeterProvider()`
+- [x] 1.6 Update `tracerCloser` to also shut down MeterProvider (rename to `telemetryCloser`)
+- [x] 1.7 Update all `SetupTelemetry` call sites in DI (provider.go, consumer.go, job.go, image_sync_job.go) to pass environment
+- [x] 1.8 Add unit tests for sampler ratio configuration and resource attribute construction
+
+## 2. External HTTP Client Instrumentation (backend-otel-instrumentation)
+
+- [x] 2.1 Add `go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp` dependency
+- [x] 2.2 Create otelhttp-wrapped `*http.Client` in DI provider.go for Gemini clients using `UseDefaultCredentials()` pattern
+- [x] 2.3 Create otelhttp-wrapped `*http.Client` in DI consumer.go for Google Maps (chain: otelhttp → RetryTransport)
+- [x] 2.4 Create otelhttp-wrapped `*http.Client` in DI provider.go for Last.fm client (replace `nil`)
+- [x] 2.5 Create otelhttp-wrapped `*http.Client` in DI provider.go for MusicBrainz client (replace `nil`)
+- [x] 2.6 Create otelhttp-wrapped `*http.Client` in DI provider.go and consumer.go for fanart.tv client and LogoFetcher (replace `nil`)
+- [x] 2.7 Add `go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc` dependency and wire `otelgrpc.NewClientHandler()` into Zitadel client via gRPC dial options
+
+## 3. UseCase Spans (backend-otel-instrumentation)
+
+- [x] 3.1 Add span in `BuildMerkleTree()` wrapping identity commitment computation and tree construction, with `merkle.leaf_count` attribute
+- [x] 3.2 Add span in `executeSearch()` wrapping `FilterNew` deduplication, with `filter.scraped_count` and `filter.new_count` attributes
+- [x] 3.3 Add span in `persistArtists()` wrapping the multi-pass dedup/merge logic, with `persist.input_count` and `persist.created_count` attributes
+
+## 4. DB Semantic Convention Enrichment (db-trace-correlation)
+
+- [x] 4.1 Extend `ExtractOperation()` to also return table name (regex for FROM/INTO/UPDATE patterns), rename to `ExtractQueryMeta()`
+- [x] 4.2 Add `dbNamespace` and `serverAddress` fields to `TracedPool` and `TracedTx`, set from `DatabaseConfig` at construction
+- [x] 4.3 Add `db.collection.name`, `db.namespace`, `server.address` attributes to `startSpan()` in TracedPool and TracedTx
+- [x] 4.4 Extract `*pgconn.PgError` code in `recordError()` and set `db.response.status_code` attribute
+- [x] 4.5 Update TracedPool/TracedTx constructor call sites in DI to pass database name and host
+- [x] 4.6 Update existing unit tests for `ExtractQueryMeta()` and add test cases for table name extraction
+
+## 5. Application Metrics (backend-otel-instrumentation)
+
+- [x] 5.1 Add `go.opentelemetry.io/otel/sdk/metric` and `go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp` dependencies
+- [x] 5.2 Create `blockchain.mint.duration` histogram and `blockchain.mint.total` counter in TicketUseCase, record on mint completion
+- [x] 5.3 Register `db.pool.active_connections` and `db.pool.idle_connections` as ObservableGauges reading from `pgxpool.Pool.Stat()`
+
+## 6. Context Propagation Fix (backend-otel-instrumentation)
+
+- [x] 6.1 Replace `context.Background()` with `context.WithoutCancel(ctx)` in `markSearchCompleted()` and `markSearchFailed()` in concert_uc.go

--- a/openspec/specs/backend-otel-instrumentation/spec.md
+++ b/openspec/specs/backend-otel-instrumentation/spec.md
@@ -1,0 +1,96 @@
+# Backend OTel Instrumentation
+
+## Purpose
+
+Defines the requirements for tracing external HTTP/gRPC client calls, adding UseCase-level spans for CPU-intensive business logic, and introducing application-level metrics in the backend service.
+
+## Requirements
+
+### Requirement: External HTTP client tracing via otelhttp transport
+The system SHALL instrument all outbound HTTP clients with `otelhttp.NewTransport()` at the DI layer, creating automatic spans for every HTTP request with standard attributes (method, URL, status code, duration).
+
+#### Scenario: Gemini API call creates an HTTP client span
+- **WHEN** the ConcertSearcher calls the Gemini Vertex AI API
+- **THEN** an OTel span SHALL be created with kind `Client`
+- **AND** the span SHALL have standard HTTP attributes (`http.request.method`, `url.full`, `http.response.status_code`)
+- **AND** the Gemini client SHALL use `ClientConfig.UseDefaultCredentials()` to layer ADC authentication on top of the otelhttp-wrapped transport
+- **AND** the otelhttp span SHALL NOT contain authorization headers in its attributes
+
+#### Scenario: Google Maps Places API call creates an HTTP client span
+- **WHEN** the Google Maps client calls the Places API
+- **THEN** an OTel span SHALL be created with kind `Client`
+- **AND** the existing `RetryTransport` SHALL be chained after `otelhttp.NewTransport()` (otelhttp outermost)
+
+#### Scenario: Last.fm API call creates an HTTP client span
+- **WHEN** the Last.fm client makes an API request
+- **THEN** an OTel span SHALL be created with kind `Client`
+- **AND** the span SHALL capture the full request duration including any throttle wait time
+
+#### Scenario: MusicBrainz API call creates an HTTP client span
+- **WHEN** the MusicBrainz client makes an API request
+- **THEN** an OTel span SHALL be created with kind `Client`
+
+#### Scenario: fanart.tv API call creates an HTTP client span
+- **WHEN** the fanart.tv client or LogoFetcher makes an HTTP request
+- **THEN** an OTel span SHALL be created with kind `Client`
+
+---
+
+### Requirement: Zitadel gRPC client tracing via otelgrpc
+The system SHALL instrument the Zitadel gRPC client with `otelgrpc` stats handler, creating automatic spans for every gRPC call.
+
+#### Scenario: Zitadel email verification call creates a gRPC client span
+- **WHEN** the EmailVerifier sends a verification email via the Zitadel gRPC API
+- **THEN** an OTel span SHALL be created with kind `Client`
+- **AND** the span SHALL have standard RPC attributes (`rpc.system`, `rpc.method`, `rpc.grpc.status_code`)
+
+---
+
+### Requirement: UseCase spans for CPU-intensive business logic
+The system SHALL create OTel spans for in-process operations where CPU-bound computation is the primary time cost, limited to methods where external API and DB spans do not cover the processing time.
+
+#### Scenario: Merkle tree construction creates a span
+- **WHEN** `BuildMerkleTree()` computes identity commitments and constructs the Merkle tree
+- **THEN** an OTel span SHALL be created with name `BuildMerkleTree`
+- **AND** the span SHALL have attribute `merkle.leaf_count` set to the number of tickets processed
+
+#### Scenario: Concert deduplication creates a span
+- **WHEN** `executeSearch()` calls `FilterNew` to deduplicate scraped concerts against existing ones
+- **THEN** an OTel span SHALL be created with name `FilterNewConcerts`
+- **AND** the span SHALL have attributes `filter.scraped_count` and `filter.new_count`
+
+#### Scenario: Artist batch persistence creates a span
+- **WHEN** `persistArtists()` performs the multi-pass deduplication and merge operation
+- **THEN** an OTel span SHALL be created with name `PersistArtists`
+- **AND** the span SHALL have attributes `persist.input_count` and `persist.created_count`
+
+---
+
+### Requirement: Application metrics
+The system SHALL expose application-level metrics via the OTel Metrics API, exported through OTLP to the OTel Collector.
+
+#### Scenario: External API call duration is recorded as a histogram
+- **WHEN** an external HTTP client completes a request
+- **THEN** `otelhttp` SHALL automatically record `http.client.request.duration` histogram
+- **AND** the metric SHALL include attributes for the target service name and response status
+
+#### Scenario: Blockchain mint operations record duration and count
+- **WHEN** a ticket mint operation completes (success or failure)
+- **THEN** the system SHALL record `blockchain.mint.duration` histogram with the total duration including retries
+- **AND** the system SHALL increment `blockchain.mint.total` counter with attribute `outcome` (success, retry_exhausted, error)
+
+#### Scenario: Database connection pool gauges are observable
+- **WHEN** the metrics export interval fires
+- **THEN** the system SHALL report `db.pool.active_connections` gauge from `pgxpool.Pool.Stat().AcquiredConns()`
+- **AND** the system SHALL report `db.pool.idle_connections` gauge from `pgxpool.Pool.Stat().IdleConns()`
+
+---
+
+### Requirement: Trace context preservation in deferred operations
+The system SHALL preserve trace context when executing deferred status updates that must outlive the parent request's cancellation.
+
+#### Scenario: Concert search status update preserves trace context
+- **WHEN** `markSearchCompleted()` or `markSearchFailed()` runs after the search completes or times out
+- **THEN** the function SHALL use `context.WithoutCancel(ctx)` instead of `context.Background()`
+- **AND** the resulting DB span SHALL be a child of the original search trace
+- **AND** the cancellation signal from the parent context SHALL NOT propagate to the status update

--- a/openspec/specs/db-trace-correlation/spec.md
+++ b/openspec/specs/db-trace-correlation/spec.md
@@ -7,7 +7,7 @@ Defines the requirements for end-to-end trace correlation between backend applic
 ## Requirements
 
 ### Requirement: OTel span creation for database queries
-The system SHALL create an OpenTelemetry child span for every database query executed through the connection pool, capturing the SQL operation, query text, and execution duration.
+The system SHALL create an OpenTelemetry child span for every database query executed through the connection pool, capturing the SQL operation, query text, execution duration, and additional Semantic Convention attributes including table name, database namespace, server address, and PostgreSQL error codes.
 
 #### Scenario: SELECT query creates a client span
 - **WHEN** a repository method executes a SELECT query via the pool wrapper
@@ -16,16 +16,32 @@ The system SHALL create an OpenTelemetry child span for every database query exe
 - **AND** the span SHALL have attribute `db.system` set to `postgresql`
 - **AND** the span SHALL have attribute `db.query.text` set to the original SQL text (without injected comments)
 - **AND** the span SHALL have attribute `db.operation.name` set to the extracted operation
+- **AND** the span SHALL have attribute `db.collection.name` set to the primary table name extracted from the SQL (e.g., `concerts` from `SELECT ... FROM concerts`)
+- **AND** the span SHALL have attribute `db.namespace` set to the database name
+- **AND** the span SHALL have attribute `server.address` set to the database host
 
 #### Scenario: INSERT query creates a client span
 - **WHEN** a repository method executes an INSERT query via the pool wrapper
 - **THEN** an OTel span SHALL be created with span name `INSERT`
+- **AND** the span SHALL have attribute `db.collection.name` set to the target table name (e.g., `artists` from `INSERT INTO artists`)
 - **AND** the span SHALL record the duration of the query execution
 
-#### Scenario: Query execution error is recorded on the span
-- **WHEN** a database query fails with an error
+#### Scenario: Query execution error records PostgreSQL error code
+- **WHEN** a database query fails with a `*pgconn.PgError`
 - **THEN** the span SHALL record the error
 - **AND** the span status SHALL be set to `Error`
+- **AND** the span SHALL have attribute `db.response.status_code` set to the PostgreSQL error code (e.g., `23505` for unique violation)
+
+#### Scenario: Query execution error without PgError
+- **WHEN** a database query fails with a non-PostgreSQL error (e.g., context cancellation)
+- **THEN** the span SHALL record the error
+- **AND** the span status SHALL be set to `Error`
+- **AND** the `db.response.status_code` attribute SHALL NOT be set
+
+#### Scenario: Table name extraction fails gracefully
+- **WHEN** a query uses complex SQL (CTEs, subqueries, dynamic SQL) where table name extraction is not possible
+- **THEN** the `db.collection.name` attribute SHALL be omitted
+- **AND** no error SHALL be recorded for the extraction failure
 
 ---
 

--- a/openspec/specs/otel-sdk-configuration/spec.md
+++ b/openspec/specs/otel-sdk-configuration/spec.md
@@ -1,0 +1,58 @@
+# OTel SDK Configuration
+
+## Purpose
+
+Defines the requirements for the OpenTelemetry SDK initialization in the backend service, covering TracerProvider, MeterProvider, resource attributes, sampler strategy, and propagator setup.
+
+## Requirements
+
+### Requirement: Environment-aware trace sampling
+The system SHALL use a `ParentBased(TraceIDRatioBased)` sampler configured via the `TELEMETRY_SAMPLER_RATIO` environment variable, defaulting to `1.0` (sample all).
+
+#### Scenario: Production uses ratio-based sampling
+- **WHEN** `TELEMETRY_SAMPLER_RATIO` is set to `0.1`
+- **THEN** the TracerProvider SHALL sample approximately 10% of new root traces
+- **AND** child spans SHALL inherit the parent's sampling decision
+
+#### Scenario: Development samples all traces
+- **WHEN** `TELEMETRY_SAMPLER_RATIO` is not set or set to `1.0`
+- **THEN** the TracerProvider SHALL sample 100% of traces (equivalent to `AlwaysSample()`)
+
+---
+
+### Requirement: Enriched resource attributes
+The system SHALL configure the OTel Resource with `deployment.environment` in addition to the existing `service.name` and `service.version`.
+
+#### Scenario: Resource includes deployment environment
+- **WHEN** the telemetry SDK is initialized
+- **THEN** the Resource SHALL include attribute `deployment.environment` derived from the `ENVIRONMENT` config value (e.g., `local`, `development`, `staging`, `production`)
+
+---
+
+### Requirement: Explicit text map propagator
+The system SHALL explicitly configure `propagation.TraceContext{}` as the global text map propagator.
+
+#### Scenario: W3C TraceContext propagator is set
+- **WHEN** the telemetry SDK is initialized
+- **THEN** `otel.SetTextMapPropagator(propagation.TraceContext{})` SHALL be called
+- **AND** cross-service trace context propagation SHALL use W3C TraceContext format
+
+---
+
+### Requirement: MeterProvider initialization
+The system SHALL initialize an OTel MeterProvider alongside the TracerProvider, sharing the same Resource and OTLP endpoint.
+
+#### Scenario: MeterProvider exports metrics via OTLP
+- **WHEN** `TELEMETRY_OTLP_ENDPOINT` is configured
+- **THEN** the MeterProvider SHALL be created with an OTLP HTTP metric exporter targeting the same endpoint
+- **AND** the MeterProvider SHALL use the same Resource as the TracerProvider
+- **AND** the global MeterProvider SHALL be set via `otel.SetMeterProvider()`
+
+#### Scenario: MeterProvider is created without exporter when endpoint is not configured
+- **WHEN** `TELEMETRY_OTLP_ENDPOINT` is not configured
+- **THEN** the MeterProvider SHALL be created without an exporter (metrics recorded but not exported)
+
+#### Scenario: MeterProvider is shut down during graceful shutdown
+- **WHEN** the application receives a shutdown signal
+- **THEN** the MeterProvider SHALL be shut down in the Observe phase alongside the TracerProvider
+- **AND** pending metric data SHALL be flushed before shutdown completes


### PR DESCRIPTION
## Summary

- Add new specs: `backend-otel-instrumentation` (external client tracing, UseCase spans, metrics, context propagation) and `otel-sdk-configuration` (sampler, resource, propagator, MeterProvider)
- Update `db-trace-correlation` spec with enriched semantic convention attributes (`db.collection.name`, `db.namespace`, `server.address`, `db.response.status_code`)
- Archive completed `enhance-backend-observability` change with all artifacts (proposal, design, specs, tasks)

## Test plan

- [x] Spec files are well-formed markdown with correct requirement/scenario structure
- [x] Archive contains all 4 artifacts
- [ ] CI checks pass

Refs: liverty-music/backend#268