### PR TITLE
feat(ticket,entry)!: require user_id on Mint/ListTickets/GetMerklePath

### DIFF
--- a/openspec/changes/align-ticket-rpcs-with-auth-scoping/.openspec.yaml
+++ b/openspec/changes/align-ticket-rpcs-with-auth-scoping/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-21

--- a/openspec/changes/align-ticket-rpcs-with-auth-scoping/design.md
+++ b/openspec/changes/align-ticket-rpcs-with-auth-scoping/design.md
@@ -1,0 +1,112 @@
+## Context
+
+The `standardize-user-scoped-rpc-auth` change (archived 2026-04-20) elevated the `rpc-auth-scoping` capability into `openspec/specs/`. Its core requirement — every authenticated per-user RPC SHALL carry an explicit `entity.v1.UserId` that the backend verifies against the JWT-derived userID — is now a cross-service convention. `UserService.Get`, `UserService.UpdateHome`, `UserService.ResendEmailVerification`, and `PushNotificationService` already comply.
+
+The ticket system's RPC surface was designed earlier under a different philosophy:
+
+```proto
+// Current (ticket_service.proto)
+message MintTicketRequest {
+  liverty_music.entity.v1.EventId event_id = 1 [(buf.validate.field).required = true];
+  reserved 2;           // deliberately not user_id
+  reserved "user_id";
+}
+message ListTicketsRequest {
+  reserved 1;
+  reserved "user_id";
+}
+
+// Current (entry_service.proto)
+message GetMerklePathRequest {
+  liverty_music.entity.v1.EventId event_id = 1 [(buf.validate.field).required = true];
+  reserved 2;
+  reserved "user_id";
+}
+```
+
+Handler code follows the JWT-only pattern:
+
+```go
+// Current ticket_handler.go (simplified)
+externalID, _ := mapper.GetExternalUserID(ctx)
+user, _ := h.userRepo.GetByExternalID(ctx, externalID)
+// proceed with user.ID — no request field to verify against
+```
+
+The `implement-ticket-system-mvp` change is at 72/79 tasks (remaining are manual verifications). Its spec deltas for `ticket-management` and `zkp-entry` have not yet been promoted to `openspec/specs/`. This change is the last clean seam to align the RPC surface before the capability specs ship in their current form.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Bring `MintTicket`, `ListTickets`, `GetMerklePath` onto the `rpc-auth-scoping` convention (explicit `user_id` + JWT-match check).
+- Keep the change atomic and small — a single proto PR, a single backend PR, a single frontend PR.
+- Reuse the existing `mapper.RequireUserIDMatch` helper. Do not introduce new abstractions.
+- Ship before `implement-ticket-system-mvp` is archived so the capability specs enter `specs/` already compliant.
+
+**Non-Goals:**
+- Changing `GetTicket`. It is keyed by `ticket_id` (not user-scoped at the request boundary); the existing uniqueness of a ticket ID is sufficient authorization scoping. Adding `user_id` would be ceremony without a threat model.
+- Changing `VerifyEntry`. Explicitly unauthenticated — the ZK proof itself is the authentication. The scanner device is operator-controlled; there is no "JWT" to match against.
+- Changing any repository, use-case, or entity-layer code. The ownership check lives entirely in the adapter layer.
+- Touching the `tickets`, `merkle_tree`, or `nullifiers` schemas.
+- Retrofitting `GetTicket` into a user-scoped RPC (future work if threat modeling calls for it).
+- Updating manual-verification.md in the MVP change (that change's owner updates it when the new proto fields land).
+
+## Decisions
+
+### Decision 1: Add `user_id` to the three breaking requests, not to `GetTicketRequest`
+
+Alternatives considered:
+- **A. Add `user_id` to all five RPCs including `GetTicket` and `VerifyEntry`.** Rejected. `VerifyEntry` is unauthenticated so there is no JWT to match; adding `user_id` would create a field with no enforcer. `GetTicket` is identifier-scoped — the canonical example in Google AIP of a resource read-by-name, not a user-scoped operation.
+- **B. Only change the two user-listing RPCs (`ListTickets`, `GetMerklePath`) and leave `MintTicket` JWT-only.** Rejected. `MintTicket` writes a record keyed to a user; the `rpc-auth-scoping` spec explicitly states the convention applies to every authenticated per-user RPC except creation RPCs that mint an internal user ID. `MintTicket` does not mint a user ID — it mints a ticket for an existing user — so it falls under the convention.
+- **C. Chosen — surgical: three breaking requests (`MintTicketRequest`, `ListTicketsRequest`, `GetMerklePathRequest`).** These are exactly the requests where the authenticated caller acts on their own user-scoped data.
+
+### Decision 2: Reuse the `user_id` field number `2` that was previously reserved
+
+Alternatives considered:
+- **A. Use a fresh field number (3 or higher).** Rejected. Proto3 field-number reuse rules only prohibit reusing a number whose tag was *in use* at any wire-compatible version. `reserved 2` on these messages was never assigned in a released proto — the field was reserved from the start. Taking field 2 keeps the wire layout tidy.
+- **B. Chosen — reuse field 2 for `user_id`.** Matches the pattern already used by `UserService.GetRequest` / `UpdateHomeRequest` / `ResendEmailVerificationRequest` (all of which placed `user_id` at field 2). Consistent with the rest of the authenticated RPC surface.
+
+For `ListTicketsRequest`, `user_id` takes field 1 (it is the only field). This matches `ListFollowsRequest` and other user-listing patterns.
+
+### Decision 3: Delegate the match check to `mapper.RequireUserIDMatch` — no new helper
+
+Alternatives considered:
+- **A. Introduce a ticket-specific interceptor that automatically enforces the match.** Rejected. The ticket handler already has its own reason to call `userRepo.GetByExternalID` (to resolve Safe address for `MintTicket`). Adding an interceptor layer duplicates the lookup.
+- **B. Chosen — call `mapper.RequireUserIDMatch(user.ID, req.Msg.GetUserId().GetValue())` inline in each handler**, mirroring `UserHandler.Get` / `UpdateHome` / `ResendEmailVerification`. Single precedent, single pattern.
+
+### Decision 4: Breaking-change discipline — one release, no shim window
+
+Alternatives considered:
+- **A. Two-phase: make `user_id` optional first, accept absence for one release, then make it required.** Rejected. No external consumers today besides this monorepo. A shim window buys nothing and costs review time.
+- **B. Chosen — single BREAKING release**, coordinated with backend + frontend PRs per the standard cross-repo release workflow. `buf skip breaking` label on the spec PR.
+
+### Decision 5: Frontend `user_id` source = existing `localStorage` cache
+
+The `standardize-user-scoped-rpc-auth` change already introduced the `externalId → userId` cache in `localStorage`, read via `UserServiceClient` on every RPC dispatch. Ticket RPC call sites plug into the same code path; no new cache, no new key.
+
+## Risks / Trade-offs
+
+- **Risk: BSR gen delay blocks backend/frontend PRs.** → Mitigation: follow the workspace's standard cross-repo release protocol — prepare backend/frontend branches locally against the planned type shape (placeholder `any`-typed `user_id` today, swap to generated types after BSR gen). Do not open the downstream PRs as drafts before BSR gen completes.
+- **Risk: A ticket RPC call site in the frontend misses the cached `user_id`, causing `INVALID_ARGUMENT` from protovalidate in production.** → Mitigation: exhaustive grep-based audit of `ticketService.*` and `entryService.*` call sites; pair with TypeScript strict checks on the generated request types after BSR gen (missing required field becomes a compile error).
+- **Risk: Manual verification runbook in `implement-ticket-system-mvp/manual-verification.md` has `curl` snippets that omit `user_id`.** → Mitigation: not in scope for this change. Flagged in tasks.md as a follow-up for the MVP change owner when they pick up 10.x/11.x/14.x.
+- **Trade-off: The `MintTicket` handler still has to call `userRepo.GetByExternalID` first** (to know `user.ID` for the match), before calling `RequireUserIDMatch`. The check is therefore not "free" as it would be under a generic interceptor. Accepted — the `GetByExternalID` call is already required for the Safe-address lookup that happens on first mint, so no new database work is introduced.
+- **Trade-off: `GetTicket` remains identifier-scoped and therefore follows a different authorization pattern** than the other ticket RPCs. Accepted — documented explicitly in the spec delta and the design above. If threat modeling later justifies tightening `GetTicket`, it will be a separate change.
+
+## Migration Plan
+
+Standard cross-repo release coordination:
+
+1. **specification**: branch, commit proto + spec delta changes, open PR with `buf skip breaking` label. CI validates lint/format. Wait for review.
+2. **Parallelize**: backend + frontend branches created against the planned type shape (placeholder types; not pushed as PRs yet).
+3. **Merge specification PR** once reviewed.
+4. **Publish GitHub Release** on specification (tag `vX.Y.Z`, marked as containing breaking changes) → triggers `buf-release.yml` → BSR publishes.
+5. **Monitor BSR gen** until success.
+6. **Upgrade dependency**: `go get buf.build/gen/go/liverty-music/schema/...@vX.Y.Z` in backend; `npm install @buf/liverty-music_schema.connectrpc_es@latest` in frontend.
+7. **Swap placeholders**: replace placeholder types with generated types at the call sites; run `make check` in each repo.
+8. **Open backend and frontend PRs** only after local `make check` passes in both. CI should pass on first push.
+
+**Rollback**: If an incident shows up post-deploy, revert the spec repo PR, publish a reversion release. Because no database or user-data change is involved, rollback is purely a wire-format revert; no migration is required.
+
+## Open Questions
+
+(None. The design re-uses all existing helpers, existing cache infrastructure, and the established cross-repo release workflow.)

--- a/openspec/changes/align-ticket-rpcs-with-auth-scoping/proposal.md
+++ b/openspec/changes/align-ticket-rpcs-with-auth-scoping/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+The `rpc-auth-scoping` capability (introduced by `standardize-user-scoped-rpc-auth`) now defines a project-wide convention: every authenticated per-user RPC SHALL carry an explicit `entity.v1.UserId` field and the handler SHALL verify it matches the JWT-derived userID via the shared `requireMatchingUserID` helper. The ticket system's RPCs (`MintTicket`, `ListTickets`, `GetMerklePath`) predate this convention and were deliberately designed with `reserved "user_id"` on the request messages, identifying the caller from the JWT alone. This leaves the ticket/entry surface as the only authenticated per-user RPCs that violate the cross-service standard. Aligning them now — before the `implement-ticket-system-mvp` change is archived — keeps the `ticket-management` and `zkp-entry` specs coherent with `rpc-auth-scoping` when they enter `specs/` and avoids a later breaking migration once external clients start depending on the MVP shape.
+
+## What Changes
+
+- **BREAKING**: `MintTicketRequest` gains a required `user_id` field (replaces the current `reserved 2 / reserved "user_id"`). The backend SHALL verify it matches the JWT-derived userID; mismatches return `PERMISSION_DENIED`.
+- **BREAKING**: `ListTicketsRequest` gains a required `user_id` field (replaces the current `reserved 1 / reserved "user_id"`). The backend SHALL verify it matches the JWT-derived userID; mismatches return `PERMISSION_DENIED`.
+- **BREAKING**: `GetMerklePathRequest` gains a required `user_id` field (replaces the current `reserved 2 / reserved "user_id"`). The backend SHALL verify it matches the JWT-derived userID; mismatches return `PERMISSION_DENIED`.
+- `GetTicketRequest` and `VerifyEntryRequest` remain unchanged — `GetTicket` is keyed by `ticket_id` (not user-scoped at the request boundary) and `VerifyEntry` is explicitly unauthenticated (the ZK proof itself is the authentication).
+- Backend: `ticket_handler.go` call sites for the three affected RPCs SHALL delegate the check to the existing shared helper `mapper.RequireUserIDMatch`, following the same pattern used by `UserHandler` today.
+- Frontend: every call site of the three affected RPCs SHALL inject the cached `user_id` from the `localStorage` cache introduced by `standardize-user-scoped-rpc-auth`.
+
+## Capabilities
+
+### New Capabilities
+<!-- None. The target capabilities (ticket-management, zkp-entry) are introduced by the parallel `implement-ticket-system-mvp` change; this change only amends their deltas before archiving. -->
+
+### Modified Capabilities
+- `ticket-management`: The `MintTicket` and `ListTickets` request requirements change to include the explicit `user_id` field and the JWT-match check. The "user identified from JWT claims" scenarios are replaced with "user_id supplied, JWT-match enforced" scenarios.
+- `zkp-entry`: The `GetMerklePath` request requirement changes to include the explicit `user_id` field and the JWT-match check. `VerifyEntry` is explicitly noted as exempt (unauthenticated by design).
+
+## Impact
+
+- **Proto (specification repo)**: Breaking changes to three request messages (`ticket/v1/ticket_service.proto`, `entry/v1/entry_service.proto`). `buf skip breaking` label required on the PR. No external consumers on `buf.build/liverty-music/schema` today other than this monorepo's backend and frontend, so the breaking change is contained.
+- **Backend**: `ticket_handler.go` updates for the three RPCs. Handler-level tests expand to cover `PERMISSION_DENIED` paths. No changes to `ticket_uc.go` or the repository layer — the check lives entirely in the adapter layer.
+- **Frontend**: Ticket RPC call sites inject the cached `user_id`. The `user_id` cache infrastructure already exists from `standardize-user-scoped-rpc-auth`; this change is additive.
+- **Database**: No schema change.
+- **Release sequence**: Specification PR → GitHub Release (new minor version, marked breaking) → BSR gen completes → backend + frontend PRs land. Follows the workspace's standard cross-repo release coordination.
+- **Dependency on `implement-ticket-system-mvp`**: This change SHOULD merge and deploy **before** `implement-ticket-system-mvp` is archived, so the capability specs that land in `openspec/specs/ticket-management/` and `openspec/specs/zkp-entry/` already reflect the `rpc-auth-scoping` convention rather than requiring an immediate corrective delta.

--- a/openspec/changes/align-ticket-rpcs-with-auth-scoping/specs/ticket-management/spec.md
+++ b/openspec/changes/align-ticket-rpcs-with-auth-scoping/specs/ticket-management/spec.md
@@ -1,0 +1,66 @@
+## ADDED Requirements
+
+### Requirement: MintTicket request carries explicit user_id
+
+The `TicketService.MintTicket` RPC SHALL carry an explicit `entity.v1.UserId user_id` field in its request message. The field SHALL be marked required via `protovalidate`. The backend SHALL compare the supplied value against the userID derived from the JWT context and reject mismatches with `PERMISSION_DENIED` via the shared `requireMatchingUserID` helper defined by the `rpc-auth-scoping` capability.
+
+#### Scenario: Matching user_id mints ticket
+
+- **WHEN** an authenticated fan calls `MintTicket` with `user_id` equal to the JWT-derived userID for a valid `event_id`
+- **THEN** the handler SHALL proceed to resolve the caller's Safe address and submit the mint transaction
+- **AND** the response SHALL contain the newly minted `Ticket`
+
+#### Scenario: Mismatched user_id is rejected
+
+- **WHEN** an authenticated fan calls `MintTicket` with `user_id` that differs from the JWT-derived userID
+- **THEN** the handler SHALL return `PERMISSION_DENIED`
+- **AND** no on-chain transaction SHALL be submitted
+- **AND** no row SHALL be inserted into the `tickets` table
+- **AND** the response SHALL NOT reveal whether the requested user exists or holds tickets
+
+#### Scenario: Missing user_id is rejected
+
+- **WHEN** an authenticated fan calls `MintTicket` with an absent or empty `user_id`
+- **THEN** the handler SHALL return `INVALID_ARGUMENT` via `protovalidate` enforcement
+- **AND** the rejection SHALL occur before any business logic executes
+
+#### Scenario: Unauthenticated request is rejected before user_id check
+
+- **WHEN** a client calls `MintTicket` without a valid JWT
+- **THEN** the authentication middleware SHALL reject the request with `UNAUTHENTICATED` before the `user_id` check runs
+
+---
+
+### Requirement: ListTickets request carries explicit user_id
+
+The `TicketService.ListTickets` RPC SHALL carry an explicit `entity.v1.UserId user_id` field in its request message. The field SHALL be marked required via `protovalidate`. The backend SHALL compare the supplied value against the userID derived from the JWT context and reject mismatches with `PERMISSION_DENIED` via the shared `requireMatchingUserID` helper.
+
+#### Scenario: Matching user_id returns the caller's tickets
+
+- **WHEN** an authenticated fan calls `ListTickets` with `user_id` equal to the JWT-derived userID
+- **THEN** the handler SHALL return every `Ticket` currently held by that user
+- **AND** no tickets belonging to other users SHALL appear in the response
+
+#### Scenario: Mismatched user_id is rejected
+
+- **WHEN** an authenticated fan calls `ListTickets` with `user_id` that differs from the JWT-derived userID
+- **THEN** the handler SHALL return `PERMISSION_DENIED`
+- **AND** the response SHALL NOT reveal whether the requested user exists or holds tickets
+
+#### Scenario: Missing user_id is rejected
+
+- **WHEN** an authenticated fan calls `ListTickets` with an absent or empty `user_id`
+- **THEN** the handler SHALL return `INVALID_ARGUMENT` via `protovalidate` enforcement
+
+---
+
+### Requirement: GetTicket remains identifier-scoped
+
+The `TicketService.GetTicket` RPC SHALL remain keyed by `ticket_id` and SHALL NOT carry a `user_id` field. The ticket identifier itself provides the authorization scope for this RPC; the `rpc-auth-scoping` convention does not apply.
+
+#### Scenario: GetTicket request shape
+
+- **WHEN** a client calls `GetTicket`
+- **THEN** the request SHALL contain only `ticket_id` as its identifying field
+- **AND** the handler SHALL return the ticket matching that identifier
+- **AND** the handler SHALL NOT perform a JWT-userID vs request-userID comparison

--- a/openspec/changes/align-ticket-rpcs-with-auth-scoping/specs/zkp-entry/spec.md
+++ b/openspec/changes/align-ticket-rpcs-with-auth-scoping/specs/zkp-entry/spec.md
@@ -1,0 +1,41 @@
+## ADDED Requirements
+
+### Requirement: GetMerklePath request carries explicit user_id
+
+The `EntryService.GetMerklePath` RPC SHALL carry an explicit `entity.v1.UserId user_id` field in its request message. The field SHALL be marked required via `protovalidate`. The backend SHALL compare the supplied value against the userID derived from the JWT context and reject mismatches with `PERMISSION_DENIED` via the shared `requireMatchingUserID` helper defined by the `rpc-auth-scoping` capability.
+
+#### Scenario: Matching user_id returns the caller's Merkle path
+
+- **WHEN** an authenticated fan calls `GetMerklePath` with `user_id` equal to the JWT-derived userID and a valid `event_id` for which the fan holds a ticket
+- **THEN** the handler SHALL return the Merkle root, path elements, path indices, and leaf needed to construct a client-side proof
+
+#### Scenario: Mismatched user_id is rejected
+
+- **WHEN** an authenticated fan calls `GetMerklePath` with `user_id` that differs from the JWT-derived userID
+- **THEN** the handler SHALL return `PERMISSION_DENIED`
+- **AND** no Merkle path data SHALL be returned
+- **AND** the response SHALL NOT reveal whether the requested user holds a ticket for the event
+
+#### Scenario: Missing user_id is rejected
+
+- **WHEN** an authenticated fan calls `GetMerklePath` with an absent or empty `user_id`
+- **THEN** the handler SHALL return `INVALID_ARGUMENT` via `protovalidate` enforcement
+
+#### Scenario: Unauthenticated request is rejected before user_id check
+
+- **WHEN** a client calls `GetMerklePath` without a valid JWT
+- **THEN** the authentication middleware SHALL reject the request with `UNAUTHENTICATED` before the `user_id` check runs
+
+---
+
+### Requirement: VerifyEntry remains unauthenticated
+
+The `EntryService.VerifyEntry` RPC SHALL remain unauthenticated and SHALL NOT carry a `user_id` field. The zero-knowledge proof itself establishes ticket-holder membership without revealing the fan's identity; the `rpc-auth-scoping` convention does not apply because there is no caller JWT to match against.
+
+#### Scenario: VerifyEntry request shape
+
+- **WHEN** a scanner device calls `VerifyEntry`
+- **THEN** the request SHALL contain only `event_id`, `proof_json`, and `public_signals_json`
+- **AND** the handler SHALL NOT require an `Authorization` header
+- **AND** the handler SHALL NOT perform a JWT-userID vs request-userID comparison
+- **AND** authorization SHALL be established entirely by the ZK proof plus the nullifier uniqueness check

--- a/openspec/changes/align-ticket-rpcs-with-auth-scoping/tasks.md
+++ b/openspec/changes/align-ticket-rpcs-with-auth-scoping/tasks.md
@@ -1,0 +1,71 @@
+## 1. Specification — Proto changes (BREAKING)
+
+- [x] 1.1 Edit `proto/liverty_music/rpc/ticket/v1/ticket_service.proto`: replace `reserved 2 / reserved "user_id"` in `MintTicketRequest` with `liverty_music.entity.v1.UserId user_id = 2 [(buf.validate.field).required = true];`
+- [x] 1.2 Update the `MintTicketRequest` message doc comment: remove the "The recipient fan is identified from the authenticated user's JWT claims, not from a request field" paragraph and replace with a comment referencing the `rpc-auth-scoping` convention
+- [x] 1.3 Edit `ticket_service.proto`: replace `reserved 1 / reserved "user_id"` in `ListTicketsRequest` with `liverty_music.entity.v1.UserId user_id = 1 [(buf.validate.field).required = true];`
+- [x] 1.4 Update the `ListTicketsRequest` message doc comment similarly
+- [x] 1.5 Edit `proto/liverty_music/rpc/entry/v1/entry_service.proto`: replace `reserved 2 / reserved "user_id"` in `GetMerklePathRequest` with `liverty_music.entity.v1.UserId user_id = 2 [(buf.validate.field).required = true];`
+- [x] 1.6 Update the `GetMerklePathRequest` message doc comment similarly
+- [x] 1.7 Confirm `GetTicketRequest` and `VerifyEntryRequest` are **not** modified (documented in design.md as deliberate)
+- [x] 1.8 Run `buf format -w` and `buf lint` locally
+
+## 2. Specification — PR and Release
+
+- [ ] 2.1 Commit proto + change artifacts on a new branch in the specification repo
+- [ ] 2.2 Open PR with the `buf skip breaking` label; `buf-pr-checks.yml` must pass
+- [ ] 2.3 Obtain review and merge to `main`
+- [ ] 2.4 Create GitHub Release on specification (new minor version `vX.Y.0`, body flagged as containing breaking changes) so `buf-release.yml` pushes to BSR
+- [ ] 2.5 Monitor `buf-release.yml` via `gh run watch --repo liverty-music/specification` until BSR gen completes
+
+## 3. Backend — Prepare branch against planned type shape
+
+- [ ] 3.1 Branch the backend repo from current `main`
+- [ ] 3.2 In `internal/adapter/rpc/ticket_handler.go`, update `MintTicket`: insert `if err := mapper.RequireUserIDMatch(user.ID, req.Msg.GetUserId().GetValue()); err != nil { return nil, err }` immediately after the `userRepo.GetByExternalID` call and before the Safe-address block
+- [ ] 3.3 Similarly update `ListTickets`: insert `RequireUserIDMatch(user.ID, req.Msg.GetUserId().GetValue())` before `ticketUseCase.ListTicketsForUser`
+- [ ] 3.4 Locate the `EntryService.GetMerklePath` handler and insert `RequireUserIDMatch(user.ID, req.Msg.GetUserId().GetValue())` before the Merkle-path lookup
+- [ ] 3.5 At each of the three call sites, leave a `// TODO: swap to generated type after BSR gen` comment next to the `req.Msg.GetUserId().GetValue()` call to mark the placeholder
+- [ ] 3.6 Confirm `GetTicket` and `VerifyEntry` handlers remain unchanged
+
+## 4. Backend — Handler tests
+
+- [ ] 4.1 In `internal/adapter/rpc/ticket_handler_test.go`, add a table-driven test case for `MintTicket` where `request.user_id != jwt.sub`-resolved user.ID, asserting `connect.CodePermissionDenied`
+- [ ] 4.2 Add a test case for `MintTicket` with matching `user_id` that proceeds to mint (happy path)
+- [ ] 4.3 Add equivalent mismatch + match test cases for `ListTickets`
+- [ ] 4.4 Add equivalent mismatch + match test cases for `GetMerklePath` (in the appropriate entry handler test file)
+- [ ] 4.5 Confirm existing JWT-absent tests still produce `UNAUTHENTICATED` (middleware still runs first)
+
+## 5. Frontend — Prepare branch against planned type shape
+
+- [ ] 5.1 Branch the frontend repo from current `main`
+- [ ] 5.2 Grep for every call site of `ticketService.mintTicket` / `.listTickets` and `entryService.getMerklePath`; list them in a local note
+- [ ] 5.3 Inject the cached `user_id` (from the `UserIdCache` service introduced by `standardize-user-scoped-rpc-auth`) into each request body — same pattern as existing `userService.get` / `userService.updateHome` call sites
+- [ ] 5.4 Add a `// TODO: swap to generated type after BSR gen` comment at each injection point
+
+## 6. Cross-repo release — BSR coordination
+
+- [ ] 6.1 After specification Release + BSR gen completes (task 2.5), run `go get buf.build/gen/go/liverty-music/schema/...@vX.Y.0` in backend; `go mod tidy`
+- [ ] 6.2 Swap placeholder types for generated types at the three backend handler call sites; remove the TODO comments
+- [ ] 6.3 Run `make check` in backend — lint + tests must pass
+- [ ] 6.4 Run `npm install @buf/liverty-music_schema.connectrpc_es@latest` in frontend
+- [ ] 6.5 Swap placeholder types for generated types at frontend call sites; remove TODO comments
+- [ ] 6.6 Run `make check` in frontend — lint + tests must pass
+
+## 7. Backend and Frontend PRs
+
+- [ ] 7.1 Push backend branch and open PR; CI must pass from first push (do not submit as draft)
+- [ ] 7.2 Push frontend branch and open PR; CI must pass from first push
+- [ ] 7.3 Obtain review, land both PRs to `main`
+- [ ] 7.4 Monitor ArgoCD / deployment workflows to confirm dev rollout completes
+
+## 8. Post-merge verification
+
+- [ ] 8.1 In dev: call `MintTicket` via curl with matching `user_id` — expect `200` and minted ticket
+- [ ] 8.2 In dev: call `MintTicket` via curl with mismatched `user_id` — expect `PERMISSION_DENIED`
+- [ ] 8.3 In dev: call `ListTickets` via curl with missing `user_id` — expect `INVALID_ARGUMENT`
+- [ ] 8.4 In dev: call `GetMerklePath` via curl with mismatched `user_id` — expect `PERMISSION_DENIED`
+- [ ] 8.5 Smoke-test the frontend ticket flow signed in as a real user: ticket list renders, mint flow works, QR generation works
+
+## 9. Follow-up handoff
+
+- [ ] 9.1 Flag to the owner of `implement-ticket-system-mvp` that `manual-verification.md` needs `user_id` added to the sample curl payloads for `MintTicket`, `ListTickets`, and `GetMerklePath`
+- [ ] 9.2 Once all tasks above are done, this change is ready for `/opsx:archive`

--- a/proto/liverty_music/rpc/entry/v1/entry_service.proto
+++ b/proto/liverty_music/rpc/entry/v1/entry_service.proto
@@ -6,6 +6,7 @@ package liverty_music.rpc.entry.v1;
 
 import "buf/validate/validate.proto";
 import "liverty_music/entity/v1/event.proto";
+import "liverty_music/entity/v1/user.proto";
 
 option go_package = "github.com/liverty-music/specification/gen/go/liverty_music/rpc/entry/v1;entryv1";
 
@@ -69,14 +70,16 @@ message VerifyEntryResponse {
   string message = 2 [(buf.validate.field).string.max_len = 256];
 }
 
-// GetMerklePathRequest identifies the event for which Merkle path data is needed.
-// The fan is identified from JWT claims to prevent querying other users' paths.
+// GetMerklePathRequest identifies the event and fan for which Merkle path data is needed.
+// The caller supplies the user_id explicitly per the rpc-auth-scoping convention;
+// the backend rejects mismatches against the JWT-derived userID with PERMISSION_DENIED.
 message GetMerklePathRequest {
   // event_id identifies the event for which the Merkle path is requested.
   liverty_music.entity.v1.EventId event_id = 1 [(buf.validate.field).required = true];
 
-  reserved 2;
-  reserved "user_id";
+  // user_id identifies the fan whose Merkle path is being requested. The backend rejects
+  // the request with PERMISSION_DENIED if it does not match the JWT-derived userID.
+  liverty_music.entity.v1.UserId user_id = 2 [(buf.validate.field).required = true];
 }
 
 // GetMerklePathResponse contains all the data a fan needs to construct a zero-knowledge

--- a/proto/liverty_music/rpc/ticket/v1/ticket_service.proto
+++ b/proto/liverty_music/rpc/ticket/v1/ticket_service.proto
@@ -7,6 +7,7 @@ package liverty_music.rpc.ticket.v1;
 import "buf/validate/validate.proto";
 import "liverty_music/entity/v1/event.proto";
 import "liverty_music/entity/v1/ticket.proto";
+import "liverty_music/entity/v1/user.proto";
 
 option go_package = "github.com/liverty-music/specification/gen/go/liverty_music/rpc/ticket/v1;ticketv1";
 
@@ -30,14 +31,15 @@ service TicketService {
 }
 
 // MintTicketRequest carries the information needed to issue a new soulbound ticket.
-// The recipient fan is identified from the authenticated user's JWT claims,
-// not from a request field, to prevent unauthorized minting on behalf of others.
+// The caller supplies the user_id explicitly per the rpc-auth-scoping convention;
+// the backend verifies it matches the JWT-derived userID before minting.
 message MintTicketRequest {
   // event_id identifies the event for which the ticket should be minted.
   liverty_music.entity.v1.EventId event_id = 1 [(buf.validate.field).required = true];
 
-  reserved 2;
-  reserved "user_id";
+  // user_id identifies the fan receiving the ticket. The backend rejects the request
+  // with PERMISSION_DENIED if it does not match the JWT-derived userID.
+  liverty_music.entity.v1.UserId user_id = 2 [(buf.validate.field).required = true];
 }
 
 // MintTicketResponse contains the newly minted ticket returned after a successful minting operation.
@@ -60,11 +62,13 @@ message GetTicketResponse {
   liverty_music.entity.v1.Ticket ticket = 1;
 }
 
-// ListTicketsRequest requests the ticket collection of the authenticated fan.
-// The user is identified from JWT claims to prevent listing other users' tickets.
+// ListTicketsRequest requests the ticket collection of a specific fan.
+// The caller supplies the user_id explicitly per the rpc-auth-scoping convention;
+// the backend rejects mismatches against the JWT-derived userID with PERMISSION_DENIED.
 message ListTicketsRequest {
-  reserved 1;
-  reserved "user_id";
+  // user_id identifies the fan whose tickets are being listed. The backend rejects
+  // the request with PERMISSION_DENIED if it does not match the JWT-derived userID.
+  liverty_music.entity.v1.UserId user_id = 1 [(buf.validate.field).required = true];
 }
 
 // ListTicketsResponse contains all tickets held by the requested fan.


### PR DESCRIPTION
## 🔗 Related Issue

N/A — spawned from an exploration of the `implement-ticket-system-mvp` worktree against latest `main`. The `rpc-auth-scoping` convention introduced by `standardize-user-scoped-rpc-auth` (archived 2026-04-20) is not yet applied to the ticket/entry RPC surface, which still uses the earlier "JWT-only, explicit `reserved user_id`" shape. This PR aligns it before `ticket-management` and `zkp-entry` capabilities are promoted to `specs/` via MVP archival.

## 📝 Summary of Changes

**BREAKING** — three request messages gain a required `entity.v1.UserId user_id` field:

| RPC | Request | Field slot | Prior state |
|---|---|---|---|
| `TicketService.MintTicket` | `MintTicketRequest` | `2` | `reserved 2 / reserved "user_id"` |
| `TicketService.ListTickets` | `ListTicketsRequest` | `1` | `reserved 1 / reserved "user_id"` |
| `EntryService.GetMerklePath` | `GetMerklePathRequest` | `2` | `reserved 2 / reserved "user_id"` |

Deliberately **unchanged**:
- `GetTicketRequest` — identifier-scoped (keyed by `ticket_id`); `rpc-auth-scoping` does not apply.
- `VerifyEntryRequest` — explicitly unauthenticated (the ZK proof is the authentication); no JWT to match against.

Also adds the `align-ticket-rpcs-with-auth-scoping` OpenSpec change (proposal, design, spec deltas for `ticket-management` / `zkp-entry`, tasks). Spec deltas are purely **ADDED Requirements** because the MVP change's existing `ticket-management` / `zkp-entry` deltas describe only contract + proof-gen concerns, not RPC auth — no MODIFIED needed.

Motivation and alternatives considered live in [`design.md`](openspec/changes/align-ticket-rpcs-with-auth-scoping/design.md) (decisions on scope, field number reuse, helper reuse, breaking-change discipline).

## Downstream rollout

Standard cross-repo release coordination per the workspace CLAUDE.md:

1. This PR merges.
2. GitHub Release `vX.Y.0` (marked breaking) → `buf-release.yml` pushes to BSR.
3. `backend` updates `buf.build/gen/go/liverty-music/schema` and calls `mapper.RequireUserIDMatch` in the three affected ticket handlers.
4. `frontend` injects the cached `user_id` from the `UserIdCache` service (infrastructure already present from `standardize-user-scoped-rpc-auth`) into the three affected request bodies.

Backend and frontend branches can be prepared in parallel with placeholder types; PRs open after BSR gen completes.

## ✅ Self-Checklist

- [x] `buf lint` passes
- [x] `buf format -w` produced no additional diff beyond the intentional changes
- [x] `buf breaking` detects the 6 expected violations (3 RPCs × removal of reserved name + reserved range) — `buf skip breaking` label applied
- [x] OpenSpec change validates: `openspec validate align-ticket-rpcs-with-auth-scoping --strict` is clean
- [x] `GetTicket` / `VerifyEntry` deliberately untouched (verified via diff)
- [ ] Reviewer confirms the spec/design rationale matches the intended rollout order
