### PR TITLE
docs(spec): archive pwa-install-fab and sync capability specs

### DIFF
--- a/openspec/changes/archive/2026-04-01-pwa-install-fab/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-01-pwa-install-fab/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-31

--- a/openspec/changes/archive/2026-04-01-pwa-install-fab/design.md
+++ b/openspec/changes/archive/2026-04-01-pwa-install-fab/design.md
@@ -1,0 +1,96 @@
+## Context
+
+The current PWA install mechanism is a `pwa-install-prompt` Toast component mounted in `app-shell.html`. It is gated by: `beforeinstallprompt` fired, not dismissed, onboarding completed, **authenticated**, and `sessionCount >= completedSessionCount + 2`. This design excludes guest users entirely and delays the prompt by at least 2 sessions after completion — both constraints that no longer serve the product goal of maximizing PWA adoption.
+
+The `signup-prompt-banner` is a `position: fixed` bar that sits flush above the Nav Bar (`inset-block-end: calc(3.5rem + env(safe-area-inset-bottom, 0px))`). When both are visible, a naive FAB placement would either overlap the banner or require dynamic offset calculation.
+
+The app shell uses a `grid` layout (`viewport` / `nav`) with overlay components positioned via `position: fixed` and `block-size: 0` to stay out of the grid flow.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Surface a persistent, discoverable PWA install entry point to all users (guest + authenticated) once onboarding completes
+- Support both Android/Chrome (`beforeinstallprompt`) and iOS Safari (manual instruction sheet via `bottom-sheet`)
+- Overlay naturally alongside `signup-prompt-banner` without layout calculation
+- Animate subtly on first appearance; remain passive thereafter
+- Disappear permanently on install (`appinstalled` event)
+
+**Non-Goals:**
+- Desktop browser support (FAB targets mobile PWA install)
+- Replacing the `PostSignupDialog` PWA install row — it stays as a parallel path for authenticated first-signup flow
+- Supporting Firefox (no `beforeinstallprompt`, no significant mobile market share for this use case)
+- Re-showing the FAB after the user navigates away and returns (it is always visible post-completion until installed)
+
+## Decisions
+
+### Decision 1: FAB overlaid on signup-banner button row, not above it
+
+**Chosen:** `position: fixed` FAB placed at the same `inset-block-end` as the signup-banner's button row (approximately `calc(3.5rem + env(safe-area-inset-bottom) + var(--space-s))` from the bottom), aligned `inset-inline-end: var(--space-s)`. The banner's "アカウント作成" button is `align-self: center` with `padding-inline: var(--space-xl)`, leaving clear horizontal space on both sides.
+
+**Alternatives considered:**
+- *Dynamic offset via ResizeObserver*: Accurate but adds JS complexity and a layout-read/write cycle every time the banner's height changes.
+- *FAB above the banner*: Requires knowing the banner's rendered height, which varies with text wrapping. Same ResizeObserver problem.
+- *Hide FAB when banner is visible*: Eliminates competition but means guest users — the primary signup-banner audience — never see the FAB.
+
+**Rationale:** The overlay approach is zero-complexity, visually clean (FAB is compact), and the spatial separation from the dismiss button (top-right of banner) is sufficient to avoid tap target collision. If the button label wraps, the FAB may shift relative to the button row, but remains within the banner's safe zone.
+
+### Decision 2: Remove auth and session-count gates from PwaInstallService
+
+**Chosen:** Eligibility reduced to: `beforeinstallprompt` fired AND onboarding completed AND not yet installed. Auth state and session count removed.
+
+**Alternatives considered:**
+- *Keep session-count gate, extend to guests*: Delays install prompt unnecessarily. The original session-count rationale was to give the notification prompt a first-session window — but with the FAB being passive (not a disruptive Toast), this concern is moot.
+- *Keep auth gate*: Excludes the guest users this feature is specifically designed to reach.
+
+**Rationale:** The FAB is non-intrusive (no dismiss needed, no "only one prompt per session" pressure). The old gates were designed for disruptive Toasts. With a passive persistent UI element, the right gate is simply "has the user seen enough of the app to understand its value" — which onboarding completion captures cleanly.
+
+### Decision 3: iOS instruction sheet uses existing bottom-sheet component
+
+**Chosen:** On iOS (detected via `!('BeforeInstallPromptEvent' in window)` and user-agent check), tapping the FAB opens the existing `bottom-sheet` component with a static 3-step instruction list.
+
+**Alternatives considered:**
+- *Custom modal*: Adds a new component primitive for a single use case.
+- *Toast with instructions*: Too small for multi-step instructions.
+
+**Rationale:** `bottom-sheet` already handles popover lifecycle, dismiss, accessibility, and `prefers-reduced-motion`. Reuse is the right call.
+
+### Decision 4: Retire the existing pwa-install-prompt Toast
+
+**Chosen:** `pwa-install-prompt` component and its `if.bind="showNav"` mount in `app-shell.html` are removed. `PwaInstallService.dismiss()` and `StorageKeys.pwaInstallPromptDismissed` are also removed.
+
+**Alternatives considered:**
+- *Keep Toast as fallback*: Two install paths with diverging logic creates confusion and test surface.
+
+**Rationale:** The FAB supersedes the Toast entirely. `PostSignupDialog` retains its own install button as a contextual path; that is sufficient as a secondary surface.
+
+### Decision 5a: FAB visibility binding — `show.bind` + `aria-hidden` instead of `if.bind`
+
+**Chosen:** The FAB `<button>` uses `show.bind="isVisible"` combined with `aria-hidden.bind="isVisible ? 'false' : 'true'"` to control visibility.
+
+**Alternatives considered:**
+- *`if.bind="isVisible"`*: Removes the element from the DOM entirely when invisible, which means assistive technology (AT) cannot discover the element before it becomes visible.
+
+**Rationale:** `show.bind` sets `display: none` but keeps the node in the DOM and the accessibility tree. This allows screen readers and AT to discover the button's existence via a tree walk even before it becomes interactive. The `aria-hidden` attribute gates actual AT exposure: `aria-hidden="true"` when hidden (so AT ignores it), `aria-hidden="false"` when visible (so AT announces it). This pattern satisfies both the "no premature AT announcement" and "discoverable in advance" requirements.
+
+### Decision 5b: Entry animation — slide-up + 2-pulse ripple, then static
+
+**Chosen:** On first render (controlled by a one-shot CSS class added after `attached()`):
+- FAB slides up: `transform: translateY(150%) → translateY(0)`, 400ms ease-out
+- After slide completes, a ripple ring animates outward and fades — `animation-iteration-count: 2`, then stops
+- Idle state: brand gradient `box-shadow` glow (matching Nav Bar top border gradient), no loop
+- Tap: `transform: scale(0.92)` for 50ms, then `scale(1)` for 100ms
+- `@media (prefers-reduced-motion: reduce)`: replace slide+ripple with `opacity: 0 → 1` fade only
+
+**Rationale:** UX guideline — continuous animations on decorative elements are distracting. The 2-pulse fires once on entry to attract attention, then stops. The static gradient glow provides brand coherence without motion.
+
+## Risks / Trade-offs
+
+- **iOS detection reliability**: User-agent sniffing is fragile. Prefer feature detection (`'BeforeInstallPromptEvent' in window` is false on iOS). This is reliable for the current Safari versions.
+- **FAB tap target near dismiss button**: The `×` dismiss of the signup-banner is top-right; the FAB is bottom-right of the banner. On very short viewports the gap may be tight. Minimum 44px touch target for each must be verified during implementation.
+- **`beforeinstallprompt` not fired on desktop**: FAB will not appear on desktop Chrome if the app does not meet installability criteria. This is acceptable — the FAB is a mobile-first feature.
+- **PostSignupDialog PWA row still uses `pwaInstall.canShow`**: After this change, `canShow` no longer requires auth or session count. The dialog row will now show on first signup session if `beforeinstallprompt` has fired. This is a behavior change — slightly more aggressive, but acceptable given the simplified model.
+
+## Open Questions
+
+- Should the FAB also appear during the `MY_ARTISTS` onboarding step (just before completion), or strictly after `COMPLETED`? Current design: strictly after `COMPLETED` to avoid distraction during the guided flow.
+- Should there be a maximum number of sessions after which the FAB is hidden even if not installed? Current design: no max — the FAB stays until installed. If this feels too persistent, a cap (e.g., 30 sessions) can be added later.

