### PR TITLE
docs(spec): add dashboard-artist-filter capability spec

### DIFF
--- a/openspec/changes/archive/2026-04-01-dashboard-artist-filter/design.md
+++ b/openspec/changes/archive/2026-04-01-dashboard-artist-filter/design.md
@@ -1,0 +1,86 @@
+## Context
+
+The dashboard route (`dashboard-route.ts`) currently loads all concerts for followed artists and renders them unconditionally via `<concert-highway>`. There is no mechanism to scope the view to a subset of artists.
+
+Push notifications are delivered through the Service Worker (`sw.ts`), which reads `notification.data.url` and navigates to it directly — no frontend integration is needed to support deep-link URLs. The existing `IHistory` adapter (used by `EventDetailSheet`) provides a clean pattern for URL state synchronisation without triggering Aurelia router transitions.
+
+The `DateGroup` entity (`entities/concert.ts`) contains `Concert[]` per lane, and each `Concert` carries an `artistId: string`. Client-side filtering over this structure is straightforward and avoids any backend changes for the frontend scope.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Parse `?artists=id1,id2` from the dashboard URL on load and apply as an in-memory filter
+- Expose a filter chip UI in the page header that reflects active filters and allows individual dismissal
+- Provide an artist-selection bottom sheet for users to actively choose which artists to filter by
+- Keep filter state in the URL (via `replaceState`) so it survives reload and is shareable
+- Support navigation from push notifications with a pre-set artist filter
+
+**Non-Goals:**
+- Backend changes to the concert fetch API (filtering remains client-side)
+- Persisting filter state in `localStorage` (URL is the single source of truth)
+- Multi-artist selection via the notification payload (notifications target one artist at a time)
+- Changes to the onboarding flow or lane intro behaviour
+
+## Decisions
+
+### Decision 1: Client-side filtering over `filteredDateGroups` computed getter
+
+**Chosen:** Filter `dateGroups` in the ViewModel via a computed getter `filteredDateGroups`. When `filteredArtistIds` is empty, return `dateGroups` unchanged. When non-empty, map each group keeping only concerts whose `artistId` is in the set, then drop groups where all three lanes are empty.
+
+**Alternatives considered:**
+- *Pass artist IDs to the backend API* — Would require a protobuf schema change, backend work, and a spec-driven release cycle. The frontend already fetches all followed-artist concerts; filtering a few dozen items client-side is negligible.
+- *Filter inside `ConcertService.toDateGroups()`* — Would bleed UI concern into a shared service. The dashboard is the only consumer that needs filtered groups.
+
+### Decision 2: URL encoding — comma-separated `?artists=id1,id2`
+
+**Chosen:** Single `artists` key with comma-separated UUIDs.
+
+**Rationale:** UUIDs contain no commas so splitting on `,` is unambiguous. The URL stays short (important for notification payloads). Reading is one call: `next.queryParams.get('artists')?.split(',') ?? []`.
+
+**Alternative:** `?artists=id1&artists=id2` (repeated key, `URLSearchParams.getAll()`). More idiomatic for multi-value params but produces longer URLs. Not worth the extra length for this use case.
+
+### Decision 3: URL sync via `IHistory.replaceState`, not Aurelia router navigation
+
+**Chosen:** Mutate the URL silently with `IHistory.replaceState(null, '', '/dashboard?artists=...')` when the user changes filters.
+
+**Rationale:** Mirrors the pattern already established by `EventDetailSheet`. A full Aurelia router navigation would re-run `loading()`, triggering a new API call and resetting all local state — unnecessary when only the filter changes. `replaceState` keeps the back-button stack clean (no extra history entry) and avoids reload.
+
+### Decision 4: Filter UI — header-integrated chips + bottom sheet trigger
+
+**Chosen:** When `filteredArtistIds` is non-empty, render dismissible artist-name chips in the page header (right side). A small trigger button (`≡`) is always present to open the artist-selection bottom sheet. The bottom sheet lists all followed artists with checkboxes.
+
+**Rationale:**
+- **No filter active:** header is unchanged — zero wasted space.
+- **Filter active:** chips communicate state at a glance; individual `×` on each chip allows quick dismissal without opening the sheet.
+- Re-uses the existing `bottom-sheet` primitive (already used by `UserHomeSelector` on the same route).
+
+**Alternative A: Horizontal chip bar below the header** — always visible, wastes vertical space on mobile when no filter is active.
+
+**Alternative B: Filter state only in the bottom sheet** — requires two taps to see the active filter; state is less discoverable.
+
+### Decision 5: `artist-filter-bar` component with two bindables only
+
+`artist-filter-bar` exposes:
+- `@bindable followedArtists: Artist[]` — the list to render in the sheet
+- `@bindable({ mode: 'two-way' }) selectedIds: string[]` — the active filter; parent mutates this directly via Aurelia two-way binding
+
+No custom events. The parent (`DashboardRoute`) reacts to `selectedIdsChanged()` via Aurelia `@observable`-style change handler on the bound property, then calls `updateFilterUrl()`.
+
+## Risks / Trade-offs
+
+| Risk | Mitigation |
+|------|-----------|
+| `filteredDateGroups` re-runs on every render cycle if implemented as a plain getter | Use `@computed` or memoise behind `@observable filteredArtistIds` so it only recalculates when the filter or `dateGroups` changes |
+| Stale URL when user navigates away and back (Aurelia re-runs `loading()`) | `loading()` always re-reads `next.queryParams`, so the URL remains the source of truth |
+| Bottom sheet and `UserHomeSelector` sheet opening simultaneously during onboarding | Disable the filter trigger button while `isOnboarding` is true (filter is irrelevant during lane intro) |
+| Very long artist name overflows header chip | Cap chip width with `max-width` + `text-overflow: ellipsis`; full name visible in the bottom sheet |
+
+## Migration Plan
+
+1. Deploy frontend change — feature is additive; URLs without `?artists` behave identically to today.
+2. Backend team updates push notification payloads to include `/dashboard?artists=<artistId>` — can happen independently after frontend ships.
+3. No rollback concern: removing `?artists` from any URL restores the unfiltered view.
+
+## Open Questions
+
+- Should the filter trigger button be visible during onboarding, or hidden entirely until onboarding is complete? (Current proposal: hidden/disabled during onboarding to avoid distraction.)

