### PR TITLE
feat(user)!: standardize user-scoped RPC auth (explicit user_id + JWT match)

### DIFF
--- a/openspec/changes/standardize-user-scoped-rpc-auth/.openspec.yaml
+++ b/openspec/changes/standardize-user-scoped-rpc-auth/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-14

--- a/openspec/changes/standardize-user-scoped-rpc-auth/design.md
+++ b/openspec/changes/standardize-user-scoped-rpc-auth/design.md
@@ -1,0 +1,113 @@
+## Context
+
+The sibling change `fix-push-notification-toggle-sync` introduces `PushNotificationService` RPCs that carry an explicit `user_id` in the request, verified against the JWT-derived userID in the handler, with mismatches rejected as `PERMISSION_DENIED`. The rationale is defense-in-depth: if a client bug constructs a request for the wrong user, the backend catches it rather than silently operating on the JWT-inferred user.
+
+`UserService` today follows a different pattern: the client sends no user identifier, and the backend resolves everything from the JWT. Adopting two inconsistent patterns in the same codebase is a long-term liability — every future reviewer has to relearn which service does which thing, and every future service author has to make the same decision again without obvious precedent.
+
+This change aligns `UserService` to the new convention so the authenticated RPC surface is uniform. The exception is `UserService.Create`: at call time, the internal user record does not yet exist, so there is no `user_id` the caller could send that could be verified against anything — `external_id` (Zitadel `sub`) remains the only meaningful identity for that RPC.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Establish a single, documented convention: every authenticated per-user RPC body carries an explicit `user_id` verified against the JWT.
+- Migrate `UserService.Get`, `UpdateHome`, and `ResendEmailVerification` to follow the convention.
+- Extract the JWT-match check into a shared helper so it is implemented once and reused across services.
+- Document `Create`-style RPCs as the one sanctioned exception to the convention.
+
+**Non-Goals:**
+- Services that have no per-user semantics (e.g., `ConcertService.List`, `ArtistService.Search`) are out of scope — they do not carry a user identifier because they are not scoped to a user.
+- Revising the JWT validation / `authn-go` middleware stack. That layer remains as defined in the `authentication` capability.
+- Introducing role-based access control or admin RPCs.
+
+## Decisions
+
+### D1: `Create` is the sanctioned exception, and is documented as such
+
+**Decision:** `UserService.Create` does not gain a `user_id` field. The convention is stated as "every authenticated RPC body carries an explicit `user_id` **once the caller's internal user ID exists**".
+
+**Rationale:** A caller cannot send an internal `user_id` before that ID has been minted. The RPC derives the internal ID from `external_id` (Zitadel `sub`) during the create path, and the resulting `user_id` is returned to the caller for use on subsequent RPCs. Forcing a fake field here would degrade the convention's clarity.
+
+**Alternatives considered:**
+- *Have the client pre-generate the UUID and send it.* Would preserve symmetry but introduces client/server coupling on UUID format and collision semantics. The generation timing is better owned by the backend.
+- *Replace `Create` with `CreateOrGet` returning the existing record on re-invocation.* Out of scope; the current create semantics work.
+
+### D2: Shared helper / interceptor for the JWT-match check
+
+**Decision:** Implement the check as a helper function invoked at the start of each relevant handler:
+
+```go
+func requireMatchingUserID(ctx context.Context, reqUserID string) error {
+    jwtUserID := ctxutil.UserIDFromContext(ctx)
+    if reqUserID == "" {
+        return apperr.InvalidArgument("user_id is required")
+    }
+    if reqUserID != jwtUserID {
+        return apperr.PermissionDenied("user_id does not match authenticated user")
+    }
+    return nil
+}
+```
+
+**Rationale:** A Connect interceptor is attractive but would need per-RPC configuration to know which field holds the `user_id` (since proto messages have no uniform field name at that layer). A helper function keeps each handler explicit about what it is checking, while still being a one-liner at the top of each RPC. Simplicity wins over the pseudo-magic of an interceptor.
+
+**Alternatives considered:**
+- *Connect interceptor with per-message reflection.* Rejected: fragile reflection, no benefit when a one-line helper does the same job.
+- *Generated code via a protoc plugin.* Over-engineered for the current footprint; revisit only if the service count grows past ~10.
+
+### D3: Ordering behind `fix-push-notification-toggle-sync`
+
+**Decision:** This change's PR lands after `fix-push-notification-toggle-sync` is merged.
+
+**Rationale:** The push notification fix is urgent (user-visible bug). This standardization has no user-visible urgency. Keeping them in separate PRs also reduces review surface. Both changes introduce `requireMatchingUserID`; the first one to land owns the helper's creation, and the second consumes it.
+
+**Alternatives considered:**
+- *Merge into a single change.* Rejected per the user's guidance — 2-change split was chosen deliberately.
+
+### D4: Frontend userID source and persistent cache
+
+**Decision:** The frontend persists the authenticated userID to `localStorage` keyed by `external_id` (Zitadel `sub`), and `UserServiceClient` reads/writes this cache transparently. `UserService.current` remains the in-memory runtime handle; the localStorage layer is the across-reload source of truth.
+
+**Rationale:** Prior to this change, the userID was only ever in memory — populated by the first `Get` response. With `Get` now requiring a `user_id`, the "first Get learns our own userID" pattern breaks. A small localStorage cache fills the gap: the first time a userID is learned (from `Create` or a prior `Get`), it is persisted; on subsequent boots the cache is read **before** any RPC is issued.
+
+**Cache shape:**
+- Key: `liverty:userId:<external_id>` (where `<external_id>` is `auth.user.profile.sub`)
+- Value: the UUID string of the internal `user_id`
+- Writer: `UserServiceClient` on every successful `Get` / `Create` / `UpdateHome` response
+- Reader: `UserServiceClient` on-demand, keyed by the current OIDC `sub`
+- Clear: `UserServiceClient.clear()` removes the entry for the current `sub` on sign-out
+
+**Cache-miss recovery (see D5):** when the cache is empty — fresh device, cleared storage, or post-sign-up — the frontend calls `UserService.Create` unconditionally. `Create` is the sanctioned exception (D1) and now also behaves idempotently (D5), so it always returns the user entity whether the record is new or pre-existing. The returned userID is then written to the cache for all subsequent calls.
+
+### D5: `UserService.Create` becomes idempotent on duplicate `external_id`
+
+**Decision:** Change `UserService.Create`'s behavior so that a duplicate `external_id` returns the existing user (HTTP success, `CreateResponse.user` populated) instead of `connect.CodeAlreadyExists`.
+
+**Rationale:** The returning-user boot path needs a way to learn its own `user_id` without already having one. `Create` is the only RPC in the exempted bootstrap surface (D1). Making it idempotent gives the frontend a single, uniform way to resolve userID from `external_id` on any device: "call Create; the response always carries my userID." This removes the old two-step `Get` → `NotFound` → `Create` → `AlreadyExists` → `Get` dance entirely.
+
+**Semantic note:** The change is backward-compatible for the sign-up path (new user) — the response shape is unchanged. It IS a semantic change for the sign-in-on-new-device path: instead of `ALREADY_EXISTS`, the caller sees success. The frontend update removes the `ALREADY_EXISTS` branch.
+
+**Alternatives considered:**
+- *Dedicated `GetSelf` boot RPC (no `user_id`, returns `{ user_id, user }`).* Rejected: adds a second bootstrap RPC when one already exists, and weakens the "only `Create` is exempt" story.
+- *Include the existing user in the `ALREADY_EXISTS` error detail.* Rejected: abuses error payloads to carry success data; Connect's error-detail pattern is not idiomatic for this.
+- *Leave `Create` as-is and return `ALREADY_EXISTS` + store userID server-side keyed by external_id in a cookie.* Rejected: cookie adds cross-cutting state; localStorage cache keyed by `sub` is simpler client-side.
+
+## Risks / Trade-offs
+
+- **Risk:** Frontend boot flow breaks if the userID is not available before the first `UserService.Get`. → **Resolved by D4 + D5**: a localStorage cache keyed by `external_id` feeds the userID to boot-time `Get`; an idempotent `Create` provides a uniform cache-miss recovery path that always yields a userID.
+- **Risk:** Breaking the request shape causes clients on older bundles to hit `INVALID_ARGUMENT` (missing `user_id`) after the backend deploys. → Mitigation: standard frontend-follows-backend deploy order; old bundles are transient.
+- **Trade-off:** Every call site is slightly more verbose. → Mitigation: the `PushService`/`UserService` frontend wrappers abstract the `user_id` injection so business code still calls `userService.get()` without passing it explicitly.
+- **Trade-off:** The JWT check duplicates work already done by the `authn-go` middleware. → Mitigation: defense-in-depth is the whole point. The middleware authenticates; the handler authorizes the specific user scope.
+
+## Migration Plan
+
+1. Merge specification PR; publish Release; BSR gen completes.
+2. Merge backend PR. Handlers now require `user_id` in the request and reject missing or mismatched values.
+3. Merge frontend PR. All call sites inject the cached userID.
+4. Old frontend bundles in the wild will start receiving `INVALID_ARGUMENT` on the three RPCs; users refreshing will pick up the new bundle and recover. No server-side migration needed.
+
+**Rollback:** Revert in reverse (frontend → backend → specification). Because proto types change, a partial rollback fails — revert as a set.
+
+## Open Questions
+
+- ~~On frontend boot, is the userID reliably available before the first `UserService.Get`?~~ **Resolved:** audit confirmed the userID is NOT reliably available on boot (no persistent cache exists today; returning users rely on the first `Get` response to learn their own userID). Addressed by D4 (localStorage cache keyed by `external_id`) and D5 (idempotent `Create` for cache-miss recovery).
+- ~~Should the helper live in a shared package reused by `PushNotificationService` (introduced by `fix-push-notification-toggle-sync`)?~~ **Resolved:** both consumers (`UserService` and `PushNotificationService`) already live in the same flat `internal/adapter/rpc/` package, so the helper is implemented as a package-private function in a new file (e.g., `auth.go`) alongside the handlers. No new subpackage is created; YAGNI wins. If a future service lives outside that package and needs the same check, promote it then.

