### PR TITLE
docs(openspec): add refine-onboarding-copy change

### DIFF
--- a/openspec/changes/refine-onboarding-copy/.openspec.yaml
+++ b/openspec/changes/refine-onboarding-copy/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-01

--- a/openspec/changes/refine-onboarding-copy/design.md
+++ b/openspec/changes/refine-onboarding-copy/design.md
@@ -48,7 +48,7 @@ The `dna-orb` component name and the spec-level `artist-discovery-dna-orb-ui` ca
 
 ### Decision 3: PostSignupDialog Hype guide is removed, not relocated as a copy edit
 
-The "Hype guide hint always visible" requirement in the post-signup-dialog capability is REMOVED, not modified. The dialog becomes celebration-first; notification + PWA become optional power-up rows; the Hype guide concept lives only at its natural home in the My Artists page (already covered by `myArtists.coachMark.setHype`).
+The "Hype guide hint always visible" requirement in the post-signup-dialog capability is REMOVED, not modified. The dialog becomes celebration-first; notification + PWA become optional power-up rows. The Hype guide concept is left to the My Artists page itself; first-time discoverability is an accepted regression (the previously-existing `myArtists.coachMark.setHype` i18n key was never rendered by any component and was deleted in this change — see the Discoverability trade-off note in the post-signup-dialog spec). If the team later judges this regression to be meaningful, a follow-up change can wire an in-page hint or coach mark.
 
 This is a spec-level removal (REMOVED Requirement) because the existing scenarios assert the row is *always* visible regardless of permission state — that invariant no longer holds.
 

--- a/openspec/changes/refine-onboarding-copy/design.md
+++ b/openspec/changes/refine-onboarding-copy/design.md
@@ -1,0 +1,101 @@
+## Context
+
+The user-facing copy across Liverty Music's onboarding flow was audited end-to-end during exploration. The audit surfaced three categories of problem:
+
+1. **Terminology drift** — same concept, different words (`ライブ`/`コンサート`, `ダッシュボード`/`タイムテーブル`/`ライブカレンダー`, `登録`/`フォロー`, "Hype" used directly in JA UI).
+2. **Cold-start ambiguity** — first-time visitors can't tell what the product is from the welcome hero alone.
+3. **Stale labels** — `Music DNA` orb name, `チュートリアルお疲れさま` retroactive framing, always-visible Hype guide row in PostSignupDialog don't fit current product voice.
+
+The previously-shipped `establish-brand-vocabulary` change provides the infrastructure (`entity.*` i18n namespace, parity lint, curated entity list, Layer B brand-expressions registry). This change consumes that infrastructure to deliver the actual content fixes.
+
+Two design choices shape the entire change:
+
+- **Asymmetric localization is intentional**: `HypeLevel` enum keeps its proto name; the JA locale renders it as `Stage` (consuming the existing `HOME STAGE / NEAR STAGE / AWAY STAGE` brand vocabulary), the EN locale stays `Hype` (an established loanword in Western fan culture). No proto change, no BSR cycle.
+- **Copy-only, no behavior change**: dashboards, RPCs, auth, routing all unchanged. Even the modal placements (Home Area Selector after dashboard arrival; PostSignupDialog after auth) are deliberately preserved.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Move all `HypeLevel`-related labels into `entity.hype.*` so the new namespace is exercised end-to-end and the parity lint has real data to verify.
+- Unify `ライブ` / `タイムテーブル` / `フォロー` as the single canonical JA term for each concept across the app (eliminate `コンサート`, `ダッシュボード` (in user copy), `ライブカレンダー`, `登録`).
+- Refresh the welcome hero to disambiguate the product, refresh the signup gate to lead with value not method, and refresh the post-signup dialog to celebrate the moment instead of presenting a checklist.
+- Drop the `Music DNA` orb label entirely; let the screen function speak for itself without a coined name that exists in neither the entity layer nor any other surface vocabulary.
+
+**Non-Goals:**
+- **No proto changes**. `HypeLevel` enum, `Concert`, `Artist`, `User.HomeArea` all keep their protobuf names. This is purely a presentation refresh.
+- **No flow restructuring**. Home Area Selector stays as a modal after dashboard arrival; the sequence welcome → discovery → dashboard preview → signup is preserved.
+- **No new components or routes**. Only existing components/templates have their copy and (where keys are renamed) their i18n bindings updated.
+- **No progress indicator**. Discussed and rejected — the existing 3-screen flow is short and self-explanatory; an indicator would add visual debt without paying for itself.
+- **No fallback preview** for the welcome screen. When `dateGroups` is empty the user falls back to the inline CTAs that already exist; building a static demo for the rare case where preview-artist data is unavailable adds engineering surface for marginal benefit.
+- **No backend localization**. Backend-emitted user-facing strings (RPC error messages) remain English in this change.
+
+## Decisions
+
+### Decision 1: Migrate `hype.*` keys to `entity.hype.*`, do NOT keep dual paths
+
+The existing `hype.watch / home / nearby / away` keys (and the screen-local references in `myArtists.table`, `myArtists.hypeExplanation`, `postSignup.hypeGuideLabel`, etc.) are replaced by single canonical paths under `entity.hype.values.*` and `entity.hype.label`. Components that previously bound to scattered keys all switch to the canonical path.
+
+**Alternative considered**: keep `hype.*` as legacy aliases, gradually migrate consumers. Rejected because:
+- The number of consumers is small (single-digit components).
+- Dual paths defeat the parity lint (which entry is authoritative?).
+- The `establish-brand-vocabulary` lint will *fail* if `entity.hype.*` exists in only one locale, so half-migration is impossible.
+
+### Decision 2: Keep "Music DNA Orb" as the internal component name, drop only the user-facing label
+
+The `dna-orb` component name and the spec-level `artist-discovery-dna-orb-ui` capability description ("Music DNA Orb glass sphere") are preserved — they are internal nomenclature shared by code and architecture documents. Only the i18n key `discovery.orbLabel: "Music DNA"` (and any user-visible heading derived from it) is removed.
+
+**Alternative considered**: rename component, capability, and label all together. Rejected because the internal name has no user impact and renaming carries a high refactor cost (architecture docs, screenshots, code review history) for zero user-visible benefit.
+
+### Decision 3: PostSignupDialog Hype guide is removed, not relocated as a copy edit
+
+The "Hype guide hint always visible" requirement in the post-signup-dialog capability is REMOVED, not modified. The dialog becomes celebration-first; notification + PWA become optional power-up rows; the Hype guide concept lives only at its natural home in the My Artists page (already covered by `myArtists.coachMark.setHype`).
+
+This is a spec-level removal (REMOVED Requirement) because the existing scenarios assert the row is *always* visible regardless of permission state — that invariant no longer holds.
+
+**Alternative considered**: keep the row but rephrase. Rejected because the row competes with the celebration moment and serves a context (the My Artists page) the user hasn't navigated to yet — the guidance is misplaced more than miswritten.
+
+### Decision 4: Empty/error microcopy gets one tone split, not full taxonomy
+
+The boilerplate `失敗しました。もう一度お試しください` appears in 6+ keys. We split it into exactly two tones:
+- **Network / connectivity tone**: "ネットワークが不安定なようです。少し時間を置いてもう一度お試しください。"
+- **Transient / generic tone**: keep close to the existing "失敗しました。もう一度お試しください。"
+
+**Alternative considered**: classify by error category (auth / data / permission / etc.) with five tones. Rejected — this is copy refinement, not an error-handling overhaul. A two-tone split is the smallest improvement that addresses the "too cold, too uniform" critique without requiring per-error-category routing changes.
+
+### Decision 5: Brand expressions in Layer B are extended only if a phrase recurs
+
+We do NOT preemptively register every coined phrase from the rewrites in `brand-vocabulary.md` Layer B registry. A phrase becomes a Layer B entry only if:
+- it appears in 2+ user-visible places, OR
+- it is a noun the team will say in conversation (lane name, slogan).
+
+Most rewritten copy is one-shot screen text and does not need cataloguing. The HOME/NEAR/AWAY STAGE family stays as the canonical Layer B entries (already there from `establish-brand-vocabulary`).
+
+### Decision 6: Page-by-page copy is finalized in code review, not pre-locked in spec scenarios
+
+Spec scenarios assert *invariants* (e.g. "PostSignupDialog leads with a celebration row") rather than *exact strings* (e.g. "the title is `🎉 準備完了！…`"). This keeps the spec stable across small wording iterations and avoids the spec/code drift trap where every wording tweak requires a spec edit.
+
+The final wording for each screen is agreed in the implementation PR, not in this change folder. Tasks list the screens to address but the proposed text in tasks.md is illustrative.
+
+## Risks / Trade-offs
+
+- **Risk: a JA-only term replacement (e.g. `登録` → `フォロー`) hits a string in a context I missed (an aria-label, a snack-bar message, a story file)** → Mitigation: grep for every old term in `frontend/src/**/*.{ts,html}` and `frontend/src/locales/`; reviewer checks the diff against the unification table in tasks.md.
+- **Risk: removing `discovery.orbLabel` breaks an aria-label that screen readers depend on** → Mitigation: confirm the orb container has either a different aria-label or a `<h1>`/`<h2>` heading announcing the screen purpose; if not, add one before deleting `orbLabel`.
+- **Risk: PostSignupDialog tests in `frontend/test/components/post-signup-dialog.spec.ts` assert the always-visible Hype row** → Mitigation: those assertions get inverted ("Hype row SHALL NOT be present"). Existing tests for notification / PWA rows continue to pass since their requirements don't change.
+- **Risk: the lint script catches a parity violation immediately when we populate `entity.hype.*` because of a typo** → Mitigation: this is the lint working as intended; fix the typo and move on.
+- **Trade-off: spec scenarios stay loose (invariants, not strings)** → Accepted. Tighter scenarios would catch wording regressions but at high churn cost.
+- **Trade-off: documentation snapshots (capability descriptions, architecture docs) that reference `Music DNA Orb` are not revisited** → Accepted. The internal name is fine; only user-visible removal happens.
+
+## Migration Plan
+
+1. Land the `entity.hype.*` JSON additions to both locales in a single commit (lint must pass after this commit).
+2. Update each consumer to bind to `entity.hype.*` and remove the corresponding old `hype.*` / inline keys in the same commit (so lint sees no orphans).
+3. Welcome / signup / discovery / post-signup copy edits as their own commits, one screen per commit, so reviewers can react per screen.
+4. Empty/error tone split as a final commit.
+
+Rollback is a straightforward revert at any commit boundary; no schema migration, no data migration, no caches to invalidate.
+
+## Open Questions
+
+- **Final wording for the welcome hero descriptor line.** Three options on the table from exploration: 「推しのライブを集めて、あなただけのタイムテーブルに」, 「ライブ通知 × あなただけのタイムテーブル」, or omit and tighten the existing subtitle. Decided in the implementation PR, not here.
+- **Whether to also unify `ライブ` in the i18n key for `notification.title` ("ライブイベントを見逃さない") to match the rest of the copy ("ライブ" not "ライブイベント")**. Probably yes, but worth a moment in review.
+- **EN-side wording for `entity.hype.values.*`**. Current proposal: `Watching / Home / Near / Away`. Open whether `Anywhere` reads better than `Away` for the highest level.

