### PR TITLE
docs(post-signup-dialog): add hype guide hint and dynamic close button spec

### DIFF
--- a/openspec/changes/archive/2026-04-05-refine-onboarding/design.md
+++ b/openspec/changes/archive/2026-04-05-refine-onboarding/design.md
@@ -28,7 +28,7 @@ Two independent issues are addressed together since both originate in the onboar
 
 **Alternatives considered**:
 - **Option A — Keep `<fieldset>`, empty `<legend>`, move header to `<div>`**: This preserves the fieldset grouping semantic but requires a hidden `<legend>` element just to satisfy the parser — a semantically odd pattern.
-- **Option B — Replace with `<section>/<h2>`**: Cleaner. `<section aria-labelledby>` provides equivalent accessibility grouping. The checkbox list gets `role="group" aria-labelledby` to preserve the WAI-ARIA group semantics. `display: flex` on `<section>` behaves predictably across all browsers.
+- **Option B — Replace with `<section>/<h2>`**: Cleaner. `<section aria-labelledby>` provides equivalent accessibility grouping. The chip list carries `aria-labelledby` referencing the heading ID (without `role="group"`, which would override the native list role and cause screen readers to lose item count information). `display: flex` on `<section>` behaves predictably across all browsers.
 
 Option B is simpler, more predictable, and semantically appropriate — `<fieldset>` is designed for form field grouping with a visible label; here the label is a heading, and the interaction is confirmed by a separate button.
 

--- a/openspec/changes/archive/2026-04-05-refine-onboarding/proposal.md
+++ b/openspec/changes/archive/2026-04-05-refine-onboarding/proposal.md
@@ -4,7 +4,7 @@ The `artist-filter-bar` sheet is misaligned from the bottom of the screen due to
 
 ## What Changes
 
-- **Fix** `artist-filter-bar` bottom-sheet layout: replace `<fieldset>/<legend>` with `<section>/<h2>` + `role="group"`, resolving the scroll-snap misalignment and the "全て解除" button positioning bug
+- **Fix** `artist-filter-bar` bottom-sheet layout: replace `<fieldset>/<legend>` with `<section>/<h2>` + `aria-labelledby` (without `role="group"` — spec prohibits it on `<ul>` as it overrides the native list role), resolving the scroll-snap misalignment and the "全て解除" button positioning bug
 - **Remove** the lane introduction sequence from the onboarding flow: delete `LaneIntroPhase` type, all lane intro state/methods/getters, and associated i18n keys
 - Simplify `onHomeSelected()`: remove the `waiting-for-home` branch — home selection now only triggers a data reload
 - Remove unused imports (`queueTask`, `watch`, `translationKey`) from `dashboard-route.ts`

--- a/openspec/changes/archive/2026-04-06-refine-post-signup-dialog/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-06-refine-post-signup-dialog/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-06

--- a/openspec/changes/archive/2026-04-06-refine-post-signup-dialog/design.md
+++ b/openspec/changes/archive/2026-04-06-refine-post-signup-dialog/design.md
@@ -1,0 +1,52 @@
+## Context
+
+The `PostSignupDialog` is a bottom sheet shown once after a user's first signup. It consolidates PWA install and push notification opt-in prompts. However, when both are already satisfied (PWA installed via standalone mode, notification permission already granted), the sheet renders with only the title and an unexplained "Later" button, which feels broken and confusing.
+
+Additionally, users currently have no in-context guidance about hype — the mechanism for controlling notification granularity per artist. The dialog is a natural moment to introduce this concept.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Always show a hype guide hint row so the sheet always has meaningful content
+- Dynamically change the footer button to "Close" (vs "Later") when no pending actions remain
+- Avoid sheet suppression logic — always show the sheet after first signup regardless of state
+
+**Non-Goals:**
+- Navigation to My Artists from within the dialog
+- Changing when or how often the sheet appears
+- Modifying notification or PWA install logic
+
+## Decisions
+
+### Always-visible hype guide row
+
+The hype guide row is added as a static, non-interactive informational row. It requires no condition because:
+- It is always relevant regardless of notification or PWA state
+- It ensures the sheet never appears empty
+- It introduces the hype concept at the ideal moment (right after signup)
+
+**Alternative considered**: Show the row only if notification is granted (user can now act on it). Rejected because it would still leave the sheet empty for users with notification denied + PWA installed.
+
+### `isAllDone` computed getter for button label
+
+A getter `isAllDone` is introduced in the ViewModel:
+
+```
+isAllDone = !canInstallPwa && notificationManager.permission === 'granted'
+```
+
+- `!canInstallPwa`: true when PWA is already installed (standalone mode) or install is not applicable
+- `permission === 'granted'`: user has opted into push notifications
+
+When both are true, the footer button uses the `postSignup.close` i18n key; otherwise `postSignup.defer`.
+
+**Binding approach**: Use `t.bind` (Aurelia i18n dynamic key binding) rather than template literal `t="${...}"`, which is not supported by the `@aurelia/i18n` attribute.
+
+### No structural changes to sheet dismissal
+
+Both "Later" and "Close" call `onDefer()`, which sets `isOpen = false`. No behavioral difference — only the label changes to communicate intent accurately.
+
+## Risks / Trade-offs
+
+- [Resolved] `isAllDone` reactivity depends on `notificationManager.permission` being observable. `NotificationManager.permission` is decorated with `@observable` (notification-manager.ts:13), so Aurelia will automatically re-evaluate `isAllDone` and update the footer button label when permission changes mid-session.
+- [Trade-off] Hype guide row has no CTA (no navigation button). Users must find My Artists themselves. → Acceptable for MVP; a navigation link can be added in a follow-up if metrics show confusion.

