### PR TITLE
docs(specs): add email-verification and consumer-poison-queue-alerting

### DIFF
--- a/openspec/changes/archive/2026-03-30-improve-consumer-observability/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-30-improve-consumer-observability/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-30

--- a/openspec/changes/archive/2026-03-30-improve-consumer-observability/design.md
+++ b/openspec/changes/archive/2026-03-30-improve-consumer-observability/design.md
@@ -1,0 +1,76 @@
+## Context
+
+The `email-verification` change implemented the `user.created → SendVerification` pipeline. A production incident revealed that when Postmark hit its free-tier rate limit, the Zitadel `SendEmailCode` call failed silently: no error was logged at the `EmailVerifier` level, the message was retried 3 times by Watermill, then routed to the `POISON` NATS stream with no further alerting. The POISON stream currently has 218 accumulated messages and zero consumers.
+
+The existing `app-error-log-alerting` spec covers ERROR-level log alerting per workload, but that only fires if an ERROR is actually emitted. The gap is twofold:
+
+1. `EmailVerifier` does not log at the call site — errors bubble silently through `UserConsumer` and into Watermill's retry/poison machinery.
+2. No consumer reads from the `POISON` stream, so poison queue accumulation never triggers the existing alert policies.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Make `EmailVerifier.SendVerification` and `ResendVerification` observable: emit structured INFO on success, ERROR on failure, at the infrastructure layer call site
+- Make Poison Queue accumulation detectable: add a consumer that emits ERROR logs for every poisoned message so existing workload alert policies fire
+- Add a Cloud Monitoring alert for NATS `POISON` stream lag as a secondary safety net
+
+**Non-Goals:**
+- Re-processing or replaying Poison Queue messages (dead-letter redelivery is out of scope)
+- Changing retry configuration or Watermill middleware
+- Frontend changes
+- Postmark plan upgrade (operational, not code)
+
+## Decisions
+
+### Decision 1: Log at the infrastructure layer, not the use-case layer
+
+**Chosen**: Add `logger` calls inside `EmailVerifier.SendVerification` / `ResendVerification` in `internal/infrastructure/zitadel/email_verifier.go`.
+
+**Alternatives considered**:
+- Log only in `UserConsumer.Handle` — already done (`"sending email verification"` log exists), but the call site result is invisible. The infrastructure layer owns the external I/O and should own the observability.
+- Log in both — redundant; the consumer already logs "sending", so the infra layer logs the outcome (success/failure).
+
+**Rationale**: Consistent with how other infrastructure clients (DB, MusicBrainz) are instrumented. Keeps the use-case layer clean.
+
+---
+
+### Decision 2: Poison Queue consumer emits ERROR logs, does not re-process
+
+**Chosen**: Add a `PoisonConsumer` handler that reads each message from the `POISON` stream, logs it at ERROR level with the original topic and error context, and acks it.
+
+**Alternatives considered**:
+- Cloud Monitoring metric-based alert on NATS stream message count — possible but requires exposing NATS metrics to Cloud Monitoring (not yet set up); the log-based approach reuses existing infrastructure.
+- Re-processing logic (retry the original handler) — complex, risky; out of scope for this change.
+
+**Rationale**: The existing `app-error-log-alerting` spec fires on any ERROR log from the consumer workload. A PoisonConsumer that logs ERROR for each dead-lettered message integrates with zero new alerting infrastructure. It also gives a permanent audit trail in Cloud Logging.
+
+---
+
+### Decision 3: Add a secondary NATS lag alert in cloud-provisioning
+
+**Chosen**: Add a Cloud Monitoring log-based alert that triggers when the POISON stream consumer lag exceeds 0 (i.e., any unprocessed poisoned message). This fires even if the PoisonConsumer is down.
+
+**Rationale**: Defense in depth. The PoisonConsumer alert requires the consumer Pod to be running. A NATS monitoring-based alert catches poison messages that accumulate when the consumer is scaled to zero (KEDA).
+
+## Risks / Trade-offs
+
+- **PoisonConsumer generates noise during incidents**: If a handler fails repeatedly for a legitimate transient reason (e.g., Postmark downtime), the POISON stream fills and the PoisonConsumer will emit many ERROR logs, triggering repeated alerts. Mitigation: the existing 12-hour notification rate limit on the alert policy suppresses duplicate Slack messages.
+
+- **KEDA scale-to-zero delays PoisonConsumer**: The consumer Pod is subject to the same KEDA scale-to-zero behaviour as other handlers. If the consumer is down when a message is poisoned, the NATS lag alert (Decision 3) provides coverage.
+
+- **POISON stream backlog (218 messages)**: On first deploy, the PoisonConsumer will process and log 218 existing messages as ERROR, triggering alerts. These are historical failures. Mitigation: drain or purge the POISON stream before deploying, or temporarily suppress alerts.
+
+## Migration Plan
+
+1. Add `logger` calls to `EmailVerifier` (backend) — no config change required
+2. Implement `PoisonConsumer` and wire into `consumer.go` — adds a new NATS consumer on the `POISON` stream
+3. Purge or acknowledge the 218 existing POISON messages before deploying (to avoid alert storm)
+4. Deploy backend consumer — PoisonConsumer begins reading new poisoned messages
+5. Add NATS lag alert in cloud-provisioning — deploy via Pulumi
+
+**Rollback**: Remove `PoisonConsumer` handler registration from `consumer.go`. The alert policy can be deleted via Pulumi. No data is affected.
+
+## Open Questions
+
+- Should the existing 218 POISON messages be purged before deploy, or individually triaged? (operational decision, not a blocker)
+- Should `PoisonConsumer` parse the CloudEvent payload and log the original topic/subject for better context? (nice-to-have, can be done in the same PR)

