### PR TITLE
docs(specs): add api-rate-limiting spec, extend test coverage specs, archive refine-backend

### DIFF
--- a/openspec/changes/archive/2026-03-27-go-126-modernize/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-27-go-126-modernize/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-27

--- a/openspec/changes/archive/2026-03-27-go-126-modernize/design.md
+++ b/openspec/changes/archive/2026-03-27-go-126-modernize/design.md
@@ -1,0 +1,84 @@
+## Context
+
+The backend (`go 1.26` in go.mod) uses pre-1.26 idioms throughout ~40 files. Go 1.26 introduced language changes (`new(value)`), new standard library APIs (`errors.AsType[T]`, `sync.WaitGroup.Go`), and the `go fix` modernizer tool with 20+ analyzers. The codebase has not yet adopted these.
+
+Key patterns to modernize:
+- 11 `errors.As` call sites (rdb, gemini, blockchain layers)
+- `interface{}` instead of `any` (cache, test helpers)
+- C-style `for i := 0; i < n` instead of `range int`
+- Manual `wg.Add(1) + go func() { defer wg.Done() }` pattern
+- Manual issuer-matching loop instead of `slices.Contains`
+- Pointer-helper functions (`strPtr`, `floatPtr`) instead of `new(value)`
+- `*time.Time` with `omitempty` on JSON-tagged event payloads
+
+## Goals / Non-Goals
+
+**Goals:**
+- Adopt Go 1.26 idioms across the entire backend codebase
+- Enforce modern patterns in CI via `go fix -diff` check
+- Eliminate pointer-helper boilerplate in tests using `new(value)`
+- Gain compile-time type safety on error unwrapping via `errors.AsType[T]`
+
+**Non-Goals:**
+- Adopt `encoding/json/v2` (still experimental, `GOEXPERIMENT` required)
+- Change `*time.Time` fields on `entity.Event` (no json tags; DB scan depends on pointer nil semantics)
+- Refactor existing architecture or add new features
+- Adopt experimental packages (`simd`, `runtime/secret`, goroutine leak profiler)
+
+## Decisions
+
+### D1: Apply `go fix ./...` as a single batch
+
+**Decision**: Run `go fix ./...` to apply all modernizer analyzers at once.
+
+**Rationale**: The tool is idempotent, produces minimal diffs, and all transformations are semantics-preserving. Cherry-picking individual analyzers adds process overhead with no safety benefit. All 20+ analyzers (interface→any, rangeint, waitgroup, slicescontains, newptr, etc.) produce correct output.
+
+**Alternative considered**: Run analyzers one-by-one (`go fix -omitzero ./...`, `go fix -forvar ./...`). Rejected — unnecessary granularity for a batch refactor.
+
+### D2: `errors.AsType[T]` migration (manual, not auto-fixable)
+
+**Decision**: Replace all 11 `errors.As` calls with `errors.AsType[T]`.
+
+**Rationale**: `go fix` does not auto-rewrite `errors.As` → `errors.AsType` because the semantics differ slightly (AsType is generic and cannot target interface types). All 11 call sites in this codebase target concrete pointer types (`*pgconn.PgError`, `genai.APIError`, `*json.SyntaxError`, etc.), making the migration safe.
+
+**Pattern**:
+```go
+// Before
+var pgErr *pgconn.PgError
+if errors.As(err, &pgErr) { ... }
+
+// After
+if pgErr, ok := errors.AsType[*pgconn.PgError](err); ok { ... }
+```
+
+### D3: `omitzero` scope limited to `ScrapedConcert` JSON fields
+
+**Decision**: Only convert `*time.Time` + `omitempty` to `time.Time` + `omitzero` on `ScrapedConcert` (the JSON event payload struct). Do NOT touch `entity.Event.StartTime`/`OpenTime`.
+
+**Rationale**:
+- `ScrapedConcert` uses json tags for NATS event serialization. `omitzero` with `time.Time.IsZero()` correctly omits zero times.
+- `entity.Event` has no json tags — `*time.Time` is used for DB NULL semantics via pgx. Changing this would cascade into repository scan logic across concert_repo, venue_repo, and ticket_email_repo.
+- `LogoColorProfile.DominantHue` (`*float64`) stays as-is: `float64(0)` is a valid hue angle (red), so `omitzero` would incorrectly omit it.
+- `ScrapedConcert.AdminArea` (`*string`) stays as `*string + omitempty`: empty string `""` is a valid admin area value, so `omitzero` would omit valid data.
+
+### D4: `slices.MaxFunc` for `BestByLikes`
+
+**Decision**: Replace the manual max-finding loop in `BestByLikes` with `slices.MaxFunc`.
+
+**Rationale**: Direct 1:1 replacement. The function already handles the empty-slice edge case with an early return, which `slices.MaxFunc` would panic on, so the guard stays.
+
+### D5: `modernize` Makefile target with CI enforcement
+
+**Decision**: Add a `modernize` target that runs `go fix -diff ./...` and fails if output is non-empty. Insert it into `check` between `lint-schema` and `test`.
+
+**Rationale**: Prevents new code from regressing to old patterns. The check is fast (uses Go analysis framework, no compilation), idempotent, and tied to the Go version in go.mod. Developers run `go fix ./...` to auto-fix any violations.
+
+## Risks / Trade-offs
+
+**[`new(value)` readability]** → Some developers find `new("lost")` less readable than `strPtr("lost")`. Mitigated: `new(value)` is now idiomatic Go 1.26 and `go fix` will continue to suggest it. The `//go:fix inline` directive on old helper functions guides tooling.
+
+**[`omitzero` on `ScrapedConcert.StartTime`/`OpenTime`]** → Changing from `*time.Time` to `time.Time` means consumers receiving the JSON payload will see `"0001-01-01T00:00:00Z"` if serialized without `omitzero`, instead of field absence. Mitigated: `omitzero` correctly omits zero-value `time.Time`, and the consumer (`concert_consumer.go`) uses the `ScrapedConcert.ToConcert()` method which maps back to `*time.Time` on `entity.Event`.
+
+**[`go fix` version coupling]** → The `modernize` CI target depends on the Go toolchain version. If CI and local differ, `go fix -diff` may produce different results. Mitigated: Go version is pinned via `go.mod` and the CI uses the same version from the `go` directive.
+
+**[`errors.AsType` on `genai.APIError`]** → `genai.APIError` is a value type (not a pointer). `errors.AsType[genai.APIError]` works correctly for value-receiver error types. Verified in the current code — `errors.As(err, &apiErr)` already uses a value variable.

