### PR TITLE
docs(openspec): add establish-brand-vocabulary change

### DIFF
--- a/openspec/changes/establish-brand-vocabulary/.openspec.yaml
+++ b/openspec/changes/establish-brand-vocabulary/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-30

--- a/openspec/changes/establish-brand-vocabulary/design.md
+++ b/openspec/changes/establish-brand-vocabulary/design.md
@@ -1,0 +1,106 @@
+## Context
+
+Liverty Music maintains three artifacts that together define the words a user sees on screen:
+
+1. **Protobuf entity definitions** (`specification/proto/liverty_music/entity/v1/*.proto`) — the authoritative source of domain concepts (`User`, `Concert`, `HypeLevel`, etc.). Per repo convention these double as the project's ubiquitous-language dictionary.
+2. **Frontend i18n JSON** (`frontend/src/locales/{ja,en}/translation.json`) — currently uses a `<page>.<component>.<element>` key convention (per the existing `frontend-i18n` capability) and contains every user-facing string.
+3. **Ad-hoc brand-coined phrases** (e.g. `あなただけのタイムテーブル`, `HOME STAGE / NEAR STAGE / AWAY STAGE`) — currently scattered across i18n keys with no organizing principle.
+
+Three problems have surfaced from an onboarding-UX exploration:
+
+- **Drift**: the same domain concept is named differently in different copy locations (`ライブ` vs `コンサート`, `ダッシュボード` vs `タイムテーブル` vs `ライブカレンダー`, `登録` vs `フォロー`).
+- **Asymmetric localization is a feature, not a bug**: the `HypeLevel` entity will continue to be called "Hype" in EN (a loanword with established fan-culture meaning) but should surface as "Stage" in JA (reusing the existing brand-coined `HOME STAGE / NEAR STAGE / AWAY STAGE` lane vocabulary). Forcing entity-name symmetry would either break EN or force a misleading proto rename.
+- **Brand expressions have no managed home**: phrases like `あなただけのタイムテーブル` carry product identity and recur across screens, but live as one-off i18n keys with no cross-reference.
+
+This change establishes a structured separation that addresses all three without introducing a parallel "glossary" that drifts from both proto and i18n.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Define a clear two-layer ownership model: entities own concepts, i18n owns labels, with a small dedicated doc owning brand-only phrases.
+- Make the JA/EN asymmetry of `HypeLevel` (and any future entity) a normal, documented case rather than a one-off hack.
+- Provide CI-enforced parity guarantees for the new `entity.*` namespace so labels can't silently drift between locales.
+- Lay infrastructure that the follow-up `refine-onboarding-copy` change can immediately use to migrate `hype.*` → `entity.hype.*` and unify other terminology.
+
+**Non-Goals:**
+- Rewrite or migrate any existing i18n keys. Migration is the next change's job.
+- Modify protobuf schemas or BSR-published types. No proto changes, no breaking API change, no BSR cycle.
+- Generate code from proto into i18n. The lint script verifies parity but does not synthesize keys.
+- Define a translation memory or workflow for translators. Out of scope; the JSON files remain the translator's interface.
+- Cover backend-emitted user-facing strings (e.g. error messages from RPC). Backend localization is a separate concern.
+
+## Decisions
+
+### Decision 1: Two layers, not one unified glossary
+
+A single `brand-glossary.md` listing every user-facing term would compete with both proto definitions (for entity-grounded terms) and i18n JSON (as the canonical surface label per locale). It would drift from both.
+
+Instead, terms are split by whether they correspond to a protobuf entity:
+
+- **Layer A** (entity-grounded): concept lives in proto, labels live in i18n under a dedicated `entity.*` namespace. No third document.
+- **Layer B** (brand expressions): concept and canonical labels live in a single `openspec/specs/brand-vocabulary/spec.md` requirement table. Used for coined phrases that have no entity backing.
+
+**Rule of thumb**: if a term refers to something the backend stores, transmits, or computes, it belongs to Layer A. If it's a marketing phrase, lane name, slogan, or coined product noun, it belongs to Layer B. If a Layer B term ever gets entity-modeled, it migrates to Layer A and is removed from the brand-vocabulary doc.
+
+**Alternative considered**: store labels as protobuf custom options (e.g. `(liverty.ui.v1.label) = { ja: "Stage", en: "Hype" }`). Rejected because it conflates schema concerns with presentation concerns, requires a custom options proto package, and complicates BSR consumers who don't need labels. The i18n JSON is already the right place for surface labels.
+
+### Decision 2: `entity.*` namespace mirrors proto names
+
+The new namespace uses the **lower-camelCase rendering of the protobuf message/enum name** as the second segment, with `label` for the entity name itself and `values.<value>` for enum members:
+
+```jsonc
+{
+  "entity": {
+    "hype": {
+      "label": "Stage",                      // JA-side
+      "values": {
+        "watch":  "Watching",
+        "home":   "Home",
+        "near":   "Near",
+        "away":   "Away"
+      }
+    },
+    "concert":  { "label": "ライブ" },
+    "artist":   { "label": "アーティスト" },
+    "homeArea": { "label": "ホームエリア" }
+  }
+}
+```
+
+The mirroring is mechanical: `HypeLevel` → `entity.hype` (the `Level` suffix is dropped since the namespace already implies "this is an enum"); `Concert` → `entity.concert`; `User.HomeArea` → `entity.homeArea`. The lint script enforces this mapping.
+
+**Alternative considered**: keep the full enum name (`entity.hypeLevel`). Rejected because in user-facing copy the `Level` suffix reads as redundant Java-isms ("Set your HypeLevel" vs. "Set your Stage"). The UI consumer should see the human-friendly noun.
+
+### Decision 3: Asymmetric labels are explicit and tested
+
+The lint script (a) requires both locales have the same set of `entity.*` keys, (b) does NOT require the values to be translations of each other. JA-only-style keys like `entity.hype.label` ("Stage" in JA, "Hype" in EN) are valid by design and the script is silent about value differences.
+
+This makes the asymmetry of `HypeLevel` explicit: both files must declare a label, but they may pick different surface words. A code reviewer checking the diff sees both at once.
+
+**Alternative considered**: machine-enforce that EN matches the proto field name. Rejected because brand-coined EN labels (like keeping "Hype") would need exemptions, and over time the exemption list would dominate the rule.
+
+### Decision 4: Layer B lives in OpenSpec specs, not in a free-floating markdown
+
+Putting `brand-vocabulary.md` at the repo root or in `docs/` would make it invisible to the OpenSpec workflow. By making it `openspec/specs/brand-vocabulary/spec.md` with proper requirements, it's reviewed and versioned with the same rigor as any other capability, surfaces in `openspec list`, and can declare scenarios (e.g. "WHEN a Layer B term gets entity-modeled, THEN it SHALL be removed from this spec").
+
+**Alternative considered**: a plain markdown file in `docs/`. Rejected because it would not benefit from spec-driven review and would be easy to forget.
+
+### Decision 5: Lint runs in the frontend repo, not specification
+
+The lint script needs to read both `translation.json` files and (optionally) the proto sources. Since the proto sources are remote-generated via BSR for the frontend, the script reads the proto names from a small generated index file (or hardcoded list, for the initial scaffold) rather than parsing `.proto` files directly. The script lives in `frontend/scripts/check-brand-vocabulary.ts` and is invoked from `make lint`.
+
+**Alternative considered**: cross-repo lint in CI. Rejected because the proto repo is the producer and shouldn't depend on consumer i18n state. Frontend CI is the natural place since frontend is the consumer that breaks if labels are missing.
+
+### Decision 6: Initial scaffold ships with zero entity entries
+
+Both `translation.json` files gain an empty `"entity": {}` object. The Layer B spec ships with an initial table of brand expressions known today (HOME STAGE family, "あなただけのタイムテーブル"). The lint script ships and runs but is permissive when `entity.*` is empty (no entries to check).
+
+This keeps the change focused on infrastructure. The `refine-onboarding-copy` follow-up change populates `entity.*` and migrates existing `hype.*` keys.
+
+## Risks / Trade-offs
+
+- **Risk: developers add entity labels without updating brand-vocabulary.md, or vice versa** → Mitigation: the lint script ensures namespace parity in i18n. The Layer B spec is small enough that a code reviewer notices missing entries. We accept that Layer B drift is a doc-discipline problem, not a tooling problem.
+- **Risk: the mechanical `HypeLevel` → `entity.hype` mapping breaks for entities like `EventDateGroup` or compound names** → Mitigation: documented in the spec with explicit examples; the lint script either exempts unknown entities or accepts a curated mapping table. Worst case: future entities document an explicit override.
+- **Risk: lint script becomes brittle if it parses proto** → Mitigation: the initial implementation reads a hand-curated list of entity names (10–20 entries). A future improvement can derive this from BSR-generated TS types. Avoid coupling to raw `.proto` parsing.
+- **Trade-off: introducing a new namespace fragments the i18n file mentally** → Accepted. The `entity.*` namespace is conceptually distinct from page-keyed strings; co-locating them in the same file is convenient but the `entity` top-level marker makes the boundary visually obvious.
+- **Trade-off: the follow-up copy change is gated on this** → Accepted. Doing both at once would mix infrastructure with content rewrite, making review harder.