--- a/openspec/changes/archive/2026-03-30-improve-consumer-observability/proposal.md
+++ b/openspec/changes/archive/2026-03-30-improve-consumer-observability/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+When a user signs up, the `user.created` event triggers an email verification via Zitadel — but if delivery fails (e.g. Postmark rate limit), no structured error log is emitted by the infrastructure layer, and the failed message is silently moved to the Poison Queue with no alerting. This makes it impossible to detect, diagnose, or recover from email delivery failures in production.
+
+## What Changes
+
+- **Add** structured logging to `EmailVerifier.SendVerification` and `EmailVerifier.ResendVerification` (backend) — success and error outcomes must be observable
+- **Add** Poison Queue consumer in the backend event consumer app — messages routed to the Poison Queue must be logged at ERROR level so existing alert policies fire
+- **Add** Poison Queue monitoring alert in cloud-provisioning — a dedicated Cloud Monitoring alert for NATS `POISON` stream message accumulation
+
+## Capabilities
+
+### New Capabilities
+
+- `consumer-poison-queue-alerting`: Covers detection and alerting when messages are routed to the Poison Queue, including a consumer that emits ERROR logs and a Cloud Monitoring alert on POISON stream lag.
+
+### Modified Capabilities
+
+- `email-verification`: The `SendVerification` and `ResendVerification` infrastructure calls must emit structured INFO (success) and ERROR (failure) log entries. This is a requirement change — the existing spec does not mandate observability at the infrastructure layer call site.
+
+## Impact
+
+- **backend**: `internal/infrastructure/zitadel/email_verifier.go` — add logger calls; new `internal/adapter/event/poison_consumer.go` handler; wire into `internal/di/consumer.go`
+- **cloud-provisioning**: `src/gcp/components/monitoring.ts` — add Poison Queue lag alert policy
+- **NATS**: The existing `POISON` stream gains a consumer subscription for logging purposes (does not re-process messages)

