### PR TITLE
docs(openspec): add dashboard-concert-cache spec, archive change, and add gcp cost reference

### DIFF
--- a/openspec/changes/archive/2026-04-06-frontend-dashboard-cache/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-06-frontend-dashboard-cache/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-06

--- a/openspec/changes/archive/2026-04-06-frontend-dashboard-cache/design.md
+++ b/openspec/changes/archive/2026-04-06-frontend-dashboard-cache/design.md
@@ -1,0 +1,81 @@
+## Context
+
+`DashboardRoute.loading()` calls three parallel RPCs on every navigation:
+1. `FollowServiceClient.getFollowedArtistMap()` → internally calls `FollowRpcClient.listFollowed()`
+2. `ConcertServiceClient.listByFollower()` → calls `ConcertRpcClient.listByFollower()`
+3. `TicketJourneyService.listByUser()`
+
+Concert data changes only on two events:
+- Weekly cron job (dev: every Friday 09:00)
+- First follow for an artist — which triggers `SearchNewConcerts()` **asynchronously** in a background goroutine; the follow RPC returns before the search completes
+
+Both services are Aurelia DI singletons that persist across route navigations for the lifetime of the session. `FollowServiceClient` already maintains `@observable followedArtists` as authoritative in-memory state, updated optimistically on every follow/unfollow/setHype.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Eliminate redundant `listByFollower()` RPC calls on re-entry to Dashboard
+- Eliminate redundant `listFollowed()` RPC calls when follow state is already in memory
+- Invalidate `listByFollower()` cache when a follow action may have changed concert data
+- Zero new runtime dependencies
+
+**Non-Goals:**
+- Caching `listByUser()` (ticket journeys — low visit frequency, complex invalidation)
+- Service Worker / Cache Storage layer for RPC responses (POST responses cannot use Workbox CacheFirst; user-ID keying adds complexity)
+- Redis or any shared cache (single backend replica; in-process MemoryCache already sufficient)
+- Persistent cache across page reloads (session memory only)
+
+## Decisions
+
+### Decision 1: Cache location — ConcertServiceClient, not ConcertRpcClient
+
+**Chosen**: cache in `ConcertServiceClient` (service layer)  
+**Alternative**: cache in `ConcertRpcClient` (adapter layer)
+
+The service layer has the semantic context needed to decide invalidation (e.g., "a follow happened"). The RPC client knows nothing about domain events. Placing the cache in the service layer also keeps it testable with Vitest without needing a mock transport.
+
+### Decision 2: TTL = 24 hours
+
+**Chosen**: 24-hour TTL as a safety backstop  
+**Alternative**: infinite (session-scoped, invalidation-only)
+
+The weekly cron job makes 24h a natural upper bound. Even if the invalidation on `follow()` is missed (e.g., network error before invalidation runs), the cache expires within 24h. This is conservative enough to avoid stale data in edge cases while still eliminating all intra-day re-fetches.
+
+### Decision 3: Invalidate on follow(), not after SearchNewConcerts completes
+
+**Chosen**: `invalidateFollowerCache()` called in `FollowServiceClient.follow()` after the follow RPC succeeds  
+**Alternative**: poll/wait for `SearchNewConcerts` background goroutine to finish
+
+`SearchNewConcerts` runs in a backend goroutine and has no notification mechanism. The follow RPC returns before it completes. Polling would add complexity and latency.
+
+**Implication**: If the user navigates to Dashboard immediately after following an artist, the freshly invalidated cache will be repopulated but may not yet contain the new artist's concerts (the background search may still be running). This is acceptable: the data will appear on the next refresh or the next day's cron. A pull-to-refresh affordance addresses the impatient case.
+
+### Decision 4: getFollowedArtistMap() continues to call listFollowed() on every navigation
+
+**Chosen**: always call `listFollowed()` — optimization deferred  
+**Originally planned**: skip the RPC when `this.followedArtists.length > 0`
+
+During implementation it became clear that `followedArtists: Artist[]` stores only artist identity, not per-artist hype levels. `getFollowedArtistMap()` must return `Map<string, { artist, hype }>`, so skipping `listFollowed()` would silently drop all hype data from the dashboard rendering.
+
+**Why deferred**: Fixing this requires refactoring `followedArtists` from `Artist[]` to `FollowedArtist[]` (which includes hype). That is a broader change touching optimistic updates in `follow()`, `unfollow()`, and hydration — out of scope for this change.
+
+**Future opportunity**: Once `followedArtists` is refactored to carry hype, `getFollowedArtistMap()` can be updated to skip the RPC when the array is already populated.
+
+## Risks / Trade-offs
+
+| Risk | Mitigation |
+|------|-----------|
+| follow() RPC fails after invalidation | Invalidation only runs inside the `try` block after `await rpcClient.follow()` succeeds; on error the existing cache remains valid |
+| `SearchNewConcerts` not done when user returns to Dashboard | Documented tradeoff; no mitigation needed beyond pull-to-refresh |
+| Circular DI: FollowServiceClient → IConcertService | `ConcertServiceClient` does not import `IFollowServiceClient`; one-way dependency is safe |
+| `followedArtists` stale on tab restore after long idle | Cache TTL (24h) covers this; on expiry the next `listByFollower()` call re-fetches |
+
+## Migration Plan
+
+No data migration. The cache is in-process only and starts empty on every session. Deploying the change requires no coordination with backend.
+
+Rollback: revert the two frontend files; no state to clean up.
+
+## Open Questions
+
+- Should `unfollow()` also invalidate the concert cache? An unfollowed artist's concerts remain in the grouping until the cache expires. The TTL (24h) is acceptable for now; explicit invalidation on unfollow could be added later.

