### PR TITLE
docs(openspec): sync specs and archive fix-post-signup-dialog-i18n

### DIFF
--- a/openspec/changes/archive/2026-03-29-fix-post-signup-dialog-i18n/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-29-fix-post-signup-dialog-i18n/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-28

--- a/openspec/changes/archive/2026-03-29-fix-post-signup-dialog-i18n/design.md
+++ b/openspec/changes/archive/2026-03-29-fix-post-signup-dialog-i18n/design.md
@@ -1,0 +1,40 @@
+## Context
+
+`PostSignupDialog` was built with most user-facing strings correctly using Aurelia 2's `t="..."` attribute binding for i18n. However, two strings were left hardcoded in Japanese:
+1. `<h2 class="post-signup-title">✅ アカウント登録完了！</h2>` — the dialog title
+2. `aria-label="アカウント登録完了"` on the `<bottom-sheet>` element
+
+When a browser reports `en` as the preferred language, the i18n system activates EN locale, rendering all other dialog text in English — but these two strings remain in Japanese. The fix is purely a template + translation file change; no component logic or service changes are needed.
+
+## Goals / Non-Goals
+
+**Goals:**
+- All user-visible strings in `PostSignupDialog` use `t="..."` bindings
+- Both JA and EN translation files have a `postSignup.title` key
+- `aria-label` is also i18n-bound so screen readers receive the correct locale
+
+**Non-Goals:**
+- Fixing i18n issues in other components (separate change if needed)
+- Adding new locale support beyond JA and EN
+- Changing any TypeScript logic in `post-signup-dialog.ts`
+
+## Decisions
+
+### Use `t` attribute binding for `aria-label`
+
+Aurelia i18n supports binding `aria-label` via `t="[aria-label]postSignup.title"` or by combining with content binding: `t="[aria-label]postSignup.ariaLabel"`. We use a dedicated `postSignup.ariaLabel` key (without the emoji) for the `aria-label`, and `postSignup.title` (with emoji for JA, without for EN) for the `<h2>` text content. This keeps screen reader text clean and culturally appropriate.
+
+**Alternatives considered:**
+- Single key for both `<h2>` and `aria-label`: Would force the emoji into the aria-label, which is unconventional for accessibility. Separate keys give clearer control.
+
+### Keep the ✅ emoji in JA translation, omit from EN
+
+The emoji is culturally fitting in the Japanese context. EN translation uses plain text `Account registration complete!` — consistent with other EN UI patterns.
+
+## Risks / Trade-offs
+
+- **Key parity check**: The `frontend-i18n` spec requires both JA and EN files to have matching keys. Adding `postSignup.title` and `postSignup.ariaLabel` to both files satisfies this requirement. [Risk: missing key in one file] → Both files are updated in the same task.
+
+## Migration Plan
+
+No migration needed. This is a pure additive change (new translation keys + template attribute replacement). No existing keys are removed or renamed.

--- a/openspec/changes/archive/2026-03-29-fix-post-signup-dialog-i18n/proposal.md
+++ b/openspec/changes/archive/2026-03-29-fix-post-signup-dialog-i18n/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+The `PostSignupDialog` component contains hardcoded Japanese strings in its HTML template (`✅ アカウント登録完了！` as the `<h2>` title and `アカウント登録完了` as the `aria-label`) that bypass the `@aurelia/i18n` translation system. When the browser locale is English, all other dialog text correctly renders in English via `t="..."` bindings, but the hardcoded strings remain in Japanese — creating a jarring mix of languages.
+
+## What Changes
+
+- Replace hardcoded `✅ アカウント登録完了！` in `<h2>` with `t="postSignup.title"` binding
+- Replace hardcoded `aria-label="アカウント登録完了"` on `<bottom-sheet>` with an i18n-bound value
+- Add `postSignup.title` key to both `ja/translation.json` and `en/translation.json`
+
+## Capabilities
+
+### New Capabilities
+<!-- None — this is a bug fix within an existing capability -->
+
+### Modified Capabilities
+- `post-signup-dialog`: Add i18n requirement that all user-visible strings (including the title and aria-label) MUST use `t` attribute bindings rather than hardcoded text.
+
+## Impact
+
+- `frontend/src/components/post-signup-dialog/post-signup-dialog.html` — template fix
+- `frontend/src/locales/ja/translation.json` — add `postSignup.title`
+- `frontend/src/locales/en/translation.json` — add `postSignup.title`
+- No API or schema changes required