--- a/openspec/changes/archive/2026-04-01-pwa-install-fab/proposal.md
+++ b/openspec/changes/archive/2026-04-01-pwa-install-fab/proposal.md
@@ -1,0 +1,35 @@
+## Why
+
+After onboarding completes, users have no persistent, low-friction path to install the PWA. The existing Toast-based install prompt is a one-shot mechanism that fires only for authenticated users on the second session after completion — missing the peak motivation moment and entirely excluding guest users. A persistent FAB on the Nav Bar surface gives every user (guest or authenticated) a discoverable, non-intrusive install entry point from the moment they first experience the app's value.
+
+## What Changes
+
+- Add a `pwa-install-fab` component: a persistent floating action button anchored above the Nav Bar (right side), visible after `OnboardingStep.COMPLETED` for all users regardless of auth state
+- On Android/Chrome: tapping the FAB triggers `beforeinstallprompt.prompt()` directly
+- On iOS Safari: tapping the FAB opens a `bottom-sheet` with step-by-step "Add to Home Screen" instructions (Safari share icon → "ホーム画面に追加")
+- FAB disappears permanently once the app is installed (`appinstalled` event)
+- Remove the `dismiss` mechanism from `PwaInstallService` — with a persistent passive FAB, one-shot dismissal is no longer the right model
+- Remove auth and session-count gating from PWA install eligibility — replaced by onboarding completion only
+- When `signup-prompt-banner` is visible, the FAB overlays the banner's button row (right side), using the horizontal whitespace beside the "アカウント作成" button — no position offset calculation needed
+- Entry animation: slide-up on first appearance + 2-pulse ripple ring; idle state: brand gradient glow; tap: scale press feedback
+
+## Capabilities
+
+### New Capabilities
+
+- `pwa-install-fab`: Persistent FAB component for PWA install, post-onboarding, guest and authenticated users; includes iOS instruction sheet
+
+### Modified Capabilities
+
+- `prompt-timing`: Remove auth and session-count requirements for PWA install prompt; onboarding completion is the sole eligibility gate
+- `post-signup-dialog`: PWA install row in PostSignupDialog remains, but now relies on `pwa-install-fab` service state rather than the old session-count gate
+
+## Impact
+
+- **Frontend only** — all changes in `frontend/src/`
+- Files affected:
+  - `src/components/pwa-install-fab/` — new component (FAB + iOS instruction sheet)
+  - `src/services/pwa-install-service.ts` — remove dismiss, remove auth/session-count gate, add `appinstalled` listener, expose iOS detection
+  - `src/app-shell.html` / `src/app-shell.css` — mount FAB alongside existing overlays
+  - `src/components/pwa-install-prompt/` — existing Toast prompt can be retired (or kept as fallback — decision in design)
+- No API, backend, proto, or infrastructure changes