--- a/openspec/changes/archive/2026-04-06-frontend-dashboard-cache/proposal.md
+++ b/openspec/changes/archive/2026-04-06-frontend-dashboard-cache/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+Every route navigation to Dashboard fires three parallel RPCs unconditionally, even when the underlying data cannot have changed (concerts update only on the weekly cron job or on a first-follow event). This produces unnecessary backend load and noticeably slow dashboard loads on re-entry. Adding a targeted in-memory cache with event-driven invalidation eliminates redundant network round-trips at zero infrastructure cost.
+
+## What Changes
+
+- `ConcertServiceClient.listByFollower()` gains a 24-hour in-memory cache keyed per authenticated user session; the cache is invalidated on `follow()`.
+- `FollowServiceClient.getFollowedArtistMap()` skips the `listFollowed()` RPC when `followedArtists` is already populated in memory (the service already tracks this state via `@observable`).
+- `FollowServiceClient.follow()` calls `concertService.invalidateFollowerCache()` after a successful follow RPC to ensure the next dashboard load reflects newly discovered concerts.
+
+## Capabilities
+
+### New Capabilities
+
+- `dashboard-concert-cache`: In-memory cache for `listByFollower()` RPC results in the frontend, with event-driven invalidation on follow actions.
+
+### Modified Capabilities
+
+<!-- No existing spec-level requirements are changing. The caching is an internal
+     implementation detail of the service layer; no public API contract or
+     existing capability spec changes. -->
+
+## Impact
+
+- **Frontend**: `src/services/concert-service.ts`, `src/services/follow-service-client.ts`
+- **No backend changes**: cache lives entirely in the Aurelia singleton service layer
+- **No new dependencies**: uses native `Date.now()` for TTL; no external cache library
+- **No SW changes**: Connect-RPC uses HTTP POST; Workbox CacheFirst strategies do not apply

