### PR TITLE
feat(specs): add ticket status ui visibility requirement to ticket-journey

### DIFF
--- a/openspec/changes/archive/2026-03-30-hide-ticket-status-for-guests/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-30-hide-ticket-status-for-guests/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-30

--- a/openspec/changes/archive/2026-03-30-hide-ticket-status-for-guests/design.md
+++ b/openspec/changes/archive/2026-03-30-hide-ticket-status-for-guests/design.md
@@ -1,0 +1,45 @@
+## Context
+
+`EventDetailSheet` is rendered both during onboarding (guest) and after authentication. It currently shows the Ticket Status section unconditionally. When a guest user clicks a status button, `setJourneyStatus()` calls `TicketJourneyRpcClient.setStatus()` with no bearer token, resulting in a 401 Unauthorized RPC error.
+
+The existing `AuthService.isAuthenticated` getter is already used throughout the codebase (e.g., `ConcertService`) to guard authenticated-only operations.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Prevent the Ticket Status UI from being displayed to unauthenticated users
+- Eliminate the 401 error that occurs when guests attempt to set a ticket status
+
+**Non-Goals:**
+- Showing a sign-in prompt or CTA in place of the hidden section
+- Persisting guest ticket intent for post-signup merge
+- Any backend changes
+
+## Decisions
+
+### Decision: Hide the section entirely vs. disable buttons
+
+**Chosen:** Hide the entire Ticket Status section (`if.bind="authService.isAuthenticated"`).
+
+**Alternatives considered:**
+- *Disable buttons with a tooltip*: Adds visual complexity for a feature that has no value in guest context. During onboarding, the goal is concert exploration, not ticket management.
+- *Replace with sign-in CTA*: Reasonable for a post-onboarding guest, but onboarding is not a sign-up funnel at this stage of the flow. Adds scope.
+
+The simplest approach — hide entirely — matches the intent ("not yet visible") and avoids new UI states.
+
+### Decision: Check `authService.isAuthenticated` in ViewModel vs. template
+
+**Chosen:** Expose `isAuthenticated` as a getter on the ViewModel that delegates to `AuthService`, and use `if.bind` in the template.
+
+This follows the existing Aurelia pattern in the codebase (binding to ViewModel-exposed getters) and keeps the template declarative.
+
+### Decision: Scope of the guard
+
+**Chosen:** Guard applies whenever `isAuthenticated === false`, regardless of whether the user is mid-onboarding or a post-onboarding guest.
+
+The ticket journey feature requires an account in all cases, so the guard condition is simply authentication state.
+
+## Risks / Trade-offs
+
+- **Minimal risk**: Change is purely additive (hiding a section). No existing authenticated flows are affected.
+- **No guest fallback needed**: The feature has no meaningful guest analog, so nothing needs to replace it.

--- a/openspec/changes/archive/2026-03-30-hide-ticket-status-for-guests/proposal.md
+++ b/openspec/changes/archive/2026-03-30-hide-ticket-status-for-guests/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+During onboarding, unauthenticated (guest) users can open the concert detail sheet and see Ticket Status buttons (TRACKING / APPLIED / LOST / UNPAID / PAID). Clicking any button triggers a `SetStatus` RPC call, which fails with a 401 Unauthorized error because no bearer token is present. The feature is not meaningful without an account, so it should not be shown to guests at all.
+
+## What Changes
+
+- Hide the Ticket Status section in `EventDetailSheet` when the user is not authenticated
+- Remove the error-prone RPC call path for unauthenticated users (no auth guard existed)
+
+## Capabilities
+
+### New Capabilities
+
+_(none)_
+
+### Modified Capabilities
+
+- `ticket-journey`: Add frontend visibility requirement — the Ticket Status UI SHALL only be rendered when the user is authenticated. Unauthenticated users SHALL NOT see the section.
+
+## Impact
+
+- **Frontend**: `EventDetailSheet` component (`event-detail-sheet.ts` / `.html`) — conditional rendering of the Ticket Status section based on `authService.isAuthenticated`
+- **No backend changes**: The RPC itself remains authenticated-only; this change prevents the UI from attempting unauthenticated calls
+- **No proto changes**: No API contract changes

