### PR TITLE
feat(push-notification): add NotifyNewConcerts debug RPC

### DIFF
--- a/openspec/changes/scope-new-concert-notifications/.openspec.yaml
+++ b/openspec/changes/scope-new-concert-notifications/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-15

--- a/openspec/changes/scope-new-concert-notifications/design.md
+++ b/openspec/changes/scope-new-concert-notifications/design.md
@@ -1,0 +1,124 @@
+## Context
+
+The push-notification delivery path today is triggered by a `CONCERT.created` NATS event whose payload is `{artist_id, artist_name, concert_count}`. The handler then **re-fetches** `upcoming` concerts via `ConcertRepository.ListByArtist(artistID, true)` and passes the full list to the notification use case. Two problems result:
+
+1. **Semantic bug**: the new-concert trigger fans out over the artist's entire upcoming catalog. Hype filters (`home`, `nearby`) incorrectly match on stale venues, and the payload count reflects total upcoming, not new.
+2. **Layering bug**: the consumer handler owns business logic (artist hydration + concert list shaping). Per clean architecture rules in `backend/CLAUDE.md`, handlers in `adapter/` should delegate to `usecase/`; they should not reach into repositories.
+
+Additionally, the only way to exercise the delivery path end-to-end today is `ConcertService.SearchNewConcerts`, which depends on a live Gemini call discovering new data. This makes integration testing non-deterministic and slow.
+
+This change fixes both bugs and introduces a debug RPC so the delivery path can be invoked deterministically.
+
+Stakeholders: backend engineers (code owners), QA / operators (integration testing), specification maintainers (proto contract).
+
+## Goals / Non-Goals
+
+**Goals:**
+- Delivery decisions (hype filter + payload) are computed strictly from the newly created concert set.
+- The consumer handler is reduced to CloudEvent decode + single use-case call.
+- The `ConcertCreatedData` struct lives in the use case layer (not the entity layer) since it is a use-case input, not a domain entity.
+- A `NotifyNewConcerts` Connect RPC exists on `PushNotificationService` for deterministic invocation of the delivery path.
+- The debug RPC is only usable in non-production environments.
+
+**Non-Goals:**
+- Changing the hype-level semantics themselves (`watch` / `home` / `nearby` / `away` rules stay as-is).
+- Changing the Web Push transport layer, VAPID key management, or 410-Gone cleanup logic.
+- Changing the client (frontend) push subscription surface (`Create` / `Get` / `Delete` / self-heal) — those requirements remain untouched.
+- Keeping backward compatibility with old `CONCERT.created` event schemas. The NATS `CONCERT` stream will be purged.
+- Making the debug RPC available to end users or shipping it to production.
+
+## Decisions
+
+### D1. Event payload becomes `{artist_id, concert_ids[]}`
+
+**Chosen**: Replace the payload entirely with an identifier-only shape.
+
+**Rationale**: The publisher already has the concrete concert list when it decides to emit the event. Passing the identifiers downstream eliminates the re-fetch race, makes the consumer work with an authoritative "this is what just happened" set, and keeps the payload tiny. Names and counts are derivable from identifiers.
+
+**Alternatives considered**:
+- *Inline concert objects*: duplicates entity data in the event; payload bloats with venue/date fields; serialization semantics drift from the DB. Rejected.
+- *Keep `concert_count` as a sibling of `concert_ids`*: redundant (count is `len(concert_ids)`) and encourages consumers to trust derivable data. Rejected.
+- *Add versioned schema field (`v2`) with dual-consume shim*: only worthwhile if we need to tolerate historical events. Since we can purge dev/staging streams, the shim is pure cost. Rejected.
+
+### D2. NATS `CONCERT` stream is purged on deploy
+
+**Chosen**: Single-shot purge of the stream in dev/staging when the backend with the new schema rolls out.
+
+**Rationale**: Pre-existing events with the old shape will fail to unmarshal into the new struct. With 7-day retention and no production usage of this feature yet, purging is simpler and safer than dual-consume logic. Purge is executed via `nats stream purge CONCERT` inside the consumer pod (or out-of-band by the operator) during the deploy window.
+
+**Risks**:
+- *Events in flight at deploy time are dropped*: accepted. The source of truth for "new concerts" is the DB; a dropped event only means a skipped notification for one batch, which is recoverable via the new debug RPC.
+- *Prod migration requires care if feature lands in prod later*: by that time the schema stabilizes and no migration of persisted events will be needed.
+
+### D3. `ConcertCreatedData` moves from `internal/entity/` to `internal/usecase/`
+
+**Chosen**: Define the struct in `internal/usecase/push_notification_uc.go` (or a sibling `notification_events.go` in the same package) and export it as `usecase.ConcertCreatedData`.
+
+**Rationale**: The struct is the input shape of a use case, not a domain entity. Placing it in `entity/` blurs layer ownership and creates a circular-feeling dependency where adapter packages import entity types only to hand them to use cases.
+
+**Alternatives considered**:
+- *Leave it in `entity/`*: status quo; violates layer responsibilities.
+- *Introduce a new `internal/event/` package*: over-engineered for a single struct. Can revisit if multiple event payloads warrant consolidation.
+
+### D4. `NotifyNewConcerts` use case hydrates artist and concerts itself
+
+**Chosen**: The use case method accepts `ConcertCreatedData` and internally calls `artistRepo.Get(artistID)` and `concertRepo.ListByIDs(concertIDs)`.
+
+**Rationale**: The consumer handler must be free of repo calls (layering). Moving hydration inside the use case means the same method can be invoked from the consumer **and** the debug RPC without duplicating fetches.
+
+**Alternatives considered**:
+- *Caller passes in hydrated `artist` and `[]concert`*: forces every caller (consumer, debug RPC) to replicate the same fetch logic. Rejected.
+- *Caller passes only `artistID` and the use case fetches concerts by `artistID` + "upcoming"*: reintroduces the original bug.
+
+### D5. New repo method `ConcertRepository.ListByIDs`
+
+**Chosen**: Add `ListByIDs(ctx, ids []string) ([]*Concert, error)` to the `ConcertRepository` interface, backed by `WHERE event_id = ANY($1)` in the pgx implementation. Return order need not match input order; the use case treats the result as a set. Missing IDs are silently dropped but logged at `WARN`.
+
+**Rationale**: Precise hydration of the "just created" set. Reuses existing pgx bulk patterns.
+
+**Open alternatives**:
+- *Return error on any missing ID*: strict but noisy under race conditions (e.g., concert deleted between publish and consume). A WARN log is a pragmatic middle ground.
+
+### D6. Debug RPC is environment-gated at the server via existing `ENVIRONMENT`
+
+**Chosen**: Add `NotifyNewConcerts` to `PushNotificationService`. The handler is always registered, but when the server's existing `config.ServerConfig.IsProduction()` returns `true`, the method returns `PERMISSION_DENIED` before doing any work. No new env var is introduced.
+
+**Rationale**:
+- The project already has an `ENVIRONMENT` config (`local` / `development` / `staging` / `production`) with `Is{Local,Development,Staging,Production}()` helpers in `pkg/config/config.go`. Debug-feature gating is a natural extension of this existing knob.
+- A dedicated `ENABLE_DEBUG_RPCS` flag would be a second source of truth, requires cloud-provisioning overlay changes in every environment, and creates a risk of combinatorial misconfiguration (e.g., `ENVIRONMENT=production` with `ENABLE_DEBUG_RPCS=true`). Reusing `ENVIRONMENT` keeps one canonical signal.
+- Keeping the RPC on the existing service avoids a new proto service surface, simplifies auth interceptor wiring, and reuses the `RequireUser` interceptor so unauthenticated calls still return `UNAUTHENTICATED`.
+- Server-side gating (not route-level omission) ensures a well-known error code surfaces in prod if someone probes the endpoint, instead of 404. This is easier to observe and alert on than a missing route.
+
+**Alternatives considered**:
+- *Dedicated `ENABLE_DEBUG_RPCS` env var*: explicit about intent, but redundant with `ENVIRONMENT` and adds per-overlay configuration burden. Rejected as over-engineered.
+- *Separate `PushNotificationDebugService` with its own interceptor chain*: cleaner ACL model but requires a second service registration and more proto surface. Rejected for complexity.
+- *Require an admin role claim in JWT*: no admin role currently exists in Zitadel for this app; adding one is out of scope.
+
+### D7. Debug RPC rejects unknown concert IDs
+
+**Chosen**: The debug RPC fetches concerts by the provided IDs filtered by `artist_id`. If any provided ID fails to resolve under that artist, return `INVALID_ARGUMENT` and do no delivery.
+
+**Rationale**: The debug RPC is for deliberate invocations; silently dropping mismatched IDs would mask operator mistakes. The consumer path (D5) is stricter-by-nature because the publisher constructed the IDs in the same transaction — mismatches there are rare race conditions, not operator errors.
+
+## Risks / Trade-offs
+
+- **[Risk]** Consumer pods deployed ahead of publisher pods will fail to parse new payloads. → **Mitigation**: deploy publisher (`server-app`) before consumer (`consumer-app`), OR purge the stream before either comes up. Both pods live in the same backend image, so rolling update ordering in the Deployment surface is sufficient.
+- **[Risk]** `ListByIDs` with a very large slice could hit Postgres parameter limits. → **Mitigation**: typical batches are `≤ 100`; document an upper bound (`max_items = 1000`) on the debug RPC request via protovalidate.
+- **[Trade-off]** The use case now makes one extra DB round-trip (`ListByIDs`) compared to the previous single `ListByArtist`. → **Acceptable**: payload correctness outweighs a ~few-millisecond overhead. A future optimization could pass concerts inline in the event if profiling shows this matters.
+- **[Risk]** Operator accidentally invokes the debug RPC against production. → **Mitigation**: server-side `PERMISSION_DENIED` when `cfg.IsProduction()`. `ENVIRONMENT=production` is already set in the prod overlay as part of standard deployment configuration; no new knob to maintain.
+- **[Trade-off]** No dual-compat for the event schema means any operator who missed the NATS purge will see consumer pods CrashLoop on bad messages. → **Acceptable**: runbook note in the task list; dev/staging only.
+
+## Migration Plan
+
+1. Land the specification PR (proto adds `NotifyNewConcerts` + request/response; backward compatible at proto level).
+2. Tag `vX.Y.Z` GitHub Release on specification → BSR generates client/server stubs.
+3. Backend PR updates BSR dep; lands the refactor (event schema, use case, consumer, repo, handler, DI, tests).
+4. Deploy to dev: as part of the rollout, purge the `CONCERT` stream (one-line operator command; document in task 7).
+5. Validate in dev with the debug RPC against the existing test user `pepperoni9+pixel@gmail.com`.
+6. Promote to staging with the same purge step.
+7. Rollback: revert backend PR; NATS stream can be re-purged; no DB migration to reverse.
+
+## Open Questions
+
+- **Debug RPC auth beyond env-gating**: for defense-in-depth, should we also require a signed header / bearer from a short-list of operator identities? Current answer: no (env-gating + JWT is enough for dev/staging), but revisit if the RPC survives beyond testing purposes.
+- **Partial delivery on consumer side**: if `ListByIDs` returns fewer concerts than requested (some race-deleted), should the use case abort or proceed with what it has? Current answer: proceed and log at WARN; revisit if telemetry shows this is common.