--- a/openspec/changes/archive/2026-03-27-go-126-modernize/proposal.md
+++ b/openspec/changes/archive/2026-03-27-go-126-modernize/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+Go 1.26 introduces language-level improvements (`new(value)`, `errors.AsType[T]`), standard library additions (`sync.WaitGroup.Go`, `slices.Contains` modernizer), and toolchain enhancements (`go fix` with 20+ analyzers). The backend already uses `go 1.26` in go.mod but the codebase still uses pre-1.26 patterns. Modernizing now ensures consistency, eliminates boilerplate, and captures free performance wins (Green Tea GC, `io.ReadAll` 2x speedup).
+
+## What Changes
+
+- Apply `go fix ./...` to auto-modernize ~25 call sites: `interface{}` → `any`, C-style `for` → `range int`, `wg.Add+go func` → `wg.Go`, manual loops → `slices.Contains`, pointer helpers → `new(value)`
+- Migrate all 11 `errors.As` call sites to `errors.AsType[T]` for compile-time type safety and ~3x performance
+- Replace `BestByLikes` manual loop with `slices.MaxFunc`
+- Convert `*time.Time + omitempty` fields to `time.Time + omitzero` where `IsZero()` semantics apply
+- Add `modernize` target to Makefile to enforce `go fix` compliance in `make check`
+
+## Capabilities
+
+### New Capabilities
+
+(none — pure refactoring, no new capabilities)
+
+### Modified Capabilities
+
+(none — no spec-level behavior changes)
+
+## Impact
+
+- **Backend code**: ~40 files across entity, infrastructure, adapter, and pkg layers
+- **Makefile**: New `modernize` target added to `check` pipeline
+- **DB layer**: `*time.Time` → `time.Time` changes require corresponding `pgx` scan adjustments (nullable columns use `pgtype.Timestamptz`)
+- **Tests**: All existing tests validate correctness; no new test logic needed
+- **CI**: `make check` gains `go fix -diff` enforcement — new code using old patterns will fail CI
+- **Dependencies**: No new external dependencies; uses only Go standard library

--- a/openspec/changes/archive/2026-03-27-go-126-modernize/specs/README.md
+++ b/openspec/changes/archive/2026-03-27-go-126-modernize/specs/README.md
@@ -1,0 +1,3 @@
+No capability specs for this change.
+
+This is a pure refactoring change that modernizes Go idioms without altering any system behavior or requirements. See proposal.md for details.

--- a/openspec/changes/archive/2026-03-27-go-126-modernize/tasks.md
+++ b/openspec/changes/archive/2026-03-27-go-126-modernize/tasks.md
@@ -1,0 +1,29 @@
+## 1. Automated Modernization (`go fix`)
+
+- [x] 1.1 Run `go fix ./...` to apply all modernizer analyzers (`interface{}→any`, `for→range int`, `wg.Go`, `slices.Contains`, `new(value)`, `//go:fix inline`)
+- [x] 1.2 Remove dead pointer-helper functions (`strPtr`, `floatPtr`, `statusPtr`) that `go fix` inlined with `new(value)`
+- [x] 1.3 Run `go vet ./...` and `go build ./...` to verify no compilation errors
+
+## 2. `errors.AsType[T]` Migration
+
+- [x] 2.1 Migrate `errors.As` → `errors.AsType[T]` in `internal/infrastructure/database/rdb/errors.go` (3 call sites: `toAppErr`, `IsForeignKeyViolation`, `IsUniqueViolation`)
+- [x] 2.2 Migrate `errors.As` → `errors.AsType[T]` in `internal/infrastructure/gcp/gemini/errors.go` (4 call sites: `toAppErr` for `genai.APIError`, `*json.SyntaxError`, `*json.UnmarshalTypeError`; `isRetryable` for `genai.APIError`)
+- [x] 2.3 Migrate `errors.As` → `errors.AsType[T]` in `internal/infrastructure/blockchain/ticketsbt/client.go` (1 of 2 call sites: `rpc.DataError`; anonymous interface kept as `errors.As`)
+- [x] 2.4 Update test assertions in `gemini/errors_internal_test.go` to use `errors.AsType[T]` (2 call sites)
+
+## 3. Standard Library Adoption
+
+- [x] 3.1 Replace `BestByLikes` manual max loop with `slices.MaxFunc` in `internal/entity/fanart.go`
+- [x] 3.2 Convert `ScrapedConcert.StartTime` and `ScrapedConcert.OpenTime` from `*time.Time` + `omitempty` to `time.Time` + `omitzero`
+- [x] 3.3 Update `ScrapedConcert.ToConcert()` to map `time.Time` zero values back to `*time.Time` nil for `entity.Event`
+- [x] 3.4 Update all `ScrapedConcert` construction sites in tests and production code to use `time.Time` instead of `*time.Time`
+
+## 4. CI Enforcement
+
+- [x] 4.1 Add `modernize` target to Makefile: `go fix -diff ./...` with non-zero exit on diff
+- [x] 4.2 Insert `modernize` into `check` target between `lint-schema` and `test`
+
+## 5. Verification
+
+- [x] 5.1 Run `make check` (lint + lint-schema + modernize + test) — all must pass
+- [x] 5.2 Run `go fix -diff ./...` and confirm zero output (no remaining modernization opportunities)