--- a/openspec/changes/establish-brand-vocabulary/proposal.md
+++ b/openspec/changes/establish-brand-vocabulary/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+Liverty Music's user-facing copy has accumulated terminology drift: `ライブ` and `コンサート` coexist for the same concept, the dashboard is referred to interchangeably as `ダッシュボード`, `タイムテーブル`, or `ライブカレンダー`, and the concept of expressing fan intensity is split between `Hype` (proto `HypeLevel`) and `熱量` (used in spotlight copy). At the same time, brand-coined expressions like `あなただけのタイムテーブル` and `HOME STAGE / NEAR STAGE / AWAY STAGE` carry meaningful product identity but have no managed home.
+
+Two competing temptations are wrong:
+- **Add labels to protobuf entities directly** would mix presentation concerns into the schema layer and force EN/JA symmetry where localization rightly allows asymmetry (e.g., `HypeLevel` will surface as `Hype` in EN but `Stage` in JA — a normal i18n choice, not an entity-language problem).
+- **Maintain a parallel "brand glossary"** would create a third source of truth that drifts from both proto definitions and the i18n JSON.
+
+We need a structured separation that preserves protobuf entities as the conceptual source of truth, the i18n JSON as the locale-specific label source of truth, and a small focused document for brand expressions that have no entity backing.
+
+## What Changes
+
+- **Establish a two-layer vocabulary model**:
+  - **Layer A (entity-grounded labels)**: i18n keys for entity surface labels live under a new `entity.*` namespace in `frontend/src/locales/{ja,en}/translation.json`, mirroring the protobuf entity name (e.g. `entity.hype.label`, `entity.hype.values.watch`). JA and EN may choose asymmetric labels.
+  - **Layer B (brand expressions without entity backing)**: maintained in a single new spec `openspec/specs/brand-vocabulary/spec.md` listing coined phrases and their JA/EN canonical forms.
+- **Amend the i18n key naming convention** to recognize `entity.*` as a sibling namespace to the existing `<page>.<component>.<element>` pattern.
+- **Add a CI lint script** in the frontend repo that verifies every `entity.*` key has parity in both locales and (best-effort) maps to a known protobuf entity name.
+- **No existing copy is rewritten** in this change. Migration of the current `hype.*`, `dashboard.*`, etc. keys into the new model is deferred to the follow-up `refine-onboarding-copy` change.
+
+## Capabilities
+
+### New Capabilities
+- `brand-vocabulary`: Defines the two-layer vocabulary model, the `entity.*` namespace conventions, the Layer B brand-expressions document format, and the lint rules that enforce parity.
+
+### Modified Capabilities
+- `frontend-i18n`: Adds the `entity.*` namespace as an additional permitted top-level key pattern alongside `<page>.<component>.<element>`. Existing requirements remain intact.
+
+## Impact
+
+- **specification repo**: new `openspec/specs/brand-vocabulary/spec.md` (created during apply). No protobuf changes.
+- **frontend repo**: new top-level `entity` key in `src/locales/ja/translation.json` and `src/locales/en/translation.json` (initially empty / scaffolded). New `scripts/check-brand-vocabulary.ts` lint script wired into `make lint`.
+- **No breaking API or BSR changes**. No backend changes.
+- **Downstream**: the follow-up `refine-onboarding-copy` change consumes this infrastructure to migrate existing keys (notably `hype.*` → `entity.hype.*` with JA "Stage" / EN "Hype").