--- a/openspec/changes/standardize-user-scoped-rpc-auth/proposal.md
+++ b/openspec/changes/standardize-user-scoped-rpc-auth/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+The `fix-push-notification-toggle-sync` change introduces a pattern where user-scoped RPC requests carry an explicit `user_id` that is compared to the userID extracted from the JWT context; mismatches are rejected with `PERMISSION_DENIED`. This provides defense-in-depth against client bugs that would otherwise silently operate on the wrong user's data. `UserService` today uses a different pattern — it reads the userID solely from the JWT and exposes no client-supplied identifier — which means the two services now follow inconsistent authentication shapes. This change aligns `UserService` with the new pattern so the entire authenticated RPC surface behaves uniformly.
+
+## What Changes
+
+- **BREAKING**: `UserService.Get` gains a required `user_id` field in `GetRequest`. The backend verifies it matches the JWT-derived userID; mismatches return `PERMISSION_DENIED`.
+- **BREAKING**: `UserService.UpdateHome` gains a required `user_id` field in `UpdateHomeRequest`, verified the same way.
+- **BREAKING**: `UserService.ResendEmailVerification` gains a required `user_id` field in `ResendEmailVerificationRequest`, verified the same way.
+- `UserService.Create` remains exempt from the `user_id` convention (no `user_id` on the request), but its behavior on duplicate `external_id` changes: instead of returning `ALREADY_EXISTS`, the RPC SHALL return the existing user as a successful response. This makes `Create` idempotent and gives the frontend a single uniform way to resolve its internal `user_id` from `external_id` on any device, which is required for the boot-time cache-miss recovery path (see `design.md` D4/D5).
+- Introduce a shared backend helper (interceptor or function) `requireMatchingUserID(ctx, reqUserID)` that compares the JWT userID to the request-supplied value, returning `PERMISSION_DENIED` on mismatch. Reuse it across `UserService` and `PushNotificationService`.
+- Frontend: update every `UserService.Get`/`UpdateHome`/`ResendEmailVerification` call site to include the cached `user_id`.
+
+## Capabilities
+
+### New Capabilities
+- `rpc-auth-scoping`: Defines the cross-service convention that every authenticated per-user RPC (except creation RPCs where the caller's internal ID does not yet exist) SHALL carry an explicit `user_id` in the request body, verified against the JWT-derived userID in the handler.
+
+### Modified Capabilities
+- `user-home`: The `UpdateHome` RPC requirement changes to include the explicit `user_id` field and the JWT-match check.
+- `email-verification`: The "Resend verification email via RPC" requirement changes to include the explicit `user_id` field and the JWT-match check.
+- `user-account-sync`: The `Create` RPC becomes idempotent on duplicate `external_id` — returns the existing user as a success instead of `ALREADY_EXISTS`. The frontend boot flow drops the `ALREADY_EXISTS` branch and the follow-up `Get` call that relied on it.
+
+## Impact
+
+- **Proto (specification repo)**: Breaking changes to three `UserService` request messages. `buf skip breaking` label required on the PR.
+- **Backend**: `UserService` handlers gain the `requireMatchingUserID` check. The shared helper is implemented as a package-private function inside the existing `backend/internal/adapter/rpc/` package (next to the handlers that consume it). Handler-level tests expand to cover `PERMISSION_DENIED` paths for the three RPCs.
+- **Frontend**: A small `localStorage` cache keyed by `external_id` (Zitadel `sub`) is introduced to hold the internal `user_id` across page reloads. `UserServiceClient` writes this cache on every successful Get / Create / UpdateHome response and reads it on-demand so that business-code call sites continue to call `userService.get()` etc. without passing `user_id` explicitly. Boot flow simplifies to: read cached `user_id` by `sub`; if present, call `Get`; if absent, call the now-idempotent `Create` to obtain/create the user and hydrate the cache.
+- **Database**: No schema change.
+- **Migration**: No data migration. Clients using the old proto will receive `INVALID_ARGUMENT` on missing `user_id` after the backend deploys; this is acceptable because frontend deploys in the same release sequence.
+- **Dependency**: This change SHOULD land after `fix-push-notification-toggle-sync`. That ordering lets this change reuse the shared `requireMatchingUserID` helper introduced there, and keeps the bug fix on its faster path.

--- a/openspec/changes/standardize-user-scoped-rpc-auth/specs/email-verification/spec.md
+++ b/openspec/changes/standardize-user-scoped-rpc-auth/specs/email-verification/spec.md
@@ -1,0 +1,51 @@
+## MODIFIED Requirements
+
+### Requirement: Resend verification email via RPC
+
+The system SHALL provide an RPC method that allows authenticated users to resend the verification email for their own account. The backend SHALL proxy this request to Zitadel's `POST /v2/users/{userId}/email/resend` API.
+
+The request SHALL carry an explicit `user_id` that the backend verifies against the JWT-derived userID; mismatches SHALL be rejected with `PERMISSION_DENIED` before any Zitadel call is made.
+
+The infrastructure layer (`EmailVerifier.ResendVerification`) SHALL emit a structured INFO log entry on successful API call completion, and a structured ERROR log entry on failure. Both log entries MUST include the `external_id` field.
+
+#### Scenario: User requests resend from Settings page
+
+- **WHEN** an authenticated user calls the resend verification RPC
+- **AND** the supplied `user_id` equals the userID derived from the JWT
+- **THEN** the backend SHALL extract the user's `external_id` from JWT claims
+- **AND** the backend SHALL call Zitadel's email resend API with the `external_id`
+- **AND** Zitadel SHALL send a new verification email to the user
+
+#### Scenario: Resend Zitadel API call succeeds
+
+- **WHEN** `EmailVerifier.ResendVerification` is called and the Zitadel `ResendEmailCode` API call completes successfully
+- **THEN** `EmailVerifier.ResendVerification` SHALL emit an INFO log entry with `msg="email verification resent"` and `external_id`
+
+#### Scenario: Resend Zitadel API call fails
+
+- **WHEN** `EmailVerifier.ResendVerification` is called and the Zitadel `ResendEmailCode` API call returns an error
+- **THEN** `EmailVerifier.ResendVerification` SHALL emit an ERROR log entry with `msg="failed to resend email code"` and `external_id`
+- **AND** the error SHALL be returned to the caller
+
+#### Scenario: User is already verified
+
+- **WHEN** an authenticated user whose email is already verified calls the resend verification RPC
+- **AND** the supplied `user_id` equals the userID derived from the JWT
+- **THEN** the backend SHALL return a `FailedPrecondition` error indicating the email is already verified
+
+#### Scenario: Rapid resend attempts
+
+- **WHEN** a user calls the resend verification RPC more than 3 times within 10 minutes
+- **THEN** the backend SHALL return a `ResourceExhausted` error
+
+#### Scenario: Unauthenticated request
+
+- **WHEN** an unauthenticated request calls the resend verification RPC
+- **THEN** the backend SHALL reject the request with an authentication error
+
+#### Scenario: user_id does not match authenticated user
+
+- **WHEN** the resend verification RPC is called with a `user_id` that differs from the userID derived from the JWT
+- **THEN** the backend SHALL return `PERMISSION_DENIED`
+- **AND** no Zitadel API call SHALL be made
+- **AND** the `EmailVerifier.ResendVerification` infrastructure path SHALL NOT be invoked

--- a/openspec/changes/standardize-user-scoped-rpc-auth/specs/rpc-auth-scoping/spec.md
+++ b/openspec/changes/standardize-user-scoped-rpc-auth/specs/rpc-auth-scoping/spec.md
@@ -1,0 +1,53 @@
+## ADDED Requirements
+
+### Requirement: Explicit user_id in authenticated per-user RPC bodies
+
+The system SHALL require that every authenticated RPC scoped to a specific user — except creation RPCs where the caller's internal user ID does not yet exist — carries an explicit `entity.v1.UserId` field in its request message. The field SHALL be marked required via `protovalidate`. The backend SHALL compare the supplied value against the userID derived from the JWT context and reject mismatches with `PERMISSION_DENIED`.
+
+#### Scenario: Matching user_id passes authorization
+
+- **WHEN** an authenticated client calls a per-user RPC with `user_id` equal to the JWT-derived userID
+- **THEN** the handler SHALL proceed with normal processing
+
+#### Scenario: Mismatched user_id is rejected
+
+- **WHEN** an authenticated client calls a per-user RPC with `user_id` that differs from the JWT-derived userID
+- **THEN** the handler SHALL return `PERMISSION_DENIED`
+- **AND** no business logic SHALL execute
+- **AND** the response SHALL NOT reveal whether the requested user exists or what data they have
+
+#### Scenario: Missing user_id is rejected
+
+- **WHEN** an authenticated client calls a per-user RPC with an absent or empty `user_id`
+- **THEN** the handler SHALL return `INVALID_ARGUMENT` via `protovalidate` enforcement
+
+#### Scenario: Unauthenticated request is rejected before user_id check
+
+- **WHEN** a client calls a per-user RPC without a valid JWT
+- **THEN** the authentication middleware SHALL reject the request with `UNAUTHENTICATED` before the `user_id` check runs
+
+### Requirement: Creation RPCs are exempt from the user_id convention
+
+The system SHALL treat creation RPCs that mint a new internal user record as an exception to the `user_id` convention. Such RPCs SHALL identify the caller via `external_id` (the identity provider's `sub` claim) extracted from the JWT, not via a client-supplied `user_id`.
+
+#### Scenario: User creation does not require user_id
+
+- **WHEN** a client calls `UserService.Create` (or any analogous creation RPC that mints a new internal user ID)
+- **THEN** the request SHALL NOT carry a `user_id` field
+- **AND** the backend SHALL extract `external_id` from the JWT context to identify the identity provider user
+- **AND** the backend SHALL return the newly minted `UserId` in the response for the client to use on subsequent RPCs
+
+### Requirement: Shared JWT-match helper
+
+The backend SHALL expose a single shared helper — implemented as either a function or an interceptor — that performs the `user_id` verification. All handlers performing the check SHALL invoke this shared helper rather than implementing the comparison inline.
+
+#### Scenario: Handlers reuse the shared helper
+
+- **WHEN** any handler performs the `user_id` vs JWT-userID check
+- **THEN** the handler SHALL delegate to the shared helper (e.g., `requireMatchingUserID(ctx, reqUserID)`)
+- **AND** the helper SHALL return the same `PERMISSION_DENIED` / `INVALID_ARGUMENT` error semantics regardless of call site
+
+#### Scenario: Helper is discoverable
+
+- **WHEN** a developer adds a new per-user RPC handler
+- **THEN** the shared helper SHALL reside in the same internal package as the handlers that use it (currently `internal/adapter/rpc/`), implemented as a package-private function. If a future service lives outside that package and needs the same check, the helper SHALL be promoted to a shared location at that point — not speculatively ahead of demand.

--- a/openspec/changes/standardize-user-scoped-rpc-auth/specs/user-account-sync/spec.md
+++ b/openspec/changes/standardize-user-scoped-rpc-auth/specs/user-account-sync/spec.md
@@ -1,0 +1,47 @@
+## MODIFIED Requirements
+
+### Requirement: User Account Provisioning on Signup
+
+The system SHALL create a local user record in the application database when a user completes the onboarding tutorial and authenticates via Passkey. The provisioning is triggered by the guest data merge process at the end of the tutorial.
+
+The `UserService.Create` RPC SHALL be idempotent on duplicate `external_id`: a second call for the same `external_id` SHALL return the existing user as a successful response rather than `connect.CodeAlreadyExists`. This allows the frontend to treat `Create` as a uniform "resolve-or-provision" bootstrap RPC on any device, regardless of whether the user was provisioned in a prior session.
+
+#### Scenario: Successful signup provisioning from tutorial
+
+- **WHEN** a user completes Passkey authentication at tutorial Step 6
+- **AND** the frontend has no cached `user_id` for the authenticated `external_id`
+- **THEN** the frontend SHALL call the `Create` RPC with the user's `email` parameter
+- **AND** the backend SHALL extract `external_id` (from JWT `sub` claim) and `name` (from JWT `name` claim)
+- **AND** the backend SHALL create a new user record with `external_id`, `email`, and `name` persisted
+- **AND** the backend SHALL return the newly created `User` entity in `CreateResponse.user`
+- **AND** the frontend SHALL cache the returned `user_id` in `localStorage` keyed by `external_id`
+- **AND** the frontend SHALL then proceed to sync guest data (follows, passion levels)
+
+#### Scenario: Successful provisioning from Login link
+
+- **WHEN** a returning user authenticates via the [Login] link on the LP
+- **AND** the frontend has no cached `user_id` for the authenticated `external_id` (e.g., fresh device or cleared storage)
+- **THEN** the frontend SHALL call the `Create` RPC with the user's `email` parameter
+- **AND** the backend SHALL either create a new record (first-ever sign-in) or return the existing record (returning user)
+- **AND** the frontend SHALL cache the returned `user_id` in `localStorage` keyed by `external_id`
+
+#### Scenario: Duplicate Create call returns the existing user idempotently
+
+- **WHEN** the `Create` RPC is called with an `external_id` that already exists in the database
+- **THEN** the backend SHALL return `OK` with `CreateResponse.user` populated from the existing row
+- **AND** the backend SHALL NOT return `connect.CodeAlreadyExists`
+- **AND** the backend SHALL NOT modify the existing `email` or `name` fields (the duplicate call is a read, not an upsert)
+- **AND** the frontend SHALL treat the response identically to a fresh creation — cache the `user_id` and proceed
+
+#### Scenario: Cached userID is reused on subsequent boots
+
+- **WHEN** the app boots for a user whose `external_id` has a cached `user_id` in `localStorage`
+- **THEN** the frontend SHALL read the cached `user_id` **before** issuing any authenticated per-user RPC
+- **AND** the frontend SHALL call `UserService.Get` with the cached `user_id` to hydrate the current profile
+- **AND** the backend SHALL verify the supplied `user_id` matches the JWT-derived userID (per `rpc-auth-scoping`)
+
+#### Scenario: Cached userID is cleared on sign-out
+
+- **WHEN** the user signs out via the auth service
+- **THEN** the frontend SHALL remove the `localStorage` entry keyed by the signed-out user's `external_id`
+- **AND** the next sign-in SHALL follow the cache-miss path (call `Create` to resolve the `user_id`)

--- a/openspec/changes/standardize-user-scoped-rpc-auth/specs/user-home/spec.md
+++ b/openspec/changes/standardize-user-scoped-rpc-auth/specs/user-home/spec.md
@@ -1,0 +1,57 @@
+## MODIFIED Requirements
+
+### Requirement: Update Home RPC
+
+The system SHALL provide a dedicated RPC for users to set or change their home area. The request SHALL carry an explicit `user_id` that the backend verifies against the JWT-derived userID; mismatches SHALL be rejected with `PERMISSION_DENIED`.
+
+#### Scenario: Set home area
+
+- **WHEN** an authenticated user calls `UserService.UpdateHome` with a valid structured `Home`
+- **AND** the supplied `user_id` equals the userID derived from the JWT
+- **THEN** the system SHALL create or update the home record in the `homes` table
+- **AND** associate it with the user's `home_id`
+- **AND** the response SHALL include the updated `User` entity
+
+#### Scenario: Invalid code values
+
+- **WHEN** `UpdateHome` is called with a `country_code` that is not a valid ISO 3166-1 alpha-2 code
+- **OR** a `level_1` that does not match a known ISO 3166-2 subdivision code
+- **THEN** the system SHALL return `INVALID_ARGUMENT`
+
+#### Scenario: Unauthenticated request
+
+- **WHEN** `UpdateHome` is called without valid authentication
+- **THEN** the system SHALL return `UNAUTHENTICATED`
+
+#### Scenario: user_id does not match authenticated user
+
+- **WHEN** `UpdateHome` is called with a `user_id` that differs from the userID derived from the JWT
+- **THEN** the system SHALL return `PERMISSION_DENIED`
+- **AND** the `homes` table SHALL NOT be modified
+
+#### Scenario: Missing user_id
+
+- **WHEN** `UpdateHome` is called without a `user_id` field
+- **THEN** the system SHALL return `INVALID_ARGUMENT` via `protovalidate` enforcement
+
+### Requirement: Home included in User retrieval
+
+The `User.home` field SHALL be populated in all RPCs that return a `User` entity. `UserService.Get` requests SHALL carry an explicit `user_id` that the backend verifies against the JWT-derived userID; mismatches SHALL be rejected with `PERMISSION_DENIED`.
+
+#### Scenario: Get returns home
+
+- **WHEN** `UserService.Get` is called for a user who has set their home area
+- **AND** the supplied `user_id` equals the userID derived from the JWT
+- **THEN** the returned `User.home` field SHALL contain the full structured home (country_code, level_1, and level_2 if set)
+
+#### Scenario: Get returns nil home
+
+- **WHEN** `UserService.Get` is called for a user who has not set their home area
+- **AND** the supplied `user_id` equals the userID derived from the JWT
+- **THEN** the returned `User.home` field SHALL be absent (not set)
+
+#### Scenario: Get rejects mismatched user_id
+
+- **WHEN** `UserService.Get` is called with a `user_id` that differs from the userID derived from the JWT
+- **THEN** the system SHALL return `PERMISSION_DENIED`
+- **AND** the response SHALL NOT carry any user data

--- a/openspec/changes/standardize-user-scoped-rpc-auth/tasks.md
+++ b/openspec/changes/standardize-user-scoped-rpc-auth/tasks.md
@@ -6,13 +6,13 @@
 
 ## 2. Specification (proto)
 
-- [ ] 2.1 Update `proto/liverty_music/rpc/user/v1/user_service.proto`: add required `entity.v1.UserId user_id = 1` to `GetRequest`
-- [ ] 2.2 Add required `entity.v1.UserId user_id` (field 1) to `UpdateHomeRequest`; shift existing `home` to field 2
-- [ ] 2.3 Add required `entity.v1.UserId user_id = 1` to `ResendEmailVerificationRequest`
-- [ ] 2.4 Update all doc comments to reflect the new `user_id` field and the JWT-match behavior, including `PERMISSION_DENIED` in the Possible Errors list for `Get`, `UpdateHome`, and `ResendEmailVerification`
-- [ ] 2.5 Do NOT add `user_id` to `CreateRequest`; update `CreateRequest`'s doc to explicitly state that creation RPCs are exempt per the `rpc-auth-scoping` capability, AND that the RPC is idempotent on duplicate `external_id` (returns the existing user rather than `ALREADY_EXISTS`) per `user-account-sync`
-- [ ] 2.6 Run `buf lint` and `buf format -w` until clean
-- [ ] 2.7 Run `buf breaking --against '.git#branch=main'` and expect breaking changes; add the `buf skip breaking` PR label
+- [x] 2.1 Update `proto/liverty_music/rpc/user/v1/user_service.proto`: add required `entity.v1.UserId user_id = 1` to `GetRequest`
+- [x] 2.2 Add required `entity.v1.UserId user_id` (field 1) to `UpdateHomeRequest`; shift existing `home` to field 2
+- [x] 2.3 Add required `entity.v1.UserId user_id = 1` to `ResendEmailVerificationRequest`
+- [x] 2.4 Update all doc comments to reflect the new `user_id` field and the JWT-match behavior, including `PERMISSION_DENIED` in the Possible Errors list for `Get`, `UpdateHome`, and `ResendEmailVerification`
+- [x] 2.5 Do NOT add `user_id` to `CreateRequest`; update `CreateRequest`'s doc to explicitly state that creation RPCs are exempt per the `rpc-auth-scoping` capability, AND that the RPC is idempotent on duplicate `external_id` (returns the existing user rather than `ALREADY_EXISTS`) per `user-account-sync`
+- [x] 2.6 Run `buf lint` and `buf format -w` until clean
+- [x] 2.7 Run `buf breaking --against '.git#branch=main'` and expect breaking changes; add the `buf skip breaking` PR label
 - [ ] 2.8 Commit and open specification PR; merge; create GitHub Release so `buf-release.yml` publishes to BSR
 
 ## 3. Backend — shared helper

--- a/openspec/changes/standardize-user-scoped-rpc-auth/tasks.md
+++ b/openspec/changes/standardize-user-scoped-rpc-auth/tasks.md
@@ -1,0 +1,53 @@
+## 1. Pre-work — audit the frontend userID boot flow
+
+- [x] 1.1 Read `frontend/src/services/user-service.ts` and the auth-callback route to document where the authenticated userID is first learned and how it is cached across reloads
+- [x] 1.2 Confirm or falsify the assumption that the userID is reliably available to `UserService.Get`'s first invocation (either from a `Create` response for sign-up, or from cached session data for returning users) — **FALSIFIED**: three boot paths (`UserHydrationTask`, `auth-callback` returning user, new device) hit `Get` before any userID is known
+- [x] 1.3 Design a minimal cache layer and document it in design.md — **Resolved**: D4 adds a `localStorage` cache keyed by `external_id`; D5 makes `UserService.Create` idempotent to provide a uniform cache-miss recovery path
+
+## 2. Specification (proto)
+
+- [ ] 2.1 Update `proto/liverty_music/rpc/user/v1/user_service.proto`: add required `entity.v1.UserId user_id = 1` to `GetRequest`
+- [ ] 2.2 Add required `entity.v1.UserId user_id` (field 1) to `UpdateHomeRequest`; shift existing `home` to field 2
+- [ ] 2.3 Add required `entity.v1.UserId user_id = 1` to `ResendEmailVerificationRequest`
+- [ ] 2.4 Update all doc comments to reflect the new `user_id` field and the JWT-match behavior, including `PERMISSION_DENIED` in the Possible Errors list for `Get`, `UpdateHome`, and `ResendEmailVerification`
+- [ ] 2.5 Do NOT add `user_id` to `CreateRequest`; update `CreateRequest`'s doc to explicitly state that creation RPCs are exempt per the `rpc-auth-scoping` capability, AND that the RPC is idempotent on duplicate `external_id` (returns the existing user rather than `ALREADY_EXISTS`) per `user-account-sync`
+- [ ] 2.6 Run `buf lint` and `buf format -w` until clean
+- [ ] 2.7 Run `buf breaking --against '.git#branch=main'` and expect breaking changes; add the `buf skip breaking` PR label
+- [ ] 2.8 Commit and open specification PR; merge; create GitHub Release so `buf-release.yml` publishes to BSR
+
+## 3. Backend — shared helper
+
+- [ ] 3.1 Add a package-private helper `requireMatchingUserID(ctx context.Context, reqUserID string) error` to `backend/internal/adapter/rpc/` (new file, e.g., `auth.go`) returning `apperr.InvalidArgument` for empty input and `apperr.PermissionDenied` for mismatch
+- [ ] 3.2 Add unit tests covering the three outcomes (match, mismatch, empty)
+- [ ] 3.3 Refactor `PushNotificationService.Get` and `Delete` handlers (introduced by `fix-push-notification-toggle-sync`) in the same `rpc` package to call the shared `requireMatchingUserID` helper
+
+## 4. Backend — UserService handlers
+
+- [ ] 4.1 Update the `UserService.Get` handler in `backend/internal/adapter/rpc/user_handler.go`: extract `req.UserId.Value`, call `requireMatchingUserID(ctx, reqUserID)`; on success, proceed with existing logic
+- [ ] 4.2 Update `UpdateHome` handler the same way
+- [ ] 4.3 Update `ResendEmailVerification` handler the same way
+- [ ] 4.4 Change `Create` handler to be idempotent on duplicate `external_id`: when the user already exists, return the existing `User` in `CreateResponse.user` with an OK response instead of `apperr.AlreadyExists`. `email`/`name` fields on the existing row SHALL NOT be overwritten
+- [ ] 4.5 Add/update unit tests for `Create`: (a) fresh user creation path (existing behavior); (b) duplicate `external_id` returns existing user via OK; (c) any remaining failure modes still map to their original errors
+- [ ] 4.6 Add handler-level unit tests for `Get` / `UpdateHome` / `ResendEmailVerification` covering: JWT-match success, mismatch (→ `PermissionDenied`), empty `user_id` (→ `InvalidArgument`)
+- [ ] 4.7 Run `make check`
+- [ ] 4.8 Open backend PR (default: hold until BSR gen completes to avoid CI noise); merge once CI passes post-BSR
+
+## 5. Frontend — userID cache + call site migration
+
+- [ ] 5.1 Add a `userId` localStorage key constant to `src/constants/storage-keys.ts` using the pattern `liverty:userId:<external_id>`, plus small read/write/clear helpers keyed by `external_id`
+- [ ] 5.2 Update `UserServiceClient` so that `get()`, `updateHome()`, and `resendEmailVerification()` read the cached `user_id` from localStorage (via `IAuthService.user.profile.sub`) and inject it into the request. Business-code call sites MUST remain unchanged (still call `userService.get()` etc. with the same signatures)
+- [ ] 5.3 Update `UserServiceClient` so that every successful `get`/`create`/`updateHome` response writes the userID to the cache keyed by the current `external_id`
+- [ ] 5.4 Simplify `auth-callback-route.ensureUserProvisioned` and `user-hydration-task` to the new flow: (a) if cache has `user_id` → call `Get`; (b) otherwise → call `Create` (now idempotent), hydrate cache, done. Remove the old `Get`-then-`Create`-on-NotFound-then-`Get`-on-AlreadyExists dance
+- [ ] 5.5 Update `UserServiceClient.clear()` and any sign-out path to remove the cached `user_id` for the signed-out `external_id`
+- [ ] 5.6 Update unit tests: (a) `UserServiceClient` reads/writes the cache correctly; (b) `auth-callback-route` cache-hit path calls `Get` only; cache-miss path calls `Create` only; (c) duplicate-external_id response is consumed without an `ALREADY_EXISTS` catch
+- [ ] 5.7 Run `make check` in `frontend/`; resolve lint / type errors
+- [ ] 5.8 Open frontend PR (default: hold until BSR gen completes); merge once CI passes post-BSR
+
+## 6. Verification
+
+- [ ] 6.1 Deploy backend + frontend to dev; confirm existing flows (Settings page load, home area change, email resend) still work end-to-end
+- [ ] 6.2 Exercise the cache-miss boot path in dev: clear localStorage, sign in as an existing user, confirm the frontend calls `Create` and receives the existing user (OK, not `ALREADY_EXISTS`), and that subsequent calls succeed
+- [ ] 6.3 Manually simulate a mismatched `user_id` via `curl` or `grpcurl` against the dev backend; confirm `PERMISSION_DENIED` is returned
+- [ ] 6.4 Manually simulate an empty `user_id`; confirm `INVALID_ARGUMENT`
+- [ ] 6.5 Confirm the ArgoCD deployment succeeded and the new backend pod is serving requests
+- [ ] 6.6 Run `openspec validate standardize-user-scoped-rpc-auth --strict` and resolve findings

--- a/proto/liverty_music/rpc/user/v1/user_service.proto
+++ b/proto/liverty_music/rpc/user/v1/user_service.proto
@@ -9,24 +9,44 @@ import "liverty_music/entity/v1/user.proto";
 service UserService {
   // Get retrieves the profile of the authenticated user.
   //
-  // The user identity is extracted from the JWT context by the backend —
-  // clients do not provide it in the request.
+  // Per the rpc-auth-scoping convention, the request carries an explicit
+  // user_id that the backend verifies against the userID derived from the
+  // JWT context; mismatches are rejected with PERMISSION_DENIED.
   //
   // Possible errors:
+  // - INVALID_ARGUMENT: The request is missing user_id or the field is malformed.
   // - NOT_FOUND: No user record exists for the authenticated identity.
+  // - PERMISSION_DENIED: The supplied user_id does not match the authenticated caller.
   // - UNAUTHENTICATED: The request lacks valid authentication credentials.
   rpc Get(GetRequest) returns (GetResponse);
 
-  // Create registers a new user profile in the system.
+  // Create registers a new user profile in the system, or returns the
+  // existing profile when the caller's external_id (Zitadel sub) is already
+  // provisioned.
+  //
+  // Create is the sanctioned exception to the rpc-auth-scoping convention:
+  // the caller's internal user_id does not yet exist at call time, so the
+  // request does NOT carry one. The backend identifies the caller via
+  // external_id extracted from the JWT.
+  //
+  // Create is idempotent on duplicate external_id: a second call for the
+  // same external_id returns the existing user as a successful response
+  // (CreateResponse.user populated) rather than ALREADY_EXISTS. The
+  // pre-existing email and name fields on the stored row are NOT overwritten
+  // — the duplicate call is a read, not an upsert. This gives the frontend a
+  // uniform "resolve-or-provision" bootstrap RPC when its local userID cache
+  // is empty (e.g., fresh device).
   //
   // The home field may be provided when the user has already selected their
   // home area during the onboarding flow (before account creation). Supplying
-  // it here persists the home area atomically with the user record, avoiding a
-  // separate UpdateHome call immediately after sign-up.
+  // it here persists the home area atomically with the initial user record,
+  // avoiding a separate UpdateHome call immediately after sign-up. On the
+  // idempotent-return path, home is ignored — use UpdateHome to change an
+  // already-provisioned user's home area.
   //
   // Possible errors:
-  // - ALREADY_EXISTS: A user with the same unique identifier or email already exists.
   // - INVALID_ARGUMENT: The provided user data is missing required fields or is malformed.
+  // - UNAUTHENTICATED: The request lacks valid authentication credentials.
   rpc Create(CreateRequest) returns (CreateResponse);
 
   // UpdateHome sets or changes the authenticated user's home area.
@@ -35,23 +55,29 @@ service UserService {
   // "Home", "Nearby", and "Away" lanes. Users typically set this during
   // onboarding and may update it later from settings.
   //
-  // The user ID is extracted from the authenticated JWT context — clients
-  // do not provide it in the request.
+  // Per the rpc-auth-scoping convention, the request carries an explicit
+  // user_id that the backend verifies against the userID derived from the
+  // JWT context; mismatches are rejected with PERMISSION_DENIED.
   //
   // Possible errors:
-  // - INVALID_ARGUMENT: The provided home value contains an unrecognized or malformed code.
+  // - INVALID_ARGUMENT: user_id is missing, or the home value contains an unrecognized or malformed code.
   // - NOT_FOUND: No user record exists for the authenticated identity.
+  // - PERMISSION_DENIED: The supplied user_id does not match the authenticated caller.
   // - UNAUTHENTICATED: The request lacks valid authentication credentials.
   rpc UpdateHome(UpdateHomeRequest) returns (UpdateHomeResponse);
 
   // ResendEmailVerification triggers a new email verification message for the
   // authenticated user via the identity provider (Zitadel).
   //
-  // The user identity is extracted from the JWT context — clients do not
-  // provide it in the request.
+  // Per the rpc-auth-scoping convention, the request carries an explicit
+  // user_id that the backend verifies against the userID derived from the
+  // JWT context; mismatches are rejected with PERMISSION_DENIED before any
+  // Zitadel API call is made.
   //
   // Possible errors:
+  // - INVALID_ARGUMENT: The request is missing user_id or the field is malformed.
   // - FAILED_PRECONDITION: The user's email is already verified.
+  // - PERMISSION_DENIED: The supplied user_id does not match the authenticated caller.
   // - RESOURCE_EXHAUSTED: The user has exceeded the resend rate limit.
   // - UNAUTHENTICATED: The request lacks valid authentication credentials.
   // - UNAVAILABLE: The email verification service is not configured.
@@ -59,8 +85,11 @@ service UserService {
 }
 
 // GetRequest is the request for retrieving the authenticated user's profile.
-// The user identity is resolved from the JWT context — no fields are required.
-message GetRequest {}
+message GetRequest {
+  // The caller's user identifier. Must match the userID derived from the
+  // authenticated session; mismatches are rejected with PERMISSION_DENIED.
+  entity.v1.UserId user_id = 1 [(buf.validate.field).required = true];
+}
 
 // GetResponse contains the profile information of the requested user.
 message GetResponse {
@@ -71,14 +100,22 @@ message GetResponse {
 // CreateRequest provides the necessary details to register a new user profile.
 // The external_id (Zitadel sub claim) and name are extracted from the authenticated JWT context
 // by the backend and MUST NOT be provided by the client.
+//
+// Unlike the other per-user RPCs, CreateRequest does NOT carry a user_id —
+// the caller's internal user_id has not yet been minted. Create is the
+// sanctioned exception to the rpc-auth-scoping convention. See the Create
+// RPC documentation for the idempotent-return semantics on duplicate
+// external_id.
 message CreateRequest {
   // Required. The user's email address for account identity.
   entity.v1.UserEmail email = 1 [(buf.validate.field).required = true];
 
   // Optional. The user's home area, when it has already been selected during
   // the onboarding flow before account creation. Providing this field here
-  // persists the home area atomically with the user record. When absent, the
-  // home area remains unset and can be configured later via UpdateHome.
+  // persists the home area atomically with the initial user record. When
+  // absent, the home area remains unset and can be configured later via
+  // UpdateHome. Ignored on the idempotent-return path (duplicate
+  // external_id) — the existing row's home is not overwritten.
   entity.v1.Home home = 2;
 }
 
@@ -89,11 +126,14 @@ message CreateResponse {
 }
 
 // UpdateHomeRequest provides the new home area for the authenticated user.
-// The user identity is extracted from the JWT context by the backend.
 message UpdateHomeRequest {
+  // The caller's user identifier. Must match the userID derived from the
+  // authenticated session; mismatches are rejected with PERMISSION_DENIED.
+  entity.v1.UserId user_id = 1 [(buf.validate.field).required = true];
+
   // Required. The structured home area representing the user's geographic base
   // for live event attendance. See entity.v1.Home for the full code system contract.
-  entity.v1.Home home = 1 [(buf.validate.field).required = true];
+  entity.v1.Home home = 2 [(buf.validate.field).required = true];
 }
 
 // UpdateHomeResponse returns the updated user profile after the home area change.
@@ -103,9 +143,13 @@ message UpdateHomeResponse {
 }
 
 // ResendEmailVerificationRequest is the request for resending the email
-// verification message. The user identity is resolved from the JWT context —
-// no fields are required.
-message ResendEmailVerificationRequest {}
+// verification message.
+message ResendEmailVerificationRequest {
+  // The caller's user identifier. Must match the userID derived from the
+  // authenticated session; mismatches are rejected with PERMISSION_DENIED
+  // before any Zitadel API call is made.
+  entity.v1.UserId user_id = 1 [(buf.validate.field).required = true];
+}
 
 // ResendEmailVerificationResponse is returned when the verification email has
 // been successfully queued for delivery.


### PR DESCRIPTION
## Summary

Aligns `UserService` with the user_id + JWT-match convention established by `PushNotificationService`. Every authenticated per-user RPC now carries an explicit `user_id` verified against the JWT-derived userID; mismatches are rejected with `PERMISSION_DENIED` (defense-in-depth against client bugs that would otherwise silently act on the wrong user's data).

`UserService.Create` remains exempt from the `user_id` requirement (the caller's internal `user_id` does not exist at call time) and additionally becomes idempotent on duplicate `external_id` — a second call for the same external_id returns the existing user as a successful response rather than `ALREADY_EXISTS`. This gives the frontend a uniform "resolve-or-provision" bootstrap RPC for its new localStorage userID cache.

Closes #410.

## OpenSpec change

`openspec/changes/standardize-user-scoped-rpc-auth/` — proposal, design, specs, tasks.

## Breaking changes (intentional — `buf skip breaking` required)

- `GetRequest` gains a required `entity.v1.UserId user_id = 1`
- `UpdateHomeRequest`: `user_id` takes field 1; existing `home` moves to field 2
- `ResendEmailVerificationRequest` gains a required `entity.v1.UserId user_id = 1`
- `Create` no longer returns `ALREADY_EXISTS` on duplicate `external_id` — returns OK with the existing user

Frontend and backend PRs will follow BSR gen completion; client code is prepared to handle the new shape at call time.

## Test plan

- [x] `buf lint` clean
- [x] `buf format -w` no-op
- [x] `buf breaking --against '.git#branch=origin/main'` reports only the three intentional breaking diffs on `UpdateHomeRequest` (field 1 rename + type change + json_name)
- [ ] Merge + create Release (`vX.Y.Z`) → `buf-release.yml` publishes to BSR
- [ ] Downstream: backend PR bumps `buf.build/gen/go/liverty-music/schema` and consumes new types
- [ ] Downstream: frontend PR bumps `@buf/liverty-music_schema.*` and consumes new types