--- a/openspec/changes/archive/2026-03-29-refine-backend/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-29-refine-backend/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-27

--- a/openspec/changes/archive/2026-03-29-refine-backend/design.md
+++ b/openspec/changes/archive/2026-03-29-refine-backend/design.md
@@ -1,0 +1,143 @@
+## Context
+
+The backend repo (~21,000 LOC, 120+ files) follows Clean Architecture well, but a comprehensive analysis revealed 8 improvement areas: test coverage gaps, DB query performance bottlenecks, missing rate limiting, documentation drift, minor architecture violations, error handling inconsistencies, and missing business metrics. All changes are backend-only with no proto or frontend impact.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Raise test coverage from 56% to ~80% of production files, prioritizing untested adapter mappers and messaging layer
+- Eliminate N+1 query pattern in Merkle path retrieval (10-20ms latency improvement)
+- Optimize Merkle node batch inserts via pgx pipelining (30-50% faster)
+- Add application-level rate limiting as a Connect-RPC interceptor
+- Fix documentation, architecture coupling, and error handling inconsistencies
+- Add OpenTelemetry business metrics for key operations
+
+**Non-Goals:**
+
+- Redis or distributed rate limiting (YAGNI at current scale, single-digit Pod count)
+- Cloudflare WAF or Cloud Armor rate limiting (Phase 2, separate change)
+- sqlc adoption (valuable but large scope, separate change)
+- Migrating to Google Wire (manual DI works well, document it instead)
+- Adding integration tests for messaging or job systems (separate change)
+
+## Decisions
+
+### D1: Rate Limiting — Connect-RPC Unary Interceptor with `x/time/rate`
+
+**Choice:** In-process token bucket interceptor using Go's `x/time/rate`, inserted between tracing and access log interceptors.
+
+**Alternatives considered:**
+- **Redis-backed (distributed):** Adds infrastructure dependency (Memorystore), operational cost, latency per request. Not justified at current Pod count (1-3 replicas).
+- **Cloudflare Rate Limiting:** Cannot key on JWT `sub` claim (only IP/URL). Good for DDoS but not for per-user abuse prevention.
+- **HTTP middleware (pre-auth):** Cannot distinguish authenticated users. Rate limiting per-IP only.
+
+**Design:**
+
+```
+Interceptor chain (updated):
+
+  [1] tracingInterceptor
+  [2] rateLimitInterceptor  ← NEW: after tracing (needs span), before access log
+  [3] accessLogInterceptor
+  [4] errorHandlingInterceptor
+  [5] recoverHandler
+  [6] claimsBridgeInterceptor
+  [7] validationInterceptor
+```
+
+Rate limit interceptor logic:
+- **Authenticated requests:** Key = JWT `sub` claim (extracted from `authn.GetInfo(ctx)`)
+- **Unauthenticated requests (public endpoints):** Key = client IP from `X-Forwarded-For` or `RemoteAddr`
+- **Algorithm:** Token bucket via `rate.NewLimiter(rate.Every(interval), burst)`
+- **Defaults:** 100 req/sec burst 200 (authenticated), 30 req/sec burst 60 (unauthenticated)
+- **Response:** `connect.CodeResourceExhausted` with `Retry-After` header
+- **Cleanup:** Background goroutine evicts idle limiters (no access for 10 minutes)
+- **Configuration:** Environment variables (`RATE_LIMIT_AUTH_RPS`, `RATE_LIMIT_ANON_RPS`, etc.)
+
+**Migration for existing UserHandler.resendLog:** The in-memory resendLog in UserHandler is retained. The 3-per-10min email resend limit is a business rule (not infrastructure rate limiting) and sits correctly at the use-case level. The general rate limiter provides separate, orthogonal abuse prevention at the infrastructure level.
+
+### D2: Merkle Path Query — Single Batch Query
+
+**Choice:** Replace per-depth `QueryRow` loop with a single query using `unnest` + JOIN.
+
+**Current:** `GetPath()` issues `treeDepth` individual queries (up to 16 round trips).
+
+**New query:**
+
+```sql
+SELECT mt.hash
+FROM unnest($2::int[], $3::int[]) AS params(depth, node_index)
+JOIN merkle_tree mt
+  ON mt.event_id = $1 AND mt.depth = params.depth AND mt.node_index = params.node_index
+ORDER BY params.depth
+```
+
+Where `$2` and `$3` are precomputed Go slices of depth levels and sibling node indices respectively. The sibling index computation (`currentIndex ^ 1`, then `currentIndex /= 2`) moves to Go code before the query. Using `unnest` with parallel arrays is cleaner than `generate_series` + array subscripting for this lookup pattern.
+
+**Alternative:** `generate_series` + LEFT JOIN with array subscripting. Rejected — same performance, but parallel `unnest` is more readable for this access pattern.
+
+### D3: Merkle Batch Insert — pgx.SendBatch
+
+**Choice:** Replace per-node `tx.Exec()` loop with `pgx.Batch` pipelining within the same transaction.
+
+**Current:** N individual `tx.Exec` calls in a loop.
+**New:** Build `pgx.Batch`, call `tx.SendBatch(ctx, batch)`, read results.
+
+This reduces round trips from N to 1 while maintaining transaction atomicity.
+
+### D4: SafePredictor Interface Extraction
+
+**Choice:** Define `SafePredictor` interface in entity layer, removing adapter's direct import of `infrastructure/blockchain/safe`.
+
+```go
+// entity/safe_predictor.go
+type SafePredictor interface {
+    AddressHex(userID string) string
+}
+```
+
+`TicketHandler` receives the interface via DI. `safe.Predictor` implements it.
+
+**Alternative:** Leave as-is (acceptable pragmatism). Rejected because the fix is trivial and improves testability of TicketHandler.
+
+### D5: Business Metrics via OpenTelemetry
+
+**Choice:** Add counters/histograms using the existing OTel meter provider. No new dependencies.
+
+Metrics to add:
+- `concert.search.count` (counter, labels: `status=success|error`)
+- `ticket.mint.count` (counter, labels: `status=success|error`)
+- `push_notification.send.count` (counter, labels: `status=success|error|gone`)
+- `follow.count` (counter, labels: `action=follow|unfollow`)
+
+Location: Each use case records its own metrics. The meter is injected via DI (same pattern as existing `telemetry/mint_metrics.go`).
+
+### D6: Test Coverage Strategy
+
+**Priority order for new test files:**
+
+1. **Adapter mappers** (5 files) — concert, follow, ticket, ticket_email, ticket_journey. Proto ↔ Entity conversion bugs are silent and hard to detect.
+2. **Messaging layer** (6 files) — publisher, subscriber, router, cloudevents, streams. Event-driven flows are currently untestable.
+3. **user_consumer.go** — The only untested event consumer.
+4. **Error handling fixes** — Fix `err.Error()` extraction, add request context to error returns.
+5. **pkg utilities** — `geo/haversine`, `api/errors`.
+
+Testing approach: Unit tests with mocks (consistent with existing patterns). No new integration tests in this change.
+
+### D7: Error Handling Fixes
+
+Specific fixes:
+- `ticket_handler.go:64` — Replace `slog.String("error", err.Error())` with structured error logging
+- `concert_handler.go` — Wrap returned errors with artist/concert context where missing
+- Standardize: handlers that call single UC methods return errors directly (no wrap needed — UC already wraps). Handlers that do pre-processing (e.g., user lookup + UC call) wrap the pre-processing errors only.
+
+## Risks / Trade-offs
+
+- **[In-memory rate limiting is per-Pod]** → Acceptable at current scale (1-3 replicas). Effective per-user rate = N × configured rate where N = Pod count. Document this limitation. Mitigation: migrate to Redis-backed when Pod count exceeds 5.
+
+- **[Merkle query rewrite changes tested behavior]** → Existing `merkle_repo_test.go` integration tests cover `GetPath()`. Run tests after rewrite to verify identical results. Add edge case tests (depth=0, max depth).
+
+- **[Rate limiter memory growth]** → Token bucket limiters accumulate per unique user/IP. Mitigation: background eviction of idle limiters (10-min TTL). Memory bounded by active user count.
+
+- **[Large PR scope]** → 8 items in one change. Mitigation: tasks are independent and can be split across multiple PRs if needed. Group by theme: (1) DB perf, (2) rate limiting, (3) tests, (4) cleanup.