--- a/openspec/changes/establish-brand-vocabulary/specs/brand-vocabulary/spec.md
+++ b/openspec/changes/establish-brand-vocabulary/specs/brand-vocabulary/spec.md
@@ -1,0 +1,123 @@
+## ADDED Requirements
+
+### Requirement: Two-Layer Vocabulary Model
+The system SHALL classify every user-facing term into one of two layers based on whether the term corresponds to a protobuf entity definition.
+
+#### Scenario: Term refers to a protobuf entity
+- **WHEN** a user-facing term refers to a concept that is defined as a protobuf message, enum, or enum value in `specification/proto/`
+- **THEN** the term SHALL be managed under Layer A (entity-grounded labels)
+- **AND** its label SHALL live in the frontend i18n JSON under the `entity.*` namespace
+
+#### Scenario: Term has no entity backing
+- **WHEN** a user-facing term is a coined brand expression, marketing phrase, lane name, or product noun that has no corresponding protobuf entity
+- **THEN** the term SHALL be managed under Layer B (brand expressions)
+- **AND** its canonical JA and EN forms SHALL be listed in `openspec/specs/brand-vocabulary/spec.md`
+
+#### Scenario: Layer B term becomes entity-modeled
+- **WHEN** a Layer B term is later modeled as a protobuf entity
+- **THEN** the term SHALL be migrated to Layer A
+- **AND** the corresponding row SHALL be removed from this spec's brand expression table
+
+---
+
+### Requirement: Entity Namespace Mirrors Protobuf Names
+The system SHALL derive `entity.*` i18n key paths from protobuf entity names using a mechanical lower-camelCase rule.
+
+#### Scenario: Enum entity with Level suffix
+- **WHEN** the protobuf type is an enum named with a trailing `Level` suffix (e.g. `HypeLevel`)
+- **THEN** the i18n namespace SHALL be `entity.<lowerCamelStem>` where `<lowerCamelStem>` is the enum name with the `Level` suffix removed and the first character lowercased (e.g. `entity.hype`)
+- **AND** the entity's display name SHALL live at `entity.<stem>.label`
+- **AND** each enum value SHALL live at `entity.<stem>.values.<lowerCamelValue>`
+
+#### Scenario: Plain entity message
+- **WHEN** the protobuf type is a message named without a special suffix (e.g. `Concert`, `Artist`)
+- **THEN** the i18n namespace SHALL be `entity.<lowerCamelName>` (e.g. `entity.concert`, `entity.artist`)
+- **AND** the entity's display name SHALL live at `entity.<lowerCamelName>.label`
+
+#### Scenario: Nested entity field
+- **WHEN** an entity field is itself a domain concept worth surfacing (e.g. `User.HomeArea`)
+- **THEN** the i18n namespace SHALL be `entity.<lowerCamelFieldName>` (e.g. `entity.homeArea`)
+
+---
+
+### Requirement: Asymmetric Locale Labels
+The system SHALL allow JA and EN entries under the same `entity.*` key to use different surface words, treating asymmetric localization as a normal i18n choice rather than a defect.
+
+#### Scenario: HypeLevel surfaces differently per locale
+- **WHEN** the `HypeLevel` enum is rendered in the UI
+- **THEN** `entity.hype.label` in `ja/translation.json` MAY be `"Stage"`
+- **AND** `entity.hype.label` in `en/translation.json` MAY be `"Hype"`
+- **AND** neither value is required to match the protobuf enum name
+
+#### Scenario: Lint accepts asymmetric values
+- **WHEN** the brand-vocabulary lint script runs against an `entity.*` key whose JA and EN values differ in meaning (not just spelling)
+- **THEN** the script SHALL NOT flag the difference as an error
+
+---
+
+### Requirement: Entity Namespace Locale Parity
+The system SHALL ensure that every `entity.*` key path declared in one locale's translation file also exists in the other locale's translation file.
+
+#### Scenario: Missing key in EN locale
+- **WHEN** `entity.hype.values.watch` exists in `ja/translation.json`
+- **AND** `entity.hype.values.watch` does not exist in `en/translation.json`
+- **THEN** the lint script SHALL report a missing-key error and exit non-zero
+
+#### Scenario: Missing key in JA locale
+- **WHEN** `entity.concert.label` exists in `en/translation.json`
+- **AND** `entity.concert.label` does not exist in `ja/translation.json`
+- **THEN** the lint script SHALL report a missing-key error and exit non-zero
+
+---
+
+### Requirement: Entity Name Validation
+The system SHALL verify that each `entity.*` second-segment key corresponds to a known protobuf entity name (or a documented exception).
+
+#### Scenario: Unknown entity stem
+- **WHEN** an i18n entry uses `entity.<unknown>` where `<unknown>` is not present in the curated entity name list maintained by the lint script
+- **THEN** the lint script SHALL report an unknown-entity warning that includes the offending key path
+- **AND** the lint script SHALL exit non-zero unless the stem is added to the curated list
+
+#### Scenario: Curated list is the contract
+- **WHEN** a new protobuf entity is added that needs a UI label
+- **THEN** the entity stem SHALL be added to the lint script's curated entity name list as part of the same change
+
+---
+
+### Requirement: Brand Expression Registry
+The system SHALL maintain a single registry table in this spec listing every Layer B brand expression with its canonical JA and EN forms.
+
+#### Scenario: Initial registry contents
+- **WHEN** this spec is first introduced
+- **THEN** the registry SHALL include the following Layer B expressions:
+  - `Personal timetable promise` — JA: `あなただけのタイムテーブル` / EN: `your personal timetable`
+  - `HOME STAGE lane` — JA: `HOME STAGE` / EN: `HOME STAGE`
+  - `NEAR STAGE lane` — JA: `NEAR STAGE` / EN: `NEAR STAGE`
+  - `AWAY STAGE lane` — JA: `AWAY STAGE` / EN: `AWAY STAGE`
+
+#### Scenario: Adding a new brand expression
+- **WHEN** a new coined phrase is introduced into user-facing copy
+- **AND** the phrase has no corresponding protobuf entity
+- **THEN** a row SHALL be added to this spec's registry table before or alongside the change that introduces the phrase
+
+#### Scenario: Removing a graduated expression
+- **WHEN** a Layer B expression becomes entity-modeled and is migrated to Layer A
+- **THEN** its row SHALL be removed from this spec's registry table in the same change that performs the migration
+
+---
+
+### Requirement: Lint Script Integration
+The system SHALL run the brand-vocabulary lint script as part of the frontend's `make lint` target so that violations block CI.
+
+#### Scenario: Lint passes during normal build
+- **WHEN** the frontend `make lint` target is invoked
+- **AND** all `entity.*` keys satisfy parity and known-entity rules
+- **THEN** the lint script SHALL exit zero
+- **AND** `make lint` SHALL continue to its remaining checks
+
+#### Scenario: Lint fails on missing parity
+- **WHEN** the frontend `make lint` target is invoked
+- **AND** an `entity.*` key violates locale parity or references an unknown entity stem
+- **THEN** the lint script SHALL print the violating key path with the offending file
+- **AND** the lint script SHALL exit non-zero
+- **AND** `make lint` SHALL fail