--- a/openspec/changes/archive/2026-04-01-pwa-install-fab/specs/post-signup-dialog/spec.md
+++ b/openspec/changes/archive/2026-04-01-pwa-install-fab/specs/post-signup-dialog/spec.md
@@ -1,0 +1,48 @@
+## MODIFIED Requirements
+
+### Requirement: Post-Signup Dialog on First Authentication
+
+The system SHALL display a dialog after the first successful signup that consolidates notification permission and PWA install prompts.
+
+#### Scenario: Dialog shown after first signup
+
+- **WHEN** the auth-callback route completes `provisionUser()` for a new user
+- **AND** `localStorage['liverty:postSignup:shown']` is not set
+- **THEN** the system SHALL set `localStorage['liverty:postSignup:shown']` to `'1'`
+- **AND** the system SHALL navigate to `/dashboard`
+- **AND** the Dashboard SHALL display the `PostSignupDialog` on load
+
+#### Scenario: Dialog not shown on subsequent logins
+
+- **WHEN** the auth-callback route completes for a returning user
+- **AND** `localStorage['liverty:postSignup:shown']` is already set
+- **THEN** the system SHALL NOT show the `PostSignupDialog`
+
+#### Scenario: Dialog content
+
+- **WHEN** the PostSignupDialog is displayed
+- **THEN** it SHALL show a success confirmation (アカウント登録完了！)
+- **AND** it SHALL offer a notification opt-in action (新着ライブ通知をオンにしよう)
+- **AND** it SHALL offer a PWA install action (ホーム画面に追加するとより快適に) if `PwaInstallService.canShowFab` is `true`
+- **AND** it SHALL provide a dismiss action (あとで)
+
+#### Scenario: Notification opt-in from dialog
+
+- **WHEN** the user taps the notification opt-in button in the PostSignupDialog
+- **THEN** the system SHALL call `PushService.subscribe()`
+- **AND** on success, the notification row SHALL show a confirmed state
+- **AND** on failure or denial, the notification row SHALL show an error state
+
+#### Scenario: PWA install from dialog
+
+- **WHEN** the user taps the PWA install button in the PostSignupDialog
+- **AND** `beforeinstallprompt` has fired
+- **THEN** the system SHALL trigger the deferred `beforeinstallprompt` event
+- **AND** if the event is not available (already installed, iOS, or not supported), the button SHALL be hidden
+
+#### Scenario: Dialog dismissed
+
+- **WHEN** the user taps あとで
+- **THEN** the PostSignupDialog SHALL close
+- **AND** the notification prompt SHALL NOT be shown again in the same session (coordinated via `IPromptCoordinator`)
+- **AND** the PWA install FAB SHALL remain visible (it is not affected by PostSignupDialog dismissal)

--- a/openspec/changes/archive/2026-04-01-pwa-install-fab/specs/prompt-timing/spec.md
+++ b/openspec/changes/archive/2026-04-01-pwa-install-fab/specs/prompt-timing/spec.md
@@ -1,0 +1,76 @@
+## MODIFIED Requirements
+
+### Requirement: PWA Install Prompt Blocked During Onboarding
+
+The system SHALL NOT display the PWA install FAB while the user is in active onboarding steps (DISCOVERY, DASHBOARD, MY_ARTISTS).
+
+#### Scenario: User is mid-tutorial on the dashboard
+
+- **WHEN** the user is at onboarding step DASHBOARD
+- **AND** the browser fires the `beforeinstallprompt` event
+- **THEN** the system SHALL capture the event
+- **AND** the system SHALL NOT display the PWA install FAB
+- **AND** `PwaInstallService.canShowFab` SHALL remain `false`
+
+#### Scenario: User has not started onboarding (LP step)
+
+- **WHEN** the user is at onboarding step LP
+- **AND** the browser fires the `beforeinstallprompt` event
+- **THEN** the system SHALL NOT display the PWA install FAB
+
+---
+
+### Requirement: PWA Install FAB Eligible After Onboarding Completion
+
+The PWA install FAB SHALL be eligible immediately after onboarding completion, regardless of authentication state or session count.
+
+#### Scenario: First session after completion — guest user
+
+- **WHEN** the user has completed onboarding
+- **AND** the user is NOT authenticated
+- **AND** `beforeinstallprompt` has fired OR the platform is iOS Safari
+- **THEN** the system SHALL display the PWA install FAB
+
+#### Scenario: First session after completion — authenticated user
+
+- **WHEN** the user has completed onboarding
+- **AND** the user is authenticated
+- **AND** `beforeinstallprompt` has fired OR the platform is iOS Safari
+- **THEN** the system SHALL display the PWA install FAB
+
+#### Scenario: Completion within the same session
+
+- **WHEN** the user transitions to `OnboardingStep.COMPLETED` within the current session
+- **THEN** the FAB SHALL become visible immediately in that same session
+
+---
+
+## REMOVED Requirements
+
+### Requirement: PWA Install Prompt Deferred to Second Post-Completion Session
+
+**Reason**: The FAB is a passive persistent element, not a disruptive Toast. The session-count deferral was designed to give the notification prompt a first-session window, which only applies to the Toast-based prompt. The FAB does not compete with the notification prompt for screen space or attention.
+
+**Migration**: The `StorageKeys.pwaCompletedSessionCount` and `StorageKeys.pwaSessionCount` localStorage keys are no longer written or read by `PwaInstallService`. Existing values are ignored and will be cleaned up lazily.
+
+#### Scenario: Second session after completion
+
+- **WHEN** the user is on the second or later session after onboarding completion
+- **AND** the `beforeinstallprompt` event has fired
+- **AND** the PWA install prompt has not been dismissed
+- **AND** no other prompt has been shown this session
+- **THEN** the system SHALL display the PWA install prompt
+
+---
+
+### Requirement: Dismissed Prompts Do Not Reappear (PWA install only)
+
+**Reason**: The FAB has no dismiss action. It is a passive UI element that remains visible until the app is installed. The concept of "dismissing" the install prompt does not apply to the FAB model.
+
+**Migration**: `StorageKeys.pwaInstallPromptDismissed` is no longer written or read. The `PwaInstallService.dismiss()` method is removed. Existing dismissed state in localStorage is ignored.
+
+#### Scenario: User dismisses PWA install prompt
+
+- **WHEN** the user taps the dismiss control on the PWA install prompt
+- **THEN** the system SHALL write the dismissal to LocalStorage
+- **AND** the PWA install prompt SHALL NOT appear on subsequent sessions

