### PR TITLE
chore(openspec): archive refine-welcome-hero-focus

### DIFF
--- a/openspec/changes/archive/2026-04-20-refine-welcome-hero-focus/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-20-refine-welcome-hero-focus/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-20

--- a/openspec/changes/archive/2026-04-20-refine-welcome-hero-focus/design.md
+++ b/openspec/changes/archive/2026-04-20-refine-welcome-hero-focus/design.md
@@ -1,0 +1,109 @@
+## Context
+
+The Welcome page at `/` currently renders two vertically-stacked screens inside a single scroll container with CSS scroll-snap. Screen 1 shows the hero (brand + title + subtitle + `[Get Started]` + `[Log In]` + language switcher + floating arrow hint); Screen 2 shows the concert timetable preview followed by a repeat of `[Get Started]` + `[Log In]`. The scroll-snap is set to `y mandatory`, forcing the viewport to snap to whichever screen is closer when the user stops scrolling. All state and markup live in `frontend/src/routes/welcome/welcome-route.{html,ts,css}`.
+
+Behaviorally, this produces a pattern the user-facing design intends as "Promise → Proof" — Screen 1 delivers the core message, Screen 2 shows what the product looks like — but three observed problems break this narrative:
+
+1. Screen 2 is undiscoverable. The only affordance is a 24×24 arrow icon at the bottom edge, which does not clearly communicate "there is another screen below."
+2. `[Get Started]` is reachable on Screen 1 before the user ever reaches the proof. In analytics terms, this means users can commit to onboarding with no exposure to the preview that is meant to raise their expectations.
+3. The arrow element is positioned with `position: absolute` but its nearest positioned ancestor is the scroll container (`welcome-route` itself), so it's pinned to the bottom of the viewport at all scroll positions and appears on Screen 2 too.
+
+Exploration with the user (see the conversation that produced this change) ruled out a full single-scroll redesign because the team values the two-screen rhythm as a narrative device. The refinement below preserves that rhythm while fixing the discoverability, funnel, and positioning issues.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Ensure every user who taps `[Get Started]` has first seen the timetable preview.
+- Make the existence of Screen 2 unambiguous from the initial viewport, without adding a separate paginator UI.
+- Keep Screen 1 focused on the hero message — no competing CTAs, no ambiguous icon-only elements.
+- Fix the floating-arrow positioning bug by removing the arrow entirely (its job is subsumed by the new affordance).
+- Preserve the "two-screen snap" aesthetic as a soft rhythm, not a hard constraint.
+- Respect `prefers-reduced-motion` for all new motion (smooth-scroll action, any new transitions).
+
+**Non-Goals:**
+- Not redesigning the timetable preview itself (read-only, data shape, card visuals all stay).
+- Not making the preview interactive (no tap-to-expand, no card actions — explicitly descoped per user decision).
+- Not touching the onboarding flow that begins after `[Get Started]`.
+- Not changing the language switcher's behavior, position, or styling.
+- Not modifying any backend, proto, or RPC. This change is frontend-only.
+- Not introducing pagination dots or other explicit "1/2, 2/2" indicators — the peek serves this role with lower visual noise.
+
+## Decisions
+
+### D1. Remove `[Get Started]` and `[Log In]` from Screen 1; keep them on Screen 2 only
+
+**Why:** This is the single highest-leverage fix for the funnel problem. As long as `[Get Started]` is reachable above the fold, a non-trivial share of users will tap it without scrolling to the preview — no amount of scroll-affordance tuning closes that leak.
+
+**Alternatives considered:**
+- *Leave `[Log In]` on Screen 1 as a text link.* Rejected because the design intent is explicitly "Screen 1 shows only the hero message." Any interactive element dilutes that focus. The 1-snap scroll cost for returning users is negligible, and returning users typically arrive at `/dashboard` directly via active session rather than hitting `/`.
+- *Keep both CTAs on both screens (current state).* Rejected — this is the existing problem.
+- *Move only `[Get Started]` and keep `[Log In]` on Screen 1.* Rejected for the same reason as the first alternative — any button on Screen 1 recreates the focus-dilution problem.
+
+### D2. Add a `[See how it works ↓]` labeled button on Screen 1 as its sole action
+
+**Why:** Replacing the icon-only arrow with a labeled `<button>` has three effects: (a) it communicates intent unambiguously ("there is something below worth seeing"), (b) it provides a tap/click target that keyboard and screen-reader users can discover (unlike a decorative `<div>`), (c) it becomes the only call-to-action on Screen 1, which reinforces the message-first framing without leaving the screen feeling dead.
+
+The button smooth-scrolls to Screen 2 when activated. Under `prefers-reduced-motion: reduce`, it jumps instantly instead.
+
+**Alternatives considered:**
+- *Animated arrow with `aria-label`.* Improves a11y but doesn't solve the visual discoverability problem for sighted users. The icon alone still reads as "decoration."
+- *Pagination dots (1/2, 2/2).* Adds a new UI affordance with its own learning cost. Redundant once the peek (D3) is in place. Decorative noise against the "hero only" intent.
+
+### D3. Size Screen 1 at ~95svh so Screen 2's top edge peeks above the fold
+
+**Why:** This is the structural signal that "more content exists below." Instead of relying on an icon to promise something, the page *shows* a sliver of that something. The peek can be the Screen 2 label ("Build your own concert timetable!") or the top of the frame/gradient — anything that visibly breaks the illusion of Screen 1 being a self-contained page.
+
+The user explicitly chose "控えめ" (subtle) over "明確" (obvious) in conversation, so 95svh (≈5svh peek) is the target. This is a starting value — tuning in a visual review is expected.
+
+**Trade-off:** A peek too deep (e.g., 85svh) undermines "hero only" by showing too much of the preview and splitting attention; a peek too shallow (e.g., 99svh) is indistinguishable from the current 100svh. 95svh sits in the "clearly intentional but not competing" band.
+
+**Alternatives considered:**
+- *Full 100svh with overlay text "scroll for more" on Screen 1.* Adds text clutter and still relies on a promise rather than evidence.
+- *Expose only at the fade-out mask.* Too subtle to register for most users; indistinguishable from a gradient decoration.
+
+### D4. Relax `scroll-snap-type` from `y mandatory` to `y proximity`
+
+**Why:** `mandatory` forces the viewport to snap whenever the user pauses scrolling, even mid-content. With Screen 2 content now peeking above the fold, a mandatory snap back to Screen 1 contradicts the peek's intent — the user sees the peek, tries to scroll a small amount to read it, and gets snapped back. `proximity` snaps only when the user's scroll position is close to a snap point, preserving mid-scroll reading.
+
+**Alternatives considered:**
+- *Remove `scroll-snap` entirely.* Equivalent to going full single-scroll. Conflicts with the team's preference for the two-screen rhythm.
+- *Keep `mandatory`.* Defeats the peek.
+
+### D5. Delete `.welcome-scroll-hint` element and its CSS entirely
+
+**Why:** The labeled button (D2) and the peek (D3) fully replace the arrow's job. Removing it is the root-cause fix for the "arrow shows on Screen 2" positioning bug — no element, no bug. Patching `position: absolute` inside `.welcome-hero` (adding `position: relative` to the parent) would also work, but the arrow itself is now redundant, so removal is preferred over repair.
+
+### D6. Keep the language switcher on Screen 1, placed between the hero copy and the new scroll button
+
+**Why:** First-visit locale discovery is important — if a Japanese user lands on the English default, they need to switch locale without committing to sign-up first. Moving the switcher to Screen 2 creates a chicken-and-egg problem (the hero copy is in the wrong language while the user is still reading it). The user confirmed in conversation that the Screen 1 Hero-下 position is acceptable.
+
+The switcher is visually low-weight (small text, low contrast) and does not compete with the hero message, so the "hero-only" intent remains intact in practice.
+
+### D7. No changes to data loading, preview composition, or CTA handler logic
+
+The `loadPreviewData()` method, the `PREVIEW_ARTIST_IDS` environment variable, the `handleGetStarted()` and `handleLogin()` methods, and the `concert-highway` props all remain as-is. This change is purely about visual layout and affordance; business logic is untouched.
+
+## Risks / Trade-offs
+
+- **Risk:** Returning users briefly confused by the absence of `[Log In]` on Screen 1 → **Mitigation:** In practice returning users with a valid session land on `/dashboard` via the `canLoad` redirect, so they rarely see `/`. Users with expired sessions have a one-screen scroll to reach `[Log In]`, which is a negligible friction increment and the labeled `[See how it works]` button visually signals "content continues." Monitor first-session-log-in funnel drop-off after release; revisit if there's a measurable impact.
+- **Risk:** 95svh peek appears different on devices with browser chrome that dynamically resizes (mobile Safari address bar, Android chrome) because `svh` excludes dynamic UI but devices vary → **Mitigation:** `svh` is specifically designed to be stable against dynamic toolbar resizing, unlike `vh`. Validate on iOS Safari and Android Chrome during QA.
+- **Risk:** `scroll-snap: y proximity` behaves inconsistently across browsers, especially on trackpads with inertia scroll → **Mitigation:** `proximity` is a well-supported, less aggressive variant of snap and inherently tolerates mid-scroll states better than `mandatory`. If any browser produces janky behavior, fall back to no snap for that browser via `@supports` feature query.
+- **Risk:** Removing CTAs from Screen 1 means the page looks "empty" above the fold on very tall desktop viewports where the peek becomes barely visible → **Mitigation:** Desktop is not the primary target (PWA, music fans). The hero title/subtitle remain, and the `[See how it works ↓]` button is large enough to anchor the space. If real-world analytics show desktop drop-off, a max-width container can compress the layout further.
+- **Trade-off:** Losing the `[Get Started]` click events on Screen 1 means the funnel metric "CTA taps per session on /" moves; downstream dashboards that chart this may show a step-change. Not a technical risk but worth flagging to the team tracking these metrics.
+
+## Migration Plan
+
+This is a visual/behavioral UX change with no data migration, no proto change, and no backend coordination. Deployment is a single frontend release:
+
+1. Implement the template/CSS/handler changes in `frontend/src/routes/welcome/`.
+2. Add i18n keys for the new button label in EN and JA resource files.
+3. Update unit tests and E2E tests to reflect the new button topology.
+4. QA on iOS Safari, Android Chrome, desktop Chrome/Firefox — verify peek, scroll affordance, snap behavior, keyboard navigation, and `prefers-reduced-motion`.
+5. Merge to `main` → ArgoCD deploys the new frontend build to dev.
+6. After soak, promote to production.
+
+**Rollback:** Revert the merge commit. No persistent state is affected; the change is stateless.
+
+## Open Questions
+
+- None blocking. The peek depth (95svh vs. 92svh vs. 97svh) is a tuning decision deferred to visual review during implementation, not a pre-commit design question.

