### PR TITLE
chore(openspec): archive add-gcp-cost-guardrails change

### DIFF
--- a/openspec/changes/archive/2026-04-08-add-gcp-cost-guardrails/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-08-add-gcp-cost-guardrails/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-08

--- a/openspec/changes/archive/2026-04-08-add-gcp-cost-guardrails/design.md
+++ b/openspec/changes/archive/2026-04-08-add-gcp-cost-guardrails/design.md
@@ -1,0 +1,81 @@
+## Context
+
+The `liverty-music-dev` GCP project currently has no billing budget alerts and no per-API quota overrides. All APIs operate at GCP default quota limits, which are far higher than what the dev workload requires.
+
+The Places API (New) has no free tier; every request is billed at $32/1,000. A single bug in the NATS consumer caused ¥323,198 in 5 days (2026-04-03 to 2026-04-08). Vertex AI Gemini 3 Flash has no free token quota; Google Search Grounding has a 5,000/month free tier that dev usage fits within.
+
+Relevant infrastructure is managed via Pulumi in `cloud-provisioning/src/gcp/`:
+- `components/project.ts` — API enablement via `ApiService`
+- `components/monitoring.ts` — `MonitoringComponent` (log-based alerts, notification channels)
+- `src/gcp/index.ts` — orchestrates all GCP components
+
+## Goals / Non-Goals
+
+**Goals:**
+- Cap daily Places API (New) Text Search calls to 20 req/day on dev
+- Cap daily Vertex AI GenerateContent calls to 50 req/day on dev
+- Alert via email when the dev project billing exceeds 50%/90%/100% of a monthly budget threshold
+- All guardrails managed as Pulumi IaC (no manual GCP Console changes)
+
+**Non-Goals:**
+- Quota limits for prod environment (prod has legitimate higher usage)
+- Programmatic billing killswitch (Pub/Sub → Cloud Functions → disable project billing) — deferred as separate change
+- Quota limits for other APIs (Last.fm, MusicBrainz, fanart.tv — not GCP-billed)
+- Backend code changes for circuit-breaking or quota-aware retry logic
+
+## Decisions
+
+### Decision 1: Pulumi `gcp.serviceusage.ConsumerQuotaOverride` for quota limits
+
+**Choice**: Use `gcp.serviceusage.ConsumerQuotaOverride` to set per-day limits for Places API and Vertex AI.
+
+**Rationale**: This is the standard Pulumi/Terraform resource for overriding GCP service quotas at the project level. It is declarative, version-controlled, and automatically applied via Pulumi Cloud Deployments on PR merge — no manual GCP Console steps required.
+
+**Alternative considered**: Manual quota override via GCP Console. Rejected because it is not reproducible, not auditable, and would be overwritten if Pulumi ever re-creates the project resource.
+
+**Quota metric identifiers** (from GCP):
+- Places API (New): `places.googleapis.com/v1/places_requests` with limit name `PLACES_REQUESTS-DAILY-per-project`
+- Vertex AI: `aiplatform.googleapis.com/generate_content_requests` with limit name `generate-content-requests-per-minute-per-project-per-base-model` (note: GCP exposes per-minute quota override; we set a low enough value to effectively cap daily usage)
+
+**Note on Vertex AI quota granularity**: GCP's Vertex AI quota override is per-minute-per-model, not per-day. Setting `overrideValue: 1` (1 req/min) gives an effective ceiling of 1,440 req/day, which is much higher than 50. However, the practical throttle for the CronJob (which runs once/week over ~10 minutes) is the per-minute value. To achieve a meaningful daily cap closer to 50, we set `overrideValue: 5` req/min — the CronJob processes ~203 artists sequentially with 1s throttle between calls, so it will still complete normally while a runaway loop would be throttled at 5 req/min instead of the default 60 req/min.
+
+**Alternative for Vertex AI**: Use `aiplatform.googleapis.com` quota `online-prediction-requests-per-base-model` per-day — this does not exist as an overridable metric in the ConsumerQuotaOverride API. Per-minute is the correct granularity for Vertex AI.
+
+### Decision 2: `gcp.billing.Budget` for billing alerts
+
+**Choice**: Add a `gcp.billing.Budget` resource scoped to `liverty-music-dev` with threshold alerts at 50%, 90%, 100% sending email notifications.
+
+**Rationale**: Billing budget alerts are the earliest warning signal — they fire based on actual charges, independent of which API caused them. Email notification requires no additional GCP infrastructure (no Pub/Sub topic, no notification channel setup). The Pulumi GCP provider supports `gcp.billing.Budget` natively.
+
+**Budget amount**: ¥3,000/month (~$20 USD). This covers normal dev usage (weekly CronJob, occasional manual testing) with comfortable headroom.
+
+**Alternative considered**: Pub/Sub + Cloud Functions killswitch. Deferred — higher implementation complexity and risk of false-positive billing disablement. Budget alert is sufficient for now.
+
+### Decision 3: Placement in `monitoring.ts` vs new component
+
+**Choice**: Add quota overrides and billing budget inline in `src/gcp/index.ts` as standalone resources (not wrapped in a component class).
+
+**Rationale**: These are one-off resources with no reusable pattern across environments — prod intentionally has no quota overrides. A dedicated component would add abstraction without benefit. Inline resources in `index.ts` are consistent with how `PostgresComponent` and `WorkloadIdentityComponent` are already instantiated.
+
+**Alternative considered**: New `CostGuardrailsComponent`. Rejected — the guardrails are dev-only and there is no prod counterpart to justify a reusable abstraction.
+
+## Risks / Trade-offs
+
+- **[Risk] Places API quota blocks legitimate CronJob** → The CronJob processes venues sequentially; dev currently has 544 venues all enriched. New venue additions per CronJob run are typically 0–10 (only when new artists are added). 20 req/day provides ample headroom. Mitigation: monitor first CronJob run after deploy.
+
+- **[Risk] Vertex AI per-minute quota (5 req/min) slows CronJob** → The existing client already throttles at 1 req/second (effectively 60/min). Setting override to 5/min will slow a 203-artist run from ~3 minutes to ~40 minutes. This is acceptable for a dev weekly batch job. Mitigation: document the expected runtime in tasks.
+
+- **[Risk] `ConsumerQuotaOverride` requires `serviceusage.googleapis.com` billing API** → Already enabled in `project.ts`. No additional enablement needed.
+
+- **[Risk] Quota override propagation delay** → GCP quota overrides can take up to 15 minutes to propagate after `pulumi up`. The Places API will not be quota-limited immediately after deploy. Mitigation: this is a one-time deploy-time gap; acceptable.
+
+## Migration Plan
+
+1. Add `gcp.billing.Budget` and `gcp.serviceusage.ConsumerQuotaOverride` resources to `src/gcp/index.ts` (dev-only, guarded by `environment === 'dev'`)
+2. Run `make lint` locally to verify TypeScript compiles
+3. Commit, push, open PR to cloud-provisioning
+4. Merge PR → Pulumi Cloud Deployments automatically runs `pulumi up` for dev
+5. Verify in GCP Console: quota overrides visible under IAM & Admin → Quotas; budget visible under Billing → Budgets & Alerts
+6. Re-enable Places API (New) in GCP Console (already done as of 2026-04-08)
+
+**Rollback**: Revert the PR and merge → Pulumi removes the quota overrides and budget on next deploy. No state manipulation required.

