### PR TITLE
docs(spec): add JetStream delivery and ack policy requirements to auto-concert-discovery

### DIFF
--- a/openspec/changes/archive/2026-04-08-fix-nats-ack-redelivery-loop/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-08-fix-nats-ack-redelivery-loop/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-07

--- a/openspec/changes/archive/2026-04-08-fix-nats-ack-redelivery-loop/README.md
+++ b/openspec/changes/archive/2026-04-08-fix-nats-ack-redelivery-loop/README.md
@@ -1,0 +1,3 @@
+# fix-nats-ack-redelivery-loop
+
+Fix NATS JetStream AckAsync and DeliverAll causing infinite message redelivery loop

--- a/openspec/changes/archive/2026-04-08-fix-nats-ack-redelivery-loop/design.md
+++ b/openspec/changes/archive/2026-04-08-fix-nats-ack-redelivery-loop/design.md
@@ -40,7 +40,7 @@ Current observed impact: ~7-minute redelivery cycles running continuously since 
 
 **Rationale**: `DeliverNew` sets `DeliverPolicy = DeliverNewPolicy`, meaning a newly created durable consumer will only receive messages published _after_ the consumer is created. This is the correct semantics for an event-driven notification system: if the consumer state is lost, we accept that historical events will not be reprocessed — the concert data is already in the DB from the first processing run.
 
-**Alternative considered**: `DeliverLastPerSubject` — delivers only the most recent message per subject on consumer creation. Rejected because subjects in this stream (`CONCERT.discovered`, etc.) are per-event UUIDs, making "last per subject" equivalent to "last overall" in practice, which is still an arbitrary historical message.
+**Alternative considered**: `DeliverLastPerSubject` — delivers only the most recent message per subject on consumer creation. Rejected because subjects in this stream are shared static event-type subjects (`CONCERT.discovered`, `CONCERT.created`, etc.) — not per-event identifiers. `DeliverLastPerSubject` would deliver exactly one arbitrary historical message per subject type, which is still an undesired historical redelivery. `DeliverNew` cleanly avoids any historical message regardless of subject scheme.
 
 **Alternative considered**: Keep `DeliverAll` and manage consumer state externally (e.g., snapshot PVC before cluster migration). Rejected as operationally fragile — any NATS pod restart would still trigger full redelivery.
 

