### PR TITLE
docs(spec): add dashboard-concert-cache capability spec

### DIFF
--- a/openspec/changes/archive/2026-04-06-frontend-dashboard-cache/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-06-frontend-dashboard-cache/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-06

--- a/openspec/changes/archive/2026-04-06-frontend-dashboard-cache/design.md
+++ b/openspec/changes/archive/2026-04-06-frontend-dashboard-cache/design.md
@@ -1,0 +1,81 @@
+## Context
+
+`DashboardRoute.loading()` calls three parallel RPCs on every navigation:
+1. `FollowServiceClient.getFollowedArtistMap()` → internally calls `FollowRpcClient.listFollowed()`
+2. `ConcertServiceClient.listByFollower()` → calls `ConcertRpcClient.listByFollower()`
+3. `TicketJourneyService.listByUser()`
+
+Concert data changes only on two events:
+- Weekly cron job (dev: every Friday 09:00)
+- First follow for an artist — which triggers `SearchNewConcerts()` **asynchronously** in a background goroutine; the follow RPC returns before the search completes
+
+Both services are Aurelia DI singletons that persist across route navigations for the lifetime of the session. `FollowServiceClient` already maintains `@observable followedArtists` as authoritative in-memory state, updated optimistically on every follow/unfollow/setHype.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Eliminate redundant `listByFollower()` RPC calls on re-entry to Dashboard
+- Eliminate redundant `listFollowed()` RPC calls when follow state is already in memory
+- Invalidate `listByFollower()` cache when a follow action may have changed concert data
+- Zero new runtime dependencies
+
+**Non-Goals:**
+- Caching `listByUser()` (ticket journeys — low visit frequency, complex invalidation)
+- Service Worker / Cache Storage layer for RPC responses (POST responses cannot use Workbox CacheFirst; user-ID keying adds complexity)
+- Redis or any shared cache (single backend replica; in-process MemoryCache already sufficient)
+- Persistent cache across page reloads (session memory only)
+
+## Decisions
+
+### Decision 1: Cache location — ConcertServiceClient, not ConcertRpcClient
+
+**Chosen**: cache in `ConcertServiceClient` (service layer)  
+**Alternative**: cache in `ConcertRpcClient` (adapter layer)
+
+The service layer has the semantic context needed to decide invalidation (e.g., "a follow happened"). The RPC client knows nothing about domain events. Placing the cache in the service layer also keeps it testable with Vitest without needing a mock transport.
+
+### Decision 2: TTL = 24 hours
+
+**Chosen**: 24-hour TTL as a safety backstop  
+**Alternative**: infinite (session-scoped, invalidation-only)
+
+The weekly cron job makes 24h a natural upper bound. Even if the invalidation on `follow()` is missed (e.g., network error before invalidation runs), the cache expires within 24h. This is conservative enough to avoid stale data in edge cases while still eliminating all intra-day re-fetches.
+
+### Decision 3: Invalidate on follow(), not after SearchNewConcerts completes
+
+**Chosen**: `invalidateFollowerCache()` called in `FollowServiceClient.follow()` after the follow RPC succeeds  
+**Alternative**: poll/wait for `SearchNewConcerts` background goroutine to finish
+
+`SearchNewConcerts` runs in a backend goroutine and has no notification mechanism. The follow RPC returns before it completes. Polling would add complexity and latency.
+
+**Implication**: If the user navigates to Dashboard immediately after following an artist, the freshly invalidated cache will be repopulated but may not yet contain the new artist's concerts (the background search may still be running). This is acceptable: the data will appear on the next refresh or the next day's cron. A pull-to-refresh affordance addresses the impatient case.
+
+### Decision 4: getFollowedArtistMap() continues to call listFollowed() on every navigation
+
+**Chosen**: always call `listFollowed()` — optimization deferred  
+**Originally planned**: skip the RPC when `this.followedArtists.length > 0`
+
+During implementation it became clear that `followedArtists: Artist[]` stores only artist identity, not per-artist hype levels. `getFollowedArtistMap()` must return `Map<string, { artist, hype }>`, so skipping `listFollowed()` would silently drop all hype data from the dashboard rendering.
+
+**Why deferred**: Fixing this requires refactoring `followedArtists` from `Artist[]` to `FollowedArtist[]` (which includes hype). That is a broader change touching optimistic updates in `follow()`, `unfollow()`, and hydration — out of scope for this change.
+
+**Future opportunity**: Once `followedArtists` is refactored to carry hype, `getFollowedArtistMap()` can be updated to skip the RPC when the array is already populated.
+
+## Risks / Trade-offs
+
+| Risk | Mitigation |
+|------|-----------|
+| follow() RPC fails after invalidation | Invalidation only runs inside the `try` block after `await rpcClient.follow()` succeeds; on error the existing cache remains valid |
+| `SearchNewConcerts` not done when user returns to Dashboard | Documented tradeoff; no mitigation needed beyond pull-to-refresh |
+| Circular DI: FollowServiceClient → IConcertService | `ConcertServiceClient` does not import `IFollowServiceClient`; one-way dependency is safe |
+| `followedArtists` stale on tab restore after long idle | Cache TTL (24h) covers this; on expiry the next `listByFollower()` call re-fetches |
+
+## Migration Plan
+
+No data migration. The cache is in-process only and starts empty on every session. Deploying the change requires no coordination with backend.
+
+Rollback: revert the two frontend files; no state to clean up.
+
+## Open Questions
+
+- Should `unfollow()` also invalidate the concert cache? An unfollowed artist's concerts remain in the grouping until the cache expires. The TTL (24h) is acceptable for now; explicit invalidation on unfollow could be added later.