--- a/openspec/changes/archive/2026-03-30-improve-consumer-observability/specs/consumer-poison-queue-alerting/spec.md
+++ b/openspec/changes/archive/2026-03-30-improve-consumer-observability/specs/consumer-poison-queue-alerting/spec.md
@@ -1,0 +1,47 @@
+## ADDED Requirements
+
+### Requirement: Poison Queue consumer emits ERROR logs
+
+The backend event consumer SHALL subscribe to the `POISON` NATS JetStream stream and emit a structured ERROR log entry for every message it receives. The log entry MUST include the original topic/subject and message UUID to enable tracing.
+
+#### Scenario: Message is routed to Poison Queue after max retries
+
+- **WHEN** a Watermill handler fails after exhausting all retries and the message is routed to the `POISON` stream
+- **THEN** the Poison Queue consumer SHALL receive the message
+- **AND** SHALL emit an ERROR log entry with `msg="message routed to poison queue"`, the original `topic`, and the message `uuid`
+- **AND** SHALL ack the message (it is not re-processed)
+
+#### Scenario: Poison Queue consumer ERROR log triggers workload alert
+
+- **WHEN** the Poison Queue consumer emits an ERROR log
+- **THEN** the existing consumer workload alert policy (from `app-error-log-alerting`) SHALL detect the log entry
+- **AND** SHALL open an Incident and send a Slack/Google Chat notification
+
+#### Scenario: Consumer is scaled to zero when message is poisoned
+
+- **WHEN** the consumer Pod is scaled to zero by KEDA and a message is routed to the Poison Queue
+- **THEN** the message SHALL remain in the `POISON` stream until the consumer Pod scales back up
+- **AND** on next consumer startup, the Poison Queue consumer SHALL process and log all pending messages
+
+### Requirement: NATS POISON stream lag alert
+
+The system SHALL have a Cloud Monitoring alert policy that detects accumulation of unprocessed messages in the NATS `POISON` stream.
+
+The alert SHALL trigger when the POISON stream consumer lag exceeds 0 for more than 5 minutes, to allow for normal consumer startup delay after KEDA scale-up.
+
+#### Scenario: Messages accumulate in POISON stream
+
+- **WHEN** the NATS `POISON` stream has unprocessed messages for more than 5 minutes
+- **THEN** the Cloud Monitoring alert policy SHALL open an Incident
+- **AND** SHALL send a notification to the configured Slack and Google Chat channels
+
+#### Scenario: POISON stream is empty
+
+- **WHEN** the NATS `POISON` stream has zero pending messages
+- **THEN** no alert SHALL fire
+
+#### Scenario: Alert uses same notification channels as backend workload alerts
+
+- **WHEN** the POISON stream lag alert fires
+- **THEN** the notification SHALL be sent to the same Slack and Google Chat channels as the `app-error-log-alerting` workload alerts
+- **AND** the same 12-hour notification rate limit SHALL apply

--- a/openspec/changes/archive/2026-03-30-improve-consumer-observability/specs/email-verification/spec.md
+++ b/openspec/changes/archive/2026-03-30-improve-consumer-observability/specs/email-verification/spec.md
@@ -4,7 +4,7 @@
 
 The system SHALL publish a `USER.created` event to NATS JetStream when a user is successfully provisioned in the backend. A consumer SHALL subscribe to this event and call Zitadel's `POST /v2/users/{externalId}/email/send` API to trigger a verification email via the configured SMTP provider (Postmark).
 
-The infrastructure layer (`EmailVerifier.SendVerification`) SHALL emit a structured INFO log entry on successful API call completion, and a structured ERROR log entry on failure. Both log entries MUST include the `external_id` field.
+The infrastructure layer (`EmailVerifier.SendVerification`) SHALL emit a structured INFO log entry on successful API call completion. On failure, the error is returned to the caller without logging — the caller (`UserConsumer`) is responsible for logging the failure. The INFO log entry MUST include the `external_id` field.
 
 #### Scenario: New user signs up via Passkey
 