--- a/openspec/changes/scope-new-concert-notifications/proposal.md
+++ b/openspec/changes/scope-new-concert-notifications/proposal.md
@@ -1,0 +1,42 @@
+## Why
+
+When new concerts are persisted for an artist, followers currently receive notifications whose filtering and payload are computed from **all** upcoming concerts of that artist — not only the freshly created ones. This causes over-notification (e.g., a `hype=home` follower in JP-13 gets notified about a new JP-40 concert because an unrelated JP-13 concert already exists) and incorrect counts in the notification body. The root cause is that the `CONCERT.created` event carries only a count, forcing the consumer to re-fetch the full upcoming list and placing business logic inside the event handler.
+
+Operationally, there is also no deterministic way to integration-test the delivery pipeline today: the only way to trigger it is to call `ConcertService.SearchNewConcerts` and hope Gemini discovers a new concert, which is non-deterministic.
+
+## What Changes
+
+- **BREAKING** Event payload for `CONCERT.created` changes shape: from `{artist_id, artist_name, concert_count}` to `{artist_id, concert_ids[]}`, carrying identifiers of **only the newly created concerts**. Pre-existing events in the NATS `CONCERT` stream (dev/staging) will be **purged** on deploy — no dual-compat shim.
+- Notification delivery becomes **scoped to newly created concerts**: the `HOME` / `NEARBY` hype filter and the notification payload count are computed exclusively over the newly-created concert set.
+- The consumer handler for `CONCERT.created` becomes a thin adapter: it parses the CloudEvent and delegates to the use case without any repository lookups. All domain logic (artist hydration, concert hydration by IDs, follower filtering, push dispatch) moves into the use case.
+- New RPC `PushNotificationService.NotifyNewConcerts(artist_id, concert_ids[])` for deterministic integration testing and operator-initiated re-delivery. Invokes the same use case path, bypassing the NATS hop.
+- The new RPC is **debug/admin-only**: it returns `PERMISSION_DENIED` in production (gated via the existing `ENVIRONMENT` config), so no new env var is introduced.
+
+## Capabilities
+
+### New Capabilities
+
+_None — all changes extend the existing `push-notification-service` capability._
+
+### Modified Capabilities
+
+- `push-notification-service`:
+  - New requirement: delivery is scoped to newly-created concerts only (filtering and payload both).
+  - New requirement: `CONCERT.created` event carries `artist_id` + `concert_ids[]` and is not published when no concerts are created.
+  - New requirement: consumer handler is a thin adapter (no direct repository access); business logic lives in the use case.
+  - New requirement: `NotifyNewConcerts` debug RPC for deterministic integration testing, restricted to non-production environments.
+
+## Impact
+
+- **Protobuf (specification repo)**: new RPC method on `PushNotificationService`; new request/response messages. Breaking check needs no label (method addition is non-breaking at proto level).
+- **Backend (Go)**:
+  - `internal/entity/event_data.go`: remove `ConcertCreatedData` (moves to usecase layer).
+  - `internal/usecase/`: introduce `usecase.ConcertCreatedData` struct, change `NotifyNewConcerts` signature, add internal hydration.
+  - `internal/entity/concert.go` and `internal/infrastructure/database/rdb/concert_repo.go`: add `ConcertRepository.ListByIDs`.
+  - `internal/usecase/concert_creation_uc.go`: publisher emits `concert_ids`; skip publish on empty.
+  - `internal/adapter/event/notification_consumer.go`: slimmed; remove artist/concert repo deps.
+  - `internal/adapter/rpc/push_notification_handler.go`: implement `NotifyNewConcerts` RPC.
+  - `internal/di/`: remove artist/concert deps from notification consumer wiring; register the debug RPC handler unconditionally, with in-handler `cfg.IsProduction()` gate.
+  - Tests across usecase/adapter layers updated to the new shape.
+- **Operations**: NATS `CONCERT` stream purge required on dev/staging deploy (single-time operation).
+- **Downstream frontend**: unaffected (no client-facing RPC behavior change; `NotifyNewConcerts` is operator-facing).

