### PR TITLE
docs(spec): archive long-press-unfollow change and sync specs

### DIFF
--- a/openspec/changes/archive/2026-04-05-long-press-unfollow/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-05-long-press-unfollow/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-05

--- a/openspec/changes/archive/2026-04-05-long-press-unfollow/design.md
+++ b/openspec/changes/archive/2026-04-05-long-press-unfollow/design.md
@@ -1,0 +1,103 @@
+## Context
+
+On touch devices (`pointer: coarse`), the unfollow trash icon column is hidden via CSS to give the
+hype slider more horizontal space. A swipe-to-unfollow replacement was explored but abandoned
+because `<table>` layout constrains `overflow-x` on `display: table-row`, making reliable
+horizontal pointer capture impossible without replacing the table structure.
+
+The existing `BottomSheet` component (Popover API, `open` bindable, `sheet-closed` event) and the
+existing `unfollowArtist()` method on `MyArtistsRoute` are both reusable without modification.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Touch devices: long-press (500ms) on any artist row opens a per-artist unfollow BottomSheet
+- Desktop: retain the existing trash icon column — zero behaviour change
+- Help page for `my-artists` documents the long-press gesture
+
+**Non-Goals:**
+- Swipe gestures — ruled out due to table layout constraints
+- Haptic feedback — no Web Vibration API usage (inconsistent browser support)
+- Animation of the row on long-press hold (visual feedback is cursor/OS-level)
+
+## Decisions
+
+### 1. Custom Attribute vs inline `pointerdown` handler
+
+**Decision**: Aurelia 2 `@customAttribute('long-press')` in `src/custom-attributes/long-press.ts`.
+
+**Rationale**: The gesture logic (timer, move-cancel, pointer event cleanup) is reusable and must
+not pollute `MyArtistsRoute`. A Custom Attribute keeps the host element clean and matches the
+project pattern (`ArtistColorCustomAttribute`, `BeamVarsCustomAttribute`).
+
+**Alternative**: Inline `pointerdown.trigger` with timeout in the route VM. Rejected — gesture
+state management in the VM increases coupling and is difficult to unit-test in isolation.
+
+### 2. Long-press detection: `setTimeout` vs `PointerEvents` pressure
+
+**Decision**: `pointerdown` starts a 500ms `setTimeout`; `pointermove`, `pointerup`, and
+`pointercancel` cancel it. Movement threshold: 10px (Manhattan distance) to tolerate minor finger
+jitter without false negatives.
+
+**Rationale**: `PointerEvent.pressure` is unreliable across browsers and devices. The
+`setTimeout` + cancel-on-move pattern is the established idiom for long-press.
+
+**Alternative**: CSS `animation` trick (start animation on `:active`, fire JS on `animationend`).
+Rejected — cannot reliably cancel on move without JS event listeners anyway, adds CSS coupling.
+
+### 3. `pointer: coarse` guard location
+
+**Decision**: The Custom Attribute itself checks `matchMedia('(pointer: coarse)')` at `attached()`
+and skips listener attachment on non-touch devices.
+
+**Rationale**: The CSS already hides the trash column via `@media (pointer: coarse)`. Keeping the
+guard in the Custom Attribute makes it self-contained — the HTML template does not need a
+conditional wrapper, and desktop behaviour is unchanged at zero cost.
+
+### 4. BottomSheet per-row vs shared singleton
+
+**Decision**: A single `<artist-unfollow-sheet>` component instance in `my-artists-route.html`,
+outside the `<tbody>` repeat. The route VM holds the currently-selected `MyArtist` and passes it
+as a bindable.
+
+**Rationale**: One BottomSheet instance in the popover layer is cheaper than N popover elements
+(one per row). The trade-off is that the route VM must track `selectedArtistForUnfollow`.
+
+**Alternative**: One `<artist-unfollow-sheet>` inside each `<tr>`. Rejected — N popover elements
+in the DOM; also, popover stacking context issues may arise inside `<table>`.
+
+### 5. Custom event vs Aurelia EventAggregator for unfollow confirmation
+
+**Decision**: The BottomSheet component emits an Aurelia `@bindable` callback (`unfollow-confirmed`
+custom event via `<artist-unfollow-sheet unfollow-confirmed.trigger="openUnfollowSheet()">`).
+Actually: the sheet fires a DOM `CustomEvent('unfollow-confirmed')` which the route handles via
+`.trigger` binding; confirmed unfollow calls the existing `unfollowArtist()`.
+
+**Rationale**: Direct `.trigger` binding is the idiomatic Aurelia 2 pattern. EventAggregator is
+global state and unnecessary here.
+
+## Risks / Trade-offs
+
+- **`pointer: coarse` media query is static at attach time** — hot-plugging a mouse on a tablet
+  will not re-enable the trash column until page reload. Acceptable: CSS already has the same
+  limitation (the `@media` query evaluates at render time for initial layout).
+
+- **Long-press conflicts with OS text selection** — `pointercancel` fires if the browser starts a
+  text-selection drag. The attribute already cancels on `pointercancel`, so no ghost sheet opens.
+  However, `user-select: none` on `<tr>` may be needed to prevent text-selection UI during hold.
+
+- **Accessibility on touch-only devices** — long-press is not discoverable. Mitigation: help text
+  in `page-help` documents the gesture. Keyboard users on touch devices still have no path to
+  unfollow unless a keyboard is attached (desktop path restored via `pointer: fine`).
+
+## Migration Plan
+
+No data migration. All changes are frontend-only:
+1. Deploy new `LongPressCustomAttribute` + `ArtistUnfollowSheet` registered in `main.ts`
+2. Updated `my-artists-route.html` + `.ts` use the new custom attribute and sheet
+3. Help page content update is delivered as a translation key update
+4. No feature flag required — the touch guard in the Custom Attribute ensures desktop is unaffected
+
+## Open Questions
+
+- None — all decisions resolved.

