### PR TITLE
docs(openspec): sync and archive refine-onboarding-ux change

### DIFF
--- a/openspec/changes/archive/2026-04-05-refine-onboarding-ux/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-05-refine-onboarding-ux/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-01

--- a/openspec/changes/archive/2026-04-05-refine-onboarding-ux/design.md
+++ b/openspec/changes/archive/2026-04-05-refine-onboarding-ux/design.md
@@ -1,0 +1,84 @@
+## Context
+
+The guest onboarding UX has three observable regressions after onboarding completes:
+
+1. **Header clutter**: `artist-filter-bar` renders artist name chips in the page header when a filter is active. The header has limited horizontal space, and chip text duplicates information already visible in the concert highway.
+
+2. **Silent laser beam failure**: `FollowServiceClient.listFollowed()` for unauthenticated users hardcodes `hype: 'watch'` for every artist. `isHypeMatched('watch', lane)` always returns `false` (HYPE_ORDER=0 < all LANE_ORDERs ≥1), so `ConcertHighway.buildBeamIndexMap()` produces an empty map and no beams render — even though the guest may have set hype levels in My Artists.
+
+   Root cause: `GuestFollow` entity lacks a `hype` field. Hype is stored separately in `GuestService.hypes: Record<string, string>` (key `liverty:guest:hypes`), but `listFollowed()` never reads it.
+
+3. **Banner copy mismatch**: Japanese banner text is two sentences and wraps to 3 lines on mobile. English text (`"🔔 To enable notifications"`) is far shorter and communicates less value.
+
+Current entity shape:
+```
+GuestFollow   { artist: Artist, home: string | null }  ← home always null
+FollowedArtist { artist: Artist, hype: Hype }
+```
+The two types are structurally incompatible despite representing the same concept (a user's relationship with an artist). `GuestFollow.home` is set to `null` everywhere and is never read — the guest's home area is stored separately in `GuestService.home`.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Remove artist name chips from filter bar header; preserve filter icon active state
+- Unify guest and authenticated follow representation under `FollowedArtist`
+- Make guest laser beams render correctly by reading persisted hype values
+- Shorten Japanese signup banner copy to ≤2 lines; align English copy in meaning
+
+**Non-Goals:**
+- Changing hype persistence storage key (`liverty:guest:hypes` key eliminated, follows now unified under `guest.followedArtists`)
+- Changing backend RPC contracts or proto schema
+- Adding new onboarding steps or flow changes
+- Fixing beam rendering for authenticated users (already works correctly)
+
+## Decisions
+
+### Decision 1: Eliminate `GuestFollow`, unify on `FollowedArtist`
+
+**Chosen**: Remove `GuestFollow`. `GuestService.follows` becomes `FollowedArtist[]`. Hype is stored inline in each follow entry. The separate `hypes: Record<string, string>` sidecar and `liverty:guest:hypes` storage key are eliminated.
+
+**Alternatives considered**:
+- *Keep `GuestFollow`, read `getHypes()` in `listFollowed()`*: Fixes the beam bug with minimal change, but leaves the structural lie (`GuestFollow` with dead `home` field) and the dual-storage awkwardness intact.
+- *Add `hype` field to `GuestFollow`*: Halfway solution — two types still diverge with no benefit.
+
+**Rationale**: `GuestFollow.home` has never been used (always `null`). The type exists solely as a historical artifact. Merging into `FollowedArtist` removes a conceptual mismatch, collapses dual storage into one key, and makes `listFollowed()` trivially correct.
+
+### Decision 2: `DEFAULT_HYPE` constant in entity layer
+
+**Chosen**: Define `export const DEFAULT_HYPE: Hype = 'watch'` in `entities/follow.ts`. All fallback assignments (`entry?.hype ?? 'watch'` in `concert-service.ts`, etc.) reference this constant.
+
+**Rationale**: The default hype value is a business rule ("new follows start at watch-only"). It belongs in the entity layer, not scattered as string literals across service and adapter files.
+
+### Decision 3: Remove chips from filter bar, retain icon active state
+
+**Chosen**: Delete the `<ul class="chips-list">` block from `artist-filter-bar.html`. The filter trigger button already has `data-active.bind="selectedIds.length > 0"` which CSS uses to change its color. Users re-open the bottom sheet to change or clear the filter.
+
+**Alternatives considered**:
+- *Keep chips but move them below the header*: Adds complexity, consumes vertical space above the concert grid.
+- *Replace chips with a count badge on the icon*: Valid, but adds a new UI element not currently designed.
+
+**Rationale**: The filter icon's active state is sufficient affordance for a secondary feature. Removing chips simplifies the header significantly.
+
+### Decision 4: localStorage migration for unified follow format
+
+**Chosen**: `loadFollows()` migrates on read. If a stored entry lacks a `hype` field (legacy `GuestFollow` format), the validator accepts it and falls back to `DEFAULT_HYPE`. No separate migration script needed.
+
+The separate `liverty:guest:hypes` key is no longer written. On data merge at signup, `GuestService.getHypes()` is replaced by reading hype from each `FollowedArtist` entry. The `clearHypes()` call in `clearAll()` is removed (key simply becomes orphaned and is ignored).
+
+## Risks / Trade-offs
+
+- **Legacy localStorage key `liverty:guest:hypes` becomes orphaned** → Acceptable. The key is not written after this change. Existing data in it is ignored. It does not affect correctness because hype is now read from the unified `guest.followedArtists` storage. A future cleanup task can remove it, but it causes no harm.
+
+- **Data merge on signup no longer calls `SetHype` separately** → The `guest-data-merge` flow currently reads from `GuestService.getHypes()`. After this change, hype values are embedded in `FollowedArtist[]` entries. The merge code must be updated to iterate `guest.follows` and call `SetHype` for entries where `hype !== DEFAULT_HYPE`. This is a correctness requirement captured in tasks.
+
+- **Filter dismiss UX change** → Users who relied on the `×` chip to dismiss individual filters lose that affordance. They must re-open the bottom sheet. This is a deliberate simplification; the bottom sheet already supports partial deselection.
+
+## Migration Plan
+
+1. Deploy frontend change only (no backend, no BSR release).
+2. Existing users with `liverty:guest:hypes` data: hype values are now embedded in `guest.followedArtists`. If both keys exist simultaneously (user had old data), the new `loadFollows()` returns entries with `hype: DEFAULT_HYPE` (from missing field fallback). Their previously-set hype values in the orphaned key are effectively lost. This is acceptable given that: (a) the affected population is small (guest users mid-session during deploy), and (b) hype can be re-set in My Artists at no cost.
+3. No server-side rollout coordination required.
+
+## Open Questions
+
+None — all decisions above are resolved based on codebase exploration.

--- a/openspec/changes/archive/2026-04-05-refine-onboarding-ux/proposal.md
+++ b/openspec/changes/archive/2026-04-05-refine-onboarding-ux/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+The guest onboarding UX has three compounding issues: the artist-filter UI clutters the header with redundant artist names; laser beam effects (a core "wow" moment) never render for guest users because `GuestFollow` lacks a `hype` field, causing all events to fall back to `hype='watch'` which never satisfies `isHypeMatched`; and the signup banner carries inconsistent copy across locales. All three are visible immediately after onboarding completes and undermine first impressions.
+
+## What Changes
+
+- **Remove filter chips from page header** — artist names SHALL NOT be rendered as chips in the header when a filter is active; the filter icon's active state (color change via `data-active`) alone conveys filter status; dismiss is achieved by re-tapping the filter icon to open the bottom sheet
+- **Eliminate `GuestFollow` entity** — replace `GuestFollow` with `FollowedArtist` as the unified follow representation for both guest and authenticated users; hype is stored inline alongside artist data rather than in a separate `hypes: Record<string, string>` sidecar; `DEFAULT_HYPE` constant defined in entity layer
+- **Fix guest laser beam rendering** — `FollowServiceClient.listFollowed()` for unauthenticated users SHALL read persisted hype from `GuestService` instead of hardcoding `'watch'`; matched events will render beam effects correctly
+- **Align signup banner copy** — Japanese banner message shortened to ≤2 lines; English message updated to match intent
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `dashboard-artist-filter`: Remove the "filter chips displayed in header" requirement; filter active state conveyed by icon styling only
+- `signup-prompt-banner`: Update banner copy requirement to reflect new Japanese text (≤2 lines) and aligned English text
+- `guest-data-merge`: `GuestFollow` storage format changes — follows are stored as `FollowedArtist[]` (with `hype` field) under a single key; separate `liverty:guest:hypes` key is eliminated; migration path required for existing localStorage data
+
+## Impact
+
+- `frontend/src/entities/follow.ts` — remove `GuestFollow`, add `DEFAULT_HYPE` constant
+- `frontend/src/adapter/storage/guest-storage.ts` — remove `saveHypes`/`loadHypes`/`clearHypes`; update `saveFollows`/`loadFollows` to use `FollowedArtist[]`; update validator to include `hype` field (with fallback for legacy data)
+- `frontend/src/services/guest-service.ts` — `follows` typed as `FollowedArtist[]`; remove `hypes` sidecar; `setHype()` updates the matching follow entry; `getHypes()` removed
+- `frontend/src/services/follow-service-client.ts` — `listFollowed()` guest branch returns `guest.follows` directly (already typed as `FollowedArtist[]`)
+- `frontend/src/components/artist-filter-bar/artist-filter-bar.html` — remove chips `<ul>` block (lines 18–32)
+- `frontend/src/locales/en/translation.json` and `ja/translation.json` — update `myArtists.signupBanner.message`
+- `frontend/src/entities/index.ts` — remove `GuestFollow` re-export
+- No backend changes; no proto changes; no BSR release needed

--- a/openspec/changes/archive/2026-04-05-refine-onboarding-ux/specs/dashboard-artist-filter/spec.md
+++ b/openspec/changes/archive/2026-04-05-refine-onboarding-ux/specs/dashboard-artist-filter/spec.md
@@ -1,0 +1,29 @@
+## MODIFIED Requirements
+
+### Requirement: Filter chip UI in page header
+The page header SHALL display a filter trigger button that visually indicates when a filter is active. Artist names SHALL NOT be rendered as chips in the header.
+
+#### Scenario: No active filter — header unchanged
+- **WHEN** `filteredArtistIds` is empty
+- **THEN** no filter indicator SHALL be visible in the header beyond the compact filter trigger button
+- **AND** the filter trigger button SHALL be in its default (inactive) visual state
+
+#### Scenario: Active filter — icon state only
+- **WHEN** `filteredArtistIds` contains one or more IDs
+- **THEN** the filter trigger button SHALL display in its active visual state (e.g., color change via `[data-active="true"]` CSS)
+- **AND** no artist name chips SHALL be rendered in the header
+
+#### Scenario: Dismissing an active filter
+- **WHEN** a filter is active and the user taps the filter trigger button
+- **THEN** the bottom sheet SHALL open with currently filtered artists pre-selected
+- **AND** the user can deselect artists and confirm to reduce or clear the filter
+
+## REMOVED Requirements
+
+### Requirement: Active filter — chips displayed (REMOVED)
+**Reason**: Chips consume significant header space and duplicate artist names already visible in the concert highway. The filter icon's active state (color change) is sufficient affordance for a secondary feature. Simplifying the header improves visual hierarchy.
+**Migration**: Remove the `<ul class="chips-list">` block and associated CSS from `artist-filter-bar.html` and `artist-filter-bar.css`. The `dismiss(id)` method in `artist-filter-bar.ts` may be removed if it is only used by the chip dismiss button.
+
+### Requirement: Long artist name overflow (REMOVED)
+**Reason**: Chips are removed; overflow truncation is no longer needed.
+**Migration**: Remove chip overflow CSS rules from `artist-filter-bar.css`.

--- a/openspec/changes/archive/2026-04-05-refine-onboarding-ux/specs/guest-data-merge/spec.md
+++ b/openspec/changes/archive/2026-04-05-refine-onboarding-ux/specs/guest-data-merge/spec.md
@@ -1,0 +1,48 @@
+## MODIFIED Requirements
+
+### Requirement: Guest Data Storage
+The system SHALL store guest session data in LocalStorage under namespaced keys during the onboarding tutorial. Guest follows SHALL be stored as `FollowedArtist[]` including hype level, under a single key.
+
+#### Scenario: Followed artists stored locally with hype
+- **WHEN** a guest user taps an artist bubble during Artist Discovery
+- **THEN** the system SHALL append `{ artist, hype: DEFAULT_HYPE }` to a JSON array in LocalStorage under `guest.followedArtists`
+
+#### Scenario: Hype update stored inline in follow entry
+- **WHEN** a guest user changes a hype level for a followed artist
+- **THEN** the system SHALL update the `hype` field of the matching entry in `guest.followedArtists`
+- **AND** the system SHALL NOT write to the `liverty:guest:hypes` key
+
+#### Scenario: Legacy data read with hype fallback
+- **WHEN** `guest.followedArtists` contains entries in the old `GuestFollow` format (missing `hype` field)
+- **THEN** the system SHALL accept those entries and assign `DEFAULT_HYPE` as the hype value
+- **AND** the system SHALL NOT throw or discard those entries
+
+### Requirement: Guest hype included in data merge on signup
+The system SHALL merge guest hype values to the backend on signup by reading hype from the unified `guest.followedArtists` entries.
+
+#### Scenario: Guest hype merged from follow entries
+- **WHEN** Passkey authentication completes successfully
+- **AND** `guest.followedArtists` contains entries with `hype !== DEFAULT_HYPE`
+- **THEN** the system SHALL call `FollowService.SetHype` for each such artist as part of the merge sequence
+- **AND** hype merge SHALL occur after artist follow calls complete
+
+#### Scenario: Hype merge failure is non-blocking
+- **WHEN** a `FollowService.SetHype` call fails during merge
+- **THEN** the system SHALL log the error
+- **AND** the system SHALL continue with remaining hype calls (best-effort)
+- **AND** the merge SHALL still be considered complete
+
+#### Scenario: Guest data cleared after merge
+- **WHEN** the data merge completes
+- **THEN** the system SHALL remove `guest.followedArtists` from localStorage as part of the standard guest data cleanup
+- **AND** the system SHALL NOT need to remove `liverty:guest:hypes` (key is no longer written)
+
+## REMOVED Requirements
+
+### Requirement: Guest Hype Data Storage (REMOVED)
+**Reason**: Hype is now stored inline in each `FollowedArtist` entry under `guest.followedArtists`. The separate `liverty:guest:hypes` key is redundant and eliminated.
+**Migration**: Remove `saveHypes`, `loadHypes`, `clearHypes` from `guest-storage.ts`. Remove `hypes: Record<string, string>` sidecar field from `GuestService`. Replace `setHype(id, hype)` + `getHypes()` methods with inline mutation of the matching entry in `follows`. Remove `clearHypes()` call from `GuestService.clearAll()`.
+
+### Requirement: Guest hype cleared after merge (superseded)
+**Reason**: Replaced by the updated "Guest data cleared after merge" scenario above, which covers hype cleanup via the unified follow entry.
+**Migration**: No separate `clearHypes()` call in the merge path; hype data is cleared as part of `guest.followedArtists` cleanup.

--- a/openspec/changes/archive/2026-04-05-refine-onboarding-ux/specs/signup-prompt-banner/spec.md
+++ b/openspec/changes/archive/2026-04-05-refine-onboarding-ux/specs/signup-prompt-banner/spec.md
@@ -1,0 +1,14 @@
+## MODIFIED Requirements
+
+### Requirement: Guest Signup Prompt Banner
+The system SHALL display a non-modal signup prompt banner to guest users after onboarding completion. The banner copy SHALL be concise (≤2 lines on mobile) and SHALL be consistent in intent across English and Japanese locales.
+
+#### Scenario: Banner copy — Japanese
+- **WHEN** the signup prompt banner is displayed to a guest user in Japanese locale
+- **THEN** the banner SHALL display: "フォロー情報を保存してコンサート通知を受け取ろう！"
+- **AND** the banner SHALL include a [アカウント作成] CTA button
+
+#### Scenario: Banner copy — English
+- **WHEN** the signup prompt banner is displayed to a guest user in English locale
+- **THEN** the banner SHALL display: "Save your followed artists and get concert notifications."
+- **AND** the banner SHALL include a [Create Account] CTA button

--- a/openspec/changes/archive/2026-04-05-refine-onboarding-ux/tasks.md
+++ b/openspec/changes/archive/2026-04-05-refine-onboarding-ux/tasks.md
@@ -1,0 +1,50 @@
+## 1. Entity Layer — Unify Follow Representation
+
+- [x] 1.1 Add `DEFAULT_HYPE: Hype = 'watch'` constant to `src/entities/follow.ts`
+- [x] 1.2 Remove `GuestFollow` interface from `src/entities/follow.ts`
+- [x] 1.3 Remove `GuestFollow` from `src/entities/index.ts` re-exports
+
+## 2. Storage Adapter — Unified Follow Format
+
+- [x] 2.1 Update `saveFollows` / `loadFollows` in `src/adapter/storage/guest-storage.ts` to use `FollowedArtist[]`
+- [x] 2.2 Update `isGuestFollow` validator to check for `hype` field; fall back to `DEFAULT_HYPE` when field is absent (legacy migration)
+- [x] 2.3 Remove `saveHypes`, `loadHypes`, `clearHypes` functions from `src/adapter/storage/guest-storage.ts`
+
+## 3. GuestService — Inline Hype Management
+
+- [x] 3.1 Change `follows` field type to `FollowedArtist[]` in `src/services/guest-service.ts`; update `loadFollows()` call
+- [x] 3.2 Remove `hypes: Record<string, string>` field and `loadHypes()` initialization
+- [x] 3.3 Rewrite `setHype(artistId, hype)` to mutate the matching `follows` entry and call `persistFollows()`
+- [x] 3.4 Remove `getHypes()` method
+- [x] 3.5 Update `follow()` to push `{ artist, hype: DEFAULT_HYPE }` (replacing `{ artist, home: null }`)
+- [x] 3.6 Remove `clearHypes()` call from `clearAll()`; remove `import { clearHypes }` from storage import
+
+## 4. FollowServiceClient — Correct Guest listFollowed
+
+- [x] 4.1 Update `listFollowed()` guest branch in `src/services/follow-service-client.ts` to return `guest.follows` directly (remove `hype: 'watch' as const` hardcode)
+
+## 5. Data Merge — Read Hype from Follow Entries
+
+- [x] 5.1 Find the signup merge path that calls `guest.getHypes()` and update it to iterate `guest.follows`, calling `SetHype` for entries where `hype !== DEFAULT_HYPE`
+
+## 6. ConcertService — Reference DEFAULT_HYPE
+
+- [x] 6.1 Replace `entry?.hype ?? 'watch'` literal in `src/services/concert-service.ts` with `entry?.hype ?? DEFAULT_HYPE`
+
+## 7. Artist Filter Bar — Remove Header Chips
+
+- [x] 7.1 Remove `<ul class="chips-list">` block (the active filter chips) from `src/components/artist-filter-bar/artist-filter-bar.html`
+- [x] 7.2 Remove chip-related CSS rules (`.chips-list`, `.chip`, `.chip-name`, `.chip-dismiss`) from `src/components/artist-filter-bar/artist-filter-bar.css`
+- [x] 7.3 Remove `dismiss(id)` method from `src/components/artist-filter-bar/artist-filter-bar.ts` if it is only used by the chip dismiss button
+
+## 8. Signup Banner — Update Copy
+
+- [x] 8.1 Update `myArtists.signupBanner.message` in `src/locales/ja/translation.json` to `"フォロー情報を保存してコンサート通知を受け取ろう！"`
+- [x] 8.2 Update `myArtists.signupBanner.message` in `src/locales/en/translation.json` to `"Save your followed artists and get concert notifications."`
+
+## 9. Verification
+
+- [x] 9.1 Run `make check` and confirm all lint + unit tests pass
+- [ ] 9.2 Manually verify: follow 2+ artists as guest → set hype on one → navigate to dashboard → confirm laser beam renders for the hype-elevated artist
+- [ ] 9.3 Manually verify: activate artist filter → confirm no chips appear in header; filter icon shows active state
+- [ ] 9.4 Manually verify: signup banner shows updated copy in both Japanese and English locales

--- a/openspec/specs/dashboard-artist-filter/spec.md
+++ b/openspec/specs/dashboard-artist-filter/spec.md
@@ -29,37 +29,28 @@ When the user changes the active filter via the UI, the dashboard URL SHALL be u
 - **THEN** the browser URL SHALL update to `/dashboard?artists=<selectedIds>` via `history.replaceState`
 - **THEN** the concert highway SHALL immediately display only matching concerts
 
-#### Scenario: User removes a filter chip
-- **WHEN** the user taps the `×` on an active artist chip
-- **THEN** that artist SHALL be removed from `filteredArtistIds`
-- **THEN** the URL SHALL update accordingly (or revert to `/dashboard` if the list becomes empty)
-
-#### Scenario: All chips dismissed
-- **WHEN** the last active filter chip is dismissed
-- **THEN** the URL SHALL revert to `/dashboard` (no `artists` param)
-- **THEN** all followed-artist concerts SHALL be displayed
-
 #### Scenario: Page reload preserves filter
 - **WHEN** the user reloads the page while a filter is active
 - **THEN** the `artists` query param SHALL be re-parsed from the URL
 - **THEN** the same filtered view SHALL be restored
 
 ### Requirement: Filter chip UI in page header
-The page header SHALL display a dismissible chip for each active artist filter. A trigger button SHALL always be available to open the artist-selection bottom sheet.
+The page header SHALL display a filter trigger button that visually indicates when a filter is active. Artist names SHALL NOT be rendered as chips in the header.
 
 #### Scenario: No active filter — header unchanged
 - **WHEN** `filteredArtistIds` is empty
-- **THEN** no filter chips SHALL be visible in the header
-- **THEN** a compact filter trigger button SHALL be visible
+- **THEN** no filter indicator SHALL be visible in the header beyond the compact filter trigger button
+- **AND** the filter trigger button SHALL be in its default (inactive) visual state
 
-#### Scenario: Active filter — chips displayed
+#### Scenario: Active filter — icon state only
 - **WHEN** `filteredArtistIds` contains one or more IDs
-- **THEN** one chip per artist SHALL appear in the header showing the artist name
-- **THEN** each chip SHALL have a `×` dismiss control
+- **THEN** the filter trigger button SHALL display in its active visual state (e.g., color change via `[data-active="true"]` CSS)
+- **AND** no artist name chips SHALL be rendered in the header
 
-#### Scenario: Long artist name overflow
-- **WHEN** an artist name exceeds available chip width
-- **THEN** the name SHALL be truncated with an ellipsis within the chip
+#### Scenario: Dismissing an active filter
+- **WHEN** a filter is active and the user taps the filter trigger button
+- **THEN** the bottom sheet SHALL open with currently filtered artists pre-selected
+- **AND** the user can deselect artists and confirm to reduce or clear the filter
 
 ### Requirement: Artist-selection bottom sheet
 A bottom sheet SHALL allow the user to select one or more followed artists as a filter.

--- a/openspec/specs/guest-data-merge/spec.md
+++ b/openspec/specs/guest-data-merge/spec.md
@@ -1,31 +1,38 @@
 ### Requirement: Guest Data Storage
 
-The system SHALL store guest session data in LocalStorage under namespaced keys during the onboarding tutorial.
+The system SHALL store guest session data in LocalStorage under namespaced keys during the onboarding tutorial. Guest follows SHALL be stored as `FollowedArtist[]` including hype level, under a single key.
 
-#### Scenario: Followed artists stored locally
+#### Scenario: Followed artists stored locally with hype
 
-- **WHEN** a guest user taps an artist bubble during Step 1 (Artist Discovery)
-- **THEN** the system SHALL append the artist's ID and name to a JSON array in LocalStorage under `liverty:guest:followedArtists`
+- **WHEN** a guest user taps an artist bubble during Artist Discovery
+- **THEN** the system SHALL append `{ artist, hype: DEFAULT_HYPE }` to a JSON array in LocalStorage under `guest.followedArtists`
+
+#### Scenario: Hype update stored inline in follow entry
+
+- **WHEN** a guest user changes a hype level for a followed artist
+- **THEN** the system SHALL update the `hype` field of the matching entry in `guest.followedArtists`
+- **AND** the system SHALL NOT write to the `liverty:guest:hypes` key
+
+#### Scenario: Legacy data read with hype fallback
+
+- **WHEN** `guest.followedArtists` contains entries in the old `GuestFollow` format (missing `hype` field)
+- **THEN** the system SHALL accept those entries and assign `DEFAULT_HYPE` as the hype value
+- **AND** the system SHALL NOT throw or discard those entries
 
 #### Scenario: Region selection stored locally
 
 - **WHEN** a guest user selects a region during Step 3 (Dashboard)
 - **THEN** the system SHALL store the selected region value in LocalStorage under `liverty:guest:region`
 
-### Requirement: Guest Hype Data Storage
+### Requirement: Guest hype included in data merge on signup
 
-The system SHALL store guest hype level selections in localStorage and merge them to the backend on signup.
+The system SHALL merge guest hype values to the backend on signup by reading hype from the unified `guest.followedArtists` entries.
 
-#### Scenario: Guest hype stored in localStorage
-
-- **WHEN** a guest user changes a hype level for an artist
-- **THEN** the system SHALL store the value in `GuestService` under `liverty:guest:hypes` as a JSON object mapping artistId → hype type string
-
-#### Scenario: Guest hype included in data merge on signup
+#### Scenario: Guest hype merged from follow entries
 
 - **WHEN** Passkey authentication completes successfully
-- **AND** `liverty:guest:hypes` contains one or more entries
-- **THEN** the system SHALL call `FollowService.SetHype` for each artist in `liverty:guest:hypes` as part of the merge sequence
+- **AND** `guest.followedArtists` contains entries with `hype !== DEFAULT_HYPE`
+- **THEN** the system SHALL call `FollowService.SetHype` for each such artist as part of the merge sequence
 - **AND** hype merge SHALL occur after artist follow calls complete
 
 #### Scenario: Hype merge failure is non-blocking
@@ -35,10 +42,11 @@ The system SHALL store guest hype level selections in localStorage and merge the
 - **AND** the system SHALL continue with remaining hype calls (best-effort)
 - **AND** the merge SHALL still be considered complete
 
-#### Scenario: Guest hype cleared after merge
+#### Scenario: Guest data cleared after merge
 
 - **WHEN** the data merge completes
-- **THEN** the system SHALL remove `liverty:guest:hypes` from localStorage as part of the standard guest data cleanup
+- **THEN** the system SHALL remove `guest.followedArtists` from localStorage as part of the standard guest data cleanup
+- **AND** the system SHALL NOT need to remove `liverty:guest:hypes` (key is no longer written)
 
 ### Requirement: Data Merge on Authentication
 

--- a/openspec/specs/guest-data-merge/spec.md
+++ b/openspec/specs/guest-data-merge/spec.md
@@ -56,8 +56,8 @@ The system SHALL sync all locally stored guest data to the backend via existing 
 
 - **WHEN** Passkey authentication completes successfully
 - **THEN** the system SHALL call `UserService.Create` with the user's email
-- **AND** the system SHALL call `ArtistService.Follow` for each artist in `liverty:guest:followedArtists`
-- **AND** upon successful completion of all calls, the system SHALL clear all `liverty:guest:*` keys from LocalStorage
+- **AND** the system SHALL call `ArtistService.Follow` for each artist in `guest.followedArtists`
+- **AND** upon successful completion of all calls, the system SHALL clear `guest.followedArtists` and `liverty:guest:region` from LocalStorage
 
 #### Scenario: User already exists during merge
 
@@ -84,11 +84,11 @@ The system SHALL remove all guest data from LocalStorage after a successful merg
 #### Scenario: Cleanup after successful merge
 
 - **WHEN** the data merge completes (regardless of partial failures)
-- **THEN** the system SHALL remove `liverty:guest:followedArtists` from LocalStorage
+- **THEN** the system SHALL remove `guest.followedArtists` from LocalStorage
 - **AND** the system SHALL remove `liverty:guest:region` from LocalStorage
 
 #### Scenario: Cleanup on fresh tutorial start
 
 - **WHEN** a user taps [Get Started] on the LP to begin the tutorial
-- **AND** stale `liverty:guest:*` keys exist in LocalStorage
-- **THEN** the system SHALL clear all `liverty:guest:*` keys before starting Step 1
+- **AND** stale guest keys (`guest.followedArtists`, `liverty:guest:region`) exist in LocalStorage
+- **THEN** the system SHALL clear those keys before starting Step 1

--- a/openspec/specs/signup-prompt-banner/spec.md
+++ b/openspec/specs/signup-prompt-banner/spec.md
@@ -8,13 +8,19 @@ Provide a persistent fixed banner on My Artists and Dashboard pages prompting un
 
 ### Requirement: Guest Signup Prompt Banner
 
-The system SHALL display a non-modal signup prompt banner to guest users after onboarding completion. The banner copy SHALL emphasize follow data persistence and notification benefit.
+The system SHALL display a non-modal signup prompt banner to guest users after onboarding completion. The banner copy SHALL be concise (≤2 lines on mobile) and SHALL be consistent in intent across English and Japanese locales.
 
-#### Scenario: Banner copy reflects data persistence and notifications
+#### Scenario: Banner copy — Japanese
 
-- **WHEN** the signup prompt banner is displayed to a guest user
-- **THEN** the banner SHALL display: "アカウントを作成してフォロー情報を保存しよう。新着コンサート通知も有効になります！"
+- **WHEN** the signup prompt banner is displayed to a guest user in Japanese locale
+- **THEN** the banner SHALL display: "フォロー情報を保存してコンサート通知を受け取ろう！"
 - **AND** the banner SHALL include a [アカウント作成] CTA button
+
+#### Scenario: Banner copy — English
+
+- **WHEN** the signup prompt banner is displayed to a guest user in English locale
+- **THEN** the banner SHALL display: "Save your followed artists and get concert notifications."
+- **AND** the banner SHALL include a [Create Account] CTA button
 
 ### Requirement: Signup Banner on My Artists
 


### PR DESCRIPTION
## Summary

- Syncs 3 delta specs from `refine-onboarding-ux` into main specs:
  - **dashboard-artist-filter**: removes chip UI requirement; filter icon active state only (`[data-active="true"]`)
  - **guest-data-merge**: consolidates hype into `guest.followedArtists` inline field; eliminates `liverty:guest:hypes` sidecar; adds legacy fallback scenario
  - **signup-prompt-banner**: splits banner copy into JA/EN locale scenarios; shortens to ≤2 lines on mobile; adds English as first-class locale
- Archives the completed change to `openspec/changes/archive/2026-04-05-refine-onboarding-ux/`

## Test plan

- [ ] CI passes (buf lint)

Close: #306