--- a/openspec/changes/archive/2026-04-06-frontend-dashboard-cache/proposal.md
+++ b/openspec/changes/archive/2026-04-06-frontend-dashboard-cache/proposal.md
@@ -5,7 +5,7 @@ Every route navigation to Dashboard fires three parallel RPCs unconditionally, e
 ## What Changes
 
 - `ConcertServiceClient.listByFollower()` gains a 24-hour in-memory cache keyed per authenticated user session; the cache is invalidated on `follow()`.
-- `FollowServiceClient.getFollowedArtistMap()` skips the `listFollowed()` RPC when `followedArtists` is already populated in memory (the service already tracks this state via `@observable`).
+- ~~`FollowServiceClient.getFollowedArtistMap()` skips the `listFollowed()` RPC when `followedArtists` is already populated in memory (the service already tracks this state via `@observable`).~~ *(deferred — see design Decision 4; `listFollowed()` is called on every invocation to provide hype data)*
 - `FollowServiceClient.follow()` calls `concertService.invalidateFollowerCache()` after a successful follow RPC to ensure the next dashboard load reflects newly discovered concerts.
 
 ## Capabilities

--- a/openspec/changes/archive/2026-04-06-frontend-dashboard-cache/proposal.md
+++ b/openspec/changes/archive/2026-04-06-frontend-dashboard-cache/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+Every route navigation to Dashboard fires three parallel RPCs unconditionally, even when the underlying data cannot have changed (concerts update only on the weekly cron job or on a first-follow event). This produces unnecessary backend load and noticeably slow dashboard loads on re-entry. Adding a targeted in-memory cache with event-driven invalidation eliminates redundant network round-trips at zero infrastructure cost.
+
+## What Changes
+
+- `ConcertServiceClient.listByFollower()` gains a 24-hour in-memory cache keyed per authenticated user session; the cache is invalidated on `follow()`.
+- `FollowServiceClient.getFollowedArtistMap()` skips the `listFollowed()` RPC when `followedArtists` is already populated in memory (the service already tracks this state via `@observable`).
+- `FollowServiceClient.follow()` calls `concertService.invalidateFollowerCache()` after a successful follow RPC to ensure the next dashboard load reflects newly discovered concerts.
+
+## Capabilities
+
+### New Capabilities
+
+- `dashboard-concert-cache`: In-memory cache for `listByFollower()` RPC results in the frontend, with event-driven invalidation on follow actions.
+
+### Modified Capabilities
+
+<!-- No existing spec-level requirements are changing. The caching is an internal
+     implementation detail of the service layer; no public API contract or
+     existing capability spec changes. -->
+
+## Impact
+
+- **Frontend**: `src/services/concert-service.ts`, `src/services/follow-service-client.ts`
+- **No backend changes**: cache lives entirely in the Aurelia singleton service layer
+- **No new dependencies**: uses native `Date.now()` for TTL; no external cache library
+- **No SW changes**: Connect-RPC uses HTTP POST; Workbox CacheFirst strategies do not apply