--- a/openspec/changes/archive/2026-04-05-long-press-unfollow/proposal.md
+++ b/openspec/changes/archive/2026-04-05-long-press-unfollow/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+On touch devices, the trash icon column for unfollowing an artist was removed (`pointer: coarse`) to give the hype slider more horizontal space. Horizontal swipe was attempted but abandoned due to `<table>` scroll container constraints. Long-press (500ms) on an artist row opening a BottomSheet confirmation is the replacement unfollow trigger for touch devices, while desktop keeps the existing trash button.
+
+## What Changes
+
+- Add long-press (500ms) gesture on artist rows (`pointer: coarse` devices only) that opens an unfollow confirmation BottomSheet
+- The BottomSheet shows artist name + "Unfollow" danger button + cancel
+- Add help text to the My Artists `page-help` explaining the long-press gesture
+- Desktop (`pointer: fine`) retains the existing trash icon column — no change
+
+## Capabilities
+
+### New Capabilities
+- `long-press-unfollow`: Long-press gesture (500ms) on an artist row on touch devices triggers an unfollow confirmation BottomSheet. Confirmed unfollow calls the existing `unfollowArtist()` method (optimistic removal + undo toast).
+
+### Modified Capabilities
+- `my-artists`: Help content updated to document the long-press-to-unfollow gesture for touch devices.
+- `onboarding-page-help`: No spec-level change — help content update is implementation detail only.
+
+## Impact
+
+- **Frontend only**: No backend or API changes
+- **Files affected**:
+  - `src/custom-attributes/long-press.ts` — new Aurelia 2 Custom Attribute (500ms timer, pointer cancel cleanup)
+  - `src/components/artist-unfollow-sheet/` — new BottomSheet component (`.ts` + `.html` + `.css`)
+  - `src/routes/my-artists/my-artists-route.html` — `long-press` attr on `<tr>`, `<artist-unfollow-sheet>` element
+  - `src/routes/my-artists/my-artists-route.ts` — `openUnfollowSheet()` method
+  - `src/main.ts` — register `LongPressCustomAttribute` + `ArtistUnfollowSheet`
+  - `src/locales/*/translation.json` — new help text key
+  - Help page content for `my-artists`
+- **Dependencies**: None — uses native `setTimeout` + Pointer Events, no new packages

