### PR TITLE
docs(specs): sync and archive improve-frontend-testability change

### DIFF
--- a/openspec/changes/archive/2026-03-30-improve-frontend-testability/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-30-improve-frontend-testability/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-30

--- a/openspec/changes/archive/2026-03-30-improve-frontend-testability/design.md
+++ b/openspec/changes/archive/2026-03-30-improve-frontend-testability/design.md
@@ -1,0 +1,132 @@
+## Context
+
+The Aurelia 2 frontend has three components that bypass the framework's DI system to access browser APIs directly:
+
+1. **`import-ticket-email-route.ts`** — reads `window.location.search` inside `loading()`, requiring tests to mutate `window.location` via `history.replaceState`.
+2. **`event-detail-sheet.ts`** — calls `history.pushState`, `history.replaceState`, and `window.addEventListener('popstate')` directly; tests spy on the global `history` object.
+3. **`dashboard-route.ts`** — calls `localStorage.getItem/setItem` via a static getter/setter and uses `this.element.closest('body')?.querySelectorAll('[data-nav]')` for DOM mutation; no unit tests exist.
+
+The existing test pattern for (1) and (2) works (`vi.spyOn(history, 'pushState')`, `window.history.replaceState(…)`), but the DOM query in (3) requires constructing a real element tree with `[data-nav]` children, making `dashboard-route` untestable without a full DOM fixture. There is no `dashboard-route.spec.ts` today.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Make `dashboard-route.ts` fully unit-testable by eliminating the DOM query dependency and making `localStorage` access injectable.
+- Align `import-ticket-email-route.ts` with Aurelia Router's `RouteNode.queryParams` API (the canonical way to read query parameters in `loading()`).
+- Replace `window.addEventListener('popstate')` in `event-detail-sheet.ts` with Aurelia's `IRouterEvents` so the subscription is mockable via DI.
+- Add `dashboard-route.spec.ts` covering the lane introduction state machine and key lifecycle paths.
+
+**Non-Goals:**
+- Refactoring the route component structure or decomposing routes into sub-controllers.
+- Adding integration-level or E2E tests.
+- Changing any observable component API (bindables, custom events, public methods).
+
+## Decisions
+
+### Decision 1: `INavDimmingService` for DOM mutation in `dashboard-route`
+
+**Why:** `setNavTabsDimmed` traverses up to `<body>` and queries `[data-nav]` elements. This is a cross-cutting concern (nav tabs live in the shell, not the route). Injecting a service turns the DOM side-effect into an injectable call, making the route's state machine testable with a mock.
+
+**Interface:**
+```typescript
+export interface INavDimmingService {
+  setDimmed(dimmed: boolean): void
+}
+export const INavDimmingService = DI.createInterface<INavDimmingService>(
+  'INavDimmingService', x => x.singleton(NavDimmingService)
+)
+```
+
+**Implementation:** The concrete `NavDimmingService` uses `document.body.querySelectorAll('[data-nav]')` to find nav tab elements and sets a `data-dimmed` attribute (via `toggleAttribute`) rather than inline `style.setProperty`. Visual treatment (opacity, transition) is expressed in the `bottom-nav-bar.css` exception layer (`[data-nav][data-dimmed]`), keeping JS responsible only for state and CSS responsible for presentation. It is registered as a singleton in `main.ts`.
+
+**Alternative considered:** Keep the DOM query in the route but accept it in tests by constructing a `document.body` fixture. Rejected because it makes tests order-dependent and brittle when shell structure changes.
+
+---
+
+### Decision 2: `ILocalStorage` for celebration/postSignup flags in `dashboard-route`
+
+**Why:** `DashboardRoute.celebrationShown` and the `postSignupShown` check use `localStorage` directly via static getters and inline `localStorage.getItem` calls. Injecting an `ILocalStorage` wrapper makes these mockable with `Registration.instance(ILocalStorage, { getItem: vi.fn(), setItem: vi.fn(), removeItem: vi.fn() })`.
+
+**Interface (minimal):**
+```typescript
+export interface ILocalStorage {
+  getItem(key: string): string | null
+  setItem(key: string, value: string): void
+  removeItem(key: string): void
+}
+export const ILocalStorage = DI.createInterface<ILocalStorage>(
+  'ILocalStorage', x => x.instance(window.localStorage)
+)
+```
+
+**Note:** `adapter/storage/` already provides typed storage helpers. `ILocalStorage` is a lower-level injectable that wraps the raw Web Storage API; the existing typed helpers remain unchanged.
+
+**Alternative considered:** Use `vi.spyOn(localStorage, 'getItem')`. This works in jsdom but leaks state between tests and cannot be scoped per DI container. Rejected in favor of the explicit injection pattern already used elsewhere in the codebase.
+
+---
+
+### Decision 3: `IRouterEvents` subscription in `event-detail-sheet`
+
+**Why:** The current `window.addEventListener('popstate', …)` handler replicates what Aurelia Router already tracks. Subscribing to `au:router:navigation-end` via `IRouterEvents` makes the subscription testable: tests inject a mock `IRouterEvents` and call the subscriber directly, with no `window.dispatchEvent(new PopStateEvent(…))` needed.
+
+**Pattern:**
+```typescript
+export class EventDetailSheet implements IDisposable {
+  private readonly routerEvents = resolve(IRouterEvents)
+  private navSub: IDisposable | null = null
+
+  public open(event: LiveEvent): void {
+    this.event = event
+    this.isOpen = true
+    void this.router.load(`concerts/${event.id}`, { historyStrategy: 'push' })
+    this.navSub = this.routerEvents.subscribe(
+      'au:router:navigation-end', () => { if (this.isOpen) this.isOpen = false }
+    )
+  }
+
+  public detaching(): void {
+    this.navSub?.dispose()
+  }
+}
+```
+
+**Alternative considered:** Keep `vi.spyOn(history, 'pushState')` as the test strategy (it already works). The existing test suite passes with this approach. However, the direct `history` calls bypass the router lifecycle, meaning the URL is pushed outside the router's state, which can cause navigation inconsistencies on back/forward. Using `IRouter.load()` + `IRouterEvents` aligns with Aurelia idioms and is the canonical pattern per the framework docs.
+
+**Trade-off:** Requires the route to have an Aurelia Router path for `/concerts/:id`. If none exists, `router.load()` will emit a navigation-error event. This is a pre-condition to verify before implementing.
+
+---
+
+### Decision 4: `RouteNode.queryParams` in `import-ticket-email-route`
+
+**Why:** Aurelia Router passes `next: RouteNode` to `loading(params, next)`. `next.queryParams` is a `URLSearchParams` instance identical to what `new URLSearchParams(window.location.search)` would return, but it is derived from the router's internal navigation state rather than the live `window.location`. Tests can pass a fabricated `RouteNode`-like object without touching `window.location`.
+
+**Signature change:**
+```typescript
+// Before
+public async loading(): Promise<void> {
+  const urlParams = new URLSearchParams(window.location.search)
+
+// After
+public async loading(_params: Params, next: RouteNode): Promise<void> {
+  const urlParams = next.queryParams
+```
+
+**Test pattern:**
+```typescript
+const fakeNext = { queryParams: new URLSearchParams('title=T&text=チケット') }
+await sut.loading({}, fakeNext as RouteNode)
+```
+
+No `window.history.replaceState` needed in tests.
+
+---
+
+## Risks / Trade-offs
+
+- **`IRouterEvents` approach requires `/concerts/:id` route** → Verify `app-shell.ts` route config before implementing. If the route does not exist, fall back to keeping `history.pushState` (with the existing spy-based test strategy) as an interim solution.
+- **`ILocalStorage` singleton uses `window.localStorage`** → In test environments (jsdom), `window.localStorage` is functional, so the default registration is safe. The DI override in tests replaces it with a mock.
+- **`INavDimmingService` couples to shell DOM structure** → The concrete implementation still depends on `[data-nav]` attribute convention. If the shell is refactored, the service's querySelector must be updated. Documented in the service's JSDoc.
+
+## Open Questions
+
+~~Does `/concerts/:id` exist as a named Aurelia route in `app-shell.ts`?~~ **Resolved:** `path: 'concerts/:id'` is already configured in `app-shell.ts` (line 38). The `IRouter.load()` + `IRouterEvents` approach is safe to implement.