--- a/openspec/changes/scope-new-concert-notifications/specs/push-notification-service/spec.md
+++ b/openspec/changes/scope-new-concert-notifications/specs/push-notification-service/spec.md
@@ -1,0 +1,111 @@
+## ADDED Requirements
+
+### Requirement: Delivery scope limited to newly created concerts
+
+When notifying followers about newly created concerts for an artist, the system SHALL use only the set of concerts that were just created in the triggering operation — not the artist's full upcoming schedule. Hype-level filtering, notification payload content, and delivery decisions SHALL all be computed against this new-concert set.
+
+#### Scenario: Home filter evaluated against new concerts only
+
+- **WHEN** a new concert is created for an artist in admin area `JP-40`
+- **AND** the artist also has pre-existing upcoming concerts in admin area `JP-13`
+- **AND** a follower with `hype = home` whose home area is `JP-13` exists
+- **THEN** the follower SHALL NOT receive a push notification
+- **AND** filtering SHALL be computed from the set `{JP-40}`, never `{JP-40, JP-13}`
+
+#### Scenario: Nearby filter evaluated against new concerts only
+
+- **WHEN** a new concert is created for an artist at a venue 300 km from a follower's home centroid
+- **AND** the artist also has pre-existing upcoming concerts within 200 km of that follower's home centroid
+- **AND** the follower's hype level is `nearby`
+- **THEN** the follower SHALL NOT receive a push notification
+- **AND** proximity SHALL be computed from only the new concerts
+
+#### Scenario: Notification count reflects new concerts only
+
+- **WHEN** 2 new concerts are created for an artist that already has 10 upcoming concerts
+- **AND** a follower with `hype = away` exists
+- **THEN** the notification payload SHALL report the count as `2`
+- **AND** the count SHALL NOT include the pre-existing upcoming concerts
+
+#### Scenario: No delivery when zero concerts are newly created
+
+- **WHEN** the concert creation operation completes with zero newly created concerts for an artist
+- **THEN** the system SHALL NOT trigger the notification pipeline for that artist
+- **AND** SHALL NOT publish a `CONCERT.created` event
+
+### Requirement: CONCERT.created event carries identifiers of newly created concerts
+
+The `CONCERT.created` CloudEvent payload SHALL carry the artist identifier and the identifiers of the concerts created in that operation, and SHALL NOT carry any aggregate counter or name fields that can be derived at consumption time.
+
+#### Scenario: Event payload shape
+
+- **WHEN** a `CONCERT.created` event is published
+- **THEN** its data payload SHALL contain exactly two fields: `artist_id` (string) and `concert_ids` (array of string)
+- **AND** `concert_ids` SHALL contain at least one element
+- **AND** each element SHALL be an identifier of a concert created in the triggering operation
+
+#### Scenario: Artist context is resolved at consumption time
+
+- **WHEN** the notification consumer processes a `CONCERT.created` event
+- **THEN** it SHALL resolve the artist entity (for the notification body) from the artist identifier at consumption time
+- **AND** the event payload SHALL NOT carry `artist_name` or other denormalized artist fields
+
+#### Scenario: No legacy fields retained
+
+- **WHEN** a `CONCERT.created` event is published by this system version
+- **THEN** its data payload SHALL NOT contain a `concert_count` field
+- **AND** SHALL NOT contain any other field beyond `artist_id` and `concert_ids`
+
+### Requirement: Notification consumer is a thin adapter over the use case
+
+The consumer handler subscribed to `CONCERT.created` SHALL only parse the CloudEvent envelope and delegate to the notification use case. It SHALL NOT perform repository queries, hydrate domain entities, or apply business filters.
+
+#### Scenario: Handler responsibilities
+
+- **WHEN** the `CONCERT.created` consumer receives a message
+- **THEN** it SHALL deserialize the CloudEvent data into the use case's input struct
+- **AND** invoke the `NotifyNewConcerts` use case method with that struct and the request context
+- **AND** propagate the use case's error (if any) unchanged
+
+#### Scenario: Handler has no direct repository dependencies
+
+- **WHEN** the notification consumer is constructed
+- **THEN** it SHALL NOT accept `ArtistRepository`, `ConcertRepository`, or any other repository as a dependency
+- **AND** all domain-data access required for notification delivery SHALL occur inside the use case
+
+### Requirement: NotifyNewConcerts debug RPC for deterministic invocation
+
+The `PushNotificationService` SHALL expose a `NotifyNewConcerts` RPC that invokes the same delivery path as the `CONCERT.created` consumer, bypassing the event bus. This RPC is intended for integration testing and operator-initiated re-delivery.
+
+#### Scenario: Request shape
+
+- **WHEN** a client calls `PushNotificationService.NotifyNewConcerts`
+- **THEN** the request SHALL carry an `ArtistId` and a repeated `ConcertId`
+- **AND** the request SHALL be validated via `protovalidate`
+- **AND** the `ConcertId` list SHALL be non-empty (`min_items = 1`)
+
+#### Scenario: Successful invocation in non-production
+
+- **WHEN** the RPC is invoked with a valid artist and concert identifiers while the server is configured for a non-production environment (`local`, `development`, or `staging`)
+- **THEN** the service SHALL execute the same delivery logic as the `CONCERT.created` consumer
+- **AND** SHALL return a successful empty response after the delivery path completes
+- **AND** all filtering and payload computation SHALL be scoped to the provided `concert_ids`
+
+#### Scenario: Disabled in production
+
+- **WHEN** the RPC is invoked while the server is configured for the `production` environment
+- **THEN** the service SHALL return `PERMISSION_DENIED`
+- **AND** no delivery SHALL occur
+- **AND** the restriction SHALL be enforced at the server side, independent of client-provided credentials
+
+#### Scenario: Unknown concert identifiers are rejected
+
+- **WHEN** the RPC is invoked with a `concert_id` that does not match any concert for the provided `artist_id`
+- **THEN** the service SHALL return `INVALID_ARGUMENT`
+- **AND** no partial delivery SHALL occur
+
+#### Scenario: Unauthenticated invocation
+
+- **WHEN** the RPC is invoked without a valid session
+- **THEN** the service SHALL return `UNAUTHENTICATED`
+- **AND** the response SHALL NOT reveal which environment the server is running in

