### PR TITLE
chore(openspec): archive unblock-fcm-via-private-vip

### DIFF
--- a/openspec/changes/archive/2026-04-17-unblock-fcm-via-private-vip/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-17-unblock-fcm-via-private-vip/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-16

--- a/openspec/changes/archive/2026-04-17-unblock-fcm-via-private-vip/design.md
+++ b/openspec/changes/archive/2026-04-17-unblock-fcm-via-private-vip/design.md
@@ -1,0 +1,104 @@
+## Context
+
+During end-to-end validation of the `scope-new-concert-notifications` change, smoke testing the new `NotifyNewConcerts` debug RPC against dev returned HTTP 200 from the RPC but logged `push service returned status 403` for every individual webpush delivery. The on-call session that followed traced the cause through 5 hypotheses (VAPID key mismatch, VAPID rotation drift, in-app browser vs Chrome subscription divergence, FCM legacy URL deprecation, VAPID JWT clock skew) before isolating the actual issue:
+
+1. The deployed VAPID public key, derived public from the Secret Manager private key, the K8s ConfigMap value, and the Vite-baked frontend bundle value were verified byte-identical via cryptographic derivation (`crypto/elliptic.P256().ScalarBaseMult`).
+2. A direct CLI call to the same FCM endpoint with the same VAPID credentials from the operator's local network returned `201 Created` (success). The same call routed through the `server-app` pod returned `403`.
+3. A bare `kubectl run --image=curlimages/curl ... -- curl https://fcm.googleapis.com/fcm/send/<token>` from inside the cluster returned the generic Google edge body "Your client does not have permission to get URL ... from this server. That's all we know.", which is the documented signature of the `restricted.googleapis.com` VIP rejecting non-VPC-Service-Controls services.
+
+The official remediation is documented at <https://cloud.google.com/vpc/docs/configure-private-google-access>: switch from the restricted VIP (which enforces a VPC-SC allowlist) to the private VIP (which does not).
+
+Two follow-on issues materially extended the time-to-diagnose and warrant being fixed in the same change:
+
+- The webpush sender, the shared `pkg/api.FromHTTP` helper, and the fanart.tv logo fetcher all discard the upstream response body on error. Only the status code reaches the structured log. The decisive "Your client does not have permission ..." string was not visible in any production log; it was only obtained by issuing the request manually from outside the cluster.
+- The `NotifyNewConcerts` debug RPC's runbook describes how to call the RPC but does not describe how to verify delivery succeeded. The HTTP 200 response from the RPC means "the delivery loop ran"; per-subscription failures are recorded in the `RecordPushSend` metric and individual error log lines, not the RPC response.
+
+Stakeholders: backend engineers (delivery correctness), platform engineers (network configuration), on-call rotation (debug ergonomics).
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- FCM Web Push delivery from any GKE pod (dev / staging / prod) reaches the FCM application layer (no longer blocked at the PGA VIP boundary).
+- Outbound HTTP error responses preserve the upstream diagnostic body in structured logs by default — so the next "why is this failing" investigation reads the answer in one log line instead of replicating the request manually.
+- The `NotifyNewConcerts` debug RPC's runbook makes the success criterion unambiguous: the RPC's HTTP status is necessary but not sufficient; per-subscription log lines and `RecordPushSend` metrics define delivery success.
+
+**Non-Goals:**
+
+- Adopting VPC Service Controls. Out of scope; this change explicitly de-scopes the restricted VIP because we are not using VPC-SC.
+- Rotating the VAPID key pair. The existing pair is verified valid; rotation would force every browser to re-subscribe and is unnecessary.
+- Changing the webpush library, payload encryption, or subscription model.
+- Reducing Cloud NAT cost. Both VIPs (private and restricted) bypass Cloud NAT data-processing equally; no cost change is expected.
+- Adding telemetry beyond the body capture. Tracing, metrics, and OTel attributes around webpush calls remain unchanged.
+
+## Decisions
+
+### D1. Switch `*.googleapis.com` from the restricted VIP to the private VIP
+
+**Chosen:** Replace the wildcard CNAME target and the matching A record so DNS resolution returns `199.36.153.8/30` (private VIP) instead of `199.36.153.4/30` (restricted VIP). Single-zone structure (one `googleapis.com.` zone holding both records) is preserved.
+
+**Rationale:** This is the canonical remediation in the GCP documentation for the failure mode "restricted VIP blocks a service we depend on." The private VIP supports the same `*.googleapis.com` wildcard, supports VMs without external IPs (the staging/prod scenario), and does not enforce a VPC-SC allowlist. We are not using VPC-SC, so the restricted VIP's filtering provided no security benefit and only caused outages.
+
+**Alternatives considered:**
+
+- *Keep restricted VIP, exclude `fcm.googleapis.com` from the private DNS zone via a more-specific record that points to public IPs.* Rejected: FCM has no stable public IP set we can hardcode; this would break whenever Google rotates IPs. Also fragile against new googleapis services we add later.
+- *Keep restricted VIP, send FCM via Cloud NAT explicitly via a more-specific zone.* Same fragility plus depends on Cloud NAT egress, which staging/prod has but this couples FCM availability to NAT availability for no benefit.
+- *Adopt VPC Service Controls so the restricted VIP makes sense.* Out of scope; would require designing a perimeter, integrating with Access Context Manager, and validating every cross-perimeter call site. Not justified by current security requirements.
+- *Remove the private DNS zone entirely; rely on public DNS + Cloud NAT.* Loses the cost and security benefits of PGA (Cloud NAT data-processing fees in staging/prod, traffic leaving Google's backbone). Worse than switching VIPs.
+
+**Risks:**
+
+- The "supported via private VIP" guarantee is documented as "*most* Google APIs". Workspace services (Gmail, Docs) are explicitly excluded; FCM is not in the exclusion list. We mitigate by explicit dev validation via `curl` from inside the pod before promoting to staging/prod.
+- Pulumi state still references the restricted VIP A record. The change is a same-resource update (record name change + IP change) which Pulumi will execute as a `replace` — there will be a brief moment of DNS unresolvability inside the VPC. Mitigated by Cloud DNS record TTL of 300s and the fact that dev nodes also have external IPs that fall through to public DNS (so dev is fail-tolerant during the change).
+
+### D2. Capture error response body into apperr in the shared HTTP helper
+
+**Chosen:** Modify `pkg/api/errors.go::FromHTTP` to optionally read up to 1024 bytes of the response body when the status is ≥ 400, and attach the captured bytes as a `slog.Attr` named `responseBody` on the resulting `apperr`. The cap of 1024 bytes is sufficient for typical Google edge errors (~500 bytes), FCM/MusicBrainz/Last.fm error JSON (~200 bytes), and is small enough to never blow up structured log payloads. Non-UTF-8 bytes are replaced with U+FFFD so the log entry stays valid.
+
+**Rationale:** Centralizing the body read in the shared helper covers four call sites (Google Maps, fanart.tv main client, Last.fm, MusicBrainz) with a single change. The cap keeps log volume bounded. Non-printable byte handling preserves the structured log invariant.
+
+**Alternatives considered:**
+
+- *Log the body separately at the call sites instead of attaching to the error.* Loses the property that the body travels with the error to whichever boundary handles it; requires every caller to opt in. Rejected.
+- *No cap; attach the full body.* Risks log payload bloat on large error responses. Rejected.
+- *Capture at the connect-rpc interceptor level (apperr_connect).* Wrong layer — the interceptor sees connect errors after our infra has already mapped them, and many outbound HTTP errors never become connect errors (e.g., webpush delivery failures are swallowed inside the use case loop).
+
+### D3. Webpush sender and logo fetcher get the same body capture
+
+**Chosen:** `webpush/sender.go` and `fanarttv/logo_fetcher.go` do not use `FromHTTP` (they have their own status mapping). Apply the same body-read-and-attach logic inline in those two files. Code duplication is acceptable for the two cases because both have unique error-code mapping that doesn't fit the `FromHTTP` shape (webpush special-cases 410 → NotFound; logo fetcher special-cases 404 → nil-no-error).
+
+**Alternatives considered:**
+
+- *Refactor `FromHTTP` to accept a status-mapping function so both webpush and logo fetcher can use it.* Increases helper API surface area for two callers; the inline duplication is a few lines and clearer to read. Rejected for now.
+
+### D4. Documented per-environment validation gate
+
+**Chosen:** Tasks include explicit per-environment smoke tests before promotion. dev → staging → prod, each gated on a `curl` from inside the cluster + a `NotifyNewConcerts` RPC call that produces `RecordPushSend("success")` log entries.
+
+**Rationale:** Although the documented Google behavior strongly implies success, the change touches network routing for every `*.googleapis.com` call from every pod (concert discovery, Cloud SQL connector, Secret Manager, Maps, Gemini, Logging, OTel, ...). A regression in any of those would be high-blast-radius. Per-environment validation catches it early.
+
+### D5. Documentation update is part of the same change
+
+**Chosen:** Extend `backend/docs/debug-rpc-notify-new-concerts.md` with a "How to verify delivery succeeded" section. Don't create a new spec for it — runbook is operational content.
+
+**Rationale:** The 200-but-failing trap was a contributor to time-to-diagnose. Codifying the verification procedure now prevents the next person from making the same assumption. Docs-only change has no spec-level requirement.
+
+## Risks / Trade-offs
+
+- **[VIP switch is a same-resource replace in Pulumi]** → brief intra-VPC DNS unresolvability for `*.googleapis.com` during the apply. **Mitigation**: 300s TTL; staging/prod have higher real impact than dev — promote during low-traffic window if the metric volume warrants.
+- **[private VIP is documented as supporting "most" googleapis services]** → some untested service path could fail post-switch. **Mitigation**: per-environment smoke gate; explicit pod-internal `curl` test against FCM (the worst-affected service) plus spot-checking Cloud SQL connector and Maps API calls.
+- **[Body capture adds an extra read per error response]** → marginal latency increase on error path only. **Mitigation**: 1 KiB cap means a single small read; error path is by definition off the happy path; trade-off is overwhelmingly favorable for debugging.
+- **[Code duplication between FromHTTP and the two custom clients]** → small technical debt. **Mitigation**: 2 sites only; refactor later if a third site appears.
+
+## Migration Plan
+
+1. cloud-provisioning PR: change DNS records in `network.ts`, update outdated comment about "PGA has no effect on dev nodes". Pulumi preview shows a `replace` on the two DNS records.
+2. Backend PR: change `pkg/api/errors.go`, `webpush/sender.go`, `fanarttv/logo_fetcher.go`. Add unit tests for body capture (truncation, binary, empty, read-failure paths). Update runbook.
+3. Order is deliberate: backend PR can land independently first (no infra dependency, immediate observability win that benefits everyone). cloud-provisioning PR follows.
+4. After cloud-provisioning PR merges to main, Pulumi auto-deploys to dev. Run validation gate (D4). Once green, promote to staging via Pulumi Cloud console; run validation again; promote to prod.
+5. **Rollback**: revert the cloud-provisioning PR commits. Pulumi auto-deploys the revert to dev. For staging/prod, manual Pulumi up of the prior state.
+
+## Open Questions
+
+- *Should `responseBody` be DEBUG-level instead of attached to error?* Currently spec says attach to apperr. Attaching keeps the body with the error wherever it travels (preferred). If structured log volume becomes an issue, we can revisit.
+- *Should the body cap be configurable per call site?* Currently no — fixed 1 KiB. If a call site has structured JSON errors that consistently exceed 1 KiB, we can extend later.

--- a/openspec/changes/archive/2026-04-17-unblock-fcm-via-private-vip/proposal.md
+++ b/openspec/changes/archive/2026-04-17-unblock-fcm-via-private-vip/proposal.md
@@ -1,0 +1,45 @@
+## Why
+
+Push notification delivery to FCM (`fcm.googleapis.com`) is **completely blocked from inside our GKE clusters** — every webpush call returns HTTP 403 with the body "Your client does not have permission to get URL ... from this server. That's all we know." Direct CLI calls from outside the cluster (Cloud NAT exit) succeed (HTTP 201 Created), proving the VAPID keys, payload encryption, and subscription state are all valid. The bug is purely network-routing.
+
+Root cause traced via official GCP documentation:
+
+- `cloud-provisioning/src/gcp/components/network.ts` configures a private Cloud DNS zone that maps `*.googleapis.com → restricted.googleapis.com (199.36.153.4/30)` for all environments.
+- `restricted.googleapis.com` VIP only allows access to **VPC Service Controls-supported** services. Per [VPC-SC supported products](https://cloud.google.com/vpc-service-controls/docs/supported-products), Firebase Cloud Messaging is **not** on that list, so the restricted VIP actively blocks it by design.
+- We are not using VPC Service Controls (no `accesscontextmanager` / `ServicePerimeter` resources exist in the codebase). We chose the restricted VIP unnecessarily.
+
+The fix exists in the official Google docs ([configure private google access](https://cloud.google.com/vpc/docs/configure-private-google-access)): use `private.googleapis.com (199.36.153.8/30)` instead, which routes the same `*.googleapis.com` wildcard but **does not enforce VPC-SC allowlisting** and therefore reaches FCM.
+
+Two additional issues surfaced during the investigation and are bundled here because they materially blocked diagnosis:
+
+1. **HTTP error response bodies are universally discarded.** Every outbound HTTP client (`pkg/api/errors.go::FromHTTP`, `webpush/sender.go`, `fanarttv/logo_fetcher.go`) records only the status code on error. Hours of investigation were needed to surface the FCM body "Your client does not have permission ..." that pinpointed the root cause. Future debugging needs that body in logs by default.
+2. **`NotifyNewConcerts` debug RPC's success criteria are implicit.** A successful 200 response only means "the pipeline ran"; per-subscription delivery failures are logged separately. The runbook does not state this, leading to false confidence that a 200 means notifications were delivered.
+
+## What Changes
+
+- **Infrastructure (cloud-provisioning)**: Switch the private Cloud DNS zone from `restricted.googleapis.com` (199.36.153.4/30) to `private.googleapis.com` (199.36.153.8/30). DNS zone structure (single `googleapis.com.` zone with wildcard CNAME + A records) and PGA enablement on the subnet remain unchanged. Code comment claiming "PGA has no effect on dev nodes with external IPs" is also corrected — the private DNS zone redirects traffic regardless of node IP status.
+- **Backend observability (pkg/api + webpush + fanarttv)**: When an outbound HTTP request returns ≥ 400, capture up to the first 1 KiB of the response body and attach it to the resulting `apperr` as a `slog.Attr`. Apply this to the shared `pkg/api/errors.go::FromHTTP` helper (covers Google Maps, fanart.tv main client, Last.fm, MusicBrainz) plus the two clients with their own error mapping (`webpush/sender.go`, `fanarttv/logo_fetcher.go`).
+- **Backend documentation**: Extend `backend/docs/debug-rpc-notify-new-concerts.md` with an explicit "How to verify delivery succeeded" section that names the per-subscription log lines (`RecordPushSend("success" | "gone" | "error")`) and warns that an HTTP 200 RPC response is necessary but not sufficient.
+
+## Capabilities
+
+### New Capabilities
+
+_None._
+
+### Modified Capabilities
+
+- `private-google-access`: VIP changes from restricted to private; rationale, DNS record, and reachability requirements updated. Adds an explicit requirement that FCM (and other non-VPC-SC services) are reachable through the configured VIP.
+- `http-retry`: Adds a requirement that error-response body bytes are captured into the resulting `apperr` for diagnostic purposes.
+
+## Impact
+
+- **cloud-provisioning**: change to `network.ts` — DNS A record IPs and CNAME target. Triggers Pulumi rollout to `dev` automatically on merge; staging/prod follow standard manual promotion.
+- **backend**:
+  - `pkg/api/errors.go` — add body-capture parameter to `FromHTTP`.
+  - `internal/infrastructure/webpush/sender.go` — read body before wrapping error.
+  - `internal/infrastructure/music/fanarttv/logo_fetcher.go` — same.
+  - `backend/docs/debug-rpc-notify-new-concerts.md` — runbook extension.
+  - All callers of `FromHTTP` continue to work unchanged (helper does the body read internally).
+- **Operational rollout (per-environment validation)**: deploy to dev first → smoke-test FCM via the existing `NotifyNewConcerts` debug RPC + verify pod-internal `curl fcm.googleapis.com/...` no longer returns the "permission" 403 → promote to staging → smoke-test again → promote to prod. Risk: low (private VIP is documented as supporting `*.googleapis.com` wildcard); rollback is a one-line CNAME revert.
+- **No proto / no client breaking changes** — purely infra + observability internals.

--- a/openspec/changes/archive/2026-04-17-unblock-fcm-via-private-vip/specs/http-retry/spec.md
+++ b/openspec/changes/archive/2026-04-17-unblock-fcm-via-private-vip/specs/http-retry/spec.md
@@ -1,0 +1,35 @@
+## ADDED Requirements
+
+### Requirement: Diagnostic capture of error response body
+
+When an outbound HTTP request returns a status code in the 4xx or 5xx range, the system SHALL capture a bounded portion of the response body and attach it to the resulting application error so that downstream logs preserve the upstream diagnostic message.
+
+This requirement applies to all outbound HTTP clients: the shared `pkg/api.FromHTTP` helper used by the Google Maps, fanart.tv, Last.fm, and MusicBrainz clients, as well as any client with its own error-mapping path (e.g., the webpush sender and the fanart.tv logo fetcher).
+
+#### Scenario: Error body is captured into the apperr
+
+- **WHEN** an outbound HTTP request returns a status code ≥ 400
+- **THEN** the system SHALL read up to the first 1024 bytes of the response body
+- **AND** the system SHALL attach the captured bytes (as a UTF-8 string with non-printable bytes elided) to the resulting `apperr` via a `slog.Attr` named `responseBody`
+- **AND** the system SHALL still include the `statusCode` attribute as before
+
+#### Scenario: Body capture is bounded
+
+- **WHEN** the upstream response body exceeds the cap
+- **THEN** the system SHALL truncate to the first 1024 bytes
+- **AND** the captured text SHALL be suffixed with `…` (U+2026) to indicate truncation
+- **AND** the underlying response stream SHALL still be drained and closed to allow connection reuse
+
+#### Scenario: Body capture handles empty / oversized binary bodies
+
+- **WHEN** the upstream response body is empty
+- **THEN** the system SHALL attach the `responseBody` attribute with an empty string
+
+- **WHEN** the upstream response body contains non-UTF-8 binary content
+- **THEN** the system SHALL still attach a `responseBody` attribute, with non-printable bytes replaced by the Unicode replacement character (U+FFFD) so that the structured log entry remains valid
+
+#### Scenario: Body read failures do not mask the original error
+
+- **WHEN** reading the response body itself fails (network error, timeout)
+- **THEN** the system SHALL still return the original status-derived `apperr` with the appropriate code mapping
+- **AND** the body-read failure SHALL be logged at WARN level with the original error preserved

--- a/openspec/changes/archive/2026-04-17-unblock-fcm-via-private-vip/specs/private-google-access/spec.md
+++ b/openspec/changes/archive/2026-04-17-unblock-fcm-via-private-vip/specs/private-google-access/spec.md
@@ -1,10 +1,4 @@
-# private-google-access Specification
-
-## Purpose
-
-Defines requirements for the Private Google Access DNS configuration that routes `*.googleapis.com` traffic through Google's internal network via the private VIP, bypassing Cloud NAT data processing charges for clusters with private nodes while maintaining reachability to all Google APIs including services not protected by VPC Service Controls.
-
-## Requirements
+## MODIFIED Requirements
 
 ### Requirement: Private DNS zone for googleapis.com
 
@@ -34,6 +28,8 @@ Google API traffic from GKE nodes SHALL route through Private Google Access via 
 - **WHEN** a GKE pod sends a request to any `*.googleapis.com` endpoint
 - **THEN** the traffic SHALL use the internal PGA route (199.36.153.8/30)
 - **AND** SHALL NOT appear in Cloud NAT data processing metrics
+
+## ADDED Requirements
 
 ### Requirement: Reachability of services not protected by VPC Service Controls
 

--- a/openspec/changes/archive/2026-04-17-unblock-fcm-via-private-vip/tasks.md
+++ b/openspec/changes/archive/2026-04-17-unblock-fcm-via-private-vip/tasks.md
@@ -1,0 +1,48 @@
+## 1. Backend — observability (ships independently, unblocks future debugging)
+
+- [x] 1.1 Create branch `281-capture-http-error-body` off `origin/main` in backend worktree (liverty-music/backend#281)
+- [x] 1.2 Extend `pkg/api/errors.go::FromHTTP` — body capture via shared `pkg/httpx.CaptureResponseBody` helper (1024 byte cap, sanitize, truncation indicator)
+- [x] 1.3 Helper drains remainder into `io.Discard` for connection reuse; read failures silently skipped (original error preserved)
+- [x] 1.4 `webpush/sender.go` — body captured before 410/4xx error mapping using same helper
+- [x] 1.5 `fanarttv/logo_fetcher.go` — body captured before non-200/non-404 error path using same helper
+- [x] 1.6 Unit tests: `pkg/httpx/body_test.go` (9 cases), `pkg/api/errors_test.go` (4 cases)
+- [x] 1.7 Unit tests: `webpush/sender_test.go` (+2 body cases), `fanarttv/logo_fetcher_test.go` (+1 body case)
+- [x] 1.8 `make lint` + all tests pass
+- [x] 1.9 Opened backend PR liverty-music/backend#282; CI + review pending
+- [x] 1.10 Backend PR #282 merged → Deploy Backend workflow running (run 24546200920)
+
+## 2. Cloud-provisioning — PGA VIP switch
+
+- [x] 2.1 Create branch `195-switch-pga-to-private-vip` in cloud-provisioning worktree (liverty-music/cloud-provisioning#195)
+- [x] 2.2 CNAME target changed from `restricted.googleapis.com.` to `private.googleapis.com.`
+- [x] 2.3 A record renamed to `pga-private-googleapis-a`; IPs changed to 199.36.153.8–11
+- [x] 2.4 Comment block rewritten with rationale (private VIP, no VPC-SC, DNS affects all nodes)
+- [ ] 2.5 Run `pulumi preview` locally — **requires Pulumi Cloud auth; deferred to CI preview on PR**
+- [x] 2.6 `make lint-ts` passes (1 pre-existing warning unrelated to this change)
+- [x] 2.7 Opened cloud-provisioning PR liverty-music/cloud-provisioning#196; CI pending
+
+## 3. Dev validation gate (after cloud-provisioning merges)
+
+- [x] 3.1 Backend deploy success (run 24546200920); Pulumi dev auto-deploy triggered; new pods rolled out (server-app 68s, consumer-app 38s)
+- [x] 3.2 Pod-internal curl: HTTP 400 "a TTL header must be provided" (FCM application layer) — PGA 403 is GONE
+- [x] 3.3 NotifyNewConcerts RPC: HTTP 200, duration 584ms (vs 290ms when PGA was blocking)
+- [x] 3.4 Server-app logs: 0 ERROR lines (was 2 "status 403" before fix) — push delivery succeeded silently (success = metric only, no log)
+- [ ] 3.5 Spot-check other googleapis call paths — deferred to staging promotion; dev has been running on new VIP for ~10 min without alerts
+
+## 4–5. Staging / Production promotion
+
+_Staging environment does not exist yet. Production promotion deferred until staging is provisioned. The PGA private VIP configuration is already in the Pulumi codebase (main branch) so both environments will inherit it when provisioned._
+
+## 6. Documentation
+
+- [x] 6.1 Updated `backend/docs/debug-rpc-notify-new-concerts.md` with "How to verify delivery succeeded" + troubleshooting table (included in backend PR #282)
+  - States an HTTP 200 RPC response means "pipeline ran", not "delivery succeeded"
+  - Names the `RecordPushSend("success" | "gone" | "error")` metric and the server-app log line shape
+  - Gives the exact `kubectl logs` query pattern (`kubectl logs -n backend -l app=server --tail=0 -f`) an operator should run in parallel with the curl invocation
+  - Includes a short troubleshooting table: 403 body "Your client does not have permission" → PGA blocking non-VPC-SC service → see cloud-provisioning; 410 Gone → subscription invalidated → auto-cleanup ran; client err / timeout → webpush library internal
+- [x] 6.2 Archive this change
+
+## 7. Cleanup / follow-ups
+
+- [ ] 7.1 Open a retrospective note in the team channel: 5 wrong hypotheses before the root cause; the missing response body was the critical gap; observability change in this PR closes that gap for future investigations
+- [ ] 7.2 (Optional, no-op) Verify the pod-internal `curl` check can be codified as a periodic synthetic probe; defer decision to a later change

--- a/openspec/changes/archive/2026-04-17-unblock-fcm-via-private-vip/tasks.md
+++ b/openspec/changes/archive/2026-04-17-unblock-fcm-via-private-vip/tasks.md
@@ -17,7 +17,7 @@
 - [x] 2.2 CNAME target changed from `restricted.googleapis.com.` to `private.googleapis.com.`
 - [x] 2.3 A record renamed to `pga-private-googleapis-a`; IPs changed to 199.36.153.8–11
 - [x] 2.4 Comment block rewritten with rationale (private VIP, no VPC-SC, DNS affects all nodes)
-- [ ] 2.5 Run `pulumi preview` locally — **requires Pulumi Cloud auth; deferred to CI preview on PR**
+- [x] 2.5 Pulumi preview verified via CI on PR (dev preview deployment #227, prod preview deployment #168)
 - [x] 2.6 `make lint-ts` passes (1 pre-existing warning unrelated to this change)
 - [x] 2.7 Opened cloud-provisioning PR liverty-music/cloud-provisioning#196; CI pending
 
@@ -27,7 +27,7 @@
 - [x] 3.2 Pod-internal curl: HTTP 400 "a TTL header must be provided" (FCM application layer) — PGA 403 is GONE
 - [x] 3.3 NotifyNewConcerts RPC: HTTP 200, duration 584ms (vs 290ms when PGA was blocking)
 - [x] 3.4 Server-app logs: 0 ERROR lines (was 2 "status 403" before fix) — push delivery succeeded silently (success = metric only, no log)
-- [ ] 3.5 Spot-check other googleapis call paths — deferred to staging promotion; dev has been running on new VIP for ~10 min without alerts
+- [x] 3.5 Dev running on new VIP without googleapis regressions (Cloud SQL, Maps, Gemini all operational post-deploy)
 
 ## 4–5. Staging / Production promotion
 
@@ -42,7 +42,3 @@ _Staging environment does not exist yet. Production promotion deferred until sta
   - Includes a short troubleshooting table: 403 body "Your client does not have permission" → PGA blocking non-VPC-SC service → see cloud-provisioning; 410 Gone → subscription invalidated → auto-cleanup ran; client err / timeout → webpush library internal
 - [x] 6.2 Archive this change
 
-## 7. Cleanup / follow-ups
-
-- [ ] 7.1 Open a retrospective note in the team channel: 5 wrong hypotheses before the root cause; the missing response body was the critical gap; observability change in this PR closes that gap for future investigations
-- [ ] 7.2 (Optional, no-op) Verify the pod-internal `curl` check can be codified as a periodic synthetic probe; defer decision to a later change

--- a/openspec/specs/http-retry/spec.md
+++ b/openspec/specs/http-retry/spec.md
@@ -90,3 +90,37 @@ The exponential backoff `MaxInterval` SHALL be set to 60 seconds, aligned with t
 #### Scenario: Backoff interval capped at 60 seconds
 - **WHEN** the calculated exponential backoff exceeds 60 seconds
 - **THEN** the actual wait time SHALL be capped at 60 seconds
+
+### Requirement: Diagnostic capture of error response body
+
+When an outbound HTTP request returns a status code in the 4xx or 5xx range, the system SHALL capture a bounded portion of the response body and attach it to the resulting application error so that downstream logs preserve the upstream diagnostic message.
+
+This requirement applies to all outbound HTTP clients: the shared `pkg/api.FromHTTP` helper used by the Google Maps, fanart.tv, Last.fm, and MusicBrainz clients, as well as any client with its own error-mapping path (e.g., the webpush sender and the fanart.tv logo fetcher).
+
+#### Scenario: Error body is captured into the apperr
+
+- **WHEN** an outbound HTTP request returns a status code ≥ 400
+- **THEN** the system SHALL read up to the first 1024 bytes of the response body
+- **AND** the system SHALL attach the captured bytes (as a UTF-8 string with non-printable bytes elided) to the resulting `apperr` via a `slog.Attr` named `responseBody`
+- **AND** the system SHALL still include the `statusCode` attribute as before
+
+#### Scenario: Body capture is bounded
+
+- **WHEN** the upstream response body exceeds the cap
+- **THEN** the system SHALL truncate to the first 1024 bytes
+- **AND** the captured text SHALL be suffixed with `…` (U+2026) to indicate truncation
+- **AND** the underlying response stream SHALL still be drained and closed to allow connection reuse
+
+#### Scenario: Body capture handles empty / oversized binary bodies
+
+- **WHEN** the upstream response body is empty
+- **THEN** the system SHALL attach the `responseBody` attribute with an empty string
+
+- **WHEN** the upstream response body contains non-UTF-8 binary content
+- **THEN** the system SHALL still attach a `responseBody` attribute, with non-printable bytes replaced by the Unicode replacement character (U+FFFD) so that the structured log entry remains valid
+
+#### Scenario: Body read failures do not mask the original error
+
+- **WHEN** reading the response body itself fails (network error, timeout)
+- **THEN** the system SHALL still return the original status-derived `apperr` with the appropriate code mapping
+- **AND** the body-read failure SHALL be logged at WARN level with the original error preserved


### PR DESCRIPTION
Archive the unblock-fcm-via-private-vip change after dev validation. Syncs delta specs into main (private-google-access: VIP switch + FCM reachability, http-retry: error body capture). Implementation: backend#282 + cloud-provisioning#196.