--- a/openspec/changes/archive/2026-04-05-long-press-unfollow/specs/long-press-unfollow/spec.md
+++ b/openspec/changes/archive/2026-04-05-long-press-unfollow/specs/long-press-unfollow/spec.md
@@ -1,0 +1,35 @@
+## ADDED Requirements
+
+### Requirement: Long-press gesture triggers unfollow confirmation on touch devices
+On touch devices (`pointer: coarse`), the system SHALL detect a 500ms long-press on an artist row
+and open an unfollow confirmation BottomSheet for that artist. The BottomSheet SHALL display the
+artist name, a danger-styled "Unfollow" button, and a cancel option. Desktop devices (`pointer: fine`)
+SHALL NOT attach the long-press listener; they retain the existing trash icon column.
+
+#### Scenario: Long-press opens unfollow sheet
+- **WHEN** user holds a pointer down on an artist row for 500ms on a touch device
+- **THEN** an unfollow confirmation BottomSheet opens showing the artist's name and an Unfollow button
+
+#### Scenario: Long-press cancelled by movement
+- **WHEN** user presses down on an artist row and moves the pointer more than 10px before 500ms elapses
+- **THEN** the long-press timer is cancelled and no BottomSheet opens
+
+#### Scenario: Long-press cancelled by pointer up
+- **WHEN** user releases the pointer before 500ms elapses
+- **THEN** the long-press timer is cancelled and no BottomSheet opens
+
+#### Scenario: Long-press cancelled by pointercancel
+- **WHEN** the browser fires a pointercancel event (e.g. OS text-selection or scroll takeover) before 500ms elapses
+- **THEN** the long-press timer is cancelled and no BottomSheet opens
+
+#### Scenario: Unfollow confirmed via BottomSheet
+- **WHEN** user taps the "Unfollow" button in the BottomSheet
+- **THEN** the BottomSheet closes and the existing unfollow flow executes (optimistic removal + undo toast)
+
+#### Scenario: Unfollow cancelled via BottomSheet
+- **WHEN** user taps the cancel button or dismisses the BottomSheet without confirming
+- **THEN** the BottomSheet closes and the artist remains in the list
+
+#### Scenario: No long-press listener on desktop
+- **WHEN** the page loads on a device where `pointer: fine` matches
+- **THEN** no long-press listener is attached to artist rows and the trash icon column remains visible

--- a/openspec/changes/archive/2026-04-05-long-press-unfollow/specs/my-artists/spec.md
+++ b/openspec/changes/archive/2026-04-05-long-press-unfollow/specs/my-artists/spec.md
@@ -1,0 +1,16 @@
+## MODIFIED Requirements
+
+### Requirement: My Artists page help content documents all available gestures
+The My Artists page help content SHALL explain all available interactions for managing followed
+artists, including the long-press-to-unfollow gesture for touch devices. The help text SHALL
+communicate that long-pressing an artist row for approximately half a second opens an unfollow
+confirmation dialog. Desktop-specific interactions (trash icon) need not be documented in help
+as they are visually self-evident.
+
+#### Scenario: Help text visible to touch device users
+- **WHEN** user opens the My Artists page help on a touch device
+- **THEN** help content includes an explanation that long-pressing an artist row opens an unfollow confirmation
+
+#### Scenario: Help text available in all supported locales
+- **WHEN** the app is displayed in any supported locale (Japanese, English)
+- **THEN** the long-press unfollow help text is translated and rendered correctly

--- a/openspec/changes/archive/2026-04-05-long-press-unfollow/tasks.md
+++ b/openspec/changes/archive/2026-04-05-long-press-unfollow/tasks.md
@@ -1,0 +1,37 @@
+## 1. LongPress Custom Attribute
+
+- [x] 1.1 Create `src/custom-attributes/long-press.ts` with `@customAttribute('long-press')`, `@bindable` callback, 500ms timer, pointer event listeners, and 10px movement-cancel threshold
+- [x] 1.2 Guard listener attachment with `matchMedia('(pointer: coarse)').matches` so desktop skips the attribute
+- [x] 1.3 Register `LongPressCustomAttribute` in `src/main.ts`
+
+## 2. ArtistUnfollowSheet Component
+
+- [x] 2.1 Create `src/components/artist-unfollow-sheet/artist-unfollow-sheet.ts` with `@bindable artist`, `@bindable open`, and unfollow-confirmed event dispatch
+- [x] 2.2 Create `src/components/artist-unfollow-sheet/artist-unfollow-sheet.html` using `<bottom-sheet>` primitive with artist name, danger "Unfollow" button, and cancel button
+- [x] 2.3 Create `src/components/artist-unfollow-sheet/artist-unfollow-sheet.css` with danger button styles
+- [x] 2.4 Register `ArtistUnfollowSheet` in `src/main.ts`
+
+## 3. My Artists Route Integration
+
+- [x] 3.1 Add `selectedArtistForUnfollow: MyArtist | null` and `unfollowSheetOpen: boolean` properties to `MyArtistsRoute`
+- [x] 3.2 Add `openUnfollowSheet(artist: MyArtist)` method that sets the selected artist and opens the sheet
+- [x] 3.3 Add `onUnfollowConfirmed()` method that calls the existing `unfollowArtist()` and closes the sheet
+- [x] 3.4 Add `long-press` attribute to `<tr>` in `my-artists-route.html` with callback bound to `openUnfollowSheet(artist)`
+- [x] 3.5 Add `<artist-unfollow-sheet>` element to `my-artists-route.html` outside `<tbody>`, bound to `selectedArtistForUnfollow` and `unfollowSheetOpen`
+
+## 4. Translations
+
+- [x] 4.1 Add `myArtists.unfollowSheet.confirm`, `myArtists.unfollowSheet.cancel`, `myArtists.unfollowSheet.sheetLabel` keys to `src/locales/ja/translation.json`
+- [x] 4.2 Add the same keys to `src/locales/en/translation.json`
+- [x] 4.3 Add `pageHelp.myArtists.longPressTip` key (long-press gesture explanation) to both locale files
+
+## 5. Help Page Content
+
+- [x] 5.1 Update help page content for `my-artists` to include the long-press-to-unfollow gesture description
+
+## 6. Verification
+
+- [x] 6.1 Run `make lint` in `frontend/` — zero errors
+- [x] 6.2 Run `make test` in `frontend/` — all tests pass
+- [x] 6.3 Manual smoke test on touch emulation: long-press opens sheet, confirm unfollows, cancel dismisses
+- [x] 6.4 Manual smoke test on desktop: trash icon still visible and functional, no long-press behaviour