--- a/openspec/changes/archive/2026-04-01-dashboard-artist-filter/proposal.md
+++ b/openspec/changes/archive/2026-04-01-dashboard-artist-filter/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+The dashboard shows concerts from all followed artists with no way to narrow the view. When a user receives a push notification about a new concert for a specific artist, there is no way to land on a filtered dashboard — every notification click drops the user into the full, unfiltered feed. Users with many followed artists cannot quickly answer "when is this artist playing?"
+
+## What Changes
+
+- Add `artists` query parameter to the dashboard URL (`/dashboard?artists=id1,id2`) supporting multiple artist IDs (comma-separated)
+- Filter the concert highway to show only concerts matching the selected artist(s) when the parameter is present
+- Synchronise filter state with the URL via `IHistory.replaceState` so the filtered view is shareable and bookmarkable
+- Add a filter UI in the page header: active-filter chips (each dismissible) + a trigger button to open an artist-selection bottom sheet
+- Update push notification payloads to include `/dashboard?artists=<artistId>` as the action URL so tapping a notification opens a pre-filtered dashboard
+
+## Capabilities
+
+### New Capabilities
+
+- `dashboard-artist-filter`: URL-driven artist filter on the dashboard — query param parsing, computed filtered date groups, URL sync, filter chip UI, and artist-selection bottom sheet
+
+### Modified Capabilities
+
+- `dashboard-lane-introduction`: No requirement changes; implementation touches the same route file but the onboarding flow is unaffected
+- `concert-highway-ce`: No requirement changes; `dateGroups` binding source changes from raw groups to filtered groups, component contract is unchanged
+
+## Impact
+
+- **Frontend routes**: `dashboard-route.ts` — `loading()` signature, new `filteredArtistIds` state, new `filteredDateGroups` getter, URL sync
+- **Frontend components**: New `artist-filter-bar` component (header chips + bottom sheet); `dashboard-route.html` updated bindings
+- **Service Worker** (`sw.ts`): No changes needed — already passes `notification.data.url` through unchanged
+- **Backend (out of scope for this change)**: Push notification service must include `/dashboard?artists=<artistId>` in the notification payload URL