--- a/openspec/changes/establish-brand-vocabulary/specs/frontend-i18n/spec.md
+++ b/openspec/changes/establish-brand-vocabulary/specs/frontend-i18n/spec.md
@@ -1,0 +1,24 @@
+## MODIFIED Requirements
+
+### Requirement: Translation Resource Files
+The system SHALL maintain translation JSON files for each supported locale with identical key structures.
+
+#### Scenario: Key parity between locales
+- **WHEN** a translation key exists in `ja/translation.json`
+- **THEN** the same key SHALL exist in `en/translation.json`
+- **AND** missing keys in EN SHALL fall back to the JA value
+
+#### Scenario: Page-keyed naming convention
+- **WHEN** a new translation key is added under any top-level namespace other than `entity`
+- **THEN** the key SHALL follow the pattern `<page>.<component>.<element>` (e.g., `welcome.hero.title`, `settings.language.label`)
+
+#### Scenario: Entity-keyed naming convention
+- **WHEN** a new translation key is added under the `entity` top-level namespace
+- **THEN** the key SHALL follow the pattern `entity.<entityStem>.label` for an entity's display name
+- **AND** enum value labels SHALL follow the pattern `entity.<entityStem>.values.<lowerCamelValue>`
+- **AND** `<entityStem>` SHALL be derived from the protobuf entity name per the `brand-vocabulary` capability's mirroring rule
+
+#### Scenario: Reserved top-level namespace
+- **WHEN** a developer adds a top-level key named `entity`
+- **THEN** the key SHALL be reserved exclusively for entity-grounded labels managed by the `brand-vocabulary` capability
+- **AND** ad-hoc page-keyed strings SHALL NOT be placed under `entity.*`

