### PR TITLE
docs(openspec): archive optimize-dev-kube-dns-replicas change

### DIFF
--- a/openspec/changes/archive/2026-04-30-optimize-dev-kube-dns-replicas/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-30-optimize-dev-kube-dns-replicas/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-28

--- a/openspec/changes/archive/2026-04-30-optimize-dev-kube-dns-replicas/design.md
+++ b/openspec/changes/archive/2026-04-30-optimize-dev-kube-dns-replicas/design.md
@@ -1,0 +1,92 @@
+## Context
+
+The dev GKE cluster runs `kube-dns` as 2 replicas because the GKE-managed `kube-dns-autoscaler` ConfigMap ships with `preventSinglePointFailure: true`. The autoscaler is the upstream Kubernetes `cluster-proportional-autoscaler` (kubernetes-sigs/cluster-proportional-autoscaler); its decision logic for our cluster is:
+
+```
+replicas = max(
+  ceil(total_cores / coresPerReplica),    = ceil(6 / 256)  = 1
+  ceil(total_nodes / nodesPerReplica),    = ceil(3 / 16)   = 1
+  min,                                     = 1
+)
+# preventSinglePointFailure: true forces ≥2 if total_nodes ≥ 2
+```
+
+The single-point-of-failure guard is the only reason kube-dns sits at 2 replicas. Each pod requests 270m CPU, so 2 replicas consume 540m — by far the largest non-DaemonSet CPU draw in the cluster (next is Zitadel API at 120m). With this 540m freed, the cluster's total request budget drops to ~2018m, comfortably fitting the 2-node ceiling (1880m allocatable) and unblocking the cluster autoscaler from retiring the 3rd spot node.
+
+GKE's stance on customization (verified across two official pages):
+
+- **`cloud.google.com/kubernetes-engine/docs/concepts/kube-dns`** ("About kube-dns for GKE") explicitly documents the ConfigMap as the supported tuning knob: *"You can modify the number of `kube-dns` replicas by editing the `kube-dns-autoscaler` ConfigMap."* The four mentioned fields are `coresPerReplica`, `nodesPerReplica`, `min`, `max`, and `preventSinglePointFailure`.
+- **`cloud.google.com/kubernetes-engine/docs/how-to/custom-kube-dns`** ("Set up a custom kube-dns Deployment") describes the heavier alternative — scaling the GKE-managed `kube-dns` and `kube-dns-autoscaler` Deployments to 0 and shipping a self-maintained replacement. That path explicitly transfers ongoing maintenance ownership and is overkill for a single-flag change.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Free ~270m CPU by reducing `kube-dns` to 1 replica in dev, enough headroom for the cluster autoscaler to retire the 3rd spot node.
+- Use the GCP-documented light-touch path (ConfigMap edit) rather than the heavyweight custom-Deployment path.
+- Make the configuration drift-resistant: ArgoCD reconciles continuously, so any GKE-side reset (cluster upgrade, auto-repair) is corrected within minutes.
+- Keep the change strictly dev-scoped via Kustomize overlay; prod and staging continue inheriting GKE's `preventSinglePointFailure: true` default.
+
+**Non-Goals:**
+- NOT switching to NodeLocal DNSCache or any other DNS topology change. The cache already runs as a DaemonSet (existing).
+- NOT replacing the GKE-managed `kube-dns` with a custom Deployment.
+- NOT modifying `coresPerReplica`, `nodesPerReplica`, `min`, or `max`. Only the single boolean.
+- NOT lowering the spot pool's `maxNodeCount` to force compaction. The autoscaler will downscale on its own once the CPU pressure clears.
+- NOT awaiting or short-circuiting the 2026-05-04 scheduled cost-verification agent. That agent verifies the *combined* result of `optimize-dev-gke-cost` plus this change.
+
+## Decisions
+
+### Decision 1: ConfigMap override via dev overlay (vs Pulumi)
+
+**Choice:** Add the ConfigMap manifest under `k8s/cluster/overlays/dev/` and register it in the dev kustomization. ArgoCD's existing `core` Application (path `k8s/cluster/overlays/dev`, sync-wave 1, automated sync + selfHeal) reconciles it.
+
+**Why:**
+- The cluster-level overlay is already where dev-only kube-system overrides belong (it currently hosts the dev `ClusterSecretStore` patch). Adding a sibling ConfigMap is symmetric.
+- ArgoCD `selfHeal: true` is the strongest available drift-recovery story: any GKE-side reset is corrected within the sync interval, no human intervention.
+- Dev-only by virtue of overlay placement — prod/staging cannot accidentally inherit it.
+
+**Alternatives considered:**
+- Manage via Pulumi `gcp.k8s.core.v1.ConfigMap` — Pulumi is meant for GCP-side primitives in this project, not in-cluster manifests. Mixing them would muddy the source-of-truth split (Pulumi for GCP, ArgoCD/Kustomize for k8s). Rejected.
+- One-shot `kubectl edit` — works once, but offers no drift recovery and no audit trail. Rejected.
+- Patch the existing kube-dns-autoscaler ConfigMap in-place via Kustomize JSON6902 patch — equivalent functionally, but the upstream ConfigMap's `data.linear` field is a JSON-serialized string (not a structured field), so a strategic merge or full-replacement manifest is cleaner than a patch. Rejected in favor of full-replacement.
+
+### Decision 2: Provide a full ConfigMap (not a patch)
+
+**Choice:** The dev overlay provides the entire `kube-dns-autoscaler` ConfigMap as a resource (with all fields explicit), not a partial patch.
+
+**Why:**
+- The upstream cluster-proportional-autoscaler reads `data.linear` as a single JSON string. A field-level patch on this nested string is awkward (Kustomize doesn't natively edit JSON-in-string values).
+- A complete ConfigMap manifest documents the dev-intended values as one readable block. Anyone reviewing the overlay sees the full configuration, not just the diff.
+- ArgoCD treats this as a regular Apply: kubectl server-side-apply merges fields, overwriting any GKE-default values for fields we declare. The `data.linear` JSON gets fully replaced with our string.
+
+**Alternatives considered:**
+- Strategic merge patch on `data.linear` — Kustomize cannot parse JSON-in-string fields. Rejected.
+- JSON6902 patch with full-string replacement — works but obscures readability. Rejected.
+
+### Decision 3: Preserve `coresPerReplica`, `nodesPerReplica`, `min`, `max` at GKE defaults
+
+**Choice:** The dev ConfigMap keeps `coresPerReplica: 256, nodesPerReplica: 16` (and any default `min`, `max`), changing only `preventSinglePointFailure: true → false`.
+
+**Why:**
+- The autoscaler formula already correctly computes 1 replica for our cluster size. Changing other fields adds variables to the rollback story without benefit.
+- Lower `coresPerReplica` (e.g., 128) would *increase* replicas as the cluster grows, the opposite of what we want.
+- Tightening `max` would forbid scale-up if the dev cluster ever needs more DNS capacity (rare but possible during traffic spikes).
+
+**Alternatives considered:**
+- Set `min: 1, max: 1` to lock the replica count — works but is more aggressive than needed and removes the autoscaler's ability to scale up if dev workload grows. Rejected.
+
+## Risks / Trade-offs
+
+- **Single kube-dns replica = brief DNS gaps during pod reschedule** → Mitigation: the cluster's `node-local-dns` DaemonSet caches resolves locally on each node, masking most pod-reschedule gaps. Go HTTP clients and browsers retry transparently. Material risk only for ultra-latency-sensitive workloads, of which dev has none.
+- **GKE may reset the ConfigMap during cluster upgrades** → ArgoCD's `selfHeal: true` reconciles within seconds, so the window of GKE-default behavior is short. Documented in design.md as expected behavior.
+- **Future GKE policy could lock the ConfigMap** → If GKE starts treating the ConfigMap as managed (similar to the kube-dns Deployment itself), the override would stop working. Mitigation: when that happens, fall back to the documented "custom kube-dns Deployment" path. Probability low; not a blocker.
+- **Estimated ¥1,300/month savings is conditional on autoscaler downscale** → If other workloads grow CPU requests in the meantime, the autoscaler may keep 3 nodes anyway. Mitigation: post-deploy verification step (re-check `kubectl get nodes` count) included in tasks.
+
+## Migration Plan
+
+1. PR opened against `cloud-provisioning/main`. CI green required.
+2. On merge, ArgoCD's `core` Application picks up the new resource within one sync interval (~3 min).
+3. ArgoCD applies the ConfigMap; the running `kube-dns-autoscaler` controller reads it on its next loop (~10 s) and scales `kube-dns` Deployment from 2 → 1.
+4. Cluster autoscaler observes the freed 270m + idle headroom on the 3rd node. After the autoscaler's idle threshold (~10 min), the 3rd node is drained (PDBs respected) and removed.
+5. Verification: `kubectl get deploy kube-dns -n kube-system` shows `1/1`; `kubectl get nodes -l cloud.google.com/gke-spot=true` shows 2 nodes.
+
+**Rollback:** revert the PR. ArgoCD removes the dev ConfigMap on next sync; GKE's reconciler restores its default `preventSinglePointFailure: true`; kube-dns scales back to 2; autoscaler may add the 3rd node back if other workloads request it.

--- a/openspec/changes/archive/2026-04-30-optimize-dev-kube-dns-replicas/design.md
+++ b/openspec/changes/archive/2026-04-30-optimize-dev-kube-dns-replicas/design.md
@@ -11,7 +11,7 @@ replicas = max(
 # preventSinglePointFailure: true forces ≥2 if total_nodes ≥ 2
 ```
 
-The single-point-of-failure guard is the only reason kube-dns sits at 2 replicas. Each pod requests 270m CPU, so 2 replicas consume 540m — by far the largest non-DaemonSet CPU draw in the cluster (next is Zitadel API at 120m). With this 540m freed, the cluster's total request budget drops to ~2018m, comfortably fitting the 2-node ceiling (1880m allocatable) and unblocking the cluster autoscaler from retiring the 3rd spot node.
+The single-point-of-failure guard is the only reason kube-dns sits at 2 replicas. Each pod requests 270m CPU, so 2 replicas consume 540m — by far the largest non-DaemonSet CPU draw in the cluster (next is Zitadel API at 120m). With ~270m freed (one of the two replicas removed), the cluster's total request budget drops to ~2018m. Although that still exceeds the 2-node allocatable ceiling (1880m) on raw request math, the cluster autoscaler scales on per-node utilization rather than aggregate requests, and retiring a node also removes that node's per-node DaemonSet pods (~378m worth). The actual post-compaction state recorded in tasks.md is ~1614m on 1880m capacity (86% packed, ~266m headroom).
 
 GKE's stance on customization (verified across two official pages):
 

--- a/openspec/changes/archive/2026-04-30-optimize-dev-kube-dns-replicas/proposal.md
+++ b/openspec/changes/archive/2026-04-30-optimize-dev-kube-dns-replicas/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+The previous change `optimize-dev-gke-cost` (archived 2026-04-28) only realized ~38% of the targeted Compute Engine cost reduction. Post-deploy investigation pinpointed the gap: total CPU requests across the dev spot pool sit at 2288m on 3 e2-medium nodes, exceeding the 2-node ceiling (1880m) by 408m. The dominant non-DaemonSet consumer is `kube-dns × 2 replicas = 540m`, kept at 2 replicas by `preventSinglePointFailure: true` in the GKE-managed `kube-dns-autoscaler` ConfigMap. With the cluster-proportional-autoscaler formula (`coresPerReplica: 256, nodesPerReplica: 16`), the calculated replica count for our 3-node, 6-vCPU dev cluster would otherwise be `max(6/256, 3/16, 1) = 1`. Disabling the single-point-of-failure guard frees ~270m, lets the cluster autoscaler retire the 3rd spot node, and completes the cost-optimization that boot-disk shrink + Zitadel replica drops alone could not.
+
+## What Changes
+
+- Add a dev-only Kubernetes manifest declaring the `kube-dns-autoscaler` ConfigMap (in `kube-system`) with `preventSinglePointFailure: false`, preserving the other linear-autoscaler parameters (`coresPerReplica: 256`, `nodesPerReplica: 16`).
+- Register the new manifest in the dev cluster overlay so ArgoCD's existing `core` Application reconciles it continuously (auto-recovering from any GKE-side resets, e.g., during cluster upgrades).
+- Document this as the GCP-supported customization path: per `cloud.google.com/kubernetes-engine/docs/concepts/kube-dns`, editing the autoscaler ConfigMap IS the documented knob; the alternative "custom kube-dns Deployment" path is explicitly heavier and out of scope.
+
+## Capabilities
+
+### New Capabilities
+None.
+
+### Modified Capabilities
+- `gke-standard-infrastructure`: ADD a requirement constraining the dev cluster's `kube-dns-autoscaler` ConfigMap to `preventSinglePointFailure: false`, with verification scenarios for ConfigMap state and the resulting `kube-dns` Deployment replica count.
+
+## Impact
+
+- **Affected code**:
+  - `cloud-provisioning/k8s/cluster/overlays/dev/kube-dns-autoscaler.yaml` (new) — the dev-only ConfigMap manifest
+  - `cloud-provisioning/k8s/cluster/overlays/dev/kustomization.yaml` (edit) — register the new resource
+  - `specification/openspec/specs/gke-standard-infrastructure/spec.md` (edit at archive time) — sync the new requirement
+- **Affected systems**: dev GKE cluster `standard-cluster-osaka` only. No prod/staging changes; they retain GKE's default `preventSinglePointFailure: true`. No Pulumi changes.
+- **Estimated savings**: ~¥1,300/month from retiring the 3rd spot node (e2-medium spot VM + 30 GB pd-standard boot disk + external IPv4). Combined with the previous change's ~¥3,800/month boot-disk savings, the dev Compute Engine SKU lands at ~¥4,400/month from the original ¥9,953/month — meeting the original ≥50% reduction target.
+- **Deployment risk**: brief DNS lookup gaps when the single `kube-dns` pod is rescheduled (Spot preemption, node drain, rolling update). Browsers, Go HTTP clients, and the in-cluster `node-local-dns` cache retry transparently for the vast majority of lookups.
+- **Dependencies**: none. ArgoCD's `core` Application (sync-wave: 1, path `k8s/cluster/overlays/dev`, automated sync + selfHeal) already covers the deploy path.

--- a/openspec/changes/archive/2026-04-30-optimize-dev-kube-dns-replicas/specs/gke-standard-infrastructure/spec.md
+++ b/openspec/changes/archive/2026-04-30-optimize-dev-kube-dns-replicas/specs/gke-standard-infrastructure/spec.md
@@ -1,0 +1,21 @@
+## ADDED Requirements
+
+### Requirement: Dev cluster `kube-dns-autoscaler` SHALL set `preventSinglePointFailure: false`
+The dev GKE cluster SHALL override the GKE-managed `kube-dns-autoscaler` ConfigMap (in `kube-system`) so that the linear scaling policy declares `preventSinglePointFailure: false`. The remaining linear-policy fields (`coresPerReplica`, `nodesPerReplica`) SHALL retain GKE's defaults of 256 and 16 respectively. Rationale: with the cluster at 6 vCPU / 3 nodes, the cluster-proportional-autoscaler formula computes 1 desired replica; the single-point-of-failure guard is the only reason kube-dns runs at 2 replicas, consuming an additional 270m CPU that prevents the cluster autoscaler from compacting to 2 spot nodes. dev does not require kube-dns HA — `node-local-dns` caching plus client retries cover the rare reschedule gap.
+
+#### Scenario: ConfigMap declares preventSinglePointFailure false
+- **WHEN** running `kubectl get configmap kube-dns-autoscaler -n kube-system -o yaml` on the dev cluster
+- **THEN** the `data.linear` JSON value SHALL contain `"preventSinglePointFailure":false`
+
+#### Scenario: kube-dns scales to one replica
+- **WHEN** running `kubectl get deployment kube-dns -n kube-system` on the dev cluster after the autoscaler has reconciled
+- **THEN** the `READY` count SHALL be `1/1`
+
+#### Scenario: Override is reconciled by ArgoCD
+- **WHEN** the GKE control plane resets the ConfigMap to its managed default (e.g., during cluster upgrade)
+- **THEN** ArgoCD's `core` Application SHALL re-apply the dev override within one sync interval, restoring `preventSinglePointFailure: false`
+
+#### Scenario: Override is dev-only
+- **WHEN** comparing rendered manifests for `prod` and `staging` overlays
+- **THEN** neither overlay SHALL include a `kube-dns-autoscaler` ConfigMap override
+- **AND** the GKE-default `preventSinglePointFailure: true` SHALL apply in those environments

--- a/openspec/changes/archive/2026-04-30-optimize-dev-kube-dns-replicas/tasks.md
+++ b/openspec/changes/archive/2026-04-30-optimize-dev-kube-dns-replicas/tasks.md
@@ -1,0 +1,33 @@
+## 1. Author the dev kube-dns-autoscaler override
+
+- [x] 1.1 Create `cloud-provisioning/k8s/cluster/overlays/dev/kube-dns-autoscaler.yaml` containing a complete `kube-dns-autoscaler` ConfigMap manifest (namespace `kube-system`) whose `data.linear` JSON value declares `coresPerReplica: 256, nodesPerReplica: 16, preventSinglePointFailure: false`. Include `includeUnschedulableNodes: true` to match the existing GKE default (preserve all currently-set fields except the boolean we are flipping).
+- [x] 1.2 Edit `cloud-provisioning/k8s/cluster/overlays/dev/kustomization.yaml`: add the new file path to the `resources` list (it is already registered for the dev `core` ArgoCD Application).
+
+## 2. Validate the manifest locally
+
+- [x] 2.1 Run `kubectl kustomize cloud-provisioning/k8s/cluster/overlays/dev` and verify the rendered output:
+  - Includes the new `ConfigMap/kube-dns-autoscaler` in `kube-system`. ✓
+  - The `data.linear` JSON contains `"preventSinglePointFailure":false`. ✓
+  - All previously-rendered resources (the two `ClusterSecretStore` patches) still render unchanged. ✓
+- [x] 2.2 Run `make check` in `cloud-provisioning` and confirm `lint-ts` exits 0. **Result: exits 0.**
+- [x] 2.3 Run `kube-linter lint` against the rendered dev cluster overlay output and confirm no errors specific to the new manifest. **Result: `No lint errors found!`.**
+
+## 3. Open and merge the PR
+
+- [x] 3.1 Commit the two-file change on a feature branch with a Conventional Commits message (e.g., `feat(infra): override kube-dns-autoscaler in dev to drop replicas to 1`). **Commit: 943e6ef on branch `optimize-dev-kube-dns-replicas`.**
+- [x] 3.2 Open a PR against `cloud-provisioning/main` titled with the commit subject. Include in the description: link to the proposal/design (this OpenSpec change), link to the GCP doc page authorizing the ConfigMap edit, expected post-merge effect (`kube-dns` Deployment 2→1, then cluster autoscaler 3→2 nodes after idle threshold). **PR: liverty-music/cloud-provisioning#210.**
+- [x] 3.3 Wait for CI green (Buf checks skip; lint-ts pass; Pulumi preview shows no changes). Use `gh api repos/liverty-music/cloud-provisioning/pulls/N/comments` to fetch any inline review comments before merging — `gh pr view --json reviews` does not surface them. **Result: all CI checks SUCCESS (CI Success / Lint × 2 / changes / claude-review). Inline review comments via gh api: 0.**
+- [x] 3.4 Merge the PR (merge commit; squash is disabled in cloud-provisioning). **Merged 2026-04-28T05:18:39Z.**
+
+## 4. Verify post-merge behavior
+
+- [x] 4.1 ArgoCD: verify the `core` Application reaches `Synced / Healthy` after the merge. Inspect the resource list for `ConfigMap/kube-dns-autoscaler` in `kube-system`. **Result: `Synced/Healthy`.**
+- [x] 4.2 Verify the live ConfigMap: `kubectl get configmap kube-dns-autoscaler -n kube-system -o jsonpath='{.data.linear}'` SHALL contain `"preventSinglePointFailure":false`. **Result: `{"coresPerReplica":256,"includeUnschedulableNodes":true,"nodesPerReplica":16,"preventSinglePointFailure":false}`.**
+- [x] 4.3 Wait up to 60 s for the autoscaler controller to reconcile, then verify `kubectl get deployment kube-dns -n kube-system` shows `READY: 1/1` (or `1/2` transitioning to 1). **Result: ConfigMap → false flip and kube-dns scale-down to 1/1 happened within ~30 s of ArgoCD sync.**
+- [x] 4.4 Wait at least 10 minutes for the cluster autoscaler's idle threshold, then verify `kubectl get nodes -l cloud.google.com/gke-spot=true` shows 2 nodes (target). If still 3, run `kubectl describe nodes -l cloud.google.com/gke-spot=true | grep -A6 'Allocated resources'` to identify which node is still pinned and what workload is the new largest CPU consumer. **Result: 2 nodes (3rd node `d4xd` retired ~25 min after merge). Per-node CPU: 824m/940m (87%) and 790m/940m (84%) = 1614m total on 1880m capacity (86% packed, ~266m headroom).**
+- [x] 4.5 Verify both spot nodes still use the optimize-dev-gke-cost disk config: `gcloud compute disks list --project liverty-music-dev --filter="name~^gke-standard-cluster--spot-pool"` shows 2 disks at 30 GB pd-standard. **Result: 2 × 30 GB pd-standard confirmed.**
+
+## 5. Archive prep (post-soak)
+
+- [ ] 5.1 After 24 h of stable 2-node operation, sync the new requirement into `openspec/specs/gke-standard-infrastructure/spec.md` and `git mv` this change to `openspec/changes/archive/YYYY-MM-DD-optimize-dev-kube-dns-replicas/` in a single archive PR.
+- [ ] 5.2 The 2026-05-04 09:00 JST scheduled remote agent (routine `trig_019bjiY5CoQUYsPkVfxnNGTW`) will pick up the *combined* `optimize-dev-gke-cost` + this change's effect when it runs. No manual coordination required.

--- a/openspec/specs/gke-standard-infrastructure/spec.md
+++ b/openspec/specs/gke-standard-infrastructure/spec.md
@@ -89,3 +89,23 @@ The dev GKE Spot node pool boot disk SHALL be explicitly configured with `diskSi
 #### Scenario: All running spot nodes use the configured disk
 - **WHEN** running `gcloud compute disks list` filtered to the spot pool node prefix
 - **THEN** every disk SHALL show `SIZE_GB: 30` and `TYPE: pd-standard`
+
+### Requirement: Dev cluster `kube-dns-autoscaler` SHALL set `preventSinglePointFailure: false`
+The dev GKE cluster SHALL override the GKE-managed `kube-dns-autoscaler` ConfigMap (in `kube-system`) so that the linear scaling policy declares `preventSinglePointFailure: false`. The remaining linear-policy fields (`coresPerReplica`, `nodesPerReplica`) SHALL retain GKE's defaults of 256 and 16 respectively. Rationale: with the cluster at 6 vCPU / 3 nodes, the cluster-proportional-autoscaler formula computes 1 desired replica; the single-point-of-failure guard is the only reason kube-dns runs at 2 replicas, consuming an additional 270m CPU that prevents the cluster autoscaler from compacting to 2 spot nodes. dev does not require kube-dns HA — `node-local-dns` caching plus client retries cover the rare reschedule gap.
+
+#### Scenario: ConfigMap declares preventSinglePointFailure false
+- **WHEN** running `kubectl get configmap kube-dns-autoscaler -n kube-system -o yaml` on the dev cluster
+- **THEN** the `data.linear` JSON value SHALL contain `"preventSinglePointFailure":false`
+
+#### Scenario: kube-dns scales to one replica
+- **WHEN** running `kubectl get deployment kube-dns -n kube-system` on the dev cluster after the autoscaler has reconciled
+- **THEN** the `READY` count SHALL be `1/1`
+
+#### Scenario: Override is reconciled by ArgoCD
+- **WHEN** the GKE control plane resets the ConfigMap to its managed default (e.g., during cluster upgrade)
+- **THEN** ArgoCD's `core` Application SHALL re-apply the dev override within one sync interval, restoring `preventSinglePointFailure: false`
+
+#### Scenario: Override is dev-only
+- **WHEN** comparing rendered manifests for `prod` and `staging` overlays
+- **THEN** neither overlay SHALL include a `kube-dns-autoscaler` ConfigMap override
+- **AND** the GKE-default `preventSinglePointFailure: true` SHALL apply in those environments


### PR DESCRIPTION
## Summary

Archive `optimize-dev-kube-dns-replicas` after end-to-end implementation + post-deploy verification.

- **Spec sync**: append the new requirement *"Dev cluster `kube-dns-autoscaler` SHALL set `preventSinglePointFailure: false`"* (with four scenarios) into `openspec/specs/gke-standard-infrastructure/spec.md`.
- **Archive placement**: change directory at `openspec/changes/archive/2026-04-30-optimize-dev-kube-dns-replicas/` (with proposal/design/specs/tasks).
- **tasks.md**: post-deploy results recorded for tasks 4.1–4.5.

## Implementation chain (already merged)

| PR | Repo | Status |
|---|---|---|
| [#210](https://github.com/liverty-music/cloud-provisioning/pull/210) | cloud-provisioning | merged 2026-04-28 — `kube-dns-autoscaler` ConfigMap override in dev overlay |

## Post-deploy verification

Recorded in archived `tasks.md`:

| Task | Result |
|---|---|
| 4.1 ArgoCD `core` app | ✅ Synced/Healthy |
| 4.2 ConfigMap `data.linear` | ✅ contains `"preventSinglePointFailure":false` |
| 4.3 kube-dns Deployment | ✅ 2/2 → 1/1 within ~30 s of ArgoCD sync |
| 4.4 Spot node count | ✅ 3 → 2 (3rd node `d4xd` retired ~25 min after merge); cluster packed at 87% / 84%, ~266m headroom |
| 4.5 Boot disks | ✅ 2 × 30 GB pd-standard preserved |

## Cost impact

Combined with the prior [`optimize-dev-gke-cost`](https://github.com/liverty-music/specification/tree/main/openspec/changes/archive/2026-04-28-optimize-dev-gke-cost) change:

```
Pre-change baseline:        ¥9,953/month (+1403% spike)
Boot disk shrink alone:    ~¥6,153/month (-38%)
+ kube-dns 1 replica:      ~¥4,400/month (-56%)  ← target ≥50% met ✅
```

The 2026-05-04 09:00 JST scheduled remote agent will pick up the *combined* effect in its verification issue.

## Note on the archive process

This archive PR was originally scheduled to be opened by a one-shot remote agent (`trig_01Y6bpRLJ99ZyUDfMUtbxLjH`) firing 2026-04-29 14:18 JST. That agent auto-disabled with `ended_reason: auto_disabled_repo_access` — it lacked GitHub repo access in its cloud-run environment. The PR is now opened manually with identical content (spec sync + change placement under archive/).

## Test plan

- [x] `openspec validate --specs gke-standard-infrastructure` passes
- [x] git diff scoped to: 1 spec.md edit + 5 new archive files (proposal/design/specs/tasks/.openspec.yaml)
- [ ] CI green (Buf PR Checks)
- [ ] HALT before merge — user reviews and merges