--- a/openspec/changes/archive/2026-03-30-improve-frontend-testability/proposal.md
+++ b/openspec/changes/archive/2026-03-30-improve-frontend-testability/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+Several Aurelia 2 frontend components access browser APIs (`window.location`, `history`, `localStorage`, DOM `querySelectorAll`) directly, making unit tests require real browser state and fragile setup. This blocks high-confidence testing of critical flows like the Dashboard lane introduction and deep-link sheet behavior. Aligning these components with Aurelia Router's lifecycle hooks and DI patterns removes the browser-API coupling and enables pure unit tests.
+
+## What Changes
+
+- **`import-ticket-email-route.ts`**: Replace `window.location.search` with `next.queryParams` from the Aurelia Router `loading(params, next: RouteNode)` hook signature, eliminating `window.location` dependency in tests.
+- **`event-detail-sheet.ts`**: Replace direct `history.pushState` / `window.addEventListener('popstate')` with `IRouterEvents` subscriptions and `IRouter.load()` for navigation, making history interaction injectable and mockable.
+- **`dashboard-route.ts`**: Extract `setNavTabsDimmed` DOM-query logic into a dedicated injectable `INavDimmingService`, and move `localStorage` access for celebration/postSignup flags into the existing `adapter/storage` pattern with an injectable `ILocalStorage` abstraction. Add `dashboard-route.spec.ts` covering the lane introduction state machine and key lifecycle scenarios.
+
+## Capabilities
+
+### New Capabilities
+
+- `frontend-router-query-params`: Using Aurelia Router's `RouteNode.queryParams` API instead of `window.location.search` in route lifecycle hooks.
+
+### Modified Capabilities
+
+- `frontend-testing`: Add `dashboard-route` test scenarios covering the lane introduction state machine, `loading()`, `attached()`, and `detaching()` hooks. Raise coverage thresholds to reflect new route tests.
+- `dashboard-lane-introduction`: The `setNavTabsDimmed` behavior is now delegated to an injectable service rather than direct DOM queries; observable contract remains the same.
+
+## Impact
+
+- `frontend/src/routes/import-ticket-email/import-ticket-email-route.ts` — signature change on `loading()`
+- `frontend/src/routes/dashboard/dashboard-route.ts` — inject `INavDimmingService`; inject `ILocalStorage` for celebration/postSignup flags
+- `frontend/src/components/live-highway/event-detail-sheet.ts` — inject `IRouterEvents` + `IRouter`; remove `window` calls
+- `frontend/src/services/nav-dimming-service.ts` — new file
+- `frontend/src/adapter/storage/local-storage.ts` — new DI-injectable wrapper (or augment existing `adapter/storage`)
+- `frontend/test/routes/dashboard-route.spec.ts` — new file
+- `frontend/test/helpers/` — new mock factories for `INavDimmingService`, `ILocalStorage`, `IRouterEvents`
+- No API or protobuf changes; frontend-only refactor