--- a/openspec/changes/archive/2026-04-06-refine-post-signup-dialog/proposal.md
+++ b/openspec/changes/archive/2026-04-06-refine-post-signup-dialog/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+The PostSignupDialog can appear nearly empty — showing only the title and a "Later" button — when the user has already installed the PWA and notification permission is already granted. This leaves users confused about what "Later" refers to and makes the app feel broken.
+
+## What Changes
+
+- Add a permanently visible hype guide hint row explaining that users can control notification scope via hype settings on the My Artists page
+- Change the footer button label from "Later" to "Close" when both PWA installation and push notification opt-in are already complete
+
+## Capabilities
+
+### New Capabilities
+
+- None
+
+### Modified Capabilities
+
+- `post-signup-dialog`: Add always-visible hype guide row and dynamic footer button label ("Later" → "Close") based on completion state of PWA install and push notification opt-in
+
+## Impact
+
+- `frontend/src/components/post-signup-dialog/post-signup-dialog.html` — template changes
+- `frontend/src/components/post-signup-dialog/post-signup-dialog.ts` — new `isAllDone` computed getter
+- `frontend/src/locales/en/translation.json` — new `postSignup.hypeGuideLabel` and `postSignup.close` keys
+- `frontend/src/locales/ja/translation.json` — same new keys in Japanese

--- a/openspec/changes/archive/2026-04-06-refine-post-signup-dialog/specs/post-signup-dialog/spec.md
+++ b/openspec/changes/archive/2026-04-06-refine-post-signup-dialog/specs/post-signup-dialog/spec.md
@@ -1,13 +1,6 @@
-# Post-Signup Dialog
-
-## Purpose
-
-Consolidates notification permission and PWA install prompts into a single dialog shown after the first successful signup, providing a streamlined post-authentication experience.
-
-## Requirements
+## MODIFIED Requirements
 
 ### Requirement: Post-Signup Dialog on First Authentication
-
 The system SHALL display a dialog after the first successful signup that consolidates notification permission and PWA install prompts.
 
 #### Scenario: Dialog shown after first signup
@@ -47,69 +40,9 @@ The system SHALL display a dialog after the first successful signup that consoli
 - **AND** either `PwaInstallService.canShowFab` is `true` OR `notificationManager.permission` is not `'granted'`
 - **THEN** the footer button SHALL display the label "Later" (あとで)
 