--- a/openspec/changes/archive/2026-04-05-swipe-to-unfollow/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-05-swipe-to-unfollow/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-01

--- a/openspec/changes/archive/2026-04-05-swipe-to-unfollow/design.md
+++ b/openspec/changes/archive/2026-04-05-swipe-to-unfollow/design.md
@@ -1,0 +1,95 @@
+## Context
+
+The My Artists page renders a `<table>` with 6 columns: artist name, 4 hype-level radio dots, and a trash icon button. On mobile (touch) devices, the trash column occupies ~48px that could widen the hype slider area. The existing `unfollowArtist()` method and View Transitions are already in place — this change adds a swipe gesture as an additional trigger.
+
+Key constraints:
+- `<table>` structure must not change (semantic HTML, screen reader accessibility)
+- `<tr>` elements are `display: table-row` — `overflow: hidden` and `transform` cannot be applied directly
+- The vertical scroll container is `artists-fieldset` (`overflow-y: auto`) — swipe must not interfere with vertical scrolling
+- No new npm packages — Pointer Events API and WAAPI are available in all target browsers
+
+## Goals / Non-Goals
+
+**Goals:**
+- On touch devices: hide trash column, giving hype dots more horizontal space
+- Add left-swipe gesture on artist rows that calls the existing `unfollowArtist()` method
+- Snap back on release if threshold not reached (with spring-like WAAPI animation)
+- Preserve keyboard and screen reader access to the unfollow action
+- Implement as a reusable Aurelia 2 Custom Attribute
+
+**Non-Goals:**
+- Swipe on non-touch (pointer: fine) devices — trash icon remains
+- Custom swipe velocity physics (distance threshold only)
+- Right-swipe or any other gesture direction
+- Changes to the unfollow confirmation/undo toast logic
+
+## Decisions
+
+### 1. Pointer Events API over Touch Events
+
+**Decision**: Use `pointerdown` / `pointermove` / `pointerup` / `pointercancel` with `setPointerCapture()`.
+
+**Why**: Touch Events require `passive: false` to call `preventDefault()` and don't unify mouse/stylus. `setPointerCapture()` ensures tracking continues even if the pointer moves outside the `<tr>` boundary — critical for a reliable swipe feel. `pointercancel` handles the case where the browser takes over scrolling.
+
+**Alternative considered**: HammerJS / gesture library — rejected (adds a package dependency, overkill for a single gesture).
+
+### 2. Animate inner cell wrappers, not `<tr>`
+
+**Decision**: Each `<td>` / `<th>` gets an inner `<div class="cell-inner">` that is translated via WAAPI. The `<tr>` itself is never transformed.
+
+**Why**: `display: table-row` elements do not reliably support `transform` in all browsers. Moving inner wrappers sidesteps this entirely while keeping the table structure intact.
+
+**Alternative considered**: Wrapping rows in a `position: relative` container and using absolute positioning — rejected (breaks table layout).
+
+### 3. `touch-action: pan-y` for scroll/swipe coexistence
+
+**Decision**: Set `touch-action: pan-y` on `.artist-row` via CSS.
+
+**Why**: This tells the browser to handle vertical pan natively, so the `pointermove` handler only fires after the gesture is confirmed horizontal. This avoids the direction-detection lock-in logic and makes the interaction feel native.
+
+**Direction lock**: On the first `pointermove`, compute `|dx|` vs `|dy|`. If `|dy| > |dx|`, release pointer capture and bail — let the browser scroll. Only commit to swipe when `|dx| > |dy| * 1.5`.
+
+### 4. `@media (pointer: coarse)` to hide trash column
+
+**Decision**: Use the CSS media query `(pointer: coarse)` to `display: none` the `.artist-unfollow-col` and its header.
+
+**Why**: This is a CSS-only, no-JS approach that correctly identifies touch-primary devices. On mixed-input devices (e.g. Surface), `pointer: fine` keeps the button visible.
+
+**Border-radius fix**: When the trash column is hidden, `.hype-col:last-child` inside `.artist-row` needs the `border-end-end-radius` / `border-start-end-radius` rules that currently live on `td:last-child`.
+
+### 5. Aurelia 2 Custom Attribute
+
+**Decision**: Implement as `swipe-to-delete` Custom Attribute that accepts a `callback` bindable.
+
+```html
+<tr swipe-to-delete.bind="{ callback: () => unfollowArtist(artist) }">
+```
+
+**Why**: Keeps gesture logic out of the route ViewModel, makes it reusable (e.g., future artist discovery list), and follows the existing codebase pattern of encapsulating cross-cutting concerns in components/attributes.
+
+### 6. Threshold: 40% of row width
+
+**Decision**: Trigger unfollow when `dx > rowWidth * 0.4`.
+
+**Why**: 40% is enough to feel intentional without being exhausting. Below threshold, WAAPI `reverse()` snaps back. Above threshold, animate to full width exit, then call `callback()` which triggers the existing View Transition.
+
+## Risks / Trade-offs
+
+- **`pointer: coarse` heuristic is imperfect** → Devices with both mouse and touch report `pointer: fine` (coarse is the secondary pointer). On such devices the trash icon stays visible and swipe is disabled. This is acceptable — the primary use case is phone/tablet. Mitigation: none needed.
+
+- **`cell-inner` wrapper adds DOM nodes** → 6 extra `<div>` elements per row. With typical artist counts (10-50), this is negligible. Mitigation: only add wrappers when `pointer: coarse` is detected (via JS check at attribute bind time).
+
+- **WAAPI `reverse()` can be janky on low-end Android** → The snap-back animation involves reversing a running animation. Mitigation: use a short duration (200ms) and `easing: 'ease-out'` so jank is barely perceptible.
+
+- **`pointercancel` during scroll mid-swipe** → If a user starts swiping and the browser decides to scroll, `pointercancel` fires. Must reset transform to 0 immediately (no animation) to avoid a stuck row. This is handled by the `pointercancel` listener.
+
+## Migration Plan
+
+Pure frontend change, no deployment coordination needed:
+1. Implement and merge — ships in next frontend deploy
+2. No rollback strategy needed (CSS media query and JS are self-contained)
+
+## Open Questions
+
+- Should the swipe reveal a red "Delete" label behind the row (iOS-style), or just a directional arrow? → Start without it for simplicity; can be added as visual polish later.
+- Should swipe work on the empty-state row? → N/A, no rows in empty state.