--- a/openspec/changes/archive/2026-04-01-dashboard-artist-filter/specs/dashboard-artist-filter/spec.md
+++ b/openspec/changes/archive/2026-04-01-dashboard-artist-filter/specs/dashboard-artist-filter/spec.md
@@ -1,0 +1,97 @@
+## ADDED Requirements
+
+### Requirement: URL-driven artist filter
+The dashboard SHALL accept an `artists` query parameter containing one or more artist IDs (comma-separated UUIDs). When present, only concerts belonging to the listed artists SHALL be displayed. When absent or empty, all followed-artist concerts SHALL be displayed as normal.
+
+#### Scenario: Single artist filter from URL
+- **WHEN** the user navigates to `/dashboard?artists=<artistId>`
+- **THEN** only concerts whose `artistId` matches `<artistId>` SHALL be shown in the concert highway
+
+#### Scenario: Multiple artist filter from URL
+- **WHEN** the user navigates to `/dashboard?artists=<id1>,<id2>`
+- **THEN** only concerts whose `artistId` is in `{id1, id2}` SHALL be shown in the concert highway
+
+#### Scenario: No filter — unfiltered view preserved
+- **WHEN** the user navigates to `/dashboard` (no `artists` param)
+- **THEN** all followed-artist concerts SHALL be displayed unchanged
+
+#### Scenario: Unknown artist ID in filter
+- **WHEN** an `artists` value contains an ID that does not match any followed artist
+- **THEN** that ID SHALL be silently ignored; concerts for remaining valid IDs SHALL still be shown
+
+#### Scenario: Filter yields empty result
+- **WHEN** the filtered artist set has no upcoming concerts
+- **THEN** the empty-state placeholder SHALL be displayed (same as the no-concerts state)
+
+### Requirement: Filter state synchronised with URL
+When the user changes the active filter via the UI, the dashboard URL SHALL be updated to reflect the new filter state without triggering a full page reload.
+
+#### Scenario: User adds an artist to the filter
+- **WHEN** the user selects an artist in the filter bottom sheet and confirms
+- **THEN** the browser URL SHALL update to `/dashboard?artists=<selectedIds>` via `history.replaceState`
+- **THEN** the concert highway SHALL immediately display only matching concerts
+
+#### Scenario: User removes a filter chip
+- **WHEN** the user taps the `×` on an active artist chip
+- **THEN** that artist SHALL be removed from `filteredArtistIds`
+- **THEN** the URL SHALL update accordingly (or revert to `/dashboard` if the list becomes empty)
+
+#### Scenario: All chips dismissed
+- **WHEN** the last active filter chip is dismissed
+- **THEN** the URL SHALL revert to `/dashboard` (no `artists` param)
+- **THEN** all followed-artist concerts SHALL be displayed
+
+#### Scenario: Page reload preserves filter
+- **WHEN** the user reloads the page while a filter is active
+- **THEN** the `artists` query param SHALL be re-parsed from the URL
+- **THEN** the same filtered view SHALL be restored
+
+### Requirement: Filter chip UI in page header
+The page header SHALL display a dismissible chip for each active artist filter. A trigger button SHALL always be available to open the artist-selection bottom sheet.
+
+#### Scenario: No active filter — header unchanged
+- **WHEN** `filteredArtistIds` is empty
+- **THEN** no filter chips SHALL be visible in the header
+- **THEN** a compact filter trigger button SHALL be visible
+
+#### Scenario: Active filter — chips displayed
+- **WHEN** `filteredArtistIds` contains one or more IDs
+- **THEN** one chip per artist SHALL appear in the header showing the artist name
+- **THEN** each chip SHALL have a `×` dismiss control
+
+#### Scenario: Long artist name overflow
+- **WHEN** an artist name exceeds available chip width
+- **THEN** the name SHALL be truncated with an ellipsis within the chip
+
+### Requirement: Artist-selection bottom sheet
+A bottom sheet SHALL allow the user to select one or more followed artists as a filter.
+
+#### Scenario: Opening the bottom sheet
+- **WHEN** the user taps the filter trigger button
+- **THEN** the bottom sheet SHALL open listing all followed artists
+
+#### Scenario: Pre-selecting current filter
+- **WHEN** the bottom sheet opens while a filter is already active
+- **THEN** the currently filtered artists SHALL be pre-selected in the list
+
+#### Scenario: Confirming selection
+- **WHEN** the user selects artists and taps the confirm button
+- **THEN** `filteredArtistIds` SHALL be updated to the selected set
+- **THEN** the bottom sheet SHALL close
+
+#### Scenario: Confirming empty selection
+- **WHEN** the user deselects all artists and confirms
+- **THEN** the filter SHALL be cleared (equivalent to no filter)
+
+### Requirement: Push notification deep-link to filtered dashboard
+Tapping a push notification that carries a `/dashboard?artists=<artistId>` URL SHALL open the dashboard pre-filtered to that artist.
+
+#### Scenario: Notification tap opens filtered dashboard
+- **WHEN** a push notification with `data.url = "/dashboard?artists=<artistId>"` is tapped
+- **THEN** the browser SHALL navigate to `/dashboard?artists=<artistId>`
+- **THEN** the dashboard SHALL display only concerts for `<artistId>`
+
+#### Scenario: Filter disabled during onboarding
+- **WHEN** the user is in the onboarding flow (lane intro active)
+- **THEN** the filter trigger button SHALL be hidden or disabled
+- **THEN** the `artists` query param SHALL be ignored until onboarding is complete