--- a/openspec/changes/archive/2026-04-08-fix-nats-ack-redelivery-loop/design.md
+++ b/openspec/changes/archive/2026-04-08-fix-nats-ack-redelivery-loop/design.md
@@ -1,0 +1,67 @@
+## Context
+
+The NATS JetStream consumer (`backend/internal/infrastructure/messaging/subscriber.go`) uses `watermill-nats v2.1.3` (`pkg/nats`). When `JetStream.Disabled` is false (the default), the library internally uses a `jsConnection` wrapper that calls `js.QueueSubscribe()` (JetStream) — not CoreNATS `conn.QueueSubscribe()`. The `DurableCalculator` produces a durable name (e.g., `CONCERT_discovered`), and `SubscribeOptions` including `AckExplicit()` and `DeliverAll()` are passed through to the JetStream subscription.
+
+Two independent bugs were introduced in commit `25c22d9` (2026-03-24):
+
+1. **`AckAsync: true`**: The `processMessage()` loop uses `m.Ack()` (fire-and-forget) instead of `m.AckSync()`. When KEDA deactivates both consumer pods simultaneously (replicas: 2 → 0), the Ack write may still be in the network buffer when `conn.Drain()` is called. Empirically confirmed by GKE event logs: KEDA deactivates at `00:40:58`, and re-activates 30 seconds later (`00:41:28`), indicating the JetStream lag did not reach 0 — some Acks were not received by the server.
+
+2. **`DeliverAll()`**: Sets `DeliverPolicy = DeliverAllPolicy` on first consumer creation. When the GKE cluster was migrated to `standard-cluster-osaka` on 2026-04-01, NATS started with a fresh PVC. The durable consumer `CONCERT_discovered` was recreated from scratch on 2026-04-03 (first concert-discovery CronJob run). Because no prior consumer state existed, `DeliverAll` delivered all messages from the beginning of the stream — including all historical `concert.created` events. Each redelivered event triggered a Places API call.
+
+Current observed impact: ~7-minute redelivery cycles running continuously since 2026-04-03.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Ensure Acks are confirmed by the NATS server before a consumer handler is considered complete
+- Prevent historical message redelivery when a durable consumer is created for the first time
+- Stop the current redelivery loop without requiring NATS state manipulation or manual intervention
+
+**Non-Goals:**
+- Exactly-once processing guarantees (idempotency at the use-case layer is a separate concern)
+- Changes to KEDA ScaledObject configuration or cooldownPeriod
+- Purging or resetting the NATS stream
+
+## Decisions
+
+### Decision 1: Remove `AckAsync: true` (use SyncAck)
+
+**Choice**: Delete `AckAsync: true` from `JetStreamConfig`. This defaults to `false`, causing the library to call `m.AckSync()` instead of `m.Ack()`.
+
+**Rationale**: `m.AckSync()` blocks until the NATS server acknowledges receipt of the Ack. This guarantees that when a handler returns, the message is permanently removed from the consumer's pending-delivery list. Fire-and-forget Ack is only appropriate when handler latency is the bottleneck and duplicate processing is acceptable — neither is true here.
+
+**Alternative considered**: Keep `AckAsync` and increase NATS `AckWait` timeout so messages are not redelivered before the pod shuts down. Rejected because it only widens the race window; under simultaneous multi-pod shutdown it remains unreliable.
+
+**Performance impact**: Each message processing call now has one additional round-trip to NATS for the Ack confirmation. Given that handlers already make DB writes and Places API calls (each >10ms), the NATS Ack round-trip (<1ms on cluster-local network) is negligible.
+
+### Decision 2: Replace `DeliverAll()` with `DeliverNew()`
+
+**Choice**: Replace `nats.DeliverAll()` with `nats.DeliverNew()` in `SubscribeOptions`.
+
+**Rationale**: `DeliverNew` sets `DeliverPolicy = DeliverNewPolicy`, meaning a newly created durable consumer will only receive messages published _after_ the consumer is created. This is the correct semantics for an event-driven notification system: if the consumer state is lost, we accept that historical events will not be reprocessed — the concert data is already in the DB from the first processing run.
+
+**Alternative considered**: `DeliverLastPerSubject` — delivers only the most recent message per subject on consumer creation. Rejected because subjects in this stream (`CONCERT.discovered`, etc.) are per-event UUIDs, making "last per subject" equivalent to "last overall" in practice, which is still an arbitrary historical message.
+
+**Alternative considered**: Keep `DeliverAll` and manage consumer state externally (e.g., snapshot PVC before cluster migration). Rejected as operationally fragile — any NATS pod restart would still trigger full redelivery.
+
+**Trade-off**: If a consumer pod crashes mid-batch and its Acks were all confirmed (SyncAck), the unprocessed messages in that batch will not be redelivered after `DeliverNew` is set. This is mitigated by SyncAck itself: if the pod crashes before `m.AckSync()` returns, the Ack was never sent, and NATS will redeliver that specific message to the next consumer — correct at-least-once behavior.
+
+## Risks / Trade-offs
+
+- **[Risk] In-flight messages at deploy time** → During rolling restart, old pods (AckAsync) and new pods (SyncAck) may coexist briefly. Old pods may still lose Acks. Mitigation: the KEDA cooldownPeriod=300s ensures that once new pods process all messages, scale-down will not trigger immediate re-activation (lag will be 0 with confirmed Acks).
+
+- **[Risk] DeliverNew skips messages published between consumer deletion and recreation** → In practice this window is the duration of NATS downtime, during which the publisher (concert-discovery CronJob) would also be unable to publish. Net effect: zero missed messages under normal operation.
+
+- **[Risk] SyncAck adds latency per message** → Measured as negligible vs. existing I/O operations. No action needed.
+
+## Migration Plan
+
+1. Apply the two-line config change to `subscriber.go`
+2. Commit, push, open PR to backend
+3. Merge PR → ArgoCD triggers rolling restart of `consumer-app` Deployment
+4. Verify: after deploy, monitor KEDA events — `KEDAScaleTargetDeactivated` should not be followed by `KEDAScaleTargetActivated` within 30 seconds
+5. **No rollback procedure needed**: reverting the PR and redeploying restores the previous behavior
+
+## Open Questions
+
+None — root cause confirmed from production logs and source code analysis.