--- a/openspec/changes/archive/2026-03-30-improve-frontend-testability/specs/dashboard-lane-introduction/spec.md
+++ b/openspec/changes/archive/2026-03-30-improve-frontend-testability/specs/dashboard-lane-introduction/spec.md
@@ -1,0 +1,34 @@
+## MODIFIED Requirements
+
+### Requirement: Lane Introduction State Management
+The lane introduction sequence SHALL be managed locally within the dashboard component, not persisted in the onboarding service. Nav-tab dimming SHALL be delegated to an injectable `INavDimmingService` rather than performed via direct DOM queries, enabling the state machine to be unit-tested without a real DOM.
+
+#### Scenario: Lane intro state is ephemeral
+- **WHEN** the dashboard component manages the lane introduction
+- **THEN** the intro state SHALL be a local variable (`laneIntroPhase: 'home' | 'near' | 'away' | 'done'`)
+- **AND** the state SHALL NOT be written to `liverty:onboardingStep` in LocalStorage
+
+#### Scenario: Page reload during lane introduction
+- **WHEN** the user reloads the page during the lane introduction sequence
+- **THEN** the system SHALL restart the lane introduction from the beginning (HOME STAGE)
+- **AND** the celebration overlay SHALL NOT replay (it uses a separate one-time flag)
+
+#### Scenario: Data loading awaited before lane intro decision
+- **WHEN** `startLaneIntro()` is called
+- **THEN** the system SHALL await the data load response before deciding whether to run or skip the lane intro
+- **AND** if the data fetch fails, the system SHALL proceed with whatever data is available (possibly empty, triggering the skip path)
+
+#### Scenario: Nav tabs are dimmed via INavDimmingService
+- **WHEN** the lane introduction starts
+- **THEN** `INavDimmingService.setDimmed(true)` SHALL be called
+- **AND** the component SHALL NOT directly query `[data-nav]` elements from the DOM
+
+#### Scenario: Nav tabs are undimmed on completion or dismissal
+- **WHEN** the lane introduction completes or the celebration is dismissed
+- **THEN** `INavDimmingService.setDimmed(false)` SHALL be called
+
+#### Scenario: Nav tab dimming is expressed via data attribute, not inline style
+- **WHEN** `INavDimmingService.setDimmed(true)` is called on a `[data-nav]` element
+- **THEN** the element SHALL receive a `data-dimmed` attribute (via `toggleAttribute`)
+- **AND** the visual treatment (opacity, transition) SHALL be applied via CSS (`[data-nav][data-dimmed]` rule in the exception layer)
+- **AND** no `style.setProperty` or `aria-disabled` manipulation SHALL occur