--- a/openspec/changes/archive/2026-04-05-swipe-to-unfollow/proposal.md
+++ b/openspec/changes/archive/2026-04-05-swipe-to-unfollow/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+The "My Artists" list always shows a trash icon column, consuming ~48px of horizontal space that could be used by the hype slider. On touch devices, unfollow via swipe is a more natural and discoverable interaction pattern — the permanent icon is wasted space.
+
+## What Changes
+
+- Remove the trash icon column from view on touch devices (`pointer: coarse`)
+- Add swipe-left gesture on artist rows to trigger unfollow
+- Adjust border-radius on the hype slider's last cell when trash column is hidden
+- Implement as an Aurelia 2 Custom Attribute (`swipe-to-delete`) for reusability
+
+## Capabilities
+
+### New Capabilities
+- `swipe-to-unfollow`: Touch gesture (swipe left) on an artist row triggers the unfollow action, replacing the always-visible trash icon on touch devices.
+
+### Modified Capabilities
+<!-- No existing spec-level behavior changes — unfollow itself is unchanged, only the trigger mechanism is added -->
+
+## Impact
+
+- **Frontend only**: No backend or API changes
+- **Files affected**:
+  - `src/routes/my-artists/my-artists-route.html` — remove `artist-unfollow-col` td on touch, add custom attribute to `<tr>`
+  - `src/routes/my-artists/my-artists-route.css` — `@media (pointer: coarse)` to hide trash column, fix border-radius
+  - `src/components/swipe-to-delete/` — new Aurelia 2 Custom Attribute (new files)
+- **Accessibility**: Trash button remains in DOM (keyboard/screen reader accessible), hidden visually on touch only
+- **Dependencies**: None — uses native Pointer Events API and WAAPI, no new packages

