### PR TITLE
feat(specs): add dev-db-access spec and update cloud-sql-connector

### DIFF
--- a/openspec/changes/archive/2026-04-13-dev-db-local-access/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-13-dev-db-local-access/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-13

--- a/openspec/changes/archive/2026-04-13-dev-db-local-access/design.md
+++ b/openspec/changes/archive/2026-04-13-dev-db-local-access/design.md
@@ -1,0 +1,80 @@
+## Context
+
+Cloud SQL is configured with PSC (Private Service Connect) only — no public IP. The PSC endpoint (`10.10.10.10`) is reachable only from within the GKE cluster's VPC (`global-vpc`). Local machines have no VPN or direct VPC route.
+
+The backend application uses the Cloud SQL Go Connector SDK with `WithPSC()` + `WithIAMAuthN()` options directly in-process. This works for production workloads running in GKE, but does not help developers or Claude Code agents who need direct DB access from outside the cluster.
+
+The dev environment already has:
+- `backend-app` Kubernetes ServiceAccount with Workload Identity binding to `backend-app@liverty-music-dev.iam.gserviceaccount.com`
+- That GSA has `roles/cloudsql.instanceUser` on the dev Cloud SQL instance
+- Private DNS zone `asia-northeast2.sql.goog.` resolves from within the cluster
+
+## Goals / Non-Goals
+
+**Goals:**
+- Enable `psql`, DBeaver, Atlas CLI, and other local tools to connect to the dev Cloud SQL instance
+- Enable Claude Code agents to run queries against the dev DB by following documented steps
+- No new GCP IAM roles, service accounts, or VPN infrastructure required
+- Dev-only: staging/prod remain unchanged
+
+**Non-Goals:**
+- Persistent always-on tunnel (port-forward is ephemeral by design)
+- Access to staging or production DB
+- Replacing local Docker Compose for integration tests (that workflow stays as-is)
+- GUI tooling setup (DBeaver configuration is user responsibility)
+
+## Decisions
+
+### Decision 1: Cloud SQL Auth Proxy as a standalone K8s Deployment (not sidecar)
+
+**Chosen**: Standalone `Deployment` in a new `tools` namespace with `kubectl port-forward` for access.
+
+**Alternatives considered**:
+| Option | Pros | Cons |
+|--------|------|------|
+| IAP SSH tunnel to GKE node | No new K8s resources | Requires SSH access to nodes, complex setup, must install Auth Proxy on node |
+| Cloud VPN | Transparent access, no port-forward | Expensive setup, requires new Pulumi infra, overkill for dev access |
+| Cloud Shell | Zero setup | Not suitable for scripted/agent use, session-based |
+| Standalone Proxy Deployment (chosen) | Simple, uses existing WI, kubectl only, dev-only cost | port-forward session can drop |
+
+A standalone Deployment (not sidecar) is preferred so it can be shared across developers without modifying backend app manifests.
+
+### Decision 2: Reuse `backend-app` ServiceAccount
+
+The existing `backend-app` KSA already has Workload Identity bound to the GSA with `cloudsql.instanceUser`. Creating a separate SA would require new Pulumi code and a new GSA IAM binding.
+
+**Constraint**: The Auth Proxy Pod must be in the `backend` namespace to use the `backend-app` KSA, OR a new KSA with the same WI annotation must be created in `tools`. We choose the `backend` namespace to avoid creating new IAM bindings.
+
+### Decision 3: Auth Proxy image and flags
+
+- Image: `gcr.io/cloud-sql-connectors/cloud-sql-proxy:2` (latest v2.x)
+- Flags: `--psc`, `--auto-iam-authn`, `--port=5432`
+- Instance connection name: `liverty-music-dev:asia-northeast2:postgres-osaka`
+- DNS resolves within cluster via existing private zone `asia-northeast2.sql.goog.`
+
+### Decision 4: Document in AGENTS.md and go-postgres skill
+
+Claude Code agents receive `backend/AGENTS.md` in context automatically. Adding the port-forward procedure there ensures agents know the correct connection string and steps without requiring the user to explain it each time.
+
+The `go-postgres` skill is consulted when writing DB code — adding a "Dev DB Access" section there provides the connection info at the right moment.
+
+## Risks / Trade-offs
+
+- **`kubectl port-forward` drops on inactivity** → Mitigation: Document that the user must keep the terminal open; provide the exact reconnect command
+- **Proxy Pod always running in dev costs CPU/memory** → Mitigation: Use minimal resources (10m CPU, 32Mi memory); deploy dev-only via overlay
+- **Auth Proxy v2 requires correct DNS resolution** → Mitigation: Cluster already has the required private DNS zone; no additional DNS setup needed
+- **IAM token expiry** → The Auth Proxy automatically refreshes IAM tokens; no manual action needed
+
+## Migration Plan
+
+1. Add `k8s/namespaces/backend/overlays/dev/sql-proxy/` manifest (Deployment + no new SA)
+2. Add to dev overlay `kustomization.yaml`
+3. Update `backend/AGENTS.md` with connection procedure
+4. Update `~/.claude/skills/go-postgres/SKILL.md` with Dev DB Access section
+5. ArgoCD auto-syncs the new Deployment on PR merge — no manual rollout needed
+
+Rollback: remove the overlay resource and re-sync ArgoCD. No state is stored in the proxy pod.
+
+## Open Questions
+
+- Should the proxy Deployment have `replicas: 0` by default and scale to 1 only when needed (to save resources)? → Current decision: `replicas: 1` always-on in dev for simplicity; revisit if dev cluster cost becomes a concern.