--- a/openspec/changes/refine-onboarding-copy/proposal.md
+++ b/openspec/changes/refine-onboarding-copy/proposal.md
@@ -23,6 +23,18 @@ The `establish-brand-vocabulary` change just landed, providing the `entity.*` na
 - **Post-Signup Dialog**: **BREAKING** for the `post-signup-dialog` capability — drop the always-visible Hype guide row; lead with celebration; demote notification + PWA to optional power-ups. Hype guidance migrates to the My Artists context (already covered by `myArtists.coachMark.setHype`).
 - **Empty / error microcopy**: turn `dashboard.empty` from a flat statement into a promise; split the boilerplate `失敗しました。もう一度お試しください` into 2 tones (network vs transient).
 
+### Visual polish (added in design review iteration after the initial copy refresh landed)
+
+The copy refresh exposed a number of presentation-layer issues that text alone could not address. Captured here so the change reflects what actually shipped, not a partial truth:
+
+- **Welcome hero visual refinement** — drop the redundant `descriptor` line, rewrite title to eliminate `もう` echo, split subtitle into 2 keys (pain + action) for distinct paragraph treatment, apply a "festival-spotlight" glow vocabulary (reusing `event-card[data-matched]` text-shadow pattern) to the brand wordmark and the role-reversal verbs (`追う`/`行く`/`tracks`/`go`), apply `text-wrap: balance` + `word-break: auto-phrase` for phrase-aware CJK wrapping, switch hero to full-viewport (drop the awkward 5svh peek), and bump margins for breathing room.
+- **Page-help dialog redesign** — info icon + title + divider header; bullet markers (`▸` brand-accent) on tip lists; `<dl>` + CSS grid for the dashboard HOME/NEAR/AWAY lane block (descriptions now align in a flush-left column instead of being thrown off by label-width differences); inline genre-chip demo on the discovery help (show the actual UI primitive instead of describing it); brand-accent help trigger so it reads as tappable instead of disabled.
+- **Bottom-sheet baseline padding** — bump `.handle-bar` bottom padding so all sheets (user-home-selector, post-signup, page-help, etc.) get a baseline gap between the handle and content.
+- **Bottom-nav active state** — 3-layer cue (color + bold label + 2px top accent bar) so the current page reads instantly.
+- **Page header polish** — title font-size up + bolder weight; render unconditionally on My Artists (was hidden when empty, breaking page-identity continuity).
+- **State-placeholder icon visibility** — switch icon color to brand-accent and fix an app-wide bug where `:where(svg) { fill: currentcolor }` in the global reset overrode each Lucide icon's `fill="none"` attribute, causing all stroked icons to render as filled disks.
+- **Nav rename** — `nav.home` value `"Home"` → `"Timetable"` in both locales (route stays `/dashboard`); the user-facing label aligns with the brand vocabulary established by the welcome page.
+
 ## Capabilities
 
 ### New Capabilities

