### PR TITLE
docs(specs): sync private-google-access specs and archive change

### DIFF
--- a/openspec/changes/archive/2026-04-05-private-google-access/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-05-private-google-access/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-01

--- a/openspec/changes/archive/2026-04-05-private-google-access/design.md
+++ b/openspec/changes/archive/2026-04-05-private-google-access/design.md
@@ -1,0 +1,67 @@
+## Context
+
+Private Google Access (PGA) has two required components:
+
+1. **Subnet flag** — `privateIpGoogleAccess: true` on the subnet. Already set in `kubernetes.ts:321`.
+2. **DNS resolution** — `*.googleapis.com` must resolve to the PGA IP range (`199.36.153.4/30` for `restricted.googleapis.com`), not to public IPs.
+
+Without the DNS component, nodes with only internal IPs attempt to reach public googleapis.com IPs, which have no route from private nodes — forcing traffic through Cloud NAT. The subnet flag alone is insufficient.
+
+Current DNS zones in `network.ts`:
+- `asia-northeast2.sql.goog.` — Cloud SQL PSC (exists)
+- Public zone for `*.liverty-music.app` (exists)
+- **No zone for `googleapis.com` or `restricted.googleapis.com`** ← missing
+
+Cloud NAT is configured with `sourceSubnetworkIpRangesToNat: 'ALL_SUBNETWORKS_ALL_IP_RANGES'`, meaning all egress including Google API calls currently goes through NAT.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Route all `*.googleapis.com` traffic through Google's internal network via PGA
+- Eliminate NAT data processing charges on Google API traffic (Logging, Monitoring, Trace, Gemini, Secret Manager, Artifact Registry) for staging/prod
+- Zero workload impact — DNS change is transparent to applications
+
+**Non-Goals:**
+- Changing the subnet flag (already correct)
+- Modifying Cloud NAT source ranges (routing takes precedence automatically; NAT source range change is not required)
+- Dev environment NAT savings — per GCP documentation, Private Google Access has no effect on VMs that have external IP addresses assigned. Dev nodes use `enablePrivateNodes: false` (public external IPs) so PGA provides no benefit there. Cloud NAT was also already removed from dev by `gke-cost-optimization`. The DNS zones are added to dev as well (no environment branching in the Pulumi code), but this is harmless — communication succeeds via the external IP path regardless.
+
+## Decisions
+
+### Decision 1: `restricted.googleapis.com` vs `private.googleapis.com`
+
+**Chosen: `restricted.googleapis.com` (199.36.153.4/30)**
+
+`restricted.googleapis.com` supports only Google APIs that are VPC Service Controls compatible — a stricter, more secure subset. All services used in this project (Vertex AI, Cloud Logging, Cloud Monitoring, Cloud Trace, Secret Manager, Artifact Registry) are supported.
+
+`private.googleapis.com` (199.36.153.8/30) includes a broader set of APIs but is less restrictive. For this project, `restricted` provides the same coverage with better security posture.
+
+### Decision 2: DNS zone structure
+
+Two zones are required per GCP documentation:
+
+1. **`googleapis.com.` private zone** — A wildcard CNAME record pointing `*.googleapis.com` → `restricted.googleapis.com`
+2. **`restricted.googleapis.com.` private zone** — An A record with all 4 IPs in the /30 range (199.36.153.4, 199.36.153.5, 199.36.153.6, 199.36.153.7)
+
+Both zones must be bound to the VPC network (`vpc-osaka`).
+
+### Decision 3: No Cloud NAT source range change needed
+
+When a node attempts to reach `googleapis.com`, DNS resolves to `199.36.153.4/30`. VPC routing automatically uses the `restricted-googleapis` route (a default route for this range is created by GCP when PGA is enabled on the subnet) — the packet never reaches the NAT gateway. No `sourceSubnetworkIpRangesToNat` change is required.
+
+## Risks / Trade-offs
+
+- **API coverage gap** → If a Google API used in future is not VPC-SC compatible, it won't be reachable via `restricted.googleapis.com`. Mitigation: monitor for `CONNECTION_REFUSED` errors; switch to `private.googleapis.com` if needed.
+- **DNS propagation** → New DNS zones take effect within seconds in Cloud DNS private zones. No restart required.
+- **No rollback complexity** → Deleting the DNS zones reverts to previous behavior instantly.
+
+## Migration Plan
+
+1. Add two DNS zones and records to `network.ts` via Pulumi
+2. Run `pulumi preview` to verify only DNS resources are added (no compute changes)
+3. Run `pulumi up`
+4. Verify: from a pod, `nslookup storage.googleapis.com` should return `199.36.153.4–7`
+
+## Open Questions
+
+- None.

