### PR TITLE
docs(openspec): add fix-post-signup-dialog change artifacts

### DIFF
--- a/openspec/changes/fix-post-signup-dialog/.openspec.yaml
+++ b/openspec/changes/fix-post-signup-dialog/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-27

--- a/openspec/changes/fix-post-signup-dialog/design.md
+++ b/openspec/changes/fix-post-signup-dialog/design.md
@@ -1,0 +1,75 @@
+## Context
+
+`BottomSheet` is the single dialog primitive used across the app. It manages the HTML Popover API lifecycle:
+
+- `attached()`: Sets `popover` attribute on the CE host element, registers `toggle` listener
+- `openChanged(isOpen)`: Calls `showPopover()` / `hidePopover()` on the CE host
+
+All existing consumers open sheets via user interaction (tap → set `open = true`), so `openChanged()` always runs after `attached()`. The PostSignupDialog is the only case where `open` is `true` at initial bind time — the parent `DashboardRoute.loading()` sets `showPostSignupDialog = true` before any child component reaches `attached()`.
+
+Aurelia 2 component lifecycle order:
+```
+binding → bound → attaching → attached
+          ↑                      ↑
+   openChanged(true)      popover attribute set
+   showPopover() fails    fallback: if(this.open) openChanged(true)
+```
+
+`showPopover()` on an element without `popover` attribute throws `InvalidStateError` (DOMException). The `attached()` fallback at line 53-55 should recover, but if the binding-phase error disrupts the lifecycle, `attached()` may not execute.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Ensure PostSignupDialog reliably opens when `active` is bound to `true` at component creation time
+- Keep the fix minimal and contained to `BottomSheet`
+
+**Non-Goals:**
+- Changing PostSignupDialog trigger logic or localStorage flag mechanism
+- Changing when `loading()` sets `showPostSignupDialog` (moving to `attached()` would work but couples dashboard logic to component lifecycle details)
+- Addressing dialog content visibility conditions (notification `granted` state, PWA `beforeinstallprompt` availability)
+
+## Decisions
+
+### Decision 1: Add try-catch around `showPopover()` in `openChanged()`
+
+**Choice**: Wrap `showPopover()` in a try-catch, matching the existing pattern used for `hidePopover()`.
+
+```typescript
+public openChanged(isOpen: boolean): void {
+    if (isOpen) {
+        this.triggerElement = document.activeElement as HTMLElement | null
+        try {
+            this.host.showPopover()
+        } catch {
+            // Pre-attach: popover attribute not yet set.
+            // attached() will retry via the if(this.open) guard.
+        }
+    } else {
+        try {
+            this.host.hidePopover()
+        } catch {
+            // Already hidden
+        }
+    }
+}
+```
+
+**Why over alternative (move flag check to `attached()`)**: The bug is in `BottomSheet`, not in the consumer. Any future consumer that binds `open` to `true` at creation time would hit the same issue. Fixing it in `BottomSheet` is the correct layered fix.
+
+**Why over alternative (set `popover` attribute in constructor)**: The CE host element may not be fully connected to the DOM in the constructor. Setting attributes in `attached()` is the Aurelia 2 convention for DOM manipulation.
+
+### Decision 2: Rely on existing `attached()` fallback for actual open
+
+The `attached()` method already has:
+```typescript
+if (this.open) {
+    this.openChanged(true)
+}
+```
+
+With the try-catch in place, the binding-phase call silently fails, and `attached()` retries successfully after the `popover` attribute is set. No new recovery logic needed.
+
+## Risks / Trade-offs
+
+- **[Silent failure masking]** → The try-catch could mask a genuine error in a future code change. Mitigated by: the comment explains the specific pre-attach scenario; `attached()` always retries if `open` is `true`.
+- **[Timing of popover open]** → The sheet opens slightly later (at `attached()` instead of `binding`). In practice this is imperceptible — both phases complete within the same microtask/render cycle.

--- a/openspec/changes/fix-post-signup-dialog/proposal.md
+++ b/openspec/changes/fix-post-signup-dialog/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+The PostSignupDialog fails to display after first-time signup due to a component lifecycle timing bug. `BottomSheet.openChanged()` calls `showPopover()` during the `binding` phase before `attached()` has set the `popover` attribute on the host element, causing an uncaught `InvalidStateError` that prevents the dialog from ever opening. This is the only path where `BottomSheet.open` is `true` at initial bind time (all other consumers open the sheet via user interaction after attach).
+
+## What Changes
+
+- Fix `BottomSheet.openChanged()` to handle the pre-attach case where `showPopover()` is called before the `popover` attribute exists on the host element
+- Add defensive error handling in `openChanged()` for the `showPopover()` call (matching the existing `try-catch` pattern already used for `hidePopover()`)
+
+## Capabilities
+
+### New Capabilities
+
+_None_
+
+### Modified Capabilities
+
+- `post-signup-dialog`: Clarify that the dialog MUST reliably open when `active` is bound to `true` at component creation time (not only on subsequent changes)
+- `bottom-sheet-ce`: `openChanged()` SHALL handle the case where `showPopover()` is called before `attached()` has initialized the `popover` attribute — the `attached()` fallback (`if (this.open) this.openChanged(true)`) ensures recovery
+
+## Impact
+
+- **Frontend**: `BottomSheet` component (`src/components/bottom-sheet/bottom-sheet.ts`) — single-line fix adding `try-catch` around `showPopover()` in `openChanged()`
+- **No API/backend/proto changes required**
+- **No breaking changes**