--- a/openspec/changes/archive/2026-04-06-frontend-dashboard-cache/specs/dashboard-concert-cache/spec.md
+++ b/openspec/changes/archive/2026-04-06-frontend-dashboard-cache/specs/dashboard-concert-cache/spec.md
@@ -1,0 +1,41 @@
+## ADDED Requirements
+
+### Requirement: listByFollower results are cached in memory for the session
+`ConcertServiceClient` SHALL cache the result of `listByFollower()` in memory within the Aurelia singleton service. The cache SHALL have a TTL of 24 hours. While the cache is valid, subsequent calls to `listByFollower()` SHALL return the cached value without issuing an RPC.
+
+#### Scenario: Cache hit on Dashboard re-entry
+- **WHEN** the user navigates to Dashboard a second time within 24 hours without having followed or unfollowed any artists
+- **THEN** `listByFollower()` SHALL return the cached result without making an RPC call
+
+#### Scenario: Cache miss on first load
+- **WHEN** `listByFollower()` is called and no cached value exists
+- **THEN** the RPC SHALL be issued and the result SHALL be stored in the cache with the current timestamp
+
+#### Scenario: Cache expiry after 24 hours
+- **WHEN** `listByFollower()` is called more than 24 hours after the cache was last populated
+- **THEN** the RPC SHALL be issued and the cache SHALL be refreshed
+
+### Requirement: Concert cache is invalidated on follow
+`ConcertServiceClient` SHALL expose an `invalidateFollowerCache()` method. `FollowServiceClient.follow()` SHALL call `invalidateFollowerCache()` after the follow RPC succeeds, so the next dashboard load fetches fresh concert data.
+
+#### Scenario: Cache invalidated after follow
+- **WHEN** the user successfully follows an artist
+- **THEN** the `listByFollower()` cache SHALL be invalidated
+- **AND** the next call to `listByFollower()` SHALL issue an RPC
+
+#### Scenario: Cache not invalidated on follow RPC failure
+- **WHEN** the `follow()` RPC call fails with an error
+- **THEN** the `listByFollower()` cache SHALL remain valid
+
+### Requirement: listFollowed RPC provides hype data on every dashboard load
+`FollowServiceClient.getFollowedArtistMap()` SHALL call `listFollowed()` on every invocation to retrieve per-artist hype levels, which are not stored in the in-memory `followedArtists: Artist[]` array.
+
+> **Note**: Skipping `listFollowed()` when `followedArtists` is already populated was considered but deferred. `followedArtists` stores only `Artist[]` (no hype), so skipping the RPC would drop hype data from dashboard rendering. This optimization is a future opportunity once `followedArtists` is refactored to `FollowedArtist[]`.
+
+#### Scenario: Follow state already in memory
+- **WHEN** `getFollowedArtistMap()` is called and `followedArtists.length > 0`
+- **THEN** `listFollowed()` SHALL still be called to retrieve current hype levels
+
+#### Scenario: Follow state not yet loaded
+- **WHEN** `getFollowedArtistMap()` is called and `followedArtists` is empty
+- **THEN** `listFollowed()` SHALL be called to populate the state and retrieve hype levels

--- a/openspec/changes/archive/2026-04-06-frontend-dashboard-cache/tasks.md
+++ b/openspec/changes/archive/2026-04-06-frontend-dashboard-cache/tasks.md
@@ -1,0 +1,20 @@
+## 1. ConcertServiceClient cache
+
+- [x] 1.1 Add `cachedGroups: ProximityGroup[] | null`, `cacheTimestamp: number | null`, and `CACHE_TTL_MS = 24 * 60 * 60 * 1000` private fields to `ConcertServiceClient`
+- [x] 1.2 Update `listByFollower()` to return `cachedGroups` on cache hit; store result and timestamp on cache miss
+- [x] 1.3 Add public `invalidateFollowerCache()` method that sets both fields to `null`
+
+## 2. FollowServiceClient integration
+
+- [x] 2.1 Inject `IConcertService` into `FollowServiceClient`
+- [x] 2.2 Call `concertService.invalidateFollowerCache()` in `follow()` after the follow RPC succeeds (inside the `try` block, after `await rpcClient.follow()`)
+- [-] 2.3 ~~Skip `listFollowed()` RPC~~ — `followedArtists: Artist[]` does not store per-artist hype; skipping the RPC would lose hype data. Deferred: requires refactoring `followedArtists` to `FollowedArtist[]` first.
+
+## 3. Tests
+
+- [x] 3.1 Add unit test: `listByFollower()` returns cached value on second call without RPC
+- [x] 3.2 Add unit test: `listByFollower()` re-fetches after cache expiry (mock `Date.now`)
+- [x] 3.3 Add unit test: `follow()` calls `invalidateFollowerCache()` on success
+- [x] 3.4 Add unit test: `follow()` does NOT call `invalidateFollowerCache()` on RPC failure
+- [x] 3.5 Add unit test: `getFollowedArtistMap()` documents that `listFollowed()` RPC is always called (hype not in memory)
+- [x] 3.6 Run `make check` and confirm all tests pass

--- a/openspec/changes/improve-consumer-observability/.openspec.yaml
+++ b/openspec/changes/improve-consumer-observability/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-30

