### PR TITLE
chore(openspec): archive fix-artist-filter-bar-empty-sheet and dashboard-artist-filter

### DIFF
--- a/openspec/changes/archive/2026-04-01-dashboard-artist-filter/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-01-dashboard-artist-filter/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-31

--- a/openspec/changes/archive/2026-04-01-fix-artist-filter-bar-empty-sheet/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-01-fix-artist-filter-bar-empty-sheet/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-01

--- a/openspec/changes/archive/2026-04-01-fix-artist-filter-bar-empty-sheet/design.md
+++ b/openspec/changes/archive/2026-04-01-fix-artist-filter-bar-empty-sheet/design.md
@@ -1,0 +1,57 @@
+## Context
+
+The artist filter bar bottom sheet (`frontend/src/components/artist-filter-bar/`) renders a list of followed artists so the user can filter concerts. The list is bound to `DashboardRoute.followedArtists`, which delegates to `FollowServiceClient.followedArtists` — an `@observable` array initialized to `[]`.
+
+`FollowServiceClient` has three mutation paths:
+1. `follow()` — adds an artist optimistically to `followedArtists`
+2. `unfollow()` — removes an artist optimistically from `followedArtists`
+3. `listFollowed()` — fetches the full list from RPC (authenticated) or guest storage, but **never assigns the result back to `followedArtists`**
+
+Because `listFollowed()` is called during page load (via `getFollowedArtistMap()`) and it never writes to `followedArtists`, the observable stays empty and the bottom sheet shows nothing.
+
+## Goals / Non-Goals
+
+**Goals:**
+- `followedArtists` observable reflects the latest fetched state after any `listFollowed()` call.
+- The fix is minimal and contained to a single file.
+- New unit tests cover the four identified edge cases in `ArtistFilterBar`.
+- Integration coverage for the `listFollowed()` side-effect is tracked or added.
+
+**Non-Goals:**
+- Refactoring the broader `FollowServiceClient` caching strategy.
+- Adding optimistic rollback or conflict resolution.
+- Changing `DashboardRoute`, `ArtistFilterBar` component, or their templates.
+- Any backend or proto changes.
+
+## Decisions
+
+### Decision: Update `followedArtists` inside `listFollowed()` (Option A)
+
+After the fetch resolves (both RPC and guest paths), assign:
+
+```typescript
+this.followedArtists = result.map((f) => f.artist)
+```
+
+**Rationale**: `followedArtists` is intended to be the canonical in-memory cache of followed artist objects. `listFollowed()` is the only method that performs a full refresh, so it is the correct and natural place to sync the cache. This is a one-line addition and does not change the method's return contract.
+
+**Alternatives considered**:
+- *Update in `getFollowedArtistMap()`*: `getFollowedArtistMap()` calls `listFollowed()` internally, so updating it there would also work. However, `listFollowed()` is the lower-level contract; updating there ensures any future caller of `listFollowed()` also benefits without extra ceremony.
+- *Update in `DashboardRoute` after `getFollowedArtistMap()`*: This would scatter cache management into consumers. Rejected to keep cache ownership in `FollowServiceClient`.
+
+### Decision: Map `FollowedArtist[]` → `Artist[]` for the assignment
+
+`listFollowed()` returns `FollowedArtist[]`. The `followedArtists` property holds `Artist[]`. The mapping `result.map((f) => f.artist)` is already used in the optimistic paths and is correct here.
+
+## Risks / Trade-offs
+
+- **Ordering risk**: If `listFollowed()` is called concurrently, the last settled promise wins. This is acceptable given current single-page sequential load patterns. → Mitigation: no action required for now; document as known limitation.
+- **Test coverage gap**: Without new tests, the regression could reappear silently. → Mitigation: add four unit tests to `ArtistFilterBar` spec and track integration coverage in tasks.
+
+## Migration Plan
+
+Single-file change; no migration steps required. The fix takes effect immediately on the next page load that calls `listFollowed()`. No rollback complexity — reverting the one-line addition restores previous behaviour.
+
+## Open Questions
+
+None.

--- a/openspec/changes/archive/2026-04-01-fix-artist-filter-bar-empty-sheet/proposal.md
+++ b/openspec/changes/archive/2026-04-01-fix-artist-filter-bar-empty-sheet/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+The artist filter bar bottom sheet always displays an empty list of followed artists, making the feature non-functional for users who want to filter concerts by their followed artists. The bug exists because `FollowServiceClient.listFollowed()` fetches from RPC/guest but never writes back to the `followedArtists` observable property, so the UI binding always sees `[]`.
+
+## What Changes
+
+- `FollowServiceClient.listFollowed()` will update `this.followedArtists` after fetching, ensuring the observable stays in sync with the latest server/guest state.
+- New unit tests will be added for `ArtistFilterBar` to cover the empty-sheet, multi-artist name resolution, double-open reset, and invalid-dismiss scenarios.
+- Integration test coverage for the `listFollowed()` side-effect will be noted/added in `FollowServiceClient` spec.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `artist-following`: The `listFollowed()` method now has a side-effect of updating the cached `followedArtists` observable, so that components reading `followedArtists` after a `listFollowed()` call see the correct list.
+
+## Impact
+
+- **Frontend only** — single source file change: `frontend/src/services/follow-service-client.ts`
+- No API, proto, or backend changes required.
+- Components reading `followedArtists` (e.g., `DashboardRoute`, `ArtistFilterBar`) will automatically receive the correct list after `listFollowed()` completes.
+- Existing `follow()` and `unfollow()` optimistic-update paths are unchanged.