--- a/openspec/changes/archive/2026-03-30-improve-frontend-testability/specs/frontend-router-query-params/spec.md
+++ b/openspec/changes/archive/2026-03-30-improve-frontend-testability/specs/frontend-router-query-params/spec.md
@@ -1,0 +1,16 @@
+## ADDED Requirements
+
+### Requirement: Route loading hooks read query parameters via RouteNode
+Route `loading()` lifecycle hooks SHALL read URL query parameters from `next.queryParams` (a `URLSearchParams` instance provided by Aurelia Router) rather than `window.location.search`, so that the parameter source is injectable and not coupled to the live browser URL.
+
+#### Scenario: Query params are read from RouteNode in loading()
+- **WHEN** `loading(_params, next)` is called with a `RouteNode` whose `queryParams` contains `title` and `text`
+- **THEN** the route SHALL read `title` and `text` from `next.queryParams` without accessing `window.location`
+
+#### Scenario: Test can inject query params without mutating window.location
+- **WHEN** a unit test calls `loading({}, { queryParams: new URLSearchParams('title=T&text=チケット') })`
+- **THEN** the route SHALL parse those params correctly, and the test SHALL NOT require `window.history.replaceState`
+
+#### Scenario: Missing query params default to empty string
+- **WHEN** `next.queryParams` does not contain `title` or `text`
+- **THEN** `emailTitle` and `emailBody` SHALL default to `''`