--- a/openspec/changes/archive/2026-04-01-pwa-install-fab/specs/pwa-install-fab/spec.md
+++ b/openspec/changes/archive/2026-04-01-pwa-install-fab/specs/pwa-install-fab/spec.md
@@ -1,0 +1,115 @@
+## ADDED Requirements
+
+### Requirement: FAB Visible After Onboarding Completion
+
+The system SHALL display a persistent PWA install FAB in the bottom-right corner of the screen, anchored above the Nav Bar, once onboarding is completed — regardless of authentication state.
+
+#### Scenario: Guest user completes onboarding
+
+- **WHEN** the user completes the onboarding flow (`OnboardingStep.COMPLETED`)
+- **AND** the user is not authenticated
+- **AND** the app has not been installed
+- **THEN** the system SHALL display the PWA install FAB
+
+#### Scenario: Authenticated user completes onboarding
+
+- **WHEN** the user completes the onboarding flow
+- **AND** the user is authenticated
+- **AND** the app has not been installed
+- **THEN** the system SHALL display the PWA install FAB
+
+#### Scenario: FAB not shown during onboarding
+
+- **WHEN** the user is in any active onboarding step (DISCOVERY, DASHBOARD, MY_ARTISTS)
+- **THEN** the system SHALL NOT display the PWA install FAB
+
+---
+
+### Requirement: FAB Install Behavior by Platform
+
+The FAB SHALL trigger the appropriate install flow based on the user's platform.
+
+#### Scenario: Android/Chrome — native install prompt
+
+- **WHEN** the user taps the FAB
+- **AND** the browser has fired `beforeinstallprompt`
+- **THEN** the system SHALL call `deferredPrompt.prompt()`
+- **AND** the native browser install dialog SHALL appear
+
+#### Scenario: iOS Safari — instruction sheet
+
+- **WHEN** the user taps the FAB
+- **AND** the browser has NOT fired `beforeinstallprompt` (iOS Safari)
+- **THEN** the system SHALL open a `bottom-sheet` component
+- **AND** the sheet SHALL display step-by-step instructions:
+  1. Safari の共有ボタン（□↑）をタップ
+  2.「ホーム画面に追加」を選択
+  3.「追加」をタップ
+- **AND** the sheet SHALL provide a single dismiss action (閉じる)
+
+#### Scenario: iOS instruction sheet dismissed
+
+- **WHEN** the user taps 閉じる on the iOS instruction sheet
+- **THEN** the sheet SHALL close
+- **AND** the FAB SHALL remain visible
+
+---
+
+### Requirement: FAB Disappears After Installation
+
+The system SHALL remove the FAB permanently once the app is installed.
+
+#### Scenario: App installed via FAB
+
+- **WHEN** the browser fires the `appinstalled` event
+- **THEN** the system SHALL hide the FAB
+- **AND** the FAB SHALL NOT reappear in subsequent sessions
+
+#### Scenario: App already installed on load
+
+- **WHEN** the app loads
+- **AND** `navigator.standalone` is `true` (iOS) OR the display mode matches `standalone` (Android)
+- **THEN** the system SHALL NOT display the FAB
+
+---
+
+### Requirement: FAB Entry Animation
+
+The FAB SHALL animate on first appearance to draw user attention, then remain static.
+
+#### Scenario: First appearance animation
+
+- **WHEN** the FAB becomes visible for the first time in a session
+- **THEN** the system SHALL animate the FAB sliding up from below (`translateY(150%) → translateY(0)`, 400ms ease-out)
+- **AND** after the slide completes, a ripple ring SHALL animate outward and fade exactly 2 times, then stop
+- **AND** the idle state SHALL show a brand gradient glow via `box-shadow` (no looping animation)
+
+#### Scenario: Reduced motion
+
+- **WHEN** `prefers-reduced-motion: reduce` is set
+- **THEN** the system SHALL replace the slide-up and ripple with a simple `opacity: 0 → 1` fade
+
+#### Scenario: Tap feedback
+
+- **WHEN** the user taps the FAB
+- **THEN** the FAB SHALL briefly scale down (`scale(0.92)` for 50ms) then return to `scale(1)` over 100ms
+
+---
+
+### Requirement: FAB Position When signup-prompt-banner Is Visible
+
+When the `signup-prompt-banner` is displayed, the FAB SHALL be overlaid on the banner's button row in the right-side whitespace.
+
+#### Scenario: Both FAB and signup-banner visible
+
+- **WHEN** the FAB is visible
+- **AND** the `signup-prompt-banner` is visible
+- **THEN** the FAB SHALL be positioned in the right whitespace of the banner's button row
+- **AND** the FAB SHALL NOT obscure the "アカウント作成" button or the banner's dismiss button
+- **AND** both elements SHALL maintain a minimum 44px touch target
+
+#### Scenario: Only FAB visible (no banner)
+
+- **WHEN** the FAB is visible
+- **AND** the `signup-prompt-banner` is not visible
+- **THEN** the FAB SHALL be positioned above the Nav Bar with `inset-inline-end: var(--space-s)` and `inset-block-end: calc(3.5rem + env(safe-area-inset-bottom, 0px) + var(--space-s))`