--- a/openspec/changes/archive/2026-04-01-dashboard-artist-filter/tasks.md
+++ b/openspec/changes/archive/2026-04-01-dashboard-artist-filter/tasks.md
@@ -1,0 +1,42 @@
+## 1. Dashboard Route — Filter State & URL Parsing
+
+- [x] 1.1 Add `filteredArtistIds: string[]` as an `@observable` property to `DashboardRoute`
+- [x] 1.2 Update `loading(_params, next: RouteNode)` to read `next.queryParams.get('artists')?.split(',').filter(Boolean) ?? []` and assign to `filteredArtistIds`
+- [x] 1.3 Add `get filteredDateGroups(): DateGroup[]` computed getter — returns `dateGroups` unchanged when `filteredArtistIds` is empty; otherwise filters each group's `home`/`nearby`/`away` arrays by `artistId` and drops empty groups
+- [x] 1.4 Add `updateFilterUrl()` private method using `IHistory.replaceState` to sync URL to `/dashboard` or `/dashboard?artists=id1,id2`
+- [x] 1.5 Add `filteredArtistIdsChanged()` change handler that calls `updateFilterUrl()`
+- [x] 1.6 Inject `IHistory` into `DashboardRoute`
+
+## 2. Dashboard Route — Onboarding Guard
+
+- [x] 2.1 Suppress reading `?artists` param (keep `filteredArtistIds` empty) when `isOnboarding` is true in `loading()`
+
+## 3. `artist-filter-bar` Component
+
+- [x] 3.1 Create `src/components/artist-filter-bar/artist-filter-bar.ts` with two bindables: `followedArtists: Artist[]` and `selectedIds: string[]` (two-way)
+- [x] 3.2 Create `src/components/artist-filter-bar/artist-filter-bar.html` — renders dismissible chips for each selected artist, plus a trigger button (`≡`) to open the bottom sheet
+- [x] 3.3 Create `src/components/artist-filter-bar/artist-filter-bar.css` — chip styles (CUBE CSS, `max-width` + `text-overflow: ellipsis`), trigger button styles; follow design-system tokens
+- [x] 3.4 Implement bottom sheet markup inside `artist-filter-bar.html` using the existing `bottom-sheet` primitive; list all `followedArtists` as checkboxes pre-selected by `selectedIds`
+- [x] 3.5 Implement confirm handler: update `selectedIds` binding and close the sheet
+- [x] 3.6 Register `artist-filter-bar` in `main.ts` (global custom element)
+
+## 4. Dashboard Template — Integrate Filter Bar
+
+- [x] 4.1 Change `<concert-highway date-groups.bind="dateGroups">` to `date-groups.bind="filteredDateGroups"` in `dashboard-route.html`
+- [x] 4.2 Add `<artist-filter-bar>` inside `<page-header>` slot (or adjacent) with bindings: `followed-artists.bind="followedArtists"` and `selected-ids.two-way="filteredArtistIds"`
+- [x] 4.3 Expose `get followedArtists(): Artist[]` getter on `DashboardRoute` from `followService.followedArtists`
+- [x] 4.4 Hide/disable the filter bar while `isOnboarding` is true (`if.bind="!isOnboarding"` or `disabled.bind`)
+
+## 5. Tests
+
+- [x] 5.1 Unit test `filteredDateGroups` getter: empty filter returns all groups; single-artist filter returns only matching concerts; filter with unknown ID returns empty groups correctly
+- [x] 5.2 Unit test `updateFilterUrl()`: empty `filteredArtistIds` produces `/dashboard`; non-empty produces `/dashboard?artists=id1,id2`
+- [x] 5.3 Unit test `loading()` query param parsing: `?artists=id1,id2` sets `filteredArtistIds`; absent param sets empty array; onboarding active ignores param
+- [x] 5.4 Component smoke test for `artist-filter-bar`: renders chips for selected IDs; chip dismiss updates `selectedIds`; confirm updates binding
+
+## 6. Verification
+
+- [x] 6.1 Run `make check` (lint + typecheck + unit tests) — all pass
+- [ ] 6.2 Manual smoke: navigate to `/dashboard?artists=<realId>` — highway shows only that artist's concerts
+- [ ] 6.3 Manual smoke: add/remove artists via UI — chips update, URL updates, highway re-filters
+- [ ] 6.4 Manual smoke: reload page with active filter — filter is restored from URL

