### PR TITLE
docs(specs): update artist-filter and remove lane-introduction specs

### DIFF
--- a/openspec/changes/archive/2026-04-05-refine-onboarding/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-05-refine-onboarding/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-05

--- a/openspec/changes/archive/2026-04-05-refine-onboarding/design.md
+++ b/openspec/changes/archive/2026-04-05-refine-onboarding/design.md
@@ -1,0 +1,57 @@
+## Context
+
+Two independent issues are addressed together since both originate in the onboarding/dashboard area and affect the same worktree branch.
+
+**Artist-filter layout bug**: Introduced in commit `f804195` ("feat(artist-filter): restyle checkboxes as chips with clear-all button"), the sheet content wrapper was changed from `<div class="stack filter-sheet-content">` to `<fieldset>`. The `<fieldset>` element has browser-special layout behaviour: even with `display: flex`, the `<legend>` child is lifted out of the flex flow and rendered as a block-level float-adjacent element. This causes incorrect height reporting to the parent `.sheet-body`, which breaks `scroll-snap-align: end` positioning — the sheet snaps to a position that does not align flush with the viewport bottom.
+
+**Lane introduction removal**: The lane intro is a sequential spotlight sequence (HOME → NEAR → AWAY) activated during onboarding. Analysis shows it adds ~130 lines of state-machine code to `DashboardRoute`, introduces reactive complexity (`@watch`, `queueTask`), and coordinates with multiple services (`INavDimmingService`, `IOnboardingService`). The UX value does not justify this complexity; users can understand the lane layout from the page-help overlay.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Fix the `artist-filter-bar` bottom sheet snap alignment so the sheet is flush with the bottom of the viewport
+- Fix the "全て解除" button layout (it appears misaligned because `<legend>` does not behave as a standard flex child)
+- Remove the lane introduction state machine from `DashboardRoute`
+- Remove associated i18n keys and dead imports
+
+**Non-Goals:**
+- Redesigning the artist filter chip UI or changing filter logic
+- Changing the onboarding step progression or `OnboardingStep` enum
+- Removing the celebration overlay (still triggered after `OnboardingStep.DASHBOARD` → `MY_ARTISTS` advance)
+- Any backend or protobuf changes
+
+## Decisions
+
+### Decision: Replace `<fieldset>/<legend>` with `<section>/<h2>` (Option B)
+
+**Chosen**: `<section aria-labelledby="filter-sheet-title">` with `<h2>` title and `<div class="sheet-header">` wrapper.
+
+**Alternatives considered**:
+- **Option A — Keep `<fieldset>`, empty `<legend>`, move header to `<div>`**: This preserves the fieldset grouping semantic but requires a hidden `<legend>` element just to satisfy the parser — a semantically odd pattern.
+- **Option B — Replace with `<section>/<h2>`**: Cleaner. `<section aria-labelledby>` provides equivalent accessibility grouping. The checkbox list gets `role="group" aria-labelledby` to preserve the WAI-ARIA group semantics. `display: flex` on `<section>` behaves predictably across all browsers.
+
+Option B is simpler, more predictable, and semantically appropriate — `<fieldset>` is designed for form field grouping with a visible label; here the label is a heading, and the interaction is confirmed by a separate button.
+
+### Decision: Remove lane intro entirely (not gate behind a feature flag)
+
+The lane introduction was always a one-time animation; there is no persistent user preference to toggle. Removing it unconditionally simplifies the code and avoids a flag that would only ever be turned off. The `celebrationShown` localStorage key and its helper methods (`isCelebrationShown`, `setCelebrationShown`) are also removed since they were solely used to guard against replaying the celebration inside the lane intro flow.
+
+### Decision: Simplify `onHomeSelected` — no lane intro branch
+
+After lane intro removal, `onHomeSelected` only needs to reload data. The `waiting-for-home` state and `laneIntroPhase` advancement logic are deleted. The home selector still works normally (for region setup) but no longer drives spotlight sequencing.
+
+## Risks / Trade-offs
+
+- **Celebration overlay is now orphaned**: The celebration was previously triggered by `completeLaneIntro()`. After this change, `showCelebration` is never set to `true`. The celebration overlay component remains in the template but will never open. This is intentional for this change — the celebration trigger path will be revisited separately if needed. [Risk: silent dead code] → Mitigation: the unused `showCelebration` property is still observable; a follow-up change can wire it to a new trigger or remove the overlay.
+- **`dashboard-lane-introduction` spec becomes obsolete**: The spec file at `openspec/specs/dashboard-lane-introduction/spec.md` describes requirements that are now removed. The spec is updated in this change to mark the capability as removed.
+- **`isOnboardingStepDashboard` getter removed**: This was the only caller of `OnboardingStep.DASHBOARD`. The enum value is not removed (it may still be used by `IOnboardingService` internals), but the getter is dead code after lane intro removal.
+
+## Migration Plan
+
+Frontend only. No data migration, no API changes.
+
+1. Update `artist-filter-bar.html` and `.css`
+2. Update `dashboard-route.ts`
+3. Update `translation.json` (ja + en)
+4. Run `make lint` and `make test` to verify
+5. Merge to `306-refine-onboarding-flow` branch