--- a/openspec/changes/archive/2026-04-01-pwa-install-fab/tasks.md
+++ b/openspec/changes/archive/2026-04-01-pwa-install-fab/tasks.md
@@ -1,0 +1,46 @@
+## 1. PwaInstallService Refactor
+
+- [x] 1.1 Remove `dismiss()` method and `StorageKeys.pwaInstallPromptDismissed` read/write from `PwaInstallService`
+- [x] 1.2 Remove `incrementSessionCount()`, `persistCompletedSessionCountIfNeeded()`, and related session-count logic from `PwaInstallService`
+- [x] 1.3 Remove `auth.isAuthenticated` gate from `evaluateVisibility()`
+- [x] 1.4 Remove `promptCoordinator.canShowPrompt('pwa-install')` gate and `markShown('pwa-install')` call from `evaluateVisibility()`
+- [x] 1.5 Add `appinstalled` event listener in `PwaInstallService` constructor; on fire set `canShow = false` and persist installed state to localStorage (`StorageKeys.pwaInstalled`)
+- [x] 1.6 Add installed-state check on init: if `StorageKeys.pwaInstalled === 'true'` or `navigator.standalone === true` or `matchMedia('(display-mode: standalone)').matches`, set `canShow = false` permanently
+- [x] 1.7 Add iOS detection property `get isIos(): boolean` using `!('BeforeInstallPromptEvent' in window)` combined with userAgent check for Safari
+- [x] 1.8 Expose `canShowFab` as the public observable (rename from `canShow` or alias); `canShowFab` is `true` when `onboarding.isCompleted && !installed && (deferredPrompt !== null || isIos)`
+- [x] 1.9 Update unit tests for `PwaInstallService` to cover new eligibility logic
+
+## 2. pwa-install-fab Component
+
+- [x] 2.1 Create `src/components/pwa-install-fab/pwa-install-fab.ts` — inject `IPwaInstallService`; expose `isVisible`, `isIos`, `isSheetOpen`; implement `handleTap()` (branch on `isIos`), `handleInstall()`, `closeSheet()`
+- [x] 2.2 Create `src/components/pwa-install-fab/pwa-install-fab.html` — FAB button with download SVG icon; conditional `<bottom-sheet>` for iOS instructions (3-step list + 閉じる button)
+- [x] 2.3 Create `src/components/pwa-install-fab/pwa-install-fab.css` — `position: fixed`, `inset-inline-end: var(--space-s)`, `inset-block-end: calc(3.5rem + env(safe-area-inset-bottom, 0px) + var(--space-s))`; brand gradient `box-shadow` glow; entry animation (`slide-up` + `ripple-pulse` 2 iterations); tap `scale(0.92)` feedback; `prefers-reduced-motion` fallback to fade
+- [x] 2.4 Add i18n keys for FAB aria-label and iOS instruction sheet content (ja + en)
+- [x] 2.5 Write unit tests for `pwa-install-fab` component (visibility binding, tap routing by platform, sheet open/close)
+
+## 3. App Shell Integration
+
+- [x] 3.1 Add `<import from="./components/pwa-install-fab/pwa-install-fab">` to `app-shell.html`
+- [x] 3.2 Mount `<pwa-install-fab if.bind="showNav"></pwa-install-fab>` in `app-shell.html` alongside existing overlays
+- [x] 3.3 Add `pwa-install-fab` to the `position: fixed; block-size: 0` overlay rule in `app-shell.css` to keep it out of the grid flow
+
+## 4. Retire pwa-install-prompt Toast
+
+- [x] 4.1 Remove `<pwa-install-prompt if.bind="showNav">` from `app-shell.html`
+- [x] 4.2 Remove `<import>` for `pwa-install-prompt` from `app-shell.html`
+- [x] 4.3 Delete `src/components/pwa-install-prompt/` directory (component + tests)
+- [x] 4.4 Remove `pwa-install-prompt` from `app-shell.css` overlay rule
+- [x] 4.5 Remove `StorageKeys.pwaSessionCount` and `StorageKeys.pwaCompletedSessionCount` from `storage-keys.ts`
+
+## 5. PostSignupDialog Update
+
+- [x] 5.1 Update `PostSignupDialog.canInstallPwa` getter to use `pwaInstall.canShowFab` (rename if needed)
+- [x] 5.2 Update `PostSignupDialog.activeChanged()` to no longer call `promptCoordinator.markShown('pwa-install')` — FAB is not suppressed by dialog dismissal
+- [x] 5.3 Verify iOS case: on iOS, `canShowFab` is `true` (no `deferredPrompt` needed), so `onInstallPwa()` in the dialog should either open the iOS sheet or be hidden — update dialog logic accordingly
+- [x] 5.4 Update `PostSignupDialog` unit tests
+
+## 6. Cleanup
+
+- [x] 6.1 Remove `StorageKeys.pwaInstallPromptDismissed` from `storage-keys.ts`
+- [x] 6.2 Search codebase for any remaining references to removed storage keys and clean up
+- [x] 6.3 Run `make check` and fix any lint/type errors

--- a/openspec/specs/post-signup-dialog/spec.md
+++ b/openspec/specs/post-signup-dialog/spec.md
@@ -29,7 +29,7 @@ The system SHALL display a dialog after the first successful signup that consoli
 - **WHEN** the PostSignupDialog is displayed
 - **THEN** it SHALL show a success confirmation (アカウント登録完了！)
 - **AND** it SHALL offer a notification opt-in action (新着ライブ通知をオンにしよう)
-- **AND** it SHALL offer a PWA install action (ホーム画面に追加するとより快適に) if `PwaInstallService.canShowFab` is `true`
+- **AND** it SHALL offer a PWA install action (ホーム画面に追加するとより快適に) if `PwaInstallService.canShowFab` is `true` AND the platform is not iOS Safari (iOS users use the persistent FAB instruction sheet instead)
 - **AND** it SHALL provide a dismiss action (あとで)
 
 #### Scenario: Notification opt-in from dialog
@@ -39,12 +39,18 @@ The system SHALL display a dialog after the first successful signup that consoli
 - **AND** on success, the notification row SHALL show a confirmed state
 - **AND** on failure or denial, the notification row SHALL show an error state
 
-#### Scenario: PWA install from dialog
+#### Scenario: PWA install from dialog (Android/Chrome)
 
 - **WHEN** the user taps the PWA install button in the PostSignupDialog
 - **AND** `beforeinstallprompt` has fired
 - **THEN** the system SHALL trigger the deferred `beforeinstallprompt` event