--- a/openspec/changes/archive/2026-03-30-improve-frontend-testability/specs/frontend-testing/spec.md
+++ b/openspec/changes/archive/2026-03-30-improve-frontend-testability/specs/frontend-testing/spec.md
@@ -1,0 +1,68 @@
+## ADDED Requirements
+
+### Requirement: Dashboard route manages lane introduction state machine
+The `DashboardRoute` SHALL manage the lane introduction onboarding flow as a pure state machine testable without a real DOM, with nav-dimming delegated to `INavDimmingService` and localStorage access delegated to `ILocalStorage`.
+
+#### Scenario: loading() sets needsRegion for authenticated user without home
+- **WHEN** `loading()` is called and `userService.current.home` is falsy
+- **THEN** `needsRegion` SHALL be `true`
+
+#### Scenario: loading() sets showSignupBanner for completed-onboarding guest
+- **WHEN** `loading()` is called and the user is unauthenticated and `onboarding.isCompleted` is `true`
+- **THEN** `showSignupBanner` SHALL be `true`
+
+#### Scenario: attached() starts lane intro when onboarding step is DASHBOARD
+- **WHEN** `attached()` is called and `onboarding.currentStep === OnboardingStep.DASHBOARD`
+- **THEN** `INavDimmingService.setDimmed(true)` SHALL be called and `laneIntroPhase` SHALL be `'home'`
+
+#### Scenario: attached() shows post-signup dialog when flag is pending
+- **WHEN** `attached()` is called and `ILocalStorage.getItem(StorageKeys.postSignupShown)` returns `'pending'`
+- **THEN** `showPostSignupDialog` SHALL be `true` and `removeItem` SHALL be called for that key
+
+#### Scenario: advanceLaneIntro progresses through phases
+- **WHEN** `onLaneIntroTap()` is called with `laneIntroPhase === 'home'`
+- **THEN** `laneIntroPhase` SHALL advance to `'near'`
+- **WHEN** called again
+- **THEN** `laneIntroPhase` SHALL advance to `'away'`
+- **WHEN** called again
+- **THEN** `completeLaneIntro()` SHALL be triggered
+
+#### Scenario: completeLaneIntro shows celebration when not yet shown
+- **WHEN** `completeLaneIntro()` is called and `ILocalStorage.getItem(StorageKeys.celebrationShown)` returns `null`
+- **THEN** `showCelebration` SHALL be `true` and `ILocalStorage.setItem(StorageKeys.celebrationShown, '1')` SHALL be called
+
+#### Scenario: completeLaneIntro undims nav when celebration already shown
+- **WHEN** `completeLaneIntro()` is called and `celebrationShown` is `true`
+- **THEN** `showCelebration` SHALL remain `false` and `INavDimmingService.setDimmed(false)` SHALL be called
+
+#### Scenario: onCelebrationDismissed undims nav and deactivates spotlight
+- **WHEN** `onCelebrationDismissed()` is called
+- **THEN** `showCelebration` SHALL be `false`, `INavDimmingService.setDimmed(false)` SHALL be called, and `onboarding.deactivateSpotlight()` SHALL be called
+
+#### Scenario: detaching clears abort controller and undims nav
+- **WHEN** `detaching()` is called
+- **THEN** the abort controller SHALL be aborted and `INavDimmingService.setDimmed(false)` SHALL be called
+
+### Requirement: Mock helpers cover INavDimmingService and ILocalStorage
+The test helper library SHALL provide typed mock factories for the new injectable services introduced by this change.
+
+#### Scenario: createMockNavDimmingService returns spy
+- **WHEN** `createMockNavDimmingService()` is called
+- **THEN** it SHALL return an object with `setDimmed` as a Vitest spy
+
+#### Scenario: createMockLocalStorage returns configurable spy
+- **WHEN** `createMockLocalStorage(initialData)` is called with an initial key-value map
+- **THEN** it SHALL return an object implementing `ILocalStorage` with `getItem`, `setItem`, `removeItem` as Vitest spies that read/write the initial data
+
+## MODIFIED Requirements
+
+### Requirement: Coverage reporting is configured
+Vitest SHALL be configured with V8 coverage reporting with raised thresholds reflecting the expanded test suite.
+
+#### Scenario: Running tests with coverage
+- **WHEN** `vitest --coverage` is executed
+- **THEN** a coverage report SHALL be generated showing statement, branch, and function coverage
+
+#### Scenario: Coverage thresholds enforce minimum levels
+- **WHEN** coverage falls below thresholds (statements: 70%, branches: 78%, functions: 70%, lines: 70%)
+- **THEN** the coverage check SHALL fail