--- a/openspec/changes/archive/2026-03-30-improve-consumer-observability/specs/email-verification/spec.md
+++ b/openspec/changes/archive/2026-03-30-improve-consumer-observability/specs/email-verification/spec.md
@@ -1,0 +1,81 @@
+## MODIFIED Requirements
+
+### Requirement: Trigger verification email on user creation
+
+The system SHALL publish a `USER.created` event to NATS JetStream when a user is successfully provisioned in the backend. A consumer SHALL subscribe to this event and call Zitadel's `POST /v2/users/{externalId}/email/send` API to trigger a verification email via the configured SMTP provider (Postmark).
+
+The infrastructure layer (`EmailVerifier.SendVerification`) SHALL emit a structured INFO log entry on successful API call completion, and a structured ERROR log entry on failure. Both log entries MUST include the `external_id` field.
+
+#### Scenario: New user signs up via Passkey
+
+- **WHEN** a new user completes Passkey registration and the backend provisions the user record
+- **THEN** the backend SHALL publish a `USER.created` event to the `USER` NATS JetStream stream
+- **AND** the consumer SHALL call Zitadel's email send API with the user's `external_id` (Zitadel user ID)
+- **AND** Zitadel SHALL send a verification email to the user's registered email address via Postmark
+
+#### Scenario: Zitadel API call succeeds
+
+- **WHEN** the consumer calls Zitadel's `SendEmailCode` API and the call completes successfully
+- **THEN** `EmailVerifier.SendVerification` SHALL emit an INFO log entry with `msg="email verification sent"` and `external_id`
+
+#### Scenario: Zitadel API call fails
+
+- **WHEN** the consumer calls Zitadel's `SendEmailCode` API and the call returns an error
+- **THEN** `EmailVerifier.SendVerification` SHALL return the error to the caller without logging (the caller is responsible for logging)
+- **AND** the error SHALL be returned to the caller (existing retry/poison queue behaviour is unchanged)
+
+#### Scenario: Zitadel API call fails transiently
+
+- **WHEN** the consumer calls Zitadel's email send API and receives a transient error (network timeout, 5xx)
+- **THEN** the NATS JetStream consumer SHALL retry the message with backoff
+- **AND** the user creation SHALL NOT be affected (already persisted)
+
+#### Scenario: User email is already verified
+
+- **WHEN** the consumer calls Zitadel's email send API for a user whose email is already verified
+- **THEN** the consumer SHALL handle the response gracefully (log and acknowledge the message)
+
+#### Scenario: Duplicate USER.created event
+
+- **WHEN** the consumer receives a duplicate `USER.created` event (e.g., NATS redelivery after ack timeout)
+- **THEN** the consumer SHALL call Zitadel's email send API
+- **AND** the operation SHALL be idempotent (re-sending a verification email has no adverse side effects)
+
+### Requirement: Resend verification email via RPC
+
+The system SHALL provide an RPC method that allows authenticated users to resend the verification email for their own account. The backend SHALL proxy this request to Zitadel's `POST /v2/users/{userId}/email/resend` API.
+
+The infrastructure layer (`EmailVerifier.ResendVerification`) SHALL emit a structured INFO log entry on successful API call completion, and a structured ERROR log entry on failure. Both log entries MUST include the `external_id` field.
+
+#### Scenario: User requests resend from Settings page
+
+- **WHEN** an authenticated user calls the resend verification RPC
+- **THEN** the backend SHALL extract the user's `external_id` from JWT claims
+- **AND** the backend SHALL call Zitadel's email resend API with the `external_id`
+- **AND** Zitadel SHALL send a new verification email to the user
+
+#### Scenario: Resend Zitadel API call succeeds
+
+- **WHEN** `EmailVerifier.ResendVerification` is called and the Zitadel `ResendEmailCode` API call completes successfully
+- **THEN** `EmailVerifier.ResendVerification` SHALL emit an INFO log entry with `msg="email verification resent"` and `external_id`
+
+#### Scenario: Resend Zitadel API call fails
+
+- **WHEN** `EmailVerifier.ResendVerification` is called and the Zitadel `ResendEmailCode` API call returns an error
+- **THEN** `EmailVerifier.ResendVerification` SHALL emit an ERROR log entry with `msg="failed to resend email code"` and `external_id`
+- **AND** the error SHALL be returned to the caller
+
+#### Scenario: User is already verified
+
+- **WHEN** an authenticated user whose email is already verified calls the resend verification RPC
+- **THEN** the backend SHALL return a `FailedPrecondition` error indicating the email is already verified
+
+#### Scenario: Rapid resend attempts
+
+- **WHEN** a user calls the resend verification RPC more than 3 times within 10 minutes
+- **THEN** the backend SHALL return a `ResourceExhausted` error
+
+#### Scenario: Unauthenticated request
+
+- **WHEN** an unauthenticated request calls the resend verification RPC
+- **THEN** the backend SHALL reject the request with an authentication error

