### PR TITLE
docs(openspec): record R7 (bootstrap-uploader Scenario 2 gap) for rename-zitadel-machine-keys

### DIFF
--- a/openspec/changes/rename-zitadel-machine-keys/design.md
+++ b/openspec/changes/rename-zitadel-machine-keys/design.md
@@ -118,6 +118,19 @@ The `self-hosted-zitadel` change was archived on 2026-05-11, so the spec target 
 
 **[R6] Verbose Go field name** — `ZitadelMachineKeyForBackendAppPath` is 33 chars (vs the prior 21). → **Mitigation:** referenced only at DI wiring (3 sites); not user-facing; readability of `envconfig` tag matters more.
 
+**[R7] `bootstrap-uploader` dual-write does not fire on already-bootstrapped instances** — The sidecar's `while [ ! -f "$KEY_FILE" ]; do sleep 2; done` loop blocks until Zitadel writes the admin key file to the shared `emptyDir`. Per the "Subsequent boots skip bootstrap" scenario in `zitadel-self-hosted-deployment`, that write only happens on first-instance bootstrap against an empty database; subsequent pod restarts leave the sidecar idling forever. → **Consequence:** PR 10's dual-write code path is only exercised on a fresh Zitadel instance. On an already-bootstrapped environment (e.g., dev at the time this change rolls out), the new GSM secret `zitadel-machine-key-for-pulumi-admin` will exist as an empty resource shell with no `SecretVersion`, and PR 11 (Pulumi switches to read the new name) would fail authentication. → **Mitigation:** between PR 10 deploy and PR 11 author/merge, an operator SHALL perform a **one-shot manual seed** of the new secret from the legacy `zitadel-admin-sa-key` value:
+
+```bash
+TMP=$(mktemp)
+gcloud secrets versions access latest --secret=zitadel-admin-sa-key \
+  --project=liverty-music-dev --out-file="$TMP"
+gcloud secrets versions add zitadel-machine-key-for-pulumi-admin \
+  --project=liverty-music-dev --data-file="$TMP"
+shred -u "$TMP"
+```
+
+The seed is byte-identical to the legacy secret, so once `bootstrap-uploader` does eventually fire (next first-instance bootstrap), its idempotency check (`if [ "$existing" = "$(cat "$KEY_FILE")" ]; then ... skipping upload`) treats the seeded value as already-current and does NOT overwrite. **Spec invariant note:** the documented invariant "only legitimate write to admin-sa-key SHALL be performed by `bootstrap-uploader`" is preserved in spirit — the seeded value is byte-equal to the value `bootstrap-uploader` would have written — but the writer of record for this one-time copy is the operator, not the sidecar. The transition completes the moment PR 12 destroys the legacy resource.
+
 ## Migration Plan
 
 ### backend-app key — 6-step zero-downtime split