--- a/openspec/specs/dashboard-artist-filter/spec.md
+++ b/openspec/specs/dashboard-artist-filter/spec.md
@@ -1,0 +1,95 @@
+### Requirement: URL-driven artist filter
+The dashboard SHALL accept an `artists` query parameter containing one or more artist IDs (comma-separated UUIDs). When present, only concerts belonging to the listed artists SHALL be displayed. When absent or empty, all followed-artist concerts SHALL be displayed as normal.
+
+#### Scenario: Single artist filter from URL
+- **WHEN** the user navigates to `/dashboard?artists=<artistId>`
+- **THEN** only concerts whose `artistId` matches `<artistId>` SHALL be shown in the concert highway
+
+#### Scenario: Multiple artist filter from URL
+- **WHEN** the user navigates to `/dashboard?artists=<id1>,<id2>`
+- **THEN** only concerts whose `artistId` is in `{id1, id2}` SHALL be shown in the concert highway
+
+#### Scenario: No filter — unfiltered view preserved
+- **WHEN** the user navigates to `/dashboard` (no `artists` param)
+- **THEN** all followed-artist concerts SHALL be displayed unchanged
+
+#### Scenario: Unknown artist ID in filter
+- **WHEN** an `artists` value contains an ID that does not match any followed artist
+- **THEN** that ID SHALL be silently ignored; concerts for remaining valid IDs SHALL still be shown
+
+#### Scenario: Filter yields empty result
+- **WHEN** the filtered artist set has no upcoming concerts
+- **THEN** the empty-state placeholder SHALL be displayed (same as the no-concerts state)
+
+### Requirement: Filter state synchronised with URL
+When the user changes the active filter via the UI, the dashboard URL SHALL be updated to reflect the new filter state without triggering a full page reload.
+
+#### Scenario: User adds an artist to the filter
+- **WHEN** the user selects an artist in the filter bottom sheet and confirms
+- **THEN** the browser URL SHALL update to `/dashboard?artists=<selectedIds>` via `history.replaceState`
+- **THEN** the concert highway SHALL immediately display only matching concerts
+
+#### Scenario: User removes a filter chip
+- **WHEN** the user taps the `×` on an active artist chip
+- **THEN** that artist SHALL be removed from `filteredArtistIds`
+- **THEN** the URL SHALL update accordingly (or revert to `/dashboard` if the list becomes empty)
+
+#### Scenario: All chips dismissed
+- **WHEN** the last active filter chip is dismissed
+- **THEN** the URL SHALL revert to `/dashboard` (no `artists` param)
+- **THEN** all followed-artist concerts SHALL be displayed
+
+#### Scenario: Page reload preserves filter
+- **WHEN** the user reloads the page while a filter is active
+- **THEN** the `artists` query param SHALL be re-parsed from the URL
+- **THEN** the same filtered view SHALL be restored
+
+### Requirement: Filter chip UI in page header
+The page header SHALL display a dismissible chip for each active artist filter. A trigger button SHALL always be available to open the artist-selection bottom sheet.
+
+#### Scenario: No active filter — header unchanged
+- **WHEN** `filteredArtistIds` is empty
+- **THEN** no filter chips SHALL be visible in the header
+- **THEN** a compact filter trigger button SHALL be visible
+
+#### Scenario: Active filter — chips displayed
+- **WHEN** `filteredArtistIds` contains one or more IDs
+- **THEN** one chip per artist SHALL appear in the header showing the artist name
+- **THEN** each chip SHALL have a `×` dismiss control
+
+#### Scenario: Long artist name overflow
+- **WHEN** an artist name exceeds available chip width
+- **THEN** the name SHALL be truncated with an ellipsis within the chip
+
+### Requirement: Artist-selection bottom sheet
+A bottom sheet SHALL allow the user to select one or more followed artists as a filter.
+
+#### Scenario: Opening the bottom sheet
+- **WHEN** the user taps the filter trigger button
+- **THEN** the bottom sheet SHALL open listing all followed artists
+
+#### Scenario: Pre-selecting current filter
+- **WHEN** the bottom sheet opens while a filter is already active
+- **THEN** the currently filtered artists SHALL be pre-selected in the list
+
+#### Scenario: Confirming selection
+- **WHEN** the user selects artists and taps the confirm button
+- **THEN** `filteredArtistIds` SHALL be updated to the selected set
+- **THEN** the bottom sheet SHALL close
+
+#### Scenario: Confirming empty selection
+- **WHEN** the user deselects all artists and confirms
+- **THEN** the filter SHALL be cleared (equivalent to no filter)
+
+### Requirement: Push notification deep-link to filtered dashboard
+Tapping a push notification that carries a `/dashboard?artists=<artistId>` URL SHALL open the dashboard pre-filtered to that artist.
+
+#### Scenario: Notification tap opens filtered dashboard
+- **WHEN** a push notification with `data.url = "/dashboard?artists=<artistId>"` is tapped
+- **THEN** the browser SHALL navigate to `/dashboard?artists=<artistId>`
+- **THEN** the dashboard SHALL display only concerts for `<artistId>`
+
+#### Scenario: Filter disabled during onboarding
+- **WHEN** the user is in the onboarding flow (lane intro active)
+- **THEN** the filter trigger button SHALL be hidden or disabled
+- **THEN** the `artists` query param SHALL be ignored until onboarding is complete


### PR DESCRIPTION
## Summary

- Adds `openspec/specs/dashboard-artist-filter/spec.md` as a new capability spec
- Archives the change artifacts to `openspec/changes/archive/2026-04-01-dashboard-artist-filter/`

## Spec: dashboard-artist-filter

4 requirements / 17 scenarios covering:

1. **URL-driven artist filter** — `?artists=id1,id2` query param; single/multi/unknown/empty-result scenarios
2. **Filter state synchronised with URL** — `history.replaceState` sync on add/remove/clear; reload persistence
3. **Filter chip UI in page header** — dismissible chips, trigger button, ellipsis overflow
4. **Artist-selection bottom sheet** — open/pre-select/confirm/clear selection
5. **Push notification deep-link** — notification tap with `data.url = "/dashboard?artists=<id>"` opens filtered view; filter disabled during onboarding

## Implementation

Implemented in liverty-music/frontend#316.

close: #316
