### PR TITLE
docs(openspec): customize local db port to 15432

### DIFF
--- a/openspec/changes/customize-local-db-port/.openspec.yaml
+++ b/openspec/changes/customize-local-db-port/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-20

--- a/openspec/changes/customize-local-db-port/design.md
+++ b/openspec/changes/customize-local-db-port/design.md
@@ -60,6 +60,14 @@ Developers frequently work on multiple projects that each run a default-port Pos
 
 **Rationale**: Integration tests run on the host against the local `postgres` container (started via `docker compose up -d postgres --wait`). Without updating this constant, `make test` would fail after the port change. A follow-up refactor to source the port from env is out of scope.
 
+### Decision 6: Align GitHub Actions service-container host ports with the new `15432`
+
+**Chosen**: Update `.github/workflows/test.yml` and `.github/workflows/atlas-ci.yml` so the `postgres` service container's host-side port mapping is `15432:5432` (container internal port stays `5432`), and the `atlas migrate apply` URLs and `DATABASE_URL` env use `localhost:15432`.
+
+**Alternative considered**: Make `setup_test.go` read the port from env (e.g., `DATABASE_PORT`), keep CI workflows at `5432`.
+
+**Rationale**: CI service containers have no cross-project conflict risk, so the original reasoning "GitHub Actions workflows are unaffected" is technically valid in isolation. However, because `setup_test.go` hardcodes `15432`, mismatched CI and local values cause `TestMain` to fail before any test runs. Aligning the host-side mapping in CI is a 4-line change (two workflow files, port mapping + migrate URL each) and preserves the simple hardcoded-constant approach without introducing env plumbing. The env-reading alternative expands scope and requires `make test` to source `.env.test`, which is an ergonomic regression for little gain.
+
 ## Risks / Trade-offs
 
 - **Risk**: Developers with existing `compose.yml` state may have a `postgres` container still listening on `5432` after `git pull`. → **Mitigation**: Document in the tasks that developers must run `docker compose down postgres` and `docker compose up -d postgres` once after pulling; persistent volume `postgres_data` is not affected.