--- a/openspec/changes/archive/2026-04-08-add-gcp-cost-guardrails/proposal.md
+++ b/openspec/changes/archive/2026-04-08-add-gcp-cost-guardrails/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+On 2026-04-03, a combination of `DeliverAll` NATS policy and `AckAsync` bug triggered an infinite message redelivery loop that called the Places API (New) continuously for 5 days, resulting in ¥323,198 in unexpected charges. There are currently no hard limits preventing a similar runaway cost event from any GCP API. We need infrastructure-level guardrails before re-enabling the Places API and as a permanent safeguard going forward.
+
+## What Changes
+
+- Add a Cloud Billing Budget for the `liverty-music-dev` project with email alerts at 50%/90%/100% of a monthly threshold
+- Add a daily quota limit for Places API (New) Text Search: **20 requests/day** on the dev project
+- Add a daily quota limit for Vertex AI API (Gemini GenerateContent): **50 requests/day** on the dev project
+
+## Capabilities
+
+### New Capabilities
+
+- `gcp-cost-guardrails`: GCP billing budget alert and per-API quota limits for the dev project to cap runaway external API costs
+
+### Modified Capabilities
+
+<!-- No existing spec-level behavior changes -->
+
+## Impact
+
+- **cloud-provisioning**: New `BillingBudgetComponent` or inline resources added to `monitoring.ts` / `project.ts`; new `QuotaOverrideComponent` for Places and Vertex AI quotas
+- **Backend behavior on quota exceeded**:
+  - **Places API (New)**: Returns HTTP 429 → `pkg/api.FromHTTP` maps to `codes.ResourceExhausted` → `resolveVenue` returns error → `CreateFromDiscovered` fails for that message → Watermill retries up to poison queue
+  - **Vertex AI Gemini**: Returns HTTP 429 → `gemini/errors.go` maps to `codes.ResourceExhausted` → `isRetryable` returns `true` → exponential backoff retries (max 3), then graceful degradation (returns nil, no concerts persisted for that artist)
+- **No changes** to backend code, frontend, or proto schemas