--- a/openspec/changes/archive/2026-04-13-dev-db-local-access/proposal.md
+++ b/openspec/changes/archive/2026-04-13-dev-db-local-access/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+Cloud SQL is configured with PSC-only connectivity (no public IP), so developers and Claude Code agents cannot connect to the dev environment database from a local machine. This blocks tasks like ad-hoc queries, schema validation, and debugging data issues that require direct DB access.
+
+## What Changes
+
+- Deploy a `cloud-sql-proxy` Deployment to the dev GKE cluster (namespace: `tools`) that exposes the Cloud SQL PSC instance over `kubectl port-forward`
+- Add a `dev-db-access` capability spec defining the access pattern and IAM requirements
+- Update `backend/AGENTS.md` with the connection procedure so Claude Code agents receive it in context
+- Update the `go-postgres` skill with a "Dev DB Access" section covering the port-forward workflow
+
+## Capabilities
+
+### New Capabilities
+
+- `dev-db-access`: Developer and agent access to the dev Cloud SQL (PSC) instance via Cloud SQL Auth Proxy Pod + `kubectl port-forward`
+
+### Modified Capabilities
+
+- `cloud-sql-connector`: Add requirement that a standalone Auth Proxy deployment SHALL exist in dev for local access
+
+## Impact
+
+- **cloud-provisioning**: New K8s Deployment manifest (`k8s/namespaces/tools/`) for the proxy pod; uses existing `backend-app` Workload Identity SA
+- **backend AGENTS.md**: New section documenting the `kubectl port-forward` procedure
+- **go-postgres skill**: New "Dev DB Access" section with connection steps and caveats
+- No application code changes required
+- No new GCP IAM roles or service accounts required (reuses `backend-app` SA)

--- a/openspec/changes/archive/2026-04-13-dev-db-local-access/specs/cloud-sql-connector/spec.md
+++ b/openspec/changes/archive/2026-04-13-dev-db-local-access/specs/cloud-sql-connector/spec.md
@@ -1,0 +1,13 @@
+## ADDED Requirements
+
+### Requirement: A standalone Auth Proxy Deployment SHALL exist in dev for local access
+
+In the `development` environment, a standalone Cloud SQL Auth Proxy Deployment SHALL be deployed to provide local DB access without modifying the application's in-process connector.
+
+#### Scenario: Proxy coexists with in-process connector
+
+- **WHEN** the dev cluster is running
+- **THEN** the `cloud-sql-proxy` Deployment SHALL exist alongside the backend server Deployment
+- **AND** both SHALL connect to the same Cloud SQL instance independently
+- **AND** the backend server SHALL continue to use the in-process Go Connector (no change)
+- **AND** the proxy Deployment SHALL be deployed only in the `dev` overlay (not staging or production)

