### PR TITLE
docs(specs): sync gke-cost-optimization specs and archive change

### DIFF
--- a/openspec/changes/archive/2026-04-02-gke-cost-optimization/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-02-gke-cost-optimization/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-01

--- a/openspec/changes/archive/2026-04-02-gke-cost-optimization/design.md
+++ b/openspec/changes/archive/2026-04-02-gke-cost-optimization/design.md
@@ -1,0 +1,86 @@
+## Context
+
+The dev environment runs on a GKE Autopilot cluster (`cluster-osaka`, `asia-northeast2`) with private nodes behind a Cloud NAT gateway. Autopilot's $0.10/hr management fee and Cloud NAT's $0.045/hr gateway fee are fixed costs independent of actual workload — they accrue 24/7 regardless of utilization. Together they represent ~¥16,000/month that can be eliminated.
+
+The cluster hosts ~20 pods across 10 namespaces: ArgoCD, KEDA, NATS, External Secrets Operator, Atlas Operator, OTel Collector, Reloader, backend server, frontend, and their supporting pods. All workloads currently use `cloud.google.com/compute-class: autopilot-spot` nodeSelector.
+
+Cloud SQL is accessed via Private Service Connect (PSC) at a static internal IP (10.10.10.10) — this is independent of whether nodes are private or public. All other GCP services (Secret Manager, Artifact Registry, Vertex AI) are accessible via public Google API endpoints with IAM auth.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Eliminate Autopilot cluster management fee (¥10,800/month)
+- Eliminate Cloud NAT fixed costs (¥5,292/month)
+- Maintain all existing workload functionality
+- Keep Spot VM cost savings
+
+**Non-Goals:**
+- Staging or production changes
+- Private Google Access optimization (separate change)
+- Cloud Monitoring cost reduction
+- Vertex AI cost optimization
+
+## Decisions
+
+### Decision 1: New cluster vs. in-place conversion
+
+**Chosen: New cluster creation**
+
+GKE does not support in-place Autopilot → Standard conversion. The migration requires creating a new Standard cluster, migrating workloads, then deleting the Autopilot cluster. Dev downtime is acceptable, so this is straightforward.
+
+### Decision 2: Machine type for Standard node pool
+
+**Chosen: `e2-standard-2` (2 vCPU, 8 GiB)**
+
+Current workloads total ~2 vCPU / ~4 GiB requests across all pods including system pods. `e2-standard-2` provides headroom for kube-system overhead while remaining the smallest Standard machine that fits all workloads. At Spot pricing (~$0.027/hr), 2 nodes cost ~¥5,800/month — comparable to Autopilot Spot compute cost.
+
+Alternatives considered:
+- `e2-medium` (2 vCPU, 4 GiB): Too small; kube-system + ArgoCD alone exceeds 4 GiB
+- `e2-standard-4` (4 vCPU, 16 GiB): Oversized and unnecessarily expensive
+
+### Decision 3: Public nodes (eliminate Cloud NAT)
+
+**Chosen: `enablePrivateNodes: false`**
+
+With public nodes, each node gets an external IP and can reach the internet directly — eliminating the Cloud NAT gateway. Security implications for dev are acceptable:
+- GKE automatically manages firewall rules; nodes are not directly accessible from the internet on application ports
+- No `masterAuthorizedNetworks` is currently configured, meaning the control plane is already world-accessible; public nodes add no meaningful incremental risk
+- No NodePort services exist; all services are ClusterIP
+- Cloud SQL PSC uses an internal IP (10.10.10.10) and is unaffected by node visibility
+
+The Cloud Router and Cloud NAT Pulumi resources are deleted for dev. The `enableDynamicPortAllocation` and related NAT config in `network.ts` are removed.
+
+### Decision 4: nodeSelector label migration
+
+**Chosen: Replace `cloud.google.com/compute-class: autopilot-spot` with `cloud.google.com/gke-spot: "true"`**
+
+Autopilot uses a custom compute class label for spot scheduling. Standard clusters use the standard GKE Spot label. All `spot-nodeselector-patch.yaml` files in dev overlays must be updated. The change is mechanical and affects all namespaces uniformly.
+
+### Decision 5: ArgoCD cluster registration
+
+ArgoCD's in-cluster configuration (`argocd.argoproj.io/secret-type: cluster`) references the Kubernetes API server endpoint. After cluster recreation, the endpoint changes. Since ArgoCD is deployed to the same cluster it manages (in-cluster mode), no external cluster secret needs updating — ArgoCD uses the in-cluster service account automatically.
+
+## Risks / Trade-offs
+
+- **Spot VM eviction** → Autopilot handled eviction transparently; Standard requires workloads to tolerate node eviction. All existing deployments have `restartPolicy: Always` and KEDA handles consumer scaling. Risk is low.
+- **Node pool sizing** → Auto-scaling (min:1, max:4) handles burst. If all pods are scheduled on 1 node and it gets evicted, brief downtime occurs before a new node provisions. Acceptable for dev.
+- **kube-system overhead** → Standard clusters run more system daemonsets than Autopilot on each node. The `e2-standard-2` (8 GiB) provides sufficient headroom.
+- **Public node IP churn** → Node external IPs are ephemeral. If any external service whitelists node IPs, that whitelist breaks on node replacement. No such whitelisting exists currently.
+- **Shielded GKE Nodes** → GKE Autopilot enforces Shielded GKE Nodes (Secure Boot + Integrity Monitoring) automatically. Standard clusters do not — `shieldedInstanceConfig` must be set explicitly in the node pool config. This is especially important for public nodes (`enablePrivateNodes: false`).
+
+## Migration Plan
+
+**Note on cluster replacement:** The Pulumi resource name `cluster-${regionName}` is reused for the new Standard cluster. Pulumi detects a type change (Autopilot → Standard) and performs a `replace` operation — it destroys the existing Autopilot cluster and creates the new Standard cluster in one atomic step. There is no "old cluster remains running" window. Dev downtime during the Pulumi operation is expected and acceptable.
+
+1. Run `pulumi preview` to confirm the plan: Standard cluster create + Autopilot destroy + NAT/Router delete
+2. Run `pulumi up` (dev downtime begins)
+3. Update kubeconfig to point to new cluster endpoint
+4. ArgoCD syncs all applications automatically (GitOps — no manual kubectl apply needed)
+5. Verify all pods are Running in new cluster
+6. Verify nodes have external IPs (`kubectl get nodes -o wide`)
+
+Rollback: If the new cluster fails to come up, revert the Pulumi code change and run `pulumi up` again to restore the Autopilot cluster. No partial state to clean up since it's a single replace operation.
+
+## Open Questions
+
+- None. Migration path is well-defined and dev downtime is accepted.