--- a/openspec/changes/archive/2026-03-30-hide-ticket-status-for-guests/specs/ticket-journey/spec.md
+++ b/openspec/changes/archive/2026-03-30-hide-ticket-status-for-guests/specs/ticket-journey/spec.md
@@ -1,0 +1,17 @@
+## ADDED Requirements
+
+### Requirement: Ticket Status UI visibility
+
+The Ticket Status UI in `EventDetailSheet` SHALL only be rendered when the user is authenticated. Unauthenticated (guest) users SHALL NOT see the Ticket Status section.
+
+#### Scenario: Authenticated user sees Ticket Status section
+
+- **WHEN** an authenticated user opens the concert detail sheet
+- **THEN** the Ticket Status section SHALL be visible
+- **AND** the user SHALL be able to select a status (TRACKING, APPLIED, LOST, UNPAID, PAID)
+
+#### Scenario: Unauthenticated user does not see Ticket Status section
+
+- **WHEN** an unauthenticated (guest) user opens the concert detail sheet
+- **THEN** the Ticket Status section SHALL NOT be rendered
+- **AND** no RPC call to `TicketJourneyService/SetStatus` SHALL be made

--- a/openspec/changes/archive/2026-03-30-hide-ticket-status-for-guests/tasks.md
+++ b/openspec/changes/archive/2026-03-30-hide-ticket-status-for-guests/tasks.md
@@ -1,0 +1,13 @@
+## 1. Frontend — EventDetailSheet ViewModel
+
+- [x] 1.1 Inject `AuthService` into `EventDetailSheet` ViewModel
+- [x] 1.2 Add `get isAuthenticated(): boolean` getter delegating to `authService.isAuthenticated`
+
+## 2. Frontend — EventDetailSheet Template
+
+- [x] 2.1 Wrap the Ticket Status section with `if.bind="isAuthenticated"` in `event-detail-sheet.html`
+
+## 3. Validation
+
+- [x] 3.1 Verify that opening the detail sheet as a guest user (onboarding) does not render the Ticket Status section and produces no RPC errors in the console
+- [x] 3.2 Verify that opening the detail sheet as an authenticated user still shows the Ticket Status section and SetStatus calls succeed

--- a/openspec/specs/ticket-journey/spec.md
+++ b/openspec/specs/ticket-journey/spec.md
@@ -103,3 +103,19 @@ The system SHALL store ticket journeys in a `ticket_journeys` table with a compo
 
 - **WHEN** a `SetStatus` operation targets an existing `(user_id, event_id)` pair
 - **THEN** the database SHALL perform `INSERT ... ON CONFLICT (user_id, event_id) DO UPDATE SET status`
+
+### Requirement: Ticket Status UI visibility
+
+The Ticket Status UI in `EventDetailSheet` SHALL only be rendered when the user is authenticated. Unauthenticated (guest) users SHALL NOT see the Ticket Status section.
+
+#### Scenario: Authenticated user sees Ticket Status section
+
+- **WHEN** an authenticated user opens the concert detail sheet
+- **THEN** the Ticket Status section SHALL be visible
+- **AND** the user SHALL be able to select a status (TRACKING, APPLIED, LOST, UNPAID, PAID)
+
+#### Scenario: Unauthenticated user does not see Ticket Status section
+
+- **WHEN** an unauthenticated (guest) user opens the concert detail sheet
+- **THEN** the Ticket Status section SHALL NOT be rendered
+- **AND** no RPC call to `TicketJourneyService/SetStatus` SHALL be made


### PR DESCRIPTION
## Summary

- Add "Ticket Status UI visibility" requirement to `ticket-journey` spec: the section SHALL only be rendered for authenticated users
- Archive `hide-ticket-status-for-guests` change (proposal, design, specs, tasks)

## Background

During onboarding, unauthenticated guests could see Ticket Status buttons and trigger `SetStatus` RPC calls without a bearer token, causing 401 errors. The frontend fix is in liverty-music/frontend#314. This PR captures the corresponding spec update.

## Test plan

- [ ] Verify `ticket-journey/spec.md` contains the new "Ticket Status UI visibility" requirement
- [ ] Verify archive directory is present at `openspec/changes/archive/2026-03-30-hide-ticket-status-for-guests/`

close: #306