--- a/openspec/changes/archive/2026-03-30-improve-consumer-observability/tasks.md
+++ b/openspec/changes/archive/2026-03-30-improve-consumer-observability/tasks.md
@@ -1,0 +1,35 @@
+## 1. Backend — EmailVerifier logging
+
+- [x] 1.1 Add `logger *logging.Logger` field to `EmailVerifier` struct in `internal/infrastructure/zitadel/email_verifier.go`
+- [x] 1.2 Update `NewEmailVerifier` to accept and store the logger (already passed as parameter — wire it into the struct)
+- [x] 1.3 Add INFO log (`msg="email verification sent"`, `external_id`) on success in `SendVerification`
+- [x] 1.4 Add ERROR log (`msg="failed to send email code"`, `external_id`) on error in `SendVerification`
+- [x] 1.5 Add INFO log (`msg="email verification resent"`, `external_id`) on success in `ResendVerification`
+- [x] 1.6 Add ERROR log (`msg="failed to resend email code"`, `external_id`) on error in `ResendVerification`
+- [x] 1.7 Update unit tests in `email_verifier_test.go` to assert log output on success and failure paths
+
+## 2. Backend — Poison Queue consumer
+
+- [x] 2.1 Create `internal/adapter/event/poison_consumer.go` with a `PoisonConsumer` struct and `Handle` method
+- [x] 2.2 `Handle` must parse the message UUID and metadata (original topic if available), emit ERROR log (`msg="message routed to poison queue"`, `topic`, `uuid`), and return nil (ack)
+- [x] 2.3 Wire `PoisonConsumer` into `internal/di/consumer.go` — register handler on `messaging.PoisonQueueSubject`
+- [x] 2.4 Add unit tests for `PoisonConsumer.Handle` covering the ERROR log assertion
+
+## 3. Pre-deploy — POISON stream cleanup
+
+- [x] 3.1 Purge the 218 existing messages from the NATS `POISON` stream in the dev environment before deploying (operational step — documented in `backend/tmp/purge-poison-stream.md`)
+
+## 4. Backend — Deploy and verify
+
+- [ ] 4.1 Run `make check` in backend repo (lint + tests pass)
+- [ ] 4.2 Open backend PR, confirm CI passes
+- [ ] 4.3 After merge, verify in Cloud Logging that `EmailVerifier` INFO logs appear for the next sign-up
+- [ ] 4.4 Verify Poison Queue consumer ERROR log appears in Cloud Logging when a poisoned message is injected (manual test or trigger a known-failing message)
+
+## 5. Cloud Provisioning — POISON stream lag alert
+
+- [x] 5.1 Research how to surface NATS JetStream consumer lag as a Cloud Monitoring metric — decided to use log-based alert (reuses existing infra, no new metric pipeline needed)
+- [x] 5.2 Add a log-based alert policy in `cloud-provisioning/src/gcp/components/monitoring.ts` that fires on consumer ERROR logs matching `"message routed to poison queue"`
+- [ ] 5.3 Run `make lint` in cloud-provisioning, open PR, confirm CI passes
+- [ ] 5.4 Run `pulumi preview` to confirm alert policy diff is correct
+- [ ] 5.5 After merge, verify alert policy appears in GCP Cloud Monitoring console

