### PR TITLE
docs(openspec): add venue-name-cache spec and archive change

### DIFF
--- a/openspec/changes/archive/2026-04-06-cache-google-maps-venue-lookup/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-06-cache-google-maps-venue-lookup/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-06

--- a/openspec/changes/archive/2026-04-06-cache-google-maps-venue-lookup/design.md
+++ b/openspec/changes/archive/2026-04-06-cache-google-maps-venue-lookup/design.md
@@ -1,0 +1,53 @@
+## Context
+
+`ConcertCreationUseCase.resolveVenue()` currently calls Google Places API (Text Search, $32/1000 requests) for every scraped concert venue. The batch-local `newVenues` map and the DB lookup by `google_place_id` only de-duplicate **within a single batch** and **after the API has already been called**. Repeated concert discoveries for the same popular venues (Budokan, Zepp, etc.) across different artists or discovery runs will trigger duplicate API calls.
+
+The `venue-normalization` spec explicitly removed an earlier name-based DB fallback in order to ensure all persisted venues have a canonical `google_place_id`. This design reintroduces a name-based pre-check while preserving that invariant: we only skip the API call when a venue record **already has a `google_place_id`** (i.e. was previously canonicalised).
+
+## Goals / Non-Goals
+
+**Goals:**
+- Eliminate Google Places API calls for venues that have been resolved before.
+- Keep the canonical `google_place_id` invariant: every venue in the DB was created from a Places API response.
+- Minimal surface change — no new infrastructure, no caching layer.
+
+**Non-Goals:**
+- Reducing API calls for brand-new venues (first resolution always hits the API).
+- Caching in-memory or in Redis.
+- Changing how `google_place_id` deduplication works post-API.
+
+## Decisions
+
+### Decision: Key the pre-check on `(listed_venue_name, admin_area)` not on normalised name
+
+The scraped `listed_venue_name` is what we have before calling the API. A normalised-name approach would require additional logic and could produce false positives (two different venues with similar names). Using the exact listed name plus optional admin area gives a precise, zero-ambiguity match for re-discovered venues.
+
+**Alternative considered — normalise before lookup**: Lowercasing + stripping punctuation before indexing would improve hit rate for minor scraping variations (e.g., "Zepp Tokyo" vs "ZEPP TOKYO"). Rejected because it adds complexity and the primary benefit (eliminating re-discoveries of the same artist's concert) does not require fuzzy matching.
+
+### Decision: Return the existing venue immediately — do not re-validate with Places API
+
+When `GetByListedName` returns a result, we return it as-is. We do not re-call the API to confirm the `google_place_id` is still valid.
+
+**Rationale**: Venue identity is stable. A venue that exists in our DB was created from a valid Places API response. Validating it again on every hit would negate the cost saving.
+
+### Decision: Add a partial unique index `(listed_venue_name, admin_area)` on the venues table
+
+A unique index (rather than a plain index) prevents duplicate entries for the same listed name + admin area combination, which could otherwise accumulate if two concurrent discovery batches race for the same new venue.
+
+**Alternative considered — application-level dedup only**: The existing batch-local `newVenues` map handles same-batch races, but not across concurrent event consumers. A DB-level index is the safer guard.
+
+### Decision: Lookup is `GetByListedName` on `VenueRepository`, not a usecase-layer cache
+
+Keeping the lookup in the repository layer preserves Clean Architecture: the usecase calls a named operation without knowing the index details. It also means the lookup is exercised by the existing integration test suite without any mock changes.
+
+## Risks / Trade-offs
+
+- **Stale listed name**: If Gemini returns a slightly different `listed_venue_name` for the same venue across scrapes, the pre-check misses and the API is called again. This creates a second venue record for the same physical location. Mitigation: the `google_place_id` unique index (`idx_venues_google_place_id`) remains in place and `GetByPlaceID` will still de-duplicate at the DB level, so no duplicate venue rows will be created — only an extra API call.
+
+- **Index maintenance cost**: Adding an index on `(listed_venue_name, admin_area)` has a minor write overhead. The venues table grows slowly (only on new concert discoveries), so this is negligible.
+
+## Migration Plan
+
+1. Atlas migration: add index `idx_venues_listed_name_admin_area` on `(listed_venue_name, admin_area)`.
+2. Deploy backend with updated `VenueRepository` and `resolveVenue()` — backward compatible (no column additions, no proto changes).
+3. No rollback risk: the pre-check is purely additive; removing it reverts behaviour to current state.

--- a/openspec/changes/archive/2026-04-06-cache-google-maps-venue-lookup/proposal.md
+++ b/openspec/changes/archive/2026-04-06-cache-google-maps-venue-lookup/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+`resolveVenue()` calls the Google Places API for every scraped concert venue, even when the same venue was resolved in a previous concert discovery batch and its record already exists in the database. Google Places Text Search is billed per request, so recurring discoveries for popular venues (e.g., Budokan, Zepp) incur unnecessary API costs.
+
+The existing `venue-normalization` spec intentionally removed name-based DB fallback in favour of always obtaining a canonical `google_place_id` from the API first. This change introduces a DB-first lookup keyed on `(listed_venue_name, admin_area)` that runs **before** the API call, preserving the canonical-ID invariant while eliminating redundant billing.
+
+## What Changes
+
+- Add `GetByListedName(listedVenueName string, adminArea *string)` to `VenueRepository`.
+- Add a `(listed_venue_name, admin_area)` index to the `venues` table.
+- Prepend a DB lookup step to `resolveVenue()` in `ConcertCreationUseCase`: if a venue is found by listed name, return it immediately without calling the Places API.
+- The existing Places API → DB (`GetByPlaceID`) → create flow is unchanged when the DB lookup misses.
+
+## Capabilities
+
+### New Capabilities
+
+- `venue-name-cache`: DB-first venue lookup by listed name and admin area to avoid redundant Google Places API calls.
+
+### Modified Capabilities
+
+- `venue-normalization`: Resolution strategy gains a DB-first step before the Places API call; the canonical `google_place_id` requirement is retained for all newly created venues.
+
+## Impact
+
+- **Backend**: `entity.VenueRepository` interface, `rdb.VenueRepository`, `ConcertCreationUseCase.resolveVenue()`.
+- **Database**: New index on `venues(listed_venue_name, admin_area)`; new `VenueRepository.GetByListedName` query.
+- **Billing**: Google Places API calls reduced for any venue seen more than once across discovery batches.
+- **No proto changes**: purely internal; no RPC surface changes.

--- a/openspec/changes/archive/2026-04-06-cache-google-maps-venue-lookup/specs/venue-name-cache/spec.md
+++ b/openspec/changes/archive/2026-04-06-cache-google-maps-venue-lookup/specs/venue-name-cache/spec.md
@@ -1,0 +1,39 @@
+## ADDED Requirements
+
+### Requirement: Venue lookup by listed name before Places API call
+
+The `VenueRepository` SHALL provide a `GetByListedName` method that looks up a venue by the exact `listed_venue_name` and optional `admin_area` as stored in the `venues` table. The `ConcertCreationUseCase` SHALL call this method before invoking the Google Places API during venue resolution.
+
+#### Scenario: Venue found by listed name — API call skipped
+
+- **WHEN** `resolveVenue` is called with a `listed_venue_name` and optional `admin_area`
+- **AND** a venue with the same `listed_venue_name` and `admin_area` already exists in the database
+- **THEN** the system SHALL return that existing venue immediately
+- **AND** the system SHALL NOT call the Google Places API
+
+#### Scenario: Venue not found by listed name — resolution continues
+
+- **WHEN** `resolveVenue` is called with a `listed_venue_name` and optional `admin_area`
+- **AND** no venue with that combination exists in the database
+- **THEN** the system SHALL proceed to call the Google Places API as before
+
+#### Scenario: Listed name match is case-sensitive and exact
+
+- **WHEN** `GetByListedName` is called
+- **THEN** the lookup SHALL use exact string equality on `listed_venue_name`
+- **AND** variations in casing or whitespace SHALL result in a miss (falling through to the API)
+
+### Requirement: Unique index on venue listed name and admin area
+
+The `venues` table SHALL have a unique index on `(listed_venue_name, admin_area)` to prevent duplicate venue records for the same scraped name and area combination, and to support efficient lookup.
+
+#### Scenario: Duplicate listed name and admin area rejected
+
+- **WHEN** a venue is inserted with the same `listed_venue_name` and `admin_area` as an existing record
+- **THEN** the database SHALL reject the insert via the unique constraint
+- **AND** `VenueRepository.Create` SHALL handle the conflict gracefully (return the existing venue or ignore)
+
+#### Scenario: Same listed name with different admin area allowed
+
+- **WHEN** two venues share the same `listed_venue_name` but have different `admin_area` values (or one is NULL)
+- **THEN** both records SHALL be permitted by the unique index

--- a/openspec/changes/archive/2026-04-06-cache-google-maps-venue-lookup/specs/venue-normalization/spec.md
+++ b/openspec/changes/archive/2026-04-06-cache-google-maps-venue-lookup/specs/venue-normalization/spec.md
@@ -1,10 +1,4 @@
-# venue-normalization Specification
-
-## Purpose
-
-The Venue Normalization capability resolves scraped venue names to canonical venue records via Google Places API during concert creation. Venues are either resolved to a canonical record (with name, coordinates, and `google_place_id`) or the concert is skipped with structured logging.
-
-## Requirements
+## MODIFIED Requirements
 
 ### Requirement: Venue Resolution During Concert Creation
 
@@ -45,32 +39,3 @@ The concert creation pipeline SHALL resolve venues via a DB-first lookup before 
 - **AND** Google Places API returns a match
 - **AND** a venue with the same `google_place_id` already exists in the database
 - **THEN** the existing venue SHALL be reused (no new venue created)
-
-### Requirement: Skip Unresolvable Venues
-
-The concert creation pipeline SHALL skip concerts whose venues cannot be resolved via Google Places API, rather than creating venue records with incomplete data.
-
-#### Scenario: Places API returns NotFound
-
-- **WHEN** `resolveVenue` calls Google Places API for a scraped venue name
-- **AND** the API returns NotFound
-- **THEN** the concert SHALL NOT be persisted to the database
-- **AND** the system SHALL emit a structured Warn log containing all fields of the `ScrapedConcert` (title, local_date, start_time, open_time, listed_venue_name, admin_area, source_url)
-- **AND** processing SHALL continue with the next concert in the batch
-
-#### Scenario: Places API returns a non-retryable error
-
-- **WHEN** `resolveVenue` calls Google Places API for a scraped venue name
-- **AND** the API returns an error that is not NotFound (e.g., InvalidArgument)
-- **THEN** the concert SHALL NOT be persisted to the database
-- **AND** the system SHALL emit a structured Warn log with the error and all `ScrapedConcert` fields
-- **AND** processing SHALL continue with the next concert in the batch
-
-### Requirement: PlaceSearcher Is Required
-
-The `ConcertCreationUseCase` SHALL require a non-nil `VenuePlaceSearcher` at construction time.
-
-#### Scenario: Nil placeSearcher at startup
-
-- **WHEN** `NewConcertCreationUseCase` is called with a nil `placeSearcher`
-- **THEN** the function SHALL panic with a descriptive message

--- a/openspec/changes/archive/2026-04-06-cache-google-maps-venue-lookup/tasks.md
+++ b/openspec/changes/archive/2026-04-06-cache-google-maps-venue-lookup/tasks.md
@@ -1,0 +1,17 @@
+## 1. Database Migration
+
+- [x] 1.1 Add Atlas migration: create unique index `idx_venues_listed_name_admin_area` on `venues(listed_venue_name, admin_area)`
+- [x] 1.2 Register the new migration file in `k8s/atlas/base/kustomization.yaml`
+
+## 2. Repository Layer
+
+- [x] 2.1 Add `GetByListedName(ctx context.Context, listedVenueName string, adminArea *string) (*Venue, error)` to the `VenueRepository` interface in `internal/entity/venue.go`
+- [x] 2.2 Implement `GetByListedName` in `internal/infrastructure/database/rdb/venue_repo.go` using an exact match on `(listed_venue_name, admin_area)`
+- [x] 2.3 Add integration test for `GetByListedName` in `internal/infrastructure/database/rdb/venue_repo_test.go` covering: found, not found, and NULL admin_area cases
+- [x] 2.4 Regenerate mocks: run `mockery` to update `internal/entity/mocks/mock_VenueRepository.go`
+
+## 3. UseCase Layer
+
+- [x] 3.1 Update `resolveVenue()` in `internal/usecase/concert_creation_uc.go` to call `venueRepo.GetByListedName` before invoking the Places API; return immediately on hit
+- [x] 3.2 Update the batch-local `newVenues` map key from `place.ExternalID` to `listed_venue_name` so the pre-check and batch cache use the same key
+- [x] 3.3 Add unit tests for `resolveVenue` covering: DB hit (API not called), DB miss → API hit → new venue, DB miss → API NotFound (skip)

--- a/openspec/specs/venue-name-cache/spec.md
+++ b/openspec/specs/venue-name-cache/spec.md
@@ -1,0 +1,45 @@
+# venue-name-cache Specification
+
+## Purpose
+
+The Venue Name Cache capability provides a DB-first lookup for venues by their scraped `listed_venue_name` and optional `admin_area` before falling through to the Google Places API. This avoids redundant external API calls when a venue has already been resolved and persisted from a prior scrape.
+
+## Requirements
+
+### Requirement: Venue lookup by listed name before Places API call
+
+The `VenueRepository` SHALL provide a `GetByListedName` method that looks up a venue by the exact `listed_venue_name` and optional `admin_area` as stored in the `venues` table. The `ConcertCreationUseCase` SHALL call this method before invoking the Google Places API during venue resolution.
+
+#### Scenario: Venue found by listed name — API call skipped
+
+- **WHEN** `resolveVenue` is called with a `listed_venue_name` and optional `admin_area`
+- **AND** a venue with the same `listed_venue_name` and `admin_area` already exists in the database
+- **THEN** the system SHALL return that existing venue immediately
+- **AND** the system SHALL NOT call the Google Places API
+
+#### Scenario: Venue not found by listed name — resolution continues
+
+- **WHEN** `resolveVenue` is called with a `listed_venue_name` and optional `admin_area`
+- **AND** no venue with that combination exists in the database
+- **THEN** the system SHALL proceed to call the Google Places API as before
+
+#### Scenario: Listed name match is case-sensitive and exact
+
+- **WHEN** `GetByListedName` is called
+- **THEN** the lookup SHALL use exact string equality on `listed_venue_name`
+- **AND** variations in casing or whitespace SHALL result in a miss (falling through to the API)
+
+### Requirement: Unique index on venue listed name and admin area
+
+The `venues` table SHALL have a unique index on `(listed_venue_name, admin_area)` to prevent duplicate venue records for the same scraped name and area combination, and to support efficient lookup.
+
+#### Scenario: Duplicate listed name and admin area rejected
+
+- **WHEN** a venue is inserted with the same `listed_venue_name` and `admin_area` as an existing record
+- **THEN** the database SHALL reject the insert via the unique constraint
+- **AND** `VenueRepository.Create` SHALL handle the conflict gracefully (return the existing venue or ignore)
+
+#### Scenario: Same listed name with different admin area allowed
+
+- **WHEN** two venues share the same `listed_venue_name` but have different `admin_area` values (or one is NULL)
+- **THEN** both records SHALL be permitted by the unique index


### PR DESCRIPTION
## Summary

- Add `venue-name-cache` capability spec describing the DB-first venue lookup by `listed_venue_name` before the Google Places API call.
- Update `venue-normalization` spec to reflect the updated 5-step venue resolution strategy.
- Archive the completed `cache-google-maps-venue-lookup` change.

## Motivation

The `resolveVenue()` flow previously called the Google Places Text Search API ($32/1000 requests) for every scraped concert. This change formalises the DB-first cache layer that short-circuits the API call for any venue resolved in a previous discovery batch.

## Resolution order (after this change)

1. Batch-local cache (keyed by `listed_venue_name`) — zero I/O
2. `VenueRepository.GetByListedName` — DB only, no API call
3. Google Places API (pay-per-request)
4. `VenueRepository.GetByPlaceID` — handles same physical venue with different scraped names
5. Create new venue (stores `listed_venue_name` for future lookups)

## Related

Backend implementation: liverty-music/backend#274