--- a/openspec/changes/scope-new-concert-notifications/tasks.md
+++ b/openspec/changes/scope-new-concert-notifications/tasks.md
@@ -1,0 +1,66 @@
+## 1. Specification (proto + release)
+
+- [x] 1.1 Create a new branch off `origin/main` in the `specification` worktree
+- [x] 1.2 Add `NotifyNewConcerts` RPC to `PushNotificationService` in `proto/liverty_music/rpc/push_notification/v1/push_notification_service.proto`
+- [x] 1.3 Define `NotifyNewConcertsRequest` with `ArtistId artist_id` and `repeated EventId concert_ids`, with protovalidate constraints (`min_items = 1`, `max_items = 1000`) and full doc comments
+- [x] 1.4 Define `NotifyNewConcertsResponse` (empty for now; reserved for future stats)
+- [x] 1.5 Run `buf lint` and `buf format -w`
+- [x] 1.6 Run `buf breaking --against '.git#branch=origin/main'` to confirm method addition is non-breaking
+- [ ] 1.7 Open specification PR; wait for `buf-pr-checks.yml` and reviewer approval
+- [ ] 1.8 After merge, cut a GitHub Release tag `vX.Y.Z` on specification → `buf-release.yml` pushes to BSR
+- [ ] 1.9 Poll `gh run watch` until BSR generation workflow completes successfully
+
+## 2. Backend — domain + event payload refactor
+
+- [ ] 2.1 Create a new branch off `origin/main` in the `backend` worktree (can start in parallel with 1.x; use placeholder types for RPC stubs)
+- [ ] 2.2 Introduce `internal/usecase/notification_events.go` (or equivalent) with exported `ConcertCreatedData` struct: fields `ArtistID string`, `ConcertIDs []string`, JSON tags `artist_id` and `concert_ids`
+- [ ] 2.3 Remove `ConcertCreatedData` from `internal/entity/event_data.go`
+- [ ] 2.4 Leave `SubjectConcertCreated` constant in `entity/event_data.go` (subject name is infrastructure naming, not payload shape)
+- [ ] 2.5 Add `ConcertRepository.ListByIDs(ctx, ids []string) ([]*Concert, error)` to the interface in `internal/entity/concert.go`
+- [ ] 2.6 Implement `ListByIDs` in `internal/infrastructure/database/rdb/concert_repo.go` using `WHERE event_id = ANY($1)` with pgx array binding; ensure venues are joined so `Concert.Venue.AdminArea` is populated
+- [ ] 2.7 Update `internal/usecase/concert_creation_uc.go`: construct `ConcertCreatedData{ArtistID, ConcertIDs: ids}`, emit event only when `len(ConcertIDs) > 0`
+
+## 3. Backend — use case + consumer refactor
+
+- [ ] 3.1 Change `PushNotificationUseCase.NotifyNewConcerts` signature in `internal/usecase/push_notification_uc.go` to `NotifyNewConcerts(ctx context.Context, data ConcertCreatedData) error`
+- [ ] 3.2 Inside the new implementation: resolve artist via `artistRepo.Get`, hydrate concerts via `concertRepo.ListByIDs`, then apply existing follower listing + hype filter + send loop unchanged
+- [ ] 3.3 If `ListByIDs` returns zero rows, log at WARN and return nil
+- [ ] 3.4 Slim `internal/adapter/event/notification_consumer.go`: parse CloudEvent into `usecase.ConcertCreatedData` and delegate; remove `artistRepo` and `concertRepo` fields and constructor parameters
+- [ ] 3.5 Remove `artistRepo`/`concertRepo` wiring from `NotificationConsumer` construction in `internal/di/consumer.go`
+
+## 4. Backend — debug RPC
+
+- [ ] 4.1 Inject `config.ServerConfig` (or the relevant subset) into the push-notification RPC handler so `IsProduction()` is available at method entry — reuses the existing `ENVIRONMENT` env var, no new env var introduced
+- [ ] 4.2 Implement `NotifyNewConcerts` handler method in `internal/adapter/rpc/push_notification_handler.go`:
+  - If `cfg.IsProduction()` is true → return `connect.CodePermissionDenied`
+  - Validate the request; resolve concerts via `concertRepo.ListByIDs` filtered by `artistID`; if any requested ID is missing from results → return `connect.CodeInvalidArgument`
+  - Delegate to `PushNotificationUseCase.NotifyNewConcerts(ctx, ConcertCreatedData{ArtistID, ConcertIDs})`
+  - Return empty response on success
+- [ ] 4.3 Wire `NotifyNewConcerts` into the Connect handler registration in `internal/di/provider.go`
+- [ ] 4.4 Ensure the existing auth interceptor continues to apply (JWT required for `UNAUTHENTICATED` path)
+- [ ] 4.5 After BSR gen completes in task 1.9, run `go get buf.build/gen/go/liverty-music/schema/...@vX.Y.Z` and `go mod tidy`
+- [ ] 4.6 Swap any placeholder RPC types at TODO markers for generated types
+
+## 5. Backend — tests
+
+- [ ] 5.1 Update `internal/usecase/push_notification_uc_test.go` for the new signature; add a case asserting `venueAreas` is computed from the passed concerts only (home-filter regression test)
+- [ ] 5.2 Update `internal/adapter/event/notification_consumer_test.go`: remove artist/concert repo mocks; assert the handler decodes the event and calls `pushNotificationUC.NotifyNewConcerts` with the expected struct
+- [ ] 5.3 Update `internal/usecase/concert_creation_uc_test.go`: assert the published event payload carries `concert_ids` (exact IDs), not `concert_count`; assert event is suppressed when zero concerts are created
+- [ ] 5.4 Add `internal/adapter/rpc/push_notification_handler_test.go` cases for `NotifyNewConcerts`:
+  - `ENVIRONMENT=production` → returns `PermissionDenied`
+  - unknown `concert_id` → returns `InvalidArgument`
+  - happy path (`ENVIRONMENT=development`) → delegates to use case and returns empty response
+- [ ] 5.5 Add an integration test that calls `NotifyNewConcerts` against a test DB and asserts `PushNotificationUseCase.NotifyNewConcerts` is invoked with the scoped concert set
+- [ ] 5.6 Run `make check` locally and confirm all tests pass
+
+## 6. Deploy + operate
+
+- [ ] 6.1 Coordinate deploy order: backend PR merged → ArgoCD syncs; during the sync window purge the NATS `CONCERT` stream in dev (e.g., `nats stream purge CONCERT` from inside the cluster)
+- [ ] 6.2 Verify consumer pod starts cleanly post-purge (no bad-payload CrashLoop)
+- [ ] 6.3 Validate end-to-end by invoking `PushNotificationService.NotifyNewConcerts` via `grpcurl` or a small script against dev, using one of `pepperoni9+pixel@gmail.com`'s followed artists and a cherry-picked upcoming concert; confirm the push arrives on the Pixel
+- [ ] 6.4 Repeat the NATS purge + validation in staging
+
+## 7. Documentation
+
+- [ ] 7.1 Add a short runbook note to `backend/docs/` describing the debug RPC (purpose, production gate, example invocation)
+- [ ] 7.2 Archive this change via `/opsx:archive` after PRs are merged and validation passes

