### PR TITLE
docs(openspec): propose optimize-dev-gke-cost change

### DIFF
--- a/openspec/changes/optimize-dev-gke-cost/.openspec.yaml
+++ b/openspec/changes/optimize-dev-gke-cost/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-27

--- a/openspec/changes/optimize-dev-gke-cost/design.md
+++ b/openspec/changes/optimize-dev-gke-cost/design.md
@@ -1,0 +1,94 @@
+## Context
+
+The dev Compute Engine bill jumped to ¥9,953/month (+1403%) following the Apr 8 Autopilot→Standard switch and the Apr 21 self-hosted Zitadel deployment. Two specific configurations dominate the spend:
+
+1. **Boot disks**: 3 nodes × 100GB pd-balanced = ~¥4,500/month. The 100GB size is the GKE NodePool default when `diskSizeGb` is unspecified; pd-balanced is the default `diskType`. Neither is justified for dev — image cache and OS rarely exceed 10GB.
+2. **3rd Spot node**: forced by Zitadel API+Login Deployments running 2 replicas each with `requiredDuringSchedulingIgnoredDuringExecution` pod anti-affinity. With 4 replicas and `topologyKey: kubernetes.io/hostname`, the scheduler cannot pack onto 2 nodes, so the autoscaler permanently runs at the new `maxNodeCount: 3`.
+
+The cluster currently runs at ~85% CPU request packing across 3 e2-medium nodes (940m allocatable each). Removing one Zitadel API replica (240m total, including its cloud-sql-proxy and bootstrap-uploader sidecars) plus one Login replica (50m) frees enough headroom that the autoscaler can downscale to 2 nodes when load is idle, eliminating the 3rd node's compute, disk, and external IP charges.
+
+dev does not require HA: a Spot preemption already causes 1-2 minute service interruptions even with 2 replicas. The cost-vs-availability trade-off favors aggressive cost reduction.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Lower dev Compute Engine SKU spend by ≥50% (target ~¥4,400/month).
+- Use the cheapest disk type compatible with the existing E2 machine series.
+- Keep the change reversible: each modification is a single config flip, not a topology change.
+- Preserve the Standard cluster + Spot nodes + public IP architecture chosen on Apr 8 (no Cloud NAT regression).
+
+**Non-Goals:**
+- Migrating to a different machine series (e.g., N4 with Hyperdisk Throughput). E2 remains the cheapest GCP general-purpose family for the dev workload size.
+- Touching staging or prod overlays. This change is dev-only.
+- Refactoring the Zitadel base manifest. Replicas are tuned via overlay only, preserving multi-environment defaults.
+- Removing the 3rd-node capacity headroom. `maxNodeCount: 3` is retained as autoscaler ceiling; only the *forced* 3rd-node baseline is eliminated.
+- Removing the cloud-sql-proxy Deployment added Apr 13 for local DB access. That tool is operator-facing infrastructure; removing it is a separate scope.
+
+## Decisions
+
+### Decision 1: pd-standard 30GB for Spot pool boot disk
+
+**Choice:** `diskType: pd-standard`, `diskSizeGb: 30`.
+
+**Why:**
+- E2 machine series does NOT support any Hyperdisk variant per `cloud.google.com/compute/docs/disks/hyperdisks` (Balanced, Throughput, Extreme, ML all show `—` for E2). Hyperdisk Throughput would otherwise be the cheapest at small sizes for newer series.
+- Among E2-compatible types (pd-standard / pd-balanced / pd-ssd), pd-standard is the cheapest at $0.052/GB/month in asia-northeast2 (vs $0.10 for pd-balanced, $0.17 for pd-ssd).
+- 30GB is GKE's recommended minimum. 10GB and 20GB options were considered but rejected: GKE evicts pods at 85% disk full (`DiskPressure` taint), and Container-Optimized OS plus the cluster's typical image cache (zitadel + cloud-sql-proxy + backend + frontend + ArgoCD + KEDA + Atlas + ESO + Reloader + OTel images) routinely consumes 8-12GB. 20GB tightens but works; 10GB risks frequent image GC churn and surprise evictions.
+- pd-standard is HDD-backed with low IOPS, which slows cold node bootstrap and image pull by a few seconds — acceptable for dev where node churn is rare.
+
+**Alternatives considered:**
+- `pd-balanced 30GB` — would still save ~¥3,150/month vs current 100GB pd-balanced, but pd-standard saves additional ~¥650/month for no functional cost in dev.
+- `pd-standard 20GB` — saves an extra ~¥230/month vs 30GB. Marginal benefit, higher risk of hitting `DiskPressure` during multi-image pulls. Rejected.
+- Switch to N4 + Hyperdisk Throughput — N4 base price exceeds E2 by enough that net cost rises. Rejected.
+
+### Decision 2: Zitadel dev replicas → 1 (both API and Login)
+
+**Choice:** Patch dev overlays for both `zitadel` and `zitadel-login` Deployments to `replicas: 1`.
+
+**Why:**
+- A single replica eliminates the `podAntiAffinity: required` constraint's effect (no siblings to spread). The autoscaler can then pack the cluster onto 2 nodes when idle.
+- Zitadel API replica savings: 1 × (zitadel 100m + cloud-sql-proxy 10m + bootstrap-uploader 10m) = 120m CPU, 352Mi memory, plus boot disk image cache pressure.
+- Zitadel Login replica savings: 1 × 50m CPU, 128Mi memory.
+- Spot preemption already causes brief outages with 2 replicas (a single Spot zone preemption can take both replicas if landed on adjacent nodes despite anti-affinity, since anti-affinity is hostname-scoped and Spot preemption is zone-scoped). Dropping to 1 replica converts the failure mode from "rare both-replica preemption" to "any preemption causes ~90s outage" — material in prod, immaterial in dev.
+
+**Alternatives considered:**
+- Keep `replicas: 2`, change anti-affinity from `required` → `preferred` — would let the scheduler pack both replicas onto one node when needed, achieving similar autoscaler outcomes. Rejected because it doubles CPU/memory/disk overhead vs single replica with no dev-visible benefit.
+- Set `replicas: 0` and use Zitadel Cloud — undoes the Apr 21 self-hosted migration entirely. Out of scope; that migration was completed for reasons unrelated to cost.
+
+### Decision 3: PDB `minAvailable: 0` in dev overlay
+
+**Choice:** Add `pdb-patch.yaml` to the dev overlay, patching both `zitadel` and `zitadel-login` PDBs to `minAvailable: 0`.
+
+**Why:**
+- The base PDB declares `minAvailable: 1`. With `replicas: 1`, the only pod is also the only voluntarily-evictable pod, and `minAvailable: 1` blocks eviction permanently. This breaks `kubectl drain`, ArgoCD-driven rollouts, GKE node auto-upgrade, and graceful Spot preemption.
+- `minAvailable: 0` allows voluntary disruption while preserving the PDB resource (so prod/staging continue to enforce `minAvailable: 1` from the base).
+- Alternative `kubectl delete pdb` via overlay's `patches: [{op: remove}]` was considered but rejected — keeping the resource present and merely relaxed makes prod/staging vs dev diff cleaner.
+
+### Decision 4: Retain `maxNodeCount: 3`
+
+**Choice:** Do not lower the autoscaler ceiling.
+
+**Why:**
+- Lowering to 2 risks `Pending` pods if cluster load briefly spikes (e.g., during a NodePool replace, batch job runs concert-discovery, or rolling deploys overlap). The autoscaler bills only for *running* nodes — keeping the ceiling at 3 is free insurance.
+- After this change, expected steady-state is 2 nodes; 3rd node only spins up under transient load and downscales after the autoscaler's idle threshold (~10 minutes).
+
+## Risks / Trade-offs
+
+- **NodePool boot disk reconfiguration is in-place (verified via `pulumi preview`)** → `diskSizeGb` and `diskType` changes resolve to `~ update` on the existing `spot-pool-osaka` NodePool, with 206 other resources untouched. GKE rolls out the new disk template via surge upgrade (node-by-node), respecting PDBs. With dev PDBs relaxed to `minAvailable: 0`, the single Zitadel/backend/frontend replica drains cleanly and reschedules onto the next node. Expected user-visible downtime per pod: <90 s during its single eviction window.
+- **30GB pd-standard slower bootstrap** → New nodes take ~30-60s longer to become Ready due to HDD image pull. Acceptable for dev. Mitigation: none needed; not user-facing.
+- **`replicas: 1` Zitadel = single point of failure during deploys** → Rolling deploy briefly has zero pods (maxUnavailable=0 + maxSurge=1 means new pod starts before old terminates, so brief overlap is preserved). Worst case: ~30s gap if new pod fails readiness. Mitigation: rely on browser retry; dev users can refresh.
+- **Autoscaler may not downscale to 2** → If the post-change CPU request total still exceeds 1880m (2 × 940m), 3rd node stays up and savings are partial. Mitigation: post-deploy verification step in tasks confirms node count and computes actual savings. If 3rd node persists, a follow-up change can right-size other workloads (cloud-sql-proxy Deployment, KEDA operator, OTel collector).
+- **PDB relaxation in dev only** → No risk to prod since base PDB and prod overlay (no patch) keep `minAvailable: 1`. Verified by `kubectl kustomize k8s/namespaces/zitadel/overlays/dev` showing only the dev manifest is affected.
+
+## Migration Plan
+
+1. Pulumi changes deploy via the auto-`pulumi up` job triggered by merge to `main` (per cloud-provisioning CLAUDE.md). The NodePool in-place update happens inside that run; GKE then performs a surge upgrade across the spot pool's nodes.
+2. Kustomize overlay changes apply via ArgoCD's existing sync to the `zitadel` Application after merge.
+3. Verification (post-deploy):
+   - `gcloud compute disks list` — boot disks show `30 pd-standard`.
+   - `kubectl get nodes` — 2 or 3 nodes (down from current 3).
+   - `kubectl get deploy -n zitadel` — both Deployments show `1/1` ready.
+   - `kubectl get pdb -n zitadel` — both PDBs show `minAvailable: 0` for dev.
+   - `gcloud billing` cost report after 7 days — Compute Engine SKU trends down to target ¥4,400/month range.
+
+**Rollback:** revert the PR and re-deploy. NodePool reverts to 100GB pd-balanced via in-place update + surge upgrade; Zitadel replicas return to 2. No data migration concerns since boot disks are stateless and PVCs are untouched.