--- a/openspec/changes/customize-local-db-port/design.md
+++ b/openspec/changes/customize-local-db-port/design.md
@@ -1,0 +1,85 @@
+## Context
+
+The backend's local development loop depends on a Docker Compose `postgres` service that binds to the host's port `5432`. Because it uses `network_mode: host` (introduced in commit `1faa575` on 2026-02-20 as a workaround for a Podman 5 + netavark + WSL2 bridge-networking bug), Docker port mapping (`ports: "X:5432"`) is not a viable escape hatch — the container grabs whichever host port the PostgreSQL process inside it listens on.
+
+Separately, the `dev-db-access` capability (archive `2026-04-13-dev-db-local-access`) instructs developers and Claude Code agents to run `kubectl port-forward deployment/cloud-sql-proxy 5432:5432` and connect via `localhost:5432`, which collides with any other project's local PostgreSQL on the same machine.
+
+Developers frequently work on multiple projects that each run a default-port PostgreSQL. Today this forces a "stop the other project's DB first" workflow. The goal is to let liverty-music coexist with other local PostgreSQL instances on `5432` without manual intervention.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Move both liverty-music local-DB access paths (Docker Compose `postgres`, and `kubectl port-forward` to dev Cloud SQL) off port `5432` onto `15432`.
+- Preserve the Podman/WSL2 host-networking workaround (no regression to the original bridge-networking bug).
+- Keep the `DatabaseConfig.Port` default value at `5432` (matches upstream PostgreSQL convention and dev/prod Cloud SQL reality).
+- Keep the developer-facing ergonomics: `make test`, `atlas migrate apply --env local`, `docker compose up -d postgres` must continue to "just work" after the change.
+
+**Non-Goals:**
+- Changing dev/prod Cloud SQL instance ports (they stay at `5432`; only the local `port-forward` LHS changes).
+- Changing GitHub Actions service-container ports (`5432:5432` in workflow files — these are isolated CI environments and free of local conflicts).
+- Introducing per-developer port customization (single fixed port `15432` for the whole project).
+- Revisiting the `network_mode: host` decision.
+
+## Decisions
+
+### Decision 1: Keep `network_mode: host`, change the PostgreSQL listen port via `-p` flag
+
+**Chosen**: Keep `network_mode: host` in `compose.yml` and pass `command: ["postgres", "-p", "15432"]` (and update the `pg_isready` healthcheck with `-p 15432`).
+
+**Alternative considered**: Remove `network_mode: host` and use port mapping `ports: "15432:5432"`.
+
+**Rationale**: Commit `1faa575` adopted host networking specifically because Podman 5 + netavark on WSL2 fails to forward bridge-network ports to the host, making `localhost:X` unreachable. Reverting to bridge networking would reintroduce that bug for affected developers. Changing the postgres listen port keeps the workaround intact while solving the conflict.
+
+### Decision 2: Port number — `15432` (1-prefix convention)
+
+**Chosen**: `15432`.
+
+**Alternative considered**: `54322` (second-postgres convention), `55432` (project-specific extension).
+
+**Rationale**: The 1-prefix convention (`15432`) is widely used in Docker tutorials and PostgreSQL documentation for "an alternate PostgreSQL instance", is easy to remember, and is unambiguous. `54322` is often already consumed by other projects following the same "second-instance" pattern.
+
+### Decision 3: Align the dev Cloud SQL `port-forward` LHS to the same `15432`
+
+**Chosen**: The `dev-db-access` spec prescribes `kubectl port-forward deployment/cloud-sql-proxy 15432:5432` and `psql "... port=15432 ..."`.
+
+**Alternative considered**: Use a different port for dev port-forward (e.g., `15433`) to allow running local compose and dev port-forward simultaneously.
+
+**Rationale**: Local compose and dev port-forward are mutually exclusive by design (the capability is explicitly "dev-only, not for local Docker Compose"). Using a single non-default port `15432` minimises what developers must memorise and keeps config uniform.
+
+### Decision 4: Keep `DatabaseConfig.Port` default at `5432`
+
+**Chosen**: Do not modify the `default:"5432"` tag on `DatabaseConfig.Port` in `backend/pkg/config/config.go`.
+
+**Alternative considered**: Change the default to `15432`.
+
+**Rationale**: `5432` is the upstream PostgreSQL standard and matches dev/prod Cloud SQL. The default represents "when nothing is specified, assume standard PostgreSQL." Local-only port variance is expressed through `.env.test`, not through the code default. Changing the default risks silent production breakage if a deployment ever omits `DATABASE_PORT`.
+
+### Decision 5: Update `setup_test.go` alongside the environment config
+
+**Chosen**: Change the hardcoded `Port: 5432` in `internal/infrastructure/database/rdb/setup_test.go:41` to `15432`.
+
+**Rationale**: Integration tests run on the host against the local `postgres` container (started via `docker compose up -d postgres --wait`). Without updating this constant, `make test` would fail after the port change. A follow-up refactor to source the port from env is out of scope.
+
+## Risks / Trade-offs
+
+- **Risk**: Developers with existing `compose.yml` state may have a `postgres` container still listening on `5432` after `git pull`. → **Mitigation**: Document in the tasks that developers must run `docker compose down postgres` and `docker compose up -d postgres` once after pulling; persistent volume `postgres_data` is not affected.
+- **Risk**: Claude Code's `.claude/settings.json` allowlist contains literal `localhost:5432` strings for Atlas commands. Stale allowlist entries trigger permission prompts for previously-approved commands. → **Mitigation**: Update all three literal entries in the same change.
+- **Risk**: Any developer-local scripts, `.pgpass`, psql bookmarks, or IDE DB connections pointing at `localhost:5432` (for liverty-music) will break silently. → **Mitigation**: Call out in proposal's "Impact" section and in the backend PR description.
+- **Trade-off**: The `DatabaseConfig.Port` default (`5432`) now diverges from the local reality (`15432`). A developer who forgets to source `.env.test` locally would fail to connect — but `.env.test` is checked into the repo and used by all tooling, so this scenario is unlikely.
+
+## Migration Plan
+
+1. Merge `specification` PR first (spec delta for `dev-db-access`).
+2. Merge `backend` PR; it covers `compose.yml`, `.env.test`, `atlas.hcl`, `.claude/settings.json`, and `setup_test.go`.
+3. Post-merge, each developer:
+   - `docker compose down postgres`
+   - `git pull`
+   - `docker compose up -d postgres --wait`
+   - Verify `psql "host=localhost port=15432 ..."` succeeds.
+4. For dev Cloud SQL access, developers now use `kubectl port-forward deployment/cloud-sql-proxy 15432:5432 -n backend`.
+
+**Rollback**: Revert both PRs. The `postgres_data` volume is compatible with either port (port is a server runtime flag, not stored in data).
+
+## Open Questions
+
+- None. All technical decisions are resolved.