--- a/openspec/changes/archive/2026-04-13-dev-db-local-access/specs/dev-db-access/spec.md
+++ b/openspec/changes/archive/2026-04-13-dev-db-local-access/specs/dev-db-access/spec.md
@@ -1,0 +1,60 @@
+# Spec: Dev DB Access
+
+## Purpose
+
+Defines how developers and Claude Code agents access the dev Cloud SQL (PSC) instance from a local machine using a Cloud SQL Auth Proxy Pod deployed in GKE.
+
+## Requirements
+
+### Requirement: A Cloud SQL Auth Proxy Deployment SHALL exist in the dev cluster
+
+A standalone Cloud SQL Auth Proxy Deployment SHALL be deployed in the `backend` namespace of the dev GKE cluster to provide an access point for local DB connections.
+
+#### Scenario: Proxy pod is running
+
+- **WHEN** the dev cluster is operational
+- **THEN** a Deployment named `cloud-sql-proxy` SHALL exist in the `backend` namespace
+- **AND** it SHALL run `gcr.io/cloud-sql-connectors/cloud-sql-proxy:2` with `--psc` and `--auto-iam-authn` flags
+- **AND** it SHALL target the instance connection name `liverty-music-dev:asia-northeast2:postgres-osaka`
+- **AND** it SHALL use the `backend-app` ServiceAccount for Workload Identity authentication
+
+### Requirement: Local DB access SHALL be established via kubectl port-forward
+
+Developers and Claude Code agents SHALL connect to the dev Cloud SQL instance by forwarding the proxy pod's port to localhost.
+
+#### Scenario: Agent or developer establishes a local connection
+
+- **WHEN** the user runs `kubectl port-forward deployment/cloud-sql-proxy 5432:5432 -n backend`
+- **THEN** `localhost:5432` SHALL be forwarded to the Cloud SQL Auth Proxy Pod
+- **AND** connections to `localhost:5432` SHALL reach the dev Cloud SQL instance via PSC
+- **AND** the user SHALL authenticate as `backend-app@liverty-music-dev.iam` (IAM auth, no password)
+
+#### Scenario: Agent connects using psql
+
+- **WHEN** port-forward is active
+- **THEN** the agent SHALL connect with: `psql "host=localhost port=5432 user=backend-app@liverty-music-dev.iam dbname=liverty-music sslmode=disable options='-c search_path=app'"`
+
+### Requirement: Dev DB access procedure SHALL be discoverable from backend/AGENTS.md
+
+The connection procedure SHALL be reachable from `backend/AGENTS.md` so that Claude Code agents can find it without manual instruction. To avoid bloating the always-loaded context, the full procedure lives in a separate reference file linked from AGENTS.md.
+
+#### Scenario: Agent receives connection context
+
+- **WHEN** a Claude Code agent loads `backend/AGENTS.md`
+- **THEN** the agent SHALL find a "Dev DB Access" section containing:
+  - A pointer to `docs/dev-db-access.md`
+  - A note that this is dev-only (not for local Docker Compose)
+- **AND** `docs/dev-db-access.md` SHALL contain:
+  - The `kubectl port-forward` command
+  - The `psql` connection string with all connection parameters
+
+### Requirement: Dev DB access SHALL use existing IAM permissions with no new service accounts
+
+The proxy Deployment SHALL reuse the existing `backend-app` Kubernetes ServiceAccount and its Workload Identity binding. No new GCP IAM roles or service accounts SHALL be created for this feature.
+
+#### Scenario: Proxy authenticates with existing Workload Identity
+
+- **WHEN** the proxy pod starts
+- **THEN** it SHALL use the `backend-app` KSA with annotation `iam.gke.io/gcp-service-account: backend-app@liverty-music-dev.iam.gserviceaccount.com`
+- **AND** it SHALL authenticate to Cloud SQL using the GSA's IAM token
+- **AND** no service account key files SHALL be mounted