--- a/openspec/changes/archive/2026-04-05-refine-onboarding/proposal.md
+++ b/openspec/changes/archive/2026-04-05-refine-onboarding/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+The `artist-filter-bar` sheet is misaligned from the bottom of the screen due to a CSS layout bug introduced when the sheet content was refactored to use `<fieldset>/<legend>` — a HTML element pair with browser-special layout behaviour that breaks `display: flex` and `scroll-snap` height calculation. Separately, the lane introduction onboarding step adds friction without measurable value: it delays users from reaching the dashboard and its complex spotlight/state-machine logic is a maintenance burden.
+
+## What Changes
+
+- **Fix** `artist-filter-bar` bottom-sheet layout: replace `<fieldset>/<legend>` with `<section>/<h2>` + `role="group"`, resolving the scroll-snap misalignment and the "全て解除" button positioning bug
+- **Remove** the lane introduction sequence from the onboarding flow: delete `LaneIntroPhase` type, all lane intro state/methods/getters, and associated i18n keys
+- Simplify `onHomeSelected()`: remove the `waiting-for-home` branch — home selection now only triggers a data reload
+- Remove unused imports (`queueTask`, `watch`, `translationKey`) from `dashboard-route.ts`
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `dashboard-artist-filter`: The bottom-sheet content structure changes from `<fieldset>/<legend>` to `<section>/<h2>` to fix the scroll-snap layout bug. The "Filter disabled during onboarding" requirement is unaffected (filter is still hidden during onboarding via `if.bind="!isOnboarding"`).
+- `dashboard-lane-introduction`: **REMOVED** — the lane introduction sequence is no longer part of the onboarding flow. The `onboarding-celebration` capability is unaffected (celebration is still shown, now triggered directly after home selection when data is available, but this path no longer exists in practice since lane intro was the sole trigger).
+
+## Impact
+
+- `frontend/src/components/artist-filter-bar/artist-filter-bar.html` — structural change only
+- `frontend/src/components/artist-filter-bar/artist-filter-bar.css` — remove `fieldset` browser-reset rules
+- `frontend/src/routes/dashboard/dashboard-route.ts` — significant reduction: ~130 lines removed
+- `frontend/src/locales/ja/translation.json` — remove `dashboard.laneIntro` key
+- `frontend/src/locales/en/translation.json` — remove `dashboard.laneIntro` key
+- No API changes, no backend changes, no protobuf changes