--- a/openspec/changes/archive/2026-04-05-swipe-to-unfollow/specs/swipe-to-unfollow/spec.md
+++ b/openspec/changes/archive/2026-04-05-swipe-to-unfollow/specs/swipe-to-unfollow/spec.md
@@ -1,0 +1,42 @@
+## ADDED Requirements
+
+### Requirement: Trash column hidden on touch devices
+On touch-primary devices (`pointer: coarse`), the unfollow trash icon column SHALL be hidden via CSS, freeing horizontal space for the hype slider.
+
+#### Scenario: Trash column hidden on touch device
+- **WHEN** the My Artists page is rendered on a device with `pointer: coarse`
+- **THEN** the trash icon column and its header SHALL NOT be visible
+
+#### Scenario: Trash column visible on pointer device
+- **WHEN** the My Artists page is rendered on a device with `pointer: fine`
+- **THEN** the trash icon column SHALL remain visible and functional
+
+#### Scenario: Row border-radius correct when trash column hidden
+- **WHEN** the trash column is hidden
+- **THEN** the last hype-level column cell SHALL have rounded right corners matching the card style
+
+### Requirement: Swipe-left gesture triggers unfollow
+On touch-primary devices, the user SHALL be able to swipe an artist row to the left to unfollow that artist.
+
+#### Scenario: Swipe past threshold triggers unfollow
+- **WHEN** the user swipes an artist row to the left past 40% of the row width
+- **THEN** the row SHALL animate off-screen and the existing unfollow action SHALL be triggered (including undo toast)
+
+#### Scenario: Swipe below threshold snaps back
+- **WHEN** the user swipes an artist row to the left less than 40% of the row width and releases
+- **THEN** the row SHALL animate back to its original position
+
+#### Scenario: Vertical scroll is not disrupted by horizontal gesture detection
+- **WHEN** the user scrolls vertically through the artist list
+- **THEN** vertical scrolling SHALL work normally and SHALL NOT be intercepted as a swipe
+
+#### Scenario: Swipe is cancelled when browser takes over scroll
+- **WHEN** a swipe gesture is interrupted by the browser (e.g. momentum scroll)
+- **THEN** the row SHALL immediately return to its original position without visual artifacts
+
+### Requirement: Unfollow action remains keyboard accessible
+The unfollow action SHALL remain accessible via keyboard and screen reader regardless of whether the trash column is visually hidden.
+
+#### Scenario: Keyboard user can unfollow on touch device
+- **WHEN** a keyboard user focuses the trash button (visually hidden but in DOM)
+- **THEN** the button SHALL be focusable and activatable via keyboard