--- a/openspec/changes/archive/2026-04-20-refine-welcome-hero-focus/proposal.md
+++ b/openspec/changes/archive/2026-04-20-refine-welcome-hero-focus/proposal.md
@@ -1,0 +1,38 @@
+## Why
+
+The current Welcome page uses a two-screen `scroll-snap: y mandatory` layout with CTAs duplicated on both screens. This configuration undermines the intended "Promise → Proof" narrative in three ways: (1) the timetable preview on Screen 2 is effectively hidden because the only affordance hinting at its existence is a small, unlabeled floating arrow icon; (2) the `[Get Started]` button on Screen 1 lets users commit to onboarding before they ever see the timetable demo that is supposed to raise their expectations; (3) the floating arrow is absolutely positioned without a proper containing block, so it bleeds into Screen 2 as well.
+
+The goal is to make the Welcome page deliver its strongest message first (hero copy in isolation), then reveal the timetable preview as the single proof moment, and only then present the commitment CTAs — without abandoning the two-screen narrative the design is built around.
+
+## What Changes
+
+- **Remove `[Get Started]` and `[Log In]` buttons from Screen 1 in the normal (preview-available) path.** Screen 1 becomes a message-only "hook" screen when Screen 2 is rendered; the CTAs live exclusively on Screen 2.
+- **Preserve an inline `[Get Started]` / `[Log In]` fallback on Screen 1 only when preview data is unavailable** (no Screen 2). Without the fallback, users would have no path to onboarding or sign-in when the preview fails to load.
+- **Add a `[See how it works ↓]` scroll-affordance button on Screen 1** as the only primary action when Screen 2 is present. Tapping it smooth-scrolls to Screen 2. Minimum 44×44px tap target, `<button>` element, keyboard-navigable. Hidden when no Screen 2 exists (the fallback CTAs take its place).
+- **Introduce a "peek" of Screen 2 above the fold.** Screen 1 uses `block-size: ~95svh` so the top edge of Screen 2 (preview label / frame) is faintly visible at the bottom of the initial viewport, providing a constant structural hint that more content exists.
+- **Relax `scroll-snap-type` from `y mandatory` to `y proximity`** so users can stop mid-scroll to read without being forced to a snap point.
+- **Remove the `.welcome-scroll-hint` floating arrow element** entirely. The labeled button and peek together replace its affordance job, and removing it also fixes the positioning bug on Screen 2.
+- **Keep the language switcher on Screen 1** (below the hero subtitle, above the new scroll button). Its current position is acceptable given the message-first intent — first-visit locale discovery matters.
+- **Respect `prefers-reduced-motion`**: disable smooth-scroll and fade-in animations under this media query (already partially in place for hero; extend to the new button's scroll action).
+- **Fix pre-existing divergence in `handleGetStarted`**: remove the `this.guest.clearAll()` call so guest follows are preserved when entering onboarding. The landing-page spec has long required "SHALL NOT clear previously stored guest artist data (guest.follows)"; the code had been wiping it. Verification surfaced this as a pre-existing gap; since this change touches `WelcomeRoute` anyway, fixing it here avoids a separate trivial PR. `handleLogin` keeps its `clearAll()` — that path has a different rationale (preventing stale guest.home from leaking into post-auth flow).
+- Out of scope: making the timetable preview interactive, redesigning the timetable visuals, touching the onboarding flow after Get Started.
+
+## Capabilities
+
+### New Capabilities
+
+_None. This change refines existing capabilities only._
+
+### Modified Capabilities
+
+- `landing-page`: CTA placement requirements change. Both `[Get Started]` and `[Log In]` CTAs are no longer rendered on Screen 1 — they are rendered only on Screen 2 alongside the preview. A new scroll-affordance button requirement is added for Screen 1. The language switcher requirement is unaffected in behavior but its positional context shifts (now adjacent to the scroll-affordance button rather than below a CTA pair).
+- `welcome-dashboard-preview`: Layout requirements change. The two-screen scroll-snap layout is retained but (a) Screen 1 no longer contains CTAs, (b) Screen 1 is sized below the viewport to reveal a Screen 2 peek, (c) snap behavior relaxes from mandatory to proximity, and (d) the floating scroll-hint element is removed. The preview content itself and the data-loading behavior are unchanged.
+
+## Impact
+
+- **Frontend code**: `frontend/src/routes/welcome/welcome-route.{html,ts,css}` — template restructure, new `scrollToPreview()` handler, CSS layout changes (peek sizing, snap relaxation, removed scroll-hint rule).
+- **i18n**: New translation keys for the `[See how it works ↓]` button label (EN + JA).
+- **Tests**: `frontend/test/routes/welcome-route.spec.ts` — update expectations around button presence on Screen 1. `frontend/e2e/functional/` — new or updated E2E assertions for the scroll-affordance flow and Screen 2 CTA interactions.
+- **Storybook**: `frontend/src/routes/welcome/welcome-route.stories.ts` — update story to reflect the new layout.
+- **No backend, proto, or infra impact.** This is a frontend-only change; no RPC or schema modification.
+- **No breaking change to public API.** Internal UX-only change.

--- a/openspec/changes/archive/2026-04-20-refine-welcome-hero-focus/specs/landing-page/spec.md
+++ b/openspec/changes/archive/2026-04-20-refine-welcome-hero-focus/specs/landing-page/spec.md
@@ -1,4 +1,4 @@
-## Requirements
+## MODIFIED Requirements
 
 ### Requirement: Passkey Authentication CTA
 
@@ -39,6 +39,8 @@ The system SHALL provide both a primary `[Get Started]` CTA and a secondary `[Lo
 - **THEN** the system SHALL NOT display email/password fields or social login buttons (Google, Spotify, etc.)
 - **AND** Passkey SHALL be the sole authentication method
 
+## ADDED Requirements
+
 ### Requirement: Hero Screen Scroll Affordance
 
 The landing page Screen 1 SHALL provide a single, clearly labeled affordance that invites the user to reveal the dashboard preview on Screen 2, whenever Screen 2 is rendered. This affordance SHALL be the only primary interactive control on Screen 1 (apart from the language switcher) when Screen 2 is present, preserving the "message-first" intent of the hero screen. When Screen 2 is not rendered (no preview data), the scroll-affordance SHALL NOT be displayed, because there is no target to scroll to — the inline CTA fallback takes its place (see `Passkey Authentication CTA`).
@@ -76,50 +78,3 @@ The landing page Screen 1 SHALL provide a single, clearly labeled affordance tha
 - **THEN** the button label SHALL display a Japanese equivalent of "See how it works ↓"
 - **WHEN** the landing page is rendered in English
 - **THEN** the button label SHALL display "See how it works ↓" (or its configured English text)
-
-### Requirement: Guest-Friendly Welcome Copy
-
-The Welcome page SHALL communicate that no account is required to try the product.
-
-#### Scenario: Guest-friendly copy displayed on Welcome page
-
-- **WHEN** the Welcome page renders
-- **THEN** the page SHALL display "アカウント不要でお試しいただけます" near the [使ってみる] CTA button
-
-### Requirement: Authenticated User Redirect
-
-The system SHALL redirect already-authenticated users away from the landing page to the Dashboard, regardless of `onboardingStep` value.
-
-#### Scenario: Authenticated user visits landing page
-
-- **WHEN** an authenticated user navigates to `/`
-- **THEN** the system SHALL redirect to the Dashboard with full unrestricted access
-- **AND** the system SHALL NOT check `onboardingStep`
-
-#### Scenario: Redirect target check fails
-
-- **WHEN** the redirect fails due to a network or API error
-- **THEN** the system SHALL display the landing page with an error toast: "Could not determine account status. Please try signing in again."
-- **AND** the system SHALL NOT crash to a white screen
-- **AND** the system SHALL allow the user to manually navigate via the Log In button
-
-### Requirement: Welcome Page Language Switcher
-
-The landing page SHALL provide a language toggle for unauthenticated users to switch between supported locales without requiring sign-in.
-
-#### Scenario: Language toggle visible on welcome page
-- **WHEN** an unauthenticated user visits the welcome page
-- **THEN** the system SHALL display a language toggle below the Log In button
-- **AND** the toggle SHALL show all supported languages (EN, JA)
-- **AND** the current active language SHALL be visually distinguished (e.g., bold or underline)
-
-#### Scenario: Switching language on welcome page
-- **WHEN** the user taps a language option
-- **THEN** the system SHALL call `i18n.setLocale(lang)` to update all translated strings immediately
-- **AND** the system SHALL persist the choice via `localStorage.setItem('language', lang)`
-- **AND** no page reload SHALL be required
-
-#### Scenario: Language preference persists across sessions
-- **WHEN** the user selects a language on the welcome page and later returns
-- **THEN** the i18next language detector SHALL read the persisted `language` key from localStorage
-- **AND** the application SHALL start in the previously selected language

--- a/openspec/changes/archive/2026-04-20-refine-welcome-hero-focus/specs/welcome-dashboard-preview/spec.md
+++ b/openspec/changes/archive/2026-04-20-refine-welcome-hero-focus/specs/welcome-dashboard-preview/spec.md
@@ -1,10 +1,4 @@
-# Welcome Dashboard Preview
-
-## Purpose
-
-Displays an interactive, read-only dashboard preview on the Welcome page using live concert data from a curated popular-artist fallback list, giving new users a tangible preview of what they will build during onboarding.
-
-## Requirements
+## MODIFIED Requirements
 
 ### Requirement: Live Dashboard Preview on Welcome Page
 

--- a/openspec/changes/archive/2026-04-20-refine-welcome-hero-focus/tasks.md
+++ b/openspec/changes/archive/2026-04-20-refine-welcome-hero-focus/tasks.md
@@ -1,0 +1,62 @@
+## 1. Template Restructure
+
+- [x] 1.1 Replace the always-visible `[Get Started]` / `[Log In]` buttons inside `.welcome-hero` in `frontend/src/routes/welcome/welcome-route.html` with a conditional composition: when `dateGroups.length > 0` render the scroll-affordance button, otherwise render an inline fallback CTA group so unauthenticated users always have a way forward
+- [x] 1.2 Remove the `.welcome-scroll-hint` `<div>` element from `.welcome-hero` in `frontend/src/routes/welcome/welcome-route.html`
+- [x] 1.3 Add a new `<button class="welcome-scroll-cta" click.trigger="scrollToPreview()" t="welcome.hero.seePreview"></button>` element inside `.welcome-hero`, placed after the language switcher
+- [x] 1.4 Ensure Screen 2 (`.welcome-screen-2`) retains its existing `[Get Started]` / `[Log In]` CTA group without changes
+- [x] 1.5 Verify language switcher (`.welcome-lang`) remains on Screen 1 between the hero subtitle and the new scroll-CTA button
+
+## 2. ViewModel & Handler
+
+- [x] 2.1 Add a `scrollToPreview()` method to `WelcomeRoute` in `frontend/src/routes/welcome/welcome-route.ts` that scrolls to the `.welcome-screen-2` element
+- [x] 2.2 Implement smooth-scroll behavior by default using `element.scrollIntoView({ behavior: 'smooth', block: 'start' })`
+- [x] 2.3 Detect `window.matchMedia('(prefers-reduced-motion: reduce)')` and fall back to `{ behavior: 'auto' }` when set
+- [x] 2.4 Guard against missing `.welcome-screen-2` element (e.g., when `dateGroups.length === 0`) by making `scrollToPreview()` a no-op in that case
+- [x] 2.5 Add logger debug entry when the scroll-affordance is activated (scope: `WelcomeRoute`)
+- [x] 2.6 Remove the `this.guest.clearAll()` call from `handleGetStarted()` so guest follows are preserved when entering onboarding. The existing `landing-page` spec already requires this (scenario: "Get Started initiates onboarding without clearing guest data"); the code had been diverging. `handleLogin()` retains its `clearAll()` call — that path has a different rationale documented inline.
+
+## 3. CSS Layout
+
+- [x] 3.1 In `frontend/src/routes/welcome/welcome-route.css`, relax `scroll-snap-type` on the scope root from `y mandatory` to `y proximity`
+- [x] 3.2 Change `.welcome-hero` `block-size` from `100svh` to approximately `95svh` (the peek target) so Screen 2's top edge is faintly visible above the fold
+- [x] 3.3 Remove the `.welcome-scroll-hint` rule block and the `@keyframes bounce-down` keyframes — both become dead code
+- [x] 3.4 Remove `.welcome-scroll-hint` reference from the `@media (prefers-reduced-motion: reduce)` block
+- [x] 3.5 Add a `.welcome-scroll-cta` rule: min 44×44px tap target, clear visible label styling, focus-visible outline, optional downward arrow decoration
+- [x] 3.6 Verify the scroll container's `scroll-behavior: smooth` interacts correctly with the new proximity snap — snap points should be at the top of `.welcome-hero` and `.welcome-screen-2`
+
+## 4. i18n Translation Keys
+
+- [x] 4.1 Add `welcome.hero.seePreview` key to the English locale resources with a value like "See how it works ↓"
+- [x] 4.2 Add `welcome.hero.seePreview` key to the Japanese locale resources with an appropriate Japanese label (e.g., "使い方を見る ↓" or equivalent confirmed by localization review)
+
+## 5. Unit Tests
+
+- [~] 5.1 Deferred to E2E per codebase convention (route components rely on E2E for DOM assertions — see `app-shell.spec.ts:52` for precedent). Covered by task 6.2.
+- [~] 5.2 Deferred to E2E per codebase convention. Covered by task 6.2.
+- [x] 5.3 Add a unit test asserting `scrollToPreview()` calls `scrollIntoView` on the Screen 2 element with `behavior: 'smooth'` when `prefers-reduced-motion` is not set
+- [x] 5.4 Add a unit test asserting `scrollToPreview()` uses `behavior: 'auto'` when `matchMedia('(prefers-reduced-motion: reduce)').matches` is true
+- [x] 5.5 Add a unit test asserting `scrollToPreview()` is a no-op when `dateGroups` is empty (preview section is not rendered)
+- [~] 5.6 Deferred to E2E per codebase convention. Covered by task 6.1 (existing E2E assertions updated for Screen 2).
+- [x] 5.7 Update `handleGetStarted` unit test to assert `guest.clearAll` is NOT called, aligning with the landing-page spec scenario "Get Started initiates onboarding without clearing guest data"
+
+## 6. E2E Tests
+
+- [x] 6.1 Update `frontend/e2e/functional/onboarding-flow.spec.ts` (or the equivalent welcome-page E2E) to reflect the new layout — `[Get Started]` is now found on Screen 2 only (with inline fallback on Screen 1 when preview is absent)
+- [x] 6.2 Add an E2E scenario: visit `/`, confirm no `[Get Started]` / `[Log In]` above the fold, tap `[See how it works ↓]`, assert viewport scrolls to Screen 2, assert `[Get Started]` is now visible
+- [x] 6.3 Add an E2E scenario for the peek: visit `/`, confirm the top portion of the concert preview (or its label) is visible within the initial viewport without any scrolling
+
+## 7. Storybook
+
+- [x] 7.1 Update `frontend/src/routes/welcome/welcome-route.stories.ts` so the default story reflects the new Screen 1 composition (documented — without RPC mocks the story renders the empty-preview fallback, see docblock)
+- [x] 7.2 Verify the empty-preview story (when `dateGroups.length === 0`) still renders correctly — scroll-CTA button hidden, inline CTAs on Screen 1 (confirmed by template + CSS — story renders fallback path by default)
+
+## 8. QA & Release
+
+- [~] 8.1 Visual QA on iOS Safari — MANUAL: not executable in CI/WSL2 env. Reviewer should load `/` on a physical iPhone and confirm the Screen 2 peek is visible above the fold both when the address bar is expanded and when it collapses on scroll.
+- [~] 8.2 Visual QA on Android Chrome — MANUAL: same check as 8.1 on Android. Confirm peek stability through dynamic toolbar resizing.
+- [~] 8.3 Visual QA on desktop Chrome and Firefox — MANUAL: with a trackpad (two-finger scroll) and a mouse wheel, scroll partway between Screen 1 and Screen 2 and confirm proximity snap does not jerk back to Screen 1 mid-read.
+- [~] 8.4 Keyboard-only QA — MANUAL: with keyboard only, Tab should reach `[See how it works ↓]` on Screen 1, Enter/Space should trigger scroll to Screen 2, focus ring should remain visible throughout, and Tab from there should reach `[Get Started]` → `[Log In]`.
+- [~] 8.5 Screen reader QA — MANUAL: with VoiceOver (iOS/macOS) or NVDA/TalkBack (Windows/Android), confirm the button is announced as "See how it works, button" in EN and "使い方を見る, ボタン" (approx) in JA.
+- [x] 8.6 Verify `prefers-reduced-motion: reduce` disables smooth scroll on activation — unit-tested (see task 5.4: `scrollToPreview` uses `behavior: 'auto'` under reduced motion).
+- [x] 8.7 Run `make check` in `frontend/` — lint, typecheck, unit tests, stylelint all pass (97 files, 1008 tests passed; `welcome-route.spec.ts` 10 tests passed; biome/stylelint clean).
+- [x] 8.8 Confirm Storybook builds without errors

--- a/openspec/specs/landing-page/spec.md
+++ b/openspec/specs/landing-page/spec.md
@@ -109,7 +109,7 @@ The landing page SHALL provide a language toggle for unauthenticated users to sw
 
 #### Scenario: Language toggle visible on welcome page
 - **WHEN** an unauthenticated user visits the welcome page
-- **THEN** the system SHALL display a language toggle below the Log In button
+- **THEN** the system SHALL display a language toggle on Screen 1, below the hero subtitle and above the scroll-affordance button (or the inline fallback CTA group when preview data is unavailable)
 - **AND** the toggle SHALL show all supported languages (EN, JA)
 - **AND** the current active language SHALL be visually distinguished (e.g., bold or underline)
 


### PR DESCRIPTION
## Summary

Archive the completed `refine-welcome-hero-focus` change: sync its delta specs into the main `landing-page` and `welcome-dashboard-preview` specs, and move the change folder to `openspec/changes/archive/2026-04-20-refine-welcome-hero-focus/`.

Implementation is tracked in `liverty-music/frontend#340` (frontend-only — no proto / backend changes).

## Spec changes

### `landing-page`
- **Modified — Passkey Authentication CTA**: CTAs now live on Screen 2 when Screen 2 is rendered (preview data available); fall back to inline Screen 1 placement otherwise. The existing "SHALL NOT clear guest.follows" contract extends to both paths.
- **Added — Hero Screen Scroll Affordance**: defines the `[See how it works ↓]` button — a single labeled control on Screen 1 that smooth-scrolls to Screen 2, jumps under `prefers-reduced-motion`, is hidden when Screen 2 is not rendered, and must be localized.

### `welcome-dashboard-preview`
- **Modified — Live Dashboard Preview on Welcome Page**: the two-screen layout scenario now specifies (a) no `[Get Started]` / `[Log In]` on Screen 1 when Screen 2 is rendered, (b) ~95svh / 5svh peek arrangement, (c) `scroll-snap-type: y proximity` (not `mandatory`), and (d) explicit prohibition of the old floating scroll-hint element.

## Change folder

Moved to [`openspec/changes/archive/2026-04-20-refine-welcome-hero-focus/`](openspec/changes/archive/2026-04-20-refine-welcome-hero-focus/) with its proposal, design, tasks, and delta specs preserved for historical reference.

## Test plan

- [x] `openspec status --change` confirmed all artifacts `done` before archiving
- [x] Delta spec analysis matches main-spec diff (manual inspection)
- [x] No naming collision with existing archives
- [ ] Reviewer confirms spec text accurately describes the behavior implemented in `frontend#340`

close: #416