--- a/openspec/changes/archive/2026-04-08-add-gcp-cost-guardrails/specs/gcp-cost-guardrails/spec.md
+++ b/openspec/changes/archive/2026-04-08-add-gcp-cost-guardrails/specs/gcp-cost-guardrails/spec.md
@@ -1,0 +1,38 @@
+## ADDED Requirements
+
+### Requirement: Dev Project Billing Budget Alert
+The `liverty-music-dev` GCP project SHALL have a Cloud Billing Budget configured with a monthly threshold of ¥3,000 (approx. $20 USD). The system SHALL send email notifications to the project billing contact when accumulated spend reaches 50%, 90%, and 100% of the monthly budget.
+
+#### Scenario: Budget threshold reached
+- **WHEN** the dev project's monthly spend reaches 50%, 90%, or 100% of the configured budget
+- **THEN** an email alert is sent to the billing contact address
+
+#### Scenario: Budget is IaC-managed
+- **WHEN** the cloud-provisioning Pulumi stack is deployed
+- **THEN** the billing budget exists as a Pulumi-managed resource and is visible in GCP Console under Billing → Budgets & Alerts
+
+### Requirement: Places API Daily Quota Limit (Dev)
+The `liverty-music-dev` GCP project SHALL have a consumer quota override limiting Places API (New) Text Search requests to **20 requests per day**. This limit SHALL be managed as a Pulumi resource and SHALL only apply to the dev environment.
+
+#### Scenario: Quota limit blocks excess requests
+- **WHEN** Places API (New) Text Search has been called 20 times within a calendar day on the dev project
+- **THEN** subsequent calls return HTTP 429 (RESOURCE_EXHAUSTED), which the backend maps to `codes.ResourceExhausted` and treats as a non-retryable error for venue resolution, skipping that venue
+
+#### Scenario: Quota is IaC-managed and dev-only
+- **WHEN** the cloud-provisioning Pulumi stack is deployed for the dev environment
+- **THEN** a `ConsumerQuotaOverride` resource exists for `places.googleapis.com` and no equivalent override exists in the prod stack
+
+### Requirement: Vertex AI Daily Quota Limit (Dev)
+The `liverty-music-dev` GCP project SHALL have a consumer quota override limiting Vertex AI Gemini `GenerateContent` requests to **5 requests per minute** (effectively throttling runaway loops while allowing normal weekly CronJob execution). This limit SHALL be managed as a Pulumi resource and SHALL only apply to the dev environment.
+
+#### Scenario: Quota throttles runaway loop
+- **WHEN** a bug causes the concert-discovery CronJob to call Vertex AI in a tight loop exceeding 5 req/min
+- **THEN** requests beyond the quota return HTTP 429, which `gemini/errors.go` maps to `codes.ResourceExhausted` and `isRetryable` returns `true`, triggering exponential backoff (max 3 retries), after which the artist's search gracefully returns nil
+
+#### Scenario: Normal CronJob completes within quota
+- **WHEN** the concert-discovery CronJob runs normally (1 Gemini call per artist with ~1s throttle between calls)
+- **THEN** all artists are processed successfully, as the 1 req/s rate is well within the 5 req/min quota
+
+#### Scenario: Quota is IaC-managed and dev-only
+- **WHEN** the cloud-provisioning Pulumi stack is deployed for the dev environment
+- **THEN** a `ConsumerQuotaOverride` resource exists for `aiplatform.googleapis.com` and no equivalent override exists in the prod stack

--- a/openspec/changes/archive/2026-04-08-add-gcp-cost-guardrails/tasks.md
+++ b/openspec/changes/archive/2026-04-08-add-gcp-cost-guardrails/tasks.md
@@ -1,0 +1,22 @@
+## 1. Billing Budget
+
+- [x] 1.1 Add `gcp.billing.Budget` resource to `src/gcp/index.ts`, scoped to `liverty-music-dev` project, with ¥3,000/month budget and 50%/90%/100% email alert thresholds (dev-only, guarded by `environment === 'dev'`)
+- [x] 1.2 Run `make lint` to verify TypeScript compiles without errors
+
+## 2. Places API Quota Override
+
+- [x] 2.1 Add `gcp.serviceusage.ConsumerQuotaOverride` for `places.googleapis.com` with daily limit of 20 requests in `src/gcp/index.ts` (dev-only)
+- [x] 2.2 Verify the quota metric name and limit name are correct (`places.googleapis.com/v1/places_requests`, `PLACES_REQUESTS-DAILY-per-project`) — adjust if needed based on Pulumi plan output
+
+## 3. Vertex AI Quota Override
+
+- [x] 3.1 Add `gcp.serviceusage.ConsumerQuotaOverride` for `aiplatform.googleapis.com` with per-minute limit of 5 requests in `src/gcp/index.ts` (dev-only)
+- [x] 3.2 Verify the quota metric name and limit name are correct for Gemini GenerateContent — adjust if needed based on Pulumi plan output
+
+## 4. Deploy and Verify
+
+- [ ] 4.1 Commit and push, open PR to cloud-provisioning
+- [ ] 4.2 Merge PR and confirm Pulumi Cloud Deployments completes successfully for dev
+- [ ] 4.3 Verify in GCP Console: billing budget visible under Billing → Budgets & Alerts
+- [ ] 4.4 Verify in GCP Console: Places API quota override visible under IAM & Admin → Quotas (20 req/day)
+- [ ] 4.5 Verify in GCP Console: Vertex AI quota override visible under IAM & Admin → Quotas (5 req/min)


### PR DESCRIPTION
## Summary

- Archive `add-gcp-cost-guardrails` OpenSpec change artifacts (proposal, design, specs, tasks)
- Implementation shipped in cloud-provisioning#192; spec added in specification#397

## Test plan

- [ ] Archive directory renders correctly on GitHub