-#### Scenario: Notification opt-in from dialog
-
-- **WHEN** the user taps the notification opt-in button in the PostSignupDialog
-- **THEN** the system SHALL call `PushService.subscribe()`
-- **AND** on success, the notification row SHALL show a confirmed state
-- **AND** on failure or denial, the notification row SHALL show an error state
-
-#### Scenario: PWA install from dialog (Android/Chrome)
-
-- **WHEN** the user taps the PWA install button in the PostSignupDialog
-- **AND** `beforeinstallprompt` has fired
-- **THEN** the system SHALL trigger the deferred `beforeinstallprompt` event
-
-#### Scenario: PWA install row hidden on iOS Safari
-
-- **WHEN** the PostSignupDialog is displayed
-- **AND** the platform is iOS Safari (`beforeinstallprompt` never fires)
-- **THEN** the PWA install row SHALL NOT be shown in the dialog
-- **AND** the persistent FAB instruction sheet provides the iOS install path instead
-
-#### Scenario: Dialog dismissed
-
-- **WHEN** the user taps あとで
-- **THEN** the PostSignupDialog SHALL close
-- **AND** the notification prompt SHALL NOT be shown again in the same session (coordinated via `IPromptCoordinator`)
-- **AND** the PWA install FAB SHALL remain visible (it is not affected by PostSignupDialog dismissal)
-
-### Requirement: Dialog reliably opens when active is true at creation time
-The PostSignupDialog SHALL reliably open when `active` is bound to `true` at component creation time, not only when `active` transitions from `false` to `true` after the component is attached.
-
-#### Scenario: Dashboard sets showPostSignupDialog in loading() before attach
-- **WHEN** `DashboardRoute.loading()` sets `showPostSignupDialog = true`
-- **AND** `PostSignupDialog` receives `active = true` during its `binding` phase
-- **THEN** `activeChanged()` SHALL set `isOpen = true`
-- **AND** the inner `<bottom-sheet>` SHALL open successfully (via the `attached()` fallback in BottomSheet)
-- **AND** the dialog SHALL be visible to the user with its full content
-
-### Requirement: PostSignupDialog title and aria-label use i18n bindings
-All user-visible strings in the PostSignupDialog component SHALL use `@aurelia/i18n` `t` attribute bindings. No hardcoded display strings are permitted in the template.
-
-#### Scenario: Title renders in active locale
-- **WHEN** the PostSignupDialog is displayed
-- **AND** the active locale is `en`
-- **THEN** the `<h2>` title SHALL render using the `postSignup.title` translation key in the EN translation
-- **AND** the rendered text SHALL be in English (e.g., `Account registration complete!`)
-
-#### Scenario: Title renders in Japanese locale
-- **WHEN** the PostSignupDialog is displayed
-- **AND** the active locale is `ja`
-- **THEN** the `<h2>` title SHALL render using the `postSignup.title` translation key in the JA translation
-- **AND** the rendered text SHALL be `✅ アカウント登録完了！`
-
-#### Scenario: aria-label follows active locale
-- **WHEN** the PostSignupDialog is displayed
-- **AND** the active locale is `en`
-- **THEN** the wrapping `<bottom-sheet>` element SHALL have an `aria-label` rendered from the `postSignup.ariaLabel` translation key in the EN translation
-
-#### Scenario: Translation key parity
-- **WHEN** `postSignup.title` or `postSignup.ariaLabel` keys exist in `ja/translation.json`
-- **THEN** the same keys SHALL exist in `en/translation.json`
+## ADDED Requirements
 
 ### Requirement: Hype guide hint always visible in PostSignupDialog
-
 The PostSignupDialog SHALL always display a hype guide hint row, regardless of notification permission state or PWA installation state.
 
 #### Scenario: Hype guide row shown when PWA installed and notification granted
@@ -128,7 +61,6 @@ The PostSignupDialog SHALL always display a hype guide hint row, regardless of n
 - **AND** the dialog SHALL NOT appear empty
 
 ### Requirement: PostSignupDialog footer button reflects completion state
-
 The footer button label in PostSignupDialog SHALL dynamically reflect whether the user has completed all available actions.
 
 #### Scenario: Button switches to "Close" after enabling notifications

--- a/openspec/changes/archive/2026-04-06-refine-post-signup-dialog/tasks.md
+++ b/openspec/changes/archive/2026-04-06-refine-post-signup-dialog/tasks.md
@@ -1,0 +1,22 @@
+## 1. i18n Translation Keys
+
+- [x] 1.1 Add `postSignup.hypeGuideLabel` key to `frontend/src/locales/ja/translation.json`
+- [x] 1.2 Add `postSignup.close` key to `frontend/src/locales/ja/translation.json`
+- [x] 1.3 Add `postSignup.hypeGuideLabel` key to `frontend/src/locales/en/translation.json`
+- [x] 1.4 Add `postSignup.close` key to `frontend/src/locales/en/translation.json`
+
+## 2. ViewModel
+
+- [x] 2.1 Add `isAllDone` computed getter to `PostSignupDialog`: returns `true` when `!canInstallPwa && notificationManager.permission === 'granted'`
+
+## 3. Template
+
+- [x] 3.1 Add always-visible hype guide hint row (💡 icon, `postSignup.hypeGuideLabel`) to `post-signup-dialog.html`
+- [x] 3.2 Update footer button to use `t.bind="isAllDone ? 'postSignup.close' : 'postSignup.defer'"` in `post-signup-dialog.html`
+
+## 4. Tests
+
+- [x] 4.1 Add unit test: hype guide row is always rendered regardless of notification permission and PWA install state
+- [x] 4.2 Add unit test: footer button shows "Later" when `canInstallPwa` is true
+- [x] 4.3 Add unit test: footer button shows "Later" when `permission !== 'granted'`
+- [x] 4.4 Add unit test: footer button shows "Close" when `!canInstallPwa && permission === 'granted'`


### PR DESCRIPTION
## Summary

- Update `post-signup-dialog` spec to require an always-visible hype guide hint row
- Add two new footer button label scenarios: "Close" when all actions complete, "Later" otherwise
- Add two new requirements: hype guide always visible, footer button reflects completion state
- Archive the `refine-post-signup-dialog` change

close: #306

## Test plan

- [x] Spec delta merged to `openspec/specs/post-signup-dialog/spec.md`
- [x] Change archived to `openspec/changes/archive/2026-04-06-refine-post-signup-dialog/`