--- a/openspec/changes/rename-zitadel-machine-keys/design.md
+++ b/openspec/changes/rename-zitadel-machine-keys/design.md
@@ -121,7 +121,12 @@ The `self-hosted-zitadel` change was archived on 2026-05-11, so the spec target 
 **[R7] `bootstrap-uploader` dual-write does not fire on already-bootstrapped instances** — The sidecar's `while [ ! -f "$KEY_FILE" ]; do sleep 2; done` loop blocks until Zitadel writes the admin key file to the shared `emptyDir`. Per the "Subsequent boots skip bootstrap" scenario in `zitadel-self-hosted-deployment`, that write only happens on first-instance bootstrap against an empty database; subsequent pod restarts leave the sidecar idling forever. → **Consequence:** PR 10's dual-write code path is only exercised on a fresh Zitadel instance. On an already-bootstrapped environment (e.g., dev at the time this change rolls out), the new GSM secret `zitadel-machine-key-for-pulumi-admin` will exist as an empty resource shell with no `SecretVersion`, and PR 11 (Pulumi switches to read the new name) would fail authentication. → **Mitigation:** between PR 10 deploy and PR 11 author/merge, an operator SHALL perform a **one-shot manual seed** of the new secret from the legacy `zitadel-admin-sa-key` value:
 
 ```bash
+set -euo pipefail
 TMP=$(mktemp)
+# Guarantee cleanup even on SIGINT / network hang. Without the trap,
+# Ctrl+C during a hung `gcloud secrets versions add` leaves the
+# admin SA private key sitting unshredded on local disk.
+trap 'shred -u "$TMP" 2>/dev/null || rm -f "$TMP"' EXIT
 gcloud secrets versions access latest --secret=zitadel-admin-sa-key \
   --project=liverty-music-dev --out-file="$TMP"
 gcloud secrets versions add zitadel-machine-key-for-pulumi-admin \

--- a/openspec/changes/rename-zitadel-machine-keys/tasks.md
+++ b/openspec/changes/rename-zitadel-machine-keys/tasks.md
@@ -91,8 +91,9 @@
 - [ ] 10.2 In `cloud-provisioning/src/gcp/index.ts` (or wherever the admin-sa GSM secret is declared), declare the new `zitadel-machine-key-for-pulumi-admin` `SecretManagerSecret` resource so Pulumi tracks the resource lifecycle (the value is written by the sidecar, but the resource itself exists in Pulumi state)
 - [ ] 10.3 Verify `pulumi preview` shows `+ create` for the new SecretManagerSecret only
 - [ ] 10.4 Open PR, description declares `Depends on: none — first step of pulumi-admin migration`
-- [ ] 10.5 After merge, trigger a Zitadel pod restart in dev (or wait for natural rotation); verify `bootstrap-uploader` logs show successful write to both GSM names
-- [ ] 10.6 Verify `gcloud secrets versions list zitadel-machine-key-for-pulumi-admin` returns at least one version
+- [ ] 10.5 After merge, trigger a Zitadel pod restart in dev (or wait for natural rotation). **Expected: bootstrap-uploader logs show `waiting for /var/zitadel/bootstrap/admin-sa.json` and idle indefinitely** on already-bootstrapped instances — Zitadel only writes the key file on first-instance bootstrap, so the dual-write code path does not fire. See design.md R7
+- [ ] 10.6 **One-shot manual seed** (consequence of R7): copy the legacy `zitadel-admin-sa-key` value into the new `zitadel-machine-key-for-pulumi-admin` so PR 11 has a populated source to read from. Use `gcloud secrets versions access ... --out-file` + `gcloud secrets versions add --data-file` via a `mktemp`'d file with restrictive permissions; `shred -u` the file immediately after upload. Verify with `diff` that both secret payloads are byte-identical before progressing
+- [ ] 10.7 Verify `gcloud secrets versions list zitadel-machine-key-for-pulumi-admin` returns at least one version
 
 ## 11. pulumi-admin PR 2 (cp) — Pulumi reads NEW GSM secret
 


### PR DESCRIPTION
## Summary

Doc-only follow-up to the merged `rename-zitadel-machine-keys` change ([#446](https://github.com/liverty-music/specification/pull/446)). Captures a post-merge discovery during deployment verification:

**Discovery**: PR 10's `bootstrap-uploader` dual-write loop only fires on first-instance bootstrap (empty database). On an already-bootstrapped environment — e.g., dev at the time this change rolls out — Zitadel does not re-write the admin key file to the shared `emptyDir`, so the sidecar idles forever in `while [ ! -f "$KEY_FILE" ]; do sleep 2; done`. The new GSM secret `zitadel-machine-key-for-pulumi-admin` thus exists as an empty shell, and PR 11 (Pulumi switches to read the new name) would fail provider authentication.

## What this PR adds

- **`design.md` R7** — full risk write-up + workaround (one-shot manual seed via `gcloud secrets versions access` → `--out-file` → `gcloud secrets versions add --data-file` → `shred -u`). Notes the spec invariant ("only `bootstrap-uploader` writes admin-sa-key") is preserved in spirit because the seeded value is byte-equal to what the sidecar would write.
- **`tasks.md` 10.6** — explicit step inserted between PR 10's dual-write deploy and PR 11's Pulumi provider switch. Renames the existing version-list verification step to 10.7.

## Mitigation already executed

The one-shot seed was performed in `liverty-music-dev` shortly after PR 10 ([#242](https://github.com/liverty-music/cloud-provisioning/pull/242)) merged:

```
gcloud secrets versions list zitadel-machine-key-for-pulumi-admin --project=liverty-music-dev
# → 1 enabled 2026-05-13T01:11:11
diff -q <(legacy admin-sa-key) <(new pulumi-admin-key)
# → no output (byte-identical)
```

Temp files were created with `umask 077` (mode 600), used briefly, and `shred -u`'d after upload.

## Why doc-only PR

The migration plan itself (proposal/specs/PR sequencing) is unchanged. Only the design-time risk catalog and the operator-facing task list need updating to reflect the Scenario 2 reality so future operators (rolling this out to staging/prod) don't repeat the live discovery.

## Test plan

- [ ] `openspec validate rename-zitadel-machine-keys` — passes locally (verified).
- [ ] Reviewer confirms R7 wording captures both the failure mode and the operator-facing workaround.
- [ ] On archive, the R7 section merges into archived design history; the new tasks.md step is reflected in the final change record.