--- a/proto/liverty_music/rpc/push_notification/v1/push_notification_service.proto
+++ b/proto/liverty_music/rpc/push_notification/v1/push_notification_service.proto
@@ -3,6 +3,8 @@ syntax = "proto3";
 package liverty_music.rpc.push_notification.v1;
 
 import "buf/validate/validate.proto";
+import "liverty_music/entity/v1/artist.proto";
+import "liverty_music/entity/v1/event.proto";
 import "liverty_music/entity/v1/push_subscription.proto";
 import "liverty_music/entity/v1/user.proto";
 
@@ -74,6 +76,22 @@ service PushNotificationService {
   //   - INTERNAL: An unexpected error occurred while removing the
   //     subscription.
   rpc Delete(DeleteRequest) returns (DeleteResponse);
+
+  // NotifyNewConcerts triggers the push notification delivery pipeline for a
+  // specific set of newly created concerts belonging to an artist. This RPC
+  // invokes the same code path as the CONCERT.created event consumer, but
+  // bypasses the NATS event bus for deterministic integration testing and
+  // operator-initiated re-delivery.
+  //
+  // This RPC is restricted to non-production environments. In production the
+  // server returns PERMISSION_DENIED regardless of the caller's credentials.
+  //
+  // Possible errors:
+  //   - UNAUTHENTICATED: The request does not carry a valid user session.
+  //   - PERMISSION_DENIED: The server is running in a production environment.
+  //   - INVALID_ARGUMENT: One or more concert_ids do not belong to the
+  //     specified artist, or validation constraints are not met.
+  rpc NotifyNewConcerts(NotifyNewConcertsRequest) returns (NotifyNewConcertsResponse);
 }
 
 // CreateRequest carries the browser-generated Web Push