--- a/openspec/changes/archive/2026-04-05-refine-onboarding/specs/dashboard-artist-filter/spec.md
+++ b/openspec/changes/archive/2026-04-05-refine-onboarding/specs/dashboard-artist-filter/spec.md
@@ -1,0 +1,61 @@
+## MODIFIED Requirements
+
+### Requirement: Artist-selection bottom sheet
+A bottom sheet SHALL allow the user to select one or more followed artists as a filter. Artists SHALL be presented as pill-shaped chip elements. A "全て解除" (Clear all) button SHALL appear beside the sheet title and allow the user to deselect all pending selections before confirming.
+
+The sheet content SHALL be structured as a `<section>` element (not `<fieldset>`) with an `<h2>` heading as the title. The chip list SHALL carry `aria-labelledby` referencing the heading ID. `role="group"` SHALL NOT be applied to the `<ul>` element as it overrides the native `list` role and causes screen readers to lose item count information.
+
+#### Scenario: Opening the bottom sheet
+- **WHEN** the user taps the filter trigger button
+- **THEN** the bottom sheet SHALL open listing all followed artists as selectable chips
+
+#### Scenario: Pre-selecting current filter
+- **WHEN** the bottom sheet opens while a filter is already active
+- **THEN** the currently filtered artists SHALL be pre-selected (chips in selected state)
+
+#### Scenario: Chip selected state
+- **WHEN** the user taps an artist chip
+- **THEN** the chip SHALL display a checkmark and a brand-colour tinted background to indicate selection
+
+#### Scenario: Clear all pending selections
+- **WHEN** one or more chips are in the pending-selected state
+- **THEN** the "全て解除" button SHALL be enabled
+- **WHEN** the user taps "全て解除"
+- **THEN** all pending selections SHALL be cleared (chips return to unselected state)
+- **AND** the change SHALL NOT be applied until the user confirms
+
+#### Scenario: Clear all button disabled when nothing selected
+- **WHEN** no chips are in the pending-selected state
+- **THEN** the "全て解除" button SHALL be disabled
+
+#### Scenario: Confirming selection
+- **WHEN** the user selects artists and taps the confirm button
+- **THEN** `filteredArtistIds` SHALL be updated to the selected set
+- **THEN** the bottom sheet SHALL close
+
+#### Scenario: Confirming empty selection
+- **WHEN** the user deselects all artists (or taps "全て解除") and confirms
+- **THEN** the filter SHALL be cleared (equivalent to no filter)
+
+#### Scenario: Sheet snaps flush to viewport bottom
+- **WHEN** the filter bottom sheet opens
+- **THEN** the sheet body SHALL be snapped flush to the bottom of the viewport via `scroll-snap-align: end` on `.sheet-body`
+- **AND** the section content height SHALL be correctly reported to the scroll container (no `fieldset`/`legend` height anomalies)
+
+### Requirement: Filter chip UI in page header
+The page header SHALL display a filter trigger button that visually indicates when a filter is active. Artist names SHALL NOT be rendered as chips in the header.
+
+#### Scenario: No active filter — header unchanged
+- **WHEN** `filteredArtistIds` is empty
+- **THEN** no filter indicator SHALL be visible in the header beyond the compact filter trigger button
+- **AND** the filter trigger button SHALL be in its default (inactive) visual state
+
+#### Scenario: Active filter — icon state only
+- **WHEN** `filteredArtistIds` contains one or more IDs
+- **THEN** the filter trigger button SHALL display in its active visual state (e.g., color change via `[data-active="true"]` CSS)
+- **AND** no artist name chips SHALL be rendered in the header
+
+#### Scenario: Filter hidden during onboarding
+- **WHEN** the user is in the onboarding flow (`isOnboarding` is true)
+- **THEN** the filter trigger button SHALL be hidden (via `if.bind="!isOnboarding"`)
+- **AND** the `artists` query param SHALL be ignored until onboarding is complete

--- a/openspec/changes/archive/2026-04-05-refine-onboarding/specs/dashboard-lane-introduction/spec.md
+++ b/openspec/changes/archive/2026-04-05-refine-onboarding/specs/dashboard-lane-introduction/spec.md
@@ -1,31 +1,18 @@
-# Dashboard Lane Introduction
+## REMOVED Requirements
 
-## Purpose
-
-Previously introduced each dashboard lane to the user during onboarding by sequentially spotlighting the STAGE headers with explanatory coach marks. All active requirements have been removed — see removal records below.
-
-## Requirements
-
-### Requirement: Sequential Lane Header Spotlight (REMOVED)
-
+### Requirement: Sequential Lane Header Spotlight
 **Reason**: The lane introduction sequence adds significant state-machine complexity (~130 lines of code in `DashboardRoute`) without proportionate UX value. Users can understand the three-lane timetable layout through the page-help overlay. The `waiting-for-home` sub-state and `@watch`/`queueTask` coordination with data loading are removed.