--- a/openspec/changes/archive/2026-04-08-fix-nats-ack-redelivery-loop/proposal.md
+++ b/openspec/changes/archive/2026-04-08-fix-nats-ack-redelivery-loop/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+After the GKE cluster migration to `standard-cluster-osaka` on 2026-04-01, NATS JetStream started with a fresh PVC (no consumer history). Two bugs in the consumer's NATS subscriber configuration combined to create an infinite message redelivery loop that has been causing Places API overcalls ($323,198 charge) for 3+ days: (1) `DeliverAll()` caused all past messages to be redelivered upon durable consumer recreation, and (2) `AckAsync: true` caused Acks to be lost when KEDA deactivated both consumer pods simultaneously, keeping the JetStream lag > 0 and triggering immediate pod re-activation.
+
+## What Changes
+
+- Remove `AckAsync: true` from `JetStreamConfig` to switch from fire-and-forget `m.Ack()` to synchronous `m.AckSync()`, ensuring Acks are confirmed by NATS server before the handler returns
+- Replace `nats.DeliverAll()` with `nats.DeliverNew()` in `SubscribeOptions` to prevent past messages from being redelivered when a durable consumer is created for the first time (e.g., after cluster migration or NATS PVC recreation)
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `auto-concert-discovery`: The consumer reliability guarantee changes — messages are now delivered at-most-once-from-history (DeliverNew) with guaranteed Ack delivery (SyncAck), preventing duplicate concert notifications caused by NATS state loss events.
+
+## Impact
+
+- **backend**: `internal/infrastructure/messaging/subscriber.go` — two-line config change
+- **No proto changes**: This is a pure infrastructure/configuration fix
+- **No DB migration**: No schema changes
+- **Operational**: Fixes the ongoing Places API cost spike; after deploy, KEDA consumer lag should reach 0 and stay there

--- a/openspec/changes/archive/2026-04-08-fix-nats-ack-redelivery-loop/specs/auto-concert-discovery/spec.md
+++ b/openspec/changes/archive/2026-04-08-fix-nats-ack-redelivery-loop/specs/auto-concert-discovery/spec.md
@@ -1,0 +1,34 @@
+## ADDED Requirements
+
+### Requirement: Consumer JetStream Delivery Policy
+
+The NATS JetStream consumer SHALL use `DeliverNew` delivery policy so that a newly created durable consumer only receives messages published after its creation time, preventing historical message redelivery when consumer state is lost due to infrastructure events (e.g., cluster migration, PVC recreation).
+
+#### Scenario: First consumer creation after state loss
+
+- **WHEN** the durable JetStream consumer is created for the first time (no prior consumer state exists)
+- **THEN** the consumer SHALL only receive messages published from that point forward
+- **AND** messages published before consumer creation SHALL NOT be redelivered
+
+#### Scenario: Consumer reconnects to existing durable
+
+- **WHEN** a consumer pod restarts and reconnects to an existing durable consumer
+- **THEN** the consumer SHALL resume from the last acknowledged message sequence
+- **AND** the delivery policy SHALL have no effect on reconnection behavior
+
+### Requirement: Consumer JetStream Acknowledgement Policy
+
+The NATS JetStream consumer SHALL use synchronous acknowledgement (`AckSync`) to guarantee that a message's Ack is confirmed by the NATS server before the handler is considered complete, preventing message redelivery due to lost Acks during pod shutdown.
+
+#### Scenario: Successful message processing
+
+- **WHEN** a message handler completes successfully
+- **THEN** the consumer SHALL wait for NATS server confirmation of the Ack before marking the handler as done
+- **AND** the NATS JetStream consumer lag SHALL reflect the acknowledged message as processed
+
+#### Scenario: Simultaneous pod scale-down
+
+- **WHEN** KEDA scales down multiple consumer pods simultaneously
+- **THEN** all in-flight Acks SHALL be confirmed by the NATS server before pod shutdown completes
+- **AND** KEDA SHALL observe consumer lag = 0 after scale-down
+- **AND** KEDA SHALL NOT re-activate the consumer deployment within the cooldown period