--- a/openspec/specs/consumer-poison-queue-alerting/spec.md
+++ b/openspec/specs/consumer-poison-queue-alerting/spec.md
@@ -1,0 +1,53 @@
+# Consumer Poison Queue Alerting
+
+## Purpose
+
+The system observes messages routed to the NATS JetStream `POISON` stream and surfaces them as actionable alerts. A dedicated consumer logs all poison queue messages as structured errors (triggering existing workload alert policies), and a Cloud Monitoring alert policy detects accumulated POISON stream lag to catch cases where the consumer is unavailable.
+
+## Requirements
+
+### Requirement: Poison Queue consumer emits ERROR logs
+
+The backend event consumer SHALL subscribe to the `POISON` NATS JetStream stream and emit a structured ERROR log entry for every message it receives. The log entry MUST include the original topic/subject and message UUID to enable tracing.
+
+#### Scenario: Message is routed to Poison Queue after max retries
+
+- **WHEN** a Watermill handler fails after exhausting all retries and the message is routed to the `POISON` stream
+- **THEN** the Poison Queue consumer SHALL receive the message
+- **AND** SHALL emit an ERROR log entry with `msg="message routed to poison queue"`, the original `topic`, and the message `uuid`
+- **AND** SHALL ack the message (it is not re-processed)
+
+#### Scenario: Poison Queue consumer ERROR log triggers workload alert
+
+- **WHEN** the Poison Queue consumer emits an ERROR log
+- **THEN** the existing consumer workload alert policy (from `app-error-log-alerting`) SHALL detect the log entry
+- **AND** SHALL open an Incident and send a Slack/Google Chat notification
+
+#### Scenario: Consumer is scaled to zero when message is poisoned
+
+- **WHEN** the consumer Pod is scaled to zero by KEDA and a message is routed to the Poison Queue
+- **THEN** the message SHALL remain in the `POISON` stream until the consumer Pod scales back up
+- **AND** on next consumer startup, the Poison Queue consumer SHALL process and log all pending messages
+
+### Requirement: NATS POISON stream lag alert
+
+The system SHALL have a Cloud Monitoring alert policy that detects accumulation of unprocessed messages in the NATS `POISON` stream.
+
+The alert SHALL trigger when the POISON stream consumer lag exceeds 0 for more than 5 minutes, to allow for normal consumer startup delay after KEDA scale-up.
+
+#### Scenario: Messages accumulate in POISON stream
+
+- **WHEN** the NATS `POISON` stream has unprocessed messages for more than 5 minutes
+- **THEN** the Cloud Monitoring alert policy SHALL open an Incident
+- **AND** SHALL send a notification to the configured Slack and Google Chat channels
+
+#### Scenario: POISON stream is empty
+
+- **WHEN** the NATS `POISON` stream has zero pending messages
+- **THEN** no alert SHALL fire
+
+#### Scenario: Alert uses same notification channels as backend workload alerts
+
+- **WHEN** the POISON stream lag alert fires
+- **THEN** the notification SHALL be sent to the same Slack and Google Chat channels as the `app-error-log-alerting` workload alerts
+- **AND** the same 12-hour notification rate limit SHALL apply

--- a/openspec/specs/email-verification/spec.md
+++ b/openspec/specs/email-verification/spec.md
@@ -10,7 +10,7 @@ The system sends a verification email to users upon account creation and allows 
 
 The system SHALL publish a `USER.created` event to NATS JetStream when a user is successfully provisioned in the backend. A consumer SHALL subscribe to this event and call Zitadel's `POST /v2/users/{externalId}/email/send` API to trigger a verification email via the configured SMTP provider (Postmark).
 
-The infrastructure layer (`EmailVerifier.SendVerification`) SHALL emit a structured INFO log entry on successful API call completion, and a structured ERROR log entry on failure. Both log entries MUST include the `external_id` field.
+The infrastructure layer (`EmailVerifier.SendVerification`) SHALL emit a structured INFO log entry on successful API call completion. On failure, the error is returned to the caller without logging — the caller (`UserConsumer`) is responsible for logging the failure. The INFO log entry MUST include the `external_id` field.
 
 #### Scenario: New user signs up via Passkey
 

