### PR TITLE
fix(specs): correct pwa-fab-neon-pulse keyframe name in pwa-install-fab spec

### DIFF
--- a/openspec/changes/archive/2026-04-01-pwa-fab-neon-style/specs/pwa-install-fab/spec.md
+++ b/openspec/changes/archive/2026-04-01-pwa-fab-neon-style/specs/pwa-install-fab/spec.md
@@ -9,7 +9,7 @@ The FAB SHALL animate on first appearance to draw user attention, then display a
 - **WHEN** the FAB becomes visible for the first time in a session
 - **THEN** the system SHALL animate the FAB sliding up from below (`translateY(150%) → translateY(0)`, 400ms ease-out)
 - **AND** after the slide completes, a ripple ring SHALL animate outward and fade exactly 2 times, then stop
-- **AND** after the entry animation, the idle state SHALL display a pulsing neon border/glow via `box-shadow` animation (`fab-neon-pulse`, 2.5s ease-in-out infinite)
+- **AND** after the entry animation, the idle state SHALL display a pulsing neon border/glow via `box-shadow` animation (`pwa-fab-neon-pulse`, 2.5s ease-in-out infinite)
 
 #### Scenario: Reduced motion
 

--- a/openspec/specs/pwa-install-fab/spec.md
+++ b/openspec/specs/pwa-install-fab/spec.md
@@ -88,7 +88,7 @@ The FAB SHALL animate on first appearance to draw user attention, then display a
 - **WHEN** the FAB becomes visible for the first time in a session
 - **THEN** the system SHALL animate the FAB sliding up from below (`translateY(150%) → translateY(0)`, 400ms ease-out)
 - **AND** after the slide completes, a ripple ring SHALL animate outward and fade exactly 2 times, then stop
-- **AND** after the entry animation, the idle state SHALL display a pulsing neon border/glow via `box-shadow` animation (`fab-neon-pulse`, 2.5s ease-in-out infinite)
+- **AND** after the entry animation, the idle state SHALL display a pulsing neon border/glow via `box-shadow` animation (`pwa-fab-neon-pulse`, 2.5s ease-in-out infinite)
 
 #### Scenario: Reduced motion
 


### PR DESCRIPTION
## Summary

`fab-neon-pulse` → `pwa-fab-neon-pulse` in `openspec/specs/pwa-install-fab/spec.md` and the archived delta spec. The keyframe name was missing the `pwa-fab-` prefix required by the naming convention for all keyframes in this component.

Fixes review comment on #382.