-- **AND** if the event is not available (already installed, iOS, or not supported), the button SHALL be hidden
+
+#### Scenario: PWA install row hidden on iOS Safari
+
+- **WHEN** the PostSignupDialog is displayed
+- **AND** the platform is iOS Safari (`beforeinstallprompt` never fires)
+- **THEN** the PWA install row SHALL NOT be shown in the dialog
+- **AND** the persistent FAB instruction sheet provides the iOS install path instead
 
 #### Scenario: Dialog dismissed
 

--- a/openspec/specs/post-signup-dialog/spec.md
+++ b/openspec/specs/post-signup-dialog/spec.md
@@ -29,7 +29,7 @@ The system SHALL display a dialog after the first successful signup that consoli
 - **WHEN** the PostSignupDialog is displayed
 - **THEN** it SHALL show a success confirmation (アカウント登録完了！)
 - **AND** it SHALL offer a notification opt-in action (新着ライブ通知をオンにしよう)
-- **AND** it SHALL offer a PWA install action (ホーム画面に追加するとより快適に)
+- **AND** it SHALL offer a PWA install action (ホーム画面に追加するとより快適に) if `PwaInstallService.canShowFab` is `true`
 - **AND** it SHALL provide a dismiss action (あとで)
 
 #### Scenario: Notification opt-in from dialog
@@ -42,14 +42,16 @@ The system SHALL display a dialog after the first successful signup that consoli
 #### Scenario: PWA install from dialog
 
 - **WHEN** the user taps the PWA install button in the PostSignupDialog
+- **AND** `beforeinstallprompt` has fired
 - **THEN** the system SHALL trigger the deferred `beforeinstallprompt` event
-- **AND** if the event is not available (already installed or not supported), the button SHALL be hidden
+- **AND** if the event is not available (already installed, iOS, or not supported), the button SHALL be hidden
 
 #### Scenario: Dialog dismissed
 
 - **WHEN** the user taps あとで
 - **THEN** the PostSignupDialog SHALL close
-- **AND** neither prompt SHALL be shown again in the same session (coordinated via `IPromptCoordinator`)
+- **AND** the notification prompt SHALL NOT be shown again in the same session (coordinated via `IPromptCoordinator`)
+- **AND** the PWA install FAB SHALL remain visible (it is not affected by PostSignupDialog dismissal)
 
 ### Requirement: Dialog reliably opens when active is true at creation time
 The PostSignupDialog SHALL reliably open when `active` is bound to `true` at component creation time, not only when `active` transitions from `false` to `true` after the component is attached.