--- a/openspec/specs/email-verification/spec.md
+++ b/openspec/specs/email-verification/spec.md
@@ -1,0 +1,87 @@
+# Email Verification
+
+## Purpose
+
+The system sends a verification email to users upon account creation and allows authenticated users to resend the verification email. Email delivery is handled by Zitadel via the configured SMTP provider (Postmark).
+
+## Requirements
+
+### Requirement: Trigger verification email on user creation
+
+The system SHALL publish a `USER.created` event to NATS JetStream when a user is successfully provisioned in the backend. A consumer SHALL subscribe to this event and call Zitadel's `POST /v2/users/{externalId}/email/send` API to trigger a verification email via the configured SMTP provider (Postmark).
+
+The infrastructure layer (`EmailVerifier.SendVerification`) SHALL emit a structured INFO log entry on successful API call completion, and a structured ERROR log entry on failure. Both log entries MUST include the `external_id` field.
+
+#### Scenario: New user signs up via Passkey
+
+- **WHEN** a new user completes Passkey registration and the backend provisions the user record
+- **THEN** the backend SHALL publish a `USER.created` event to the `USER` NATS JetStream stream
+- **AND** the consumer SHALL call Zitadel's email send API with the user's `external_id` (Zitadel user ID)
+- **AND** Zitadel SHALL send a verification email to the user's registered email address via Postmark
+
+#### Scenario: Zitadel API call succeeds
+
+- **WHEN** the consumer calls Zitadel's `SendEmailCode` API and the call completes successfully
+- **THEN** `EmailVerifier.SendVerification` SHALL emit an INFO log entry with `msg="email verification sent"` and `external_id`
+
+#### Scenario: Zitadel API call fails
+
+- **WHEN** the consumer calls Zitadel's `SendEmailCode` API and the call returns an error
+- **THEN** `EmailVerifier.SendVerification` SHALL return the error to the caller without logging (the caller is responsible for logging)
+- **AND** the error SHALL be returned to the caller (existing retry/poison queue behaviour is unchanged)
+
+#### Scenario: Zitadel API call fails transiently
+
+- **WHEN** the consumer calls Zitadel's email send API and receives a transient error (network timeout, 5xx)
+- **THEN** the NATS JetStream consumer SHALL retry the message with backoff
+- **AND** the user creation SHALL NOT be affected (already persisted)
+
+#### Scenario: User email is already verified
+
+- **WHEN** the consumer calls Zitadel's email send API for a user whose email is already verified
+- **THEN** the consumer SHALL handle the response gracefully (log and acknowledge the message)
+
+#### Scenario: Duplicate USER.created event
+
+- **WHEN** the consumer receives a duplicate `USER.created` event (e.g., NATS redelivery after ack timeout)
+- **THEN** the consumer SHALL call Zitadel's email send API
+- **AND** the operation SHALL be idempotent (re-sending a verification email has no adverse side effects)
+
+### Requirement: Resend verification email via RPC
+
+The system SHALL provide an RPC method that allows authenticated users to resend the verification email for their own account. The backend SHALL proxy this request to Zitadel's `POST /v2/users/{userId}/email/resend` API.
+
+The infrastructure layer (`EmailVerifier.ResendVerification`) SHALL emit a structured INFO log entry on successful API call completion, and a structured ERROR log entry on failure. Both log entries MUST include the `external_id` field.
+
+#### Scenario: User requests resend from Settings page
+
+- **WHEN** an authenticated user calls the resend verification RPC
+- **THEN** the backend SHALL extract the user's `external_id` from JWT claims
+- **AND** the backend SHALL call Zitadel's email resend API with the `external_id`
+- **AND** Zitadel SHALL send a new verification email to the user
+
+#### Scenario: Resend Zitadel API call succeeds
+
+- **WHEN** `EmailVerifier.ResendVerification` is called and the Zitadel `ResendEmailCode` API call completes successfully
+- **THEN** `EmailVerifier.ResendVerification` SHALL emit an INFO log entry with `msg="email verification resent"` and `external_id`
+
+#### Scenario: Resend Zitadel API call fails
+
+- **WHEN** `EmailVerifier.ResendVerification` is called and the Zitadel `ResendEmailCode` API call returns an error
+- **THEN** `EmailVerifier.ResendVerification` SHALL emit an ERROR log entry with `msg="failed to resend email code"` and `external_id`
+- **AND** the error SHALL be returned to the caller
+
+#### Scenario: User is already verified
+
+- **WHEN** an authenticated user whose email is already verified calls the resend verification RPC
+- **THEN** the backend SHALL return a `FailedPrecondition` error indicating the email is already verified
+
+#### Scenario: Rapid resend attempts
+
+- **WHEN** a user calls the resend verification RPC more than 3 times within 10 minutes
+- **THEN** the backend SHALL return a `ResourceExhausted` error
+
+#### Scenario: Unauthenticated request
+
+- **WHEN** an unauthenticated request calls the resend verification RPC
+- **THEN** the backend SHALL reject the request with an authentication error


### PR DESCRIPTION
## Summary

- Adds `openspec/specs/email-verification/spec.md` — documents the `SendVerification`/`ResendVerification` logging behaviour and the `USER.created` → email send flow
- Adds `openspec/specs/consumer-poison-queue-alerting/spec.md` — documents `PoisonConsumer` ERROR log requirements and the NATS POISON stream lag alert policy
- Archives `improve-consumer-observability` change to `openspec/changes/archive/2026-03-30-improve-consumer-observability/`

## Test plan

- [ ] CI passes on this PR

close: #268
