### PR TITLE
docs(specs): sync specs and archive fix-laser-beam-visibility and pwa-fab-neon-style

### DIFF
--- a/openspec/changes/archive/2026-04-01-fix-laser-beam-visibility/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-01-fix-laser-beam-visibility/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-01

--- a/openspec/changes/archive/2026-04-01-fix-laser-beam-visibility/design.md
+++ b/openspec/changes/archive/2026-04-01-fix-laser-beam-visibility/design.md
@@ -1,0 +1,41 @@
+## Context
+
+The Concert Highway component renders two visual layers for hype-matched events:
+
+- **Layer A** — viewport-fixed triangular laser beam overlay (`.beam-overlay` / `.laser-beam`) rendered in `concert-highway.html`
+- **Layer B** — card-level spotlight effect via `[data-matched]` CSS selector in `event-card.css`
+
+Layer B is working correctly. Layer A is invisible.
+
+The `.beam-overlay` uses `position: fixed; inset: 0` to span the full viewport. However, its parent `concert-highway` has `:scope { overflow: hidden }`. In modern browsers (Chrome 103+, Safari 15.4+), an ancestor element with `overflow: hidden` combined with `position: relative` can act as a containing block for `position: fixed` descendants, clipping them to the ancestor's bounds. Since the beams have `block-size: var(--beam-h, 0)` with default `0`, and the containing block is `concert-highway` (not the viewport), the beams render but are clipped to zero height.
+
+Additionally, `concert-highway[data-blurred="true"] { filter: blur(4px) }` in `dashboard-route.css` would also break `position: fixed` containment (filter creates a new stacking context), though this only affects the blurred onboarding state.
+
+The scroll overflow is fully handled by `.concert-scroll { overflow-block: auto; overflow-inline: hidden }`, so `overflow: hidden` on `:scope` is redundant.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Make Layer A laser beams visible across the full viewport for hype-matched events
+- No regressions in card layout, scroll behaviour, or header positioning
+
+**Non-Goals:**
+- Fixing the `filter: blur` containment issue (the blurred state is intentional and beam visibility during blur is not required)
+- Changing beam positioning logic or the `updateBeamPositions()` algorithm
+
+## Decisions
+
+### Remove `overflow: hidden` from `concert-highway :scope`
+
+**Decision**: Delete the `overflow: hidden` declaration from `:scope` in `concert-highway.css`.
+
+**Why**: `.concert-scroll` already declares `overflow-block: auto; overflow-inline: hidden`, which handles all scroll clipping. The `:scope`-level overflow is defensive/redundant and is the direct cause of the `position: fixed` containment issue.
+
+**Alternative considered**: Move `.beam-overlay` outside `concert-highway` (portal pattern). Rejected — would require significant refactoring of `updateBeamPositions()` DOM queries and `getBeamIndex()` cross-component communication with no additional benefit.
+
+**Alternative considered**: Change `.beam-overlay` from `position: fixed` to `position: absolute` with `inset: 0` on a full-height container. Rejected — beams need to stay fixed relative to the viewport during scroll to produce the correct visual effect.
+
+## Risks / Trade-offs
+
+- **[Risk] Content overflow**: Without `:scope` overflow clipping, some child element could theoretically overflow `concert-highway`. → **Mitigation**: `.concert-scroll` clips its own content; the stage header is contained within the grid. Visual regression testing covers this.
+- **[Risk] `filter: blur` still breaks beams**: `dashboard-route.css` applies `filter: blur(4px)` to `concert-highway` during the onboarding region-selection state. During this state, `position: fixed` children are still contained. → **Accepted**: Beams are not needed while the UI is blurred (it's a blocking modal state).

--- a/openspec/changes/archive/2026-04-01-fix-laser-beam-visibility/proposal.md
+++ b/openspec/changes/archive/2026-04-01-fix-laser-beam-visibility/proposal.md
@@ -1,0 +1,22 @@
+## Why
+
+The viewport-fixed laser beam overlay (Layer A) in the Concert Highway is not visible on hype-matched event cards in the dashboard. The root cause is a CSS containment issue: `concert-highway` has `overflow: hidden` on its `:scope`, which in modern browsers clips `position: fixed` children to the element's bounds, preventing the beam overlay from rendering across the full viewport.
+
+## What Changes
+
+- Remove `overflow: hidden` from `concert-highway`'s `:scope` rule — scroll clipping is already handled by `.concert-scroll`'s own `overflow-block: auto; overflow-inline: hidden`
+- Verify that removing `:scope` overflow does not cause visual regressions (cards, headers, or beams overflowing unexpectedly)
+
+## Capabilities
+
+### New Capabilities
+<!-- none -->
+
+### Modified Capabilities
+- `concert-highway`: Laser beam overlay now renders correctly across the full viewport for hype-matched events
+
+## Impact
+
+- `frontend/src/components/live-highway/concert-highway.css` — single-line removal
+- Visual regression risk: low; `.concert-scroll` retains its own overflow clipping
+- No API, proto, or backend changes required

--- a/openspec/changes/archive/2026-04-01-fix-laser-beam-visibility/specs/concert-highway-ce/spec.md
+++ b/openspec/changes/archive/2026-04-01-fix-laser-beam-visibility/specs/concert-highway-ce/spec.md
@@ -1,10 +1,4 @@
-# Concert Highway Custom Element
-
-## Purpose
-
-Reusable custom element that renders the 3-column concert lane grid (home/nearby/away) with stage headers, date separators, event cards, and laser beam effects. Used by both the authenticated dashboard and the Welcome page preview.
-
-## Requirements
+## MODIFIED Requirements
 
 ### Requirement: Concert Highway Custom Element
 

--- a/openspec/changes/archive/2026-04-01-fix-laser-beam-visibility/tasks.md
+++ b/openspec/changes/archive/2026-04-01-fix-laser-beam-visibility/tasks.md
@@ -1,0 +1,10 @@
+## 1. CSS Fix
+
+- [x] 1.1 Remove `overflow: hidden` from `:scope` in `frontend/src/components/live-highway/concert-highway.css`
+
+## 2. Verification
+
+- [ ] 2.1 Confirm laser beams (Layer A) are visible on hype-matched cards in the dashboard
+- [ ] 2.2 Confirm scroll behaviour is unchanged (`.concert-scroll` still clips correctly)
+- [ ] 2.3 Confirm no visual regressions in card layout, stage header, or date separators
+- [x] 2.4 Run `make lint` to verify no linting errors

--- a/openspec/changes/archive/2026-04-01-pwa-fab-neon-style/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-01-pwa-fab-neon-style/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-01

--- a/openspec/changes/archive/2026-04-01-pwa-fab-neon-style/design.md
+++ b/openspec/changes/archive/2026-04-01-pwa-fab-neon-style/design.md
@@ -1,0 +1,120 @@
+## Context
+
+The PWA install FAB (`pwa-install-fab`) is a circular button fixed to the bottom-right corner. Its CSS lives entirely in `pwa-install-fab.css` under `@layer block { @scope (pwa-install-fab) { ... } }`.
+
+Current idle state:
+```css
+box-shadow:
+    0 0 10px oklch(from var(--_glow-color-from) l c h / 35%),
+    0 0 20px oklch(from var(--_glow-color-to)   l c h / 20%);
+```
+This is a static, non-animated shadow. The `signup-prompt-banner` uses an animated `cta-glow` keyframe (2.5s, ease-in-out, infinite) pulsing between low and high opacity box-shadows. The same pattern should be applied here.
+
+The icon (`.pwa-fab-icon`) is currently `1.25rem × 1.25rem`. It can be enlarged to `1.5rem` without changing the button container size (`--_size: 2.75rem`), since the container has `display: flex; align-items: center; justify-content: center`.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Make the FAB icon larger and more legible
+- Add a pulsing neon border/glow animation that attracts attention in idle state
+- Reuse existing design tokens (`--_glow-color-from`, `--_glow-color-to`)
+- Fix `aria-hidden="false"` anti-pattern and add `tabindex` control
+
+**Non-Goals:**
+- Changing button size or position
+- Adding new animations to the entry/ripple sequence
+- Changing the icon itself or the iOS instruction sheet
+- Refactoring `show.bind` → `if.bind` (separate concern)
+
+## Decisions
+
+### Use `box-shadow` spread-radius to simulate a neon border
+
+**Decision**: Use a multi-layer `box-shadow` where the first layer has `spread-radius: 2px` to act as a visible "border ring", followed by blur layers for the glow. Animate these with a `pwa-fab-neon-pulse` keyframe.
+
+**Why**: `border-image` does not work with `border-radius: full`. A `border` with solid color would override the entry animation and look flat. `box-shadow` with `0 0 0 2px` (no blur, with spread) produces a crisp ring that visually reads as a border.
+
+**Keyframe naming**: Follow the existing `pwa-fab-*` prefix convention in the file:
+- `pwa-fab-enter` (existing)
+- `pwa-fab-ripple` (existing)
+- `pwa-fab-fade` (existing, reduced-motion)
+- `pwa-fab-neon-pulse` (new)
+
+**Pulse keyframe**:
+```css
+@keyframes pwa-fab-neon-pulse {
+    0%, 100% {
+        box-shadow:
+            0 0 0 2px oklch(from var(--_glow-color-from) l c h / 50%),
+            0 0 10px oklch(from var(--_glow-color-from) l c h / 30%),
+            0 0 22px oklch(from var(--_glow-color-to)   l c h / 15%);
+    }
+    50% {
+        box-shadow:
+            0 0 0 2px oklch(from var(--_glow-color-from) l c h / 90%),
+            0 0 16px oklch(from var(--_glow-color-from) l c h / 55%),
+            0 0 32px oklch(from var(--_glow-color-to)   l c h / 30%);
+    }
+}
+```
+
+**Applied via comma-joined `animation` shorthand** (single property, readable):
+```css
+animation:
+    pwa-fab-enter 400ms ease-out both,
+    pwa-fab-neon-pulse 2.5s ease-in-out 400ms infinite;
+```
+
+### Reduced motion block must explicitly suppress pulse
+
+The `prefers-reduced-motion: reduce` block overrides `.pwa-fab { animation }` with `pwa-fab-fade`. Since this replaces the animation shorthand, `pwa-fab-neon-pulse` is automatically removed. However, a static `box-shadow` fallback must be restored in the same block so the button retains visual definition:
+
+```css
+@media (prefers-reduced-motion: reduce) {
+    .pwa-fab {
+        animation: pwa-fab-fade 300ms ease-out both;
+        /* Static fallback — pulse suppressed */
+        box-shadow:
+            0 0 0 2px oklch(from var(--_glow-color-from) l c h / 50%),
+            0 0 10px oklch(from var(--_glow-color-from) l c h / 30%),
+            0 0 22px oklch(from var(--_glow-color-to)   l c h / 15%);
+    }
+    ...
+}
+```
+
+### Pause pulse animation on focus-visible
+
+The neon pulse `box-shadow` animates opacity. When the button receives keyboard focus, the `focus-visible` outline renders on top but the animating shadow can visually compete with it. Pausing the animation on focus makes the outline clearly readable:
+
+```css
+&:focus-visible {
+    outline: 2px solid var(--color-brand-accent);
+    outline-offset: 5px;  /* widened from 3px to clear the pulse ring */
+    animation-play-state: paused;
+}
+```
+
+### Fix `aria-hidden` anti-pattern and add `tabindex` control
+
+`aria-hidden="false"` does not expose an element to AT — it is a no-op. The correct pattern is to omit the attribute entirely when the element should be visible to AT. Since `show.bind` keeps the button in the DOM, `tabindex` must also be controlled so hidden state removes the button from the tab order:
+
+```html
+<button
+  show.bind="isVisible"
+  aria-hidden.bind="isVisible ? null : 'true'"
+  tabindex.bind="isVisible ? '0' : '-1'"
+  ...
+```
+
+### Icon size: 1.25rem → 1.5rem
+
+**Decision**: Change `.pwa-fab-icon { inline-size: 1.5rem; block-size: 1.5rem; }`.
+
+**Why**: The current 20px icon leaves significant padding inside the 44px button. 24px (1.5rem) fills the container more proportionally and improves tap target legibility. No layout changes needed.
+
+## Risks / Trade-offs
+
+- **[Risk] Animation competes with entry ripple**: Adding `pwa-fab-neon-pulse` with `400ms` delay means it starts as the entry animation finishes. → **Mitigation**: Comma-joined `animation` shorthand with explicit delay handles sequencing cleanly.
+- **[Risk] `prefers-reduced-motion` loses box-shadow entirely**: Replacing `animation` removes the animated shadow but does not restore a static one. → **Mitigation**: Explicitly re-declare `box-shadow` in the reduced-motion block.
+- **[Risk] Visual noise on low-end devices**: Three simultaneous animations (entry, ripple, pulse). → **Accepted**: The ripple runs only twice and stops; the pulse is the only looping animation in idle state.

--- a/openspec/changes/archive/2026-04-01-pwa-fab-neon-style/proposal.md
+++ b/openspec/changes/archive/2026-04-01-pwa-fab-neon-style/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+The PWA install FAB is easy to miss. The icon is small (1.25rem / 20px) and the idle glow is static — it lacks the visual energy of other CTAs in the app such as the signup banner. Enlarging the icon and adding a pulsing neon border brings the FAB in line with the app's neon aesthetic and makes it more noticeable without adding new UI elements.
+
+## What Changes
+
+- Increase the FAB icon size from `1.25rem` to `1.5rem`
+- Replace the static idle `box-shadow` glow with a `2.5s ease-in-out infinite` pulsing neon animation (matching the `cta-glow` pattern from `signup-prompt-banner`)
+- The pulse uses an inset spread-radius layer (`0 0 0 2px`) to simulate a neon border, since `border-image` is incompatible with `border-radius: full`
+- Color tokens remain: `--color-brand-primary` and `--color-brand-accent` (existing `--_glow-color-from` / `--_glow-color-to` variables)
+
+## Capabilities
+
+### New Capabilities
+<!-- none -->
+
+### Modified Capabilities
+- `pwa-install-fab`: Idle state gains pulsing neon border animation; icon rendered larger
+
+## Impact
+
+- `frontend/src/components/pwa-install-fab/pwa-install-fab.css` — CSS-only change
+- No TypeScript, HTML, or test changes required
+- No API or backend changes

--- a/openspec/changes/archive/2026-04-01-pwa-fab-neon-style/specs/pwa-install-fab/spec.md
+++ b/openspec/changes/archive/2026-04-01-pwa-fab-neon-style/specs/pwa-install-fab/spec.md
@@ -1,0 +1,52 @@
+## MODIFIED Requirements
+
+### Requirement: FAB Entry Animation
+
+The FAB SHALL animate on first appearance to draw user attention, then display a continuous neon pulse in idle state.
+
+#### Scenario: First appearance animation
+
+- **WHEN** the FAB becomes visible for the first time in a session
+- **THEN** the system SHALL animate the FAB sliding up from below (`translateY(150%) → translateY(0)`, 400ms ease-out)
+- **AND** after the slide completes, a ripple ring SHALL animate outward and fade exactly 2 times, then stop
+- **AND** after the entry animation, the idle state SHALL display a pulsing neon border/glow via `box-shadow` animation (`fab-neon-pulse`, 2.5s ease-in-out infinite)
+
+#### Scenario: Reduced motion
+
+- **WHEN** `prefers-reduced-motion: reduce` is set
+- **THEN** the system SHALL replace the slide-up and ripple with a simple `opacity: 0 → 1` fade
+- **AND** the pulsing neon animation SHALL be suppressed; a static `box-shadow` glow SHALL be shown instead
+
+#### Scenario: Tap feedback
+
+- **WHEN** the user taps the FAB
+- **THEN** the FAB SHALL briefly scale down (`scale(0.92)` for 50ms) then return to `scale(1)` over 100ms
+
+---
+
+### Requirement: FAB Icon Size
+
+The FAB icon SHALL be rendered at `1.5rem × 1.5rem` to improve visual prominence within the button container.
+
+#### Scenario: Icon is visually prominent
+
+- **WHEN** the FAB is visible
+- **THEN** the install icon SHALL be rendered at `1.5rem` (24px) inline and block size
+
+---
+
+### Requirement: FAB Accessibility State
+
+The FAB SHALL correctly communicate its visibility state to assistive technology and be removed from the tab order when hidden.
+
+#### Scenario: FAB is visible
+
+- **WHEN** the FAB is visible (`isVisible = true`)
+- **THEN** the button element SHALL NOT have an `aria-hidden` attribute
+- **AND** the button element SHALL have `tabindex="0"`
+
+#### Scenario: FAB is hidden
+
+- **WHEN** the FAB is hidden (`isVisible = false`)
+- **THEN** the button element SHALL have `aria-hidden="true"`
+- **AND** the button element SHALL have `tabindex="-1"` to remove it from the tab order

--- a/openspec/changes/archive/2026-04-01-pwa-fab-neon-style/tasks.md
+++ b/openspec/changes/archive/2026-04-01-pwa-fab-neon-style/tasks.md
@@ -1,0 +1,27 @@
+## 1. CSS Changes
+
+- [x] 1.1 Increase `.pwa-fab-icon` size from `1.25rem` to `1.5rem` in `frontend/src/components/pwa-install-fab/pwa-install-fab.css`
+- [x] 1.2 Add `pwa-fab-neon-pulse` keyframe to `pwa-install-fab.css` using `--_glow-color-from` / `--_glow-color-to` tokens
+- [x] 1.3 Replace the static `box-shadow` on `.pwa-fab` with comma-joined animation: `pwa-fab-enter 400ms ease-out both, pwa-fab-neon-pulse 2.5s ease-in-out 400ms infinite`
+- [x] 1.4 Widen `outline-offset` on `&:focus-visible` from `3px` to `5px` and add `animation-play-state: paused`
+
+## 2. Reduced Motion
+
+- [x] 2.1 In the `prefers-reduced-motion: reduce` block, keep `animation: pwa-fab-fade ...` (which suppresses pulse) and add a static `box-shadow` fallback matching the `0%, 100%` keyframe values
+
+## 3. Accessibility (HTML)
+
+- [x] 3.1 In `pwa-install-fab.html`, change `aria-hidden.bind="isVisible ? 'false' : 'true'"` → `aria-hidden.bind="isVisible ? null : 'true'"`
+- [x] 3.2 Add `tabindex.bind="isVisible ? '0' : '-1'"` to the button element
+
+## 4. Spec Update
+
+- [x] 4.1 Update `openspec/changes/pwa-fab-neon-style/specs/pwa-install-fab/spec.md` to add `aria-hidden` / `tabindex` control requirement
+
+## 5. Verification
+
+- [ ] 5.1 Confirm the icon is visibly larger in the FAB
+- [ ] 5.2 Confirm the neon border pulses in idle state after the entry animation completes
+- [ ] 5.3 Confirm the pulse pauses on keyboard focus (focus-visible outline is clearly readable)
+- [ ] 5.4 Confirm the pulse is absent under `prefers-reduced-motion: reduce` and static box-shadow is shown
+- [x] 5.5 Run `make lint` to verify no linting errors

--- a/openspec/specs/pwa-install-fab/spec.md
+++ b/openspec/specs/pwa-install-fab/spec.md
@@ -81,24 +81,54 @@ The system SHALL remove the FAB permanently once the app is installed.
 
 ### Requirement: FAB Entry Animation
 
-The FAB SHALL animate on first appearance to draw user attention, then remain static.
+The FAB SHALL animate on first appearance to draw user attention, then display a continuous neon pulse in idle state.
 
 #### Scenario: First appearance animation
 
 - **WHEN** the FAB becomes visible for the first time in a session
 - **THEN** the system SHALL animate the FAB sliding up from below (`translateY(150%) → translateY(0)`, 400ms ease-out)
 - **AND** after the slide completes, a ripple ring SHALL animate outward and fade exactly 2 times, then stop
-- **AND** the idle state SHALL show a brand gradient glow via `box-shadow` (no looping animation)
+- **AND** after the entry animation, the idle state SHALL display a pulsing neon border/glow via `box-shadow` animation (`fab-neon-pulse`, 2.5s ease-in-out infinite)
 
 #### Scenario: Reduced motion
 
 - **WHEN** `prefers-reduced-motion: reduce` is set
 - **THEN** the system SHALL replace the slide-up and ripple with a simple `opacity: 0 → 1` fade
+- **AND** the pulsing neon animation SHALL be suppressed; a static `box-shadow` glow SHALL be shown instead
 
 #### Scenario: Tap feedback
 
 - **WHEN** the user taps the FAB
 - **THEN** the FAB SHALL briefly scale down (`scale(0.92)` for 50ms) then return to `scale(1)` over 100ms
+
+---
+
+### Requirement: FAB Icon Size
+
+The FAB icon SHALL be rendered at `1.5rem × 1.5rem` to improve visual prominence within the button container.
+
+#### Scenario: Icon is visually prominent
+
+- **WHEN** the FAB is visible
+- **THEN** the install icon SHALL be rendered at `1.5rem` (24px) inline and block size
+
+---
+
+### Requirement: FAB Accessibility State
+
+The FAB SHALL correctly communicate its visibility state to assistive technology and be removed from the tab order when hidden.
+
+#### Scenario: FAB is visible
+
+- **WHEN** the FAB is visible (`isVisible = true`)
+- **THEN** the button element SHALL NOT have an `aria-hidden` attribute
+- **AND** the button element SHALL have `tabindex="0"`
+
+#### Scenario: FAB is hidden
+
+- **WHEN** the FAB is hidden (`isVisible = false`)
+- **THEN** the button element SHALL have `aria-hidden="true"`
+- **AND** the button element SHALL have `tabindex="-1"` to remove it from the tab order
 
 ---
 


### PR DESCRIPTION
## Summary

- `concert-highway-ce` spec: add constraint that CE CSS must not establish a containing block clipping `position: fixed` children (root cause of invisible laser beams)
- `pwa-install-fab` spec: add neon pulse idle animation requirement, FAB icon size (`1.5rem`) requirement, and accessibility state requirement (`aria-hidden` / `tabindex` control)
- Archive `fix-laser-beam-visibility` and `pwa-fab-neon-style` changes

close: #306