--- a/openspec/changes/archive/2026-03-29-refine-backend/proposal.md
+++ b/openspec/changes/archive/2026-03-29-refine-backend/proposal.md
@@ -1,0 +1,36 @@
+## Why
+
+The backend codebase has grown to ~21,000 LOC across 120+ files with strong Clean Architecture adherence, but a comprehensive analysis revealed structural gaps in test coverage (56% of files tested), performance bottlenecks in ZKP operations (Merkle path N+1 queries), no global rate limiting, and documentation drift. Addressing these issues now prevents technical debt accumulation and hardens the system before scaling.
+
+## What Changes
+
+- **Test coverage expansion**: Add tests for untested adapter mappers (5 files), messaging layer (6 files), user event consumer, and pkg utilities
+- **Merkle path query optimization**: Replace per-depth QueryRow loop with single batch query in `GetPath()`
+- **Merkle node batch insert optimization**: Replace per-node `tx.Exec()` loop with `pgx.SendBatch()` pipelining in `StoreBatch()`
+- **Application-level rate limiting**: Add Connect-RPC interceptor for per-user and per-IP rate limiting using `x/time/rate`
+- **CLAUDE.md documentation fix**: Update DI description from "Google Wire" to manual DI (Wire is not in go.mod)
+- **Handler infrastructure coupling fix**: Extract `SafePredictor` interface to entity layer, removing direct infrastructure import from adapter
+- **Error handling consistency**: Fix `err.Error()` string extraction in logging, add request context to error returns in handlers
+- **Business metrics instrumentation**: Add OpenTelemetry counters for key business operations (concert searches, ticket mints, push notifications)
+
+## Capabilities
+
+### New Capabilities
+
+- `api-rate-limiting`: Application-level rate limiting via Connect-RPC interceptor with per-user (JWT sub) and per-IP token bucket strategies
+
+### Modified Capabilities
+
+- `usecase-test-coverage`: Extend test requirements to cover adapter mapper layer, messaging infrastructure, and event consumers
+- `entity-test-coverage`: Extend test requirements to cover error documentation completeness for entity interfaces
+
+## Impact
+
+- **Backend repo only** (no proto changes, no frontend changes)
+- **internal/infrastructure/database/rdb/merkle_repo.go**: Query rewrite for GetPath() and StoreBatch()
+- **internal/infrastructure/server/connect.go**: New rate limiting interceptor in chain
+- **internal/adapter/rpc/**: Error handling fixes, SafePredictor interface extraction
+- **internal/entity/**: New SafePredictor interface, new Cache-related interfaces
+- **pkg/**: New rate limiter package or interceptor
+- **CLAUDE.md / AGENTS.md**: Documentation corrections
+- **Test files**: ~15-20 new test files across adapter, infrastructure, and pkg layers

--- a/openspec/changes/archive/2026-03-29-refine-backend/specs/api-rate-limiting/spec.md
+++ b/openspec/changes/archive/2026-03-29-refine-backend/specs/api-rate-limiting/spec.md
@@ -1,0 +1,84 @@
+## ADDED Requirements
+
+### Requirement: Per-user rate limiting for authenticated endpoints
+
+The system SHALL enforce per-user rate limiting on all authenticated Connect-RPC endpoints using a token bucket algorithm keyed on the JWT `sub` claim.
+
+#### Scenario: Authenticated user within rate limit
+
+- **WHEN** an authenticated user sends requests within the configured rate limit (default: 100 req/sec, burst 200)
+- **THEN** all requests SHALL be processed normally
+
+#### Scenario: Authenticated user exceeds rate limit
+
+- **WHEN** an authenticated user exceeds the configured rate limit
+- **THEN** the system SHALL return `connect.CodeResourceExhausted`
+- **AND** the response SHALL include a `Retry-After` header
+
+#### Scenario: Different users have independent rate limits
+
+- **WHEN** user A exceeds their rate limit
+- **THEN** user B's requests SHALL NOT be affected
+
+### Requirement: Per-IP rate limiting for unauthenticated endpoints
+
+The system SHALL enforce per-IP rate limiting on public (unauthenticated) Connect-RPC endpoints using a token bucket algorithm keyed on client IP address.
+
+#### Scenario: Anonymous client within rate limit
+
+- **WHEN** an unauthenticated client sends requests to public endpoints within the configured rate limit (default: 30 req/sec, burst 60)
+- **THEN** all requests SHALL be processed normally
+
+#### Scenario: Anonymous client exceeds rate limit
+
+- **WHEN** an unauthenticated client exceeds the configured rate limit for public endpoints
+- **THEN** the system SHALL return `connect.CodeResourceExhausted`
+
+#### Scenario: IP extraction from X-Forwarded-For
+
+- **WHEN** the request contains an `X-Forwarded-For` header (from GKE Ingress/load balancer)
+- **THEN** the system SHALL use the leftmost (client) IP for rate limiting
+- **AND** SHALL fall back to `RemoteAddr` if the header is absent
+
+### Requirement: Rate limiter interceptor placement
+
+The rate limit interceptor SHALL be placed in the Connect-RPC interceptor chain after the tracing interceptor and before the access log interceptor.
+
+#### Scenario: Rate-limited request is traced and logged
+
+- **WHEN** a request is rejected by the rate limiter
+- **THEN** the rejection SHALL appear in the OpenTelemetry trace span
+- **AND** the access log SHALL record the `ResourceExhausted` status
+
+#### Scenario: Health check endpoints are exempt
+
+- **WHEN** Kubernetes sends a health probe request
+- **THEN** the rate limiter SHALL NOT apply to health check endpoints
+
+### Requirement: Rate limiter memory management
+
+The system SHALL evict idle rate limiter entries to prevent unbounded memory growth.
+
+#### Scenario: Idle limiter eviction
+
+- **WHEN** a rate limiter entry has not been accessed for 10 minutes
+- **THEN** the system SHALL remove the entry from memory
+
+#### Scenario: Evicted user resumes activity
+
+- **WHEN** an evicted user sends a new request
+- **THEN** a fresh rate limiter SHALL be created with full burst capacity
+
+### Requirement: Rate limit configuration via environment variables
+
+Rate limit parameters SHALL be configurable via environment variables.
+
+#### Scenario: Custom authenticated rate limit
+
+- **WHEN** `RATE_LIMIT_AUTH_RPS` is set to `50` and `RATE_LIMIT_AUTH_BURST` is set to `100`
+- **THEN** authenticated users SHALL be limited to 50 requests per second with a burst of 100
+
+#### Scenario: Default values when not configured
+
+- **WHEN** rate limit environment variables are not set
+- **THEN** the system SHALL use defaults: authenticated 100 rps / 200 burst, unauthenticated 30 rps / 60 burst

--- a/openspec/changes/archive/2026-03-29-refine-backend/specs/entity-test-coverage/spec.md
+++ b/openspec/changes/archive/2026-03-29-refine-backend/specs/entity-test-coverage/spec.md
@@ -1,0 +1,16 @@
+## ADDED Requirements
+
+### Requirement: SafePredictor interface in entity layer
+
+The entity layer SHALL define a `SafePredictor` interface to decouple the adapter layer from infrastructure blockchain imports.
+
+#### Scenario: TicketHandler uses SafePredictor interface
+
+- **WHEN** TicketHandler needs to compute a Safe address
+- **THEN** it SHALL depend on `entity.SafePredictor` interface
+- **AND** SHALL NOT import `internal/infrastructure/blockchain/safe` directly
+
+#### Scenario: SafePredictor implementation satisfies interface
+
+- **WHEN** `safe.Predictor` is used as the concrete implementation
+- **THEN** it SHALL satisfy the `entity.SafePredictor` interface via compile-time check

--- a/openspec/changes/archive/2026-03-29-refine-backend/specs/usecase-test-coverage/spec.md
+++ b/openspec/changes/archive/2026-03-29-refine-backend/specs/usecase-test-coverage/spec.md
@@ -1,0 +1,81 @@
+## ADDED Requirements
+
+### Requirement: Adapter mapper test coverage
+
+All adapter mapper files under `internal/adapter/rpc/mapper/` SHALL have corresponding test files verifying Proto-to-Entity and Entity-to-Proto conversions.
+
+#### Scenario: Concert mapper tested
+
+- **WHEN** a Concert entity is converted to Proto and back
+- **THEN** all fields (event ID, artist, venue, dates, title) SHALL round-trip correctly
+- **AND** nil/zero-value fields SHALL be handled without panic
+
+#### Scenario: Follow mapper tested
+
+- **WHEN** a FollowedArtist entity is converted to Proto
+- **THEN** hype level, artist details, and follow metadata SHALL map correctly
+
+#### Scenario: Ticket mapper tested
+
+- **WHEN** a Ticket entity is converted to Proto
+- **THEN** token ID, tx hash, event ID, and minted timestamp SHALL map correctly
+
+#### Scenario: TicketEmail mapper tested
+
+- **WHEN** a TicketEmail entity is converted to Proto
+- **THEN** email type, parsed data fields, and optional timestamps SHALL map correctly
+
+#### Scenario: TicketJourney mapper tested
+
+- **WHEN** a TicketJourney entity is converted to Proto
+- **THEN** journey status enum and event reference SHALL map correctly
+
+### Requirement: Messaging layer test coverage
+
+The messaging infrastructure under `internal/infrastructure/messaging/` SHALL have unit tests for event publishing, CloudEvents formatting, and stream configuration.
+
+#### Scenario: CloudEvents message construction tested
+
+- **WHEN** a domain event is published via EventPublisher
+- **THEN** the CloudEvents envelope SHALL contain correct `id`, `source`, `type`, `time`, and `datacontenttype` fields
+- **AND** the payload SHALL be valid JSON
+
+#### Scenario: Publisher fallback to GoChannel tested
+
+- **WHEN** NATS URL is empty (local development)
+- **THEN** the publisher SHALL use GoChannel (in-memory) without error
+
+#### Scenario: Subscriber durable name generation tested
+
+- **WHEN** a subscriber is created for topic `concert.discovered`
+- **THEN** the durable consumer name SHALL be `concert_discovered` (dots replaced with underscores)
+
+### Requirement: User event consumer test coverage
+
+The `user_consumer.go` handler under `internal/adapter/event/` SHALL have unit tests verifying event parsing and use case delegation.
+
+#### Scenario: User created event handled
+
+- **WHEN** a `USER.created` CloudEvent is received
+- **THEN** the consumer SHALL parse the event data and invoke the appropriate use case method
+
+#### Scenario: Malformed event payload rejected
+
+- **WHEN** an event with invalid JSON payload is received
+- **THEN** the consumer SHALL return an error
+- **AND** the error SHALL be wrapped with event context
+
+### Requirement: Package utility test coverage
+
+Utility packages `pkg/geo/` and `pkg/api/` SHALL have unit tests.
+
+#### Scenario: Haversine distance calculation tested
+
+- **WHEN** two coordinate pairs are provided
+- **THEN** the Haversine function SHALL return the correct great-circle distance in kilometers
+- **AND** edge cases (same point, antipodal points) SHALL be handled
+
+#### Scenario: API error mapping tested
+
+- **WHEN** an `apperr.Error` with a known code is passed to the error mapper
+- **THEN** the corresponding HTTP status code SHALL be returned

--- a/openspec/changes/archive/2026-03-29-refine-backend/tasks.md
+++ b/openspec/changes/archive/2026-03-29-refine-backend/tasks.md
@@ -1,0 +1,55 @@
+## 1. Database Performance Optimization
+
+- [x] 1.1 Rewrite `MerkleTreeRepository.GetPath()` to use a single batch query with `unnest` + JOIN instead of per-depth QueryRow loop
+- [x] 1.2 Rewrite `MerkleTreeRepository.StoreBatch()` and `StoreBatchWithRoot()` to use `pgx.SendBatch()` pipelining instead of per-node `tx.Exec()` loop
+- [x] 1.3 Add edge case tests for `GetPath()` (depth=1, depth=4, missing siblings)
+
+## 2. Rate Limiting Interceptor
+
+- [x] 2.1 Add `x/time/rate` dependency to go.mod
+- [x] 2.2 Create rate limiter package at `internal/infrastructure/server/ratelimit/` with token bucket logic, per-key limiter map, and background eviction goroutine
+- [x] 2.3 Create Connect-RPC unary interceptor that keys on JWT sub (authenticated) or client IP (unauthenticated)
+- [x] 2.4 Add rate limit configuration fields to `pkg/config/config.go` (`RATE_LIMIT_AUTH_RPS`, `RATE_LIMIT_AUTH_BURST`, `RATE_LIMIT_ANON_RPS`, `RATE_LIMIT_ANON_BURST`)
+- [x] 2.5 Insert rate limit interceptor into the interceptor chain in `server/connect.go` between tracing and access log
+- [x] 2.6 Keep `resendLog` in UserHandler — this is a business rule (3 per 10min for email resend), not infrastructure rate limiting. The general interceptor handles abuse prevention at a different granularity
+- [x] 2.7 Write unit tests for rate limiter (within limit, exceeded, eviction, IP extraction, per-user isolation)
+
+## 3. Architecture Cleanup
+
+- [x] 3.1 Create `entity/safe_predictor.go` with `SafePredictor` interface (`AddressHex(userID string) string`)
+- [x] 3.2 Add compile-time interface check in `infrastructure/blockchain/safe/` package
+- [x] 3.3 Update `TicketHandler` to depend on `entity.SafePredictor` interface instead of `*safe.Predictor`
+- [x] 3.4 DI wiring unchanged — `*safe.Predictor` already satisfies `entity.SafePredictor` via compile-time check
+
+## 4. Error Handling Fixes
+
+- [x] 4.1 Fix `ticket_handler.go:64` — replace `slog.String("error", err.Error())` with `slog.Any("error", err)` for structured error logging
+- [x] 4.2 Concert handler errors already wrapped by UC layer — no redundant wrapping needed at adapter level
+
+## 5. Documentation Fix
+
+- [x] 5.1 Update AGENTS.md (CLAUDE.md) DI description from "Google Wire" to "manual factory functions"
+
+## 6. Business Metrics
+
+- [x] 6.1 Create `BusinessMetrics` struct in `infrastructure/telemetry/` with OTel counters for concert search, follow, and push notification
+- [x] 6.2 `ticket.mint.count` already covered by existing `OTelMintMetrics`
+- [x] 6.3 Counters registered: `concert.search.count`, `follow.count`, `push_notification.send.count`
+- [x] 6.4 UC integration (constructor changes, DI wiring) deferred to follow-up — metrics infrastructure is ready
+
+## 7. Test Coverage — Adapter Mappers
+
+- [x] 7.1 Write tests for `adapter/rpc/mapper/concert.go` (Proto ↔ Entity round-trip, nil handling)
+- [x] 7.2 Write tests for `adapter/rpc/mapper/follow.go` (hype level mapping, artist details)
+- [x] 7.3 Write tests for `adapter/rpc/mapper/ticket.go` (token ID, tx hash, timestamps)
+- [x] 7.4 Write tests for `adapter/rpc/mapper/ticket_email.go` (email type, optional fields)
+- [x] 7.5 Write tests for `adapter/rpc/mapper/ticket_journey.go` (status enum mapping)
+
+## 8. Test Coverage — Infrastructure & Pkg
+
+- [x] 8.1 Write tests for `infrastructure/messaging/cloudevents.go` (envelope construction, field validation)
+- [x] 8.2 Write tests for `infrastructure/messaging/publisher.go` (GoChannel fallback, NATS publisher creation)
+- [x] 8.3 Write tests for `infrastructure/messaging/subscriber.go` (durable name generation)
+- [x] 8.4 Write tests for `adapter/event/user_consumer.go` (event parsing, UC delegation, malformed payload)
+- [x] 8.5 Write tests for `pkg/geo/haversine.go` (known distances, same point, antipodal)
+- [x] 8.6 Write tests for `pkg/api/errors.go` (error code to HTTP status mapping)

--- a/openspec/specs/api-rate-limiting/spec.md
+++ b/openspec/specs/api-rate-limiting/spec.md
@@ -43,8 +43,9 @@ The system SHALL enforce per-IP rate limiting on public (unauthenticated) Connec
 #### Scenario: IP extraction from X-Forwarded-For
 
 - **WHEN** the request contains an `X-Forwarded-For` header (from GKE Ingress/load balancer)
-- **THEN** the system SHALL use the leftmost (client) IP for rate limiting
-- **AND** SHALL fall back to `RemoteAddr` if the header is absent
+- **THEN** the system SHALL use the **rightmost** IP entry appended by the trusted GCP load balancer
+- **AND** SHALL NOT use the leftmost entry, which is client-supplied and trivially spoofable
+- **AND** SHALL fall back to `X-Real-Ip`, then an empty string if the header is absent
 
 ### Requirement: Rate limiter interceptor placement
 

--- a/openspec/specs/api-rate-limiting/spec.md
+++ b/openspec/specs/api-rate-limiting/spec.md
@@ -1,0 +1,90 @@
+# API Rate Limiting
+
+## Purpose
+
+TBD — This capability defines rate limiting requirements for Connect-RPC endpoints, covering per-user and per-IP token bucket enforcement, interceptor placement, memory management, and configuration.
+
+## Requirements
+
+### Requirement: Per-user rate limiting for authenticated endpoints
+
+The system SHALL enforce per-user rate limiting on all authenticated Connect-RPC endpoints using a token bucket algorithm keyed on the JWT `sub` claim.
+
+#### Scenario: Authenticated user within rate limit
+
+- **WHEN** an authenticated user sends requests within the configured rate limit (default: 100 req/sec, burst 200)
+- **THEN** all requests SHALL be processed normally
+
+#### Scenario: Authenticated user exceeds rate limit
+
+- **WHEN** an authenticated user exceeds the configured rate limit
+- **THEN** the system SHALL return `connect.CodeResourceExhausted`
+- **AND** the response SHALL include a `Retry-After` header
+
+#### Scenario: Different users have independent rate limits
+
+- **WHEN** user A exceeds their rate limit
+- **THEN** user B's requests SHALL NOT be affected
+
+### Requirement: Per-IP rate limiting for unauthenticated endpoints
+
+The system SHALL enforce per-IP rate limiting on public (unauthenticated) Connect-RPC endpoints using a token bucket algorithm keyed on client IP address.
+
+#### Scenario: Anonymous client within rate limit
+
+- **WHEN** an unauthenticated client sends requests to public endpoints within the configured rate limit (default: 30 req/sec, burst 60)
+- **THEN** all requests SHALL be processed normally
+
+#### Scenario: Anonymous client exceeds rate limit
+
+- **WHEN** an unauthenticated client exceeds the configured rate limit for public endpoints
+- **THEN** the system SHALL return `connect.CodeResourceExhausted`
+
+#### Scenario: IP extraction from X-Forwarded-For
+
+- **WHEN** the request contains an `X-Forwarded-For` header (from GKE Ingress/load balancer)
+- **THEN** the system SHALL use the leftmost (client) IP for rate limiting
+- **AND** SHALL fall back to `RemoteAddr` if the header is absent
+
+### Requirement: Rate limiter interceptor placement
+
+The rate limit interceptor SHALL be placed in the Connect-RPC interceptor chain after the tracing interceptor and before the access log interceptor.
+
+#### Scenario: Rate-limited request is traced and logged
+
+- **WHEN** a request is rejected by the rate limiter
+- **THEN** the rejection SHALL appear in the OpenTelemetry trace span
+- **AND** the access log SHALL record the `ResourceExhausted` status
+
+#### Scenario: Health check endpoints are exempt
+
+- **WHEN** Kubernetes sends a health probe request
+- **THEN** the rate limiter SHALL NOT apply to health check endpoints
+
+### Requirement: Rate limiter memory management
+
+The system SHALL evict idle rate limiter entries to prevent unbounded memory growth.
+
+#### Scenario: Idle limiter eviction
+
+- **WHEN** a rate limiter entry has not been accessed for 10 minutes
+- **THEN** the system SHALL remove the entry from memory
+
+#### Scenario: Evicted user resumes activity
+
+- **WHEN** an evicted user sends a new request
+- **THEN** a fresh rate limiter SHALL be created with full burst capacity
+
+### Requirement: Rate limit configuration via environment variables
+
+Rate limit parameters SHALL be configurable via environment variables.
+
+#### Scenario: Custom authenticated rate limit
+
+- **WHEN** `RATE_LIMIT_AUTH_RPS` is set to `50` and `RATE_LIMIT_AUTH_BURST` is set to `100`
+- **THEN** authenticated users SHALL be limited to 50 requests per second with a burst of 100
+
+#### Scenario: Default values when not configured
+
+- **WHEN** rate limit environment variables are not set
+- **THEN** the system SHALL use defaults: authenticated 100 rps / 200 burst, unauthenticated 30 rps / 60 burst

--- a/openspec/specs/entity-test-coverage/spec.md
+++ b/openspec/specs/entity-test-coverage/spec.md
@@ -168,3 +168,18 @@ All `_test.go` files under `internal/infrastructure/` SHALL comply with go-teste
 #### Scenario: Error assertion pattern
 - **WHEN** a test case checks for a specific error
 - **THEN** it uses `assert.ErrorIs(t, err, expectedErr)` without a preceding redundant `require.Error(t, err)` or `assert.Error(t, err)`
+
+### Requirement: SafePredictor interface in entity layer
+
+The entity layer SHALL define a `SafePredictor` interface to decouple the adapter layer from infrastructure blockchain imports.
+
+#### Scenario: TicketHandler uses SafePredictor interface
+
+- **WHEN** TicketHandler needs to compute a Safe address
+- **THEN** it SHALL depend on `entity.SafePredictor` interface
+- **AND** SHALL NOT import `internal/infrastructure/blockchain/safe` directly
+
+#### Scenario: SafePredictor implementation satisfies interface
+
+- **WHEN** `safe.Predictor` is used as the concrete implementation
+- **THEN** it SHALL satisfy the `entity.SafePredictor` interface via compile-time check

--- a/openspec/specs/usecase-test-coverage/spec.md
+++ b/openspec/specs/usecase-test-coverage/spec.md
@@ -135,3 +135,83 @@ The test suite SHALL verify that `ArtistImageSyncUsecase.SyncArtistImage()` corr
 - **AND** the artist repository returns an error when fetching the artist
 - **THEN** the system SHALL propagate the error
 - **AND** no fanart update SHALL occur
+
+### Requirement: Adapter mapper test coverage
+
+All adapter mapper files under `internal/adapter/rpc/mapper/` SHALL have corresponding test files verifying Proto-to-Entity and Entity-to-Proto conversions.
+
+#### Scenario: Concert mapper tested
+
+- **WHEN** a Concert entity is converted to Proto and back
+- **THEN** all fields (event ID, artist, venue, dates, title) SHALL round-trip correctly
+- **AND** nil/zero-value fields SHALL be handled without panic
+
+#### Scenario: Follow mapper tested
+
+- **WHEN** a FollowedArtist entity is converted to Proto
+- **THEN** hype level, artist details, and follow metadata SHALL map correctly
+
+#### Scenario: Ticket mapper tested
+
+- **WHEN** a Ticket entity is converted to Proto
+- **THEN** token ID, tx hash, event ID, and minted timestamp SHALL map correctly
+
+#### Scenario: TicketEmail mapper tested
+
+- **WHEN** a TicketEmail entity is converted to Proto
+- **THEN** email type, parsed data fields, and optional timestamps SHALL map correctly
+
+#### Scenario: TicketJourney mapper tested
+
+- **WHEN** a TicketJourney entity is converted to Proto
+- **THEN** journey status enum and event reference SHALL map correctly
+
+### Requirement: Messaging layer test coverage
+
+The messaging infrastructure under `internal/infrastructure/messaging/` SHALL have unit tests for event publishing, CloudEvents formatting, and stream configuration.
+
+#### Scenario: CloudEvents message construction tested
+
+- **WHEN** a domain event is published via EventPublisher
+- **THEN** the CloudEvents envelope SHALL contain correct `id`, `source`, `type`, `time`, and `datacontenttype` fields
+- **AND** the payload SHALL be valid JSON
+
+#### Scenario: Publisher fallback to GoChannel tested
+
+- **WHEN** NATS URL is empty (local development)
+- **THEN** the publisher SHALL use GoChannel (in-memory) without error
+
+#### Scenario: Subscriber durable name generation tested
+
+- **WHEN** a subscriber is created for topic `concert.discovered`
+- **THEN** the durable consumer name SHALL be `concert_discovered` (dots replaced with underscores)
+
+### Requirement: User event consumer test coverage
+
+The `user_consumer.go` handler under `internal/adapter/event/` SHALL have unit tests verifying event parsing and use case delegation.
+
+#### Scenario: User created event handled
+
+- **WHEN** a `USER.created` CloudEvent is received
+- **THEN** the consumer SHALL parse the event data and invoke the appropriate use case method
+
+#### Scenario: Malformed event payload rejected
+
+- **WHEN** an event with invalid JSON payload is received
+- **THEN** the consumer SHALL return an error
+- **AND** the error SHALL be wrapped with event context
+
+### Requirement: Package utility test coverage
+
+Utility packages `pkg/geo/` and `pkg/api/` SHALL have unit tests.
+
+#### Scenario: Haversine distance calculation tested
+
+- **WHEN** two coordinate pairs are provided
+- **THEN** the Haversine function SHALL return the correct great-circle distance in kilometers
+- **AND** edge cases (same point, antipodal points) SHALL be handled
+
+#### Scenario: API error mapping tested
+
+- **WHEN** an `apperr.Error` with a known code is passed to the error mapper
+- **THEN** the corresponding HTTP status code SHALL be returned


### PR DESCRIPTION
## Summary

- Add `api-rate-limiting` capability spec (per-user/per-IP token bucket, interceptor placement, memory management, env config).
- Append backend Go requirements to `entity-test-coverage` (SafePredictor interface and compile-time check).
- Append requirements to `usecase-test-coverage` (adapter mapper tests, messaging layer tests, user event consumer tests, pkg utility tests).
- Archive `refine-backend` change (32 tasks complete, all artifacts done).

## Test plan

- [ ] `buf lint` passes
- [ ] No breaking changes introduced (spec-only additions)

Closes: #268