--- a/openspec/references/gcp-cost-analysis-2026-03.md
+++ b/openspec/references/gcp-cost-analysis-2026-03.md
@@ -1,0 +1,165 @@
+# GCP Cost Analysis — liverty-music-dev (March 2026)
+
+## Billing Summary (Mar 2 – Mar 31)
+
+| Service | Usage Cost | Savings | Subtotal | % Change |
+|---------|-----------|---------|----------|----------|
+| Kubernetes Engine | ¥14,055 | -¥5,447 | ¥8,608 | +6% |
+| Networking | ¥7,352 | -¥2,463 | ¥4,889 | +41% |
+| Cloud Monitoring | ¥4,721 | ¥0 | ¥4,721 | +33% |
+| Vertex AI | ¥2,627 | ¥0 | ¥2,627 | +1312% |
+| Cloud SQL | ¥1,841 | ¥0 | ¥1,841 | +2% |
+| Compute Engine | ¥669 | ¥0 | ¥669 | +346% |
+| Cloud DNS | ¥61 | ¥0 | ¥61 | +15% |
+| Artifact Registry | ¥35 | ¥0 | ¥35 | — |
+
+Savings program: Spending-based discount
+
+---
+
+## Infrastructure Configuration (as-is)
+
+### GKE Cluster
+
+- **Name**: `cluster-osaka`
+- **Mode**: Autopilot
+- **Location**: `asia-northeast2` (Osaka), zonal (`asia-northeast2-a`)
+- **Kubernetes version**: v1.34.4-gke.1193000
+- **Active nodes**: 2 (as of investigation date)
+  - `gk3-cluster-osaka-nap-*` (Node Auto Provisioning, 10h old)
+  - `gk3-cluster-osaka-pool-6-*` (2d11h old)
+- **Spot scheduling**: `cloud.google.com/compute-class: autopilot-spot` (all dev workloads)
+- **Private nodes**: `enablePrivateNodes: true`
+- **Private endpoint**: `enablePrivateEndpoint: false` (control plane is public)
+- **masterAuthorizedNetworks**: not configured (control plane accessible from any IP)
+- **Dataplane**: Advanced Datapath (Dataplane V2)
+
+### Deployed Workloads (~20 pods across 10 namespaces)
+
+| Namespace | Workloads |
+|-----------|-----------|
+| backend | server-app (1 replica), consumer-app (KEDA 0–2) |
+| frontend | web-app (1 replica) |
+| argocd | 7 pods (controller, server, redis, repo-server, etc.) |
+| atlas-operator | 1 pod |
+| external-secrets | 3 pods |
+| keda | 3 pods |
+| nats | nats-0 (StatefulSet) |
+| otel-collector | 1 pod (2 restarts observed) |
+| reloader | 1 pod |
+| gateway | GKE L7 Gateway (managed) |
+
+### Cloud SQL
+
+- **Instance**: `postgres-osaka`
+- **Version**: PostgreSQL 18
+- **Tier**: `db-f1-micro`
+- **Availability**: ZONAL (dev)
+- **Connectivity**: Private Service Connect (PSC), internal IP 10.10.10.10
+- **SSL**: ENCRYPTED_ONLY
+
+### Networking
+
+- **VPC**: `vpc-osaka`, custom, `asia-northeast2`
+- **Subnet**: `cluster-subnet-osaka`, 10.10.0.0/20
+- **Pod CIDR**: 10.20.0.0/16
+- **Services CIDR**: 10.30.0.0/20
+- **Cloud NAT**: `nat-osaka`, AUTO_ONLY IPs, ALL_SUBNETWORKS_ALL_IP_RANGES, dynamic port allocation enabled
+- **Cloud Router**: `nat-router-osaka`
+- **L7 LB**: GKE Gateway (`gke-l7-global-external-managed`), static IP `api-gateway-static-ip`, HTTPS :443
+- **Forwarding rules**: 1 (HTTPS listener)
+- **HTTPRoutes**: backend (`api.dev.liverty-music.app`), frontend (`dev.liverty-music.app`)
+- **Cross-zone traffic**: none (single-zone cluster)
+- **`privateIpGoogleAccess`**: `true` on subnet (already set in Pulumi)
+- **PGA DNS zones**: NOT configured (`restricted.googleapis.com` / `googleapis.com` private zones missing)
+
+### Vertex AI / Gemini
+
+- **Model**: `gemini-3-flash-preview` (all environments)
+- **Location**: `global` (config), `asia-northeast2` (code)
+- **Used by**: `concert-discovery` CronJob
+- **Dev schedule**: Fridays only (`0 9 * * 5`) → ~4 runs/month
+- **Prod/staging schedule**: Daily (`0 9 * * *`)
+- **Processing**: All `followed_artists` per run (no batch limit)
+  - Dev: 3,157 artists (as of 2026-04-01)
+- **Google Search grounding**: enabled
+- **MaxOutputTokens**: 16,384
+- **searchCacheTTL**: 24h (skips artist if searched within 24h)
+
+---
+
+## Cost Root Cause Analysis
+
+### GKE ¥14,055
+
+- **Primary**: Autopilot cluster management fee $0.10/hr × 720h = **$72/月 = ¥10,800** (fixed, unavoidable on Autopilot)
+- **Secondary**: Pod-request-based compute (Spot discount already applied → subtotal ¥8,608)
+
+### Networking ¥7,352
+
+- **Cloud NAT gateway fee**: $0.045/hr × 720h = $32.4 = **¥4,860** (fixed)
+- **Cloud NAT external IP**: ~¥432 (fixed)
+- **L7 Global LB forwarding rule**: $0.025/hr × 720h = $18 = **¥2,700** (fixed)
+- **Static IP**: ~¥216 (fixed)
+- **NAT data processing**: $0.045/GiB — includes Google API traffic that bypasses PGA due to missing DNS zones
+- Total fixed: ~¥8,200 before spending-based discount
+
+### Vertex AI ¥2,627 (+1312%)
+
+- `gemini-3-flash-preview` billing started **2026-01-05**; prior month had no charge → explains spike
+- Grounding pricing for Gemini 3 preview: **$14/1,000 search queries** (not per prompt), free tier **5,000 queries/month**
+- Dev: ~12,628 queries/month (3,157 artists × 4 runs) → ~7,628 billable → $106 theoretical
+- Actual ¥2,627 ≈ token cost only → suggests grounding queries still within free tier or counted differently
+- **Scale risk**: at 10,000 artists, grounding cost reaches ~¥1.3M/month if uncapped
+
+### Cloud Monitoring ¥4,721
+
+- GMP (Managed Prometheus) is mandatory on Autopilot v1.25+, cannot be disabled
+- **Free**: GKE system metrics, Google Cloud platform metrics
+- **Billed**: Custom application metrics (KEDA NATS metrics, OTel spans)
+- Cloud Trace: $0.20/M spans (2.5M free/month)
+- Primary cost likely Cloud Logging ingestion (50 GiB/month free, $0.50/GiB after)
+
+---
+
+## Official Pricing Reference (JPY @ ¥150/USD)
+
+| SKU | Price |
+|-----|-------|
+| GKE Autopilot cluster management | $0.10/hr = ¥10,800/月 |
+| GKE Standard zonal (1st cluster) | **¥0** |
+| GKE Autopilot vCPU (us-central1) | $0.0445/hr |
+| GKE Autopilot memory | $0.0049/GiB/hr |
+| e2-standard-2 Spot | ~$0.027/hr |
+| Cloud NAT gateway | $0.045/hr = ¥4,860/月 |
+| Cloud NAT data processing | $0.045/GiB |
+| L7 Global LB forwarding rule | $0.025/hr = ¥2,700/月 |
+| Gemini 3 preview grounding | $14/1,000 search queries (5,000/月 free) |
+| Gemini 2.0 Flash grounding | $35/1,000 grounded prompts (1,500/日 free) |
+| Cloud Monitoring metrics (samples) | $0.06/M samples |
+| Cloud Logging storage | $0.50/GiB (50 GiB/月 free) |
+| Cloud Trace | $0.20/M spans (2.5M/月 free) |
+| Internet egress (Premium, asia) | $0.12/GiB (first 1 TB) |
+
+---
+
+## Proposed Changes
+
+| Change | Location | Estimated Savings |
+|--------|----------|-------------------|
+| [`gke-cost-optimization`](../changes/gke-cost-optimization/) | Autopilot→Standard + public nodes + NAT removal | ~¥16,000/月 |
+| [`private-google-access`](../changes/private-google-access/) | PGA DNS zones for googleapis.com | NAT data processing 削減 (staging/prod) |
+
+### `gke-cost-optimization` 削減内訳
+
+| 項目 | 削減額 |
+|------|--------|
+| GKE management fee 消滅 | -¥10,800/月 |
+| Cloud NAT gateway + IP 固定費 | -¥5,292/月 |
+| **合計** | **~¥16,000/月** |
+
+### `private-google-access` 削減内訳
+
+- NAT data processing から Google API トラフィック分を除外
+- staging/prod の private cluster で有効
+- 削減額は実際の Google API egress 量次第（Cloud NAT metrics で確認要）