--- a/openspec/changes/optimize-dev-gke-cost/proposal.md
+++ b/openspec/changes/optimize-dev-gke-cost/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+The dev GCP project's Compute Engine spend jumped +1403% in the last 30 days (¥663 → ¥9,953/month). Investigation traced the spike to two compounding factors: GKE node boot disks defaulting to 100GB pd-balanced (~45% of the Compute Engine bill), and the Apr 21 self-hosted Zitadel deployment forcing a 3rd Spot node via 2 anti-affinity-spread API replicas. dev does not need HA or large boot volumes — these defaults are pure waste.
+
+## What Changes
+
+- **GKE Spot node pool boot disk SHALL be 30GB pd-standard** (down from default 100GB pd-balanced). E2 machine series does not support Hyperdisk per GCP documentation; pd-standard is the cheapest available type for E2.
+- **Zitadel API and Login dev overlay replicas SHALL be reduced from 2 to 1**. The self-hosted Zitadel base manifests retain `replicas: 2` for staging/prod parity; only the dev overlay is patched.
+- **Zitadel PodDisruptionBudget dev overlay SHALL relax `minAvailable` from 1 to 0**, since `replicas: 1 + minAvailable: 1` permanently blocks voluntary eviction (rolling updates, node drains, Spot preemption graceful handling).
+- The `spot-pool` autoscaler `maxNodeCount: 3` setting is retained (raised from 2 on Apr 22 for Zitadel capacity); the autoscaler will downscale to 2 when total CPU requests fit. No spec change needed there.
+- **NodePool boot disk update is in-place** (verified by `pulumi preview --stack dev`): `~ update` on `spot-pool-osaka` only, 206 other resources untouched. GKE rolls out the new disk template via surge upgrade, respecting PDBs.
+
+## Capabilities
+
+### New Capabilities
+None.
+
+### Modified Capabilities
+- `gke-standard-infrastructure`: Add a requirement specifying the Spot node pool boot disk size (30GB) and type (pd-standard), with the rationale that E2 does not support Hyperdisk.
+
+## Impact
+
+- **Affected code**:
+  - `cloud-provisioning/src/gcp/components/kubernetes.ts` — add `diskSizeGb` and `diskType` to spot pool `nodeConfig`
+  - `cloud-provisioning/k8s/namespaces/zitadel/overlays/dev/deployment-patch.yaml` — `replicas: 2 → 1`
+  - `cloud-provisioning/k8s/namespaces/zitadel/overlays/dev/deployment-login-patch.yaml` — `replicas: 2 → 1`
+  - `cloud-provisioning/k8s/namespaces/zitadel/overlays/dev/` — new `pdb-patch.yaml` + register in overlay `kustomization.yaml`
+- **Affected systems**: dev GKE cluster `standard-cluster-osaka` only. Staging/prod unaffected (no overlay changes for those environments; node pool config is gated on `environment === 'dev'`).
+- **Estimated savings**: ~¥3,800/month (boot disk) + ~¥1,700/month (Zitadel replica drops, conditional on autoscaler reaching 2 nodes) ≈ **~¥5,500/month**, lowering dev Compute Engine spend from ¥9,953 to an estimated ¥4,400.
+- **Deployment risk**: brief (<90 s) per-pod eviction window during the GKE surge upgrade after the in-place NodePool update. Acceptable for dev. No data loss (boot disks are stateless; PVCs untouched).
+- **Dependencies**: None — change is self-contained within `cloud-provisioning`.