--- a/openspec/changes/archive/2026-04-06-frontend-dashboard-cache/specs/dashboard-concert-cache/spec.md
+++ b/openspec/changes/archive/2026-04-06-frontend-dashboard-cache/specs/dashboard-concert-cache/spec.md
@@ -1,0 +1,41 @@
+## ADDED Requirements
+
+### Requirement: listByFollower results are cached in memory for the session
+`ConcertServiceClient` SHALL cache the result of `listByFollower()` in memory within the Aurelia singleton service. The cache SHALL have a TTL of 24 hours. While the cache is valid, subsequent calls to `listByFollower()` SHALL return the cached value without issuing an RPC.
+
+#### Scenario: Cache hit on Dashboard re-entry
+- **WHEN** the user navigates to Dashboard a second time within 24 hours without having followed or unfollowed any artists
+- **THEN** `listByFollower()` SHALL return the cached result without making an RPC call
+
+#### Scenario: Cache miss on first load
+- **WHEN** `listByFollower()` is called and no cached value exists
+- **THEN** the RPC SHALL be issued and the result SHALL be stored in the cache with the current timestamp
+
+#### Scenario: Cache expiry after 24 hours
+- **WHEN** `listByFollower()` is called more than 24 hours after the cache was last populated
+- **THEN** the RPC SHALL be issued and the cache SHALL be refreshed
+
+### Requirement: Concert cache is invalidated on follow
+`ConcertServiceClient` SHALL expose an `invalidateFollowerCache()` method. `FollowServiceClient.follow()` SHALL call `invalidateFollowerCache()` after the follow RPC succeeds, so the next dashboard load fetches fresh concert data.
+
+#### Scenario: Cache invalidated after follow
+- **WHEN** the user successfully follows an artist
+- **THEN** the `listByFollower()` cache SHALL be invalidated
+- **AND** the next call to `listByFollower()` SHALL issue an RPC
+
+#### Scenario: Cache not invalidated on follow RPC failure
+- **WHEN** the `follow()` RPC call fails with an error
+- **THEN** the `listByFollower()` cache SHALL remain valid
+
+### Requirement: listFollowed RPC provides hype data on every dashboard load
+`FollowServiceClient.getFollowedArtistMap()` SHALL call `listFollowed()` on every invocation to retrieve per-artist hype levels, which are not stored in the in-memory `followedArtists: Artist[]` array.
+
+> **Note**: Skipping `listFollowed()` when `followedArtists` is already populated was considered but deferred. `followedArtists` stores only `Artist[]` (no hype), so skipping the RPC would drop hype data from dashboard rendering. This optimization is a future opportunity once `followedArtists` is refactored to `FollowedArtist[]`.
+
+#### Scenario: Follow state already in memory
+- **WHEN** `getFollowedArtistMap()` is called and `followedArtists.length > 0`
+- **THEN** `listFollowed()` SHALL still be called to retrieve current hype levels
+
+#### Scenario: Follow state not yet loaded
+- **WHEN** `getFollowedArtistMap()` is called and `followedArtists` is empty
+- **THEN** `listFollowed()` SHALL be called to populate the state and retrieve hype levels

--- a/openspec/changes/archive/2026-04-06-frontend-dashboard-cache/tasks.md
+++ b/openspec/changes/archive/2026-04-06-frontend-dashboard-cache/tasks.md
@@ -1,0 +1,20 @@
+## 1. ConcertServiceClient cache
+
+- [x] 1.1 Add `cachedGroups: ProximityGroup[] | null`, `cacheTimestamp: number | null`, and `CACHE_TTL_MS = 24 * 60 * 60 * 1000` private fields to `ConcertServiceClient`
+- [x] 1.2 Update `listByFollower()` to return `cachedGroups` on cache hit; store result and timestamp on cache miss
+- [x] 1.3 Add public `invalidateFollowerCache()` method that sets both fields to `null`
+
+## 2. FollowServiceClient integration
+
+- [x] 2.1 Inject `IConcertService` into `FollowServiceClient`
+- [x] 2.2 Call `concertService.invalidateFollowerCache()` in `follow()` after the follow RPC succeeds (inside the `try` block, after `await rpcClient.follow()`)
+- [-] 2.3 ~~Skip `listFollowed()` RPC~~ — `followedArtists: Artist[]` does not store per-artist hype; skipping the RPC would lose hype data. Deferred: requires refactoring `followedArtists` to `FollowedArtist[]` first.
+
+## 3. Tests
+
+- [x] 3.1 Add unit test: `listByFollower()` returns cached value on second call without RPC
+- [x] 3.2 Add unit test: `listByFollower()` re-fetches after cache expiry (mock `Date.now`)
+- [x] 3.3 Add unit test: `follow()` calls `invalidateFollowerCache()` on success
+- [x] 3.4 Add unit test: `follow()` does NOT call `invalidateFollowerCache()` on RPC failure
+- [x] 3.5 Add unit test: `getFollowedArtistMap()` documents that `listFollowed()` RPC is always called (hype not in memory)
+- [x] 3.6 Run `make check` and confirm all tests pass