--- a/openspec/changes/fix-post-signup-dialog/specs/bottom-sheet-ce/spec.md
+++ b/openspec/changes/fix-post-signup-dialog/specs/bottom-sheet-ce/spec.md
@@ -1,0 +1,19 @@
+## MODIFIED Requirements
+
+### Requirement: Bottom Sheet Custom Element
+The system SHALL provide a `<bottom-sheet>` custom element as the single dialog primitive for all overlay content, using the Popover API with CSS scroll-snap dismiss.
+
+#### Scenario: Basic open/close via bindable
+- **WHEN** `<bottom-sheet open.bind="isOpen">` has `open` set to `true`
+- **THEN** the CE SHALL call `showPopover()` on the CE host element (via `resolve(INode)`)
+- **AND** the sheet-body SHALL be visible at the bottom of the viewport via CSS `initial-snap` animation (no JS `scrollTo` required)
+- **WHEN** `open` is set to `false`
+- **THEN** the CE SHALL call `hidePopover()` on the CE host element and the sheet SHALL animate out
+
+#### Scenario: Open bound to true at component creation time
+- **WHEN** `open` is bound to `true` at initial bind time (before `attached()`)
+- **AND** `openChanged(true)` is called during the `binding` phase
+- **THEN** `showPopover()` SHALL be called but MAY fail silently if the `popover` attribute is not yet set
+- **AND** the error SHALL be caught and suppressed (matching the existing `hidePopover()` try-catch pattern)
+- **AND** the `attached()` lifecycle hook SHALL retry via `if (this.open) this.openChanged(true)` after the `popover` attribute is initialized
+- **AND** the sheet SHALL open successfully at `attached()` time

--- a/openspec/changes/fix-post-signup-dialog/specs/post-signup-dialog/spec.md
+++ b/openspec/changes/fix-post-signup-dialog/specs/post-signup-dialog/spec.md
@@ -1,0 +1,11 @@
+## ADDED Requirements
+
+### Requirement: Dialog reliably opens when active is true at creation time
+The PostSignupDialog SHALL reliably open when `active` is bound to `true` at component creation time, not only when `active` transitions from `false` to `true` after the component is attached.
+
+#### Scenario: Dashboard sets showPostSignupDialog in loading() before attach
+- **WHEN** `DashboardRoute.loading()` sets `showPostSignupDialog = true`
+- **AND** `PostSignupDialog` receives `active = true` during its `binding` phase
+- **THEN** `activeChanged()` SHALL set `isOpen = true`
+- **AND** the inner `<bottom-sheet>` SHALL open successfully (via the `attached()` fallback in BottomSheet)
+- **AND** the dialog SHALL be visible to the user with its full content

--- a/openspec/changes/fix-post-signup-dialog/tasks.md
+++ b/openspec/changes/fix-post-signup-dialog/tasks.md
@@ -1,0 +1,9 @@
+## 1. Fix BottomSheet pre-attach showPopover error
+
+- [x] 1.1 Add try-catch around `this.host.showPopover()` in `BottomSheet.openChanged()` (`frontend/src/components/bottom-sheet/bottom-sheet.ts`) — matching the existing `hidePopover()` catch pattern
+- [x] 1.2 Add unit test: BottomSheet with `open` bound to `true` at creation time opens successfully after `attached()`
+
+## 2. Verify PostSignupDialog opens
+
+- [x] 2.1 Run existing PostSignupDialog tests to confirm no regressions
+- [ ] 2.2 Manual verification: signup with a new account on dev environment and confirm PostSignupDialog BottomSheet opens on dashboard


### PR DESCRIPTION
## Summary

- Add OpenSpec change artifacts for `fix-post-signup-dialog`: proposal, design, delta specs (bottom-sheet-ce, post-signup-dialog), and tasks
- Documents the BottomSheet pre-attach `showPopover()` timing bug and the try-catch fix

## Test plan

- [x] Artifacts follow OpenSpec schema (proposal → design → specs → tasks)
- [x] Implementation PR: liverty-music/frontend#310