--- a/openspec/changes/archive/2026-04-05-swipe-to-unfollow/tasks.md
+++ b/openspec/changes/archive/2026-04-05-swipe-to-unfollow/tasks.md
@@ -1,0 +1,43 @@
+## 1. CSS: Hide trash column on touch devices
+
+- [x] 1.1 Add `@media (pointer: coarse)` rule to hide `.artist-unfollow-col` and its `<th>` header
+- [x] 1.2 Add `touch-action: pan-y` to `.artist-row` for scroll/swipe coexistence
+- [x] 1.3 Fix border-radius: move `border-inline-end` and end-radius rules to `.hype-col:last-child` inside `.artist-row` under the `(pointer: coarse)` query
+
+## 2. HTML: Add inner wrappers and custom attribute binding
+
+- [x] 2.1 Wrap each `<th>` and `<td>` cell content in `<div class="cell-inner">` in `my-artists-route.html`
+- [x] 2.2 Add `swipe-to-delete` custom attribute binding to the `<tr repeat.for>` element
+
+## 3. Implement `swipe-to-delete` Custom Attribute
+
+- [x] 3.1 Scaffold `src/custom-attributes/swipe-to-delete.ts` as an Aurelia 2 Custom Attribute with a `callback` bindable
+- [x] 3.2 Register the component in `main.ts` (or the relevant DI registration file)
+- [x] 3.3 Implement `pointerdown` handler: record start position, call `setPointerCapture()`
+- [x] 3.4 Implement `pointermove` handler: direction-lock logic (`|dx| > |dy| * 1.5`), translate `cell-inner` elements via WAAPI
+- [x] 3.5 Implement `pointerup` handler: check threshold (40% of row width), either trigger callback or snap back via WAAPI `reverse()`
+- [x] 3.6 Implement `pointercancel` handler: immediately reset all `cell-inner` transforms to 0
+- [x] 3.7 Clean up all event listeners in `detaching()` lifecycle hook
+
+## 4. CSS: Animate cell-inner wrappers
+
+- [x] 4.1 Add `.cell-inner` base styles (display: contents or flex passthrough so layout is unaffected)
+- [x] 4.2 Verify table layout is visually unchanged after adding wrappers
+
+## 5. Verification
+
+- [x] 5.1 Manual test on touch device (or devtools touch emulation): swipe past threshold triggers unfollow + undo toast
+- [x] 5.2 Manual test: swipe below threshold snaps back cleanly
+- [x] 5.3 Manual test: vertical scroll in artist list is not interrupted
+- [ ] 5.4 Manual test on desktop (pointer: fine): trash icon visible, no swipe behavior
+- [ ] 5.5 Keyboard test: tab to hidden trash button, Enter triggers unfollow
+- [x] 5.6 Run `make check` and fix any lint/type errors
+
+## 6. Decision: Abandoned
+
+- [x] 6.1 Swipe approach abandoned — `<table>` scroll container prevents reliable horizontal swipe
+  detection. `overflow-y: auto` on the fieldset ancestor takes pointer precedence over
+  `touch-action: none` on `<tr>`. No CSS-native solution exists for this constraint.
+  Replaced by: `long-press-unfollow` change (long-press → BottomSheet confirmation).
+- [x] 6.2 Rollback: removed `swipe-to-delete.ts`, `cell-inner` wrappers, `touch-action` from CSS.
+  CSS-only changes (pointer: coarse hide + border-radius fix) retained in `long-press-unfollow`.

--- a/openspec/specs/long-press-unfollow/spec.md
+++ b/openspec/specs/long-press-unfollow/spec.md
@@ -1,0 +1,49 @@
+# Capability: Long-Press Unfollow
+
+## Purpose
+
+Enable touch device users to unfollow an artist via a long-press gesture on an artist row, presenting an unfollow confirmation BottomSheet before executing the action.
+
+## Requirements
+
+### Requirement: Long-press gesture triggers unfollow confirmation on touch devices
+
+On touch devices (`pointer: coarse`), the system SHALL detect a 500ms long-press on an artist row
+and open an unfollow confirmation BottomSheet for that artist. The BottomSheet SHALL display the
+artist name, a danger-styled "Unfollow" button, and a cancel option. Desktop devices (`pointer: fine`)
+SHALL NOT attach the long-press listener; they retain the existing trash icon column.
+
+#### Scenario: Long-press opens unfollow sheet
+
+- **WHEN** user holds a pointer down on an artist row for 500ms on a touch device
+- **THEN** an unfollow confirmation BottomSheet opens showing the artist's name and an Unfollow button
+
+#### Scenario: Long-press cancelled by movement
+
+- **WHEN** user presses down on an artist row and moves the pointer more than 10px before 500ms elapses
+- **THEN** the long-press timer is cancelled and no BottomSheet opens
+
+#### Scenario: Long-press cancelled by pointer up
+
+- **WHEN** user releases the pointer before 500ms elapses
+- **THEN** the long-press timer is cancelled and no BottomSheet opens
+
+#### Scenario: Long-press cancelled by pointercancel
+
+- **WHEN** the browser fires a pointercancel event (e.g. OS text-selection or scroll takeover) before 500ms elapses
+- **THEN** the long-press timer is cancelled and no BottomSheet opens
+
+#### Scenario: Unfollow confirmed via BottomSheet
+
+- **WHEN** user taps the "Unfollow" button in the BottomSheet
+- **THEN** the BottomSheet closes and the existing unfollow flow executes (optimistic removal + undo toast)
+
+#### Scenario: Unfollow cancelled via BottomSheet
+
+- **WHEN** user taps the cancel button or dismisses the BottomSheet without confirming
+- **THEN** the BottomSheet closes and the artist remains in the list
+
+#### Scenario: No long-press listener on desktop
+
+- **WHEN** the page loads on a device where `pointer: fine` matches
+- **THEN** no long-press listener is attached to artist rows and the trash icon column remains visible