-
 **Migration**: Remove `LaneIntroPhase` type, `laneIntroPhase` / `selectedPrefectureName` properties, `startLaneIntro()`, `advanceLaneIntro()`, `completeLaneIntro()`, `updateSpotlightForPhase()`, `onLaneIntroTap()`, `laneIntroSelector`, `laneIntroMessage`, `isLaneIntroActive`, `isOnboardingStepDashboard` from `DashboardRoute`. Remove `@watch` on `dateGroups.length` and `isLoading`. Remove `queueTask` and `watch` imports. Simplify `onHomeSelected()` to only reload data. Remove `dashboard.laneIntro` keys from `ja/translation.json` and `en/translation.json`.
 
-### Requirement: Lane Introduction State Management (REMOVED)
-
+### Requirement: Lane Introduction State Management
 **Reason**: Removed along with the lane introduction sequence. `INavDimmingService.setDimmed(true)` is no longer called at onboarding start; `setDimmed(false)` is still called on celebration dismiss.
-
 **Migration**: Remove all `laneIntroPhase`-guarded `navDimming.setDimmed(true)` calls. The `navDimming.setDimmed(false)` call in `onCelebrationDismissed()` and `detaching()` is retained.
 
 ### Requirement: Auto-advance timer (2-second per phase) (REMOVED)
-
 **Reason**: Already removed in a prior change. No migration needed.
 
 ### Requirement: Transition to first card spotlight after lane intro (REMOVED)
-
 **Reason**: Already removed in a prior change. No migration needed.
 
 ### Requirement: Data loading awaited before lane intro decision (polling loop) (REMOVED)
-
 **Reason**: Already removed in a prior change. No migration needed.

--- a/openspec/changes/archive/2026-04-05-refine-onboarding/tasks.md
+++ b/openspec/changes/archive/2026-04-05-refine-onboarding/tasks.md
@@ -1,0 +1,33 @@
+## 1. Fix artist-filter-bar bottom sheet layout
+
+- [x] 1.1 Replace `<fieldset>` with `<section aria-labelledby="filter-sheet-title">` in `artist-filter-bar.html`
+- [x] 1.2 Replace `<legend class="sheet-header">` with `<div class="sheet-header">` containing `<h2 class="sheet-title">`
+- [x] 1.3 Add `role="group" aria-labelledby="filter-sheet-title"` to `<ul class="artists-list">`
+- [x] 1.4 Remove `fieldset` browser-default resets (`margin: 0; border: none;`) from `artist-filter-bar.css`
+- [x] 1.5 Verify sheet snaps flush to viewport bottom in browser
+
+## 2. Remove lane introduction from DashboardRoute
+
+- [x] 2.1 Remove `LaneIntroPhase` type export from `dashboard-route.ts`
+- [x] 2.2 Remove `laneIntroPhase` and `selectedPrefectureName` properties
+- [x] 2.3 Remove `startLaneIntro()`, `advanceLaneIntro()`, `completeLaneIntro()`, `updateSpotlightForPhase()` private methods
+- [x] 2.4 Remove `onLaneIntroTap()` public method
+- [x] 2.5 Remove `laneIntroSelector`, `laneIntroMessage`, `isLaneIntroActive` getters
+- [x] 2.6 Remove `isOnboardingStepDashboard` getter (no remaining callers)
+- [x] 2.7 Remove `isCelebrationShown` getter and `setCelebrationShown()` method
+- [x] 2.8 Remove `startLaneIntro()` call from `attached()`
+- [x] 2.9 Simplify `onHomeSelected()` — remove `waiting-for-home` branch, keep only data reload
+- [x] 2.10 Remove `@watch` decorators for `dateGroups.length` and `isLoading` (lane intro only)
+- [x] 2.11 Remove `onboarding.deactivateSpotlight()` call from `onCelebrationDismissed()`
+- [x] 2.12 Remove unused imports: `queueTask`, `watch`, `translationKey`
+
+## 3. Remove lane intro i18n keys
+
+- [x] 3.1 Remove `dashboard.laneIntro` block from `src/locales/ja/translation.json`
+- [x] 3.2 Remove `dashboard.laneIntro` block from `src/locales/en/translation.json`
+
+## 4. Verification
+
+- [x] 4.1 Run `make lint` — no errors or warnings
+- [x] 4.2 Run `npx tsc --noEmit` — no type errors
+- [x] 4.3 Run `make test` — all tests pass