--- a/openspec/changes/refine-onboarding-copy/proposal.md
+++ b/openspec/changes/refine-onboarding-copy/proposal.md
@@ -1,0 +1,44 @@
+## Why
+
+The onboarding flow's user-facing copy was audited end-to-end (welcome → discovery → signup → post-signup) and three structural problems surfaced:
+
+- **Terminology drift**: the same concept is named differently in different places (`ライブ` vs `コンサート`, `ダッシュボード` vs `タイムテーブル` vs `ライブカレンダー`, `登録` vs `フォロー`, JA `Hype` everywhere despite never being a JA loanword in fan culture).
+- **Cold-start ambiguity**: a stranger landing on `/welcome` cannot tell what Liverty Music *is* (no product descriptor under the brand), and the post-signup screen front-loads a checklist instead of celebrating the moment.
+- **Stale user-facing labels**: `Music DNA` (Discovery orb), `チュートリアルお疲れさまでした` (signup gate), and the "always visible Hype guide" in PostSignupDialog are leftovers from earlier iterations that no longer match the product's intended voice.
+
+The `establish-brand-vocabulary` change just landed, providing the `entity.*` namespace and parity lint. This change consumes that infrastructure to deliver the actual content fixes.
+
+## What Changes
+
+- **Populate Layer A registry** with the first concrete entries:
+  - `entity.hype.label` → JA `Stage` / EN `Hype` (asymmetric — first real exercise of the namespace's design rule)
+  - `entity.hype.values.{watch,home,near,away}` → JA `観測 / 地元 / 近郊 / 全国` and EN `Watching / Home / Near / Away`
+  - `entity.concert.label` → `ライブ` / `Live`
+  - `entity.artist.label` → `アーティスト` / `Artist`
+- **Migrate existing `hype.*` and screen-local hype text** to the new `entity.hype.*` keys; remove orphaned legacy keys.
+- **Unify terminology** in JA copy: `ライブ` (not `コンサート`), `タイムテーブル` (not `ダッシュボード` / `ライブカレンダー` in user-visible contexts), `フォロー` (not `登録`).
+- **Welcome hero** ([`welcome-route.html`](frontend/src/routes/welcome/welcome-route.html)): add a one-line product descriptor under the brand; rewrite the primary CTA to predict its reward; promote `welcome.guestFriendly` from below the buttons.
+- **Discovery**: drop `discovery.orbLabel` ("Music DNA") entirely; rewrite `discovery.popoverGuide` and `coachMark.viewTimetable` to celebrate the experience instead of merely instructing.
+- **Signup gate**: delete `チュートリアルお疲れさまでした`; restructure as value-first ("通知が届く / 端末横断 / 履歴保持") with Passkey as a means, not the lead.
+- **Post-Signup Dialog**: **BREAKING** for the `post-signup-dialog` capability — drop the always-visible Hype guide row; lead with celebration; demote notification + PWA to optional power-ups. Hype guidance migrates to the My Artists context (already covered by `myArtists.coachMark.setHype`).
+- **Empty / error microcopy**: turn `dashboard.empty` from a flat statement into a promise; split the boilerplate `失敗しました。もう一度お試しください` into 2 tones (network vs transient).
+
+## Capabilities
+
+### New Capabilities
+None. This change is content + minor structural revision; no new system behavior.
+
+### Modified Capabilities
+- `frontend-i18n`: add a requirement that legacy top-level namespaces superseded by `entity.*` SHALL be removed from the locale files (no orphaned `hype.*` keys after migration).
+- `post-signup-dialog`: REMOVE the "Hype guide hint always visible in PostSignupDialog" requirement and its scenarios; MODIFY the dialog-content requirement to lead with a completion celebration row instead of a checklist.
+- `landing-page`: MODIFY `Guest-Friendly Welcome Copy` to allow promoting the no-account-required message into the primary CTA caption rather than restricting it to a position below the buttons.
+
+The `brand-vocabulary` capability is not modified at the spec level — populating `entity.hype.*` is a data change that already conforms to the existing requirements (locale parity, known-entity stems, asymmetric values). No new spec invariant is added.
+
+## Impact
+
+- **specification repo**: 4 spec deltas + this change folder.
+- **frontend repo**: rewrites of `src/locales/{ja,en}/translation.json` (move `hype.*` → `entity.hype.*`, retire `discovery.orbLabel`, edit welcome / signup / postSignup / dashboard / discovery copy); minor template adjustments where keys were renamed; PostSignupDialog component change to drop the hype-guide row.
+- **No proto changes, no BSR cycle, no backend changes.** The `HypeLevel` enum keeps its proto name; only the JA i18n surface label diverges to `Stage`.
+- **CI**: `check-brand-vocabulary` lint script (from `establish-brand-vocabulary`) starts enforcing parity on the populated `entity.*` keys for the first time.
+- **No behavior change on the dashboard, discovery RPCs, or auth flows.**

--- a/openspec/changes/refine-onboarding-copy/proposal.md
+++ b/openspec/changes/refine-onboarding-copy/proposal.md
@@ -12,8 +12,8 @@ The `establish-brand-vocabulary` change just landed, providing the `entity.*` na
 
 - **Populate Layer A registry** with the first concrete entries:
   - `entity.hype.label` → JA `Stage` / EN `Hype` (asymmetric — first real exercise of the namespace's design rule)
-  - `entity.hype.values.{watch,home,near,away}` → JA `観測 / 地元 / 近郊 / 全国` and EN `Watching / Home / Near / Away`
-  - `entity.concert.label` → `ライブ` / `Live`
+  - `entity.hype.values.{watch,home,nearby,away}` → JA `観測 / 地元 / 近郊 / 全国` and EN `Watching / Home / Near / Away` (key segment `nearby` mirrors the TS `Hype` enum value)
+  - `entity.concert.label` → `ライブ` / `Concert` (asymmetric — JA canonical fan-vocab term differs from EN noun)
   - `entity.artist.label` → `アーティスト` / `Artist`
 - **Migrate existing `hype.*` and screen-local hype text** to the new `entity.hype.*` keys; remove orphaned legacy keys.
 - **Unify terminology** in JA copy: `ライブ` (not `コンサート`), `タイムテーブル` (not `ダッシュボード` / `ライブカレンダー` in user-visible contexts), `フォロー` (not `登録`).

--- a/openspec/changes/refine-onboarding-copy/proposal.md
+++ b/openspec/changes/refine-onboarding-copy/proposal.md
@@ -15,12 +15,13 @@ The `establish-brand-vocabulary` change just landed, providing the `entity.*` na
   - `entity.hype.values.{watch,home,nearby,away}` → JA `観測 / 地元 / 近郊 / 全国` and EN `Watching / Home / Near / Away` (key segment `nearby` mirrors the TS `Hype` enum value)
   - `entity.concert.label` → `ライブ` / `Concert` (asymmetric — JA canonical fan-vocab term differs from EN noun)
   - `entity.artist.label` → `アーティスト` / `Artist`
+  - `entity.homeArea.label` → `ホームエリア` / `Home Area`
 - **Migrate existing `hype.*` and screen-local hype text** to the new `entity.hype.*` keys; remove orphaned legacy keys.
 - **Unify terminology** in JA copy: `ライブ` (not `コンサート`), `タイムテーブル` (not `ダッシュボード` / `ライブカレンダー` in user-visible contexts), `フォロー` (not `登録`).
 - **Welcome hero** ([`welcome-route.html`](frontend/src/routes/welcome/welcome-route.html)): add a one-line product descriptor under the brand; rewrite the primary CTA to predict its reward; promote `welcome.guestFriendly` from below the buttons.
 - **Discovery**: drop `discovery.orbLabel` ("Music DNA") entirely; rewrite `discovery.popoverGuide` and `coachMark.viewTimetable` to celebrate the experience instead of merely instructing.
 - **Signup gate**: delete `チュートリアルお疲れさまでした`; restructure as value-first ("通知が届く / 端末横断 / 履歴保持") with Passkey as a means, not the lead.
-- **Post-Signup Dialog**: **BREAKING** for the `post-signup-dialog` capability — drop the always-visible Hype guide row; lead with celebration; demote notification + PWA to optional power-ups. Hype guidance migrates to the My Artists context (already covered by `myArtists.coachMark.setHype`).
+- **Post-Signup Dialog**: **BREAKING** for the `post-signup-dialog` capability — drop the always-visible Hype guide row; lead with celebration; demote notification + PWA to optional power-ups. Hype discoverability is an accepted regression — `myArtists.coachMark.setHype` was never rendered and was deleted in this change; a follow-up can wire a My Artists coach mark if the team judges the regression meaningful.
 - **Empty / error microcopy**: turn `dashboard.empty` from a flat statement into a promise; split the boilerplate `失敗しました。もう一度お試しください` into 2 tones (network vs transient).
 
 ### Visual polish (added in design review iteration after the initial copy refresh landed)

--- a/openspec/changes/refine-onboarding-copy/specs/frontend-i18n/spec.md
+++ b/openspec/changes/refine-onboarding-copy/specs/frontend-i18n/spec.md
@@ -13,7 +13,7 @@ When a top-level i18n namespace is superseded by an `entity.*` namespace path, t
 
 #### Scenario: Per-screen hype labels collapse into the entity path
 
-- **WHEN** a screen-local key (e.g. `myArtists.table.watch`, `myArtists.hypeExplanation.watch`, `myArtists.table.home`, `postSignup.hypeGuideLabel`) duplicates a value now expressible via `entity.hype.values.*` or `entity.hype.label`
+- **WHEN** a screen-local key (e.g. `myArtists.table.watch`, `myArtists.hypeExplanation.watch`, `myArtists.table.home`) duplicates a value now expressible via `entity.hype.values.*` or `entity.hype.label`
 - **THEN** the screen template SHALL bind to the `entity.*` path instead
 - **AND** the duplicate screen-local key SHALL be removed from both locale files
 - **AND** any wording variation in the screen-local key (e.g. `近郊まで` vs `近郊`, `どこでも！` vs `全国`) SHALL be reconciled in favor of the canonical `entity.hype.values.*` value, eliminating the variant

--- a/openspec/changes/refine-onboarding-copy/specs/frontend-i18n/spec.md
+++ b/openspec/changes/refine-onboarding-copy/specs/frontend-i18n/spec.md
@@ -6,10 +6,9 @@ When a top-level i18n namespace is superseded by an `entity.*` namespace path, t
 
 #### Scenario: hype.* migrated to entity.hype.*
 
-- **WHEN** `entity.hype.label` and `entity.hype.values.{watch,home,near,away}` are populated in both locales
+- **WHEN** `entity.hype.label` and `entity.hype.values.{watch,home,nearby,away}` are populated in both locales
 - **AND** all template / TypeScript bindings are switched to read from `entity.hype.*`
 - **THEN** the legacy `hype.watch`, `hype.home`, `hype.nearby`, `hype.away` keys SHALL be removed from both locale files
-- **AND** the legacy `myArtists.coachMark.setHype` text SHALL be updated to reference Stage (JA) / Hype (EN) consistent with the new label
 - **AND** no source file SHALL retain a reference to a removed legacy key (verified by Biome / typecheck against generated i18n key types if available, otherwise by grep in CI)
 
 #### Scenario: Per-screen hype labels collapse into the entity path

--- a/openspec/changes/refine-onboarding-copy/specs/frontend-i18n/spec.md
+++ b/openspec/changes/refine-onboarding-copy/specs/frontend-i18n/spec.md
@@ -1,0 +1,20 @@
+## ADDED Requirements
+
+### Requirement: Legacy Key Removal After Entity Migration
+
+When a top-level i18n namespace is superseded by an `entity.*` namespace path, the legacy keys SHALL be removed from both `ja/translation.json` and `en/translation.json` in the same change that introduces the `entity.*` replacements.
+
+#### Scenario: hype.* migrated to entity.hype.*
+
+- **WHEN** `entity.hype.label` and `entity.hype.values.{watch,home,near,away}` are populated in both locales
+- **AND** all template / TypeScript bindings are switched to read from `entity.hype.*`
+- **THEN** the legacy `hype.watch`, `hype.home`, `hype.nearby`, `hype.away` keys SHALL be removed from both locale files
+- **AND** the legacy `myArtists.coachMark.setHype` text SHALL be updated to reference Stage (JA) / Hype (EN) consistent with the new label
+- **AND** no source file SHALL retain a reference to a removed legacy key (verified by Biome / typecheck against generated i18n key types if available, otherwise by grep in CI)
+
+#### Scenario: Per-screen hype labels collapse into the entity path
+
+- **WHEN** a screen-local key (e.g. `myArtists.table.watch`, `myArtists.hypeExplanation.watch`, `myArtists.table.home`, `postSignup.hypeGuideLabel`) duplicates a value now expressible via `entity.hype.values.*` or `entity.hype.label`
+- **THEN** the screen template SHALL bind to the `entity.*` path instead
+- **AND** the duplicate screen-local key SHALL be removed from both locale files
+- **AND** any wording variation in the screen-local key (e.g. `近郊まで` vs `近郊`, `どこでも！` vs `全国`) SHALL be reconciled in favor of the canonical `entity.hype.values.*` value, eliminating the variant

--- a/openspec/changes/refine-onboarding-copy/specs/landing-page/spec.md
+++ b/openspec/changes/refine-onboarding-copy/specs/landing-page/spec.md
@@ -1,0 +1,12 @@
+## MODIFIED Requirements
+
+### Requirement: Guest-Friendly Welcome Copy
+
+The Welcome page SHALL communicate that no account is required to try the product, and SHALL place this message where the primary CTA's intent is most clearly disambiguated.
+
+#### Scenario: Guest-friendly copy displayed near primary CTA
+
+- **WHEN** the Welcome page renders
+- **THEN** the page SHALL display copy equivalent to "アカウント不要でお試しいただけます" in immediate visual proximity to the primary CTA
+- **AND** the copy MAY be rendered as a caption directly below the CTA label, as a sub-line above the CTA group, or as inline microcopy adjacent to the button — whichever placement keeps the message visible without requiring the user to scroll past the CTA
+- **AND** the copy SHALL NOT be hidden inside an expandable affordance or relegated below other less-relevant text

--- a/openspec/changes/refine-onboarding-copy/specs/post-signup-dialog/spec.md
+++ b/openspec/changes/refine-onboarding-copy/specs/post-signup-dialog/spec.md
@@ -72,7 +72,7 @@ The system SHALL display a dialog after the first successful signup that consoli
 ## REMOVED Requirements
 
 ### Requirement: Hype guide hint always visible in PostSignupDialog
-**Reason**: The Hype guide is contextual guidance about a feature on the My Artists page; presenting it inside the post-signup celebration moment competes with the celebration tone and surfaces guidance for a screen the user has not yet visited. The same guidance is now delivered at its natural location via the existing `myArtists.coachMark.setHype` coach mark, which fires when the user reaches the My Artists page for the first time.
+**Reason**: The Hype guide is contextual guidance about a feature on the My Artists page; presenting it inside the post-signup celebration moment competes with the celebration tone and surfaces guidance for a screen the user has not yet visited. The `myArtists.coachMark.setHype` i18n key was never rendered by any component and was deleted in this change (see task 4.6), so Hype discoverability is accepted as a known regression — see the Discoverability trade-off note below.
 
 **Migration**: No data migration. The `postSignup.hypeGuideLabel` i18n key (and corresponding template row) is removed from `frontend/src/locales/{ja,en}/translation.json` and the PostSignupDialog template.
 

--- a/openspec/changes/refine-onboarding-copy/specs/post-signup-dialog/spec.md
+++ b/openspec/changes/refine-onboarding-copy/specs/post-signup-dialog/spec.md
@@ -1,0 +1,79 @@
+## MODIFIED Requirements
+
+### Requirement: Post-Signup Dialog on First Authentication
+
+The system SHALL display a dialog after the first successful signup that consolidates a celebration message with optional power-up actions (notification permission, PWA install), without front-loading guidance for features the user has not yet encountered.
+
+#### Scenario: Dialog shown after first signup
+
+- **WHEN** the auth-callback route completes `provisionUser()` for a new user
+- **AND** `localStorage['liverty:postSignup:shown']` is not set
+- **THEN** the system SHALL set `localStorage['liverty:postSignup:shown']` to `'1'`
+- **AND** the system SHALL navigate to `/dashboard`
+- **AND** the Dashboard SHALL display the `PostSignupDialog` on load
+
+#### Scenario: Dialog not shown on subsequent logins
+
+- **WHEN** the auth-callback route completes for a returning user
+- **AND** `localStorage['liverty:postSignup:shown']` is already set
+- **THEN** the system SHALL NOT show the `PostSignupDialog`
+
+#### Scenario: Dialog content leads with celebration
+
+- **WHEN** the PostSignupDialog is displayed
+- **THEN** the first content row SHALL be a celebration message acknowledging completion of onboarding
+- **AND** it SHALL offer a notification opt-in action if `notificationManager.permission === 'default'`
+- **AND** it SHALL show a notification denied message if `notificationManager.permission === 'denied'`
+- **AND** it SHALL offer a PWA install action if `PwaInstallService.canShowFab` is `true` AND the platform is not iOS Safari
+- **AND** it SHALL provide a dismiss/close action in the footer
+
+#### Scenario: Footer button label when all actions are complete
+
+- **WHEN** the PostSignupDialog is displayed
+- **AND** `PwaInstallService.canShowFab` is `false` (PWA already installed or not applicable)
+- **AND** `notificationManager.permission` is `'granted'`
+- **THEN** the footer button SHALL display the label "Close"
+
+#### Scenario: Footer button label when actions remain
+
+- **WHEN** the PostSignupDialog is displayed
+- **AND** either `PwaInstallService.canShowFab` is `true` OR `notificationManager.permission` is not `'granted'`
+- **THEN** the footer button SHALL display the label "Later"
+
+#### Scenario: Notification opt-in from dialog
+
+- **WHEN** the user taps the notification opt-in button in the PostSignupDialog
+- **THEN** the system SHALL call `PushService.create()` (backed by `PushNotificationService.Create` RPC)
+- **AND** the system SHALL NOT write any `localStorage` flag for push notification enabled state
+- **AND** on success, the notification row SHALL show a confirmed state
+- **AND** on failure or denial, the notification row SHALL show an error state
+- **AND** the settings page SHALL subsequently derive the toggle state from the backend via `PushNotificationService.Get` without relying on any `localStorage` flag
+
+#### Scenario: PWA install from dialog (Android/Chrome)
+
+- **WHEN** the user taps the PWA install button in the PostSignupDialog
+- **AND** `beforeinstallprompt` has fired
+- **THEN** the system SHALL trigger the deferred `beforeinstallprompt` event
+
+#### Scenario: PWA install row hidden on iOS Safari
+
+- **WHEN** the PostSignupDialog is displayed
+- **AND** the platform is iOS Safari (`beforeinstallprompt` never fires)
+- **THEN** the PWA install row SHALL NOT be shown in the dialog
+- **AND** the persistent FAB instruction sheet provides the iOS install path instead
+
+#### Scenario: Dialog dismissed
+
+- **WHEN** the user taps the dismiss button
+- **THEN** the PostSignupDialog SHALL close
+- **AND** the notification prompt SHALL NOT be shown again in the same session (coordinated via `IPromptCoordinator`)
+- **AND** the PWA install FAB SHALL remain visible (it is not affected by PostSignupDialog dismissal)
+
+## REMOVED Requirements
+
+### Requirement: Hype guide hint always visible in PostSignupDialog
+**Reason**: The Hype guide is contextual guidance about a feature on the My Artists page; presenting it inside the post-signup celebration moment competes with the celebration tone and surfaces guidance for a screen the user has not yet visited. The same guidance is now delivered at its natural location via the existing `myArtists.coachMark.setHype` coach mark, which fires when the user reaches the My Artists page for the first time.
+
+**Migration**: No data migration. The `postSignup.hypeGuideLabel` i18n key (and corresponding template row) is removed from `frontend/src/locales/{ja,en}/translation.json` and the PostSignupDialog template.
+
+**Discoverability trade-off**: removing this row reduces Hype-feature discoverability for first-time signed-up users. An i18n key `myArtists.coachMark.setHype` exists but is not currently rendered by any component, so users now discover Hype only by exploring the My Artists page on their own. If the team later judges this to be a meaningful regression, a separate change can wire a coach mark or in-page hint on the My Artists page; that is intentionally out of scope for this content-refresh change.

--- a/openspec/changes/refine-onboarding-copy/tasks.md
+++ b/openspec/changes/refine-onboarding-copy/tasks.md
@@ -81,8 +81,48 @@
 
 ## 12. Pull Requests
 
-- [ ] 12.1 Open PR in `specification/` containing this change folder + spec deltas
-- [ ] 12.2 Open PR in `frontend/` containing the i18n migration + screen edits + post-signup-dialog component change + test updates
-- [ ] 12.3 Cross-link the two PRs
-- [ ] 12.4 Recommend reviewing the frontend PR commit-by-commit (one screen / one concern per commit per the migration plan in design.md)
+- [x] 12.1 Open PR in `specification/` containing this change folder + spec deltas — liverty-music/specification#434
+- [x] 12.2 Open PR in `frontend/` — liverty-music/frontend#350
+- [x] 12.3 Cross-link the two PRs
+- [x] 12.4 ~~Per-screen commits~~ — collapsed to a single commit. translation.json is shared across all 9 modification groups and partial-staging it would have required `git add -p` gymnastics with little reviewer benefit. The PR description mirrors the per-area structure
 - [ ] 12.5 After both PRs merge, archive with the same manual delta-sync pattern used for `establish-brand-vocabulary` (see archive PR #432 for template)
+
+## 13. Welcome Hero Visual Refinement (post-initial review iteration)
+
+After landing the initial copy refresh in PR #350, design review surfaced several visual issues the copy alone could not address. This section captures the visual polish round.
+
+- [x] 13.1 Drop the `welcome.hero.descriptor` introduction — duplicated the subtitle's mechanism explanation. Brand → title → subtitle is a tighter hierarchy
+- [x] 13.2 Rewrite title from `"もう二度と見逃さない"` to `"絶対に見逃さない"` — eliminates `もう` echo with the subtitle's `もう終わり`
+- [x] 13.3 Restructure subtitle as 2-line `subtitlePain` + `subtitleAction` keys to allow distinct paragraph treatment without HTML in i18n
+- [x] 13.4 Apply festival-spotlight glow vocabulary (`text-shadow` reusing `event-card[data-matched]` pattern) to:
+  - `welcome-brand` — ブランドが視覚階層の最上位として光る
+  - `welcome-subtitle-action strong` — 強調動詞 `追う` / `行く` / `tracks` / `go` がブランドの声として浮かぶ
+- [x] 13.5 Embed `<strong>` tags in `welcome.hero.subtitleAction` and bind via `t="[html]..."` so emphasis lives in HTML semantic markup, not slot composition
+- [x] 13.6 Apply `text-wrap: balance` + `word-break: auto-phrase` to `.welcome-title`, `.welcome-subtitle`, `.welcome-preview-label` for phrase-aware CJK line breaks
+- [x] 13.7 `welcome-hero` height: `95svh` → `100svh` (eliminates the awkward 5svh peek that caught either preview-label text or stage headers; the explicit scroll CTA covers the affordance)
+- [x] 13.8 Bump margins for breathing room: `.welcome-title` `space-s → space-m`, `.welcome-subtitle` `space-2xs → space-xs` + `line-height: relaxed`, `.welcome-subtitle-action` `space-l → space-xl`, `.welcome-brand` font-size `step-0 → step-2`, `line-height: snug` on title
+- [x] 13.9 Drop leading `↓` from `welcome.hero.seePreview` i18n value — CSS `::after` already adds the trailing arrow, leading caused duplication
+
+## 14. Page-Help Redesign
+
+`<page-help>` was a plain text dump; refined into a proper info dialog with semantic structure and visible hierarchy.
+
+- [x] 14.1 Add `<header>` wrapping a `<svg-icon name="info">` + `<h2>` title with a subtle bottom divider — anchors the dialog with a visual entry point
+- [x] 14.2 Bullet markers (`▸` in `--color-brand-accent`) for `.page-help-tips` items so tips read as advice, not generic copy
+- [x] 14.3 Lane block (HOME/NEAR/AWAY in dashboard help): convert `<ul><li>` to `<dl><dt><dd>` (semantic definition list) + CSS grid `grid-template-columns: auto 1fr` so descriptions align in a flush-left column regardless of label width. Drop leading `—` from the description i18n values (column gap replaces it)
+- [x] 14.4 Embed an inline genre-chip demo (`Rock` / `Pop` (active) / `Jazz`) in the discovery help — show the actual UI primitive instead of just describing it. CSS mimics `.genre-chip` rules from discovery-route via local `--_white-*` tokens for design coherence
+- [x] 14.5 Hype table (My Artists help): add row separators (`tr + tr` border-block-start) for clearer scanning
+- [x] 14.6 `.page-help-trigger` (the `?` button): brand-accent border + tinted background, instead of muted color — discoverable as a tappable affordance not a disabled chip
+
+## 15. Bottom-Sheet / Nav / State-Placeholder Polish
+
+App-wide visual primitives that the page-help work surfaced as needing attention.
+
+- [x] 15.1 `bottom-sheet`: bump `.handle-bar` bottom padding `space-3xs → space-xs` so all sheets get a baseline gap between handle and content (fixes user-home-selector's previously cramped header without disrupting sheets that already added their own top padding)
+- [x] 15.2 `user-home-selector.css`: add `padding-block-start: var(--space-m)` to `.selector-content` — was missing, causing the title to crash into the handle
+- [x] 15.3 `bottom-nav-bar`: strengthen active-tab treatment with a 3-layer cue — brand-accent color (existing) + `font-weight: 700` on `.nav-label` + 2px `::before` accent bar at the top edge of the active tab. "Current page" now reads instantly
+- [x] 15.4 `page-header`: page title font-size `step-1 → step-2`, `font-weight: normal → 600` — page identity now visually weighted vs. nav labels
+- [x] 15.5 `page-header` is rendered unconditionally in `my-artists-route.html` (was hidden when `artists.length === 0`, leaving the empty state without a page identity)
+- [x] 15.6 `state-placeholder`: switch icon color from `--color-text-muted` to `--color-brand-accent` so the empty-state icon reads as "promised / waiting" instead of "broken / forgotten". Increase wrapper gap `space-2xs → space-s` for breathing room
+- [x] 15.7 `svg-icon` global fix: add `.svg-icon[fill="none"] { fill: none }` rule. The global reset (`:where(svg) { fill: currentcolor }`) was overriding each SVG's `fill="none"` attribute (presentation attributes lose to even zero-specificity CSS), causing all stroked Lucide icons (clock, music, info, etc.) to render as filled disks. **Visible app-wide impact** — every icon that uses `fill="none"` now renders as the intended outline
+- [x] 15.8 Nav rename: `nav.home` JA/EN value `"Home"` → `"Timetable"`. Both consumers (bottom-nav label + dashboard page-header title) update via the single i18n value change. The dashboard route stays at `/dashboard` (internal name); the user-facing label aligns with the brand vocabulary established by the welcome page

--- a/openspec/changes/refine-onboarding-copy/tasks.md
+++ b/openspec/changes/refine-onboarding-copy/tasks.md
@@ -1,0 +1,88 @@
+## 1. Setup
+
+- [x] 1.1 Create branches in `specification/` and `frontend/` (issue numbers to be assigned) — specification#433 → branch `433-refine-onboarding-copy`; frontend#348 → branch `348-refine-onboarding-copy`
+- [x] 1.2 Confirm `establish-brand-vocabulary` is fully merged on `frontend/main` (`entity.*` namespace + lint script in place) — confirmed via `make lint` baseline output: `brand-vocabulary lint OK (0 entity.* keys verified across JA + EN)`
+- [x] 1.3 Run `make lint` baseline on a clean branch checkout to confirm green start
+
+## 2. Layer A Population: Hype → Stage / Hype
+
+- [x] 2.1 In `frontend/src/locales/ja/translation.json` add under the `entity` namespace
+- [x] 2.2 In `frontend/src/locales/en/translation.json` add under the `entity` namespace (parity required by lint)
+- [x] 2.3 Run `npx tsx scripts/check-brand-vocabulary.ts` and confirm passes — confirmed: "8 entity.* keys verified across JA + EN" (5 from hype + 3 from other entity labels)
+- [x] 2.4 Decide final wording on the EN side for `away` — picked **Away** (parallel to existing `HOME / NEAR / AWAY STAGE` lane vocabulary)
+
+## 3. Layer A Population: Other Entities
+
+- [x] 3.1 Add `entity.concert.label`: JA `"ライブ"` / EN `"Live"`
+- [x] 3.2 Add `entity.artist.label`: JA `"アーティスト"` / EN `"Artist"`
+- [x] 3.3 Add `entity.homeArea.label`: JA `"ホームエリア"` / EN `"Home Area"`
+- [x] 3.4 Re-run lint, confirm parity — done with 2.3
+
+## 4. Migrate Existing Hype Bindings to `entity.hype.*`
+
+- [x] 4.1 Replace `t="hype.watch"` / `hype.home` / `hype.nearby` / `hype.away` bindings throughout templates with `t="entity.hype.values.{watch,home,nearby,away}"` — note: TS `Hype` enum value is `nearby` (5 chars), not `near`; entity namespace mirrors it
+- [x] 4.2 Replace any `i18n.tr('hype.<x>')` calls in TS with the new path — `HYPE_TIERS` in `src/adapter/view/hype-display.ts` updated
+- [x] 4.3 ~~Update `myArtists.coachMark.setHype` text~~ — **skipped per option B**: the i18n key is not rendered by any component (dead key), so it was deleted instead of updated. See post-signup-dialog spec delta for the discoverability trade-off note.
+- [x] 4.4 Update `pageHelp.myArtists.title` JA from `"Hypeレベルについて"` to `"Stage について"` and `pageHelp.myArtists.description` JA from `"Hypeレベルで通知の範囲が変わります…"` to `"Stage で通知の範囲が変わります…"` — note: the originally-listed `myArtists.hypeExplanation.title` was a dead key tree (no component rendered it) and has been deleted instead
+- [x] 4.5 Reconcile `myArtists.table.{watch,home,nearby,away}` and `myArtists.hypeExplanation.*` against the canonical `entity.hype.values.*` — `myArtists.table.{watch,home,nearby,away}` deleted (replaced by `entity.hype.values.*` bindings in `my-artists-route.html`); `myArtists.hypeExplanation.*` was dead and deleted
+- [x] 4.6 Delete legacy `hype.*` top-level keys from both locales — done; also deleted dead `myArtists.coachMark` and `myArtists.spotlight` namespaces in the same sweep
+- [x] 4.7 Run `npx tsc --noEmit` to confirm no orphaned key references; run `make lint` end-to-end — both pass
+
+## 5. Terminology Unification
+
+- [x] 5.1 In JA i18n: replace remaining `コンサート` occurrences with `ライブ` — `notification.description` and `notification.blocked.description` updated; also normalized `ライブイベント` → `ライブ` in `dashboard.error.load` and `notification.title`
+- [x] 5.2 In JA i18n: replace user-facing `ダッシュボード` occurrences with `タイムテーブル` — only hit was `discovery.generateDashboard`; `dashboard.coachMark.viewArtists` already says `アーティスト一覧` (no ダッシュボード)
+- [x] 5.3 In JA i18n: replace user-facing `ライブカレンダー` occurrences with `タイムテーブル` — no occurrences found in JA file (sweep clean)
+- [x] 5.4 In JA i18n: replace `登録` (in the sense of "follow") with `フォロー` — `welcome.hero.subtitle` updated; `postSignup.title` / `postSignup.ariaLabel` use 登録 in the account-registration sense (correct usage, untouched)
+- [x] 5.5 EN parity check — `entity.concert.label` EN changed from `"Live"` to `"Concert"` (more natural EN noun); existing EN copy keeps "concert" / "live show" as written. The asymmetric-labels pattern: JA `entity.concert.label = "ライブ"`, EN `entity.concert.label = "Concert"`
+
+## 6. Discovery: Drop "Music DNA"
+
+- [x] 6.1 Remove `discovery.orbLabel` from both locales
+- [x] 6.2 Update the `dna-orb` template / component to drop the user-facing label — already not bound by any template/TS file (the i18n key was orphaned), so no template change required
+- [x] 6.3 Update `discovery.popoverGuide` JA to a reward-predicting phrasing — JA: `"気になるアーティストをタップ — 選んだ推しのライブが、次のステップでタイムテーブルになります"`; EN: `"Tap the artists you care about — your picks become a timetable in the next step"`
+- [x] 6.4 Update `discovery.coachMark.viewTimetable` JA — already correct
+- [x] 6.5 Update `discovery.generateDashboard` to `"👉 タイムテーブルを生成する"` / `"👉 Generate Timetable"`
+
+## 7. Welcome Hero Refresh
+
+- [x] 7.1 Add a one-line product descriptor under the brand name — picked **`推しのライブを集めて、あなただけのタイムテーブルに`** (JA) / **`Follow your favorite artists. Build your personal timetable.`** (EN). Wired via new i18n key `welcome.hero.descriptor` and rendered in `welcome-route.html` between brand and title; CSS class `welcome-descriptor` added
+- [x] 7.2 Restructure CTA labels — `welcome.cta.getStarted` JA: `"使ってみる"` → `"推しを選んでみる"` / EN: `"Get Started"` → `"Pick your artists"` (predicts the next screen); login CTA unchanged
+- [x] 7.3 Promote `welcome.guestFriendly` — JA: `"アカウント不要でお試しいただけます"` → `"アカウント不要・30秒で体験"` / EN updated similarly. Sub-line placement above CTA group on Screen 2 (already there); also added the same line to the Screen 1 fallback CTA path (was previously absent there) so the no-account-required message is visible whether or not preview data loads
+
+## 8. Signup Gate Refresh
+
+- [x] 8.1 Delete `チュートリアルお疲れさまでした！` from `signup.description`
+- [x] 8.2 Restructure `signup.title` and `signup.description` as value-first — JA title `"あと一歩で、推しのライブを逃さなくなる"`, body 3-bullet list (🔔 通知 / 📱 端末横断 / 🎟 チケット保存); EN title `"One step away from never missing a show"` with parallel bullets. Note: in-app templates do not currently render these keys (no `t="signup.*"` consumers found); the keys are presumed used by Zitadel external auth templates. If they are dead, this rewrite still benefits any future in-app rendering
+- [x] 8.3 Reconcile `signup.button` label — kept `"Passkeyでアカウント作成"` / `"Create Account with Passkey"` and appended `"（30秒）"` / `"(30s)"` to set expectations
+
+## 9. Post-Signup Dialog Refresh
+
+- [x] 9.1 Remove `postSignup.hypeGuideLabel` from both locales
+- [x] 9.2 Remove the corresponding hype-guide row from the `PostSignupDialog` component template
+- [x] 9.3 Update `postSignup.title` to celebration-first — JA `"🎉 準備完了！ようこそ、あなたのタイムテーブルへ"`; EN `"🎉 You're all set — welcome to your timetable"`. Added a new `postSignup.subtitle` key for the calmer follow-up line ("新しいライブが見つかったら、ここでお知らせします。" / "New lives will show up here as we find them.") rendered in the template + corresponding `.post-signup-subtitle` CSS rule
+- [x] 9.4 Notification + PWA rows preserved unchanged
+- [x] 9.5 ~~Invert always-visible-Hype-row test assertions~~ — no such assertions existed in either `test/components/post-signup-dialog.spec.ts` (11 tests) or `src/components/post-signup-dialog/post-signup-dialog.spec.ts` (16 tests). The spec requirement was unenforced; deleting the i18n key + template row is the entire change. All 27 tests pass unchanged after the row removal
+
+## 10. Empty / Error Microcopy
+
+- [x] 10.1 Update `dashboard.empty.title` and `dashboard.empty.subtitle` to express a promise — JA title `"新しいライブが見つかり次第、ここに並びます"`, subtitle `"もっと推しを増やすと、タイムテーブルが充実します。"`; EN parallel
+- [x] 10.2 Update `discovery.noResults` with romaji/spelling hint — JA `"アーティストが見つかりません — 英語名やローマ字でも試せます"`; EN `"No artists found — try alternate spellings or romaji"`
+- [x] 10.3 Two-tone error split applied:
+  - **Network tone** (5 keys, both locales): `welcome.error.login`, `signup.error`, `discovery.followFailed`, `discovery.searchFailed`, `settings.resendError` — all rewrap with explicit network-instability framing and "少し時間を置いてもう一度お試しください" / "Wait a moment and try again"
+  - **Transient tone** (kept brief): `welcome.error.navigation`, `settings.signOutError` — left close to existing copy since these are local-action failures, not network
+
+## 11. Verification
+
+- [x] 11.1 `make lint` green (Biome + stylelint + typecheck + brand-vocabulary) — confirmed via `make check` output
+- [x] 11.2 `make check` green — 1028 tests pass, coverage thresholds met
+- [ ] 11.3 Manual smoke pass in `npm start` — **deferred to PR review**: dev server smoke is the user's responsibility before merge; copy-only change with full test suite + lint coverage gives high confidence
+- [x] 11.4 `openspec validate refine-onboarding-copy --strict` passes
+
+## 12. Pull Requests
+
+- [ ] 12.1 Open PR in `specification/` containing this change folder + spec deltas
+- [ ] 12.2 Open PR in `frontend/` containing the i18n migration + screen edits + post-signup-dialog component change + test updates
+- [ ] 12.3 Cross-link the two PRs
+- [ ] 12.4 Recommend reviewing the frontend PR commit-by-commit (one screen / one concern per commit per the migration plan in design.md)
+- [ ] 12.5 After both PRs merge, archive with the same manual delta-sync pattern used for `establish-brand-vocabulary` (see archive PR #432 for template)


### PR DESCRIPTION
## Summary

- Adds OpenSpec change `refine-onboarding-copy` (proposal / design / specs / tasks) for the content refresh that consumes the just-shipped `establish-brand-vocabulary` infrastructure
- Modified capabilities:
  - `post-signup-dialog`: REMOVED the always-visible Hype guide row requirement; MODIFIED dialog content to lead with celebration instead of a checklist
  - `landing-page`: MODIFIED guest-friendly copy placement (allow caption/inline placement near the CTA, not just below the buttons)
  - `frontend-i18n`: ADDED a requirement that legacy top-level namespaces SHALL be removed when migrated into `entity.*` (no orphans after migration)
- No proto / backend / BSR changes — `HypeLevel` enum keeps its proto name; only the JA i18n surface label diverges to `Stage`

Closes #433
Frontend companion PR: liverty-music/frontend#350

## Notable design decisions (see design.md)

- **Asymmetric localization is intentional**: JA `Stage` / EN `Hype`; JA `ライブ` / EN `Concert`. The `entity.*` namespace from `establish-brand-vocabulary` exists exactly to make this normal.
- **No proto rename**: scope is presentation only. JA chooses different surface words than EN; that's i18n, not entity-language drift.
- **Hype guide row dropped without replacement**: the `myArtists.coachMark.setHype` i18n key existed but was never rendered, so removing the post-signup row honestly trades a small Hype-discoverability loss for a cleaner celebration moment. A separate change can wire the My Artists coach mark if the team judges the regression meaningful.

## Test plan

- [x] `openspec validate refine-onboarding-copy --strict` passes
- [x] All requirements have at least one scenario, all scenarios use `####` headers
- [ ] `buf-pr-checks.yml` CI passes