--- a/openspec/specs/dashboard-concert-cache/spec.md
+++ b/openspec/specs/dashboard-concert-cache/spec.md
@@ -1,0 +1,47 @@
+# dashboard-concert-cache
+
+## Purpose
+
+Defines in-memory caching behavior for concert and follow data on the Dashboard, reducing unnecessary RPC calls while ensuring data freshness after follow actions.
+
+## Requirements
+
+### Requirement: listByFollower results are cached in memory for the session
+`ConcertServiceClient` SHALL cache the result of `listByFollower()` in memory within the Aurelia singleton service. The cache SHALL have a TTL of 24 hours. While the cache is valid, subsequent calls to `listByFollower()` SHALL return the cached value without issuing an RPC.
+
+#### Scenario: Cache hit on Dashboard re-entry
+- **WHEN** the user navigates to Dashboard a second time within 24 hours without having followed or unfollowed any artists
+- **THEN** `listByFollower()` SHALL return the cached result without making an RPC call
+
+#### Scenario: Cache miss on first load
+- **WHEN** `listByFollower()` is called and no cached value exists
+- **THEN** the RPC SHALL be issued and the result SHALL be stored in the cache with the current timestamp
+
+#### Scenario: Cache expiry after 24 hours
+- **WHEN** `listByFollower()` is called more than 24 hours after the cache was last populated
+- **THEN** the RPC SHALL be issued and the cache SHALL be refreshed
+
+### Requirement: Concert cache is invalidated on follow
+`ConcertServiceClient` SHALL expose an `invalidateFollowerCache()` method. `FollowServiceClient.follow()` SHALL call `invalidateFollowerCache()` after the follow RPC succeeds, so the next dashboard load fetches fresh concert data.
+
+#### Scenario: Cache invalidated after follow
+- **WHEN** the user successfully follows an artist
+- **THEN** the `listByFollower()` cache SHALL be invalidated
+- **AND** the next call to `listByFollower()` SHALL issue an RPC
+
+#### Scenario: Cache not invalidated on follow RPC failure
+- **WHEN** the `follow()` RPC call fails with an error
+- **THEN** the `listByFollower()` cache SHALL remain valid
+
+### Requirement: listFollowed RPC provides hype data on every dashboard load
+`FollowServiceClient.getFollowedArtistMap()` SHALL call `listFollowed()` on every invocation to retrieve per-artist hype levels, which are not stored in the in-memory `followedArtists: Artist[]` array.
+
+> **Note**: Skipping `listFollowed()` when `followedArtists` is already populated was considered but deferred. `followedArtists` stores only `Artist[]` (no hype), so skipping the RPC would drop hype data from dashboard rendering. This optimization is a future opportunity once `followedArtists` is refactored to `FollowedArtist[]`.
+
+#### Scenario: Follow state already in memory
+- **WHEN** `getFollowedArtistMap()` is called and `followedArtists.length > 0`
+- **THEN** `listFollowed()` SHALL still be called to retrieve current hype levels
+
+#### Scenario: Follow state not yet loaded
+- **WHEN** `getFollowedArtistMap()` is called and `followedArtists` is empty
+- **THEN** `listFollowed()` SHALL be called to populate the state and retrieve hype levels

--- a/openspec/specs/dashboard-concert-cache/spec.md
+++ b/openspec/specs/dashboard-concert-cache/spec.md
@@ -10,7 +10,7 @@ Defines in-memory caching behavior for concert and follow data on the Dashboard,
 `ConcertServiceClient` SHALL cache the result of `listByFollower()` in memory within the Aurelia singleton service. The cache SHALL have a TTL of 24 hours. While the cache is valid, subsequent calls to `listByFollower()` SHALL return the cached value without issuing an RPC.
 
 #### Scenario: Cache hit on Dashboard re-entry
-- **WHEN** the user navigates to Dashboard a second time within 24 hours without having followed or unfollowed any artists
+- **WHEN** the user navigates to Dashboard a second time within 24 hours without having followed any artists
 - **THEN** `listByFollower()` SHALL return the cached result without making an RPC call
 
 #### Scenario: Cache miss on first load


### PR DESCRIPTION
## Summary

- Add `openspec/specs/dashboard-concert-cache/` — new capability spec defining in-memory 24h TTL caching for `listByFollower()` and event-driven cache invalidation on `follow()`
- Archive `openspec/changes/frontend-dashboard-cache` (completed change, implementation shipped in liverty-music/frontend#331)

## Spec Overview

**dashboard-concert-cache** covers three requirements:

1. `listByFollower()` results cached in memory for 24h — cache hit skips RPC
2. Cache invalidated on successful `follow()` — next dashboard load re-fetches
3. `listFollowed()` called on every `getFollowedArtistMap()` invocation — hype data is not stored in `followedArtists: Artist[]`, so skipping is deferred

close: #330