--- a/openspec/changes/optimize-dev-gke-cost/specs/gke-standard-infrastructure/spec.md
+++ b/openspec/changes/optimize-dev-gke-cost/specs/gke-standard-infrastructure/spec.md
@@ -1,0 +1,16 @@
+## ADDED Requirements
+
+### Requirement: Dev cluster Spot node pool boot disk SHALL be 30GB pd-standard
+The dev GKE Spot node pool boot disk SHALL be explicitly configured with `diskSizeGb: 30` and `diskType: pd-standard`. The default GKE values (100GB, pd-balanced) SHALL NOT be used. Rationale: the E2 machine series does not support any Hyperdisk variant per GCP documentation, so pd-standard is the cheapest available type, and 30GB is GKE's recommended minimum that comfortably fits the cluster's image cache without triggering DiskPressure evictions.
+
+#### Scenario: Boot disk size is 30GB
+- **WHEN** describing the dev Spot node pool `nodeConfig`
+- **THEN** `diskSizeGb` SHALL equal `30`
+
+#### Scenario: Boot disk type is pd-standard
+- **WHEN** describing the dev Spot node pool `nodeConfig`
+- **THEN** `diskType` SHALL equal `"pd-standard"`
+
+#### Scenario: All running spot nodes use the configured disk
+- **WHEN** running `gcloud compute disks list` filtered to the spot pool node prefix
+- **THEN** every disk SHALL show `SIZE_GB: 30` and `TYPE: pd-standard`