--- a/openspec/specs/my-artists/spec.md
+++ b/openspec/specs/my-artists/spec.md
@@ -6,31 +6,10 @@ Display and manage the user's followed artists, providing list and grid views wi
 
 ## Requirements
 
-### Requirement: Artist List Row
+### Requirement: Artist List Row (REMOVED)
 
-Each artist row in the My Artists list view SHALL be a horizontal scroll-snap container with the artist content and a dismiss trigger.
-
-#### Scenario: Artist row layout
-
-- **WHEN** an artist row is rendered in list view
-- **THEN** the row SHALL be a horizontal scroll container with `scroll-snap-type: x mandatory` and hidden scrollbar
-- **AND** the row content SHALL display the artist name (left) and inline dot slider (right) using `grid-template-areas: "name watch home nearby away"`
-- **AND** the artist name SHALL truncate with ellipsis if it exceeds available space
-- **AND** a dismiss trigger element SHALL be placed after the content as the scroll-snap end target
-
-#### Scenario: Swipe-to-dismiss unfollows artist
-
-- **WHEN** the user swipes an artist row left past the dismiss threshold
-- **THEN** the scroll-snap SHALL snap to the dismiss-end position
-- **AND** the system SHALL trigger unfollow for that artist
-- **AND** if the View Transitions API is available, the remaining rows SHALL animate smoothly to fill the gap
-- **AND** if the View Transitions API is unavailable, the unfollow SHALL execute immediately without animation
-
-#### Scenario: Swipe cancel snaps back
-
-- **WHEN** the user swipes an artist row left but does NOT pass the dismiss threshold
-- **THEN** the scroll-snap SHALL snap back to the start position (content fully visible)
-- **AND** no unfollow action SHALL be triggered
+**Reason**: The swipe-to-dismiss unfollow mechanism was abandoned due to `display: table-row` layout constraints that prevented the scroll-snap container from functioning correctly inside the artist list. Replaced by the long-press-to-unfollow flow.
+**Migration**: The horizontal scroll-snap dismiss trigger is removed. Unfollow is initiated by long-pressing an artist row for ~500ms, which opens an `ArtistUnfollowSheet` confirmation bottom sheet. See `long-press-unfollow` capability spec.
 
 #### Scenario: Hype slider replaces passion icon
 

--- a/openspec/specs/my-artists/spec.md
+++ b/openspec/specs/my-artists/spec.md
@@ -110,3 +110,21 @@ The Grid view SHALL display followed artists as poster-style tiles in a responsi
 - **GIVEN** the Grid view is active
 - **WHEN** the user long-presses a tile
 - **THEN** a context menu SHALL appear with passion level options and an unfollow action
+
+### Requirement: My Artists page help content documents all available gestures
+
+The My Artists page help content SHALL explain all available interactions for managing followed
+artists, including the long-press-to-unfollow gesture for touch devices. The help text SHALL
+communicate that long-pressing an artist row for approximately half a second opens an unfollow
+confirmation dialog. Desktop-specific interactions (trash icon) need not be documented in help
+as they are visually self-evident.
+
+#### Scenario: Help text visible to touch device users
+
+- **WHEN** user opens the My Artists page help on a touch device
+- **THEN** help content includes an explanation that long-pressing an artist row opens an unfollow confirmation
+
+#### Scenario: Help text available in all supported locales
+
+- **WHEN** the app is displayed in any supported locale (Japanese, English)
+- **THEN** the long-press unfollow help text is translated and rendered correctly


### PR DESCRIPTION
## Summary

- Archive `long-press-unfollow` and `swipe-to-unfollow` completed changes
- Add `long-press-unfollow` capability spec
- Update `my-artists` spec with help content requirement for documenting the long-press gesture on touch devices

## Context

Implements the spec side of liverty-music/frontend#323 (long-press unfollow for touch devices). The change artifacts were completed and are now archived alongside the synced capability specs.