--- a/openspec/changes/archive/2026-03-30-improve-frontend-testability/tasks.md
+++ b/openspec/changes/archive/2026-03-30-improve-frontend-testability/tasks.md
@@ -1,0 +1,52 @@
+## 1. New Injectable Services
+
+- [x] 1.1 Create `src/services/nav-dimming-service.ts` — define `INavDimmingService` interface with `setDimmed(dimmed: boolean): void`, implement `NavDimmingService` using `document.body.querySelectorAll('[data-nav]')`, register as singleton with `DI.createInterface`
+- [x] 1.2 Create `src/adapter/storage/local-storage.ts` — define `ILocalStorage` interface (`getItem`, `setItem`, `removeItem`), register default instance as `window.localStorage` via `DI.createInterface` with `x.instance(window.localStorage)`
+- [x] 1.3 Register `INavDimmingService` in `src/main.ts`
+
+## 2. Refactor: dashboard-route.ts
+
+- [x] 2.1 Inject `INavDimmingService` and replace all `setNavTabsDimmed()` DOM query calls with `this.navDimming.setDimmed(dimmed)`
+- [x] 2.2 Inject `ILocalStorage` and replace the static `celebrationShown` getter/setter (which calls `localStorage` directly) with instance calls through `ILocalStorage`
+- [x] 2.3 Replace the inline `localStorage.getItem(StorageKeys.postSignupShown)` call in `attached()` with `ILocalStorage.getItem(…)`
+- [x] 2.4 Remove the `private static get/set celebrationShown` accessors (now handled via `ILocalStorage`)
+
+## 3. Refactor: import-ticket-email-route.ts
+
+- [x] 3.1 Change `loading()` signature to `loading(_params: Params, next: RouteNode): Promise<void>`
+- [x] 3.2 Replace `new URLSearchParams(window.location.search)` with `next.queryParams`
+- [x] 3.3 Update `import-ticket-email-route.spec.ts` — remove all `window.history.replaceState(…)` setup calls; pass `{ queryParams: new URLSearchParams('…') }` as second argument to `loading()`
+
+## 4. Refactor: event-detail-sheet.ts
+
+- [x] 4.1 Inject `IRouter` (from `@aurelia/router`) and `IRouterEvents`
+- [x] 4.2 In `open()`, replace `history.pushState(…)` with `void this.router.load(\`concerts/${event.id}\`, { historyStrategy: 'push' })`
+- [x] 4.3 Replace `window.addEventListener('popstate', this.onPopstate)` with `this.navSub = this.routerEvents.subscribe('au:router:navigation-end', …)` that closes the sheet when `isOpen` is true and the navigation is not to `/concerts/:id`
+- [x] 4.4 In `close()` and `onSheetClosed()`, replace `history.replaceState(null, '', '/dashboard')` with `void this.router.load('dashboard', { historyStrategy: 'replace' })`
+- [x] 4.5 In `detaching()`, replace `window.removeEventListener` with `this.navSub?.dispose()`
+- [x] 4.6 Update `event-detail-sheet.spec.ts` — replace `vi.spyOn(history, 'pushState')` with mock `IRouter.load` spy; replace `vi.spyOn(history, 'replaceState')` with assertions on `mockRouter.load`; inject mock `IRouterEvents` with a `subscribe` spy
+
+## 5. New Test Helpers
+
+- [x] 5.1 Create `test/helpers/mock-nav-dimming-service.ts` — export `createMockNavDimmingService()` returning `{ setDimmed: vi.fn() }`
+- [x] 5.2 Create `test/helpers/mock-local-storage.ts` — export `createMockLocalStorage(initial?: Record<string, string>)` that returns an in-memory `ILocalStorage` implementation with `getItem`, `setItem`, `removeItem` as Vitest spies
+- [x] 5.3 Create `test/helpers/mock-router-events.ts` — export `createMockRouterEvents()` returning `{ subscribe: vi.fn().mockReturnValue({ dispose: vi.fn() }) }`
+
+## 6. New Test: dashboard-route.spec.ts
+
+- [x] 6.1 Create `test/routes/dashboard-route.spec.ts` with `vi.mock` stubs for all 8 service imports (auth, concert, follow, journey, onboarding, guest, user, i18n) plus `INavDimmingService` and `ILocalStorage`
+- [x] 6.2 Write `describe('loading')` — authenticated user with/without home sets `needsRegion`; unauthenticated completed-onboarding user sets `showSignupBanner`
+- [x] 6.3 Write `describe('attached')` — DASHBOARD onboarding step triggers lane intro; `postSignupShown === 'pending'` sets `showPostSignupDialog`
+- [x] 6.4 Write `describe('lane intro state machine')` — `startLaneIntro` → home phase; `onLaneIntroTap` advances through home→near→away→done; `completeLaneIntro` shows celebration when not yet shown; `completeLaneIntro` undims nav when already shown
+- [x] 6.5 Write `describe('onCelebrationDismissed')` — sets `showCelebration = false`, calls `setDimmed(false)`, calls `deactivateSpotlight()`
+- [x] 6.6 Write `describe('detaching')` — aborts controller, calls `setDimmed(false)`
+- [x] 6.7 Write `describe('@watch onDateGroupsChanged')` — when `dateGroups.length` transitions from 0 to >0 during `'home'` phase in onboarding, `updateSpotlightForPhase` is called (via `queueTask` + `vi.advanceTimersByTime`)
+
+## 7. Coverage Threshold Update
+
+- [x] 7.1 Update `vitest.config.ts` coverage thresholds: statements → 70%, branches → 78%, functions → 70%, lines → 70%
+
+## 8. Verification
+
+- [x] 8.1 Run `make lint` — no Biome or TypeScript errors
+- [x] 8.2 Run `make test` — all unit tests pass, coverage thresholds met