--- a/openspec/changes/customize-local-db-port/proposal.md
+++ b/openspec/changes/customize-local-db-port/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+Multiple projects on the same developer machine run PostgreSQL on the default port `5432`, causing port conflicts that force developers to stop other projects' databases before working on liverty-music. The backend's local Docker Compose `postgres` service and the dev Cloud SQL Auth Proxy `port-forward` both hardcode `5432`, making peaceful coexistence impossible without manual workarounds.
+
+## What Changes
+
+- Move the local Docker Compose `postgres` listen port from `5432` to `15432` (keep `network_mode: host` to preserve the Podman/WSL2 bridge-networking workaround).
+- Update `dev-db-access` capability so `kubectl port-forward` and the `psql` reference use `localhost:15432` instead of `localhost:5432`.
+- Keep the `DatabaseConfig.Port` default value at `5432` in `backend/pkg/config/config.go` (the default represents the upstream PostgreSQL standard; dev/prod Cloud SQL targets are unchanged).
+- Update all local-developer-facing configuration (`.env.test`, `atlas.hcl` env "local", Claude `settings.json` allowlist, integration test setup) to use `15432`.
+
+## Capabilities
+
+### New Capabilities
+<!-- None -->
+
+### Modified Capabilities
+- `dev-db-access`: The `kubectl port-forward` command and `psql` connection example change their localhost port from `5432` to `15432`. No change to the remote side (Cloud SQL still listens on `5432` via PSC).
+
+## Impact
+
+- **Affected repos**: `specification` (spec delta), `backend` (compose, env, atlas config, settings, test setup).
+- **Not affected**: `cloud-provisioning` (Cloud SQL / K8s DATABASE_PORT stays `5432`), GitHub Actions service containers, `backend/k8s/atlas/base/atlas-migration.yaml`.
+- **Developer action required**: After merging, developers must `docker compose down` and recreate the local `postgres` container; any cached `localhost:5432` bookmarks/scripts pointing to liverty-music's local DB must be updated to `15432`.
+- **No data migration**: Port change only; the `postgres_data` volume is preserved.
+- **BSR / generated code**: No proto changes.

--- a/openspec/changes/customize-local-db-port/proposal.md
+++ b/openspec/changes/customize-local-db-port/proposal.md
@@ -19,8 +19,8 @@ Multiple projects on the same developer machine run PostgreSQL on the default po
 
 ## Impact
 
-- **Affected repos**: `specification` (spec delta), `backend` (compose, env, atlas config, settings, test setup).
-- **Not affected**: `cloud-provisioning` (Cloud SQL / K8s DATABASE_PORT stays `5432`), GitHub Actions service containers, `backend/k8s/atlas/base/atlas-migration.yaml`.
+- **Affected repos**: `specification` (spec delta), `backend` (compose, env, atlas config, settings, test setup, CI workflow port mappings).
+- **Not affected**: `cloud-provisioning` (Cloud SQL / K8s DATABASE_PORT stays `5432`), `backend/k8s/atlas/base/atlas-migration.yaml`.
 - **Developer action required**: After merging, developers must `docker compose down` and recreate the local `postgres` container; any cached `localhost:5432` bookmarks/scripts pointing to liverty-music's local DB must be updated to `15432`.
 - **No data migration**: Port change only; the `postgres_data` volume is preserved.
 - **BSR / generated code**: No proto changes.

--- a/openspec/changes/customize-local-db-port/specs/dev-db-access/spec.md
+++ b/openspec/changes/customize-local-db-port/specs/dev-db-access/spec.md
@@ -1,0 +1,17 @@
+## MODIFIED Requirements
+
+### Requirement: Local DB access SHALL be established via kubectl port-forward
+
+Developers and Claude Code agents SHALL connect to the dev Cloud SQL instance by forwarding the proxy pod's port to localhost on port `15432`. Using `15432` avoids conflicts with other locally-running PostgreSQL instances on the default port `5432`.
+
+#### Scenario: Agent or developer establishes a local connection
+
+- **WHEN** the user runs `kubectl port-forward deployment/cloud-sql-proxy 15432:5432 -n backend`
+- **THEN** `localhost:15432` SHALL be forwarded to the Cloud SQL Auth Proxy Pod on its port `5432`
+- **AND** connections to `localhost:15432` SHALL reach the dev Cloud SQL instance via PSC
+- **AND** the user SHALL authenticate as `backend-app@liverty-music-dev.iam` (IAM auth, no password)
+
+#### Scenario: Agent connects using psql
+
+- **WHEN** port-forward is active
+- **THEN** the agent SHALL connect with: `psql "host=localhost port=15432 user=backend-app@liverty-music-dev.iam dbname=liverty-music sslmode=disable options='-c search_path=app'"`