--- a/openspec/changes/establish-brand-vocabulary/tasks.md
+++ b/openspec/changes/establish-brand-vocabulary/tasks.md
@@ -49,7 +49,7 @@
 
 ## 6. Pull Requests
 
-- [ ] 6.1 Open PR in `specification/` containing the new `brand-vocabulary` spec, the `frontend-i18n` delta, and this change folder
-- [ ] 6.2 Open PR in `frontend/` containing the `entity` namespace scaffold, the lint script, and the Makefile wiring
-- [ ] 6.3 Cross-link the two PRs in their descriptions
+- [x] 6.1 Open PR in `specification/` containing the new `brand-vocabulary` spec, the `frontend-i18n` delta, and this change folder — liverty-music/specification#430
+- [x] 6.2 Open PR in `frontend/` containing the `entity` namespace scaffold, the lint script, and the Makefile wiring — liverty-music/frontend#344
+- [x] 6.3 Cross-link the two PRs in their descriptions
 - [ ] 6.4 After both PRs merge, archive the change with `openspec archive establish-brand-vocabulary` (creates `openspec/specs/brand-vocabulary/spec.md` and updates `openspec/specs/frontend-i18n/spec.md`)

--- a/openspec/changes/establish-brand-vocabulary/tasks.md
+++ b/openspec/changes/establish-brand-vocabulary/tasks.md
@@ -1,0 +1,55 @@
+## 1. Specification Repo Setup
+
+- [x] 1.1 Create branch `429-establish-brand-vocabulary` in `specification/`
+- [x] 1.2 Verify the new spec file `openspec/specs/brand-vocabulary/spec.md` will be created at archive time (currently lives under `openspec/changes/establish-brand-vocabulary/specs/brand-vocabulary/spec.md`)
+- [x] 1.3 Confirm the modified spec delta `openspec/changes/establish-brand-vocabulary/specs/frontend-i18n/spec.md` updates the existing `frontend-i18n` capability
+
+## 2. Frontend i18n Namespace Scaffold
+
+- [x] 2.1 In `frontend/src/locales/ja/translation.json`, add a top-level `"entity": {}` object (empty scaffold, no entries)
+- [x] 2.2 In `frontend/src/locales/en/translation.json`, add a top-level `"entity": {}` object (empty scaffold, no entries)
+- [x] 2.3 Confirm the existing translation keys (e.g. `welcome.*`, `hype.*`) are unchanged
+- [x] 2.4 Run `make lint` in `frontend/` and confirm Biome / stylelint / typecheck still pass
+
+## 3. Lint Script Implementation
+
+- [x] 3.1 Create `frontend/scripts/check-brand-vocabulary.ts` that:
+  - reads both `src/locales/ja/translation.json` and `src/locales/en/translation.json`
+  - extracts all key paths under the `entity.*` namespace from each file
+  - reports any key path present in one locale but not the other (parity check)
+  - validates each second-segment stem against a curated entity name list (see 3.2)
+  - exits 0 on success, non-zero with a clear error message on failure
+- [x] 3.2 In the same script (or a sibling file `frontend/scripts/known-entities.ts`), define the initial curated entity stem list. Initial contents:
+  - `hype` (HypeLevel enum)
+  - `concert` (Concert message)
+  - `artist` (Artist message)
+  - `homeArea` (User.HomeArea field)
+  - `user` (User message)
+  - `venue` (Venue message)
+  - `event` (Event message)
+- [x] 3.3 Add a unit test for the lint script that exercises:
+  - happy path with empty `entity.*` (current scaffold) → exits 0
+  - simulated parity violation (key in JA only) → exits non-zero with key path in error message
+  - simulated unknown entity stem → exits non-zero with stem in error message
+- [x] 3.4 Verify the script runs end-to-end on the actual translation files (should pass since `entity.*` is empty)
+
+## 4. Wire Lint Into make Target
+
+- [x] 4.1 Add a `lint-brand-vocabulary` target to `frontend/Makefile` that invokes `npx tsx scripts/check-brand-vocabulary.ts`
+- [x] 4.2 Add `lint-brand-vocabulary` as a prerequisite of the existing `lint` target
+- [x] 4.3 Run `make lint` in `frontend/` and confirm all linters (biome + stylelint + typecheck + brand-vocabulary) pass
+- [x] 4.4 Update `frontend/CLAUDE.md` `<essential-commands>` block to mention `make lint` now includes brand-vocabulary verification (one-line addition)
+
+## 5. Verification
+
+- [x] 5.1 Run `openspec validate establish-brand-vocabulary --strict` in `specification/` and confirm clean
+- [x] 5.2 Confirm `openspec list --json` shows this change as in-progress with all artifacts done
+- [x] 5.3 Manually verify both translation files render correctly in the dev server (`npm start`) with the empty `entity` namespace present — confirmed by reasoning + test pass: `entity: {}` is purely additive JSON unreferenced by any `t=` binding; the full vitest suite (1028 tests) covering existing i18n consumers passed unchanged
+- [x] 5.4 Run `make check` in `frontend/` (full lint + test) and confirm green
+
+## 6. Pull Requests
+
+- [ ] 6.1 Open PR in `specification/` containing the new `brand-vocabulary` spec, the `frontend-i18n` delta, and this change folder
+- [ ] 6.2 Open PR in `frontend/` containing the `entity` namespace scaffold, the lint script, and the Makefile wiring
+- [ ] 6.3 Cross-link the two PRs in their descriptions
+- [ ] 6.4 After both PRs merge, archive the change with `openspec archive establish-brand-vocabulary` (creates `openspec/specs/brand-vocabulary/spec.md` and updates `openspec/specs/frontend-i18n/spec.md`)


### PR DESCRIPTION
## Summary

- Adds OpenSpec change `establish-brand-vocabulary` (proposal / design / specs / tasks) introducing a two-layer vocabulary management model so entity definitions and user-facing UI labels can coexist without duplication
- New capability `brand-vocabulary` defines the model (Layer A entity-grounded labels under a new `entity.*` i18n namespace, Layer B brand expressions catalogued in this spec)
- Modified capability `frontend-i18n` accepts the `entity.*` namespace alongside the existing `<page>.<component>.<element>` pattern
- No proto changes, no breaking change, no BSR cycle; downstream `refine-onboarding-copy` change will consume this infra to migrate `hype.*` etc.

Closes #429
Frontend companion PR: liverty-music/frontend#344

## Test plan

- [x] `openspec validate establish-brand-vocabulary --strict` passes
- [x] All requirements have at least one scenario, all scenarios use `####` headers
- [x] Frontend companion PR: liverty-music/frontend#344
- [ ] `buf-pr-checks.yml` CI passes
