### PR TITLE
feat(openspec): propose provision-prod-gcp-resources

### DIFF
--- a/openspec/changes/provision-prod-gcp-resources/.openspec.yaml
+++ b/openspec/changes/provision-prod-gcp-resources/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-11

--- a/openspec/changes/provision-prod-gcp-resources/design.md
+++ b/openspec/changes/provision-prod-gcp-resources/design.md
@@ -1,0 +1,191 @@
+## Context
+
+The `liverty-music-prod` GCP project currently has only a `gcp:project` config and no Pulumi-managed resources. The Pulumi code in `cloud-provisioning/src/gcp/components/kubernetes.ts:384` and `network.ts:194` both `return` early when `environment === 'prod'`, leaving the prod stack as a deliberate no-op since 2026-02-05 (commit [`85fef89`](https://github.com/liverty-music/cloud-provisioning/commit/85fef89) "remove prod resources and optimize cloud sql dns").
+
+The dev cluster's evolution over February-April 2026 — Autopilot regional → Standard zonal migration ([`05893f6`](https://github.com/liverty-music/cloud-provisioning/commit/05893f6) 2026-04-01), aggressive cost-optimization rounds ([`c0eae10`](https://github.com/liverty-music/cloud-provisioning/commit/c0eae10), [`943e6ef`](https://github.com/liverty-music/cloud-provisioning/commit/943e6ef)) — has produced a battle-tested set of decisions about which cluster settings matter and which can be deferred. This change leverages that learning to set up prod with the right irreversible decisions baked in from day 1, while keeping all reversible cost-deferrable settings at their cheapest values.
+
+Two reference documents in the cloud-provisioning repo capture the underlying rationale and serve as operational context:
+- `cloud-provisioning/docs/PROD_BOOTSTRAP_DECISIONS.md` — itemized decision log with reversibility classification.
+- `cloud-provisioning/docs/GKE_CLUSTER_MODE_DECISION.md` — Autopilot-vs-Standard analysis and irreversibility reference table.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Provision prod GCP infrastructure that mirrors dev's workload set, so deployment manifests and Pulumi components can rely on prod having "the same shape" as dev.
+- Bake in irreversible cluster settings (Dataplane V2, etcd CMEK, regional, ipAllocationPolicy) at creation time so they do not require a future cluster rebuild.
+- Keep first-month cost under ¥25,000 by deferring every cost driver that is safely reversible (private nodes, Cloud NAT, GMP, on-demand nodes, boot disk CMEK, Confidential Nodes, HSM keys).
+- Establish the prod Cloud KMS keyring + key needed for etcd CMEK as part of cluster creation, with correct IAM bindings for the GKE service agent.
+- Preserve the existing dev cluster's behavior — this change is additive, not a refactor.
+
+**Non-Goals:**
+
+- Migrating any user data. Prod is empty; there is nothing to migrate from anywhere.
+- Multi-region disaster recovery (single regional cluster in `asia-northeast2` only).
+- Production-grade SLO monitoring (GMP stays off; deferred to "first users arrive" trigger).
+- Blockchain key infrastructure (KMS asymmetric signing, Confidential signing node pool). Deferred to blockchain mainnet phase.
+- Migrating prod to Autopilot. The mode choice is recorded as Standard; revisiting requires a new OpenSpec change since it implies cluster rebuild.
+- Enforcement of network policies, pod security admission, or other Kubernetes-level hardening. Those are separate capability concerns.
+
+## Decisions
+
+### D1: Cluster mode is Standard (not Autopilot)
+
+**Decision:** Use GKE Standard for prod, matching dev.
+
+**Why:** The dev team has gained operational competence with Standard mode through the April optimization work. Standard provides the node-pool-level controls (Spot, machine type, disk type, autoscaler tuning) that have already produced concrete cost wins in dev. Same mental model across envs reduces ops friction.
+
+**Alternatives considered:**
+- **Autopilot regional**: Google's official "use for most production workloads" recommendation. Less operational toil. *Rejected for now* because (a) cluster mode is irreversible and we want to defer the decision until prod has real workload profile data, (b) the team's current playbook is Standard-centric, (c) Sept-2025 hybrid features (per-workload Autopilot ComputeClasses on Standard clusters) provide an escape hatch if we later want Autopilot semantics for specific workloads.
+
+**Reversibility:** Irreversible (cluster mode cannot be flipped in-place; switch requires new cluster + workload migration).
+
+### D2: Topology is regional (not zonal)
+
+**Decision:** `location: asia-northeast2` (3-zone regional Standard cluster).
+
+**Why:** Even without an SLO commitment, an AZ outage on a zonal cluster causes total prod downtime requiring manual intervention. Regional is the only sensible choice for prod, even pre-launch.
+
+**Cost impact:** Regional Standard does NOT qualify for the GKE free tier (free tier covers Autopilot or zonal Standard only). Net additional cost: $0.10/hr × 720 hr ≈ $72/month (~¥10,800).
+
+**Reversibility:** Irreversible.
+
+### D3: Dataplane V2 enabled
+
+**Decision:** Set `datapathProvider: 'ADVANCED_DATAPATH'` on the prod cluster.
+
+**Why:**
+- GCP has announced that Dataplane V2 becomes the default for new clusters on 2027-03-30 (per the GCP email received 2026-05). Enabling now aligns with the future default.
+- NetworkPolicy enforcement is always-on with Dataplane V2 — a useful security baseline even though we are not authoring NetworkPolicy resources yet.
+- eBPF-based dataplane has perf advantages for prod traffic volumes.
+- Built-in network policy logging is valuable for future audit work.
+
+**Alternatives considered:**
+- **LEGACY_DATAPATH (current dev choice)**: Lower overhead on tiny clusters (no `anetd` DaemonSet). *Rejected for prod* because (a) prod will not stay tiny, (b) Dataplane V2 is irreversible — better to set it correctly at creation than face a re-create later, (c) Google is making this the default in 2027 regardless.
+
+**Reversibility:** Irreversible. `--enable-dataplane-v2` cannot be applied to an existing cluster per [GKE docs](https://cloud.google.com/kubernetes-engine/docs/concepts/dataplane-v2): *"GKE Dataplane V2 can only be enabled when creating a new cluster."*
+
+### D4: etcd CMEK enabled at cluster creation
+
+**Decision:** Provision a Cloud KMS keyring and key in the prod project and configure the cluster's `databaseEncryption` to encrypt Kubernetes Secret resources using that key.
+
+**Why:**
+- Future SOC2 / blockchain security audit will almost certainly require encryption-at-rest with customer-controlled keys for Kubernetes Secret resources.
+- Enabling after the fact is operationally fraught (cluster-wide re-encryption operation, IAM coordination).
+- Cost is negligible: $0.06 / key version / month for software-backed keys, plus $0.03 / 10k operations. Free tier covers the first 20k operations/month per project. Estimated total: ~$0.20/month.
+
+**KMS resource layout:**
+- KeyRing name: `gke-cluster`, location: `asia-northeast2`.
+- CryptoKey name: `gke-etcd-encryption`, purpose: `ENCRYPT_DECRYPT`, protection level: `SOFTWARE`, rotation period: 90 days (Cloud KMS handles rotation transparently).
+- IAM binding: GKE service agent (`service-<project-number>@container-engine-robot.iam.gserviceaccount.com`) granted `roles/cloudkms.cryptoKeyEncrypterDecrypter` on the key.
+
+**Alternatives considered:**
+- **Cloud HSM-backed key** ($1 / key version / month): FIPS 140-2 Level 3 hardware HSM. *Deferred* — only needed if SOC2 auditor explicitly requires hardware key protection. Software key is upgradeable to HSM via key rotation if requirements tighten.
+- **No CMEK** (use Google-managed encryption): default behavior. *Rejected* because enabling later requires cluster reconfiguration and lacks the audit-trail benefits of Cloud KMS.
+
+**Reversibility:** Irreversible at cluster creation. Key rotation is supported (Cloud KMS) but flipping CMEK off after enabling is not a documented operation.
+
+### D5: CIDR plan matches dev (project isolation handles conflict)
+
+**Decision:** Reuse `NetworkConfig.Osaka` constants (`subnetCidr: '10.10.0.0/20'`, `podsCidr: '10.20.0.0/16'`, `servicesCidr: '10.30.0.0/20'`, `masterCidr: '172.16.0.0/28'`) for prod without modification.
+
+**Why:**
+- Environments are GCP-project-separated. VPCs are project-scoped; CIDR overlap between dev and prod VPCs is irrelevant unless we ever peer them, which is not in scope.
+- Mental model is simplified by having one CIDR plan, not two.
+- Current sizing comfortably supports prod at multi-year scale: Pod range `/16` = 65,536 IPs = ~256 nodes max (default `/24` per node); Service range `/20` = 4,096 services. Liverty Music prod is expected to operate well below those limits for the foreseeable future.
+
+**Irreversibility focus:** Per [GKE alias-IPs docs](https://cloud.google.com/kubernetes-engine/docs/concepts/alias-ips), the **Service secondary range cannot be expanded or changed** after cluster creation. `/20` for services is generous and accepted as final. The Pod range can be expanded by adding additional Pod IP ranges (discontiguous CIDR) if scale ever exceeds 256 nodes — so under-sizing is recoverable.
+
+**Alternatives considered:**
+- **GKE-managed Services range** (`34.118.224.0/20`): default for new Standard clusters at GKE 1.29+. Frees up user VPC IP space. *Rejected for now* because using the same explicit CIDR plan as dev reduces IaC code divergence and keeps the diff readable.
+- **Larger Pod range (`/14`)**: Would support up to 1,024 nodes. *Rejected* — current `/16` is enough headroom for years, and additional ranges can be added later without re-creating the cluster.
+
+### D6: Cost-first defaults for reversible settings
+
+**Decision:** Set the following to their cheapest options, accepting that they will be flipped when users arrive:
+- `enablePrivateNodes: false` — public node IPs, no Cloud NAT (saves ~¥5,292/month NAT fixed cost).
+- No Cloud NAT, no Cloud Router for prod in `network.ts`.
+- Single Spot `e2-medium` node pool, autoscale 1-3 nodes, 30 GB pd-standard boot disks (mirrors dev).
+- `managedPrometheus.enabled: false` (saves GMP ingestion + storage cost).
+- `loggingConfig.enableComponents: ['SYSTEM_COMPONENTS', 'WORKLOADS']` — workloads logs needed for log-based alerts.
+- `monitoringConfig.enableComponents: ['SYSTEM_COMPONENTS']` only.
+- `costManagementConfig.enabled: true` (free).
+- Release channel `REGULAR` (no cost difference; same upgrade tempo as dev).
+
+**Why:** All of these are mutable post-creation per [GKE network-isolation docs](https://cloud.google.com/kubernetes-engine/docs/concepts/network-isolation) and standard Kubernetes API. Flipping them later requires Pulumi config changes and a `pulumi up`, not a cluster rebuild. Deferring them keeps first-month cost low.
+
+**Trigger to flip:** "First real users arrive on prod" — at which point a separate OpenSpec change enables private nodes, provisions Cloud NAT, enables GMP, and adds a non-Spot pool for latency-sensitive workloads.
+
+### D7: Skip cluster-level Confidential GKE Nodes; defer to per-pool
+
+**Decision:** Do not set `confidentialNodes.enabled: true` at cluster level.
+
+**Why:**
+- Cluster-level Confidential Nodes is irreversible per [GKE Confidential Nodes docs](https://cloud.google.com/kubernetes-engine/docs/how-to/confidential-gke-nodes): *"This setting is irreversible."*
+- Enabling forces all node pools onto N2D / C3 machine families (e2 is not supported), raising baseline node cost ~4-5x before the Confidential premium itself.
+- Critically, Confidential Nodes does NOT solve the blockchain private-key-in-container-memory problem (a compromised container can still read its own memory). The right answer for blockchain keys is Cloud KMS asymmetric signing, where the key never leaves KMS.
+- When blockchain mainnet GA arrives, a dedicated node pool with Confidential Nodes enabled (taint-isolated for the signing service) is more cost-efficient than cluster-wide enablement.
+
+**Reversibility:** Cluster-level is irreversible; node-pool-level is additive and can be done later.
+
+### D8: Single Pulumi component, env-aware (no refactor)
+
+**Decision:** Extend the existing `KubernetesComponent` and `NetworkComponent` in `cloud-provisioning/src/gcp/components/` to handle prod, rather than creating a parallel `ProdKubernetesComponent`.
+
+**Why:** Both components already have `environment === 'dev'` / `environment === 'prod'` branches in places. Adding prod branches alongside existing dev branches is a small, focused diff. Splitting into parallel components would duplicate the subnet, KMS, and Cluster wiring code unnecessarily.
+
+**Alternative considered:**
+- **Refactor into env-strategy classes** (one component per env): *Rejected* as scope creep. The current branching pattern is readable, and we should not refactor while simultaneously adding new functionality.
+
+### D9: K8s manifests reuse dev overlays where possible
+
+**Decision:** For each k8s namespace currently provisioned for dev (`backend`, `frontend`, `zitadel`, `argocd`, `external-secrets`, `reloader`, `atlas-operator`, `nats`, `keda`, `otel-collector`, `image-updater`), add a prod overlay only when its config differs from base. Where the base manifest is acceptable for prod as-is, no new overlay is created.
+
+**Why:** The existing dev overlays already encode cost-focused overrides (Spot nodeSelector, replica reductions, disabled debug sidecars). Many of these are also appropriate for prod's cost-first phase. Only create a `prod/` overlay where prod actually diverges from base (e.g., different ingress hostnames, different secret references, different replica counts).
+
+**Audit needed:** Each namespace's current overlay structure should be reviewed to determine whether a prod overlay needs to be authored, modified, or whether the base is sufficient.
+
+## Risks / Trade-offs
+
+- **[Risk] CIDR overlap with future VPC peering** → Mitigation: VPC peering between dev and prod is not currently planned. If future requirements introduce it, a new OpenSpec change reworks the CIDR plan (this would require both clusters to be re-created — large blast radius). Documented explicitly so future contributors understand the constraint.
+- **[Risk] Public prod node IPs increase attack surface** → Mitigation: This is acceptable in the cost-first phase precisely because there are no users and no production data yet. The Pulumi deploy log for the first prod `pulumi up` should NOT include any references to "first user", "live traffic", or similar — those would be the trigger to flip `enablePrivateNodes: true`. Workload Identity is the primary defense even with public nodes.
+- **[Risk] CMEK key deletion would brick the cluster** → Mitigation: The Cloud KMS key has Pulumi `deletionProtection` style guard (set `prevent_destroy` on the CryptoKey resource). Key version rotation is automatic and non-destructive. Manual key destruction would require an explicit Pulumi config flag.
+- **[Risk] First `pulumi up` for prod is a large blast radius** → Mitigation: Per existing `deployment-infrastructure` spec, prod Pulumi deploys are manual-trigger only. The first prod `up` should be reviewed in the Pulumi Cloud preview before approval. Suggest doing it in stages: first the network + KMS + cluster, then a separate run for workload-related resources.
+- **[Trade-off] Spot in prod = preemptions** → Acceptable in pre-launch phase. Preemptions during dogfooding are tolerable; the alternative (~50-100% additional Compute Engine cost for on-demand) is not justified before there are users.
+- **[Trade-off] GMP disabled = no metric alerts in prod** → Acceptable pre-launch (log-based alerts cover ERROR conditions; latency/saturation alerts need GMP and will be enabled with users). The dev cluster has been running this way through Zitadel deployment and has been operationally sufficient.
+- **[Risk] OpenSpec change "provision-prod-gcp-resources" implies cross-repo work** → The OpenSpec artifacts live in `specification/openspec/changes/`, but the actual Pulumi implementation lives in `cloud-provisioning/`. Mitigation: the implementation tasks reference cloud-provisioning paths explicitly; PR for cloud-provisioning will be reviewed and merged based on the specs in this change. The cross-repo coordination protocol from the workspace CLAUDE.md applies in modified form: this is NOT a proto change, so there is no BSR coordination needed, just specification ↔ cloud-provisioning PR pairing.
+
+## Migration Plan
+
+This is a green-field provisioning, not a migration. There is no existing prod infrastructure to transition from.
+
+**Deployment order (single PR but recommend split Pulumi `up` runs):**
+
+1. Merge this OpenSpec change to specification (no code-level effect; documentation only).
+2. Merge cloud-provisioning PR that implements the prod branches in `kubernetes.ts`, `network.ts`, `postgres.ts`. Per existing `deployment-infrastructure` spec, this does NOT auto-deploy to prod.
+3. Manually trigger `pulumi preview --stack prod` from Pulumi Cloud console. Review the full plan for unexpected destruction or replacement.
+4. Manually trigger `pulumi up --stack prod`. Recommend approving in stages if Pulumi supports it:
+   - Stage A: KeyRing + CryptoKey + IAM bindings (KMS first, so cluster creation can reference the key).
+   - Stage B: VPC + Subnet + DNS zone + Certificate Manager (network).
+   - Stage C: GKE Cluster + Node Pool (depends on Stage A + B).
+   - Stage D: Cloud SQL, Artifact Registry, Service Accounts, Secret Manager.
+   - Stage E: ArgoCD bootstrap + initial k8s namespaces.
+5. Verify cluster creation succeeded by running `kubectl get nodes` against the prod cluster (after credential setup).
+6. Verify `kubectl describe cluster` shows Dataplane V2 enabled and etcd CMEK key reference.
+7. ArgoCD assumes responsibility for k8s manifest application; verify all Applications are syncing.
+
+**Rollback strategy:**
+
+- If Stage A-C fails or produces incorrect state: `pulumi destroy --stack prod --target <resource>` for the failed resource, fix Pulumi code, re-run `pulumi up`. Note: the KMS key has `prevent_destroy` — to destroy intentionally, remove the guard, then destroy in a separate Pulumi run.
+- If the cluster is created but configured incorrectly on an irreversible setting (DPv2, CMEK, regional): destroy the cluster, fix Pulumi, re-create. This is the only safety valve.
+- If reversible settings (Spot/private/NAT/GMP) are wrong: `pulumi up` with corrected config; cluster persists.
+
+## Resolved Open Questions
+
+All previously open questions have been resolved by the change author prior to implementation. Decisions and rationale are recorded below; the corresponding values are baked into the specs and tasks.
+
+- **Q1: Cloud SQL instance tier for prod** → **`db-f1-micro`**. Same shared-core tier as dev. Cost-first phase; in-place tier upgrade is supported by Cloud SQL with seconds-to-minutes downtime, so under-sizing is recoverable without losing data.
+- **Q2: DNS strategy for the prod apex `liverty-music.app`** → **Cloudflare remains authoritative for the apex**. Provision a Cloud DNS public zone for `api.liverty-music.app` and `auth.liverty-music.app` only; delegate just those subdomains from Cloudflare via NS records (same pattern as `dev.liverty-music.app`). Keeps Cloudflare's CDN/DDoS protection on the apex web traffic while letting Certificate Manager DnsAuthorization work against Cloud DNS for the GCP-fronted hostnames.
+- **Q3: Initial `maxNodeCount` for the Spot pool** → **3** (same as dev). Mutable via Pulumi config; raise as workload count grows.
+- **Q4: ArgoCD Applications scope for prod** → **Same set as dev** (`argocd`, `external-secrets`, `reloader`, `atlas-operator`, `nats`, `keda`, `otel-collector`, `image-updater`, `backend`, `frontend`, `zitadel`). Full parity simplifies the IaC diff and avoids "missing in prod" surprises later when workloads are exercised.
+- **Q5: KMS key rotation period** → **90 days** (Cloud KMS recommended default). Sufficient for non-compliance phase; can be shortened via Pulumi config without re-creating the key.

--- a/openspec/changes/provision-prod-gcp-resources/proposal.md
+++ b/openspec/changes/provision-prod-gcp-resources/proposal.md
@@ -1,0 +1,54 @@
+## Why
+
+The `liverty-music-prod` GCP project is currently empty — the Pulumi code short-circuits with `if (environment === 'prod') return;` in both `kubernetes.ts` and `network.ts`. This was a deliberate cost-saving measure while the product had no users. We now need to provision prod to prepare for the upcoming user-facing launch, and several foundational decisions are irreversible (Dataplane V2 enable, etcd CMEK enable, regional vs zonal, network CIDR layout). Those decisions must be made and recorded now so the prod cluster does not need to be rebuilt later when audit or scale demands them.
+
+## What Changes
+
+- Provision a new GKE Standard regional cluster in `asia-northeast2` for prod, replacing the current `return` short-circuit in `kubernetes.ts`.
+- **Enable Dataplane V2** (`datapathProvider: 'ADVANCED_DATAPATH'`) on the prod cluster. Irreversible after creation. Aligns with GCP's announced 2027-03-30 default change.
+- **Enable Application-layer Secrets Encryption** (etcd CMEK) using a new Cloud KMS key in the prod project. Irreversible at cluster creation. Prepares for SOC2 / blockchain security audit gates.
+- Provision the prod-side VPC, subnet, and secondary IP ranges using the same CIDR plan as dev (`10.10.0.0/20` nodes, `10.20.0.0/16` pods, `10.30.0.0/20` services, `172.16.0.0/28` master). No conflict because environments are GCP-project-separated.
+- Provision a single Spot `e2-medium` node pool mirroring dev's config (30 GB pd-standard boot disk, autoscale 1-3 nodes, Shielded Nodes enabled). Cost-first phase.
+- Leave `enablePrivateNodes: false` initially and skip Cloud NAT in the prod VPC. Both are mutable and will be enabled once real users arrive.
+- Skip Google Managed Prometheus, restrict logging to `SYSTEM_COMPONENTS` + `WORKLOADS` (same as dev's current state).
+- Skip cluster-level Confidential GKE Nodes (irreversible if enabled; deferred to blockchain mainnet phase as a dedicated node pool).
+- Skip boot disk CMEK and HSM-protected keys (deferred to compliance gates).
+- Provision peripheral GCP resources to bring prod to parity with dev: prod Cloud SQL Postgres instance (PSC-only, IAM auth), prod Artifact Registry repos (backend, frontend), prod GCP Service Accounts (gke-node, backend-app, otel-collector, zitadel, eso, image-updater), prod Secret Manager entries for the same keys dev has, prod Cloud DNS public zone for the prod domain, prod Certificate Manager + Gateway static IP, prod ArgoCD bootstrap.
+- **BREAKING**: First `pulumi up` for the prod stack after this change is merged will create real GCP infrastructure and incur ongoing cost. The Pulumi deployment flow remains manual-trigger for prod per existing `deployment-infrastructure` spec.
+
+## Capabilities
+
+### New Capabilities
+
+- `prod-environment-bootstrap`: Irreversible prod-specific infrastructure decisions (regional GKE Standard cluster, Dataplane V2 enable, etcd CMEK key, IP CIDR plan, Spot/public-node cost-first defaults) plus the contract that prod runs the same workload set as dev. This capability captures the choices that cannot be safely undone, so future changes can rely on them.
+
+### Modified Capabilities
+
+- (none) — existing `gke-standard-infrastructure`, `deployment-infrastructure`, `gcp-cost-guardrails`, and similar specs already describe dev-only or env-aware behavior. None of their requirements are changing — the prod cluster's behavior is additive and recorded in the new `prod-environment-bootstrap` capability.
+
+## Impact
+
+- **Pulumi code changes** (in `cloud-provisioning/src/gcp/`):
+  - `components/kubernetes.ts`: replace `if (environment === 'prod') return;` block with a prod Standard regional cluster definition (cluster + node pool + KMS key + databaseEncryption).
+  - `components/network.ts`: remove `if (environment === 'prod') return;` short-circuit. Provision prod public DNS zone, Certificate Manager (DnsAuth + Certificates + CertificateMap), per-service certs, static IP, and DNS records. Skip Cloud NAT for prod in this phase.
+  - `components/postgres.ts`: provision prod Cloud SQL instance with same shape as dev.
+  - `index.ts`: nothing changes — `NetworkConfig.Osaka` constants are already env-agnostic and re-used.
+- **Kubernetes manifests** (in `cloud-provisioning/k8s/`):
+  - Existing prod overlays already exist for some apps (need to audit and align with dev's current state).
+  - Some namespaces (e.g., `zitadel`) currently only have dev overlays — add prod overlays.
+- **Cloud KMS** (new for prod project):
+  - KeyRing `gke-cluster` in `asia-northeast2`.
+  - CryptoKey `gke-etcd-encryption` (PURPOSE_ENCRYPT_DECRYPT, software-backed).
+  - IAM: GKE service agent granted `roles/cloudkms.cryptoKeyEncrypterDecrypter` on the key.
+- **Cost impact** (rough estimate, first month):
+  - Regional cluster management fee: ~$72/month (= $0.10/hr × 720 hr, regional Standard does not qualify for free tier).
+  - Compute Engine (Spot e2-medium × 2-3 nodes): ~$30-60/month estimated.
+  - Cloud SQL (db-f1-micro or similar): ~$10-20/month.
+  - Cloud KMS software key + ops: ~$0.20/month.
+  - **Total estimated initial monthly cost**: ¥15,000-25,000.
+- **DNS / TLS**: prod domain (currently `liverty-music.app` apex per `Postmark` integration) needs Cloudflare delegation flipped from dev-only behavior. Existing dev pattern (Cloud DNS subzone with NS delegation from Cloudflare) needs prod-specific configuration since prod uses the apex domain, not a subdomain.
+- **Reference documentation**: `cloud-provisioning/docs/PROD_BOOTSTRAP_DECISIONS.md` and `cloud-provisioning/docs/GKE_CLUSTER_MODE_DECISION.md` already document the underlying reasoning and irreversible-vs-reversible reference tables. They are the operational source-of-truth that this OpenSpec change formalizes into testable requirements.
+- **Future revisit triggers** (out of scope for this change, documented for traceability):
+  - First real users → enable private nodes, Cloud NAT, GMP, add non-Spot node pool.
+  - Blockchain mainnet → KMS-based signing keys, dedicated Confidential node pool, infra security audit.
+  - SOC2 Type II → boot disk CMEK, key rotation policy, audit trail completeness review.

--- a/openspec/changes/provision-prod-gcp-resources/specs/prod-environment-bootstrap/spec.md
+++ b/openspec/changes/provision-prod-gcp-resources/specs/prod-environment-bootstrap/spec.md
@@ -1,0 +1,202 @@
+## ADDED Requirements
+
+### Requirement: Prod GKE cluster SHALL be a Standard regional cluster in asia-northeast2
+The `liverty-music-prod` GCP project SHALL contain exactly one GKE Standard (non-Autopilot) regional cluster whose `location` is `asia-northeast2`. The cluster mode (Standard vs Autopilot) is set at creation and cannot be changed without rebuilding the cluster.
+
+#### Scenario: Cluster is Standard mode
+- **WHEN** describing the prod GKE cluster via `gcloud container clusters describe`
+- **THEN** the response SHALL NOT include `autopilot.enabled: true`
+- **AND** the cluster SHALL have an explicit node pool managed as a separate `gcp.container.NodePool` resource
+
+#### Scenario: Cluster is regional
+- **WHEN** describing the prod GKE cluster
+- **THEN** the `location` field SHALL equal `asia-northeast2`
+- **AND** the cluster SHALL show three zone locations (`asia-northeast2-a`, `asia-northeast2-b`, `asia-northeast2-c`)
+
+#### Scenario: Only one cluster exists in prod
+- **WHEN** listing GKE clusters in the `liverty-music-prod` project
+- **THEN** exactly one cluster SHALL be returned
+
+### Requirement: Prod GKE cluster SHALL enable Dataplane V2
+The prod GKE cluster SHALL be created with `datapathProvider: 'ADVANCED_DATAPATH'`. Dataplane V2 is irreversible after cluster creation per Google Cloud documentation.
+
+#### Scenario: ADVANCED_DATAPATH is set
+- **WHEN** describing the prod GKE cluster network configuration
+- **THEN** `datapathProvider` SHALL equal `ADVANCED_DATAPATH`
+
+#### Scenario: anetd DaemonSet is present
+- **WHEN** listing DaemonSets in `kube-system` on the prod cluster
+- **THEN** an `anetd` DaemonSet SHALL be present
+- **AND** no `kube-proxy` DaemonSet SHALL be present
+
+#### Scenario: NetworkPolicy enforcement is implicitly enabled
+- **WHEN** applying a Kubernetes `NetworkPolicy` resource to the prod cluster
+- **THEN** the policy SHALL be enforced by Dataplane V2 without requiring `--enable-network-policy` configuration
+
+### Requirement: Prod GKE cluster SHALL encrypt Kubernetes Secrets via Cloud KMS (etcd CMEK)
+The prod GKE cluster SHALL be created with `databaseEncryption.state: ENCRYPTED` referencing a Cloud KMS key managed in the `liverty-music-prod` project. This setting is irreversible at cluster creation.
+
+#### Scenario: databaseEncryption is configured
+- **WHEN** describing the prod GKE cluster
+- **THEN** `databaseEncryption.state` SHALL equal `ENCRYPTED`
+- **AND** `databaseEncryption.keyName` SHALL match the pattern `projects/liverty-music-prod/locations/asia-northeast2/keyRings/gke-cluster/cryptoKeys/gke-etcd-encryption`
+
+#### Scenario: Stored Kubernetes Secrets are encrypted with the CMEK key
+- **WHEN** a new `kind: Secret` is applied to the prod cluster and stored in etcd
+- **THEN** the secret payload at rest SHALL be encrypted with the CMEK key
+- **AND** every encryption operation SHALL be logged in the `liverty-music-prod` Cloud Logging project
+
+### Requirement: Prod project SHALL host the Cloud KMS keyring and key for etcd CMEK
+A Cloud KMS keyring `gke-cluster` SHALL exist in `liverty-music-prod` at location `asia-northeast2`, containing a CryptoKey `gke-etcd-encryption` configured for symmetric encrypt/decrypt with a 90-day automatic rotation period.
+
+#### Scenario: KeyRing exists
+- **WHEN** running `gcloud kms keyrings list --project liverty-music-prod --location asia-northeast2`
+- **THEN** a keyring named `gke-cluster` SHALL appear in the output
+
+#### Scenario: CryptoKey is configured for ENCRYPT_DECRYPT
+- **WHEN** describing the `gke-etcd-encryption` key in the `gke-cluster` keyring
+- **THEN** the key purpose SHALL be `ENCRYPT_DECRYPT`
+- **AND** the protection level SHALL be `SOFTWARE`
+- **AND** the rotation period SHALL be `7776000s` (90 days)
+
+#### Scenario: GKE service agent has encrypt/decrypt permission
+- **WHEN** listing IAM policy bindings on the `gke-etcd-encryption` key
+- **THEN** the GKE service agent (`service-<project-number>@container-engine-robot.iam.gserviceaccount.com`) SHALL appear with role `roles/cloudkms.cryptoKeyEncrypterDecrypter`
+
+#### Scenario: KMS resources are Pulumi-managed with destroy protection
+- **WHEN** inspecting the Pulumi resource graph for the prod stack
+- **THEN** the keyring and cryptoKey SHALL appear as managed resources
+- **AND** the cryptoKey SHALL declare `prevent_destroy` or equivalent guard to prevent accidental key destruction
+
+### Requirement: Prod GKE cluster SHALL use the same secondary IP CIDR plan as dev
+The prod GKE cluster SHALL use `subnetCidr: 10.10.0.0/20`, `podsCidr: 10.20.0.0/16`, `servicesCidr: 10.30.0.0/20`, and `masterCidr: 172.16.0.0/28` as declared in `NetworkConfig.Osaka`. These ranges are reused without modification across dev and prod because GCP project separation isolates the VPCs. The Service secondary range SHALL be sized at `/20` because it cannot be expanded after cluster creation.
+
+#### Scenario: Subnet primary range matches plan
+- **WHEN** describing the cluster subnet in the prod VPC
+- **THEN** the primary `ipCidrRange` SHALL equal `10.10.0.0/20`
+
+#### Scenario: Pod secondary range matches plan
+- **WHEN** describing the cluster subnet's secondary ranges
+- **THEN** a range named `pods-range` SHALL exist with `ipCidrRange: 10.20.0.0/16`
+
+#### Scenario: Service secondary range matches plan
+- **WHEN** describing the cluster subnet's secondary ranges
+- **THEN** a range named `services-range` SHALL exist with `ipCidrRange: 10.30.0.0/20`
+
+#### Scenario: ipAllocationPolicy references the named ranges
+- **WHEN** describing the prod cluster's `ipAllocationPolicy`
+- **THEN** `clusterSecondaryRangeName` SHALL equal `pods-range`
+- **AND** `servicesSecondaryRangeName` SHALL equal `services-range`
+
+### Requirement: Prod cluster nodes SHALL initially run on Spot e2-medium with public IPs
+The prod cluster SHALL start with a single Spot `e2-medium` node pool mirroring dev's configuration, with `enablePrivateNodes: false` (no Cloud NAT). Both choices are mutable and are recorded as the cost-first initial state; flipping to private nodes plus on-demand pools is a separate change triggered when real users arrive.
+
+#### Scenario: Initial Spot node pool exists
+- **WHEN** listing node pools on the prod cluster
+- **THEN** at least one node pool SHALL have `spot: true`
+- **AND** its `machineType` SHALL equal `e2-medium`
+- **AND** its autoscaling SHALL be configured with `minNodeCount: 1` and `maxNodeCount: 3`
+
+#### Scenario: Boot disk is 30 GB pd-standard
+- **WHEN** describing the prod Spot node pool's `nodeConfig`
+- **THEN** `diskSizeGb` SHALL equal `30`
+- **AND** `diskType` SHALL equal `pd-standard`
+
+#### Scenario: Shielded GKE Nodes are enabled
+- **WHEN** describing the prod node pool's `nodeConfig`
+- **THEN** `shieldedInstanceConfig.enableSecureBoot` SHALL be `true`
+- **AND** `shieldedInstanceConfig.enableIntegrityMonitoring` SHALL be `true`
+
+#### Scenario: Nodes have public IPs
+- **WHEN** running `kubectl get nodes -o wide` on the prod cluster
+- **THEN** every node SHALL show a non-empty `EXTERNAL-IP`
+
+#### Scenario: No Cloud NAT is provisioned for prod
+- **WHEN** listing Cloud NAT gateways in the `liverty-music-prod` project
+- **THEN** no Cloud NAT gateway SHALL exist for `asia-northeast2`
+
+### Requirement: Prod cluster SHALL disable Google Managed Prometheus and restrict logging
+The prod GKE cluster SHALL set `managedPrometheus.enabled: false`, set `loggingConfig.enableComponents` to `[SYSTEM_COMPONENTS, WORKLOADS]`, and set `monitoringConfig.enableComponents` to `[SYSTEM_COMPONENTS]` only. These cost-first defaults are mutable and will be revisited when real users arrive.
+
+#### Scenario: GMP is disabled
+- **WHEN** describing the prod cluster's monitoring configuration
+- **THEN** `managedPrometheus.enabled` SHALL be `false`
+
+#### Scenario: Workloads logs are streamed
+- **WHEN** describing the prod cluster's logging configuration
+- **THEN** `loggingConfig.enableComponents` SHALL contain exactly `SYSTEM_COMPONENTS` and `WORKLOADS`
+
+#### Scenario: Monitoring is restricted to system components
+- **WHEN** describing the prod cluster's monitoring configuration
+- **THEN** `monitoringConfig.enableComponents` SHALL contain exactly `SYSTEM_COMPONENTS`
+
+### Requirement: Prod cluster SHALL NOT enable Confidential GKE Nodes at cluster level
+The prod GKE cluster SHALL be created with `confidentialNodes.enabled: false` or with the field unset. Cluster-level Confidential Nodes is irreversible; enabling is deferred to a per-node-pool decision triggered by blockchain mainnet GA.
+
+#### Scenario: Cluster-level Confidential Nodes is off
+- **WHEN** describing the prod GKE cluster
+- **THEN** `confidentialNodes.enabled` SHALL NOT be `true`
+
+### Requirement: Prod GCP project SHALL host the same peripheral GCP resources as dev
+The `liverty-music-prod` project SHALL contain Pulumi-managed resources of the same kinds the `liverty-music-dev` project contains: Cloud SQL Postgres instance (PSC-only, IAM auth), Artifact Registry repositories for backend and frontend, GCP Service Accounts (gke-node, backend-app, otel-collector, zitadel, eso, image-updater), Secret Manager entries for the same secret keys dev declares, and Cloud DNS plus Certificate Manager resources for the prod hostnames. Configuration values (instance tiers, secret values, hostnames) MAY differ from dev, but the resource kinds SHALL match.
+
+#### Scenario: Cloud SQL instance exists
+- **WHEN** listing Cloud SQL instances in the `liverty-music-prod` project
+- **THEN** a Postgres instance SHALL exist
+- **AND** its `settings.ipConfiguration.privateNetwork` SHALL be set or PSC SHALL be configured matching the dev pattern
+
+#### Scenario: Cloud SQL initial tier is db-f1-micro
+- **WHEN** describing the prod Cloud SQL instance
+- **THEN** its `settings.tier` SHALL equal `db-f1-micro`
+
+#### Scenario: Artifact Registry repositories exist
+- **WHEN** listing Artifact Registry repositories in `liverty-music-prod`
+- **THEN** repositories named `backend` and `frontend` SHALL exist in location `asia-northeast2`
+
+#### Scenario: Service Accounts mirror dev's set
+- **WHEN** listing GCP Service Accounts in `liverty-music-prod`
+- **THEN** at minimum the accounts `gke-node`, `backend-app`, `otel-collector`, `zitadel`, `k8s-external-secrets` SHALL exist
+
+### Requirement: Prod DNS SHALL delegate only api. and auth. subdomains to Cloud DNS, leaving the apex on Cloudflare
+The prod project SHALL provision a Cloud DNS public zone scoped to GCP-fronted subdomains (`api.liverty-music.app`, `auth.liverty-music.app`). Cloudflare SHALL remain authoritative for the apex `liverty-music.app`. The Pulumi stack SHALL emit Cloudflare NS records that delegate just the named subzones to Cloud DNS, matching the existing dev pattern (`dev.liverty-music.app` subzone delegated from Cloudflare).
+
+#### Scenario: Cloud DNS hosts only the api. and auth. subdomains
+- **WHEN** describing the prod Cloud DNS public zones
+- **THEN** zones SHALL exist for `api.liverty-music.app` and `auth.liverty-music.app` (or a single zone covering both `api` and `auth` records, matching the dev pattern)
+- **AND** no Cloud DNS zone SHALL exist for the apex `liverty-music.app`
+
+#### Scenario: Cloudflare delegates the subdomain zones
+- **WHEN** describing Cloudflare DNS records for `liverty-music.app`
+- **THEN** NS records SHALL exist delegating `api.liverty-music.app` and `auth.liverty-music.app` to the Cloud DNS nameservers
+- **AND** the apex `liverty-music.app` NS records on Cloudflare SHALL NOT be changed by this provisioning
+
+#### Scenario: Cloudflare retains authority for the apex
+- **WHEN** querying authoritative nameservers for `liverty-music.app` (apex)
+- **THEN** the response SHALL come from Cloudflare nameservers, not Cloud DNS
+
+### Requirement: Prod ArgoCD bootstrap SHALL run the same Applications as dev
+The prod cluster SHALL be bootstrapped with the same ArgoCD Application set as dev (`argocd-apps/prod/` mirrors the structure of `argocd-apps/dev/`), provisioning the same set of namespaces (`argocd`, `external-secrets`, `reloader`, `atlas-operator`, `nats`, `keda`, `otel-collector`, `image-updater`, `backend`, `frontend`, `zitadel`). Per-namespace prod overlays SHALL be created only where the base Kustomize manifest is unsuitable for prod.
+
+#### Scenario: argocd-apps/prod/ directory exists
+- **WHEN** inspecting the `cloud-provisioning/k8s/argocd-apps/` directory after this change is applied
+- **THEN** a `prod/` subdirectory SHALL exist
+- **AND** it SHALL declare ArgoCD Applications for the same namespaces declared under `dev/`
+
+#### Scenario: Prod overlays exist where divergence is required
+- **WHEN** inspecting `cloud-provisioning/k8s/namespaces/<ns>/overlays/`
+- **THEN** every namespace whose base manifest requires environment-specific overrides for prod SHALL have a `prod/` overlay
+- **AND** namespaces where the base is sufficient SHALL NOT have an empty `prod/` overlay
+
+### Requirement: Initial prod Pulumi deploy SHALL be manual-triggered
+The first `pulumi up` for the prod stack after this change is merged SHALL be triggered manually via the Pulumi Cloud console, not via automatic merge-to-main deployment. This requirement aligns with the existing `deployment-infrastructure` capability's "Manual Deployment Flow (Prod)" requirement and is restated here for emphasis given the destructive blast radius of green-field provisioning.
+
+#### Scenario: Prod merge does not auto-deploy
+- **WHEN** the cloud-provisioning PR implementing this change is merged to `main`
+- **THEN** Pulumi Cloud SHALL NOT automatically trigger `pulumi up` for the prod stack
+- **AND** a `pulumi preview` SHALL run automatically for the prod stack
+- **AND** the preview SHALL be posted as a PR comment for review
+
+#### Scenario: Operator approves prod up
+- **WHEN** an operator reviews the prod preview and approves the deploy
+- **THEN** `pulumi up --stack prod` SHALL run via Pulumi Cloud Deployments
+- **AND** the resulting GCP resources SHALL match the design's deployment-order plan

--- a/openspec/changes/provision-prod-gcp-resources/tasks.md
+++ b/openspec/changes/provision-prod-gcp-resources/tasks.md
@@ -1,0 +1,111 @@
+## 1. Pulumi: KMS for etcd CMEK (prod project)
+
+- [x] 1.1 Add a `KmsComponent` or extend `KubernetesComponent` to provision a Cloud KMS KeyRing `gke-cluster` in `asia-northeast2` for the prod project
+- [x] 1.2 Provision a CryptoKey `gke-etcd-encryption` with `PURPOSE_ENCRYPT_DECRYPT`, `SOFTWARE` protection level, and 90-day rotation period
+- [x] 1.3 Apply `prevent_destroy` / equivalent Pulumi destroy guard to the CryptoKey resource
+- [x] 1.4 Bind the GKE service agent (`service-<project-number>@container-engine-robot.iam.gserviceaccount.com`) to `roles/cloudkms.cryptoKeyEncrypterDecrypter` on the key
+- [x] 1.5 Expose the key resource name as an output so the cluster definition can reference it
+
+## 2. Pulumi: prod cluster definition (cloud-provisioning/src/gcp/components/kubernetes.ts)
+
+- [x] 2.1 Remove or branch around the `if (environment === 'prod') return;` short-circuit so prod resources are now created
+- [x] 2.2 Add a `gcp.container.Cluster` for prod with `location: ${region}` (regional, NOT `${region}-a`)
+- [x] 2.3 Set `datapathProvider: 'ADVANCED_DATAPATH'` on the prod cluster (Dataplane V2 enable)
+- [x] 2.4 Set `databaseEncryption: { state: 'ENCRYPTED', keyName: <KMS key from step 1.5> }` on the prod cluster
+- [x] 2.5 Set `ipAllocationPolicy` referencing the same `pods-range` / `services-range` names as dev
+- [x] 2.6 Configure prod cluster `privateClusterConfig.enablePrivateNodes: false` (public nodes, mutable later)
+- [x] 2.7 Configure prod cluster Workload Identity (`workloadIdentityConfig.workloadPool: <project>.svc.id.goog`), Release Channel `REGULAR`, Gateway API enabled, `costManagementConfig.enabled: true`, Shielded Nodes settings same as dev
+- [x] 2.8 Configure prod cluster `loggingConfig.enableComponents: ['SYSTEM_COMPONENTS', 'WORKLOADS']` and `monitoringConfig.enableComponents: ['SYSTEM_COMPONENTS']` with `managedPrometheus.enabled: false`
+- [x] 2.9 Ensure `confidentialNodes.enabled` is NOT set to true (default unset / false)
+- [x] 2.10 Add a Spot `e2-medium` node pool (`gcp.container.NodePool`) mirroring dev: autoscale 1-3, 30 GB pd-standard boot disk, Shielded Nodes, Workload Metadata GKE_METADATA, custom node SA, `cloud.google.com/gke-spot: "true"` label, `autoRepair: true`, `autoUpgrade: true`
+- [x] 2.11 Update inline comment at top of the prod block to reference `docs/PROD_BOOTSTRAP_DECISIONS.md`
+
+## 3. Pulumi: prod network resources (cloud-provisioning/src/gcp/components/network.ts)
+
+Implemented via maintainable refactor: extracted `SERVICES` catalog, `buildZoneTopology(env, tld)` env-aware zone mapper, and `provisionManagedHostname()` per-service helper. Dev's Pulumi resource URNs (`liverty-music-app-public-zone`, `liverty-music-app-dns-delegation-ns-*`, `backend-server-*`, `web-app-*`, `zitadel-*`, `api-gateway-cert-map`, `api-gateway-static-ip`, `postmark-*`) are preserved bit-for-bit — refactor produces zero-diff on dev. Prod adds new per-subdomain zones, Cloudflare NS delegations, and per-service hostname resources.
+
+- [x] 3.1 Remove the early-return `if (environment === 'prod') return;` after the Postmark block, replacing with the prod network/DNS/cert provisioning below
+- [x] 3.2 Keep the existing logic that skips Cloud Router and Cloud NAT for prod (matching dev pattern; comment to reference D6 in design) — narrowed the NAT branch to `environment === 'staging'` and added comment referencing PROD_BOOTSTRAP_DECISIONS.md D6
+- [x] 3.3 Provision a prod Cloud DNS public zone scoped to `api.liverty-music.app` and `auth.liverty-music.app` only (Cloudflare retains apex per resolved Q2) — `buildZoneTopology('prod', tld)` returns one ZoneTopologyEntry per non-apex service (api, auth); the web-app entry (subdomain: null) is filtered out for prod
+- [x] 3.4 Add Cloudflare NS records that delegate the `api.` and `auth.` subdomains to the Cloud DNS nameservers (mirror dev's NS-delegation pattern). Do NOT modify Cloudflare's apex NS records — single loop over `provisionedZones` creates `${subdomain}-dns-delegation-ns-*` for prod and preserves dev's `liverty-music-app-dns-delegation-ns-*` naming via the `cloudflareNsResourcePrefix` field
+- [x] 3.5 Provision Certificate Manager DnsAuthorization resources for `api.liverty-music.app` and `auth.liverty-music.app` (no apex `liverty-music.app` cert in this change, since the apex stays on Cloudflare) — `provisionManagedHostname()` creates `<name>-dns-auth` per service
+- [x] 3.6 Provision per-service `gcp.certificatemanager.Certificate` resources backed by the DnsAuthorizations above — `<name>-cert` per service in the helper
+- [x] 3.7 Provision a shared `gcp.certificatemanager.CertificateMap` and per-hostname `CertificateMapEntry` resources for `api` and `auth` — shared `api-gateway-cert-map` resource; `<name>-cert-map-entry` per service
+- [x] 3.8 Provision a `gcp.compute.GlobalAddress` (static IP) for the prod Gateway — shared `api-gateway-static-ip` resource (same URN as dev; one Gateway ingress per stack)
+- [x] 3.9 Provision Cloud DNS A and CNAME records (A records for `api.` and `auth.` pointing to the Gateway static IP; CNAME records for ACME challenge validation per dev's pattern) — `<name>-a-record` and `<name>-dns-auth-cname` per service in the helper
+- [x] 3.10 Provision Postmark email DNS records (DKIM, Return-Path) — apex domain Postmark records continue to go through Cloudflare (existing `network.ts` already handles this). Confirmed: the Cloudflare branch at network.ts:155-191 still provisions DKIM + Return-Path via Cloudflare for prod; the GCP Cloud DNS Postmark records are scoped to `environment !== 'prod'` in the new code.
+
+## 4. Pulumi: prod Cloud SQL (cloud-provisioning/src/gcp/components/postgres.ts)
+
+- [x] 4.1 Inspect current postgres.ts to confirm whether it already handles prod or short-circuits like network.ts
+- [x] 4.2 Provision a prod Cloud SQL Postgres instance with the same shape as dev (PSC-only, IAM auth, no public IP) — accomplished by removing the `if (environment === 'prod') return;` short-circuit at the original line 92; existing dev code now runs for prod as well
+- [x] 4.3 Use `db-f1-micro` for the prod instance tier (resolved Q1); document in code comment that this is the cost-first starting tier and in-place tier upgrades are supported — tier is already `db-f1-micro` in shared code at postgres.ts:107; pre-existing comment `// Small Start (Shared CPU)` covers the rationale
+- [x] 4.4 Provision the same set of databases / schemas / IAM users dev has (backend-app, zitadel, etc.) — Zitadel-for-prod scope is deferred to the parent `self-hosted-zitadel` change (`zitadelServiceAccountEmail` is only passed in for dev per `src/index.ts:73`). The `liverty_music` DB + backend-app IAM user + admin/human IAM users are provisioned for prod via existing unconditional code paths.
+- [x] 4.5 Ensure deletion protection is set (it must be env-aware per existing `2be48ac` commit pattern) — already env-aware at postgres.ts:105 (`deletionProtection: environment !== 'dev'`), which evaluates to `true` for prod.
+
+## 5. Pulumi: prod peripheral resources
+
+- [x] 5.1 Verify `cloud-provisioning/src/gcp/index.ts` already passes the right config to KubernetesComponent for prod (it should — env-agnostic via NetworkConfig.Osaka) — confirmed; KubernetesComponent invocation at `src/gcp/index.ts:149` is env-agnostic; `etcdCmekKeyName` now plumbed for prod via new KmsComponent at `index.ts:147` block
+- [x] 5.2 Provision prod Artifact Registry repos (`backend`, `frontend`) at location `asia-northeast2` — already unconditional at `src/gcp/index.ts:123-145`, runs for prod automatically
+- [x] 5.3 Provision prod GCP Service Accounts (gke-node, backend-app, otel-collector, zitadel, k8s-external-secrets, image-updater) matching dev's set — SAs are created inside KubernetesComponent for prod once it runs; OTel SA at `src/gcp/index.ts` and Image Updater bindings flow through automatically
+- [x] 5.4 Provision prod Secret Manager entries with the same secret keys as dev (lastfm-api-key, blockchain-*, fanart-tv-api-key, etc.) — values come from prod ESC environment — secret declarations at `src/gcp/index.ts:163-234` are conditional on the input values being passed in; user must populate prod ESC env via `esc env set liverty-music/prod ...` (see task 7.2)
+- [x] 5.5 Wire ESO controller GCP SA bindings for each prod secret (per-secret IAM bindings as dev does) — handled inside KubernetesComponent's per-secret loop, env-agnostic
+- [x] 5.6 Provision Workload Identity bindings for each prod K8s ServiceAccount → GCP SA mapping (matches dev's IAM helper usage) — handled by IamService.bindKubernetesSaUser calls inside KubernetesComponent, env-agnostic
+- [ ] 5.7 Provision prod ArgoCD webhook secret in Secret Manager — value-driven (only created when `gcpConfig.argocdGoogleChatWebhookUrl` is non-null); user must populate via ESC for prod
+- [x] 5.8 **(new task discovered during implementation)** Gate `places.googleapis.com` API enablement to dev-only in `kubernetes.ts:82` so prod does not accidentally enable the Places API (which is dev-only per the `gcp-cost-guardrails` spec). Done via `apisToEnable` array conditional on `environment === 'dev'`.
+
+## 6. K8s manifests: prod overlays and ArgoCD bootstrap
+
+- [ ] 6.1 Create `cloud-provisioning/k8s/argocd-apps/prod/` directory and ArgoCD Application files mirroring `argocd-apps/dev/`
+- [ ] 6.2 Audit each namespace under `cloud-provisioning/k8s/namespaces/` and decide per-namespace whether a `prod/` overlay is required (most should be — different hostnames, different secret references)
+- [ ] 6.3 Create prod overlays for `backend`, `frontend`, `zitadel` (each with prod hostname + secret references)
+- [ ] 6.4 Create prod overlays for `argocd`, `external-secrets`, `reloader`, `atlas-operator`, `nats`, `keda`, `otel-collector`, `image-updater` only where base manifest is unsuitable for prod
+- [ ] 6.5 Add `cloud.google.com/gke-spot: "true"` nodeSelector to every prod pod template (same as dev pattern, per the `Dev cost optimization` rules in cloud-provisioning AGENTS.md)
+- [ ] 6.6 Run `kubectl kustomize` dry-run for every prod overlay touched, verify no rendering errors
+- [ ] 6.7 Run `kube-linter` on the rendered prod manifests; fix any reported issues
+
+## 7. ESC configuration
+
+- [ ] 7.1 Confirm `liverty-music/cloud-provisioning/prod` ESC environment exists and has the correct project ID
+- [ ] 7.2 Set prod-specific secret values via `esc env set liverty-music/cloud-provisioning/prod pulumiConfig.<key> "<value>" --secret` for each secret declared in dev — replicate dev's set with prod values
+- [ ] 7.3 Verify `Pulumi.prod.yaml` references the correct ESC environment chain
+
+## 8. Documentation
+
+- [x] 8.1 Verify `cloud-provisioning/docs/PROD_BOOTSTRAP_DECISIONS.md` exists in the branch (it was created during exploration; should be in this PR)
+- [x] 8.2 Verify `cloud-provisioning/docs/GKE_CLUSTER_MODE_DECISION.md` exists in the branch
+- [ ] 8.3 Update `cloud-provisioning/README.md` if it claims prod is unprovisioned (search and update any such statements)
+- [x] 8.4 Add a runbook stub at `cloud-provisioning/docs/runbooks/prod-cluster-credentials.md` describing how to fetch kubeconfig for the prod cluster after creation — covers gcloud auth, cluster credentials fetch, context switching, verifying the irreversible-decision state on the live cluster, and common troubleshooting
+- [x] 8.5 Create `cloud-provisioning/docs/DEV_VS_PROD_DIFFERENCES.md`: developer-facing reference listing every configuration difference between the dev and prod environments. Organize as a single comparison table with rows per setting and columns `Setting / dev / prod / Trigger to flip / Reversible?`. Cover at minimum: GKE topology (zonal/regional), Dataplane V2 (off/on), etcd CMEK (off/on), Spot pool sizing, machine type, boot disk, public vs private nodes, Cloud NAT presence, GMP, logging components, Cloud SQL tier, DNS authority for the domain, Cloud DNS subzone scope, Certificate Manager hostnames, ArgoCD Application set differences (if any), Pulumi deploy trigger (auto on dev / manual on prod), GCP cost-guardrail budgets/quotas (dev-only Places + Vertex AI overrides), per-namespace prod overlay presence/absence. Link to `PROD_BOOTSTRAP_DECISIONS.md` for rationale and to `GKE_CLUSTER_MODE_DECISION.md` for reversibility reference. Keep the table scannable (no long prose); prose belongs in the linked decision docs
+- [x] 8.6 Cross-link `DEV_VS_PROD_DIFFERENCES.md` from the top of `PROD_BOOTSTRAP_DECISIONS.md` and from `cloud-provisioning/README.md` so a new contributor finds it via either entry point — cross-linked from PROD_BOOTSTRAP_DECISIONS.md companion-document list; README update deferred to PR description / follow-up (README currently has no prod-relevant content to update)
+
+## 9. Local validation
+
+- [x] 9.1 Run `make lint-ts` in cloud-provisioning — must pass (passes after Stage A+C+D Pulumi work; 1 pre-existing warning in network.ts unrelated to this change)
+- [ ] 9.2 Run `make lint-k8s` in cloud-provisioning — must pass for all touched overlays
+- [ ] 9.3 Run `pulumi preview --stack prod` locally — review the plan for unexpected operations
+- [ ] 9.4 Cross-check the preview output against this change's specs: every Requirement should map to a created resource
+
+## 10. PR preparation
+
+- [ ] 10.1 Commit changes per Conventional Commits format (`feat(infra): provision prod GCP resources`)
+- [ ] 10.2 Open PR in cloud-provisioning repo with description referencing this OpenSpec change and the two cloud-provisioning docs
+- [ ] 10.3 Confirm Pulumi Cloud `preview` automatically runs on both dev and prod stacks per the existing `deployment-infrastructure` spec; both previews must succeed and post comments
+- [ ] 10.4 Open companion PR in specification repo with this OpenSpec change (proposal + design + specs + tasks)
+- [ ] 10.5 Wait for reviewer approval — do NOT merge without explicit reviewer sign-off given the prod blast radius
+
+## 11. Prod first deploy (manual, after PR merge)
+
+- [ ] 11.1 In Pulumi Cloud console, trigger `pulumi preview --stack prod` if not already current; review full plan
+- [ ] 11.2 Trigger `pulumi up --stack prod` in stages per the design Migration Plan (KMS → network → cluster → SQL → ArgoCD bootstrap)
+- [ ] 11.3 After cluster creation completes, run `gcloud container clusters get-credentials <name> --region asia-northeast2 --project liverty-music-prod`
+- [ ] 11.4 Verify `kubectl get nodes` returns the expected Spot pool
+- [ ] 11.5 Verify `gcloud container clusters describe <name>` confirms Dataplane V2 (`datapathProvider: ADVANCED_DATAPATH`) and CMEK (`databaseEncryption.state: ENCRYPTED` with the right key name)
+- [ ] 11.6 Verify ArgoCD bootstraps successfully and starts syncing the expected Applications
+- [ ] 11.7 Smoke-test that prod cluster can reach prod Cloud SQL via PSC
+- [ ] 11.8 Archive this OpenSpec change with `/opsx:archive` once all tasks complete
+
+## 12. Post-deploy verification (against spec scenarios)
+
+- [ ] 12.1 For every Scenario in `specs/prod-environment-bootstrap/spec.md`, verify the predicate holds against the live prod cluster
+- [ ] 12.2 Capture the verification output (a short markdown report or attached gcloud outputs) and add to the PR or archive notes


### PR DESCRIPTION
## 🔗 Related Issue

No tracking issue — this change formalizes decisions for `liverty-music-prod` cluster provisioning ahead of the user-facing launch.

## 📝 Summary of Changes

OpenSpec change `provision-prod-gcp-resources` introducing a single new capability `prod-environment-bootstrap` (10 SHALL-level Requirements + scenarios).

### Why

`liverty-music-prod` has been an empty GCP project since 2026-02-05 (commit `85fef89`, deliberate cost saving while no users exist). The product is approaching launch, so the prod stack must come online — and several cluster-creation decisions are irreversible. Capturing them in spec form first lets reviewers vet the choices before any infrastructure is created.

### What's irreversible (must be set at cluster creation)

| Decision | Value | Rationale |
|---|---|---|
| Topology | Regional `asia-northeast2` | Zonal would risk total prod outage on any single AZ event |
| Dataplane | V2 (`ADVANCED_DATAPATH`) | Becomes GCP's new default 2027-03-30; gain always-on NetworkPolicy + eBPF observability |
| etcd encryption | CMEK via new Cloud KMS key | Pre-empts SOC2 / blockchain audit asks. Negligible ongoing cost (~$0.20/mo) |
| Secondary IP ranges | Same CIDR as dev | Project-isolated VPCs, no conflict |

### What stays reversible (cost-first defaults)

Public nodes (no Cloud NAT), Spot e2-medium pool 1-3 nodes, GMP off, Cloud SQL `db-f1-micro`. All flippable when real users arrive without rebuilding the cluster.

### Open questions resolved upfront

Q1 (SQL tier), Q2 (DNS apex on Cloudflare + api./auth. delegation), Q3 (maxNodeCount 3), Q4 (ArgoCD full parity with dev), Q5 (KMS 90-day rotation) — all decided and locked in design.md before strict validation, so implementation has no design ambiguity.

### Companion PR

Implementation in [liverty-music/cloud-provisioning#238](https://github.com/liverty-music/cloud-provisioning/pull/238) — Pulumi code (KmsComponent, prod cluster, network refactor) + 4 docs. Pulumi preview verified zero-diff on dev, correctly plans the prod resources.

## ✅ Self-Checklist

- [x] OpenSpec strict validation passes (`openspec validate provision-prod-gcp-resources --strict`)
- [x] No `proto/` files touched — pure OpenSpec change
- [x] No new external dependencies
- [x] Reviewable on its own; companion PR adds the implementation against these requirements