--- a/openspec/changes/customize-local-db-port/tasks.md
+++ b/openspec/changes/customize-local-db-port/tasks.md
@@ -18,6 +18,8 @@
 - [ ] 3.2 Update the `env "local"` block in `backend/atlas.hcl` so `url` uses `localhost:15432`
 - [ ] 3.3 Replace `localhost:5432` with `localhost:15432` in all three atlas allowlist entries in `backend/.claude/settings.json`
 - [ ] 3.4 Change `Port: 5432` to `Port: 15432` in `backend/internal/infrastructure/database/rdb/setup_test.go:41`
+- [ ] 3.5 Update `backend/.github/workflows/test.yml`: change both postgres service port mappings to `15432:5432` and both `atlas migrate apply` URLs to `localhost:15432`
+- [ ] 3.6 Update `backend/.github/workflows/atlas-ci.yml`: change the postgres service port mapping to `15432:5432` and the `DATABASE_URL` env to `localhost:15432`
 
 ## 4. Backend repo — verification
 

--- a/openspec/changes/customize-local-db-port/tasks.md
+++ b/openspec/changes/customize-local-db-port/tasks.md
@@ -1,0 +1,38 @@
+## 1. Specification repo — spec delta
+
+- [x] 1.1 Run `openspec validate customize-local-db-port --strict` and fix any issues
+- [x] 1.2 Commit spec delta on branch `customize-local-db-port`
+- [ ] 1.3 Open PR to `specification/main`, wait for `buf-pr-checks.yml` to pass
+- [ ] 1.4 Merge PR
+
+## 2. Backend repo — local Docker Compose postgres listen port
+
+- [ ] 2.1 Add `command: ["postgres", "-p", "15432"]` to the `postgres` service in `backend/compose.yml`
+- [ ] 2.2 Update the `postgres` healthcheck in `backend/compose.yml` to `pg_isready -U test-user -d test-db -p 15432`
+- [ ] 2.3 Recreate the container locally: `docker compose down postgres` then `docker compose up -d postgres --wait`
+- [ ] 2.4 Verify connectivity: `psql -h localhost -p 15432 -U test-user -d test-db -c 'SELECT 1'` succeeds
+
+## 3. Backend repo — developer-facing configuration
+
+- [ ] 3.1 Change `DATABASE_PORT=5432` to `DATABASE_PORT=15432` in `backend/.env.test`
+- [ ] 3.2 Update the `env "local"` block in `backend/atlas.hcl` so `url` uses `localhost:15432`
+- [ ] 3.3 Replace `localhost:5432` with `localhost:15432` in all three atlas allowlist entries in `backend/.claude/settings.json`
+- [ ] 3.4 Change `Port: 5432` to `Port: 15432` in `backend/internal/infrastructure/database/rdb/setup_test.go:41`
+
+## 4. Backend repo — verification
+
+- [ ] 4.1 Run `atlas migrate apply --env local` and confirm migrations apply against the new port
+- [ ] 4.2 Run `make test` and confirm all unit tests pass
+- [ ] 4.3 Run `make check` and confirm no regressions
+
+## 5. Backend repo — commit and PR
+
+- [ ] 5.1 Commit on branch `customize-local-db-port` with a conventional commit message
+- [ ] 5.2 Open PR referencing the specification PR (or the merged spec commit if already merged)
+- [ ] 5.3 Merge after CI passes
+
+## 6. Post-merge verification
+
+- [ ] 6.1 Confirm `docker compose up -d postgres --wait` succeeds from a clean `git pull` in another worktree
+- [ ] 6.2 Confirm dev Cloud SQL access: `kubectl port-forward deployment/cloud-sql-proxy 15432:5432 -n backend` works and the updated `psql` command from the spec delta connects successfully
+- [ ] 6.3 Archive the OpenSpec change via `/opsx:archive`


### PR DESCRIPTION
## Summary

- Adds OpenSpec change `customize-local-db-port`.
- Modifies the `dev-db-access` capability so the `kubectl port-forward` target and the `psql` reference command use `localhost:15432` instead of `localhost:5432`.
- Enables liverty-music local development to coexist with other locally-running PostgreSQL instances on the default port `5432`.

## Context

Backend Docker Compose `postgres` currently binds `5432` on the host (via `network_mode: host`, a Podman/WSL2 workaround from `1faa575`). Together with `kubectl port-forward cloud-sql-proxy 5432:5432`, this forces developers to stop other projects' databases before working on liverty-music.

This change only touches the local-access side (host-side port of the proxy forward + local compose). Dev/prod Cloud SQL remains on `5432`, and `DatabaseConfig.Port` default stays `5432` to reflect the upstream PostgreSQL standard.

The paired backend PR (compose + env + atlas + Claude settings + test setup) will open after this PR is merged.

## Test plan

- [ ] `openspec validate customize-local-db-port --strict` passes
- [ ] `buf-pr-checks.yml` CI passes