--- a/openspec/specs/dashboard-concert-cache/spec.md
+++ b/openspec/specs/dashboard-concert-cache/spec.md
@@ -1,0 +1,47 @@
+# dashboard-concert-cache
+
+## Purpose
+
+Defines in-memory caching behavior for concert and follow data on the Dashboard, reducing unnecessary RPC calls while ensuring data freshness after follow actions.
+
+## Requirements
+
+### Requirement: listByFollower results are cached in memory for the session
+`ConcertServiceClient` SHALL cache the result of `listByFollower()` in memory within the Aurelia singleton service. The cache SHALL have a TTL of 24 hours. While the cache is valid, subsequent calls to `listByFollower()` SHALL return the cached value without issuing an RPC.
+
+#### Scenario: Cache hit on Dashboard re-entry
+- **WHEN** the user navigates to Dashboard a second time within 24 hours without having followed or unfollowed any artists
+- **THEN** `listByFollower()` SHALL return the cached result without making an RPC call
+
+#### Scenario: Cache miss on first load
+- **WHEN** `listByFollower()` is called and no cached value exists
+- **THEN** the RPC SHALL be issued and the result SHALL be stored in the cache with the current timestamp
+
+#### Scenario: Cache expiry after 24 hours
+- **WHEN** `listByFollower()` is called more than 24 hours after the cache was last populated
+- **THEN** the RPC SHALL be issued and the cache SHALL be refreshed
+
+### Requirement: Concert cache is invalidated on follow
+`ConcertServiceClient` SHALL expose an `invalidateFollowerCache()` method. `FollowServiceClient.follow()` SHALL call `invalidateFollowerCache()` after the follow RPC succeeds, so the next dashboard load fetches fresh concert data.
+
+#### Scenario: Cache invalidated after follow
+- **WHEN** the user successfully follows an artist
+- **THEN** the `listByFollower()` cache SHALL be invalidated
+- **AND** the next call to `listByFollower()` SHALL issue an RPC
+
+#### Scenario: Cache not invalidated on follow RPC failure
+- **WHEN** the `follow()` RPC call fails with an error
+- **THEN** the `listByFollower()` cache SHALL remain valid
+
+### Requirement: listFollowed RPC provides hype data on every dashboard load
+`FollowServiceClient.getFollowedArtistMap()` SHALL call `listFollowed()` on every invocation to retrieve per-artist hype levels, which are not stored in the in-memory `followedArtists: Artist[]` array.
+
+> **Note**: Skipping `listFollowed()` when `followedArtists` is already populated was considered but deferred. `followedArtists` stores only `Artist[]` (no hype), so skipping the RPC would drop hype data from dashboard rendering. This optimization is a future opportunity once `followedArtists` is refactored to `FollowedArtist[]`.
+
+#### Scenario: Follow state already in memory
+- **WHEN** `getFollowedArtistMap()` is called and `followedArtists.length > 0`
+- **THEN** `listFollowed()` SHALL still be called to retrieve current hype levels
+
+#### Scenario: Follow state not yet loaded
+- **WHEN** `getFollowedArtistMap()` is called and `followedArtists` is empty
+- **THEN** `listFollowed()` SHALL be called to populate the state and retrieve hype levels


### PR DESCRIPTION
## Summary

- Adds `dashboard-concert-cache` capability spec defining in-memory caching of `listByFollower()` RPC results with 24h TTL and event-driven invalidation on follow
- Archives the completed `frontend-dashboard-cache` change (proposal, design, spec snapshot, and tasks)
- Initialises the `improve-consumer-observability` change directory
- Adds March 2026 GCP cost analysis reference document

## Details

The `dashboard-concert-cache` spec captures:
- Cache hit/miss/expiry behaviour for `listByFollower()`
- Invalidation via `invalidateFollowerCache()` on successful follow
- Decision to keep `listFollowed()` unconditional (hype data not in `Artist[]` array)

close: liverty-music/frontend#330

## Test plan

- [ ] Verify buf lint passes in CI
- [ ] Confirm no breaking changes flagged