--- a/openspec/changes/archive/2026-04-08-fix-nats-ack-redelivery-loop/tasks.md
+++ b/openspec/changes/archive/2026-04-08-fix-nats-ack-redelivery-loop/tasks.md
@@ -1,0 +1,9 @@
+## 1. Backend: Fix NATS Subscriber Configuration
+
+- [x] 1.1 In `backend/internal/infrastructure/messaging/subscriber.go`, remove `AckAsync: true` from `JetStreamConfig`
+- [x] 1.2 In the same file, replace `nats.DeliverAll()` with `nats.DeliverNew()` in `SubscribeOptions`
+
+## 2. Verification
+
+- [x] 2.1 Run `make check` in `backend/` to confirm lint and tests pass
+- [x] 2.2 Open a PR to backend and confirm CI passes

--- a/openspec/specs/auto-concert-discovery/spec.md
+++ b/openspec/specs/auto-concert-discovery/spec.md
@@ -104,3 +104,36 @@ The concert search SHALL gracefully handle incomplete or invalid responses from 
 - **WHEN** the Gemini API returns an invalid response on the first attempt but a valid response on a subsequent retry
 - **THEN** the system SHALL parse the valid response normally
 - **AND** return the discovered concerts
+
+### Requirement: Consumer JetStream Delivery Policy
+
+The NATS JetStream consumer SHALL use `DeliverNew` delivery policy so that a newly created durable consumer only receives messages published after its creation time, preventing historical message redelivery when consumer state is lost due to infrastructure events (e.g., cluster migration, PVC recreation).
+
+#### Scenario: First consumer creation after state loss
+
+- **WHEN** the durable JetStream consumer is created for the first time (no prior consumer state exists)
+- **THEN** the consumer SHALL only receive messages published from that point forward
+- **AND** messages published before consumer creation SHALL NOT be redelivered
+
+#### Scenario: Consumer reconnects to existing durable
+
+- **WHEN** a consumer pod restarts and reconnects to an existing durable consumer
+- **THEN** the consumer SHALL resume from the last acknowledged message sequence
+- **AND** the delivery policy SHALL have no effect on reconnection behavior
+
+### Requirement: Consumer JetStream Acknowledgement Policy
+
+The NATS JetStream consumer SHALL use synchronous acknowledgement (`AckSync`) to guarantee that a message's Ack is confirmed by the NATS server before the handler is considered complete, preventing message redelivery due to lost Acks during pod shutdown.
+
+#### Scenario: Successful message processing
+
+- **WHEN** a message handler completes successfully
+- **THEN** the consumer SHALL wait for NATS server confirmation of the Ack before marking the handler as done
+- **AND** the NATS JetStream consumer lag SHALL reflect the acknowledged message as processed
+
+#### Scenario: Simultaneous pod scale-down
+
+- **WHEN** KEDA scales down multiple consumer pods simultaneously
+- **THEN** all in-flight Acks SHALL be confirmed by the NATS server before pod shutdown completes
+- **AND** KEDA SHALL observe consumer lag = 0 after scale-down
+- **AND** KEDA SHALL NOT re-activate the consumer deployment within the cooldown period


### PR DESCRIPTION
## Summary

Add two new requirements to the `auto-concert-discovery` spec, capturing the NATS JetStream consumer configuration constraints identified during the Places API cost spike investigation (¥323,198 over 3 days).

**Root cause confirmed**: `AckAsync: true` + `DeliverAll()` in `backend/internal/infrastructure/messaging/subscriber.go` caused an infinite redelivery loop after the GKE cluster migration on 2026-04-01. See liverty-music/backend#276 for the implementation fix (already merged).

## Spec Changes

**`auto-concert-discovery`**: Added 2 new requirements

- **Consumer JetStream Delivery Policy**: Consumer SHALL use `DeliverNew` delivery policy — prevents historical message redelivery when durable consumer state is lost (cluster migration, PVC recreation)
- **Consumer JetStream Acknowledgement Policy**: Consumer SHALL use `AckSync` — guarantees Acks are confirmed by NATS server before handler completes, preventing redelivery from lost Acks during simultaneous pod scale-down

## OpenSpec Change

Archived change `2026-04-08-fix-nats-ack-redelivery-loop` with full proposal, design, and tasks artifacts.

close: #275