--- a/openspec/changes/archive/2026-04-13-dev-db-local-access/tasks.md
+++ b/openspec/changes/archive/2026-04-13-dev-db-local-access/tasks.md
@@ -1,0 +1,17 @@
+## 1. K8s Manifest — Cloud SQL Auth Proxy Deployment (dev overlay)
+
+- [x] 1.1 Create `k8s/namespaces/backend/overlays/dev/sql-proxy/deployment.yaml` with Cloud SQL Auth Proxy v2, `--psc`, `--auto-iam-authn`, `--port=5432`, and `backend-app` ServiceAccount
+- [x] 1.2 Add `sql-proxy/deployment.yaml` to `k8s/namespaces/backend/overlays/dev/kustomization.yaml` resources
+
+## 2. Documentation — backend/AGENTS.md
+
+- [x] 2.1 Add a "Dev DB Access" section to `backend/AGENTS.md` with the `kubectl port-forward` command, `psql` connection string, and a note that it is dev-only (not for local Docker Compose)
+
+## 3. Skill Update — go-postgres
+
+- [x] 3.1 Add a "Dev DB Access" section to `~/.claude/skills/go-postgres/SKILL.md` with the port-forward procedure and connection parameters for the dev Cloud SQL instance
+
+## 4. Verification
+
+- [x] 4.1 Confirm `kubectl port-forward deployment/cloud-sql-proxy 5432:5432 -n backend` connects successfully after ArgoCD sync
+- [x] 4.2 Confirm `psql "host=localhost port=5432 user=backend-app@liverty-music-dev.iam dbname=liverty-music sslmode=disable options='-c search_path=app'"` returns a prompt