--- a/openspec/specs/dashboard-lane-introduction/spec.md
+++ b/openspec/specs/dashboard-lane-introduction/spec.md
@@ -110,7 +110,7 @@ The system SHALL introduce each dashboard lane by sequentially spotlighting the 
 
 ### Requirement: Lane Introduction State Management
 
-The lane introduction sequence SHALL be managed locally within the dashboard component, not persisted in the onboarding service. Reactive data observation SHALL be used to coordinate spotlight activation with data availability.
+The lane introduction sequence SHALL be managed locally within the dashboard component, not persisted in the onboarding service. Nav-tab dimming SHALL be delegated to an injectable `INavDimmingService` rather than performed via direct DOM queries, enabling the state machine to be unit-tested without a real DOM. Reactive data observation SHALL be used to coordinate spotlight activation with data availability.
 
 #### Scenario: Lane intro state is ephemeral
 
@@ -137,6 +137,21 @@ The lane introduction sequence SHALL be managed locally within the dashboard com
 - **THEN** `queueTask()` SHALL schedule spotlight activation after Aurelia completes its template update cycle
 - **AND** the `if.bind="dateGroups.length > 0"` on the stage header SHALL have been evaluated
 - **AND** `concert-highway [data-stage="home"]` SHALL be present in the DOM when the spotlight activates
+
+#### Scenario: Nav tabs are dimmed via INavDimmingService
+- **WHEN** the lane introduction starts
+- **THEN** `INavDimmingService.setDimmed(true)` SHALL be called
+- **AND** the component SHALL NOT directly query `[data-nav]` elements from the DOM
+
+#### Scenario: Nav tabs are undimmed on completion or dismissal
+- **WHEN** the lane introduction completes or the celebration is dismissed
+- **THEN** `INavDimmingService.setDimmed(false)` SHALL be called
+
+#### Scenario: Nav tab dimming is expressed via data attribute, not inline style
+- **WHEN** `INavDimmingService.setDimmed(true)` is called on a `[data-nav]` element
+- **THEN** the element SHALL receive a `data-dimmed` attribute (via `toggleAttribute`)
+- **AND** the visual treatment (opacity, transition) SHALL be applied via CSS (`[data-nav][data-dimmed]` rule in the exception layer)
+- **AND** no `style.setProperty` or `aria-disabled` manipulation SHALL occur
 
 ### Requirement: Data loading awaited before lane intro decision (polling loop) (REMOVED)
 

