### PR TITLE
docs(openspec): fix internal contradictions in optimize-dev-gke-cost artifacts

### DIFF
--- a/openspec/changes/optimize-dev-gke-cost/design.md
+++ b/openspec/changes/optimize-dev-gke-cost/design.md
@@ -5,7 +5,7 @@ The dev Compute Engine bill jumped to ¥9,953/month (+1403%) following the Apr 8
 1. **Boot disks**: 3 nodes × 100GB pd-balanced = ~¥4,500/month. The 100GB size is the GKE NodePool default when `diskSizeGb` is unspecified; pd-balanced is the default `diskType`. Neither is justified for dev — image cache and OS rarely exceed 10GB.
 2. **3rd Spot node**: forced by Zitadel API+Login Deployments running 2 replicas each with `requiredDuringSchedulingIgnoredDuringExecution` pod anti-affinity. With 4 replicas and `topologyKey: kubernetes.io/hostname`, the scheduler cannot pack onto 2 nodes, so the autoscaler permanently runs at the new `maxNodeCount: 3`.
 
-The cluster currently runs at ~85% CPU request packing across 3 e2-medium nodes (940m allocatable each). Removing one Zitadel API replica (240m total, including its cloud-sql-proxy and bootstrap-uploader sidecars) plus one Login replica (50m) frees enough headroom that the autoscaler can downscale to 2 nodes when load is idle, eliminating the 3rd node's compute, disk, and external IP charges.
+The cluster currently runs at ~85% CPU request packing across 3 e2-medium nodes (940m allocatable each). Removing one Zitadel API replica (120m total, including its cloud-sql-proxy and bootstrap-uploader sidecars) plus one Login replica (50m) frees enough headroom that the autoscaler can downscale to 2 nodes when load is idle, eliminating the 3rd node's compute, disk, and external IP charges.
 
 dev does not require HA: a Spot preemption already causes 1-2 minute service interruptions even with 2 replicas. The cost-vs-availability trade-off favors aggressive cost reduction.
 

--- a/openspec/changes/optimize-dev-gke-cost/tasks.md
+++ b/openspec/changes/optimize-dev-gke-cost/tasks.md
@@ -25,11 +25,11 @@
 ## 4. Pre-merge validation
 
 - [x] 4.1 Run `make check` in `cloud-provisioning` (lint-ts + lint-k8s) and confirm all checks pass. **Result: `make check` exits 0. (Pre-commit target only runs lint-ts; lint-k8s is broken by Helm v4 in argocd overlay — see 3.4 note.)**
-- [ ] 4.2 Open a PR against `cloud-provisioning/main`. Note in the description that NodePool replacement triggers a ~2-3 minute reschedule window.
+- [ ] 4.2 Open a PR against `cloud-provisioning/main`. Note in the description that the NodePool in-place update triggers a GKE surge upgrade (~90 s per-pod eviction window).
 
 ## 5. Deploy and verify (post-merge)
 
-- [ ] 5.1 Monitor the auto-`pulumi up` job at https://app.pulumi.com/pannpers/liverty-music/dev/deployments until the NodePool replace completes successfully.
+- [ ] 5.1 Monitor the auto-`pulumi up` job at https://app.pulumi.com/pannpers/liverty-music/dev/deployments until the NodePool in-place update and GKE surge upgrade complete successfully.
 - [ ] 5.2 Verify boot disks: `gcloud compute disks list --filter="name~^gke-standard-cluster--spot-pool"` shows all spot node disks at `SIZE_GB: 30` and `TYPE: pd-standard`.
 - [ ] 5.3 Wait for ArgoCD to sync the `zitadel` Application after the cloud-provisioning merge. Verify `kubectl get deploy -n zitadel` shows both Deployments at `1/1`.
 - [ ] 5.4 Verify `kubectl get pdb -n zitadel` shows both PDBs with `MIN AVAILABLE: 0`.


### PR DESCRIPTION
## Summary

Resolves two unaddressed Claude review-bot comments from #425 (merged with the issues in place).

- **design.md** Context: `240m total` → `120m total` for "one Zitadel API replica" — the 240m figure was for two replicas; Decision 2's own arithmetic (100+10+10=120m per replica) is the correct one. Internal contradiction fixed.
- **tasks.md** tasks 4.2 and 5.1: rewrite "NodePool replacement" / "until the NodePool replace completes successfully" to describe the actual `~ update` (in-place) behavior + GKE surge upgrade (~90 s per-pod eviction window) that task 1.3 verified. design.md and proposal.md already had the corrected wording; tasks.md was the only remaining artifact carrying the stale "replace" framing.

Both changes are artifact-only — no spec requirement or code changes. The corrective scope is intentionally narrow so the original change's intent stays visible in git history.

## Original review threads

- https://github.com/liverty-music/specification/pull/425#discussion_r3145508845
- https://github.com/liverty-music/specification/pull/425#discussion_r3145510115

## Test plan

- [x] `openspec validate optimize-dev-gke-cost` passes
- [x] git diff scoped to the two intended lines (design.md:8 + tasks.md:28,32)
- [ ] CI green (Buf PR Checks)
- [ ] Bot review pass (or no comments)