--- a/openspec/changes/archive/2026-04-01-fix-artist-filter-bar-empty-sheet/specs/artist-following/spec.md
+++ b/openspec/changes/archive/2026-04-01-fix-artist-filter-bar-empty-sheet/specs/artist-following/spec.md
@@ -1,0 +1,51 @@
+## MODIFIED Requirements
+
+### Requirement: ListFollowed Response
+
+The system SHALL return the user's followed artists via the ListFollowed RPC. After the response is received, the client-side `FollowServiceClient.followedArtists` observable SHALL be updated to reflect the fetched list, so that UI components bound to `followedArtists` display the correct set of artists without requiring a separate trigger.
+
+#### Scenario: Response uses FollowedArtist wrapper
+
+- **WHEN** a user calls ListFollowed
+- **THEN** each entry SHALL be a FollowedArtist wrapper containing the artist entity and the user's passion level
+
+#### Scenario: followedArtists observable updated after fetch (authenticated)
+
+- **WHEN** `listFollowed()` is called for an authenticated user and the RPC returns a non-empty list
+- **THEN** `FollowServiceClient.followedArtists` SHALL be set to the array of Artist objects extracted from the response
+
+#### Scenario: followedArtists observable updated after fetch (guest)
+
+- **WHEN** `listFollowed()` is called for a guest user and guest storage contains followed artists
+- **THEN** `FollowServiceClient.followedArtists` SHALL be set to the array of Artist objects extracted from guest follows
+
+#### Scenario: followedArtists observable set to empty when no follows exist
+
+- **WHEN** `listFollowed()` is called and the result is an empty list
+- **THEN** `FollowServiceClient.followedArtists` SHALL be set to `[]`
+
+## ADDED Requirements
+
+### Requirement: ArtistFilterBar sheet initializes pendingIds from followedArtists
+
+The ArtistFilterBar component SHALL initialize `pendingIds` from the current `followedArtists` list when `openSheet()` is called.
+
+#### Scenario: Empty followedArtists on openSheet
+
+- **WHEN** `followedArtists` is `[]` and `openSheet()` is called
+- **THEN** `pendingIds` SHALL be `[]`
+
+#### Scenario: Multiple followed artists on openSheet
+
+- **WHEN** `followedArtists` contains multiple artists and `openSheet()` is called
+- **THEN** `artistNameFor()` SHALL resolve the correct name for each artist in `followedArtists`
+
+#### Scenario: openSheet called twice resets pendingIds
+
+- **WHEN** `openSheet()` is called a second time after state was modified
+- **THEN** `pendingIds` SHALL be reset to `selectedIds`, discarding any uncommitted changes from the previous session
+
+#### Scenario: dismiss with unknown ID does not modify selectedIds
+
+- **WHEN** `dismiss()` is called with an artist ID that is not in `selectedIds`
+- **THEN** `selectedIds` SHALL remain unchanged

--- a/openspec/changes/archive/2026-04-01-fix-artist-filter-bar-empty-sheet/tasks.md
+++ b/openspec/changes/archive/2026-04-01-fix-artist-filter-bar-empty-sheet/tasks.md
@@ -1,0 +1,22 @@
+## 1. Fix FollowServiceClient
+
+- [x] 1.1 In `frontend/src/services/follow-service-client.ts`, inside `listFollowed()`, add `this.followedArtists = result.map((f) => f.artist)` after the result is assembled (both authenticated and guest branches are covered by the single assignment after the if/else block)
+
+## 2. Unit Tests — ArtistFilterBar
+
+- [x] 2.1 In `frontend/src/components/artist-filter-bar/artist-filter-bar.spec.ts`, add test: `followedArtists` が空のとき `openSheet()` 後 `pendingIds` は `[]`
+- [x] 2.2 Add test: `followedArtists` が複数のとき `artistNameFor()` が正しく全て解決できる
+- [x] 2.3 Add test: `openSheet()` を2回呼んだとき前回の `pendingIds` がリセットされる
+- [x] 2.4 Add test: `dismiss()` で存在しない ID を渡しても `selectedIds` が変わらない
+
+## 3. Integration Tests — FollowServiceClient
+
+- [x] 3.1 In `frontend/src/services/follow-service-client.spec.ts` (create if it does not exist), add test: authenticated `listFollowed()` sets `followedArtists` to the mapped Artist array returned by the RPC client
+- [x] 3.2 Add test: guest `listFollowed()` sets `followedArtists` from guest storage follows
+- [x] 3.3 Add test: `listFollowed()` with empty result sets `followedArtists` to `[]`
+
+## 4. Verification
+
+- [x] 4.1 Run `make lint` in the frontend repo and confirm no errors
+- [x] 4.2 Run `make test` in the frontend repo and confirm all new and existing tests pass
+- [x] 4.3 Manually open the artist filter bar bottom sheet in the dev server and confirm followed artists are displayed


### PR DESCRIPTION
## Summary

- Archives `fix-artist-filter-bar-empty-sheet` change (spec synced via #380)
- Archives `dashboard-artist-filter` change (spec synced via #378)

Both changes are fully complete. Archiving keeps the active changes list clean.

close: #319