--- a/openspec/changes/optimize-dev-gke-cost/tasks.md
+++ b/openspec/changes/optimize-dev-gke-cost/tasks.md
@@ -1,0 +1,41 @@
+## 1. Pulumi: GKE Spot node pool boot disk
+
+- [x] 1.1 Edit `cloud-provisioning/src/gcp/components/kubernetes.ts`: in the `dev` branch's `gcp.container.NodePool` `nodeConfig`, add `diskSizeGb: 30` and `diskType: 'pd-standard'`.
+- [x] 1.2 Run `make lint-ts` in `cloud-provisioning` to verify biome + tsc pass.
+- [x] 1.3 Run `pulumi preview --stack dev` and confirm the plan shows `+- replace` (or `~ update`) on `spot-pool-osaka` only, with `diskSizeGb: 100 → 30` and `diskType: pd-balanced → pd-standard`. Verify no other resources are affected unexpectedly. **Result: `~ update` (in-place) — GKE handles via surge upgrade, no full NodePool replacement. Resources: 1 to update, 206 unchanged.**
+
+## 2. Kubernetes: Zitadel dev overlay replicas → 1
+
+- [x] 2.1 Edit `cloud-provisioning/k8s/namespaces/zitadel/overlays/dev/deployment-patch.yaml`: change `replicas: 2` to `replicas: 1`.
+- [x] 2.2 Edit `cloud-provisioning/k8s/namespaces/zitadel/overlays/dev/deployment-login-patch.yaml`: change `replicas: 2` to `replicas: 1`.
+- [x] 2.3 Update the comment in both patch files to reflect `replicaCount 1` (replacing the existing `replicaCount 2 to satisfy PDB minAvailable=1` rationale, since PDB will be relaxed below).
+
+## 3. Kubernetes: Zitadel dev PDB relaxation
+
+- [x] 3.1 Create `cloud-provisioning/k8s/namespaces/zitadel/overlays/dev/pdb-patch.yaml` with two PDB patches (`zitadel` and `zitadel-login`), each setting `spec.minAvailable: 0`.
+- [x] 3.2 Edit `cloud-provisioning/k8s/namespaces/zitadel/overlays/dev/kustomization.yaml`: add `pdb-patch.yaml` to the `patches` (or `patchesStrategicMerge`) list following the existing patch entries' pattern.
+- [x] 3.3 Run `kubectl kustomize cloud-provisioning/k8s/namespaces/zitadel/overlays/dev` and verify:
+  - `Deployment/zitadel` shows `replicas: 1`. ✓
+  - `Deployment/zitadel-login` shows `replicas: 1`. ✓
+  - `PodDisruptionBudget/zitadel` shows `minAvailable: 0`. ✓
+  - `PodDisruptionBudget/zitadel-login` shows `minAvailable: 0`. ✓
+  - Spot nodeSelector and `enableServiceLinks: false` from base are preserved. ✓
+- [x] 3.4 Run `make lint-k8s` (or the kube-linter step from `make lint`) and confirm zero errors. **Note: `make lint-k8s` fails on argocd overlay due to pre-existing Helm v4 incompatibility (unrelated to this change). Ran `kube-linter` on the rendered zitadel overlay directly: `No lint errors found!`. Spot nodeSelector check: `OK: All workloads have Spot VM nodeSelector.`**
+
+## 4. Pre-merge validation
+
+- [x] 4.1 Run `make check` in `cloud-provisioning` (lint-ts + lint-k8s) and confirm all checks pass. **Result: `make check` exits 0. (Pre-commit target only runs lint-ts; lint-k8s is broken by Helm v4 in argocd overlay — see 3.4 note.)**
+- [ ] 4.2 Open a PR against `cloud-provisioning/main`. Note in the description that NodePool replacement triggers a ~2-3 minute reschedule window.
+
+## 5. Deploy and verify (post-merge)
+
+- [ ] 5.1 Monitor the auto-`pulumi up` job at https://app.pulumi.com/pannpers/liverty-music/dev/deployments until the NodePool replace completes successfully.
+- [ ] 5.2 Verify boot disks: `gcloud compute disks list --filter="name~^gke-standard-cluster--spot-pool"` shows all spot node disks at `SIZE_GB: 30` and `TYPE: pd-standard`.
+- [ ] 5.3 Wait for ArgoCD to sync the `zitadel` Application after the cloud-provisioning merge. Verify `kubectl get deploy -n zitadel` shows both Deployments at `1/1`.
+- [ ] 5.4 Verify `kubectl get pdb -n zitadel` shows both PDBs with `MIN AVAILABLE: 0`.
+- [ ] 5.5 Wait at least 15 minutes for the cluster autoscaler idle threshold, then run `kubectl get nodes -l cloud.google.com/gke-spot=true`. Record the node count (target: 2; acceptable: 3 if other workloads still pin a 3rd node).
+
+## 6. Cost impact follow-up (after 7+ days)
+
+- [ ] 6.1 Re-pull the GCP Billing report for the dev project, scoped to Compute Engine SKU. Compare daily Compute Engine cost from before the change vs the trailing 3-day average after the change. Target: ≥50% reduction.
+- [ ] 6.2 If the autoscaler still pins 3 nodes (i.e., savings fall short), open a follow-up issue investigating which workload's CPU requests prevent compaction (likely candidates: cloud-sql-proxy Deployment, KEDA operator, OTel collector).


