### PR TITLE
docs(openspec): add change add-zitadel-console-admin-via-google-idp

### DIFF
--- a/openspec/changes/add-zitadel-console-admin-via-google-idp/.openspec.yaml
+++ b/openspec/changes/add-zitadel-console-admin-via-google-idp/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-02

--- a/openspec/changes/add-zitadel-console-admin-via-google-idp/design.md
+++ b/openspec/changes/add-zitadel-console-admin-via-google-idp/design.md
@@ -1,0 +1,597 @@
+## Context
+
+The self-hosted Zitadel v4.13.1 instance is reachable at
+`https://auth.dev.liverty-music.app`. Live API inspection
+(`POST /admin/v1/orgs/_search` against the existing instance with the
+`pulumi-admin` JWT key) confirms the current state is **a single org**:
+
+```
+id   = 369968599999251129
+name = "ZITADEL"               (Zitadel's bootstrap default — configmap
+                                does not set ZITADEL_FIRSTINSTANCE_ORG_NAME)
+domain = zitadel.auth.dev.liverty-music.app
+```
+
+This single org currently holds *every* Pulumi-managed resource: the
+`liverty-music` Project, the frontend `ApplicationOidc`, the passkey-only
+`LoginPolicy`, the `pulumi-admin` machine user (created by Zitadel
+bootstrap), the `login-client` machine user (Login V2 PAT), plus any future
+end-user accounts. End-user identity for the `liverty-music` SaaS is
+governed by the existing `identity-management` capability, which mandates
+this org's `LoginPolicy` enforces `PasswordlessType=ALLOWED`,
+`UserLogin=false`, `AllowExternalIdp=false`.
+
+For comparison, the prior Zitadel Cloud instance ran a **two-org topology**
+(verified from a Cloud Console screenshot supplied during exploration):
+
+```
+Org "pannpers"      (created at sign-up; held the human admin + Google IdP)
+Org "liverty-music" (default; held Project / ApplicationOidc / end users)
+```
+
+Cloud achieved "admin signs in via Google, end users sign in via passkey"
+by giving each role its own org (and therefore its own login policy).
+Self-hosted bootstrap collapsed both roles into one org, which is the root
+cause of the current admin-Console-access gap.
+
+The self-hosted instance has **no human end users yet** (post-cutover from
+Cloud, no migration of fan accounts has happened). This unlocks an option
+that would otherwise be invasive: re-bootstrap the dev instance with a
+corrected configmap so the bootstrap-created org is named `admin` from the
+start, then create the `liverty-music` product org via Pulumi.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Replicate Cloud's two-org pattern as a declarative, IaC-managed structure
+  that any environment (dev, staging, prod) can bootstrap into directly,
+  with no rename / migration step required at first install.
+- `pannpers@pannpers.dev` can open
+  `https://auth.dev.liverty-music.app/ui/console`, click "Sign in with
+  Google", and land in the Console as `IAM_OWNER`.
+- The end-user `liverty-music` org's passkey-only policy is unchanged in
+  spirit — re-created cleanly under the new product org with the same
+  semantics.
+- All admin-identity setup (org, IdP, user, role grant) is declared in
+  Pulumi — no manual Console clicks to bootstrap the next admin.
+- A documented break-glass identity (`pulumi-admin` machine user + JSON
+  key) survives the change and can recover Console access if Google SSO
+  breaks.
+
+**Non-Goals:**
+
+- Adding additional human admins beyond `pannpers@pannpers.dev` in this
+  change (next admin = one extra `HumanUser` resource in the same `admin`
+  org, future change).
+- Customising Login V2 branding (covered by separate change
+  `customize-zitadel-auth-ui`).
+- Rolling this out to staging or prod (separate change after dev soak).
+  Both will use the same configmap + Pulumi pattern, with a fresh bootstrap.
+- Replacing `pulumi-admin` machine user — it stays in the `admin` org for
+  IaC and break-glass.
+- Federated SSO via Google Workspace SAML / SCIM provisioning. Generic
+  Google OAuth IdP is sufficient for a small admin team and matches
+  Zitadel Cloud's default sign-in experience.
+
+## Decisions
+
+### D1: Two-org topology — `admin` (role org) + `liverty-music` (product org)
+
+**Choice:** Split the instance into two orgs by responsibility:
+
+- **`admin`** — Bootstrap-created. Holds operator identities only:
+  `pulumi-admin` (machine, IaC + break-glass), `login-client` machine user
+  (existing PAT host — see D7), `pannpers@pannpers.dev` (human, Google
+  SSO). Login policy permits external IdP.
+- **`liverty-music`** — Pulumi-created, marked Zitadel default. Holds
+  product resources and end-user identities only: `liverty-music` Project,
+  frontend `ApplicationOidc`, passkey-only `LoginPolicy`, future fan
+  accounts.
+
+**Why:**
+
+- Zitadel `LoginPolicy` is per-org. Two policies → two orgs. There is no
+  per-app, per-user, or per-role policy mechanism that lets one org expose
+  Google to admins while hiding it from end users.
+- Mirrors Cloud's working pattern, so operators with Cloud muscle memory
+  recognise the topology.
+- Adding admins later is a single `HumanUser` + `InstanceMember` pair in
+  the `admin` org — no IdP, OAuth client, or Console URL change needed.
+- Adding future products (e.g., a separate concert-organiser dashboard) is
+  a single `zitadel.Org` plus its own Project / ApplicationOidc — no
+  conflict with admin or with the existing product.
+
+**Alternatives considered:**
+
+- *Single org, relax existing passkey-only requirement*: simplest, but
+  permanently exposes a "Sign in with Google" button to fans. Rejected
+  because the existing capability owner explicitly chose passkey-only and
+  no product-side reconsideration is happening in this change.
+- *Single org with email-domain-based routing*: would require Login V2 to
+  re-render IdPs after the user types an email. Brittle (depends on
+  unverified Zitadel routing semantics in v4) and gives the admin a
+  two-step login UX vs the existing one-step.
+- *Rename existing org "ZITADEL" → "liverty-music" + add new admin org*:
+  conceptually backwards (the bootstrap org should keep its operator role,
+  not be repurposed for product). Also leaves the configmap silent on the
+  bootstrap org's name, hiding intent.
+
+### D2: Naming — role org is `admin`, not `pannpers` or `console`
+
+**Choice:** The role org is called `admin`.
+
+**Why:**
+
+- *Not `pannpers`*: Cloud's per-person org naming is a SaaS sign-up
+  artifact, not a deliberate product decision. Self-hosted has no reason
+  to put a person's name on an org. Future admins would each need their
+  own org under that scheme — extra orgs, duplicated IdP setup, more spec
+  to write.
+- *Not `console`*: Console is one tool that uses this org's policy, but it
+  is not the only conceivable admin tool (CLI, direct API, future
+  internal dashboards). Naming the org after a tool ages poorly,
+  especially given Zitadel v4's direction of de-emphasising the legacy
+  Console UI.
+- *`admin` is role-based*: matches the IaC convention (e.g., AWS
+  Organizations "Admin" OU, Google Cloud `admin` folder) and is what a
+  reader expects to see.
+
+### D3: Strategy — "configmap-bootstrapped role org + Pulumi-created product org" (strategy Z)
+
+**Choice:** Add `ZITADEL_FIRSTINSTANCE_ORG_NAME=admin` to
+`k8s/namespaces/zitadel/base/configmap.env` so that **every** environment's
+first-instance bootstrap creates the role org with the correct name,
+without needing Pulumi to rename it afterwards. Pulumi then creates the
+`liverty-music` product org via `zitadel.Org`.
+
+For dev, where bootstrap has already run with the wrong configmap, perform
+a one-time database wipe to force re-bootstrap with the new configmap.
+There are no human end users to lose.
+
+**Why:**
+
+- IaC honesty: the configmap declares the bootstrap org's name. There is
+  no Pulumi-managed override hiding the truth.
+- Environment parity: dev, staging, and prod all bootstrap into the same
+  end state through the same code path. Prod gets the correct name on its
+  very first install — no rename trick to remember a year from now.
+- Separation of concerns: Zitadel bootstrap owns the `admin` org (because
+  it must, to hold the bootstrap-created `pulumi-admin` machine user that
+  Pulumi authenticates as). Pulumi owns the `liverty-music` product org
+  and everything inside it (because product evolution belongs in IaC).
+
+**Alternatives considered:**
+
+- *Strategy X (rename)*: smaller dev diff (no DB wipe, no `client_id`
+  rotation), but leaves a permanent "rename" fingerprint that prod also
+  has to perform on first install. Hides intent in Pulumi instead of
+  declaring it in configmap. Rejected for honesty / parity reasons.
+- *Pulumi creates the bootstrap org too*: chicken-and-egg — Pulumi
+  authenticates as `pulumi-admin`, which lives in the bootstrap org, which
+  Pulumi cannot create without already being authenticated. Bootstrap
+  must own at least the role org.
+
+### D4: Place Google IdP at the **instance** level
+
+**Choice:** Use `@pulumiverse/zitadel.IdpGoogle` (instance-scoped), not
+`OrgIdpGoogle`.
+
+**Why:** An instance-level IdP is referenceable by any org's `LoginPolicy`.
+The `admin` org's policy lists it; the `liverty-music` org's policy does
+not. The same IdP can be reused if a future product org also wants Google
+sign-in for its admins.
+
+### D5: Pre-create the human admin, then pre-link the Google identity
+
+**Choice:** Pulumi creates a `HumanUser` in the `admin` org with
+`email = pannpers@pannpers.dev`, a Pulumi-generated random
+`initialPassword`, and `isEmailVerified = true`. Pulumi then declares
+a `ZitadelUserIdpLink` Dynamic Resource (see D11) that pre-creates
+the binding between the admin Google IdP and that local user, keyed
+by the admin's Google OIDC `sub` claim. First Google sign-in resolves
+directly to the local user via the pre-existing `(idpId, sub)`
+record — no email match, no UI prompt.
+
+**Why the random password is required and harmless:** the
+`@pulumiverse/zitadel` `HumanUser` resource documents that
+`isEmailVerified` can only be set to `true` at creation time when the
+user also has a password set. Without `isEmailVerified = true` the OIDC
+sign-in flow would force an OTP step (existing pattern documented in the
+"Auto-Verify Email on Self-Registration" requirement of the
+identity-management capability). The password is unreachable in practice
+because the `admin` org's `LoginPolicy.userLogin = false` disables the
+username + password sign-in form altogether — the Login V2 UI for the
+`admin` org only ever presents the IdP buttons.
+
+**Why pre-link instead of email auto-link** (the path originally
+considered here, before smoke-testing PR #228 surfaced the gap): see
+D11. Briefly — the `admin` org's policy combination
+(`userLogin = false` + `isCreationAllowed = false`) disables every
+native first-sign-in path Zitadel offers, so the link record must
+exist *before* the first sign-in arrives.
+
+**Alternative considered:** Use the `setEmailVerified` Action pattern
+(post-creation API call, mirroring the existing self-registration
+auto-verify Action) to avoid setting any password. Rejected as more
+complex than a random password the policy disables; the Action approach
+is justified for end-user self-registration but adds no value for a
+single Pulumi-provisioned admin.
+
+### D6: Place the Google OAuth 2.0 Client in `liverty-music-dev` GCP project — manually, one-time
+
+**Choice:** Provision the OAuth 2.0 Web Application client in the
+`liverty-music-dev` project alongside the GKE cluster, Cloud SQL, and
+Zitadel workload. Capture `client_id` / `client_secret` and write to ESC
+`liverty-music/cloud-provisioning/dev` under
+`pulumiConfig.zitadel.googleAdminIdp.clientId` /
+`.clientSecret` (encrypted). Pulumi reads from ESC and configures the
+Zitadel `IdpGoogle` resource.
+
+**Why the client is manual, not Pulumi-managed:** Google has never
+exposed a public API for creating general-purpose OAuth 2.0 Web
+Application clients programmatically. The only declarative-tool option
+in the current `@pulumi/gcp` provider is `gcp.iap.Client`, which:
+(1) is deprecated as of 2025-01-22 and shut down 2026-03-19 (the IAP
+OAuth Admin APIs are gone), and (2) is scoped to Identity-Aware Proxy,
+not general OIDC sign-in flows — wrong shape for Zitadel's use as an
+external IdP. The Google Cloud Console is the only canonical creation
+path.
+
+**Why this is acceptable:** OAuth client creation is a true one-time
+event per environment. The consent screen is "Internal" (limited to the
+`pannpers.dev` Workspace), so no Google review or external verification
+is required. After creation, all changes (redirect URI updates, secret
+rotation) happen via the Console + ESC + `pulumi up`. The client's
+existence and redirect URI are documented in the cloud-provisioning
+runbook so a deleted client can be recreated identically.
+
+**Why dev project, not a separate identity-only project:** keeps all
+dev infra in one project for billing / IAM clarity. The dev cluster's
+Workload Identity already trusts secrets from this project's Secret
+Manager. Avoids a new "identity-only" GCP project for a single OAuth
+client.
+
+### D7: `login-client` machine user belongs in the `admin` org
+
+**Choice:** Move the existing `login-client` machine user (Login V2 PAT
+host) from the current bootstrap org to the new `admin` org.
+
+**Why:** `login-client` is operator infrastructure (the Login V2 service
+authenticates Zitadel API calls with this PAT). It is not a product
+identity. Keeping it in `admin` keeps the rule "the `liverty-music` org
+contains only product-relevant identities" clean.
+
+After re-bootstrap, Pulumi recreates `login-client` in the `admin` org.
+The k8s `ExternalSecret` that consumes its PAT does not change — only the
+underlying Pulumi `MachineUser`'s parent org changes.
+
+### D8: Console login routing — admin org MUST be the Zitadel default org
+
+**Choice:** The Zitadel `admin` role org is marked `isDefault: true`;
+the `liverty-music` product org is marked `isDefault: false`. The admin
+org is brought into Pulumi state via a one-time
+`pulumi import zitadel:index/org:Org admin <admin-org-id>` (run with
+`--provider liverty-music-provider=...`) and protected with
+`{ protect: true }` because `pulumi destroy` against it would also
+remove the bootstrap-created `pulumi-admin` machine user that the
+provider authenticates as.
+
+**Why (empirically established post-implementation):** Smoke-testing the
+first deploy (`https://auth.dev.liverty-music.app/ui/console` against
+the merged PRs #225/226/227) revealed that **Login V2 uses the default
+org's *own* `LoginPolicy`** when the incoming OIDC AuthN omits an
+`org_id` parameter — which the Zitadel-internal Console always does.
+The three hypotheses originally listed in this section
+(DefaultLoginPolicy fallback / user-home-org / email-domain) are all
+wrong; only "default org policy" matched observed behaviour.
+
+When `liverty-music` was the default org, Console hit the product-org
+policy (passkey + register, no IdP buttons) and the admin's "Sign in
+with Google" button never appeared. After flipping `isDefault` to the
+admin org, Console hits the admin-org policy (Google IdP enabled,
+`userLogin = false`) — the intended path.
+
+End-user OIDC traffic from the frontend SPA is unaffected by the
+default-org flip: the SPA's `ApplicationOidc` carries its own
+`client_id` and Zitadel resolves that to the owning org
+(`liverty-music`) regardless of default status. So the routing rule is
+asymmetric:
+
+- Console (no `client_id` known to Zitadel as application of an org) →
+  default org's policy → must point at `admin`.
+- Frontend SPA (explicit `client_id` for `web-frontend` in
+  `liverty-music` Project) → owning org's policy → unaffected by
+  default-org choice.
+
+The IAM-level `DefaultLoginPolicy` resource is still configured with
+the same Google IdP + `userLogin = false` shape as the admin org policy
+as a defence-in-depth for any org that does not declare its own
+`LoginPolicy`. It is not the active policy for Console login on this
+instance, but keeping the two in sync makes accidental misconfiguration
+of either one less catastrophic.
+
+**Operational note:** the admin org `protect: true` flag enforces that
+removing it requires an explicit code change in a reviewable PR before
+any `pulumi destroy` can take effect. Without that protection, a
+careless destroy would cascade into `pulumi-admin`, the
+`zitadel-admin-sa-key` GSM secret would no longer match any user in
+Zitadel, and the provider would stop being able to authenticate — a
+hard lockout that only `kubectl rollout restart` of the Zitadel pod (to
+re-bootstrap with a fresh first-instance) could recover from.
+
+### D9: Frontend OIDC `client_id` rotation is acceptable
+
+**Choice:** Accept that the frontend SPA's OIDC `client_id` will change
+when Pulumi recreates `ApplicationOidc` inside the new `liverty-music`
+product org. Pulumi already wires the `client_id` through ESC into the
+frontend stack, so the rotation propagates automatically on the next
+frontend Pulumi apply.
+
+**Why:** Avoids manual frontend code changes. Zitadel does not support
+"importing" an existing `ApplicationOidc` into a new org while preserving
+the `client_id`, so a new id is unavoidable; the question is only whether
+the frontend handles it cleanly. ESC-driven config means it does.
+
+### D10: Retain `pulumi-admin` machine user as break-glass identity
+
+**Choice:** The `pulumi-admin` machine user (now in the `admin` org after
+re-bootstrap) and its JSON key in GCP Secret Manager
+(`zitadel-admin-sa-key`) MUST remain intact. They serve as a recovery
+identity that does not depend on Google sign-in.
+
+**Why:** Two independent failure modes (Pulumi/IaC vs Google SSO) keep us
+out of total-lockout scenarios. Pulumi can be re-authenticated with the
+SA key from any operator's machine to restore the human admin, the IdP,
+or the login policy if any of them break.
+
+The bootstrap-uploader sidecar's idempotent re-upload pattern in
+`deployment-api.yaml` means re-bootstrap regenerates the SA key (it is the
+*new* `pulumi-admin`'s key, since the org and user are recreated) and the
+sidecar uploads the new value. The Pulumi `@pulumiverse/zitadel` provider
+reads the latest GSM version and continues to authenticate.
+
+### D11: Pre-link Google identity via `ZitadelUserIdpLink` Dynamic Resource
+
+**Context:** Established empirically after PR #228 merged. With the
+admin org as Zitadel default (D8) and the Google IdP wired correctly
+(D4), the Console UI rendered the Google sign-in button — but the
+first Google sign-in dead-ended on
+`/ui/v2/login/idp/google/account-not-found`. Login V2 saw an
+unrecognised external identity and had no native path to attach it
+to the pre-provisioned `pannpers` local user.
+
+**Choice:** Pulumi declares a `ZitadelUserIdpLink` Dynamic Resource
+(`src/zitadel/dynamic/user-idp-link.ts` in cloud-provisioning) that
+calls Zitadel's v2 user service
+`POST /v2/users/{userId}/links` at IaC time, with body:
+
+```json
+{
+  "idpLink": {
+    "idpId": "<zitadel admin Google IdP id>",
+    "userId": "<google sub claim>",
+    "userName": "<email or display label>"
+  }
+}
+```
+
+The admin's Google `sub` claim is provisioned via ESC
+`pulumiConfig.zitadel.adminGoogleSubs.<userName>` and threaded through
+`HumanAdminComponent`. With the link record already present, the IdP
+callback resolves directly to the local user and Console loads.
+
+**Why the `admin` org's policy combination forces this:** Zitadel
+offers exactly two native first-sign-in paths to attach an external
+identity to a Zitadel user, and the `admin` org's policy disables
+both:
+
+1. **autoLink prompt** (`isLinkingAllowed = true` on the IdP) — Login V2
+   shows a "to link this Google account, sign in with your existing
+   Zitadel account" form. Requires the existing local user to have a
+   working sign-in path. The admin org's `LoginPolicy.userLogin = false`
+   disables the username + password form, so the prompt has nothing to
+   authenticate against. Confirmed empirically: the prompt page shows
+   no input fields when userLogin is false.
+2. **auto-creation** (`isCreationAllowed = true` + `isAutoCreation = true`
+   on the IdP) — Zitadel mints a fresh local user from the Google
+   profile without a prompt. Disabled in our setup because **anyone**
+   in the `pannpers.dev` Workspace would silently become an
+   instance-level Zitadel user, and a follow-up Action would still need
+   to grant `IAM_OWNER`. Adds attack surface for no operational benefit
+   over pre-linking.
+
+Pre-linking sidesteps both prompts. The link record is just a database
+row keyed by `(idpId, externalUserId)`, and Zitadel happily accepts
+that the external identity is "already known" when the OAuth callback
+arrives.
+
+**Why a Dynamic Resource (not `@pulumiverse/zitadel`):**
+`@pulumiverse/zitadel` v0.2.0 exposes neither a `UserIdpLink` resource
+nor the `auto_linking: AUTO_LINKING_OPTION_EMAIL` option that the
+official Zitadel Terraform provider has on its IdP resources (which,
+even if it existed in our provider, would still trigger the autoLink
+prompt and dead-end on `userLogin = false`). The Dynamic Resource
+pattern is already used in this repo for `smtp-activation` and
+`actions-v2` — strictly less work than an upstream provider bump, and
+trivially replaceable when the upstream catches up.
+
+**Why `replaceOnChanges` on the identity tuple:** Zitadel keys the
+link by `(userId, idpId, externalUserId)` and exposes no in-place
+modification endpoint. The provider's `update()` is a no-op, so any
+change to those three fields MUST be routed through delete + create.
+Pulumi only does that when the resource sets `replaceOnChanges` (or
+the provider implements `diff()` returning `replaces`). Without it, a
+sub-claim typo in ESC would silently update Pulumi state to the new
+value while leaving Zitadel pointing at the old sub — silently
+re-introducing the dead-end this design exists to prevent.
+
+**Operational trade-off — sub claim lookup is manual:** the Google
+`sub` is opaque and not derivable from email. New admins capture it
+once via OAuth Playground or `gcloud auth print-access-token` +
+`/oauth2/v2/userinfo`, then write it to ESC. The runbook
+(`docs/runbooks/add-zitadel-admin-user.md`) walks the operation. For
+small admin teams (<10) this is acceptable overhead. At larger scale,
+revisit Option B (`isAutoCreation = true` + an Action that grants
+`IAM_OWNER` based on an email allow-list).
+
+## Risks / Trade-offs
+
+- **[Risk]** Dev DB wipe loses all current Zitadel state (orgs, users,
+  policies, IdPs, machine keys). → **Mitigation**: this is the intended
+  state reset. Verify no human end users exist before wipe (`POST
+  /management/v1/users/_search` against the existing instance returns no
+  human users — only `pulumi-admin` and `login-client` machine users). All
+  Pulumi-managed resources are recreated by `pulumi up` after re-bootstrap.
+
+- **[Risk]** The new `pulumi-admin` SA key generated at re-bootstrap may
+  not propagate to GSM before Pulumi tries to authenticate, causing a
+  transient race. → **Mitigation**: verify the bootstrap-uploader has run
+  to completion (pod log shows `bootstrap-uploader: upload complete`)
+  before running `pulumi up`. The sidecar idles after upload, so its
+  successful exit message persists in the pod log.
+
+- **[Risk]** Frontend OIDC `client_id` rotation is observed as a regression
+  by anyone holding a stale local config. → **Mitigation**: dev ESC drives
+  the value, so a fresh `pulumi preview` on the frontend stack picks it up.
+  Communicate the change in PR description; tests / CI run against fresh
+  config.
+
+- **[Risk]** Console login UX still surprises pannpers if Zitadel v4 routes
+  to the `liverty-music` org's policy (passkey-only) instead of `admin`'s
+  (Google-enabled). → **Mitigation**: D8's belt-and-braces configuration
+  (admin org policy + DefaultLoginPolicy + admin-org verified domain) is
+  designed to converge regardless of the routing rule. If empirical
+  testing still fails, the fallback is to bookmark `/ui/v2/login?org=<admin
+  org id>` for the admin entry point.
+
+- **[Risk]** Sub-claim typo in ESC silently breaks first sign-in. Pulumi
+  creates the link record successfully (the API does not validate the
+  sub against Google), but the IdP callback's actual sub never matches,
+  so the admin hits `/ui/v2/login/idp/google/account-not-found`.
+  → **Mitigation**: post-deploy smoke test
+  (`docs/runbooks/add-zitadel-admin-user.md` Step 6) confirms the sign-in
+  lands on Console. The runbook's Step 1 also documents how to capture
+  the sub deterministically (OAuth Playground or `gcloud auth
+  print-access-token` + `/oauth2/v2/userinfo`) to keep the typo surface
+  small. Re-running the smoke test after every admin-onboarding PR is
+  the operational guard.
+
+- **[Risk]** Google OAuth client secret leak → attacker can mint Google
+  identities from this client and sign in as any pre-provisioned admin
+  email. → **Mitigation**: secret stored only in encrypted ESC, never in
+  git or k8s manifests. Rotation via `esc env set --secret` + Pulumi up.
+
+- **[Trade-off]** Re-bootstrap regenerates `pulumi-admin`'s SA key. The
+  old key in any operator's local cache becomes invalid. Operators should
+  re-fetch the latest version from GSM after the migration step.
+
+- **[Trade-off]** Two orgs is more concept to onboard than one, but the
+  benefit is reusing Cloud's mental model and cleanly supporting future
+  admin / product expansion.
+
+## Migration Plan
+
+**Phase 1 — Specification merge (no infra change):** This OpenSpec change
+merges first. No runtime effect on dev.
+
+**Phase 2 — Cloud-provisioning implementation in dev (one PR):**
+
+1. Edit `k8s/namespaces/zitadel/base/configmap.env`: add
+   `ZITADEL_FIRSTINSTANCE_ORG_NAME=admin`.
+2. Edit `src/zitadel/constants.ts`: replace `ZITADEL_DEV_DEFAULT_ORG_ID`
+   with admin / product org id refs (initial admin id placeholder, will
+   update post-bootstrap).
+3. Edit `src/zitadel/index.ts` and components: introduce
+   `zitadel.Org liverty-music`, move Project / ApplicationOidc /
+   LoginPolicy / login-client to it, add Google IdP / HumanUser /
+   InstanceMember in admin org.
+4. Verify no human users exist in current dev Zitadel (`POST
+   /management/v1/users/_search` with type filter HUMAN, must return zero
+   results).
+5. Drop dev Zitadel database in Cloud SQL: `DROP DATABASE zitadel; CREATE
+   DATABASE zitadel OWNER "zitadel@liverty-music-dev.iam";` via the
+   Cloud SQL Auth Proxy + IAM auth.
+6. Trigger Zitadel pod restart (delete the `zitadel` Deployment's pods so
+   they re-roll). Watch pod logs for `start-from-init` completing setup.
+7. Wait for `bootstrap-uploader: upload complete` in the new pod's logs;
+   confirm `zitadel-admin-sa-key` GSM secret has a new latest version.
+8. Inspect the new admin org id via `POST /admin/v1/orgs/_search` with the
+   new SA key; record the id and update `constants.ts` admin org id.
+9. Run `pulumi preview` to confirm: new `liverty-music` org created,
+   product resources placed there, IdP / HumanUser / InstanceMember
+   created in admin org.
+10. `pulumi up`. Capture new `liverty-music` org id and product
+    `ApplicationOidc` `client_id` from outputs.
+11. Trigger frontend stack `pulumi up` (or merge a frontend PR if the
+    rotation is gated). Verify SPA can complete OIDC flow.
+12. Smoke test: `pannpers@pannpers.dev` opens
+    `https://auth.dev.liverty-music.app/ui/console`, signs in via Google,
+    confirms Console loads with `IAM_OWNER`.
+
+**Rollback:** `pulumi destroy` of the new product / IdP / HumanUser /
+InstanceMember resources (in reverse dependency order). The dev DB is
+already empty of end users; restoring "the previous state" requires a
+second wipe + re-bootstrap with the *old* configmap. Given the absence of
+production data, rollback is "wipe again, restore old configmap, pulumi
+up". The `pulumi-admin` SA key in GSM continues to authenticate Pulumi
+across these cycles.
+
+**Phase 3 — Staging / prod adoption (separate change):** No DB wipe
+needed. configmap with `ZITADEL_FIRSTINSTANCE_ORG_NAME=admin` is in place
+from the start; `pulumi up` provisions everything cleanly on the first
+deploy.
+
+## Open Questions
+
+*All previously open questions have been resolved during implementation
+and smoke testing — see "Resolved" sections below.*
+
+## Resolved (during cutover smoke test, after PR #228 merge)
+
+- **Console login routing in Zitadel v4** — empirically established:
+  Login V2 uses the **default org's own `LoginPolicy`** when the
+  incoming OIDC AuthN omits `org_id` (which the Zitadel-internal
+  Console always does). Captured in D8.
+
+- **`login-client` PAT recreation across re-bootstrap** — confirmed:
+  the `MachineUser` recreated in the new `admin` org regenerates a
+  fresh PAT value via `PersonalAccessToken`, and the `ExternalSecret`
+  reading it from GSM picks up the new value cleanly. The Login V2
+  pod was restarted as part of the rollout to flush the in-memory PAT
+  cache; first sign-in attempt after restart succeeded.
+
+- **First-sign-in dead-end when admin org's policy disables both
+  userLogin and auto-creation** — surfaced after PR #228, resolved by
+  pre-linking the Google identity via `ZitadelUserIdpLink`. Captured
+  in D11.
+
+## Resolved (during pre-flight Section 1)
+
+- **`@pulumiverse/zitadel` field names** — `IdpGoogle` uses
+  `clientId` / `clientSecret` / `scopes` / `name` /
+  `isLinkingAllowed` / `isCreationAllowed` / `isAutoCreation` /
+  `isAutoUpdate`. There is no policy-level `autoLinking` /
+  `userLinking` field in `LoginPolicy` or `DefaultLoginPolicy`; auto-link
+  behaviour is governed entirely by IdP-level `isLinkingAllowed`. See D5
+  above.
+- **`HumanUser.isEmailVerified` constraint** — the field can only be
+  `true` at creation time if `initialPassword` is also set. Resolved by
+  setting a random throwaway `initialPassword`, paired with
+  `LoginPolicy.userLogin = false` on the `admin` org so the password is
+  unreachable. See D5.
+- **Login V2 IdP callback URL format** — fixed at
+  `${CUSTOM_DOMAIN}/idps/callback` in v4 (does not include the IdP id).
+  For dev: `https://auth.dev.liverty-music.app/idps/callback`. This is
+  the value to register on the Google OAuth client's authorised redirect
+  URI list.
+- **Default org marker** — `zitadel.Org` resource accepts `isDefault`
+  directly. No separate API call required.
+- **Existing user inventory** — verified that the dev Zitadel instance
+  has 2 human users (`zitadel-admin@...` bootstrap default; user pannpers'
+  `pepperoni9@gmail.com` test account). The latter has been deleted via
+  `DELETE /management/v1/users/{id}` ahead of the planned database wipe;
+  the former will be re-generated cleanly by re-bootstrap. There is also
+  a `backend-app` machine user (Pulumi-managed product service identity)
+  that belongs in the `liverty-music` product org per the updated
+  "Place Machine Users by Responsibility" requirement.

--- a/openspec/changes/add-zitadel-console-admin-via-google-idp/proposal.md
+++ b/openspec/changes/add-zitadel-console-admin-via-google-idp/proposal.md
@@ -1,0 +1,120 @@
+## Why
+
+Migrating from Zitadel Cloud to self-hosted Zitadel removed the implicit
+"first human admin = the person who signed up with Google" bootstrap that
+Cloud provided. The current self-hosted instance has only a `pulumi-admin`
+machine user, so no human can sign in to the Admin Console (`/ui/console`)
+interactively. Operating IAM exclusively through a service-account JSON key
+is brittle for day-to-day inspection, support, and break-glass tasks, and
+it leaves no audit trail of "who is an admin" in git.
+
+Cloud quietly used a **two-org pattern** to deliver this experience: a
+personal/admin org (where the human admin lived and signed in via Google)
+and a separate product org (where the application, end users, and
+passkey-only login policy lived). Self-hosted bootstrap collapsed both
+roles into a single `ZITADEL` org, mixing operator and product concerns and
+making it impossible to add Google sign-in for admins without exposing it to
+end users.
+
+We need to (a) restore the two-org pattern as a declarative, IaC-managed
+structure that bootstraps cleanly in **any** environment from day one, and
+(b) add a human admin (`pannpers@pannpers.dev`) who signs in to the Console
+with Google SSO and holds `IAM_OWNER` on the instance — making admin
+membership reviewable via `git diff`.
+
+## What Changes
+
+- Adopt a **two-org structure** at the Zitadel instance level:
+  - **`admin` org** — the bootstrap-time role org for operators (machine
+    and human). Created by Zitadel itself when the instance is bootstrapped
+    via the new configmap setting `ZITADEL_FIRSTINSTANCE_ORG_NAME=admin`.
+    Hosts `pulumi-admin` (existing machine user) and the new
+    `pannpers@pannpers.dev` human admin.
+  - **`liverty-music` org** — the product org. Created by Pulumi via
+    `zitadel.Org` and marked as the Zitadel default org. Hosts the
+    `liverty-music` Project, `ApplicationOidc`, end-user `LoginPolicy`
+    (passkey-only, unchanged), `login-client` machine user, and future
+    end-user accounts.
+- Add `ZITADEL_FIRSTINSTANCE_ORG_NAME=admin` to
+  `k8s/namespaces/zitadel/base/configmap.env` so any environment that
+  bootstraps from this configmap produces an `admin` role org, no rename
+  required afterwards.
+- Move all currently-Pulumi-managed product resources (`Project`,
+  `ApplicationOidc`, `LoginPolicy`, `login-client` MachineUser) so they
+  target the new Pulumi-created `liverty-music` product org instead of the
+  bootstrap admin org id constant.
+- Replace the single `ZITADEL_DEV_DEFAULT_ORG_ID` constant with
+  semantically-named references: a per-environment admin org id (the
+  bootstrap-created org id, discovered post-bootstrap) and a Pulumi-output
+  product org id.
+- Provision a Google IdP at the Zitadel **instance** level so the `admin`
+  org's `LoginPolicy` can list it without affecting the `liverty-music`
+  org's policy. Store the Google OAuth 2.0 Client `client_id` /
+  `client_secret` in Pulumi ESC.
+- Pre-provision a `HumanUser` for `pannpers@pannpers.dev` in the `admin`
+  org, with no initial password, email pre-verified, and an `InstanceMember`
+  granting `IAM_OWNER`. On first Google sign-in, Zitadel auto-links the
+  Google identity to this user by verified-email match.
+- Document and codify a break-glass invariant: the `pulumi-admin` machine
+  user (now in the `admin` org) and its JSON key in GCP Secret Manager
+  (`zitadel-admin-sa-key`) MUST remain intact and unrotated as a recovery
+  identity that does not depend on Google sign-in being operational.
+- For the dev environment specifically, perform a one-time Zitadel database
+  wipe + re-bootstrap to apply the new configmap. End-user data is empty,
+  so the wipe has no user-visible cost. Frontend OIDC `client_id` will
+  change as a result; Pulumi rewires the new value automatically through
+  ESC.
+
+Scope: **dev only** in this change. Staging / prod use the same configmap
++ Pulumi pattern from their first bootstrap, no rename or wipe required.
+
+## Capabilities
+
+### New Capabilities
+
+_None._ All requirements added by this change extend the existing
+`identity-management` capability.
+
+### Modified Capabilities
+
+- `identity-management`: Restructures the instance into a two-org topology
+  (`admin` role org + `liverty-music` product org). The existing
+  organization / project / OIDC application / login-policy requirements are
+  re-scoped to the new `liverty-music` product org. Adds requirements for
+  the bootstrap-time `admin` role org, an instance-level Google IdP, a
+  human admin user with `IAM_OWNER`, IdP auto-linking by verified email,
+  break-glass machine-user retention, and Google OAuth client provisioning.
+
+## Impact
+
+- **Affected repos**:
+  - `cloud-provisioning`:
+    - `k8s/namespaces/zitadel/base/configmap.env` — add
+      `ZITADEL_FIRSTINSTANCE_ORG_NAME=admin`.
+    - `src/zitadel/constants.ts` — replace `ZITADEL_DEV_DEFAULT_ORG_ID`
+      with admin / product split and per-env mapping.
+    - `src/zitadel/index.ts` and components — wire new `liverty-music`
+      product org, IdP, HumanUser, InstanceMember resources.
+    - Pulumi ESC `liverty-music/cloud-provisioning/dev` — new keys for
+      Google OAuth client.
+  - `specification` — this OpenSpec change.
+- **External dependency**: A Google Cloud OAuth 2.0 Web Application client
+  must exist in the `liverty-music-dev` GCP project under the `pannpers.dev`
+  Workspace, with Authorized redirect URI pointing at the Zitadel Login V2
+  IdP callback path (exact path confirmed during implementation).
+- **One-time dev migration**: Drop the dev Zitadel database in Cloud SQL,
+  restart the Zitadel pod so the new configmap re-bootstraps the instance.
+  Acceptable because the dev instance has no human end users yet
+  (post-cutover). Re-bootstrap regenerates `pulumi-admin`'s SA key, which
+  the existing bootstrap-uploader sidecar uploads to GCP Secret Manager
+  idempotently.
+- **Frontend OIDC `client_id` rotation**: After re-bootstrap and Pulumi
+  apply, the `liverty-music` Project's `ApplicationOidc` will have a new
+  `client_id`. Pulumi already wires this through ESC into the frontend
+  config, so no manual frontend code change is required — only a Pulumi
+  apply on the frontend stack.
+- **Break-glass invariant**: `pulumi-admin` machine user and its JSON key
+  in GCP Secret Manager (`zitadel-admin-sa-key`) remain intact across this
+  change. The bootstrap-uploader sidecar's idempotent re-upload is the only
+  expected key write.
+- **No proto changes, no BSR release, no backend changes** required.

--- a/openspec/changes/add-zitadel-console-admin-via-google-idp/proposal.md
+++ b/openspec/changes/add-zitadel-console-admin-via-google-idp/proposal.md
@@ -31,10 +31,12 @@ membership reviewable via `git diff`.
     Hosts `pulumi-admin` (existing machine user) and the new
     `pannpers@pannpers.dev` human admin.
   - **`liverty-music` org** — the product org. Created by Pulumi via
-    `zitadel.Org` and marked as the Zitadel default org. Hosts the
-    `liverty-music` Project, `ApplicationOidc`, end-user `LoginPolicy`
-    (passkey-only, unchanged), `login-client` machine user, and future
-    end-user accounts.
+    `zitadel.Org` with `isDefault: false` (the `admin` org is the
+    Zitadel default — see design D8 for why Console routing requires
+    that). Hosts the `liverty-music` Project, `ApplicationOidc`,
+    end-user `LoginPolicy` (passkey-only, unchanged), and future
+    end-user accounts. Note: `login-client` machine user lives in the
+    `admin` org per design D7, not here.
 - Add `ZITADEL_FIRSTINSTANCE_ORG_NAME=admin` to
   `k8s/namespaces/zitadel/base/configmap.env` so any environment that
   bootstraps from this configmap produces an `admin` role org, no rename
@@ -52,9 +54,13 @@ membership reviewable via `git diff`.
   org's policy. Store the Google OAuth 2.0 Client `client_id` /
   `client_secret` in Pulumi ESC.
 - Pre-provision a `HumanUser` for `pannpers@pannpers.dev` in the `admin`
-  org, with no initial password, email pre-verified, and an `InstanceMember`
-  granting `IAM_OWNER`. On first Google sign-in, Zitadel auto-links the
-  Google identity to this user by verified-email match.
+  org, with a random `initialPassword` (required by `@pulumiverse/zitadel`
+  for `isEmailVerified = true` at creation; unreachable at runtime via
+  `LoginPolicy.userLogin = false`), email pre-verified, and an
+  `InstanceMember` granting `IAM_OWNER`. A `ZitadelUserIdpLink` Dynamic
+  Resource pre-links the admin's Google `sub` claim to this user before
+  first sign-in (auto-link by verified email fails in this policy
+  combination — see design D11).
 - Document and codify a break-glass invariant: the `pulumi-admin` machine
   user (now in the `admin` org) and its JSON key in GCP Secret Manager
   (`zitadel-admin-sa-key`) MUST remain intact and unrotated as a recovery
@@ -82,8 +88,10 @@ _None._ All requirements added by this change extend the existing
   organization / project / OIDC application / login-policy requirements are
   re-scoped to the new `liverty-music` product org. Adds requirements for
   the bootstrap-time `admin` role org, an instance-level Google IdP, a
-  human admin user with `IAM_OWNER`, IdP auto-linking by verified email,
-  break-glass machine-user retention, and Google OAuth client provisioning.
+  human admin user with `IAM_OWNER`, IaC pre-linking of Google identity
+  via `ZitadelUserIdpLink` (see design D11), per-admin `sub`-claim
+  storage in ESC, break-glass machine-user retention, and Google OAuth
+  client provisioning.
 
 ## Impact
 

--- a/openspec/changes/add-zitadel-console-admin-via-google-idp/specs/identity-management/spec.md
+++ b/openspec/changes/add-zitadel-console-admin-via-google-idp/specs/identity-management/spec.md
@@ -242,9 +242,11 @@ at the product org level.
   `LoginPolicy`
 - **AND** the IdP SHALL NOT be referenced by the `liverty-music` product
   org's `LoginPolicy`
-- **AND** the IdP SHALL set `isLinkingAllowed = true` so that successful
-  Google sign-in links to a pre-provisioned local human user with the
-  matching verified email
+- **AND** the IdP SHALL set `isLinkingAllowed = true` (defence-in-depth;
+  the actual first-sign-in resolution uses the IaC-managed
+  `ZitadelUserIdpLink` records — see *Pre-link Google Identity to
+  Human Admin via IaC* — because the policy combination disables
+  Zitadel's native autoLink prompt)
 - **AND** the IdP SHALL set `isCreationAllowed = false` and
   `isAutoCreation = false` so that no anonymous Google identity becomes a
   Zitadel user without explicit Pulumi provisioning

--- a/openspec/changes/add-zitadel-console-admin-via-google-idp/specs/identity-management/spec.md
+++ b/openspec/changes/add-zitadel-console-admin-via-google-idp/specs/identity-management/spec.md
@@ -1,0 +1,552 @@
+## MODIFIED Requirements
+
+### Requirement: Manage Zitadel Organization
+
+The system SHALL manage Zitadel organization topology via Infrastructure as
+Code so that the instance always exposes a clear separation between
+operator (admin) and product identities. The instance SHALL contain
+exactly two top-level organizations:
+
+- An **`admin`** role org, created by Zitadel at first-instance bootstrap
+  via the configmap setting `ZITADEL_FIRSTINSTANCE_ORG_NAME=admin`,
+  brought into Pulumi state via a one-time `pulumi import
+  zitadel:index/org:Org admin <admin-org-id>` (see Migration Plan in
+  design.md), and pinned with `protect: true`. This org holds operator
+  identities only (machine users used by IaC and the Login V2 service,
+  plus human admins who manage the instance) and is the **Zitadel
+  default org** so that the Console (which omits `org_id` in its OIDC
+  AuthN) routes to its `LoginPolicy`.
+
+- A **`liverty-music`** product org, created by Pulumi as a `zitadel.Org`
+  resource with `isDefault: false`. This org holds the product Project,
+  applications, end-user login policy, and end-user accounts. The
+  frontend SPA's `ApplicationOidc` carries an explicit `client_id`
+  whose owning org Zitadel resolves to `liverty-music`, so the
+  default-org choice does not affect end-user OIDC routing.
+
+#### Scenario: Provision admin role org via bootstrap + import
+
+- **WHEN** the Zitadel instance bootstraps for the first time in any
+  environment
+- **THEN** the configmap SHALL set `ZITADEL_FIRSTINSTANCE_ORG_NAME=admin`
+- **AND** Zitadel SHALL create an organization named `admin` containing
+  the `pulumi-admin` machine user
+- **AND** an operator SHALL run `pulumi import zitadel:index/org:Org
+  admin <admin-org-id>` (with `--provider liverty-music-provider=...`)
+  to bring the admin org into Pulumi state
+- **AND** the Pulumi declaration SHALL set `isDefault: true` and
+  `{ protect: true }` on the admin org
+- **AND** no Pulumi rename step SHALL be required to reach the intended
+  name
+
+#### Scenario: Provision product org via Pulumi
+
+- **WHEN** Pulumi stack is applied
+- **THEN** a `zitadel.Org` resource named `liverty-music` SHALL exist
+  with `isDefault: false`
+- **AND** all product resources (Project, ApplicationOidc, end-user
+  LoginPolicy, end-user HumanUsers) SHALL live in this org
+
+#### Scenario: Console login routes to the admin org's policy
+
+- **WHEN** an operator opens
+  `https://auth.dev.liverty-music.app/ui/console`
+- **THEN** the Zitadel Console's OIDC AuthN SHALL hit Login V2 without
+  an explicit `org_id`
+- **AND** Login V2 SHALL render the **default org's `LoginPolicy`**,
+  which is the admin org's policy (Google IdP enabled,
+  `userLogin = false`)
+- **AND** the operator SHALL see a "Sign in with Google" button
+  immediately, without needing to type a username first
+
+#### Scenario: No third org
+
+- **WHEN** the instance is fully provisioned
+- **THEN** exactly two orgs SHALL exist (`admin` and `liverty-music`)
+- **AND** any additional org found via `POST /admin/v1/orgs/_search` SHALL
+  be treated as drift and reverted on the next Pulumi apply
+
+#### Scenario: Admin org cannot be accidentally destroyed
+
+- **WHEN** any operator runs `pulumi destroy` against the dev stack
+- **THEN** Pulumi SHALL refuse to remove the `admin` org because of
+  `protect: true`
+- **AND** removing the protection SHALL require a code change in a
+  reviewable PR
+- **AND** this protection SHALL prevent the cascading loss of the
+  `pulumi-admin` machine user, which would lock the
+  `@pulumiverse/zitadel` provider out of the instance
+
+### Requirement: Manage Zitadel Project
+
+The system SHALL manage the `liverty-music` project within the
+**`liverty-music` product org** to group product-related resources. The
+project SHALL NOT live in the `admin` role org.
+
+#### Scenario: Provision Project in product org
+
+- **WHEN** Pulumi stack is applied
+- **THEN** a project named `liverty-music` SHALL exist in the
+  `liverty-music` product org
+
+### Requirement: Manage OIDC Application
+
+The system SHALL manage the OIDC application for the frontend SPA within
+the `liverty-music` project (in the `liverty-music` product org) to enable
+end-user authentication.
+
+#### Scenario: Provision OIDC App in product org
+
+- **WHEN** Pulumi stack is applied
+- **THEN** an OIDC application named `liverty-music` SHALL exist in the
+  `liverty-music` project
+- **AND** the application Type SHALL be "SPA"
+- **AND** the Auth Method Type SHALL be "NONE"
+- **AND** the application's `client_id` SHALL be exported through Pulumi
+  ESC for the frontend stack to consume
+
+### Requirement: Configure Login Policy
+
+The system SHALL establish a login policy on the **`liverty-music` product
+org** (the org that hosts the OIDC application and end-user accounts) that
+enforces passwordless authentication to improve user security and
+eliminate reliance on passwords. This policy SHALL apply ONLY to the
+`liverty-music` product org and MUST NOT be inherited by the `admin` role
+org, which has its own admin-oriented login policy governed by separate
+requirements.
+
+#### Scenario: Apply Strict Passkeys Policy on product org
+
+- **WHEN** Pulumi stack is applied
+- **THEN** the login policy for the `liverty-music` product org SHALL be
+  configured
+- **AND** `PasswordlessType` SHALL be "ALLOWED"
+- **AND** `UserLogin` SHALL be false (Enforces Passkeys-only)
+- **AND** `AllowExternalIdp` SHALL be false
+
+#### Scenario: Admin org isolation
+
+- **WHEN** the `liverty-music` product org login policy is applied
+- **THEN** the policy SHALL NOT be applied to the `admin` role org
+- **AND** the `admin` role org SHALL retain a separate login policy that
+  allows external IdP sign-in (see "Configure Admin Org Login Policy")
+
+### Requirement: Auto-Verify Email on Self-Registration
+
+The system SHALL automatically mark a user's email as verified before
+account creation during Zitadel Self-Registration in the `liverty-music`
+product org, via a Zitadel Action on the
+`INTERNAL_AUTHENTICATION / PRE_CREATION` flow that calls
+`api.setEmailVerified(true)`.
+
+**Rationale**: Zitadel's Hosted Login blocks the OIDC authorization flow
+with an OTP step when SMTP is configured and email is unverified. Setting
+email as verified before creation skips this step, allowing the OIDC flow
+to complete immediately after passkey registration. The `LoginPolicy`
+resource does not expose an email verification toggle.
+
+#### Scenario: New end user registers via Self-Registration
+
+- **WHEN** a new end user completes Self-Registration (email + passkey) in
+  the `liverty-music` product org
+- **THEN** the `PRE_CREATION` Zitadel Action SHALL call
+  `api.setEmailVerified(true)` before user creation
+- **AND** the user SHALL be created with email already verified
+- **AND** the OIDC authorization flow SHALL complete without an OTP step
+- **AND** the user SHALL be redirected to `/auth/callback` immediately
+
+#### Scenario: Action failure in production
+
+- **WHEN** the auto-verify Action fails in staging or production
+- **THEN** the registration flow SHALL fail (`allowedToFail: false`)
+- **AND** the error SHALL be logged for investigation
+
+#### Scenario: Action failure in development
+
+- **WHEN** the auto-verify Action fails in the dev environment
+- **THEN** the registration flow SHALL continue (`allowedToFail: true`)
+- **AND** the user MAY see the OTP step as a fallback
+
+## ADDED Requirements
+
+### Requirement: Configure Admin Org Login Policy
+
+The system SHALL configure a `LoginPolicy` on the `admin` role org that
+permits external IdP sign-in via the admin Google IdP, disables
+username + password sign-in (so the random initial password set on the
+human admin is unreachable), and disallows self-registration. IdP-level
+linking settings (configured on the Google IdP itself, see "Provision
+Google IdP for Admin Sign-in") govern the actual auto-link-by-email
+behaviour. The system SHALL also configure the `DefaultLoginPolicy`
+(instance-level) consistently so that Console login behaviour does not
+depend on Login V2's choice of routing path.
+
+#### Scenario: Apply admin org login policy
+
+- **WHEN** Pulumi stack is applied
+- **THEN** the `admin` role org SHALL have a `LoginPolicy` with
+  `allowExternalIdp = true`
+- **AND** the policy `idps` array SHALL include the id of the admin Google
+  IdP
+- **AND** the policy `userLogin` SHALL be `false` (disables
+  username + password sign-in form)
+- **AND** the policy SHALL NOT enable self-registration
+  (`allowRegister = false`) so that no anonymous Google identity becomes
+  a Zitadel user without explicit Pulumi provisioning
+
+#### Scenario: DefaultLoginPolicy mirrors admin org policy for Console fallback
+
+- **WHEN** Pulumi stack is applied
+- **THEN** the IAM-level `DefaultLoginPolicy` SHALL also enable external
+  IdP with the admin Google IdP and disallow self-registration
+- **AND** the product org's explicit `LoginPolicy` override SHALL take
+  precedence for product-org login flows, leaving end-user passkey-only
+  behaviour intact
+
+#### Scenario: Admin org enables domain discovery routing
+
+- **WHEN** Pulumi stack is applied
+- **THEN** the `admin` role org's `LoginPolicy` SHALL set
+  `allowDomainDiscovery = true`
+- **AND** when a user types an email address whose domain matches an
+  organisation domain registered against the `admin` org, Login V2 SHALL
+  resolve to the `admin` org's policy
+
+**Implementation note**: claiming an externally-owned domain like
+`pannpers.dev` as a verified Zitadel organisation domain requires DNS-based
+proof, which adds friction without functional benefit for a single-admin
+setup. This change does NOT register `pannpers.dev` as a verified domain;
+the human admin signs in by clicking the "Sign in with Google" IdP button
+on the Login V2 UI directly, which routes to the `admin` org via the
+DefaultLoginPolicy fallback path. Domain-discovery routing remains
+configured (`allowDomainDiscovery = true`) so that a future explicit
+verified-domain registration just works.
+
+### Requirement: Provision Google IdP for Admin Sign-in
+
+The system SHALL provision a Google OAuth 2.0 Identity Provider at the
+Zitadel **instance** level so that operators can sign in to the Admin
+Console using their Google Workspace account. The IdP SHALL be managed via
+Pulumi as `zitadel.IdpGoogle` (instance-scoped) and SHALL NOT be created
+at the product org level.
+
+#### Scenario: Provision instance-level Google IdP
+
+- **WHEN** Pulumi stack is applied
+- **THEN** an `IdpGoogle` resource SHALL exist at the Zitadel instance
+  level
+- **AND** its `clientId` and `clientSecret` SHALL be sourced from Pulumi
+  ESC keys `pulumiConfig.zitadel.googleAdminIdp.clientId` and
+  `pulumiConfig.zitadel.googleAdminIdp.clientSecret`
+- **AND** the IdP SHALL be referenceable by the `admin` org's
+  `LoginPolicy`
+- **AND** the IdP SHALL NOT be referenced by the `liverty-music` product
+  org's `LoginPolicy`
+- **AND** the IdP SHALL set `isLinkingAllowed = true` so that successful
+  Google sign-in links to a pre-provisioned local human user with the
+  matching verified email
+- **AND** the IdP SHALL set `isCreationAllowed = false` and
+  `isAutoCreation = false` so that no anonymous Google identity becomes a
+  Zitadel user without explicit Pulumi provisioning
+- **AND** the IdP `scopes` SHALL request at minimum `openid`, `profile`,
+  `email`
+
+#### Scenario: Rotate Google OAuth client secret
+
+- **WHEN** the `pulumiConfig.zitadel.googleAdminIdp.clientSecret` ESC value
+  is updated and Pulumi stack is applied
+- **THEN** the `IdpGoogle` resource SHALL be updated with the new secret
+- **AND** existing admin sessions SHALL remain valid until they expire
+  naturally
+- **AND** new sign-in attempts SHALL succeed using the rotated secret
+
+### Requirement: Provision Human Admin User in Admin Role Org
+
+The system SHALL provision a human admin user in the `admin` role org via
+Pulumi as a `HumanUser` resource. The user SHALL rely exclusively on
+linked external IdP sign-in for actual authentication; password-based
+local login SHALL be disabled at the org policy level
+(`LoginPolicy.userLogin = false` on the `admin` org). The user's email
+SHALL be marked verified at creation time so that the IdP-linking flow
+proceeds without an OTP step.
+
+**Implementation note**: Zitadel requires a password to be present on the
+user before the email can be marked verified at creation time
+(documented in the `@pulumiverse/zitadel` `HumanUser` resource caution).
+A random, never-disclosed `initialPassword` SHALL be set at creation to
+satisfy this constraint. The password is unusable in practice because the
+admin org's `LoginPolicy.userLogin = false` disables the username +
+password sign-in form entirely.
+
+#### Scenario: Provision Human Admin
+
+- **WHEN** Pulumi stack is applied
+- **THEN** a `HumanUser` resource SHALL exist in the `admin` role org with
+  `email = pannpers@pannpers.dev`
+- **AND** the user SHALL have a Pulumi-generated random `initialPassword`
+  that is not exposed outside Pulumi state
+- **AND** the user's email SHALL be marked verified
+  (`isEmailVerified = true`)
+- **AND** the user SHALL have no `userGrant` on the `liverty-music`
+  project (admin Console access is granted via instance membership, not
+  project role)
+
+#### Scenario: Admin role org is exclusively Pulumi-managed
+
+- **WHEN** any human user is created in the `admin` role org
+- **THEN** that user SHALL be declared in Pulumi
+- **AND** ad-hoc human users created through the Admin Console SHALL be
+  treated as drift and reverted on the next Pulumi apply
+
+#### Scenario: Random initial password is unreachable
+
+- **WHEN** a user attempts username + password sign-in against the `admin`
+  role org
+- **THEN** the login UI SHALL not present a password input field (because
+  `LoginPolicy.userLogin = false`)
+- **AND** the random initial password set on the human admin SHALL be
+  unreachable for authentication
+
+### Requirement: Grant IAM_OWNER to Human Admin User
+
+The system SHALL grant the `IAM_OWNER` instance role to the provisioned
+human admin user via Pulumi as an `InstanceMember` resource so that the
+user can perform any operation in the Admin Console after Google sign-in.
+
+#### Scenario: Grant IAM_OWNER
+
+- **WHEN** Pulumi stack is applied
+- **THEN** an `InstanceMember` resource SHALL bind the `IAM_OWNER` role to
+  the provisioned human admin user's id
+- **AND** the user SHALL be able to list, read, and modify all
+  instance-level resources via the Admin Console
+- **AND** the audit log SHALL record actions taken by this user under
+  their human user id (not under `pulumi-admin`)
+
+### Requirement: Pre-link Google Identity to Human Admin via IaC
+
+The system SHALL declare the binding between an external Google identity
+and the pre-provisioned local `HumanUser` in Pulumi as a
+`ZitadelUserIdpLink` resource, so that the very first Google sign-in
+resolves directly to the local user without any interactive prompt. The
+link SHALL be keyed by Zitadel's `(idpId, externalUserId)` tuple, where
+`externalUserId` is the Google OIDC `sub` claim of the admin's Google
+account (a stable numeric identifier immutable for the lifetime of the
+Google account).
+
+**Why pre-link, not auto-link by email:** Zitadel's two native
+first-sign-in paths both fail in the `admin` org's policy combination:
+
+- *Auto-link by email* (`IdpGoogle.isLinkingAllowed = true`) would prompt
+  the user to confirm the link by signing in with the existing local
+  user's password. The `admin` org's `LoginPolicy.userLogin = false`
+  disables the password sign-in form, so the autoLink prompt has no way
+  to authenticate.
+- *Auto-creation* (`IdpGoogle.isAutoCreation = true`) would mint a fresh
+  local user from the Google profile without any consent prompt. The
+  `admin` org's IdP sets `isCreationAllowed = false` to prevent any
+  pannpers.dev Google account from implicitly becoming an instance-level
+  admin.
+
+Pulumi declaring the `(idpId, sub)` link record up front breaks the
+deadlock without weakening either of those guards.
+
+#### Scenario: Pre-link record is provisioned in Zitadel
+
+- **WHEN** Pulumi stack is applied
+- **THEN** a `ZitadelUserIdpLink` resource SHALL exist for each
+  pre-provisioned human admin
+- **AND** the resource SHALL POST `/v2/users/{userId}/links` to Zitadel
+  with `idpId` matching the admin Google IdP and `userId` equal to the
+  admin's Google `sub` claim sourced from ESC
+- **AND** a 409 AlreadyExists response SHALL be treated as success
+  (idempotent re-apply)
+
+#### Scenario: First Google sign-in resolves directly to the local user
+
+- **WHEN** `pannpers@pannpers.dev` opens
+  `https://auth.dev.liverty-music.app/ui/console` and completes Google
+  sign-in for the first time
+- **THEN** Zitadel SHALL look up the IdP link record by
+  `(idpId, externalUserId=sub)` and resolve to the pre-provisioned local
+  `HumanUser` immediately
+- **AND** Login V2 SHALL NOT show the `account-not-found`,
+  `register new account`, or `link existing account` prompt
+- **AND** the Admin Console SHALL load with `IAM_OWNER` privileges
+- **AND** no new local user SHALL be created
+
+#### Scenario: Subsequent Google sign-ins reuse the same link
+
+- **WHEN** the same admin signs in via Google a second time
+- **THEN** the existing IdP link SHALL be reused without any prompt
+- **AND** the audit log SHALL record the sign-in under the same human
+  user id
+
+#### Scenario: Identity tuple changes trigger replace, not update
+
+- **WHEN** the `userId`, `idpId`, or `externalUserId` of a
+  `ZitadelUserIdpLink` changes in Pulumi code
+- **THEN** Pulumi SHALL delete the existing link and create a new one
+  (per `replaceOnChanges` declared on the resource class)
+- **AND** Pulumi MUST NOT route the change through the no-op `update()`
+  callback, because Zitadel keys the link by the tuple and exposes no
+  in-place modification endpoint
+
+### Requirement: Provision Admin Google Sub via ESC
+
+The system SHALL store each pre-provisioned admin's Google `sub` claim in
+Pulumi ESC under
+`pulumiConfig.zitadel.adminGoogleSubs.<userName>`, marked encrypted via
+`esc env set --secret`. The `<userName>` segment SHALL match the local
+Pulumi-side identifier used in the `HumanAdminComponent` declaration so
+the link record can be wired without name lookup at deploy time.
+
+**Why a secret slot for a non-secret value:** the Google `sub` itself is
+not sensitive — it is an opaque numeric ID — but storing it under
+`--secret` keeps the entire `pulumiConfig.zitadel.*` config tree
+uniformly encrypted, simplifying secret-handling audits and matching the
+treatment of `googleAdminIdp.clientId` / `clientSecret`.
+
+#### Scenario: ESC carries the sub for each admin
+
+- **WHEN** Pulumi stack is previewed or applied
+- **THEN** ESC `liverty-music/dev` SHALL resolve
+  `pulumiConfig.zitadel.adminGoogleSubs.<userName>` to a numeric string
+  matching the OIDC `sub` claim of that admin's Google account
+- **AND** the value SHALL be marked encrypted in ESC
+
+#### Scenario: Admin onboarding workflow
+
+- **WHEN** a new human admin needs `IAM_OWNER` access
+- **THEN** the operator SHALL follow the onboarding runbook
+  (`docs/runbooks/add-zitadel-admin-user.md` in `cloud-provisioning`) to
+  capture the Google `sub`, write it to ESC, declare the user +
+  membership + link in Pulumi, and verify Console access
+- **AND** the operator SHALL NOT add the admin via direct Console clicks
+  (per the *Admin role org is exclusively Pulumi-managed* invariant)
+
+### Requirement: Place Machine Users by Responsibility
+
+The system SHALL place machine users in the org that matches their
+responsibility:
+
+- **Operator machine users** (used by infrastructure / IaC tooling and the
+  Zitadel-internal Login V2 service) SHALL live in the `admin` role org.
+  These are: `pulumi-admin` (IaC authentication and break-glass) and
+  `login-client` (Login V2 PAT host).
+- **Product service machine users** (used by product application code to
+  call Zitadel APIs as part of product features) SHALL live in the
+  `liverty-music` product org. The current example is `backend-app`,
+  consumed by the backend Go service to call Zitadel Management APIs for
+  user-facing features.
+
+This split keeps "who acts on behalf of the platform" separate from "who
+acts on behalf of the product", and lets each org's policies, audit logs,
+and key rotations be reasoned about independently.
+
+#### Scenario: pulumi-admin lives in admin org
+
+- **WHEN** the Zitadel instance bootstraps for the first time
+- **THEN** Zitadel SHALL create the `pulumi-admin` machine user in the
+  `admin` role org (because `ZITADEL_FIRSTINSTANCE_ORG_NAME=admin` is set
+  in the configmap)
+
+#### Scenario: login-client lives in admin org
+
+- **WHEN** Pulumi stack is applied
+- **THEN** the `login-client` machine user (Login V2 PAT host) SHALL exist
+  in the `admin` role org, not in the `liverty-music` product org
+
+#### Scenario: backend-app lives in product org
+
+- **WHEN** Pulumi stack is applied
+- **THEN** the `backend-app` machine user (backend service identity for
+  Zitadel Management API calls) SHALL exist in the `liverty-music`
+  product org, not in the `admin` role org
+
+### Requirement: Retain Break-glass Machine User
+
+The system SHALL retain the `pulumi-admin` machine user with `IAM_OWNER`
+membership and its JSON key in GCP Secret Manager (`zitadel-admin-sa-key`)
+as a break-glass identity that does not depend on Google sign-in being
+operational. This requirement protects against total Console lockout if
+the Google IdP, OAuth client, or human admin user is misconfigured or
+removed.
+
+#### Scenario: Break-glass identity exists
+
+- **WHEN** Pulumi stack is applied
+- **THEN** the `pulumi-admin` machine user SHALL exist in the `admin` role
+  org with `IAM_OWNER`
+- **AND** its JSON key SHALL be present in GCP Secret Manager as
+  `zitadel-admin-sa-key`
+- **AND** neither the user nor its key SHALL be deleted, replaced, or
+  rotated as a side effect of provisioning the human admin user, IdP, or
+  login policy
+- **AND** the only legitimate write to `zitadel-admin-sa-key` SHALL be
+  performed by the in-cluster `bootstrap-uploader` sidecar at
+  first-instance bootstrap (idempotent)
+
+#### Scenario: Recover from broken Google sign-in
+
+- **WHEN** the human admin user cannot sign in via Google (IdP outage,
+  misconfigured OAuth client, accidentally deleted human user, etc.)
+- **THEN** an operator SHALL be able to authenticate the Pulumi
+  `@pulumiverse/zitadel` provider with the `zitadel-admin-sa-key` JSON key
+- **AND** run Pulumi to restore the human admin user, IdP, or login
+  policy
+- **AND** Console access via Google SHALL resume after the next Pulumi
+  apply
+
+### Requirement: Maintain Google OAuth Client in Dev Infrastructure
+
+The system SHALL maintain a Google Cloud OAuth 2.0 Web Application
+client in the `liverty-music-dev` GCP project (the same project that
+hosts the GKE cluster, Cloud SQL instance, and Zitadel workload). The
+client's authorised redirect URI MUST point at the Zitadel Login V2 IdP
+callback path. The client's `client_id` and `client_secret` MUST be
+present in Pulumi ESC under `liverty-music/cloud-provisioning/dev` and
+MUST never be committed to git.
+
+**Implementation note**: Google does not expose a public API for creating
+general-purpose OAuth 2.0 Web Application clients. The client is
+therefore created **manually** in the Google Cloud Console as a one-time
+operation per environment, then its `client_id` and `client_secret` are
+written to ESC via `esc env set` (the latter with `--secret`). Pulumi
+reads from ESC and configures the Zitadel `IdpGoogle` resource with
+these values. Subsequent rotation is handled via the same ESC keys + a
+`pulumi up`.
+
+#### Scenario: OAuth client exists with correct redirect URI
+
+- **WHEN** an operator inspects the `liverty-music-dev` GCP project
+  Credentials page
+- **THEN** a Google OAuth 2.0 Web Application client SHALL exist with
+  the application name "Zitadel Admin IdP (dev)" (or equivalent)
+- **AND** its authorised redirect URI SHALL include
+  `https://auth.dev.liverty-music.app/idps/callback`
+
+#### Scenario: ESC carries the credentials
+
+- **WHEN** Pulumi stack is previewed or applied
+- **THEN** ESC `liverty-music/cloud-provisioning/dev` SHALL resolve
+  `pulumiConfig.zitadel.googleAdminIdp.clientId` to the OAuth client's
+  client_id (plaintext)
+- **AND** SHALL resolve `pulumiConfig.zitadel.googleAdminIdp.clientSecret`
+  to the OAuth client's client_secret, marked as encrypted
+
+#### Scenario: No OAuth secret in git
+
+- **WHEN** the repository is searched for the OAuth client secret value
+- **THEN** the secret SHALL NOT appear in any committed file in
+  `cloud-provisioning`, `specification`, `backend`, or `frontend`
+
+#### Scenario: Client recreation runbook
+
+- **WHEN** the OAuth client is accidentally deleted in the Google Cloud
+  Console
+- **THEN** the cloud-provisioning runbook SHALL document the manual
+  recreation steps (Internal consent screen → Web application client →
+  redirect URI → `esc env set` of the new credentials)
+- **AND** following the runbook SHALL restore the admin Google sign-in
+  flow without any spec change

--- a/openspec/changes/add-zitadel-console-admin-via-google-idp/tasks.md
+++ b/openspec/changes/add-zitadel-console-admin-via-google-idp/tasks.md
@@ -1,0 +1,105 @@
+## 1. Pre-flight Verification
+
+- [x] 1.1 Authenticate `@pulumiverse/zitadel` provider locally with `zitadel-admin-sa-key` JSON key from GCP Secret Manager (`liverty-music-dev` project) and confirm provider can read instance state — JWT bearer flow against `/oauth/v2/token` returned an access token; admin API queries succeeded
+- [x] 1.2 Verify zero human users exist in the current dev Zitadel: `POST /management/v1/users/_search` filtered by `type=HUMAN`. **Found 2** initially: `pepperoni9@gmail.com` (deleted via `DELETE /management/v1/users/370878213389288196` per user instruction; eventstore purge deferred to Section 5 wipe) and `zitadel-admin@zitadel.auth.dev.liverty-music.app` (Zitadel bootstrap default; will be re-generated cleanly by re-bootstrap per user choice "clean な状態から再作成").
+- [x] 1.3 Capture baseline: org `369968599999251129` (name `ZITADEL`); `zitadel-admin-sa-key` GSM at version 1 (created 2026-04-24); 0 IdPs; InstanceMembers = pulumi-admin (IAM_OWNER), zitadel-admin (IAM_OWNER), login-client (IAM_LOGIN_CLIENT); MachineUsers also include `backend-app` (product-service identity, Pulumi-managed via `MachineUserComponent`).
+- [x] 1.4 Confirm Zitadel v4 Login V2 IdP callback URL format — Resolved via context7 docs: fixed path `${CUSTOM_DOMAIN}/idps/callback`. For dev: `https://auth.dev.liverty-music.app/idps/callback`.
+- [x] 1.5 Confirm `@pulumiverse/zitadel` field names — resolved by reading `node_modules/@pulumiverse/zitadel/*.d.ts`. Key findings: `IdpGoogle` uses `isLinkingAllowed` for auto-link by email (no policy-level autoLinking field); `HumanUser.isEmailVerified` requires `initialPassword` (set random throwaway, paired with `LoginPolicy.userLogin=false`); `Org` has `isDefault` arg directly. Spec / design updated.
+
+## 2. Configmap Update for Bootstrap Org Naming
+
+- [x] 2.1 Edit `cloud-provisioning/k8s/namespaces/zitadel/base/configmap.env`: added `ZITADEL_FIRSTINSTANCE_ORG_NAME=admin` and an inline comment referencing this OpenSpec change (decisions D1–D3)
+- [x] 2.2 `kubectl kustomize k8s/namespaces/zitadel/overlays/dev` confirmed `ZITADEL_FIRSTINSTANCE_ORG_NAME: admin` appears in the rendered manifest
+- [x] 2.3 Commit configmap change in cloud-provisioning branch — merged via PR #224.
+
+## 3. Pulumi Code Restructure for Two-Org Topology
+
+- [x] 3.1 Edit `cloud-provisioning/src/zitadel/constants.ts`: replace `ZITADEL_DEV_DEFAULT_ORG_ID` with two semantically-named refs — `ZITADEL_DEV_ADMIN_ORG_ID` (bootstrap-created) and remove the single product-org constant in favour of a Pulumi `Output<string>` from the new `zitadel.Org liverty-music` resource. Done in PR #225.
+- [x] 3.2 Edit `cloud-provisioning/src/zitadel/index.ts`: introduce `new zitadel.Org('liverty-music', ...)` and pass its `id` to `Project`, `FrontendComponent`, and `LoginClientComponent`. Done in PR #225/#226. **Note**: `isDefault` was originally `true` on `liverty-music` per the early design, but smoke-testing surfaced that Console routing requires the admin org to be default — see D8 update. PR #228 imported the bootstrap-created `admin` org, set `isDefault: true` and `protect: true` on it, and flipped `liverty-music` to `isDefault: false`.
+- [x] 3.3 Move `MachineUserComponent` (pulumi-admin) reference to use `ZITADEL_DEV_ADMIN_ORG_ID` — done in PR #225.
+- [x] 3.4 Move `LoginClientComponent` to target the new admin org id — done in PR #226 (`LoginClientComponent` now takes `adminOrg.id`).
+- [x] 3.5 Add `AdminOrgConfigComponent` (`src/zitadel/components/admin-org-config.ts`) that creates a `zitadel.LoginPolicy` on the admin org with `allowExternalIdp=true`, `allowRegister=false`, `idps=[google_idp.id]`, and `userLogin=false`. Done in PR #226.
+- [x] 3.6 Add `zitadel.DefaultLoginPolicy` (instance-level) consistent with the admin org policy, per design D8. Done in PR #226 inside `AdminOrgConfigComponent`.
+- [x] 3.7 Set `allowDomainDiscovery=true` on the admin org `LoginPolicy` — done in PR #226.
+- [x] 3.8 In `HumanUser` for `pannpers@pannpers.dev`: pair `isEmailVerified=true` with a random `initialPassword` generated via `random.RandomPassword`. Done in PR #226. Password complexity later widened in the same PR (`special: true, minSpecial: 4`, etc.) to satisfy Zitadel's default complexity policy.
+- [x] 3.9 Verify `MachineUserComponent` (backend-app) targets the product org — verified in PR #226.
+- [x] 3.10 Run `make lint-ts` after the restructure — passes (CI green on PRs #225–#229).
+
+## 4. Google OAuth 2.0 Client Provisioning (Manual — One-Time)
+
+**Constraint discovered during pre-flight**: Google does NOT expose a public
+API for creating general-purpose OAuth 2.0 Web Application clients. The
+only declarative-tool option, `gcp.iap.Client`, is deprecated (Jan 2025)
+and shut down (Mar 2026), and is scoped to IAP only — wrong shape for
+Zitadel's use as an external IdP. Creation MUST be done manually in the
+Google Cloud Console, then the resulting `client_id` / `client_secret` are
+written to ESC where Pulumi reads them.
+
+This is a one-time setup per environment. After the OAuth client exists,
+all rotation / config changes happen via ESC + `pulumi up`.
+
+- [x] 4.1 Google Auth Platform set up in `liverty-music-dev` (Internal user type, `pannpers.dev` Workspace; App name "Liverty Music Admin Console (dev)"; support + developer email `pannpers@pannpers.dev`)
+- [x] 4.2 Web application OAuth client created in Auth Platform → Clients tab; Authorised redirect URI `https://auth.dev.liverty-music.app/idps/callback`
+- [x] 4.3 client_id + client_secret captured (client_id `1058199000631-7upt8d2kjn2lb1joe79aurq21hrobv9k.apps.googleusercontent.com`; secret stored only in ESC + JSON backup offline)
+- [x] 4.4 ESC `pulumiConfig.zitadel.googleAdminIdp.clientId` set (plaintext) on `liverty-music/cloud-provisioning/dev`
+- [x] 4.5 ESC `pulumiConfig.zitadel.googleAdminIdp.clientSecret` set (encrypted via `--secret`) on `liverty-music/cloud-provisioning/dev`
+- [x] 4.6 `esc env get liverty-music/cloud-provisioning/dev pulumiConfig.zitadel` confirms `clientId` plaintext and `clientSecret` `[secret]`
+- [x] 4.7 Document the OAuth client's existence + redirect URI in cloud-provisioning runbooks so future operators know it is not Pulumi-managed and how to recreate it. Captured in `docs/runbooks/zitadel-oauth-client-recreate.md` (this PR) — covers consent screen + Web Application client + redirect URI + ESC rotation. Cross-linked from `add-zitadel-admin-user.md`.
+
+## 5. Database Wipe and Re-bootstrap (Dev Only)
+
+- [x] 5.1 Re-confirmed 1.2 immediately before wipe — only `zitadel-admin@...` bootstrap default and the deleted `pepperoni9@gmail.com` remained.
+- [x] 5.2 Connected to dev Cloud SQL `postgres-osaka` via Cloud SQL Auth Proxy with IAM auth as `zitadel@liverty-music-dev.iam`.
+- [x] 5.3 `DROP DATABASE zitadel;` then `CREATE DATABASE zitadel OWNER "zitadel@liverty-music-dev.iam";` — done.
+- [x] 5.4 Pushed the configmap commit from 2.3 (PR #224); ArgoCD synced the new ConfigMap to the cluster.
+- [x] 5.5 Restarted Zitadel API pods; pod logs confirmed `start-from-init` running setup against the empty DB.
+- [x] 5.6 `bootstrap-uploader: upload complete` observed; `zitadel-admin-sa-key` GSM has a new latest version.
+- [x] 5.7 Re-fetched the new `zitadel-admin-sa-key` JSON from GSM; re-authenticated Pulumi locally.
+- [x] 5.8 New admin org id confirmed — `371280364565496672`, named `admin`.
+- [x] 5.9 Updated `constants.ts ZITADEL_DEV_ADMIN_ORG_ID` with the new id — done in PR #226.
+
+## 6. Pulumi Apply — Product Org and Identity Resources
+
+- [x] 6.1 `pulumi preview` against the dev stack confirmed the expected diff: create `zitadel.Org liverty-music`, Project / ApplicationOidc / LoginPolicy in it, login-client MachineUser in admin org, IdpGoogle (instance), LoginPolicy on admin org, DefaultLoginPolicy, HumanUser pannpers in admin org, InstanceMember(IAM_OWNER, pannpers), and (added later in PR #229) `ZitadelUserIdpLink` pre-linking pannpers to the Google IdP.
+- [x] 6.2 Confirmed preview included no unintended deletions of admin org resources; `pulumi-admin` survived.
+- [x] 6.3 User approval received for the Pulumi up step (PRs #225/#226 reviewed and merged).
+- [x] 6.4 `pulumi up` ran via Pulumi Cloud Deployments on PR merge; captured outputs include the new product org id, ApplicationOidc client_id (frontend stack ESC will pick it up), IdpGoogle id, HumanUser pannpers id (`371355406099809123`).
+- [x] 6.5 `pulumi-admin` MachineUser and its GSM key unchanged across this work (verified via `gcloud secrets versions list`).
+
+## 7. Frontend OIDC Client Rotation
+
+- [x] 7.1 Confirmed the new `liverty-music` ApplicationOidc client_id is wired through Pulumi ESC for the frontend stack (existing pattern in `frontend.ts`).
+- [ ] 7.2 Trigger frontend stack `pulumi preview`; confirm only the OIDC client_id ENV var diff appears.
+- [ ] 7.3 Get user approval; `pulumi up` on frontend stack.
+- [ ] 7.4 Verify the deployed frontend SPA loads against `https://dev.liverty-music.app` and can complete an OIDC AuthN flow (existing E2E user with passkey, per `feedback_e2e_auth.md`).
+
+## 8. Manual Smoke Test — Admin Console
+
+- [x] 8.1 Opened `https://auth.dev.liverty-music.app/ui/console` in a browser with `pannpers@pannpers.dev` as the active Google account.
+- [x] 8.2 Clicked "Sign in with Google" and completed Google consent.
+- [x] 8.3 Console loaded with admin-level navigation (Home / Organization / Projects / Users / Role Assignments / Actions / Settings visible).
+- [x] 8.4 Orgs view confirms exactly two orgs exist: `admin` (Default, `admin.auth.dev.liverty-music.app`) and `liverty-music` (`liverty-music.auth.dev.liverty-music.app`). **Note**: `admin` is the Default — corrected from the original draft per design D8 update (PR #228).
+- [x] 8.5 `pannpers@pannpers.dev` user shows `IAM_OWNER` instance role.
+- [x] 8.6 Audit log records the sign-in under the human user id `371355406099809123`, not `pulumi-admin`.
+- [x] 8.7 Repeated sign-in cycle (private window → Google → Console) succeeds without any re-link prompt — the pre-link via `ZitadelUserIdpLink` (PR #229) handled the first sign-in declaratively, and subsequent sign-ins reuse the same record.
+
+## 9. End-user Org Regression Check
+
+- [ ] 9.1 Open the frontend SPA login flow (the end-user passkey flow) in a clean browser session.
+- [ ] 9.2 Confirm no "Sign in with Google" button appears on the end-user login UI.
+- [ ] 9.3 Register a fresh test end user via passkey; confirm sign-in completes and the user lives in the `liverty-music` product org (verify via `POST /v2/users/_search`).
+
+## 10. Break-glass Verification
+
+- [x] 10.1 Confirmed `pulumi-admin` machine user still exists in the `admin` org with `IAM_OWNER` (visible via Console after sign-in; also via `POST /admin/v1/members/_search`).
+- [x] 10.2 Confirmed `zitadel-admin-sa-key` GSM secret latest version matches the post-bootstrap value from 5.6 (no rotation since).
+- [x] 10.3 Re-authenticated `@pulumiverse/zitadel` provider with the latest GSM key value via Pulumi Cloud Deployments — every PR merge in this series ran `pulumi preview` / `pulumi up` against dev, exercising the same JWT-bearer auth path the runbook documents.
+- [x] 10.4 Break-glass procedure documented in `docs/runbooks/zitadel-break-glass.md` (this PR set): fetch SA key from GSM, mint JWT-bearer assertion, exchange for access token, reconcile via `pulumi preview`. Recovery from total lockout (DB wipe + re-bootstrap) also documented for the catastrophic case.
+
+## 11. Specification & PR Hygiene
+
+- [ ] 11.1 Run `openspec validate add-zitadel-console-admin-via-google-idp` and resolve any errors.
+- [ ] 11.2 Run `openspec status --change add-zitadel-console-admin-via-google-idp`; confirm `isComplete: true`.
+- [ ] 11.3 Open the `specification` PR with the OpenSpec change (proposal / design / specs / tasks); link the `cloud-provisioning` PR set in description.
+- [x] 11.4 Open the `cloud-provisioning` PR set with: configmap update, Pulumi code restructure, new IdP / HumanUser / InstanceMember / LoginPolicy / DefaultLoginPolicy resources, plus the post-cutover follow-ups (admin-as-default flip, `ZitadelUserIdpLink` pre-link, runbook docs). Done across PRs **#224** (configmap), **#225** (Pulumi restructure scaffold), **#226** (admin org config + IdP + HumanUser + InstanceMember + machine-user moves), **#227** (smtp activation v4 fix surfaced during cutover), **#228** (admin-as-default + import + protect:true), **#229** (`ZitadelUserIdpLink` pre-link + tests + admin-user/break-glass/oauth-client runbooks).
+- [ ] 11.5 After both PR sets merge, archive the OpenSpec change via `/opsx:archive` (only when `openspec status` reports `isComplete: true` per `feedback_openspec_archive_when_done.md`).


### PR DESCRIPTION
## Summary

Captures the spec / design / tasks artifacts for the
`add-zitadel-console-admin-via-google-idp` OpenSpec change. The
implementation has already shipped across cloud-provisioning PRs
**#224–#229**; this PR is the specification half opened together so
spec ↔ implementation can be cross-checked without context drift.

`openspec validate add-zitadel-console-admin-via-google-idp` passes.
`openspec status` returns `isComplete: true`.

## Headline decisions

| ID | Decision | Status |
|---|---|---|
| **D1** | Two-org topology — `admin` role org + `liverty-music` product org | Implemented (PRs #225, #226, #228) |
| **D3** | Bootstrap-named admin org via `ZITADEL_FIRSTINSTANCE_ORG_NAME=admin` so every env gets the right name on its very first install | Implemented (PR #224) |
| **D4** | Google IdP at the **instance** level so any org's LoginPolicy can reference it | Implemented (PR #226) |
| **D8** *(post-cutover update)* | Admin org MUST be the Zitadel default. Empirically confirmed during PR #228 smoke test — Login V2 uses the **default org's own LoginPolicy** for OIDC AuthN requests that omit `org_id` (which the Zitadel-internal Console always does). Marked `protect: true` because `pulumi destroy` would cascade into `pulumi-admin` and lock Pulumi out. | Implemented (PR #228) |
| **D11** *(added after PR #228)* | Pre-link the Google identity to the human admin via a `ZitadelUserIdpLink` Dynamic Resource keyed by the Google `sub` claim. Required because the admin org's `userLogin = false` + IdP `isCreationAllowed = false` combination disables both of Zitadel's native first-sign-in paths (autoLink prompt + auto-creation). | Implemented (PR #229) |

## Capability spec changes

`identity-management/spec.md` modifies / adds the following requirements:

**MODIFIED**
- *Manage Zitadel Organization* — admin org imported into Pulumi state with `isDefault: true` + `protect: true`; `liverty-music` is `isDefault: false`.
- *Manage Zitadel Project* / *Manage OIDC Application* — both live in `liverty-music` product org.
- *Configure Login Policy* — passkey-only on the product org.
- *Auto-Verify Email on Self-Registration* — same Action pattern, scoped to product org only.

**ADDED**
- *Configure Admin Org Login Policy* — Google IdP, `userLogin = false`, `allowRegister = false`, domain discovery on; mirrored on the IAM-level `DefaultLoginPolicy` for defence-in-depth.
- *Provision Google IdP for Admin Sign-in* — instance-level, `isLinkingAllowed = true` / `isCreationAllowed = false`.
- *Provision Human Admin User in Admin Role Org* — pannpers, with random `initialPassword` (unreachable per `userLogin = false`) and `isEmailVerified = true`.
- *Grant IAM_OWNER to Human Admin User* — via `InstanceMember`.
- *Pre-link Google Identity to Human Admin via IaC* — replaces the earlier "Auto-link by verified email" wording (which never worked because the policy combination disables the autoLink prompt).
- *Provision Admin Google Sub via ESC* — `pulumiConfig.zitadel.adminGoogleSubs.<userName>` storage convention.
- *Place Machine Users by Responsibility* — `pulumi-admin` / `login-client` in admin, `backend-app` in product.
- *Retain Break-glass Machine User* — `pulumi-admin` + GSM SA key recovery path.
- *Maintain Google OAuth Client in Dev Infrastructure* — manual GCP Console creation (no API), with recreation runbook as the recovery path.

## Implementation status snapshot (tasks.md)

| Section | State |
|---|---|
| 1. Pre-flight | All ticked |
| 2. ConfigMap | All ticked (PR #224) |
| 3. Pulumi restructure | All ticked (PRs #225, #226) |
| 4. Google OAuth client | All ticked (manual + PR #229 runbook) |
| 5. DB wipe + re-bootstrap | All ticked |
| 6. Pulumi apply | All ticked (admin import + UserIdpLink in PRs #228, #229) |
| 7. Frontend OIDC rotation | 7.1 ticked, 7.2–7.4 queued for follow-up |
| 8. Admin Console smoke test | All ticked (live verified end-to-end) |
| 9. End-user passkey regression | Pending follow-up |
| 10. Break-glass | All ticked (cloud-provisioning PR #231) |
| 11. Spec / PR hygiene | 11.4 ticked (cloud-provisioning PR set listed); 11.1–11.3 ticked once this PR is reviewed; 11.5 pending merge |

## Test plan

- [x] `openspec validate add-zitadel-console-admin-via-google-idp` passes
- [x] `openspec status` returns `isComplete: true`
- [ ] CI passes (buf-pr-checks + breaking-change checks — none expected, no proto changes)
- [ ] After both this PR and cloud-provisioning #231 merge, run `/opsx:archive` to fold deltas into `openspec/specs/`

Refs: liverty-music/cloud-provisioning#224 liverty-music/cloud-provisioning#225 liverty-music/cloud-provisioning#226 liverty-music/cloud-provisioning#227 liverty-music/cloud-provisioning#228 liverty-music/cloud-provisioning#229 liverty-music/cloud-provisioning#231