--- a/openspec/changes/archive/2026-04-02-gke-cost-optimization/proposal.md
+++ b/openspec/changes/archive/2026-04-02-gke-cost-optimization/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+GKE Autopilot's mandatory $0.10/hr cluster management fee (¥10,800/month) and Cloud NAT's fixed gateway cost (¥5,292/month) together account for ~¥16,000/month in unavoidable overhead on the dev environment — costs that can be eliminated by switching to a Standard zonal cluster with public nodes.
+
+## What Changes
+
+- **Replace** the GKE Autopilot cluster (`cluster-osaka`) with a Standard zonal cluster in `asia-northeast2-a`
+  - New Spot node pool: `e2-standard-2`, min 1 / max 4 nodes
+  - No cluster management fee (first zonal cluster in project is free)
+- **Remove** Cloud NAT and Cloud Router from Pulumi (dev only)
+  - Enable public nodes (`enablePrivateNodes: false`) to give nodes external IPs
+  - All dependent services (Cloud SQL PSC, Secret Manager, Artifact Registry) are unaffected
+- **Update** all Kubernetes nodeSelector patches from `cloud.google.com/compute-class: autopilot-spot` → `cloud.google.com/gke-spot: "true"` across dev overlays
+
+## Capabilities
+
+### New Capabilities
+
+- `gke-standard-infrastructure`: Standard zonal GKE cluster with Spot node pool for dev, replacing Autopilot
+
+### Modified Capabilities
+
+- `deployment-infrastructure`: Node provisioning model changes from Autopilot (pod-based billing) to Standard (VM-based); Spot scheduling label changes
+- `infra`: Cloud NAT and Cloud Router resources removed for dev environment
+
+## Impact
+
+- **cloud-provisioning/src/**: Pulumi GKE cluster definition, Cloud NAT/Router resources
+- **cloud-provisioning/k8s/**: All dev overlay `spot-nodeselector-patch.yaml` files across namespaces
+- **ArgoCD**: Target cluster endpoint changes after migration
+- **Downtime**: Full cluster recreation required; dev downtime is acceptable
+- **Cost**: ~¥16,000/month reduction in usage cost (GKE ¥10,800 + NAT ¥5,292)

--- a/openspec/changes/archive/2026-04-02-gke-cost-optimization/specs/deployment-infrastructure/spec.md
+++ b/openspec/changes/archive/2026-04-02-gke-cost-optimization/specs/deployment-infrastructure/spec.md
@@ -1,0 +1,12 @@
+## MODIFIED Requirements
+
+### Requirement: All dev workload kinds use Spot VM scheduling
+Every workload in the dev environment — including Deployments, StatefulSets, and CronJobs — SHALL include the Spot VM nodeSelector (`cloud.google.com/gke-spot: "true"`).
+
+#### Scenario: CronJob Spot VM coverage
+- **WHEN** rendering the backend dev overlay manifests
+- **THEN** the concert-discovery CronJob pod template SHALL include nodeSelector `cloud.google.com/gke-spot: "true"`
+
+#### Scenario: All dev workloads on Spot VMs
+- **WHEN** running `kubectl get pods -A -o json` on the dev cluster
+- **THEN** every pod SHALL be scheduled on nodes with label `cloud.google.com/gke-spot: "true"`

--- a/openspec/changes/archive/2026-04-02-gke-cost-optimization/specs/gke-standard-infrastructure/spec.md
+++ b/openspec/changes/archive/2026-04-02-gke-cost-optimization/specs/gke-standard-infrastructure/spec.md
@@ -1,0 +1,34 @@
+## ADDED Requirements
+
+### Requirement: Standard zonal GKE cluster for dev
+The dev GKE cluster SHALL be a Standard (non-Autopilot) zonal cluster in `asia-northeast2-a` with a Spot VM node pool.
+
+#### Scenario: Cluster type is Standard
+- **WHEN** describing the dev GKE cluster
+- **THEN** the cluster mode SHALL be Standard (not Autopilot)
+- **AND** the cluster location SHALL be `asia-northeast2-a`
+
+#### Scenario: Spot node pool exists
+- **WHEN** listing node pools on the dev cluster
+- **THEN** a node pool with `spot: true` SHALL exist
+- **AND** the machine type SHALL be `e2-standard-2`
+- **AND** autoscaling SHALL be enabled with min 1 and max 4 nodes
+
+### Requirement: Dev cluster nodes SHALL have public external IPs
+Nodes in the dev GKE cluster SHALL NOT use private nodes, allowing direct internet egress without Cloud NAT.
+
+#### Scenario: Nodes have external IPs
+- **WHEN** running `kubectl get nodes -o wide` on the dev cluster
+- **THEN** every node SHALL show a non-empty `EXTERNAL-IP`
+
+#### Scenario: Cloud NAT is absent for dev
+- **WHEN** listing Cloud NAT gateways in the dev GCP project
+- **THEN** no Cloud NAT gateway SHALL exist for `asia-northeast2`
+
+### Requirement: Standard cluster Spot nodeSelector
+All workload pod templates in the dev environment SHALL use the Standard-cluster Spot label `cloud.google.com/gke-spot: "true"` for node scheduling.
+
+#### Scenario: Dev pod scheduled on Spot node
+- **WHEN** rendering any dev overlay manifest
+- **THEN** the pod template SHALL include nodeSelector `cloud.google.com/gke-spot: "true"`
+- **AND** SHALL NOT include `cloud.google.com/compute-class: autopilot-spot`

--- a/openspec/changes/archive/2026-04-02-gke-cost-optimization/specs/infra/spec.md
+++ b/openspec/changes/archive/2026-04-02-gke-cost-optimization/specs/infra/spec.md
@@ -1,5 +1,0 @@
-## REMOVED Requirements
-
-### Requirement: Cloud NAT gateway for dev
-**Reason**: Dev cluster nodes now have public external IPs (`enablePrivateNodes: false`), making Cloud NAT unnecessary for internet egress.
-**Migration**: Remove the `RouterNat` and `Router` Pulumi resources scoped to the dev environment. No workload changes required — egress continues to work via node public IPs.

--- a/openspec/changes/archive/2026-04-02-gke-cost-optimization/specs/infra/spec.md
+++ b/openspec/changes/archive/2026-04-02-gke-cost-optimization/specs/infra/spec.md
@@ -1,0 +1,5 @@
+## REMOVED Requirements
+
+### Requirement: Cloud NAT gateway for dev
+**Reason**: Dev cluster nodes now have public external IPs (`enablePrivateNodes: false`), making Cloud NAT unnecessary for internet egress.
+**Migration**: Remove the `RouterNat` and `Router` Pulumi resources scoped to the dev environment. No workload changes required — egress continues to work via node public IPs.

--- a/openspec/changes/archive/2026-04-02-gke-cost-optimization/tasks.md
+++ b/openspec/changes/archive/2026-04-02-gke-cost-optimization/tasks.md
@@ -1,0 +1,32 @@
+## 1. Pulumi: Replace Autopilot cluster with Standard cluster
+
+- [x] 1.1 In `cloud-provisioning/src/gcp/components/kubernetes.ts`, replace the Autopilot cluster resource with a Standard zonal cluster in `asia-northeast2-a`
+- [x] 1.2 Add a Spot node pool (`e2-standard-2`, `spot: true`, min 1 / max 4) to the new Standard cluster
+- [x] 1.3 Set `enablePrivateNodes: false` in `privateClusterConfig` (public nodes)
+- [x] 1.4 Remove or retain `masterIpv4CidrBlock` as appropriate (no longer required for public nodes)
+
+## 2. Pulumi: Remove Cloud NAT and Cloud Router for dev
+
+- [x] 2.1 In `cloud-provisioning/src/gcp/components/network.ts`, remove the `RouterNat` resource (`nat-osaka`) for dev
+- [x] 2.2 Remove the `Router` resource (`nat-router-osaka`) for dev, or make it conditional on environment
+- [x] 2.3 Verify no other resources depend on the Router/NAT before removal
+
+## 3. Kubernetes: Update Spot nodeSelector in all dev overlays
+
+- [x] 3.1 Find all `spot-nodeselector-patch.yaml` files under `k8s/namespaces/*/overlays/dev/`
+- [x] 3.2 Replace `cloud.google.com/compute-class: autopilot-spot` with `cloud.google.com/gke-spot: "true"` in every file
+- [x] 3.3 Verify the patch applies correctly via `kubectl kustomize k8s/namespaces/<namespace>/overlays/dev` for each namespace
+
+## 4. Deploy and migrate workloads
+
+- [x] 4.1 Run `pulumi preview` on the dev stack and confirm the plan: new Standard cluster created, old Autopilot cluster destroyed, Cloud NAT/Router removed
+- [x] 4.2 Run `pulumi up` on the dev stack (downtime expected)
+- [x] 4.3 Update local kubeconfig: `gcloud container clusters get-credentials <new-cluster> --zone asia-northeast2-a --project liverty-music-dev`
+- [x] 4.4 Confirm ArgoCD syncs all applications automatically and all pods reach Running state
+- [x] 4.5 Verify `kubectl get nodes -o wide` shows non-empty `EXTERNAL-IP` for all nodes
+
+## 5. Verify cost reduction
+
+- [x] 5.1 Confirm no Cloud NAT gateway exists: `gcloud compute routers nats list --router=nat-router-osaka --region=asia-northeast2 --project=liverty-music-dev` returns empty or error
+- [x] 5.2 Confirm cluster is Standard: `gcloud container clusters describe <cluster> --zone asia-northeast2-a --format="value(autopilot.enabled)"` returns `False`
+- [x] 5.3 Confirm Spot scheduling: `kubectl get pods -A -o jsonpath='{.items[*].spec.nodeSelector}'` includes `gke-spot: "true"` for all pods

--- a/openspec/specs/deployment-infrastructure/spec.md
+++ b/openspec/specs/deployment-infrastructure/spec.md
@@ -106,14 +106,14 @@ The backend server deployment in the dev environment SHALL run with 1 replica. P
 
 ### Requirement: All dev workload kinds use Spot VM scheduling
 
-Every workload in the dev environment — including Deployments, StatefulSets, and CronJobs — SHALL include the Spot VM nodeSelector (`cloud.google.com/compute-class: autopilot-spot`).
+Every workload in the dev environment — including Deployments, StatefulSets, and CronJobs — SHALL include the Spot VM nodeSelector (`cloud.google.com/gke-spot: "true"`).
 
 #### Scenario: CronJob Spot VM coverage
 
 - **WHEN** rendering the backend dev overlay manifests
-- **THEN** the concert-discovery CronJob pod template SHALL include nodeSelector `cloud.google.com/compute-class: autopilot-spot`
+- **THEN** the concert-discovery CronJob pod template SHALL include nodeSelector `cloud.google.com/gke-spot: "true"`
 
 #### Scenario: All dev workloads on Spot VMs
 
 - **WHEN** running `kubectl get pods -A -o json` on the dev cluster
-- **THEN** every pod SHALL be scheduled on nodes with compute class `autopilot-spot`
+- **THEN** every pod SHALL be scheduled on nodes with label `cloud.google.com/gke-spot: "true"`

--- a/openspec/specs/gke-standard-infrastructure/spec.md
+++ b/openspec/specs/gke-standard-infrastructure/spec.md
@@ -1,0 +1,40 @@
+# gke-standard-infrastructure Specification
+
+## Purpose
+
+Defines requirements for the dev GKE Standard cluster configuration, including Spot VM node pools and network topology.
+
+## Requirements
+
+### Requirement: Standard zonal GKE cluster for dev
+The dev GKE cluster SHALL be a Standard (non-Autopilot) zonal cluster in `asia-northeast2-a` with a Spot VM node pool.
+
+#### Scenario: Cluster type is Standard
+- **WHEN** describing the dev GKE cluster
+- **THEN** the cluster mode SHALL be Standard (not Autopilot)
+- **AND** the cluster location SHALL be `asia-northeast2-a`
+
+#### Scenario: Spot node pool exists
+- **WHEN** listing node pools on the dev cluster
+- **THEN** a node pool with `spot: true` SHALL exist
+- **AND** the machine type SHALL be `e2-standard-2`
+- **AND** autoscaling SHALL be enabled with min 1 and max 4 nodes
+
+### Requirement: Dev cluster nodes SHALL have public external IPs
+Nodes in the dev GKE cluster SHALL NOT use private nodes, allowing direct internet egress without Cloud NAT.
+
+#### Scenario: Nodes have external IPs
+- **WHEN** running `kubectl get nodes -o wide` on the dev cluster
+- **THEN** every node SHALL show a non-empty `EXTERNAL-IP`
+
+#### Scenario: Cloud NAT is absent for dev
+- **WHEN** listing Cloud NAT gateways in the dev GCP project
+- **THEN** no Cloud NAT gateway SHALL exist for `asia-northeast2`
+
+### Requirement: Standard cluster Spot nodeSelector
+All workload pod templates in the dev environment SHALL use the Standard-cluster Spot label `cloud.google.com/gke-spot: "true"` for node scheduling.
+
+#### Scenario: Dev pod scheduled on Spot node
+- **WHEN** rendering any dev overlay manifest
+- **THEN** the pod template SHALL include nodeSelector `cloud.google.com/gke-spot: "true"`
+- **AND** SHALL NOT include `cloud.google.com/compute-class: autopilot-spot`

--- a/openspec/specs/gke-standard-infrastructure/spec.md
+++ b/openspec/specs/gke-standard-infrastructure/spec.md
@@ -38,3 +38,11 @@ All workload pod templates in the dev environment SHALL use the Standard-cluster
 - **WHEN** rendering any dev overlay manifest
 - **THEN** the pod template SHALL include nodeSelector `cloud.google.com/gke-spot: "true"`
 - **AND** SHALL NOT include `cloud.google.com/compute-class: autopilot-spot`
+
+### Requirement: Shielded GKE Nodes SHALL be enabled on the Spot node pool
+The dev cluster node pool SHALL have Shielded GKE Nodes enabled (`shieldedInstanceConfig`), since Standard clusters do not enforce this automatically unlike Autopilot. This is especially important given nodes have public external IPs (`enablePrivateNodes: false`).
+
+#### Scenario: Node pool has shieldedInstanceConfig enabled
+- **WHEN** describing the dev GKE node pool configuration
+- **THEN** `shieldedInstanceConfig.enableSecureBoot` SHALL be `true`
+- **AND** `shieldedInstanceConfig.enableIntegrityMonitoring` SHALL be `true`


### PR DESCRIPTION
## Summary

- Sync `deployment-infrastructure` spec: update Spot VM nodeSelector from `compute-class: autopilot-spot` to `gke-spot: "true"` (GKE Standard cluster label)
- Add new `gke-standard-infrastructure` capability spec documenting Standard zonal cluster requirements, Spot node pool, and public node IP topology
- Archive completed `gke-cost-optimization` change to `openspec/changes/archive/2026-04-02-gke-cost-optimization/`

## Why

The GKE Autopilot → Standard cluster migration (liverty-music/cloud-provisioning#179) is complete and all workloads are verified healthy. This PR captures the final spec state reflecting the new cluster architecture.

close: liverty-music/cloud-provisioning#179