--- a/openspec/changes/archive/2026-04-05-refine-onboarding/tasks.md
+++ b/openspec/changes/archive/2026-04-05-refine-onboarding/tasks.md
@@ -2,7 +2,7 @@
 
 - [x] 1.1 Replace `<fieldset>` with `<section aria-labelledby="filter-sheet-title">` in `artist-filter-bar.html`
 - [x] 1.2 Replace `<legend class="sheet-header">` with `<div class="sheet-header">` containing `<h2 class="sheet-title">`
-- [x] 1.3 Add `role="group" aria-labelledby="filter-sheet-title"` to `<ul class="artists-list">`
+- [x] 1.3 Add `aria-labelledby="filter-sheet-title"` to `<ul class="artists-list">` (omit `role="group"` — spec prohibits it on `<ul>`)
 - [x] 1.4 Remove `fieldset` browser-default resets (`margin: 0; border: none;`) from `artist-filter-bar.css`
 - [x] 1.5 Verify sheet snaps flush to viewport bottom in browser
 

--- a/openspec/specs/dashboard-artist-filter/spec.md
+++ b/openspec/specs/dashboard-artist-filter/spec.md
@@ -55,6 +55,8 @@ The page header SHALL display a filter trigger button that visually indicates wh
 ### Requirement: Artist-selection bottom sheet
 A bottom sheet SHALL allow the user to select one or more followed artists as a filter. Artists SHALL be presented as pill-shaped chip elements. A "全て解除" (Clear all) button SHALL appear beside the sheet title and allow the user to deselect all pending selections before confirming.
 
+The sheet content SHALL be structured as a `<section>` element (not `<fieldset>`) with an `<h2>` heading as the title. The chip list SHALL carry `aria-labelledby` referencing the heading ID. `role="group"` SHALL NOT be applied to the `<ul>` element as it overrides the native `list` role and causes screen readers to lose item count information.
+
 #### Scenario: Opening the bottom sheet
 - **WHEN** the user taps the filter trigger button
 - **THEN** the bottom sheet SHALL open listing all followed artists as selectable chips
@@ -87,6 +89,11 @@ A bottom sheet SHALL allow the user to select one or more followed artists as a 
 - **WHEN** the user deselects all artists (or taps "全て解除") and confirms
 - **THEN** the filter SHALL be cleared (equivalent to no filter)
 
+#### Scenario: Sheet snaps flush to viewport bottom
+- **WHEN** the filter bottom sheet opens
+- **THEN** the sheet body SHALL be snapped flush to the bottom of the viewport via `scroll-snap-align: end` on `.sheet-body`
+- **AND** the section content height SHALL be correctly reported to the scroll container (no `fieldset`/`legend` height anomalies)
+
 ### Requirement: Push notification deep-link to filtered dashboard
 Tapping a push notification that carries a `/dashboard?artists=<artistId>` URL SHALL open the dashboard pre-filtered to that artist.
 
@@ -95,7 +102,7 @@ Tapping a push notification that carries a `/dashboard?artists=<artistId>` URL S
 - **THEN** the browser SHALL navigate to `/dashboard?artists=<artistId>`
 - **THEN** the dashboard SHALL display only concerts for `<artistId>`
 
-#### Scenario: Filter disabled during onboarding
-- **WHEN** the user is in the onboarding flow (lane intro active)
-- **THEN** the filter trigger button SHALL be hidden or disabled
-- **THEN** the `artists` query param SHALL be ignored until onboarding is complete
+#### Scenario: Filter hidden during onboarding
+- **WHEN** the user is in the onboarding flow (`isOnboarding` is true)
+- **THEN** the filter trigger button SHALL be hidden (via `if.bind="!isOnboarding"`)
+- **AND** the `artists` query param SHALL be ignored until onboarding is complete


### PR DESCRIPTION
## Summary

- Update `dashboard-artist-filter` spec: add `<section>/<h2>` structure requirement, prohibit `role="group"` on `<ul>`, add scroll-snap height correctness scenario
- Mark all `dashboard-lane-introduction` requirements as REMOVED with migration notes
- Archive `refine-onboarding` change artifacts to `openspec/changes/archive/2026-04-05-refine-onboarding/`

Companion frontend PR: liverty-music/frontend#327