--- a/openspec/changes/archive/2026-04-05-private-google-access/proposal.md
+++ b/openspec/changes/archive/2026-04-05-private-google-access/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+`cluster-subnet-osaka` already has `privateIpGoogleAccess: true` in Pulumi, but without the corresponding private DNS zones for `googleapis.com`, Google API traffic still resolves to public IPs and routes through Cloud NAT — incurring $0.045/GiB data processing charges unnecessarily. Adding the DNS zones completes the Private Google Access configuration so that all `*.googleapis.com` traffic bypasses Cloud NAT entirely.
+
+## What Changes
+
+- **Add** a private Cloud DNS zone for `googleapis.com` resolving to `restricted.googleapis.com` (199.36.153.4/30) in `network.ts`
+- **Add** a private Cloud DNS zone for `restricted.googleapis.com` with an A record pointing to 199.36.153.4–7
+- No subnet change needed — `privateIpGoogleAccess: true` is already set
+
+## Capabilities
+
+### New Capabilities
+
+- `private-google-access`: Private DNS configuration that routes `*.googleapis.com` traffic through Google's internal network, bypassing Cloud NAT data processing charges
+
+### Modified Capabilities
+
+_(none — subnet flag is already correct; only DNS is missing)_
+
+## Impact
+
+- **cloud-provisioning/src/gcp/components/network.ts**: Two new `gcp.dns.ManagedZone` and `gcp.dns.RecordSet` resources
+- **Environments**: Applies to all environments that have private nodes (staging, prod); dev will benefit once Cloud NAT is removed by `gke-cost-optimization` only for staging/prod impact
+- **Cost**: Eliminates NAT data processing charges on all Google API egress traffic for staging/prod private clusters (~unknown volume, but all logging/monitoring/trace/Gemini API calls qualify)
+- **Risk**: Low — DNS change only; no workload restarts required

--- a/openspec/changes/archive/2026-04-05-private-google-access/specs/private-google-access/spec.md
+++ b/openspec/changes/archive/2026-04-05-private-google-access/specs/private-google-access/spec.md
@@ -1,0 +1,24 @@
+## ADDED Requirements
+
+### Requirement: Private DNS zone for googleapis.com
+A private Cloud DNS zone for `googleapis.com.` SHALL exist and be bound to the project VPC, resolving `*.googleapis.com` to `restricted.googleapis.com`.
+
+#### Scenario: googleapis.com resolves via internal route
+- **WHEN** a pod on a private GKE node performs a DNS lookup for any `*.googleapis.com` hostname
+- **THEN** the resolved IP SHALL be within `199.36.153.4/30` (restricted.googleapis.com range)
+- **AND** the lookup SHALL NOT return a public googleapis.com IP
+
+### Requirement: Private DNS zone for restricted.googleapis.com
+A private Cloud DNS zone for `restricted.googleapis.com.` SHALL exist and be bound to the project VPC, with A records for all four IPs in the `/30` range.
+
+#### Scenario: restricted.googleapis.com A records are present
+- **WHEN** querying `restricted.googleapis.com` from within the VPC
+- **THEN** the response SHALL contain A records for 199.36.153.4, 199.36.153.5, 199.36.153.6, and 199.36.153.7
+
+### Requirement: Google API traffic bypasses Cloud NAT
+Google API traffic from GKE nodes SHALL route through Private Google Access and SHALL NOT be processed by the Cloud NAT gateway.
+
+#### Scenario: No NAT processing for googleapis.com traffic
+- **WHEN** a GKE pod sends a request to any `*.googleapis.com` endpoint
+- **THEN** the traffic SHALL use the internal PGA route (199.36.153.4/30)
+- **AND** SHALL NOT appear in Cloud NAT data processing metrics