--- a/openspec/changes/archive/2026-03-29-fix-post-signup-dialog-i18n/specs/post-signup-dialog/spec.md
+++ b/openspec/changes/archive/2026-03-29-fix-post-signup-dialog-i18n/specs/post-signup-dialog/spec.md
@@ -1,0 +1,25 @@
+## ADDED Requirements
+
+### Requirement: PostSignupDialog title and aria-label use i18n bindings
+All user-visible strings in the PostSignupDialog component SHALL use `@aurelia/i18n` `t` attribute bindings. No hardcoded display strings are permitted in the template.
+
+#### Scenario: Title renders in active locale
+- **WHEN** the PostSignupDialog is displayed
+- **AND** the active locale is `en`
+- **THEN** the `<h2>` title SHALL render using the `postSignup.title` translation key in the EN translation
+- **AND** the rendered text SHALL be in English (e.g., `Account registration complete!`)
+
+#### Scenario: Title renders in Japanese locale
+- **WHEN** the PostSignupDialog is displayed
+- **AND** the active locale is `ja`
+- **THEN** the `<h2>` title SHALL render using the `postSignup.title` translation key in the JA translation
+- **AND** the rendered text SHALL be `✅ アカウント登録完了！`
+
+#### Scenario: aria-label follows active locale
+- **WHEN** the PostSignupDialog is displayed
+- **AND** the active locale is `en`
+- **THEN** the wrapping `<bottom-sheet>` element SHALL have an `aria-label` rendered from the `postSignup.ariaLabel` translation key in the EN translation
+
+#### Scenario: Translation key parity
+- **WHEN** `postSignup.title` or `postSignup.ariaLabel` keys exist in `ja/translation.json`
+- **THEN** the same keys SHALL exist in `en/translation.json`

--- a/openspec/changes/archive/2026-03-29-fix-post-signup-dialog-i18n/tasks.md
+++ b/openspec/changes/archive/2026-03-29-fix-post-signup-dialog-i18n/tasks.md
@@ -1,0 +1,16 @@
+## 1. Translation Keys
+
+- [x] 1.1 Add `postSignup.title` key to `frontend/src/locales/ja/translation.json` with value `✅ アカウント登録完了！`
+- [x] 1.2 Add `postSignup.ariaLabel` key to `frontend/src/locales/ja/translation.json` with value `アカウント登録完了`
+- [x] 1.3 Add `postSignup.title` key to `frontend/src/locales/en/translation.json` with value `Account registration complete!`
+- [x] 1.4 Add `postSignup.ariaLabel` key to `frontend/src/locales/en/translation.json` with value `Account registration complete`
+
+## 2. Template Fix
+
+- [x] 2.1 Replace `<h2 class="post-signup-title">✅ アカウント登録完了！</h2>` with `<h2 class="post-signup-title" t="postSignup.title"></h2>` in `post-signup-dialog.html`
+- [x] 2.2 Replace `aria-label="アカウント登録完了"` on `<bottom-sheet>` with `t="[aria-label]postSignup.ariaLabel"` in `post-signup-dialog.html`
+
+## 3. Verification
+
+- [x] 3.1 Run `make lint` in `frontend/` and confirm no errors
+- [x] 3.2 Run `make test` in `frontend/` and confirm no regressions

--- a/openspec/specs/post-signup-dialog/spec.md
+++ b/openspec/specs/post-signup-dialog/spec.md
@@ -60,3 +60,27 @@ The PostSignupDialog SHALL reliably open when `active` is bound to `true` at com
 - **THEN** `activeChanged()` SHALL set `isOpen = true`
 - **AND** the inner `<bottom-sheet>` SHALL open successfully (via the `attached()` fallback in BottomSheet)
 - **AND** the dialog SHALL be visible to the user with its full content
+
+### Requirement: PostSignupDialog title and aria-label use i18n bindings
+All user-visible strings in the PostSignupDialog component SHALL use `@aurelia/i18n` `t` attribute bindings. No hardcoded display strings are permitted in the template.
+
+#### Scenario: Title renders in active locale
+- **WHEN** the PostSignupDialog is displayed
+- **AND** the active locale is `en`
+- **THEN** the `<h2>` title SHALL render using the `postSignup.title` translation key in the EN translation
+- **AND** the rendered text SHALL be in English (e.g., `Account registration complete!`)
+
+#### Scenario: Title renders in Japanese locale
+- **WHEN** the PostSignupDialog is displayed
+- **AND** the active locale is `ja`
+- **THEN** the `<h2>` title SHALL render using the `postSignup.title` translation key in the JA translation
+- **AND** the rendered text SHALL be `✅ アカウント登録完了！`
+
+#### Scenario: aria-label follows active locale
+- **WHEN** the PostSignupDialog is displayed
+- **AND** the active locale is `en`
+- **THEN** the wrapping `<bottom-sheet>` element SHALL have an `aria-label` rendered from the `postSignup.ariaLabel` translation key in the EN translation
+
+#### Scenario: Translation key parity
+- **WHEN** `postSignup.title` or `postSignup.ariaLabel` keys exist in `ja/translation.json`
+- **THEN** the same keys SHALL exist in `en/translation.json`


### PR DESCRIPTION
## Summary

- Add new requirement to `post-signup-dialog` spec: all user-visible strings (including title and aria-label) SHALL use `t` attribute bindings
- Archive `fix-post-signup-dialog-i18n` OpenSpec change

## Test plan

- [x] Spec synced via `openspec-sync-specs`
- [x] Change archived to `openspec/changes/archive/2026-03-29-fix-post-signup-dialog-i18n/`

close: #300