--- a/openspec/specs/prompt-timing/spec.md
+++ b/openspec/specs/prompt-timing/spec.md
@@ -80,9 +80,9 @@ The system SHALL display at most one permission prompt (PWA install or push noti
 
 ---
 
-### Requirement: Notification Prompt Priority Over PWA Install
+### Requirement: Notification Prompt Priority Over Disruptive PWA Prompts
 
-The notification prompt SHALL have higher priority than the PWA install prompt. When both prompts are eligible in the same session, the notification prompt SHALL be displayed.
+The notification prompt SHALL have higher priority than any disruptive PWA install prompt. The PWA install FAB is passive UI and is not subject to this constraint — it SHALL remain visible regardless of whether the notification prompt is shown.
 
 #### Scenario: Both prompts eligible (first or later post-completion session)
 
@@ -91,7 +91,7 @@ The notification prompt SHALL have higher priority than the PWA install prompt. 
 - **AND** the notification prompt has not been dismissed
 - **AND** the PWA install FAB is also eligible
 - **THEN** the system SHALL display the notification prompt
-- **AND** the system SHALL NOT display the PWA install prompt in the same session
+- **AND** the PWA install FAB SHALL remain visible (it is passive UI and does not compete with the notification prompt)
 
 #### Scenario: Notification prompt already dismissed
 

--- a/openspec/specs/prompt-timing/spec.md
+++ b/openspec/specs/prompt-timing/spec.md
@@ -2,27 +2,27 @@
 
 ## Purpose
 
-Defines the eligibility rules for displaying PWA install and push notification permission prompts. Prompts are gated by authentication state, onboarding completion, session count, and a per-session single-prompt constraint to avoid overwhelming the user.
+Defines the eligibility rules for displaying PWA install and push notification permission prompts. Prompts are gated by authentication state, onboarding completion, and a per-session single-prompt constraint to avoid overwhelming the user.
 
 ## Requirements
 
 ### Requirement: PWA Install Prompt Blocked During Onboarding
 
-The system SHALL NOT display the PWA install prompt while the user is in onboarding Steps 1-6.
+The system SHALL NOT display the PWA install FAB while the user is in active onboarding steps (DISCOVERY, DASHBOARD, MY_ARTISTS).
 
-#### Scenario: User is mid-tutorial on the dashboard (Step 3)
+#### Scenario: User is mid-tutorial on the dashboard
 
-- **WHEN** the user is at onboarding Step 3 (Dashboard)
+- **WHEN** the user is at onboarding step DASHBOARD
 - **AND** the browser fires the `beforeinstallprompt` event
 - **THEN** the system SHALL capture the event
-- **AND** the system SHALL NOT display the PWA install banner
-- **AND** `PwaInstallService.canShow` SHALL remain `false`
+- **AND** the system SHALL NOT display the PWA install FAB
+- **AND** `PwaInstallService.canShowFab` SHALL remain `false`
 
-#### Scenario: User has not started onboarding (Step 0)
+#### Scenario: User has not started onboarding (LP step)
 
-- **WHEN** the user is at onboarding Step 0 (LP)
+- **WHEN** the user is at onboarding step LP
 - **AND** the browser fires the `beforeinstallprompt` event
-- **THEN** the system SHALL NOT display the PWA install banner
+- **THEN** the system SHALL NOT display the PWA install FAB
 
 ---
 
@@ -46,11 +46,11 @@ The system SHALL NOT display the push notification prompt when the user is not a
 
 ### Requirement: Notification Prompt Blocked During Onboarding
 
-The system SHALL NOT display the push notification prompt during onboarding Steps 1-6.
+The system SHALL NOT display the push notification prompt during active onboarding steps.
 
-#### Scenario: User at Step 5 (My Artists) before sign-up
+#### Scenario: User at MY_ARTISTS step before sign-up
 
-- **WHEN** the user is at onboarding Step 5
+- **WHEN** the user is at onboarding step MY_ARTISTS
 - **THEN** the system SHALL NOT display the notification prompt
 - **AND** the notification prompt component SHALL not evaluate visibility
 
@@ -84,32 +84,30 @@ The system SHALL display at most one permission prompt (PWA install or push noti
 
 The notification prompt SHALL have higher priority than the PWA install prompt. When both prompts are eligible in the same session, the notification prompt SHALL be displayed.
 
-#### Scenario: Both prompts eligible (second or later post-completion session)
+#### Scenario: Both prompts eligible (first or later post-completion session)
 
 - **WHEN** the user has completed onboarding
 - **AND** notification permission is not yet granted
 - **AND** the notification prompt has not been dismissed
-- **AND** the PWA install prompt is also eligible
-- **AND** the user is on the second or later session after onboarding completion
+- **AND** the PWA install FAB is also eligible
 - **THEN** the system SHALL display the notification prompt
-- **AND** the system SHALL NOT display the PWA install prompt
+- **AND** the system SHALL NOT display the PWA install prompt in the same session
 
-#### Scenario: Notification prompt already dismissed (second or later session)
+#### Scenario: Notification prompt already dismissed
 
 - **WHEN** the user has previously dismissed the notification prompt
-- **AND** the PWA install prompt is eligible
-- **AND** the user is on the second or later session after onboarding completion
-- **THEN** the system SHALL display the PWA install prompt
+- **AND** the PWA install FAB is eligible
+- **THEN** the system SHALL display the PWA install FAB
 
 ---
 
 ### Requirement: Notification Prompt Eligible on First Post-Completion Session
 
-The notification prompt SHALL be eligible to display on the first session after onboarding completion (Step 7), when user motivation is highest.
+The notification prompt SHALL be eligible to display on the first session after onboarding completion, when user motivation is highest.
 
 #### Scenario: User completes onboarding and returns
 
-- **WHEN** the user has completed onboarding (Step 7)
+- **WHEN** the user has completed onboarding (`OnboardingStep.COMPLETED`)
 - **AND** the user starts a new session (page load)
 - **AND** the user is authenticated
 - **AND** the notification prompt has not been dismissed
@@ -118,44 +116,43 @@ The notification prompt SHALL be eligible to display on the first session after 
 
 #### Scenario: User completes onboarding within the same session
 
-- **WHEN** the user completes Step 6 and transitions to Step 7 within the current session
-- **THEN** the system SHALL NOT display any prompt in the same session as completion
-- **AND** the prompt SHALL be eligible starting from the next session
+- **WHEN** the user transitions to `OnboardingStep.COMPLETED` within the current session
+- **THEN** the system SHALL NOT display any notification prompt in the same session as completion
+- **AND** the notification prompt SHALL be eligible starting from the next session
 
 ---
 
-### Requirement: PWA Install Prompt Deferred to Second Post-Completion Session
+### Requirement: PWA Install FAB Eligible After Onboarding Completion
 
-The PWA install prompt SHALL be eligible starting from the second session after onboarding completion, giving the notification prompt a clear first-session window.
+The PWA install FAB SHALL be eligible immediately after onboarding completion, regardless of authentication state or session count.
 
-#### Scenario: First session after completion
+#### Scenario: First session after completion — guest user
 
-- **WHEN** the user is on the first session after onboarding completion
-- **AND** the `beforeinstallprompt` event has fired
-- **THEN** the system SHALL NOT display the PWA install prompt, regardless of notification prompt dismissal state
+- **WHEN** the user has completed onboarding
+- **AND** the user is NOT authenticated
+- **AND** `beforeinstallprompt` has fired OR the platform is iOS Safari
+- **THEN** the system SHALL display the PWA install FAB
 
-#### Scenario: Second session after completion
+#### Scenario: First session after completion — authenticated user
 
-- **WHEN** the user is on the second or later session after onboarding completion
-- **AND** the `beforeinstallprompt` event has fired
-- **AND** the PWA install prompt has not been dismissed
-- **AND** no other prompt has been shown this session
-- **THEN** the system SHALL display the PWA install prompt
+- **WHEN** the user has completed onboarding
+- **AND** the user is authenticated
+- **AND** `beforeinstallprompt` has fired OR the platform is iOS Safari
+- **THEN** the system SHALL display the PWA install FAB
+
+#### Scenario: Completion within the same session
+
+- **WHEN** the user transitions to `OnboardingStep.COMPLETED` within the current session
+- **THEN** the FAB SHALL become visible immediately in that same session
 
 ---
 
 ### Requirement: Dismissed Prompts Do Not Reappear
 
-When the user dismisses a prompt, the system SHALL persist the dismissal and SHALL NOT show that prompt again. This is existing behavior preserved by this change.
+When the user dismisses a prompt, the system SHALL persist the dismissal and SHALL NOT show that prompt again. This applies to the notification prompt; the PWA install FAB has no dismiss action.
 
 #### Scenario: User dismisses notification prompt
 
 - **WHEN** the user taps the dismiss control on the notification prompt
 - **THEN** the system SHALL write the dismissal to LocalStorage
 - **AND** the notification prompt SHALL NOT appear on subsequent sessions
-
-#### Scenario: User dismisses PWA install prompt
-
-- **WHEN** the user taps the dismiss control on the PWA install prompt
-- **THEN** the system SHALL write the dismissal to LocalStorage
-- **AND** the PWA install prompt SHALL NOT appear on subsequent sessions

--- a/openspec/specs/pwa-install-fab/spec.md
+++ b/openspec/specs/pwa-install-fab/spec.md
@@ -1,0 +1,121 @@
+# PWA Install FAB
+
+## Purpose
+
+Defines the behavior and presentation of the persistent PWA install Floating Action Button (FAB) displayed after onboarding completion. The FAB provides a passive, non-disruptive install entry point that is always available until the app is installed.
+
+## Requirements
+
+### Requirement: FAB Visible After Onboarding Completion
+
+The system SHALL display a persistent PWA install FAB in the bottom-right corner of the screen, anchored above the Nav Bar, once onboarding is completed — regardless of authentication state.
+
+#### Scenario: Guest user completes onboarding
+
+- **WHEN** the user completes the onboarding flow (`OnboardingStep.COMPLETED`)
+- **AND** the user is not authenticated
+- **AND** the app has not been installed
+- **THEN** the system SHALL display the PWA install FAB
+
+#### Scenario: Authenticated user completes onboarding
+
+- **WHEN** the user completes the onboarding flow
+- **AND** the user is authenticated
+- **AND** the app has not been installed
+- **THEN** the system SHALL display the PWA install FAB
+
+#### Scenario: FAB not shown during onboarding
+
+- **WHEN** the user is in any active onboarding step (DISCOVERY, DASHBOARD, MY_ARTISTS)
+- **THEN** the system SHALL NOT display the PWA install FAB
+
+---
+
+### Requirement: FAB Install Behavior by Platform
+
+The FAB SHALL trigger the appropriate install flow based on the user's platform.
+
+#### Scenario: Android/Chrome — native install prompt
+
+- **WHEN** the user taps the FAB
+- **AND** the browser has fired `beforeinstallprompt`
+- **THEN** the system SHALL call `deferredPrompt.prompt()`
+- **AND** the native browser install dialog SHALL appear
+
+#### Scenario: iOS Safari — instruction sheet
+
+- **WHEN** the user taps the FAB
+- **AND** the browser has NOT fired `beforeinstallprompt` (iOS Safari)
+- **THEN** the system SHALL open a `bottom-sheet` component
+- **AND** the sheet SHALL display step-by-step instructions:
+  1. Safari の共有ボタン（□↑）をタップ
+  2.「ホーム画面に追加」を選択
+  3.「追加」をタップ
+- **AND** the sheet SHALL provide a single dismiss action (閉じる)
+
+#### Scenario: iOS instruction sheet dismissed
+
+- **WHEN** the user taps 閉じる on the iOS instruction sheet
+- **THEN** the sheet SHALL close
+- **AND** the FAB SHALL remain visible
+
+---
+
+### Requirement: FAB Disappears After Installation
+
+The system SHALL remove the FAB permanently once the app is installed.
+
+#### Scenario: App installed via FAB
+
+- **WHEN** the browser fires the `appinstalled` event
+- **THEN** the system SHALL hide the FAB
+- **AND** the FAB SHALL NOT reappear in subsequent sessions
+
+#### Scenario: App already installed on load
+
+- **WHEN** the app loads
+- **AND** `navigator.standalone` is `true` (iOS) OR the display mode matches `standalone` (Android)
+- **THEN** the system SHALL NOT display the FAB
+
+---
+
+### Requirement: FAB Entry Animation
+
+The FAB SHALL animate on first appearance to draw user attention, then remain static.
+
+#### Scenario: First appearance animation
+
+- **WHEN** the FAB becomes visible for the first time in a session
+- **THEN** the system SHALL animate the FAB sliding up from below (`translateY(150%) → translateY(0)`, 400ms ease-out)
+- **AND** after the slide completes, a ripple ring SHALL animate outward and fade exactly 2 times, then stop
+- **AND** the idle state SHALL show a brand gradient glow via `box-shadow` (no looping animation)
+
+#### Scenario: Reduced motion
+
+- **WHEN** `prefers-reduced-motion: reduce` is set
+- **THEN** the system SHALL replace the slide-up and ripple with a simple `opacity: 0 → 1` fade
+
+#### Scenario: Tap feedback
+
+- **WHEN** the user taps the FAB
+- **THEN** the FAB SHALL briefly scale down (`scale(0.92)` for 50ms) then return to `scale(1)` over 100ms
+
+---
+
+### Requirement: FAB Position When signup-prompt-banner Is Visible
+
+When the `signup-prompt-banner` is displayed, the FAB SHALL be overlaid on the banner's button row in the right-side whitespace.
+
+#### Scenario: Both FAB and signup-banner visible
+
+- **WHEN** the FAB is visible
+- **AND** the `signup-prompt-banner` is visible
+- **THEN** the FAB SHALL be positioned in the right whitespace of the banner's button row
+- **AND** the FAB SHALL NOT obscure the "アカウント作成" button or the banner's dismiss button
+- **AND** both elements SHALL maintain a minimum 44px touch target
+
+#### Scenario: Only FAB visible (no banner)
+
+- **WHEN** the FAB is visible
+- **AND** the `signup-prompt-banner` is not visible
+- **THEN** the FAB SHALL be positioned above the Nav Bar with `inset-inline-end: var(--space-s)` and `inset-block-end: calc(3.5rem + env(safe-area-inset-bottom, 0px) + var(--space-s))`


### PR DESCRIPTION
## Summary

- Archive completed `pwa-install-fab` change to `openspec/changes/archive/`
- Sync delta specs to `openspec/specs/`: new `pwa-install-fab` capability, updated `prompt-timing`, updated `post-signup-dialog`

## Spec changes

**New:** `openspec/specs/pwa-install-fab/spec.md` — FAB visibility rules, platform-specific install behavior (Android native prompt / iOS instruction sheet), disappearance on install, entry animation, positioning relative to signup-prompt-banner

**Modified:** `openspec/specs/prompt-timing/spec.md` — remove session-count deferral requirement for PWA (FAB is eligible immediately); add FAB eligibility requirement; rename `canShow` → `canShowFab`; update step references to enum values

**Modified:** `openspec/specs/post-signup-dialog/spec.md` — PWA install row conditioned on `canShowFab`; iOS guard hides dialog row; FAB unaffected by dialog dismissal

close: #306