--- a/openspec/changes/archive/2026-04-05-private-google-access/specs/private-google-access/spec.md
+++ b/openspec/changes/archive/2026-04-05-private-google-access/specs/private-google-access/spec.md
@@ -8,12 +8,8 @@ A private Cloud DNS zone for `googleapis.com.` SHALL exist and be bound to the p
 - **THEN** the resolved IP SHALL be within `199.36.153.4/30` (restricted.googleapis.com range)
 - **AND** the lookup SHALL NOT return a public googleapis.com IP
 
-### Requirement: Private DNS zone for restricted.googleapis.com
-A private Cloud DNS zone for `restricted.googleapis.com.` SHALL exist and be bound to the project VPC, with A records for all four IPs in the `/30` range.
-
-#### Scenario: restricted.googleapis.com A records are present
-- **WHEN** querying `restricted.googleapis.com` from within the VPC
-- **THEN** the response SHALL contain A records for 199.36.153.4, 199.36.153.5, 199.36.153.6, and 199.36.153.7
+### ~~Requirement: Private DNS zone for restricted.googleapis.com~~
+**Superseded — see tasks.md 1.3.** The original plan created a separate `restricted.googleapis.com.` private zone, but Cloud DNS private zones do not follow cross-zone CNAMEs. The A record for `restricted.googleapis.com` was placed in the same `googleapis.com.` zone instead (PR #188). The living spec at `openspec/specs/private-google-access/spec.md` reflects the correct single-zone implementation.
 
 ### Requirement: Google API traffic bypasses Cloud NAT
 Google API traffic from GKE nodes SHALL route through Private Google Access and SHALL NOT be processed by the Cloud NAT gateway.

--- a/openspec/changes/archive/2026-04-05-private-google-access/tasks.md
+++ b/openspec/changes/archive/2026-04-05-private-google-access/tasks.md
@@ -1,0 +1,18 @@
+## 1. Add private DNS zones in Pulumi
+
+- [x] 1.1 In `cloud-provisioning/src/gcp/components/network.ts`, add a private `ManagedZone` for `googleapis.com.` bound to the VPC (`vpc-osaka`)
+- [x] 1.2 Add a wildcard CNAME `RecordSet` `*.googleapis.com.` → `restricted.googleapis.com.` in the `googleapis.com` zone
+- [x] 1.3 Add a private `ManagedZone` for `restricted.googleapis.com.` bound to the VPC
+- [x] 1.4 Add an A `RecordSet` in the `restricted.googleapis.com` zone with all four IPs: 199.36.153.4, 199.36.153.5, 199.36.153.6, 199.36.153.7
+
+## 2. Deploy
+
+- [x] 2.1 Run `pulumi preview` on the dev stack and confirm only DNS resources (2 zones, 2 record sets) are added — no compute or network changes
+- [x] 2.2 Run `pulumi up` on the dev stack
+- [x] 2.3 Repeat `pulumi preview` + `pulumi up` for staging and prod stacks
+
+## 3. Verify
+
+- [x] 3.1 From a running pod, verify DNS resolution: `kubectl exec -n backend deploy/server-app -- nslookup storage.googleapis.com` — response IPs must be in 199.36.153.4–7
+- [x] 3.2 Verify Logging/Monitoring still works after DNS change (check Cloud Logging for recent entries from backend pods)
+- [x] 3.3 For staging/prod: confirm Cloud NAT data processing metrics show reduced bytes after rollout

--- a/openspec/changes/archive/2026-04-05-private-google-access/tasks.md
+++ b/openspec/changes/archive/2026-04-05-private-google-access/tasks.md
@@ -2,12 +2,12 @@
 
 - [x] 1.1 In `cloud-provisioning/src/gcp/components/network.ts`, add a private `ManagedZone` for `googleapis.com.` bound to the VPC (`vpc-osaka`)
 - [x] 1.2 Add a wildcard CNAME `RecordSet` `*.googleapis.com.` → `restricted.googleapis.com.` in the `googleapis.com` zone
-- [x] 1.3 Add a private `ManagedZone` for `restricted.googleapis.com.` bound to the VPC
-- [x] 1.4 Add an A `RecordSet` in the `restricted.googleapis.com` zone with all four IPs: 199.36.153.4, 199.36.153.5, 199.36.153.6, 199.36.153.7
+- [x] 1.3 ~~Add a private `ManagedZone` for `restricted.googleapis.com.` bound to the VPC~~ — **Superseded by PR #188**: original two-zone plan failed because Cloud DNS private zones do not follow cross-zone CNAMEs. No separate `restricted.googleapis.com.` zone was created.
+- [x] 1.4 Add an A `RecordSet` for `restricted.googleapis.com.` with all four IPs (199.36.153.4–7) — placed in the **same `googleapis.com.` zone** (not a separate zone, corrected in PR #188)
 
 ## 2. Deploy
 
-- [x] 2.1 Run `pulumi preview` on the dev stack and confirm only DNS resources (2 zones, 2 record sets) are added — no compute or network changes
+- [x] 2.1 Run `pulumi preview` on the dev stack and confirm only DNS resources are added — no compute or network changes (note: final architecture has 1 zone + 2 record sets, not 2 zones)
 - [x] 2.2 Run `pulumi up` on the dev stack
 - [x] 2.3 Repeat `pulumi preview` + `pulumi up` for staging and prod stacks
 

--- a/openspec/specs/private-google-access/spec.md
+++ b/openspec/specs/private-google-access/spec.md
@@ -1,0 +1,28 @@
+# private-google-access Specification
+
+## Purpose
+
+Defines requirements for the Private Google Access DNS configuration that routes `*.googleapis.com` traffic through Google's internal network, bypassing Cloud NAT data processing charges for clusters with private nodes.
+
+## Requirements
+
+### Requirement: Private DNS zone for googleapis.com
+A private Cloud DNS zone for `googleapis.com.` SHALL exist and be bound to the project VPC. The zone SHALL contain both a wildcard CNAME record (`*.googleapis.com → restricted.googleapis.com`) and an A record (`restricted.googleapis.com → 199.36.153.4/30`) in the **same zone**, enabling full intra-zone DNS resolution without cross-zone CNAME dependencies.
+
+#### Scenario: googleapis.com resolves via internal route
+- **WHEN** a pod on a private GKE node performs a DNS lookup for any `*.googleapis.com` hostname
+- **THEN** the resolved IP SHALL be within `199.36.153.4/30` (restricted.googleapis.com range)
+- **AND** the lookup SHALL NOT return a public googleapis.com IP
+
+#### Scenario: restricted.googleapis.com A records are present in the googleapis.com zone
+- **WHEN** querying `restricted.googleapis.com` from within the VPC
+- **THEN** the response SHALL contain A records for 199.36.153.4, 199.36.153.5, 199.36.153.6, and 199.36.153.7
+- **AND** these records SHALL be in the `googleapis.com.` private zone (not a separate zone)
+
+### Requirement: Google API traffic bypasses Cloud NAT
+Google API traffic from GKE nodes SHALL route through Private Google Access and SHALL NOT be processed by the Cloud NAT gateway.
+
+#### Scenario: No NAT processing for googleapis.com traffic
+- **WHEN** a GKE pod sends a request to any `*.googleapis.com` endpoint
+- **THEN** the traffic SHALL use the internal PGA route (199.36.153.4/30)
+- **AND** SHALL NOT appear in Cloud NAT data processing metrics


### PR DESCRIPTION
## Summary

- Add new `private-google-access` capability spec documenting the Private Google Access DNS configuration (single `googleapis.com.` private zone with CNAME + A records per GCP documentation)
- Archive completed `private-google-access` change to `openspec/changes/archive/2026-04-05-private-google-access/`

## Why

Private Google Access DNS configuration is complete and verified across dev and prod environments. The spec captures the correct implementation: both the wildcard CNAME (`*.googleapis.com → restricted.googleapis.com`) and the A record (`restricted.googleapis.com → 199.36.153.4/30`) live in the same `googleapis.com.` private zone — an important correction from the initial delta spec which described a separate `restricted.googleapis.com` zone (which doesn't work in Cloud DNS private zone cross-zone CNAME resolution).

close: liverty-music/cloud-provisioning#179