@@ -144,3 +162,31 @@ message DeleteRequest {
 // a persisted subscription. Deleting a subscription that did not exist also
 // returns a successful empty response (idempotency).
 message DeleteResponse {}
+
+// NotifyNewConcertsRequest identifies the artist and the specific set of
+// newly created concerts for which push notifications should be delivered.
+//
+// The caller must supply at least one concert identifier, and every supplied
+// identifier must belong to the specified artist. If any identifier does not
+// resolve to a concert owned by the artist, the entire request is rejected
+// with INVALID_ARGUMENT (no partial delivery).
+message NotifyNewConcertsRequest {
+  // The artist whose followers should be notified.
+  entity.v1.ArtistId artist_id = 1 [(buf.validate.field).required = true];
+
+  // The identifiers of the concerts that were just created. Each must be a
+  // valid event UUID belonging to the specified artist. The delivery pipeline
+  // computes hype-level filtering and notification payloads exclusively from
+  // this set — pre-existing concerts for the same artist are excluded.
+  repeated entity.v1.EventId concert_ids = 2 [(buf.validate.field) = {
+    required: true
+    repeated: {
+      min_items: 1
+      max_items: 1000
+    }
+  }];
+}
+
+// NotifyNewConcertsResponse is returned after the delivery pipeline completes.
+// Currently empty; reserved for future delivery statistics.
+message NotifyNewConcertsResponse {}


### PR DESCRIPTION
## Summary

- Add `NotifyNewConcerts` RPC to `PushNotificationService` for deterministic integration testing of the new-concert notification delivery pipeline, bypassing the NATS event bus
- Request carries `ArtistId` + `repeated EventId` with protovalidate constraints (`min_items=1`, `max_items=1000`)
- Add OpenSpec change artifacts (proposal, design, specs, tasks) for the `scope-new-concert-notifications` change

## Test plan

- [x] `buf lint` passes
- [x] `buf format -w` applied
- [x] `buf breaking --against origin/main` confirms non-breaking (method addition only)
- [ ] CI `buf-pr-checks.yml` passes
