### PR TITLE
docs(openspec): propose cutover-warning-fixes

### DIFF
--- a/openspec/changes/cutover-warning-fixes/.openspec.yaml
+++ b/openspec/changes/cutover-warning-fixes/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-01

--- a/openspec/changes/cutover-warning-fixes/design.md
+++ b/openspec/changes/cutover-warning-fixes/design.md
@@ -1,0 +1,106 @@
+## Context
+
+The `self-hosted-zitadel` cutover went live 2026-04-30. The cutover smoke-test passed and dev runs entirely on `auth.dev.liverty-music.app`. During the cutover incident chain, four operational gaps emerged that did not exist in the original proposal:
+
+1. **Dead webhook handler.** The original `auto-verify-email` Action was supposed to set `email.is_verified = true` on incoming `AddHumanUser` requests via an Actions v2 `request:*` Execution. Empirically this turned out to be impossible because Zitadel v4 `request:*` Executions REPLACE the entire request body with the webhook response (zitadel/zitadel#9748), so a webhook returning `{email: {is_verified: true}}` stripped Profile / Phone / Username and broke `AddHumanUser` validation. cloud-provisioning#215 removed the Zitadel-side Target + Execution, but the backend handler was not removed in the same PR — it sits at `internal/adapter/webhook/auto_verify_email_handler.go` receiving zero traffic.
+
+2. **`ResendEmailVerification` regression.** The backend RPC currently calls Zitadel's User Service v2 `_resend_code` endpoint. This endpoint **only resends an existing code**; if no code was ever generated (e.g., SMTP was inactive at sign-up time, which was the §13.16 incident path), the call fails with `Code is empty (EMAIL-5w5ilin4yt)` and the frontend Settings page surfaces a vague "Failed to send verification email" error to the user. The Management v1 `_resend_verification` endpoint generates a new code AND sends the email — this is what users actually mean by "resend".
+
+3. **Manual SMTP activation.** `@pulumiverse/zitadel.SmtpConfig` (v0.2.0) provisions a `SmtpConfig` resource but does NOT call the separate `_activate` admin endpoint that Zitadel v4 requires before SMTP traffic flows. The cutover required a one-shot `curl POST /admin/v1/smtp/{id}/_activate` to unstick first-sign-up email verification. Every Zitadel rebuild silently re-introduces the same gap until the operator remembers.
+
+4. **Missing Pulumi Dynamic Resource tests.** During the cutover chain, two implementation bugs in the Dynamic Resource module each cost a deploy cycle: PR #211 (PATCH→POST on Target update — Zitadel's API expects POST for both create and update on Actions v2) and PR #212 (`targets: [{target: id}]` vs. `targets: [id]` — the proto shape is `string[]`, not `[]Target`). Both bugs would have been caught by lifecycle tests. The original proposal §4.5 acknowledged this gap and deferred it; this change closes it.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Eliminate the `/auto-verify-email` dead code from the backend so the webhook surface matches the actual Zitadel-side configuration (one route: `/pre-access-token`).
+- Make `ResendEmailVerification` work in the post-cutover state where users were created with no initial verification code.
+- Move the SMTP `_activate` step from operator memory to Pulumi-managed declarative state.
+- Lock in the wire-level Dynamic Resource contract via fast-feedback unit tests so the next addition (e.g., the `pulumi-deploy-safeguards` deploy hook, or the §18.10 Cloud-tenant teardown) cannot regress on the same shape mistakes.
+
+**Non-Goals:**
+
+- Rewriting `auto-verify-email` to actually work (option (c) from §18.4: full `AddHumanUser` payload reconstruction in the webhook). Decided in §18.4 to accept Zitadel's default OTP step.
+- Touching Zitadel v1 Action infrastructure (none remains; the v1→v2 migration was completed in the cutover).
+- Adding integration tests against a live Zitadel — out of scope; mocked-HTTP fast tests cover the contract that broke during the cutover.
+- Frontend changes. The Settings page Resend button stays as-is; the change is fully server-side.
+- Bundling §18.6.2 Cloud Monitoring alert (separate concern, not warning-tier).
+
+## Decisions
+
+### D1. Use Zitadel Management v1 `_resend_verification` endpoint, not v2 `_resend_code`
+
+The v2 User Service `_resend_code` is intentionally narrow: it resends an _existing_ code without re-generating one, useful when a user requests another delivery of the code they already have. The v1 Management `_resend_verification` is broader: it generates a fresh code and sends the email. The user-facing "Resend verification email" button on the Settings page maps to the broader semantic — users don't think in terms of "is there an existing code". v1 it is.
+
+The risk of using a v1 endpoint: Zitadel could deprecate v1 in a future major. Mitigation: v1 Management is the most-used and most-stable surface in Zitadel; deprecation, when it comes, will be telegraphed years out. We will catch it in the upgrade test cycle and re-target as needed.
+
+**Alternative considered:** Pre-create the verification code at sign-up time (so v2 `_resend_code` always has something to resend). Rejected — requires a separate post-`AddHumanUser` API call in the sign-up flow, adds a failure mode to sign-up itself, and doesn't match the user-intent semantic.
+
+### D2. Implement `ZitadelSmtpActivation` as a Pulumi Dynamic Resource, not as a Pulumi Command resource
+
+We already have three Dynamic Resources for the same kind of "Pulumi-managed Zitadel REST API call" pattern: `ZitadelTarget`, `ZitadelExecutionFunction`, `ZitadelExecutionRequest`. Adding a fourth keeps the pattern consistent and lets the new test suite cover all four uniformly.
+
+**Alternative considered:** Use Pulumi `command.local.Command` to fire `curl _activate` after `SmtpConfig` is up. Rejected — `command.local.Command` runs on the deployer's machine (or Pulumi Cloud Deployments runner), not against the Zitadel API auth context the Dynamic Resource already has, and would require re-implementing the OAuth `client_credentials` token exchange ad hoc. The Dynamic Resource extends `getAccessToken(jwtProfileJson)` from `dynamic/zitadel-api-client.ts`, so it gets auth for free.
+
+The `ZitadelSmtpActivation` resource tracks no state — it's a pure side-effect call. The `create` handler fires `_activate`; the `update` handler is a no-op (re-activating an already-active SMTP returns 200 from Zitadel, and there's no "deactivate" semantic in the API surface we care about); the `delete` handler is also a no-op (deleting the activation record doesn't deactivate the upstream SMTP). The resource exists to make the Pulumi state graph see "activation happened" as a tracked fact, not to maintain bidirectional state.
+
+### D3. Test framework: vitest with `vi.fn()` HTTP mocking, not `nock` or a record/replay tool
+
+`cloud-provisioning` is a TypeScript project; `vitest` is the natural pick (faster than Jest, native ESM, the project's other TypeScript code already uses vitest where tests exist). Mocking is via `vi.fn()` on the `fetch` API — the Dynamic Resources call `fetch` directly (no library wrapping), so mocking at that boundary captures the wire-level contract that the §13.5/§13.6 incidents broke.
+
+**Alternative considered:** Use `nock` for HTTP-level interception. Rejected — `nock` is a Node-only library that intercepts at the `http`/`https` module level; we'd need to verify it works with `fetch` in the Pulumi Node runtime, and it adds a dependency for no functional gain over `vi.fn`.
+
+**Alternative considered:** Record/replay against a live Zitadel sandbox. Rejected — the goal is to catch shape mistakes (PATCH vs POST, array vs object) at PR-time on every developer's machine. Record/replay couples test runs to a live tenant.
+
+### D4. Test fixtures encode the v4 contract that broke during cutover
+
+Each Dynamic Resource gets at least these test cases:
+
+- `create()` MUST issue a `POST` to the documented path, with the request body shape that Zitadel v4 actually accepts (e.g., `targets: string[]` for Execution, NOT `targets: [{target: string}]`).
+- `update()` MUST issue a `POST` (NOT `PATCH`) — Zitadel v4 returns `405 Method Not Allowed` on PATCH for Actions v2 resources.
+- `delete()` MUST issue a `DELETE` to `<path>/{id}`.
+- `read()` MUST tolerate the `404 Not Found` case (resource was deleted out-of-band) by returning `null` rather than throwing.
+
+These four cases collectively encode the §13.5 / §13.6 incident shapes plus the standard Pulumi Dynamic Resource lifecycle expectations. Any future Dynamic Resource added to the module gets the same four-test scaffold by copy-edit.
+
+### D5. Backend RPC change is a 1-line endpoint swap, not an architectural rework
+
+`internal/infrastructure/zitadel/email_verifier.go::ResendVerification` builds an HTTP request to a Zitadel API path string. The change is the path string + the HTTP method (the v1 Management endpoint is also a POST, so method doesn't change) + minor JSON body adjustments if any. The RPC handler signature, the upstream RPC contract, the JWT-derived authorization check, the rate-limit, and the error-mapping all stay identical.
+
+This is intentional: the regression was a wrong-endpoint choice, not a flawed architecture. Re-architecting would risk introducing new bugs to fix a one-line bug.
+
+### D6. Order the four sub-deliverables by blast radius
+
+The implementation order in tasks.md is:
+
+1. **PR-A1**: Delete dead `/auto-verify-email` handler. Pure subtraction; smallest risk.
+2. **PR-A2**: Switch `ResendEmailVerification` endpoint. User-visible bug fix, but a single-line endpoint change with existing tests.
+3. **PR-B1**: Add Dynamic Resource test suite (Tests for the existing three resources only — no new functionality). Locks in the contract before PR-B2 introduces the fourth Dynamic Resource.
+4. **PR-B2**: Add `ZitadelSmtpActivation` Dynamic Resource + wire into `smtp.ts` + extend the test suite from PR-B1 with the new resource. This requires a `pulumi up` against the dev stack.
+
+PR-B1 lands before PR-B2 so the test scaffold exists when the new resource is added, avoiding "tests retrofit later" debt.
+
+## Risks / Trade-offs
+
+- **[Risk] Zitadel deprecates Management v1 after we adopt it for Resend.** → Mitigation: D1 rationale. When deprecation is announced, we re-target via a follow-up; in the meantime the user-visible bug is fixed.
+- **[Risk] `_activate` returns a non-200 success code or a Zitadel-specific "already active" error that the Dynamic Resource mis-classifies as failure.** → Mitigation: empirically verified during the manual cutover step; PR-B2 test fixtures encode the actual response shape, not the assumed shape.
+- **[Risk] Deleting the orphan handler breaks an unrelated test or Wire DI binding.** → Mitigation: `make check` in backend runs the full test suite + Wire codegen; failures show up at PR time.
+- **[Risk] The Dynamic Resource test suite breaks every time Zitadel changes the Actions v2 wire format.** → Tradeoff: this is the design intent. Tests SHOULD break when the upstream API changes shape; that signal is exactly what we lacked during cutover.
+- **[Trade-off] `ZitadelSmtpActivation` is a side-effect-only resource with no state to read.** → The Pulumi state graph records that activation happened, but cannot detect drift if an operator manually `_deactivate`-s SMTP out-of-band. Acceptable for dev; if drift becomes a recurring problem, add a `read()` handler that GETs `/admin/v1/smtp/{id}` and checks the `state` field.
+
+## Migration Plan
+
+This change has no migration in the database / schema sense. Steps:
+
+1. PR-A1 (backend) merges → `make check` passes → ArgoCD rolls out new image. The `/auto-verify-email` route 404s afterwards; nothing was calling it, so no downstream breakage.
+2. PR-A2 (backend) merges → backend pod rolls. The Settings page "Resend verification email" button starts working for users created during the SMTP-inactive window.
+3. PR-B1 (cloud-provisioning) merges → CI runs vitest; no infra change.
+4. PR-B2 (cloud-provisioning) merges → Pulumi Cloud Deployments runs `pulumi up`. The first run creates the `ZitadelSmtpActivation` resource and fires `_activate`; subsequent runs are no-ops.
+
+Rollback: each PR is a single revert. PR-B2 rollback removes the Dynamic Resource from state but does not deactivate SMTP (that's idempotent and harmless).
+
+## Open Questions
+
+- **Q1**: Does the Management v1 `_resend_verification` endpoint require any specific scope on the backend's MachineUser token beyond what `ResendEmailVerification` already uses? → To verify during PR-A2 implementation. Mitigation: empirically the cutover smoke test fired this endpoint with the existing `backend-app` MachineUser token and got a 200, so the scope set is sufficient.
+- **Q2**: When `self-hosted-zitadel` is archived, do this change's `identity-management` deltas still apply cleanly? → Both this change and `self-hosted-zitadel` modify the same requirement. Resolution: rebase this change onto archived `self-hosted-zitadel` so the requirement exists in main specs at the time the delta lands.

--- a/openspec/changes/cutover-warning-fixes/design.md
+++ b/openspec/changes/cutover-warning-fixes/design.md
@@ -55,14 +55,16 @@ The `ZitadelSmtpActivation` resource tracks no state — it's a pure side-effect
 
 ### D4. Test fixtures encode the v4 contract that broke during cutover
 
-Each Dynamic Resource gets at least these test cases:
+The four-case scaffold below applies to **stateful** Dynamic Resources — those that map to a Zitadel API resource readable via `GET /<path>/{id}`. The current three (`ZitadelTarget`, `ZitadelExecutionFunction`, `ZitadelExecutionRequest`) all qualify. Test cases:
 
 - `create()` MUST issue a `POST` to the documented path, with the request body shape that Zitadel v4 actually accepts (e.g., `targets: string[]` for Execution, NOT `targets: [{target: string}]`).
 - `update()` MUST issue a `POST` (NOT `PATCH`) — Zitadel v4 returns `405 Method Not Allowed` on PATCH for Actions v2 resources.
 - `delete()` MUST issue a `DELETE` to `<path>/{id}`.
 - `read()` MUST tolerate the `404 Not Found` case (resource was deleted out-of-band) by returning `null` rather than throwing.
 
-These four cases collectively encode the §13.5 / §13.6 incident shapes plus the standard Pulumi Dynamic Resource lifecycle expectations. Any future Dynamic Resource added to the module gets the same four-test scaffold by copy-edit.
+These four cases collectively encode the §13.5 / §13.6 incident shapes plus the standard Pulumi Dynamic Resource lifecycle expectations.
+
+**Carve-out for side-effect-only resources.** `ZitadelSmtpActivation` (the new resource introduced in PR-B2) intentionally diverges from this scaffold: activation is a one-shot side effect with no individually addressable `_activate` resource at the API surface — there is no `GET /admin/v1/smtp/{id}/_activation` endpoint to read, no separate `_deactivate` endpoint, and no inputs other than `smtpConfigId` to update. Its `update()` / `read()` / `delete()` handlers are no-ops by design (per D2's "side-effect-only resource" framing and the spec's idempotency scenario), so its test scaffold is narrower: assert that `create()` POSTs and that the other three lifecycle methods make ZERO HTTP calls. Future Dynamic Resources added to the module SHOULD inherit the four-case scaffold unless they are also side-effect-only, in which case they SHOULD inherit the narrower scaffold and call out the divergence in their tasks document (as PR-B2 does in §4.1 and §4.4).
 
 ### D5. Backend RPC change is a 1-line endpoint swap, not an architectural rework
 

--- a/openspec/changes/cutover-warning-fixes/proposal.md
+++ b/openspec/changes/cutover-warning-fixes/proposal.md
@@ -1,0 +1,64 @@
+## Why
+
+The `self-hosted-zitadel` cutover landed end-to-end on 2026-04-30 (smoke test passed, sign-up + login working against `auth.dev.liverty-music.app`). Subsequent `/opsx:verify` surfaced four post-cutover hygiene items that, individually, are too small to warrant their own change but collectively block archive readiness:
+
+- A backend webhook handler that no longer has a Zitadel-side caller (dead code surface).
+- A user-visible bug in the `ResendEmailVerification` RPC that surfaces when SMTP was inactive at sign-up time (incident-path regression from the cutover).
+- A manual operational step (SMTP activation via `curl`) that breaks every fresh Zitadel rebuild silently until the operator remembers to run it.
+- A test gap in the Pulumi Dynamic Resource module that directly cost ~3 hours of incident response during the cutover (PR #211 PATCH→POST and #212 array-of-strings shape mistakes would have been caught by lifecycle tests).
+
+These four items share one archive-readiness goal and ship in a single batch over ~1 week. Bundling avoids splitting nearly-identical post-cutover commit footers across four PRs.
+
+## What Changes
+
+- **Delete the orphan `/auto-verify-email` backend webhook handler** (`internal/adapter/webhook/auto_verify_email_handler.go` + tests + DI wiring + `:9090` route registration). The Zitadel-side Target + Execution were removed in cloud-provisioning#215 during the cutover incident chain; the handler is now dead code with no caller. The `:9090` listener and `/pre-access-token` handler remain unchanged.
+- **Switch `liverty_music.rpc.user.v1.UserService/ResendEmailVerification` from Zitadel v2 `_resend_code` to Zitadel v1 Management `POST /management/v1/users/{userId}/email/_resend_verification`**. The v2 endpoint only resends an EXISTING code; if SMTP was inactive at sign-up time (the §13.16 incident path), no code was ever generated, and the call fails with `Code is empty (EMAIL-5w5ilin4yt)`. The v1 endpoint generates a fresh code AND sends the email — this is the contract users actually expect from "resend." Verified to work via direct API call during the cutover smoke test.
+- **Add a `ZitadelSmtpActivation` Pulumi Dynamic Resource** at `cloud-provisioning/src/zitadel/dynamic/smtp-activation.ts` that calls `POST /admin/v1/smtp/{id}/_activate` after `SmtpConfig` creation, mirroring the existing `ZitadelTarget` / `ZitadelExecutionFunction` pattern. Wire it into `src/zitadel/components/smtp.ts`. Idempotent on retries (re-activating an already-active SMTP returns success). Without this, every Zitadel rebuild silently fails first-sign-up email verification until an operator fires the `_activate` `curl` manually.
+- **Add a `vitest`-based mocked-HTTP test suite** for the lifecycle of `ZitadelTarget`, `ZitadelExecutionFunction`, `ZitadelExecutionRequest`, and the new `ZitadelSmtpActivation`. Fixtures SHALL reflect the actual Zitadel v4 REST API contract (POST for both create AND update, JSON shape with `targets: string[]` rather than `targets: {target: string}[]`). The PR #211/#212 incident chain would have been caught by these tests.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `email-verification`: The "Resend verification email via RPC" requirement is updated to specify the Zitadel Management v1 `_resend_verification` endpoint (rather than v2 `_resend_code`) and gains a scenario covering the "no prior code exists" case, which the v2 endpoint does not handle.
+- `identity-management`: The "SMTP Configuration Must Be Activated After Creation" requirement (introduced by `self-hosted-zitadel`) gains a scenario codifying that activation occurs declaratively via the `ZitadelSmtpActivation` Pulumi Dynamic Resource, not via a manual operator step. The requirement's intent is unchanged — the new scenario constrains the implementation contract.
+
+## Impact
+
+**Affected repositories**
+
+- `backend/`:
+  - `internal/adapter/webhook/auto_verify_email_handler.go` + tests + Wire DI module references (deleted).
+  - `internal/infrastructure/zitadel/email_verifier.go` (or wherever `ResendVerification` lives) — endpoint change from v2 to v1 Management.
+  - `internal/server/webhook.go` (or equivalent) — drop the `:9090` route registration for `/auto-verify-email`.
+- `cloud-provisioning/`:
+  - `src/zitadel/dynamic/smtp-activation.ts` (new) — Dynamic Resource implementation.
+  - `src/zitadel/dynamic/index.ts` — export the new class.
+  - `src/zitadel/components/smtp.ts` — instantiate the activation resource after `SmtpConfig`.
+  - `src/zitadel/dynamic/__tests__/*.test.ts` (new) — mocked-HTTP lifecycle tests for all four Dynamic Resources.
+  - `package.json` — add `vitest` as a dev dependency if not already present.
+
+**Affected systems**
+
+- Dev `auth.dev.liverty-music.app` Zitadel instance: the next `pulumi up` after this change SHALL transition `SmtpConfig` from `INACTIVE` to `ACTIVE` declaratively. No data change.
+- Backend `:9090` webhook listener: shrinks from two routes to one (`/pre-access-token` only). External attack surface unchanged (still cluster-internal `ClusterIP` only).
+- Frontend Settings page "Resend verification email" button: starts working in the post-cutover state where the user signed up while SMTP was inactive.
+
+**Dependencies**
+
+- None on external services. The Zitadel v1 Management API is documented as long-stable (no deprecation horizon at v4) per the Zitadel maintainer reference linked from §18.2.
+- Soft dependency on `self-hosted-zitadel` archiving (or its spec deltas merging) so that the `identity-management` "SMTP Configuration" requirement exists in main specs before this change's delta modifies it. If `self-hosted-zitadel` is still active when this change archives, the modification SHALL be re-targeted at the in-flight delta rather than at main specs.
+
+**Out of scope (already covered or deferred)**
+
+- §18.9.1 Pulumi state-recovery runbook → existing `pulumi-deploy-safeguards` change stub.
+- §18.7 K8s deploy rename → existing `k8s-naming-cleanup` change stub.
+- §18.8 GSM secret rename → existing `rename-zitadel-machine-key-secret` change stub.
+- §18.10 Cloud tenant decommission → existing `archive-zitadel-cloud-tenant` change stub.
+- §18.4 auto-verify-email behavior → decided (keep default OTP); no implementation work.
+- §18.5 Playwright password test user → tracked outside openspec at `liverty-music/frontend#345`.
+- §18.6 Zitadel hang monitoring (alert) → not warning-tier; passive observation continues until cooldown ends ~2026-05-14.

--- a/openspec/changes/cutover-warning-fixes/specs/email-verification/spec.md
+++ b/openspec/changes/cutover-warning-fixes/specs/email-verification/spec.md
@@ -1,0 +1,62 @@
+## MODIFIED Requirements
+
+### Requirement: Resend verification email via RPC
+
+The system SHALL provide an RPC method that allows authenticated users to resend the verification email for their own account. The backend SHALL proxy this request to Zitadel's Management v1 API `POST /management/v1/users/{externalId}/email/_resend_verification`, which generates a fresh verification code AND triggers email delivery via the configured SMTP provider.
+
+The request SHALL carry an explicit `user_id` that the backend verifies against the JWT-derived userID; mismatches SHALL be rejected with `PERMISSION_DENIED` before any Zitadel call is made.
+
+The infrastructure layer (`EmailVerifier.ResendVerification`) SHALL emit a structured INFO log entry on successful API call completion, and a structured ERROR log entry on failure. Both log entries MUST include the `external_id` field.
+
+**Rationale**: The Zitadel User Service v2 endpoint `POST /v2/users/{userId}/email/_resend_code` was previously used here. That endpoint only resends an _existing_ code — if no code was generated at sign-up time (the §13.16 cutover incident path: sign-up succeeded against an inactive `SmtpConfig`, so no `EMAIL.code.added` event was emitted, so no code exists to resend), it returns `Code is empty (EMAIL-5w5ilin4yt)` and the frontend Settings page surfaces a vague "Failed to send verification email" error. The Management v1 `_resend_verification` endpoint has the broader "regenerate AND send" semantic that matches the user-intent of clicking "Resend." Verified working during the cutover smoke test.
+
+#### Scenario: User requests resend from Settings page
+
+- **WHEN** an authenticated user calls the resend verification RPC
+- **AND** the supplied `user_id` equals the userID derived from the JWT
+- **THEN** the backend SHALL extract the user's `external_id` from JWT claims
+- **AND** the backend SHALL call Zitadel's Management v1 `_resend_verification` API with the `external_id`
+- **AND** Zitadel SHALL generate a fresh verification code AND send a new verification email to the user
+
+#### Scenario: User had no prior verification code (post-cutover regression case)
+
+- **WHEN** an authenticated user signed up while the upstream `SmtpConfig` was inactive (no code was generated at user-creation time)
+- **AND** the user calls the resend verification RPC after the SMTP config is activated
+- **THEN** the backend SHALL call the Management v1 `_resend_verification` endpoint
+- **AND** Zitadel SHALL generate a NEW code (no "Code is empty" error)
+- **AND** the user SHALL receive a verification email
+- **AND** the RPC SHALL return success
+
+#### Scenario: Resend Zitadel API call succeeds
+
+- **WHEN** `EmailVerifier.ResendVerification` is called and the Zitadel `_resend_verification` API call completes successfully
+- **THEN** `EmailVerifier.ResendVerification` SHALL emit an INFO log entry with `msg="email verification resent"` and `external_id`
+
+#### Scenario: Resend Zitadel API call fails
+
+- **WHEN** `EmailVerifier.ResendVerification` is called and the Zitadel `_resend_verification` API call returns an error
+- **THEN** `EmailVerifier.ResendVerification` SHALL emit an ERROR log entry with `msg="failed to resend email code"` and `external_id`
+- **AND** the error SHALL be returned to the caller
+
+#### Scenario: User is already verified
+
+- **WHEN** an authenticated user whose email is already verified calls the resend verification RPC
+- **AND** the supplied `user_id` equals the userID derived from the JWT
+- **THEN** the backend SHALL return a `FailedPrecondition` error indicating the email is already verified
+
+#### Scenario: Rapid resend attempts
+
+- **WHEN** a user calls the resend verification RPC more than 3 times within 10 minutes
+- **THEN** the backend SHALL return a `ResourceExhausted` error
+
+#### Scenario: Unauthenticated request
+
+- **WHEN** an unauthenticated request calls the resend verification RPC
+- **THEN** the backend SHALL reject the request with an authentication error
+
+#### Scenario: user_id does not match authenticated user
+
+- **WHEN** the resend verification RPC is called with a `user_id` that differs from the userID derived from the JWT
+- **THEN** the backend SHALL return `PERMISSION_DENIED`
+- **AND** no Zitadel API call SHALL be made
+- **AND** the `EmailVerifier.ResendVerification` infrastructure path SHALL NOT be invoked

--- a/openspec/changes/cutover-warning-fixes/specs/identity-management/spec.md
+++ b/openspec/changes/cutover-warning-fixes/specs/identity-management/spec.md
@@ -1,0 +1,30 @@
+## MODIFIED Requirements
+
+### Requirement: SMTP Configuration Must Be Activated After Creation
+
+The system SHALL invoke the Zitadel admin API `POST /admin/v1/smtp/{id}/_activate` after creating a `SmtpConfig` resource via a **Pulumi Dynamic Resource (`ZitadelSmtpActivation`)** that fires as a declarative dependency of the `SmtpConfig` resource, because Zitadel v4 ships new SMTP configurations in `SMTP_CONFIG_INACTIVE` state and the `@pulumiverse/zitadel.SmtpConfig` resource does not flip the activation flag.
+
+**Rationale**: An inactive SMTP config silently swallows all outbound notification events. Verification emails, password reset emails, and admin notifications are queued but never delivered to the SMTP provider. The failure mode is invisible — the API call to send the email returns success (202-equivalent), the notification worker logs nothing, and the user-facing UX is "no email arrived." Discovered during the dev cutover smoke test when sign-up succeeded but verification emails never reached Postmark. The original requirement said "Pulumi Dynamic Resource OR equivalent"; this modification removes the "OR equivalent" escape and pins the contract to the Dynamic Resource so a manual `curl` step cannot be a "valid implementation" — every Zitadel rebuild must activate SMTP declaratively without operator memory.
+
+#### Scenario: Newly provisioned SMTP config is activated automatically
+
+- **WHEN** Pulumi provisions a `SmtpConfig` resource on a fresh Zitadel instance
+- **THEN** the `ZitadelSmtpActivation` Dynamic Resource SHALL call `POST /admin/v1/smtp/{id}/_activate` as part of the same `pulumi up`
+- **AND** the resulting state SHALL be `SMTP_CONFIG_ACTIVE`
+- **AND** subsequent verification emails SHALL be queued AND delivered to the SMTP provider
+
+#### Scenario: Activation is idempotent across re-apply
+
+- **WHEN** Pulumi re-applies the stack and the SMTP config is already active
+- **THEN** the `ZitadelSmtpActivation` resource's `update` handler SHALL be a no-op AND SHALL NOT fail
+- **AND** SHALL NOT trigger a destructive replace
+- **AND** the Pulumi state graph SHALL continue to record the resource as up-to-date
+
+#### Scenario: Activation runs on a fresh Zitadel rebuild without operator intervention
+
+- **WHEN** the dev (or future staging / prod) Zitadel instance is destroyed and recreated from scratch
+- **AND** Pulumi runs `pulumi up` against the recreated instance
+- **THEN** the `SmtpConfig` resource SHALL be recreated
+- **AND** the `ZitadelSmtpActivation` resource SHALL fire `_activate` automatically as the next step in the dependency graph
+- **AND** the operator SHALL NOT need to run any manual `curl` or `gcloud` step
+- **AND** the first user sign-up after the rebuild SHALL receive a verification email

--- a/openspec/changes/cutover-warning-fixes/tasks.md
+++ b/openspec/changes/cutover-warning-fixes/tasks.md
@@ -24,7 +24,7 @@ Goal: fix the user-visible "Failed to send verification email" bug for users cre
 
 ## 3. PR-B1 — cloud-provisioning: Pulumi Dynamic Resource lifecycle test suite
 
-Goal: lock in the Zitadel v4 wire-level contract (POST for both create and update; `targets: string[]` not `[]Target`; 404 tolerance on read) that the §13.5 / §13.6 incidents broke. Tests cover the existing three resources only; the new `ZitadelSmtpActivation` resource lands in PR-B2 and gets the same scaffold by copy-edit.
+Goal: lock in the Zitadel v4 wire-level contract (POST for both create and update; `targets: string[]` not `[]Target`; 404 tolerance on read) that the §13.5 / §13.6 incidents broke. Tests cover the existing three resources only; the new `ZitadelSmtpActivation` resource lands in PR-B2 and gets a narrower side-effect-only scaffold (per design.md D4) that reuses this PR's mock-`fetch` infrastructure.
 
 - [ ] 3.1 Add `vitest` as a `devDependency` in `cloud-provisioning/package.json` if not already present; ensure `package.json` `scripts.test` invokes it
 - [ ] 3.2 Create `cloud-provisioning/src/zitadel/dynamic/__tests__/zitadel-api-client.test.ts` with a `vi.fn()` fetch mock + a `getAccessToken` happy-path test that asserts the `client_credentials` grant URL and request body

--- a/openspec/changes/cutover-warning-fixes/tasks.md
+++ b/openspec/changes/cutover-warning-fixes/tasks.md
@@ -44,18 +44,23 @@ Goal: lock in the Zitadel v4 wire-level contract (POST for both create and updat
 
 Goal: make Zitadel SMTP activation declarative so every rebuild does not silently break first-sign-up email verification.
 
-- [ ] 4.1 Create `cloud-provisioning/src/zitadel/dynamic/smtp-activation.ts` exporting `ZitadelSmtpActivation` extending `pulumi.dynamic.Resource`. Lifecycle handlers:
+- [ ] 4.1 Create `cloud-provisioning/src/zitadel/dynamic/smtp-activation.ts` exporting `ZitadelSmtpActivation` extending `pulumi.dynamic.Resource`. Lifecycle handlers (note: this resource intentionally diverges from the Target / Execution four-case lifecycle because activation is a one-shot side effect with no readable or updatable state at the Zitadel API surface):
   - `create(inputs.smtpConfigId)`: get OAuth token via `getAccessToken`, then `POST /admin/v1/smtp/{id}/_activate`. Return an outputs object containing `smtpConfigId` and `activatedAt` (timestamp).
-  - `update()`: re-fire `_activate` (idempotent on Zitadel side); store new `activatedAt`.
+  - `update()`: **no-op**. Do NOT re-fire `_activate`; do NOT mutate `activatedAt`. Pulumi handles input-diff replace-vs-update internally; an `update` call here means inputs other than `smtpConfigId` changed (none exist in the input shape today), so there is nothing to do. Aligns with `design.md` D2 and the spec scenario "Activation is idempotent across re-apply."
   - `delete()`: no-op (no `_deactivate` semantic in our use-case).
-  - `read()`: optional GET `/admin/v1/smtp/{id}` to confirm `state === SMTP_CONFIG_ACTIVE`; return current outputs unchanged. Skip if Zitadel API surface is awkward; log warning instead.
+  - `read()`: no-op returning current outputs unchanged. Activation is a side effect with no separate readable state at the Zitadel API surface (one would GET `SmtpConfig`, which is owned by a different resource). Drift detection is explicitly deferred per `design.md` D2 Risks.
 - [ ] 4.2 Export `ZitadelSmtpActivation` from `src/zitadel/dynamic/index.ts`
 - [ ] 4.3 In `src/zitadel/components/smtp.ts`, instantiate `ZitadelSmtpActivation` with `smtpConfigId: smtpConfig.id` and `dependsOn: [smtpConfig]`
-- [ ] 4.4 Extend `__tests__/smtp-activation.test.ts` (new file) with the same four-case scaffold from PR-B1: `create()` POSTs, `update()` POSTs, `delete()` no-op, `read()` tolerates 404. Mock fetch responses match Zitadel's actual `_activate` 200 and "already active" responses
+- [ ] 4.4 Add `__tests__/smtp-activation.test.ts` (new file). The test scaffold is **deliberately narrower** than the four-case scaffold from PR-B1 because of the resource's side-effect-only semantics:
+  - `create()` issues `POST /admin/v1/smtp/{id}/_activate` with the expected request shape; mock 200 response satisfies the call
+  - `create()` succeeds when the upstream returns the "already active" response shape (idempotency on first apply against an out-of-band-activated SMTP)
+  - `update()` makes ZERO HTTP requests (no `fetch` invocation); asserts the mock was not called
+  - `delete()` makes ZERO HTTP requests
+  - `read()` makes ZERO HTTP requests and returns current outputs unchanged
 - [ ] 4.5 Run `make check`; all tests + lint green
 - [ ] 4.6 Run `pulumi preview --stack dev` from a clean checkout; expected diff: `+ create urn:...:ZitadelSmtpActivation:smtp-activation` and zero replacements / deletes
 - [ ] 4.7 Open cloud-provisioning PR titled `feat(zitadel): auto-activate SmtpConfig via Pulumi Dynamic Resource`; verify the `pulumi preview` output is attached to the PR description; merge after approval
-- [ ] 4.8 Post-merge: confirm Pulumi Cloud Deployment auto-runs `pulumi up`; SMTP state in dev Zitadel transitions from current state to `SMTP_CONFIG_ACTIVE` (already active from the manual `curl` step, so the `update` handler's no-op path runs)
+- [ ] 4.8 Post-merge: confirm Pulumi Cloud Deployment auto-runs `pulumi up`; SMTP state in dev Zitadel remains `SMTP_CONFIG_ACTIVE` (already active from the manual `curl` step). The first apply executes `create()` (which calls `_activate`; Zitadel returns the "already active" response and the operation succeeds idempotently). Subsequent applies execute `update()` as a no-op with zero HTTP traffic.
 - [ ] 4.9 Confirm via Zitadel admin API: `GET /admin/v1/smtp/{id}` returns `state: SMTP_CONFIG_ACTIVE`
 
 ## 5. Verification

--- a/openspec/changes/cutover-warning-fixes/tasks.md
+++ b/openspec/changes/cutover-warning-fixes/tasks.md
@@ -1,0 +1,65 @@
+## 1. PR-A1 — Backend: delete orphan `/auto-verify-email` handler
+
+Goal: cleanly remove the dead webhook handler that lost its caller in cloud-provisioning#215. Keep `:9090` listener and `/pre-access-token` handler unchanged.
+
+- [ ] 1.1 Delete `backend/internal/adapter/webhook/auto_verify_email_handler.go`
+- [ ] 1.2 Delete `backend/internal/adapter/webhook/auto_verify_email_handler_test.go`
+- [ ] 1.3 Drop the `/auto-verify-email` route registration from the `:9090` mux setup (`internal/server/webhook.go` or equivalent — find via `grep -rn "auto-verify-email"`)
+- [ ] 1.4 Drop the `auto_verify_email_handler` provider from the Wire DI module (`internal/di/`); regenerate Wire if needed
+- [ ] 1.5 Remove any orphaned imports / type references that the deletions surface
+- [ ] 1.6 Run `make check` in `backend/` — lint + tests must pass
+- [ ] 1.7 Open backend PR titled `cleanup(webhook): remove orphan /auto-verify-email handler`; CI green; merge after review
+
+## 2. PR-A2 — Backend: switch `ResendEmailVerification` to Management v1 endpoint
+
+Goal: fix the user-visible "Failed to send verification email" bug for users created during the SMTP-inactive cutover window.
+
+- [ ] 2.1 Locate `ResendVerification` in `backend/internal/infrastructure/zitadel/email_verifier.go` (or wherever the v2 path string is constructed)
+- [ ] 2.2 Change the endpoint path from `/v2/users/{externalId}/email/_resend_code` (or whatever the current v2 path is) to `/management/v1/users/{externalId}/email/_resend_verification`
+- [ ] 2.3 Adjust the request body shape if the v1 endpoint requires a different JSON envelope; verify against Zitadel docs and the smoke-test trace from §13.16
+- [ ] 2.4 Update existing unit tests that assert the URL path / request method to match the new endpoint
+- [ ] 2.5 Add a unit test covering the "no prior code exists" case — the endpoint should succeed (mocked 200) without the `Code is empty (EMAIL-5w5ilin4yt)` upstream error
+- [ ] 2.6 Run `make check` in `backend/` — lint + tests pass
+- [ ] 2.7 Open backend PR titled `fix(zitadel): use Management v1 _resend_verification for ResendEmailVerification`; verify in dev after rollout that Settings page button works for the SMTP-inactive-window users; merge
+
+## 3. PR-B1 — cloud-provisioning: Pulumi Dynamic Resource lifecycle test suite
+
+Goal: lock in the Zitadel v4 wire-level contract (POST for both create and update; `targets: string[]` not `[]Target`; 404 tolerance on read) that the §13.5 / §13.6 incidents broke. Tests cover the existing three resources only; the new `ZitadelSmtpActivation` resource lands in PR-B2 and gets the same scaffold by copy-edit.
+
+- [ ] 3.1 Add `vitest` as a `devDependency` in `cloud-provisioning/package.json` if not already present; ensure `package.json` `scripts.test` invokes it
+- [ ] 3.2 Create `cloud-provisioning/src/zitadel/dynamic/__tests__/zitadel-api-client.test.ts` with a `vi.fn()` fetch mock + a `getAccessToken` happy-path test that asserts the `client_credentials` grant URL and request body
+- [ ] 3.3 Create `__tests__/target.test.ts` covering `ZitadelTarget`:
+  - `create()` issues `POST /v2/actions/targets` with the expected body shape
+  - `update()` issues `POST` (NOT `PATCH`) — encodes the §13.5 incident shape
+  - `delete()` issues `DELETE /v2/actions/targets/{id}`
+  - `read()` returns `null` on `404` rather than throwing
+- [ ] 3.4 Create `__tests__/execution.test.ts` covering `ZitadelExecutionFunction` and `ZitadelExecutionRequest`:
+  - `create()` body MUST be `{ targets: ["<id>"] }` (string array) — encodes the §13.6 incident shape
+  - same `update`-uses-`POST`, `delete`-issues-`DELETE`, `read`-tolerates-`404` cases
+- [ ] 3.5 Run `npm test` (or whatever script vitest is wired to) in `cloud-provisioning/`; all green
+- [ ] 3.6 Run `make check` — lint + tests pass; CI mirrors local
+- [ ] 3.7 Open cloud-provisioning PR titled `test(zitadel): add Pulumi Dynamic Resource lifecycle tests`; merge
+
+## 4. PR-B2 — cloud-provisioning: `ZitadelSmtpActivation` Dynamic Resource + auto-activate `SmtpConfig`
+
+Goal: make Zitadel SMTP activation declarative so every rebuild does not silently break first-sign-up email verification.
+
+- [ ] 4.1 Create `cloud-provisioning/src/zitadel/dynamic/smtp-activation.ts` exporting `ZitadelSmtpActivation` extending `pulumi.dynamic.Resource`. Lifecycle handlers:
+  - `create(inputs.smtpConfigId)`: get OAuth token via `getAccessToken`, then `POST /admin/v1/smtp/{id}/_activate`. Return an outputs object containing `smtpConfigId` and `activatedAt` (timestamp).
+  - `update()`: re-fire `_activate` (idempotent on Zitadel side); store new `activatedAt`.
+  - `delete()`: no-op (no `_deactivate` semantic in our use-case).
+  - `read()`: optional GET `/admin/v1/smtp/{id}` to confirm `state === SMTP_CONFIG_ACTIVE`; return current outputs unchanged. Skip if Zitadel API surface is awkward; log warning instead.
+- [ ] 4.2 Export `ZitadelSmtpActivation` from `src/zitadel/dynamic/index.ts`
+- [ ] 4.3 In `src/zitadel/components/smtp.ts`, instantiate `ZitadelSmtpActivation` with `smtpConfigId: smtpConfig.id` and `dependsOn: [smtpConfig]`
+- [ ] 4.4 Extend `__tests__/smtp-activation.test.ts` (new file) with the same four-case scaffold from PR-B1: `create()` POSTs, `update()` POSTs, `delete()` no-op, `read()` tolerates 404. Mock fetch responses match Zitadel's actual `_activate` 200 and "already active" responses
+- [ ] 4.5 Run `make check`; all tests + lint green
+- [ ] 4.6 Run `pulumi preview --stack dev` from a clean checkout; expected diff: `+ create urn:...:ZitadelSmtpActivation:smtp-activation` and zero replacements / deletes
+- [ ] 4.7 Open cloud-provisioning PR titled `feat(zitadel): auto-activate SmtpConfig via Pulumi Dynamic Resource`; verify the `pulumi preview` output is attached to the PR description; merge after approval
+- [ ] 4.8 Post-merge: confirm Pulumi Cloud Deployment auto-runs `pulumi up`; SMTP state in dev Zitadel transitions from current state to `SMTP_CONFIG_ACTIVE` (already active from the manual `curl` step, so the `update` handler's no-op path runs)
+- [ ] 4.9 Confirm via Zitadel admin API: `GET /admin/v1/smtp/{id}` returns `state: SMTP_CONFIG_ACTIVE`
+
+## 5. Verification
+
+- [ ] 5.1 Run `/opsx:verify cutover-warning-fixes` after PR-A1, PR-A2, PR-B1, PR-B2 are all merged
+- [ ] 5.2 Confirm the §18.1, §18.2, §18.3, §4.5 / §18.9 follow-up checkboxes in `self-hosted-zitadel/tasks.md` are all checkable; tick them
+- [ ] 5.3 Run `/opsx:archive cutover-warning-fixes` to fold deltas into main `openspec/specs/`


### PR DESCRIPTION
## Summary

Propose `cutover-warning-fixes` — bundle the 4 actionable WARNING-level findings from `/opsx:verify self-hosted-zitadel` into a single openspec change with full artifact set (proposal + design + specs + tasks).

The cutover (#420) shipped end-to-end on 2026-04-30; smoke test passed. This change closes the post-cutover hygiene gaps that block archive readiness.

## Scope

| # | Sub-deliverable | Repo |
|---|-----------------|------|
| 1 | Delete orphan `/auto-verify-email` backend handler (lost its caller in cloud-provisioning#215) | backend |
| 2 | Switch `ResendEmailVerification` RPC from Zitadel v2 `_resend_code` to Management v1 `_resend_verification` (fixes user-visible "Failed to send verification email" bug for users created during the SMTP-inactive window) | backend |
| 3 | Add `ZitadelSmtpActivation` Pulumi Dynamic Resource to declaratively flip new `SmtpConfig` from `INACTIVE` to `ACTIVE` (removes a manual `curl` step from every Zitadel rebuild) | cloud-provisioning |
| 4 | Add `vitest` mocked-HTTP lifecycle tests for all four Pulumi Dynamic Resources, encoding the v4 wire contract the §13.5/§13.6 cutover incidents (PATCH→POST, array-of-strings) broke | cloud-provisioning |

PR order in implementation: A1 → A2 → B1 → B2 (B1 lands the test scaffold before B2 introduces the new resource).

## Capabilities modified

- **`email-verification`**: tighten "Resend verification email via RPC" to use Management v1 endpoint; add post-cutover regression scenario covering "no prior code exists."
- **`identity-management`**: tighten "SMTP Configuration Must Be Activated After Creation" from "Pulumi Dynamic Resource OR equivalent" to "MUST be a Pulumi Dynamic Resource"; add fresh-rebuild scenario asserting no operator step is needed.

## Out of scope (tracked elsewhere)

- §18.9.1 Pulumi state-recovery runbook → openspec `pulumi-deploy-safeguards` stub
- §18.7 K8s deploy rename → openspec `k8s-naming-cleanup` stub
- §18.8 GSM secret rename → openspec `rename-zitadel-machine-key-secret` stub
- §18.10 Cloud tenant decommission → openspec `archive-zitadel-cloud-tenant` stub
- §18.4 auto-verify behavior → decided (keep default OTP); rationale + Zitadel discussion #4145 in `self-hosted-zitadel/tasks.md`
- §18.5 Playwright password test user → liverty-music/frontend#345
- §18.6 Zitadel hang monitoring → not warning-tier; passive observation continues until cooldown ends ~2026-05-14

## Dependency

Soft-depends on `self-hosted-zitadel` (PR #420) merging or being archived: the `identity-management` delta in this change modifies a requirement that the `self-hosted-zitadel` change introduces. If #420 is still open at merge time, this change rebases onto it; if archived, this delta lands cleanly against `openspec/specs/`.

## Test plan

- [x] `openspec validate cutover-warning-fixes` → valid
- [ ] Reviewer reads through all 4 artifacts (proposal + design + specs + tasks) and confirms scope matches the verify findings
- [ ] On merge, `/opsx:apply cutover-warning-fixes` is invoked to start implementing PR-A1