--- a/openspec/specs/frontend-router-query-params/spec.md
+++ b/openspec/specs/frontend-router-query-params/spec.md
@@ -1,0 +1,22 @@
+# Frontend Router Query Parameters
+
+## Purpose
+
+Define the canonical pattern for reading URL query parameters in Aurelia 2 route lifecycle hooks. Route `loading()` hooks SHALL use `RouteNode.queryParams` rather than `window.location.search` to decouple from the live browser URL and enable pure unit testing.
+
+## Requirements
+
+### Requirement: Route loading hooks read query parameters via RouteNode
+Route `loading()` lifecycle hooks SHALL read URL query parameters from `next.queryParams` (a `URLSearchParams` instance provided by Aurelia Router) rather than `window.location.search`, so that the parameter source is injectable and not coupled to the live browser URL.
+
+#### Scenario: Query params are read from RouteNode in loading()
+- **WHEN** `loading(_params, next)` is called with a `RouteNode` whose `queryParams` contains `title` and `text`
+- **THEN** the route SHALL read `title` and `text` from `next.queryParams` without accessing `window.location`
+
+#### Scenario: Test can inject query params without mutating window.location
+- **WHEN** a unit test calls `loading({}, { queryParams: new URLSearchParams('title=T&text=チケット') })`
+- **THEN** the route SHALL parse those params correctly, and the test SHALL NOT require `window.history.replaceState`
+
+#### Scenario: Missing query params default to empty string
+- **WHEN** `next.queryParams` does not contain `title` or `text`
+- **THEN** `emailTitle` and `emailBody` SHALL default to `''`

--- a/openspec/specs/frontend-testing/spec.md
+++ b/openspec/specs/frontend-testing/spec.md
@@ -405,6 +405,17 @@ The test helper library SHALL provide typed mock factories for all DI interfaces
 - **WHEN** `createMockErrorBoundary` is called
 - **THEN** it SHALL return a `Partial<IErrorBoundaryService>` with `captureError` and `dismiss` as Vitest spies
 
+### Requirement: Mock helpers cover INavDimmingService and ILocalStorage
+The test helper library SHALL provide typed mock factories for the nav-dimming and local-storage injectable services.
+
+#### Scenario: createMockNavDimmingService returns spy
+- **WHEN** `createMockNavDimmingService()` is called
+- **THEN** it SHALL return an object with `setDimmed` as a Vitest spy
+
+#### Scenario: createMockLocalStorage returns configurable spy
+- **WHEN** `createMockLocalStorage(initialData)` is called with an initial key-value map
+- **THEN** it SHALL return an object implementing `ILocalStorage` with `getItem`, `setItem`, `removeItem` as Vitest spies that read/write the initial data
+
 ### Requirement: Timer cleanup uses afterEach unconditionally
 All tests that use `vi.useFakeTimers()` SHALL restore real timers in `afterEach`, never inside individual `it()` blocks.
 
@@ -428,7 +439,7 @@ Vitest SHALL be configured with V8 coverage reporting with raised thresholds ref
 - **THEN** a coverage report SHALL be generated showing statement, branch, and function coverage
 
 #### Scenario: Coverage thresholds enforce minimum levels
-- **WHEN** coverage falls below thresholds (statements: 65%, branches: 75%, functions: 65%, lines: 65%)
+- **WHEN** coverage falls below thresholds (statements: 70%, branches: 78%, functions: 70%, lines: 70%)
 - **THEN** the coverage check SHALL fail
 
 #### Scenario: Dead config patterns are removed


### PR DESCRIPTION
## Summary

Sync and archive the `improve-frontend-testability` OpenSpec change.

- **frontend-testing spec**: Updated coverage thresholds (70/78/70/70), added scenarios for `INavDimmingService` and `ILocalStorage` mock helpers
- **dashboard-lane-introduction spec**: Added requirements for `INavDimmingService` delegation, `data-dimmed` attribute pattern for nav tab dimming
- **frontend-router-query-params spec**: New capability spec documenting the `RouteNode.queryParams` pattern for injectable query param reading in route lifecycle hooks

Change archived to `openspec/changes/archive/2026-03-30-improve-frontend-testability/` after all tasks completed.

## Test plan

- [x] All delta specs synced to main specs at `openspec/specs/`
- [x] Archive contains full artifact set (proposal, design, tasks, delta specs)
- [x] `buf lint` passes (no proto changes in this PR)

close: #300