### PR DESCRIPTION
## Summary

OpenSpec change proposal `optimize-dev-gke-cost`: cut dev GCP Compute Engine spend (~¥9,953/month, ↑1403%) by ~50% via two targeted config flips:

- **Spot node pool boot disks**: 100 GB pd-balanced → **30 GB pd-standard** (E2 doesn't support Hyperdisk; pd-standard is the cheapest E2-compatible type)
- **Zitadel dev overlay**: API + Login replicas 2 → 1, PDBs `minAvailable` → 0 — removes the `requiredDuringScheduling` anti-affinity spread requirement so the cluster autoscaler can compact back to 2 spot nodes

## Spec impact

ADDED requirement on `gke-standard-infrastructure`:

> Dev cluster Spot node pool boot disk SHALL be 30GB pd-standard.

with three verification scenarios.

> Note: the existing scenario `autoscaling SHALL be enabled with min 1 and max 2 nodes` is currently drifted from reality (Apr 22 raised `maxNodeCount: 2 → 3` for Zitadel capacity, no spec update at the time). This PR intentionally does NOT touch that — separate clean-up to keep this scope tight.

## Implementation PR

- liverty-music/cloud-provisioning#208 (already opened)
- `pulumi preview --stack dev` confirmed `~ update` (in-place) on `spot-pool-osaka` only — 1 to update, 206 unchanged
- `make check` clean, kustomize render verified, kube-linter zero errors

## Test plan

- [x] `openspec validate optimize-dev-gke-cost` passes
- [x] proposal / design / spec delta / tasks all generated and consistent
- [x] cloud-provisioning impl PR opened (#208) and lint/preview verified
- [ ] After cloud-provisioning#208 merges and rolls out, archive this change via `/opsx:archive`