--- a/openspec/specs/cloud-sql-connector/spec.md
+++ b/openspec/specs/cloud-sql-connector/spec.md
@@ -54,3 +54,15 @@ The application SHALL validate that `InstanceConnectionName` is present if `ENVI
 - **WHEN** `ENVIRONMENT` is not `local`
 - **AND** `DATABASE_INSTANCE_CONNECTION_NAME` is empty
 - **THEN** application fails to start with descriptive error
+
+### Requirement: A standalone Auth Proxy Deployment SHALL exist in dev for local access
+
+In the `development` environment, a standalone Cloud SQL Auth Proxy Deployment SHALL be deployed to provide local DB access without modifying the application's in-process connector.
+
+#### Scenario: Proxy coexists with in-process connector
+
+- **WHEN** the dev cluster is running
+- **THEN** the `cloud-sql-proxy` Deployment SHALL exist alongside the backend server Deployment
+- **AND** both SHALL connect to the same Cloud SQL instance independently
+- **AND** the backend server SHALL continue to use the in-process Go Connector (no change)
+- **AND** the proxy Deployment SHALL be deployed only in the `dev` overlay (not staging or production)

--- a/openspec/specs/dev-db-access/spec.md
+++ b/openspec/specs/dev-db-access/spec.md
@@ -1,0 +1,60 @@
+# Spec: Dev DB Access
+
+## Purpose
+
+Defines how developers and Claude Code agents access the dev Cloud SQL (PSC) instance from a local machine using a Cloud SQL Auth Proxy Pod deployed in GKE.
+
+## Requirements
+
+### Requirement: A Cloud SQL Auth Proxy Deployment SHALL exist in the dev cluster
+
+A standalone Cloud SQL Auth Proxy Deployment SHALL be deployed in the `backend` namespace of the dev GKE cluster to provide an access point for local DB connections.
+
+#### Scenario: Proxy pod is running
+
+- **WHEN** the dev cluster is operational
+- **THEN** a Deployment named `cloud-sql-proxy` SHALL exist in the `backend` namespace
+- **AND** it SHALL run `gcr.io/cloud-sql-connectors/cloud-sql-proxy:2` with `--psc` and `--auto-iam-authn` flags
+- **AND** it SHALL target the instance connection name `liverty-music-dev:asia-northeast2:postgres-osaka`
+- **AND** it SHALL use the `backend-app` ServiceAccount for Workload Identity authentication
+
+### Requirement: Local DB access SHALL be established via kubectl port-forward
+
+Developers and Claude Code agents SHALL connect to the dev Cloud SQL instance by forwarding the proxy pod's port to localhost.
+
+#### Scenario: Agent or developer establishes a local connection
+
+- **WHEN** the user runs `kubectl port-forward deployment/cloud-sql-proxy 5432:5432 -n backend`
+- **THEN** `localhost:5432` SHALL be forwarded to the Cloud SQL Auth Proxy Pod
+- **AND** connections to `localhost:5432` SHALL reach the dev Cloud SQL instance via PSC
+- **AND** the user SHALL authenticate as `backend-app@liverty-music-dev.iam` (IAM auth, no password)
+
+#### Scenario: Agent connects using psql
+
+- **WHEN** port-forward is active
+- **THEN** the agent SHALL connect with: `psql "host=localhost port=5432 user=backend-app@liverty-music-dev.iam dbname=liverty-music sslmode=disable options='-c search_path=app'"`
+
+### Requirement: Dev DB access procedure SHALL be discoverable from backend/AGENTS.md
+
+The connection procedure SHALL be reachable from `backend/AGENTS.md` so that Claude Code agents can find it without manual instruction. To avoid bloating the always-loaded context, the full procedure lives in a separate reference file linked from AGENTS.md.
+
+#### Scenario: Agent receives connection context
+
+- **WHEN** a Claude Code agent loads `backend/AGENTS.md`
+- **THEN** the agent SHALL find a "Dev DB Access" section containing:
+  - A pointer to `docs/dev-db-access.md`
+  - A note that this is dev-only (not for local Docker Compose)
+- **AND** `docs/dev-db-access.md` SHALL contain:
+  - The `kubectl port-forward` command
+  - The `psql` connection string with all connection parameters
+
+### Requirement: Dev DB access SHALL use existing IAM permissions with no new service accounts
+
+The proxy Deployment SHALL reuse the existing `backend-app` Kubernetes ServiceAccount and its Workload Identity binding. No new GCP IAM roles or service accounts SHALL be created for this feature.
+
+#### Scenario: Proxy authenticates with existing Workload Identity
+
+- **WHEN** the proxy pod starts
+- **THEN** it SHALL use the `backend-app` KSA with annotation `iam.gke.io/gcp-service-account: backend-app@liverty-music-dev.iam.gserviceaccount.com`
+- **AND** it SHALL authenticate to Cloud SQL using the GSA's IAM token
+- **AND** no service account key files SHALL be mounted


### PR DESCRIPTION
## Summary

- Add `openspec/specs/dev-db-access/spec.md` — new capability spec for dev Cloud SQL access via Cloud SQL Auth Proxy port-forward
- Update `openspec/specs/cloud-sql-connector/spec.md` — add standalone Auth Proxy Deployment requirement (dev-only)
- Archive `openspec/changes/dev-db-local-access` → `openspec/changes/archive/2026-04-13-dev-db-local-access/`

## Context

The dev Cloud SQL instance is PSC-only (no public IP). This change documents the architecture decision to deploy a standalone Cloud SQL Auth Proxy Pod in the dev GKE cluster, enabling developers and Claude Code agents to connect via `kubectl port-forward`.

Implementation is in companion PRs:
- liverty-music/cloud-provisioning#194 — K8s Auth Proxy Deployment (dev overlay)
- liverty-music/backend#277 — `backend/AGENTS.md` and `docs/dev-db-access.md`

## Test plan

- [ ] `buf lint` passes (no proto changes)
- [ ] Spec files render correctly in GitHub
