### PR TITLE
openspec: k8s-naming-cleanup change (rename + prod overlay scaffold)

### DIFF
--- a/openspec/changes/k8s-naming-cleanup/design.md
+++ b/openspec/changes/k8s-naming-cleanup/design.md
@@ -1,0 +1,150 @@
+# Design — k8s-naming-cleanup
+
+## Decisions
+
+### 1. Hostname patch strategy: both overlays patch; base has no `hostnames`
+
+`base/httproute.yaml` currently hardcodes `auth.dev.liverty-music.app` — env-specific value leaking into base. Moving the field to per-environment overlays makes the env-leak explicit and matches how `backend/base/server/httproute.yaml` and `frontend/base/web/httproute.yaml` already work (those files omit `hostnames` entirely — they don't need scoping because they don't have a `/` catch-all rule).
+
+Zitadel's HTTPRoute is special: it has a `/` catch-all rule (`/ui/v2/login` plus everything-else → API). Without an explicit `hostnames` filter, the `/` catch-all would intercept all Gateway traffic, breaking `backend` and `frontend` routing. Hostname scoping is therefore **load-bearing** for zitadel and must be preserved per environment.
+
+**Implementation**:
+
+```yaml
+# base/httproute.yaml — REMOVE hostnames field
+spec:
+  parentRefs: [...]
+  # hostnames removed
+  rules: [...]
+
+# overlays/dev/httproute-patch.yaml — NEW
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: zitadel-route
+spec:
+  hostnames:
+  - auth.dev.liverty-music.app
+
+# overlays/prod/httproute-patch.yaml — NEW
+spec:
+  hostnames:
+  - auth.liverty-music.app
+```
+
+Both overlay `kustomization.yaml`s add the patch entry.
+
+Prod hostname is the bare apex `auth.liverty-music.app` — prod is treated as the canonical environment (no env subdomain). Dev gets the `*.dev.liverty-music.app` family as the alternate. Must be aligned with GCP cert map prod-IP binding (out of scope; prerequisite).
+
+### 2. Prod replicas + node pool: `replicas: 2` + spot
+
+| Resource | Dev | Prod (chosen) |
+|---|---|---|
+| `zitadel-api` replicas | 1 | **2** |
+| `zitadel-web` replicas | 1 | **2** |
+| Node pool | spot | **spot** (cost-driven) |
+| Pod anti-affinity | base — `hostname` topology, `requiredDuringScheduling` | inherits base |
+| PDB `minAvailable` | 0 (dev relaxed) | **1** (base) |
+
+**Rationale for spot in prod**:
+- Service has not yet launched — cost matters more than rock-solid uptime
+- Base already has `podAntiAffinity` requiring different hosts per replica ([deployment-api.yaml:40-47](cloud-provisioning/k8s/namespaces/zitadel/base/deployment-api.yaml#L40-L47)) — this is exactly the spot-tolerance safeguard. Comment at L38-39: "Keep both replicas on different nodes so a single Spot preemption cannot take the entire API plane down."
+- PDB `minAvailable: 1` (base) + replicas 2 → at most one pod can be voluntarily evicted at a time
+- Spot preemption guarantees ≤30s graceful drain notice; with 2 replicas on different hosts, the surviving replica continues serving while the evicted one rescheduled
+
+**Acknowledged risks**:
+- Simultaneous preemption of both spot nodes is rare but possible. If it happens, ≤30s window where both pods rescheduling concurrently. Acceptable pre-launch.
+- Eviction during a deploy can compound: rolling update + spot preemption could briefly land at 0 ready. `maxSurge: 1, maxUnavailable: 0` (base) keeps the deploy from going below 1 voluntarily, but spot can take 1 below 1 involuntarily.
+
+Revisit `non-spot` once traffic exists / SLO matters more than dev/prod parity.
+
+### 3. ArgoCD prod Application: created in this change
+
+Add `argocd-apps/prod/zitadel.yaml` mirroring `argocd-apps/dev/zitadel.yaml` but pointing at `k8s/namespaces/zitadel/overlays/prod`.
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: zitadel
+  namespace: argocd
+  finalizers:
+  - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/liverty-music/cloud-provisioning.git
+    targetRevision: main
+    path: k8s/namespaces/zitadel/overlays/prod
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: zitadel
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+    - CreateNamespace=true
+    - ServerSideApply=true
+```
+
+**Open prerequisite** (out of scope, must precede prod sync):
+- Prod ArgoCD instance bootstrapped (currently only dev ArgoCD exists; `argocd-apps/dev/` is the only argocd-apps directory)
+- Prod Cloud SQL DB + Postgres admin secret (`zitadel-postgres-admin-password` in GSM prod)
+- Prod GSM secrets backing the ExternalSecrets (`zitadel-machine-key-for-backend-app-prod`, etc.)
+- Prod ESC environment values (`liverty-music/prod`)
+- Prod GCP cert map binding `auth.{prod-hostname}` → prod Gateway static IP
+
+Because these prereqs are absent at the moment, ArgoCD will report `OutOfSync` / `Healthy: Missing` until they exist. The Application file lands in source, and sync becomes useful once prereqs are provisioned in a follow-up. **No syncPolicy adjustment** — we want ArgoCD to start syncing immediately once prereqs land, not require a separate flip.
+
+### 4. Container short-naming
+
+Confirmed from proposal: `zitadel` → `api` (in `zitadel-api` Deployment), `zitadel-login` → `web` (in `zitadel-web` Deployment). Log readability:
+
+```
+Before: kubectl logs -n zitadel deploy/zitadel -c zitadel
+After:  kubectl logs -n zitadel deploy/zitadel-api -c api
+```
+
+Sidecars (`cloud-sql-proxy`, `bootstrap-uploader`) keep their existing names — they're shared patterns elsewhere in the platform.
+
+### 5. Service-link env-var comment update
+
+[deployment-api.yaml:30-36](cloud-provisioning/k8s/namespaces/zitadel/base/deployment-api.yaml#L30-L36) explains why `enableServiceLinks: false` is needed:
+
+> Without this, the `zitadel` Service in this namespace injects `ZITADEL_PORT=tcp://<ip>:80` into every pod, which Viper then parses as the top-level Zitadel config field `Port` (expected uint16) — causing startup to fail.
+
+After rename, the conflicting env var name becomes `ZITADEL_API_PORT` (Service `zitadel-api` → service-link env vars are `ZITADEL_API_*`). Viper would map this to `Api.Port` — Zitadel has no such config field, so the conflict actually *goes away*. But `enableServiceLinks: false` stays defensively (other Services could be added; the flag is cheap insurance).
+
+**Action**: update the comment to reflect the new Service name and clarify that the original conflict no longer applies after rename but the flag stays defensively.
+
+### 6. Stale comment cleanup
+
+[deployment-login.yaml:37-38](cloud-provisioning/k8s/namespaces/zitadel/base/deployment-login.yaml#L37-L38):
+
+```
+# ZITADEL_API_URL points at the in-cluster API Service so the login UI
+# can call the API without egressing the cluster.
+```
+
+This contradicts the actual value (`https://auth.dev.liverty-music.app`) and the detailed rationale a few lines below (L59-71). Leftover from before [cloud-provisioning#214](https://github.com/liverty-music/cloud-provisioning/pull/214). Removed as part of this change (the file is being renamed anyway).
+
+## Trade-offs explored and rejected
+
+### Hostname strategy B: keep base = dev hostname, prod patches only
+Rejected because base would continue to embed env-specific data. The dev overlay would have no httproute artifact while prod would — asymmetric.
+
+### Hostname strategy C: Kustomize replacements + ConfigMap variable
+Rejected as over-engineering. No other namespace uses Kustomize `replacements` for hostnames; introducing the pattern for one value across two overlays is not worth the cognitive overhead.
+
+### Replicas: 3 + non-spot
+Rejected for cost during pre-launch. Pod anti-affinity already gives 2-replicas-on-different-nodes guarantee; 3rd replica adds cost without proportional safety on spot.
+
+### ArgoCD Application deferred to separate change
+Rejected by explicit user decision: bundle Application in this change so the source tree captures the complete prod topology at once. The Application's `OutOfSync` state until prereqs land is an acceptable interim signal.
+
+## Out-of-scope cleanups noted
+
+- `concert-data-store` namespace MAY have similar naming drift; deferred to a follow-up change.
+- Backend / frontend HTTPRoutes have inconsistencies vs zitadel (no `hostnames`, no path-prefix rules) — that's a Gateway-level routing topology question, separately worth designing. Out of scope here.
+- Prod ESC / Pulumi / GCP cert map / prod ArgoCD bootstrap — flagged as prerequisites, tracked via the natural OutOfSync signal on the new Application.

--- a/openspec/changes/k8s-naming-cleanup/design.md
+++ b/openspec/changes/k8s-naming-cleanup/design.md
@@ -6,7 +6,7 @@
 
 `base/httproute.yaml` currently hardcodes `auth.dev.liverty-music.app` — env-specific value leaking into base. Moving the field to per-environment overlays makes the env-leak explicit and matches how `backend/base/server/httproute.yaml` and `frontend/base/web/httproute.yaml` already work (those files omit `hostnames` entirely — they don't need scoping because they don't have a `/` catch-all rule).
 
-Zitadel's HTTPRoute is special: it has a `/` catch-all rule (`/ui/v2/login` plus everything-else → API). Without an explicit `hostnames` filter, the `/` catch-all would intercept all Gateway traffic, breaking `backend` and `frontend` routing. Hostname scoping is therefore **load-bearing** for zitadel and must be preserved per environment.
+Zitadel's HTTPRoute is special: it has two rules — a path-prefix match for `/ui/v2/login` (→ `zitadel-web`) and a `/` catch-all (→ `zitadel-api`). Without an explicit `hostnames` filter, the `/` catch-all would intercept all Gateway traffic, breaking `backend` and `frontend` routing. Hostname scoping is therefore **load-bearing** for zitadel and must be preserved per environment.
 
 **Implementation**:
 

--- a/openspec/changes/k8s-naming-cleanup/proposal.md
+++ b/openspec/changes/k8s-naming-cleanup/proposal.md
@@ -5,12 +5,16 @@ K8s resource naming across the platform's namespaces is inconsistent. The `self-
 The mismatch shows up at every operator touchpoint:
 
 - `kubectl get deploy -n zitadel` returns `zitadel`, `zitadel-login` — operator must know that `zitadel` here means the API tier, not the namespace.
-- `ZITADEL_API_URL` in `deployment-login.yaml` points at `https://auth.dev.liverty-music.app`, but for in-cluster shortcut diagnostics the Service name is `zitadel.zitadel.svc.cluster.local` — the doubly-`zitadel` qualifier is confusing.
-- HTTPRoute `backendRefs` in `httproute.yaml` reference `zitadel` and `zitadel-login` Services; renaming Services means coordinated updates across the route, the Deployment selector, the PDB selector, and the HealthCheckPolicy targetRef.
+- In-cluster Service DNS reads `zitadel.zitadel.svc.cluster.local` — the doubly-`zitadel` qualifier is confusing for anyone diagnosing routing.
+- HTTPRoute `backendRefs` in `httproute.yaml` reference `zitadel` and `zitadel-login` Services; the same names appear in PDB selectors, Deployment selectors, and HealthCheckPolicy `targetRef`s — every cross-reference repeats the inconsistent naming.
 
-This change standardizes the zitadel namespace on `zitadel-api` (API container) and `zitadel-web` (Login V2 UI container), matching the platform's existing `<role>-<tier>` convention. Container names follow (`api`, `web`) for log-readability. The rename window is brief but does require ArgoCD to perform delete-then-create on the renamed Deployment / Service / PDB resources, so it is scheduled as a deliberate change rather than ridden along an unrelated PR.
+Alongside the rename, the zitadel namespace currently has only a `dev` overlay; a `prod` overlay is required before the service launches. Bundling the prod overlay scaffold with the rename keeps the renamed identifiers as the single canonical naming the prod overlay learns — avoiding a "prod inherits old names, immediately gets renamed" churn.
+
+This change standardizes the zitadel namespace on `zitadel-api` (API container) and `zitadel-web` (Login V2 UI container), matching the platform's existing `<role>-<tier>` convention. Container names follow (`api`, `web`) for log-readability. ArgoCD performs delete-then-create on renamed resources; **the service has not yet launched, so no user-facing impact and no maintenance window required**.
 
 ## What Changes
+
+### Rename (base + dev overlay)
 
 - **Zitadel namespace Deployments SHALL be renamed**:
   - `zitadel` → `zitadel-api`
@@ -18,19 +22,34 @@ This change standardizes the zitadel namespace on `zitadel-api` (API container) 
 - **Zitadel namespace Services SHALL be renamed**:
   - `zitadel` → `zitadel-api`
   - `zitadel-login` → `zitadel-web`
-- **`HTTPRoute` `backendRefs`, `PodDisruptionBudget` `selector`s, `HealthCheckPolicy` `targetRef`s** SHALL be updated to point at the new names.
+- **`HTTPRoute` `backendRefs`, `PodDisruptionBudget` `selector`s + `metadata.name`s, `HealthCheckPolicy` `targetRef`s + `metadata.name`s** SHALL be updated to point at the new names.
 - **Container names within the Deployments SHALL be renamed**:
   - In `zitadel-api`: `zitadel` → `api`. Sidecars (`cloud-sql-proxy`, `bootstrap-uploader`) keep their existing names.
   - In `zitadel-web`: `zitadel-login` → `web`.
-- **The `ZITADEL_API_URL` env var on `zitadel-web`** SHALL continue to point at the public URL (`https://auth.dev.liverty-music.app`) per the existing `self-hosted-zitadel` requirement; the rename is for cluster-internal naming clarity only.
-- **Brief downtime** during ArgoCD's delete-then-create on renamed resources is acceptable in `dev`. PDB `minAvailable: 0` (already in place per `optimize-dev-gke-cost`) cleanly permits the eviction.
-- **No other namespaces are touched in this change** — out-of-scope but tracked: `backend/server/atlas/external-secrets/reloader/argocd/cloudflared` already follow `<role>-<tier>`; the `concert-data-store` namespace MAY have similar drift but is deferred to a follow-up.
+- **The `ZITADEL_API_URL` env var on `zitadel-web`** SHALL continue to point at the public URL (`https://auth.dev.liverty-music.app`) per the existing `self-hosted-zitadel` requirement; the rename is for cluster-internal naming clarity only. The stale header comment in `deployment-login.yaml` (lines 37–38, "ZITADEL_API_URL points at the in-cluster API Service…") is leftover from before the public-URL cutover (cloud-provisioning#214) and SHALL be removed at the same time.
+
+### Prod overlay scaffold (new)
+
+- **`overlays/prod/` SHALL be created**, mirroring the structural pattern of `overlays/dev/` but with prod-appropriate values. Exact parameter choices (replica count, node pool, image policy, hostname patch strategy) are deferred to `design.md`. The minimum scaffold:
+  - `overlays/prod/kustomization.yaml` — references `../../base`; **does not include `cronjob-restart-zitadel.yaml`** (that resource is an explicit dev-only band-aid for `self-hosted-zitadel` §18.6 hang, scoped to dev by design — see the dev kustomization comment).
+  - Patches for the renamed Deployments (`zitadel-api`, `zitadel-web`) with prod replica + nodeSelector posture.
+  - HTTPRoute hostname patch — base currently hardcodes `auth.dev.liverty-music.app`; prod requires its own hostname. Resolution strategy (move hostname out of base into per-env patches vs override via a JSON patch in prod) is a `design.md` decision.
+- **Open prod-overlay design questions** captured in `design.md`:
+  - Hostname strategy (where does `auth.<env>.liverty-music.app` live?)
+  - Replica count and PDB inheritance (`minAvailable: 1` from base, vs higher floor for prod)
+  - Node pool / spot vs non-spot (current dev uses `cloud.google.com/gke-spot: "true"`)
+  - Resource requests/limits for prod load profile
+
+### Out of scope
+
+- Other namespaces: `backend/server/atlas/external-secrets/reloader/argocd/cloudflared` already follow `<role>-<tier>`; `concert-data-store` MAY have similar drift but is deferred to a follow-up change.
+- Prod ESC/Pulumi resources backing the new `prod` overlay (Cloud SQL DB, IAM, Secret Manager entries for prod Zitadel). The scaffold uses placeholder values that prod-resource provisioning will replace; tracked separately.
 
 ## Capabilities
 
 ### Modified Capabilities
 
-- `zitadel-self-hosted-deployment`: Three requirements that name resources (`zitadel-api Deployment`, `zitadel-web Deployment`, in-cluster Service URL) SHALL be updated to use the new names. The semantics of each requirement (two-container layout, public Gateway URL, Cloud SQL proxy sidecar pattern) do not change.
+- `zitadel-self-hosted-deployment`: Three requirements that name resources (`zitadel-api Deployment`, `zitadel-web Deployment`, in-cluster Service URL) SHALL be updated to use the new names. The semantics of each requirement (two-container layout, public Gateway URL, Cloud SQL proxy sidecar pattern) do not change. A new requirement SHALL describe the per-environment overlay pattern (dev = current cost-optimized posture; prod = scaffold per this change with design-determined parameters).
 
 ### New Capabilities
 
@@ -42,29 +61,40 @@ None.
 
 ## Impact
 
-**Affected files**
+**Affected files (rename)**
 
-- `cloud-provisioning/k8s/namespaces/zitadel/base/deployment-api.yaml` — file rename + `metadata.name` change + container `name`.
-- `cloud-provisioning/k8s/namespaces/zitadel/base/deployment-login.yaml` → `deployment-web.yaml` — file rename + `metadata.name` change + container `name`.
+- `cloud-provisioning/k8s/namespaces/zitadel/base/deployment-api.yaml` — `metadata.name` change + container `name`.
+- `cloud-provisioning/k8s/namespaces/zitadel/base/deployment-login.yaml` → renamed to `deployment-web.yaml` — `metadata.name` change + container `name` + remove stale header comment.
 - `cloud-provisioning/k8s/namespaces/zitadel/base/service-api.yaml` — `metadata.name` + selector.
-- `cloud-provisioning/k8s/namespaces/zitadel/base/service-login.yaml` → `service-web.yaml` — file rename + `metadata.name` + selector.
-- `cloud-provisioning/k8s/namespaces/zitadel/base/httproute.yaml` — `backendRefs[].name`.
-- `cloud-provisioning/k8s/namespaces/zitadel/base/pdb.yaml` — selector for both PDBs.
-- `cloud-provisioning/k8s/namespaces/zitadel/base/kustomization.yaml` — file list.
-- `cloud-provisioning/k8s/namespaces/zitadel/overlays/dev/{deployment-patch,deployment-login-patch,pdb-patch}.yaml` — patch targets renamed.
+- `cloud-provisioning/k8s/namespaces/zitadel/base/service-login.yaml` → renamed to `service-web.yaml` — `metadata.name` + selector.
+- `cloud-provisioning/k8s/namespaces/zitadel/base/httproute.yaml` — `backendRefs[].name` (2 rules).
+- `cloud-provisioning/k8s/namespaces/zitadel/base/pdb.yaml` — `metadata.name` + selector for both PDBs.
+- `cloud-provisioning/k8s/namespaces/zitadel/base/healthcheckpolicy.yaml` — `metadata.name` + `targetRef.name` for both HealthCheckPolicies.
+- `cloud-provisioning/k8s/namespaces/zitadel/base/kustomization.yaml` — resource file list (renamed entries).
+- `cloud-provisioning/k8s/namespaces/zitadel/overlays/dev/kustomization.yaml` — patch `target.name`s.
+- `cloud-provisioning/k8s/namespaces/zitadel/overlays/dev/deployment-patch.yaml` — `metadata.name`.
+- `cloud-provisioning/k8s/namespaces/zitadel/overlays/dev/deployment-login-patch.yaml` → renamed to `deployment-web-patch.yaml` — `metadata.name`.
+- `cloud-provisioning/k8s/namespaces/zitadel/overlays/dev/pdb-patch.yaml` — `metadata.name`s for both PDBs.
+
+**Affected files (prod overlay scaffold)**
+
+- `cloud-provisioning/k8s/namespaces/zitadel/overlays/prod/kustomization.yaml` — new file; mirrors dev structure minus the dev-only CronJob.
+- `cloud-provisioning/k8s/namespaces/zitadel/overlays/prod/deployment-api-patch.yaml` — new file; prod replica + nodeSelector posture.
+- `cloud-provisioning/k8s/namespaces/zitadel/overlays/prod/deployment-web-patch.yaml` — new file; prod replica + nodeSelector posture.
+- Additional files (hostname patch, PDB patch if needed) determined in `design.md`.
 
 **Affected systems**
 
 - Cluster-internal callers of the Zitadel API service: only the `zitadel-web` Login UI container, via `ZITADEL_API_URL`. Since `ZITADEL_API_URL` is the public URL (per the cutover spec), no Service-name update is needed there. If any future consumer adopts the in-cluster shortcut (`zitadel-api.zitadel.svc.cluster.local`), it picks up the new name natively.
+- ArgoCD `dev` Application: performs delete-then-create on renamed Deployments / Services / PDBs / HealthCheckPolicies. With the service not yet launched, this is a clean rebuild — no eviction concerns.
+- ArgoCD `prod` Application: needs to be created/wired to point at the new `overlays/prod/` directory. Whether this is in scope of this change or done as part of prod-resource provisioning is a `design.md` decision.
 
 **Reversibility**
 
-- Single revert of the merge commit recreates the old names. ArgoCD performs the inverse delete-then-create rollback. PDB `minAvailable: 0` makes the eviction window symmetric.
-
-**Downtime**
-
-- ArgoCD performs delete-then-create on renamed Deployments / Services. With `replicas: 1` (dev) and `minAvailable: 0`, expect ~30–60 s of `auth.dev.liverty-music.app` unavailability per Deployment rename. Schedule outside business hours; coordinate with whoever is running E2E.
+- Single revert of the merge commit recreates the old names. ArgoCD performs the inverse delete-then-create rollback. The prod overlay scaffold is removed by the revert as well; no orphan resources because prod hasn't synced yet (or has synced placeholders only).
 
 **Dependencies**
 
-- Requires `self-hosted-zitadel` archived. Independent of the other three follow-ups but coordination-friendly with `rename-zitadel-machine-key-secret` if both are scheduled in the same maintenance window.
+- Requires `self-hosted-zitadel` archived ✓ (archived 2026-05-11).
+- Independent of `rename-zitadel-machine-keys` ✓ (archived 2026-05-13); the two are now decoupled.
+- Prod-resource provisioning (Cloud SQL, IAM, GSM) is **NOT** required for this change to merge; the prod overlay scaffold may render to manifests that reference yet-to-exist secrets/DBs, but ArgoCD only syncs prod once the prod Application is created and resources exist. The scaffold lands in source first.

--- a/openspec/changes/k8s-naming-cleanup/specs/zitadel-self-hosted-deployment/spec.md
+++ b/openspec/changes/k8s-naming-cleanup/specs/zitadel-self-hosted-deployment/spec.md
@@ -1,0 +1,111 @@
+## MODIFIED Requirements
+
+### Requirement: Two-Container Deployment with Path-Based Routing
+
+The system SHALL deploy Zitadel as two separate Kubernetes Deployments — one for the API container (`ghcr.io/zitadel/zitadel`, port `8080`, Deployment name `zitadel-api`, container name `api`) and one for the Login V2 UI container (`ghcr.io/zitadel/zitadel-login`, port `3000`, Deployment name `zitadel-web`, container name `web`) — and SHALL expose both through a single hostname via a GKE Gateway `HTTPRoute` that routes the path prefix `/ui/v2/login` to the Web Service (`zitadel-web`) and all other paths to the API Service (`zitadel-api`).
+
+**Rationale**: Zitadel v4 split the Login UI into a dedicated container. Keeping both on the same hostname preserves OIDC issuer identity; path-based routing avoids the extra DNS and certificate surface of a second hostname. Resource names follow the platform-wide `<role>-<tier>` convention (`zitadel-api`, `zitadel-web`) so operator tooling (`kubectl get -n zitadel`, in-cluster DNS) is unambiguous; container names are the short forms (`api`, `web`) for log readability. The image path is `ghcr.io/zitadel/zitadel-login`, NOT `ghcr.io/zitadel/login` (the latter 404s); the upstream Helm chart default uses the same path.
+
+#### Scenario: API request reaches the API container
+
+- **WHEN** a request arrives at `https://auth.dev.liverty-music.app/oauth/v2/keys`
+- **THEN** the HTTPRoute SHALL forward the request to the `zitadel-api` Service on port `8080`
+
+#### Scenario: Login UI request reaches the Web container
+
+- **WHEN** a browser requests `https://auth.dev.liverty-music.app/ui/v2/login/register`
+- **THEN** the HTTPRoute SHALL forward the request to the `zitadel-web` Service on port `3000`
+
+#### Scenario: HealthCheckPolicy targets the renamed Services
+
+- **WHEN** the GKE Gateway evaluates backend health
+- **THEN** a `HealthCheckPolicy` named `zitadel-api-policy` SHALL target the `zitadel-api` Service with probe path `/debug/healthz`
+- **AND** a `HealthCheckPolicy` named `zitadel-web-policy` SHALL target the `zitadel-web` Service with probe path `/ui/v2/login`
+
+### Requirement: Login V2 UI Calls Zitadel API via Public URL
+
+The `zitadel-web` container SHALL set `ZITADEL_API_URL` to the public issuer URL (`https://auth.dev.liverty-music.app`), NOT the cluster-internal Service URL (`http://zitadel-api.zitadel.svc.cluster.local`).
+
+**Rationale**: Zitadel v4 selects the virtual instance from the request's `Host` header and matches it against the configured `InstanceDomains`. The cluster-internal Service hostname is not registered as an InstanceDomain, so calls with `Host: zitadel-api.zitadel.svc.cluster.local` return HTTP 404 before reaching any handler — the Login UI's SSR sees `Failed to fetch security settings ... status:404` and returns HTTP 500. Setting `ZITADEL_API_URL` to the public URL makes the Login UI's outbound calls carry the correct `Host` header. Traffic still stays in-cluster (`zitadel-web` Pod → Gateway external IP → HTTPRoute `/` catch-all → `zitadel-api` Service); the Gateway round-trip adds ~10ms versus a direct Service hop, acceptable for dev. The naming rename (`zitadel`→`zitadel-api`, `zitadel-login`→`zitadel-web`) does not affect this behavior — it only changes the cluster-internal hostname that is, by design, NOT used here.
+
+#### Scenario: Login UI Pod reaches Zitadel API via the public hostname
+
+- **WHEN** the `zitadel-web` Pod issues an outbound request to fetch instance settings
+- **THEN** the request URL SHALL be `https://auth.dev.liverty-music.app/...` (or the prod equivalent in prod)
+- **AND** the resulting `Host` header SHALL match the configured `ExternalDomain`
+- **AND** Zitadel SHALL resolve the request to the correct virtual instance
+
+#### Scenario: Login UI does not bypass the Gateway
+
+- **WHEN** the `zitadel-web` Pod's `ZITADEL_API_URL` is configured
+- **THEN** the value SHALL be the public HTTPS URL (terminated at the Gateway)
+- **AND** the value SHALL NOT be the cluster-internal Service URL — that bypass produces 404s because the Service hostname is not in `InstanceDomains`
+
+### Requirement: Resilient Scheduling on Shared Spot Node Pool
+
+The Zitadel API (`zitadel-api`) and Web (`zitadel-web`) Deployments SHALL each be authored against the base manifest with `replicaCount: 2`, a `PodDisruptionBudget` of `minAvailable: 1`, a required `podAntiAffinity` on `kubernetes.io/hostname`, a readiness probe pointed at the component's health endpoint (`/debug/ready` for API; `/ui/v2/login` for Web), and a rolling update strategy of `maxUnavailable: 0`. The `dev` overlay MAY relax `replicaCount` and `minAvailable` per the `optimize-dev-gke-cost` change to trade resilience for cost; the `prod` overlay SHALL inherit the base values for replica count and PDB while explicitly applying the Spot-pool `nodeSelector`.
+
+**Rationale**: Both `dev` and `prod` overlays target the shared Spot node pool pre-launch. Base `podAntiAffinity` (hostname topology) prevents a single preemption from taking both replicas; the readiness probe holds Gateway traffic off until migrations complete. In `dev`, the `optimize-dev-gke-cost` change collapses both Deployments to `replicas: 1` and PDBs to `minAvailable: 0` — anti-affinity becomes a no-op for a single pod, and the relaxed PDB is what lets that single pod drain during node upgrades. The dev posture explicitly accepts a brief auth outage per node event for cost savings. The prod posture keeps base resilience (2 replicas, PDB ≥1) but stays on Spot until service traffic justifies non-Spot allocation.
+
+#### Scenario: Replicas land on different nodes (base / prod)
+
+- **WHEN** two `zitadel-api` pods are scheduled in `prod` (or in any environment whose overlay does not collapse `replicaCount` to 1)
+- **THEN** they SHALL land on different Kubernetes nodes
+- **AND** an unscheduled third pod (e.g., during a rollout surge) SHALL wait for a different node to become available
+
+#### Scenario: Single-replica dev Deployment drains cleanly during node upgrade
+
+- **WHEN** the `dev` overlay reduces `replicaCount` to 1 and PDB `minAvailable` to 0
+- **AND** the cluster autoscaler or a node upgrade evicts the node hosting the Zitadel pod
+- **THEN** the eviction SHALL succeed (PDB does not block)
+- **AND** the Deployment SHALL re-schedule the pod onto another spot node
+- **AND** the auth outage during this gap SHALL be acceptable per the dev cost posture
+
+#### Scenario: Unready pod is excluded from Gateway backend
+
+- **WHEN** a Zitadel pod is starting or running a migration
+- **THEN** its readiness probe SHALL return non-200 until ready
+- **AND** the Gateway SHALL NOT route traffic to that pod until the probe succeeds
+
+## ADDED Requirements
+
+### Requirement: Per-Environment Overlay Topology
+
+The Zitadel namespace SHALL provide both `overlays/dev/` and `overlays/prod/` Kustomize overlays, each importing from `overlays/../base`, such that the renamed canonical names (`zitadel-api`, `zitadel-web`) are present in any rendered manifest tree. The `prod` overlay SHALL match the `dev` overlay's structural shape (kustomization, Deployment patches, HTTPRoute hostname patch) but SHALL NOT include resources scoped to `dev` only (notably the weekly restart CronJob marked with the `liverty-music.app/temporary` annotation).
+
+The HTTPRoute `hostnames` field SHALL NOT appear in `base/httproute.yaml`; instead each overlay SHALL contribute a patch that supplies its environment-specific hostname (`auth.dev.liverty-music.app` for dev; `auth.liverty-music.app` for prod, treating prod as the canonical apex). Both overlays SHALL apply the Spot-pool `nodeSelector` to both Deployments.
+
+**Rationale**: Production-readiness of the manifest topology must land in source before prod ArgoCD picks it up — otherwise prod would briefly inherit the old (pre-rename) names and immediately churn. The hostname-out-of-base discipline keeps `base/` free of environment-specific values and mirrors how `backend` and `frontend` HTTPRoutes work (no hostnames in base). The dev-only CronJob is an explicit band-aid scoped to dev's `self-hosted-zitadel` §18.6 hang; prod must not silently inherit it.
+
+#### Scenario: Prod overlay renders the renamed resources
+
+- **WHEN** `kubectl kustomize k8s/namespaces/zitadel/overlays/prod` is executed
+- **THEN** the rendered output SHALL contain a Deployment named `zitadel-api` with a container named `api`
+- **AND** a Deployment named `zitadel-web` with a container named `web`
+- **AND** Services named `zitadel-api` and `zitadel-web`
+- **AND** PodDisruptionBudgets named `zitadel-api` and `zitadel-web`
+- **AND** HealthCheckPolicies named `zitadel-api-policy` and `zitadel-web-policy`
+- **AND** an HTTPRoute with `hostnames: [auth.liverty-music.app]`
+
+#### Scenario: Dev overlay renders its hostname patch
+
+- **WHEN** `kubectl kustomize k8s/namespaces/zitadel/overlays/dev` is executed
+- **THEN** the rendered HTTPRoute SHALL have `hostnames: [auth.dev.liverty-music.app]`
+- **AND** the rendered overlay SHALL still include the dev-only `cronjob-restart-zitadel` CronJob
+
+#### Scenario: Prod overlay omits the dev-only CronJob
+
+- **WHEN** `kubectl kustomize k8s/namespaces/zitadel/overlays/prod` is executed
+- **THEN** the rendered output SHALL NOT contain any CronJob named `restart-zitadel` (or any CronJob carrying the `liverty-music.app/temporary` annotation)
+
+#### Scenario: Base HTTPRoute has no hostnames field
+
+- **WHEN** `base/httproute.yaml` is inspected
+- **THEN** the `spec.hostnames` field SHALL be absent
+- **AND** rendering the base directly (without an overlay) SHALL produce an HTTPRoute without `hostnames`
+
+#### Scenario: Prod ArgoCD Application targets the prod overlay
+
+- **WHEN** the ArgoCD Application source `k8s/argocd-apps/prod/zitadel.yaml` is reconciled
+- **THEN** its `spec.source.path` SHALL be `k8s/namespaces/zitadel/overlays/prod`
+- **AND** its `spec.syncPolicy.automated` SHALL be enabled with `prune: true` and `selfHeal: true`

--- a/openspec/changes/k8s-naming-cleanup/specs/zitadel-self-hosted-deployment/spec.md
+++ b/openspec/changes/k8s-naming-cleanup/specs/zitadel-self-hosted-deployment/spec.md
@@ -96,7 +96,15 @@ The HTTPRoute `hostnames` field SHALL NOT appear in `base/httproute.yaml`; inste
 #### Scenario: Prod overlay omits the dev-only CronJob
 
 - **WHEN** `kubectl kustomize k8s/namespaces/zitadel/overlays/prod` is executed
-- **THEN** the rendered output SHALL NOT contain any CronJob named `restart-zitadel` (or any CronJob carrying the `liverty-music.app/temporary` annotation)
+- **THEN** the rendered output SHALL NOT contain any CronJob named `zitadel-restart` (or any CronJob carrying the `liverty-music.app/temporary` annotation)
+
+#### Scenario: Prod overlay overrides env-specific values from base
+
+- **WHEN** `kubectl kustomize k8s/namespaces/zitadel/overlays/prod` is executed
+- **THEN** the rendered `zitadel-web` Deployment's container env SHALL include `ZITADEL_API_URL: https://auth.liverty-music.app`
+- **AND** the rendered `zitadel-config` ConfigMap SHALL have `ZITADEL_EXTERNALDOMAIN: auth.liverty-music.app`
+- **AND** the rendered `zitadel-config` ConfigMap SHALL have `ZITADEL_DATABASE_POSTGRES_USER_USERNAME: zitadel@liverty-music-prod.iam`
+- **AND** the rendered `zitadel-config` ConfigMap SHALL have `ZITADEL_DATABASE_POSTGRES_ADMIN_USERNAME: zitadel@liverty-music-prod.iam`
 
 #### Scenario: Base HTTPRoute has no hostnames field
 

--- a/openspec/changes/k8s-naming-cleanup/tasks.md
+++ b/openspec/changes/k8s-naming-cleanup/tasks.md
@@ -2,131 +2,150 @@
 
 ## 1. Repo-wide audit (find every reference)
 
-- [ ] 1.1 `git grep -nE '\bzitadel(-login)?\b'` across the cloud-provisioning repo to list every reference to the old names. Bucket the hits:
-  - K8s manifests (in-scope)
-  - Pulumi source (`src/**`) — likely some `MachineUser.userName` references; check whether they should also rename
-  - Comments / docs (in-scope, opportunistic clean-up)
-  - Tests / fixtures
-- [ ] 1.2 Confirm `backend` Go source has NO hardcoded reference to the Service hostname `zitadel.zitadel.svc.cluster.local` (it uses public URL per `self-hosted-zitadel` requirements; verify).
-- [ ] 1.3 Confirm `frontend` source has NO hardcoded reference to either name.
-- [ ] 1.4 Decide whether `MachineUser.userName: zitadel` (if any) is in or out of scope; default: out — Pulumi resource names are an internal artifact, the K8s rename is independent.
+- [x] 1.1 `git grep -nE '\bzitadel(-login)?\b'` across the cloud-provisioning repo. Buckets:
+  - **In-scope** K8s manifests: `k8s/namespaces/zitadel/base/*`, `k8s/namespaces/zitadel/overlays/dev/*`
+  - **In-scope** K8s Secret rename (consumer-encoded name): `zitadel-login-pat` → `zitadel-web-pat` (ExternalSecret resource + target K8s Secret + file). GSM-side key name stays per Pulumi ownership.
+  - **Marginal touch-up** comments referring to the renamed Deployment by name:
+    - `k8s/namespaces/otel-collector/base/deployment.yaml:11` — "Pairs with the same annotation on the `zitadel` Deployment" → `zitadel-api`
+    - `src/gcp/components/zitadel-monitoring.ts:160` and `:255` — runbook hints (`kubectl rollout restart deployment/zitadel`)
+  - **Out-of-scope** (different naming axis or upstream-derived):
+    - Pulumi `src/zitadel/components/**` — Zitadel-side concepts (Provider/Org/Project), upstream SDK package, MachineUser names. None of these are K8s resource names.
+    - `src/gcp/components/{network,postgres,kubernetes}.ts` — `zitadelApp = 'zitadel'` Pulumi resource ids, namespace name, cert map name, SA name. Unchanged.
+    - `k8s/argocd-apps/dev/zitadel.yaml` — Application name is top-level (one per namespace), not tied to renamed Deployments.
+    - `k8s/cluster/base/cluster-secret-store.yaml:12 - zitadel` — namespace allowlist entry; namespace name unchanged.
+    - `k8s/namespaces/backend/{server,consumer}/**` — `zitadel-machine-key-*` references use the `zitadel-machine-key-for-<principal>` GSM convention (separate rename axis, archived in `rename-zitadel-machine-keys`).
+    - Image path `ghcr.io/zitadel/zitadel-login` — upstream artifact name, NOT the K8s container/Deployment name.
+    - Container `zitadel-config` ConfigMap, `zitadel-secrets` Secret, `zitadel-db-grant` Job, `zitadel-restart` CronJob — orthogonal names not tied to API/Login tiers.
+    - `external-secret.yaml: name: zitadel-secrets` — namespace-scoped secrets name. Unchanged.
+    - K8s ServiceAccount name `zitadel` — namespace-shared SA; renaming cascades to GCP IAM SA and Workload Identity binding. Out of scope.
+- [x] 1.2 Backend `git grep -nE 'zitadel(-login)?\.zitadel\.svc'` returned 0 matches. Confirmed: no cluster-internal hostname references in backend Go source.
+- [x] 1.3 Frontend `git grep` returned only `urn:zitadel:iam:...` URN (Zitadel-protocol identifier, unrelated to K8s) and `/zitadel\.cloud/` OTel ignore regex (legacy hostname, separate concern). No K8s resource references.
+- [x] 1.4 Decision: Pulumi `MachineUser.userName` and other Pulumi resource ids are out of scope. K8s rename is independent.
 
 ## 2. Base manifest renames (`k8s/namespaces/zitadel/base/`)
 
-- [ ] 2.1 `deployment-api.yaml`:
-  - [ ] 2.1.1 `metadata.name`: `zitadel` → `zitadel-api`
-  - [ ] 2.1.2 `metadata.labels.app`: keep `zitadel`; `component`: keep `api` (already correct)
-  - [ ] 2.1.3 `spec.selector.matchLabels` / `spec.template.metadata.labels`: keep `app: zitadel, component: api`
-  - [ ] 2.1.4 Container `name`: `zitadel` → `api`
-  - [ ] 2.1.5 Update header comment (the `enableServiceLinks: false` block at L30-37): change `ZITADEL_PORT` → `ZITADEL_API_PORT` in the explanatory text; note that after rename, the Viper-config conflict no longer materializes but the flag stays as defensive insurance.
-  - [ ] 2.1.6 Verify the `podAntiAffinity.matchLabels` (`app: zitadel, component: api`) still references the labels (labels are unchanged, only resource name changes).
+- [x] 2.1 `deployment-api.yaml`:
+  - [x] 2.1.1 `metadata.name`: `zitadel` → `zitadel-api`
+  - [x] 2.1.2 `metadata.labels.app`: keep `zitadel`; `component`: keep `api` (already correct, verified)
+  - [x] 2.1.3 `spec.selector.matchLabels` / `spec.template.metadata.labels`: keep `app: zitadel, component: api` (verified, no change)
+  - [x] 2.1.4 Container `name`: `zitadel` → `api`
+  - [x] 2.1.5 Service-link comment rewritten to explain: post-rename the injected env var becomes `ZITADEL_API_PORT` (no matching uint16 config field) so the specific Viper conflict no longer materializes; flag stays as defensive insurance for any future Service. DNS-based discovery (`zitadel-api.zitadel.svc.cluster.local`) works regardless.
+  - [x] 2.1.6 `podAntiAffinity.matchLabels` (`app: zitadel, component: api`) intact (labels unchanged).
+  - **EXTRA (drift fix)**: Added explicit `spec.replicas: 2` to base. The spec.md asserted "base replicaCount: 2" but the file had no `replicas:` field, which would default to 1. Now base declares HA intent; dev overlay explicitly relaxes to 1; prod overlay inherits 2 naturally.
 
-- [ ] 2.2 `deployment-login.yaml` → rename file to `deployment-web.yaml`:
-  - [ ] 2.2.1 `git mv` the file.
-  - [ ] 2.2.2 `metadata.name`: `zitadel-login` → `zitadel-web`
-  - [ ] 2.2.3 `metadata.labels.component`: `login` → `web`
-  - [ ] 2.2.4 `spec.selector.matchLabels.component` / pod template `component`: `login` → `web`
-  - [ ] 2.2.5 Container `name`: `zitadel-login` → `web`
-  - [ ] 2.2.6 **Remove the stale header comment block at L37-38** (`ZITADEL_API_URL points at the in-cluster API Service...`).
-  - [ ] 2.2.7 Verify image path stays `ghcr.io/zitadel/zitadel-login` (image name reflects upstream artifact, NOT the container/Deployment name; this is intentional per spec rationale).
-  - [ ] 2.2.8 Update `topologyKey` / `podAntiAffinity matchLabels.component`: `login` → `web`.
+- [x] 2.2 `deployment-login.yaml` → renamed to `deployment-web.yaml`:
+  - [x] 2.2.1 `git mv` executed.
+  - [x] 2.2.2 `metadata.name`: `zitadel-login` → `zitadel-web`
+  - [x] 2.2.3 `metadata.labels.component`: `login` → `web`
+  - [x] 2.2.4 `spec.selector.matchLabels.component` + pod template `component`: `login` → `web`
+  - [x] 2.2.5 Container `name`: `zitadel-login` → `web`
+  - [x] 2.2.6 **Removed** the stale header comment block (`ZITADEL_API_URL points at the in-cluster API Service...`).
+  - [x] 2.2.7 Image path stays `ghcr.io/zitadel/zitadel-login` (upstream artifact name, separate from K8s rename).
+  - [x] 2.2.8 `podAntiAffinity matchLabels.component`: `login` → `web`.
+  - **EXTRA**: Updated internal hostname reference in rationale comment (`zitadel.zitadel.svc.cluster.local` → `zitadel-api.zitadel.svc.cluster.local`); updated catch-all rule comment (`zitadel` Service → `zitadel-api` Service); updated cross-file comment reference (`external-secret-login-pat.yaml` → `external-secret-web-pat.yaml`); updated `secretName: zitadel-login-pat` → `zitadel-web-pat` (mount); added explicit `spec.replicas: 2` (same drift fix as 2.1).
 
-- [ ] 2.3 `service-api.yaml`:
-  - [ ] 2.3.1 `metadata.name`: `zitadel` → `zitadel-api`
-  - [ ] 2.3.2 `spec.selector.component`: keep `api` (already correct).
+- [x] 2.3 `service-api.yaml`:
+  - [x] 2.3.1 `metadata.name`: `zitadel` → `zitadel-api`
+  - [x] 2.3.2 `spec.selector.component`: keep `api`.
 
-- [ ] 2.4 `service-login.yaml` → rename file to `service-web.yaml`:
-  - [ ] 2.4.1 `git mv` the file.
-  - [ ] 2.4.2 `metadata.name`: `zitadel-login` → `zitadel-web`
-  - [ ] 2.4.3 `spec.selector.component`: `login` → `web`.
+- [x] 2.4 `service-login.yaml` → renamed to `service-web.yaml`:
+  - [x] 2.4.1 `git mv` executed.
+  - [x] 2.4.2 `metadata.name`: `zitadel-login` → `zitadel-web`
+  - [x] 2.4.3 `spec.selector.component` + `metadata.labels.component`: `login` → `web`.
 
-- [ ] 2.5 `httproute.yaml`:
-  - [ ] 2.5.1 **Remove `spec.hostnames` field entirely** (moved to overlays per design decision 1).
-  - [ ] 2.5.2 `backendRefs[0].name` (Login UI rule): `zitadel-login` → `zitadel-web`
-  - [ ] 2.5.3 `backendRefs[1].name` (catch-all rule): `zitadel` → `zitadel-api`
-  - [ ] 2.5.4 Add comment on the catch-all `/` rule explaining that `hostnames` is set per-overlay to scope this rule to the Zitadel hostname only.
+- [x] 2.5 `httproute.yaml`:
+  - [x] 2.5.1 `spec.hostnames` field **removed** (moved to overlays).
+  - [x] 2.5.2 `backendRefs[0].name` (Login UI rule): `zitadel-login` → `zitadel-web`
+  - [x] 2.5.3 `backendRefs[1].name` (catch-all rule): `zitadel` → `zitadel-api`
+  - [x] 2.5.4 Comment added explaining the per-overlay `hostnames` discipline and why it is load-bearing (the `/` catch-all would otherwise intercept all Gateway traffic).
 
-- [ ] 2.6 `pdb.yaml`:
-  - [ ] 2.6.1 First PDB `metadata.name`: `zitadel` → `zitadel-api`; `selector.matchLabels.component`: keep `api`.
-  - [ ] 2.6.2 Second PDB `metadata.name`: `zitadel-login` → `zitadel-web`; `selector.matchLabels.component`: `login` → `web`.
+- [x] 2.6 `pdb.yaml`:
+  - [x] 2.6.1 First PDB `metadata.name`: `zitadel` → `zitadel-api`.
+  - [x] 2.6.2 Second PDB `metadata.name`: `zitadel-login` → `zitadel-web`; `selector.matchLabels.component`: `login` → `web`.
 
-- [ ] 2.7 `healthcheckpolicy.yaml`:
-  - [ ] 2.7.1 First policy `metadata.name`: `zitadel-api-policy` (already correct).
-  - [ ] 2.7.2 First policy `targetRef.name`: `zitadel` → `zitadel-api`.
-  - [ ] 2.7.3 Second policy `metadata.name`: `zitadel-login-policy` → `zitadel-web-policy`.
-  - [ ] 2.7.4 Second policy `targetRef.name`: `zitadel-login` → `zitadel-web`.
-  - [ ] 2.7.5 Second policy `labels.component`: `login` → `web`.
+- [x] 2.7 `healthcheckpolicy.yaml`:
+  - [x] 2.7.1 First policy `metadata.name`: `zitadel-api-policy` (verified, unchanged).
+  - [x] 2.7.2 First policy `targetRef.name`: `zitadel` → `zitadel-api`.
+  - [x] 2.7.3 Second policy `metadata.name`: `zitadel-login-policy` → `zitadel-web-policy`.
+  - [x] 2.7.4 Second policy `targetRef.name`: `zitadel-login` → `zitadel-web`.
+  - [x] 2.7.5 Second policy `labels.component`: `login` → `web`.
 
-- [ ] 2.8 `kustomization.yaml`:
-  - [ ] 2.8.1 Resource list: `deployment-login.yaml` → `deployment-web.yaml`; `service-login.yaml` → `service-web.yaml`.
+- [x] 2.8 `kustomization.yaml`:
+  - [x] 2.8.1 Resource list: `deployment-login.yaml` → `deployment-web.yaml`; `service-login.yaml` → `service-web.yaml`; `external-secret-login-pat.yaml` → `external-secret-web-pat.yaml`.
 
-- [ ] 2.9 `external-secret-login-pat.yaml` (verify):
-  - [ ] 2.9.1 Check if this ExternalSecret targets a K8s Secret consumed by `zitadel-web` (was `zitadel-login`). If the secret name encodes the consumer, decide whether to rename the secret too (likely IN scope: `zitadel-login-pat` → `zitadel-web-pat`). If yes, follow through in the mount in `deployment-web.yaml` and the ExternalSecret resource itself.
-  - [ ] 2.9.2 If renaming the K8s Secret triggers a Reloader-driven Pod restart, that's fine pre-launch.
+- [x] 2.9 `external-secret-login-pat.yaml` → renamed to `external-secret-web-pat.yaml`:
+  - [x] 2.9.1 K8s-side rename applied: ExternalSecret `metadata.name`, `spec.target.name` both `zitadel-login-pat` → `zitadel-web-pat`. GSM `remoteRef.key` keeps `zitadel-login-pat` (Pulumi-owned). Mount in `deployment-web.yaml` updated. Header comment expanded to explain the K8s-vs-GSM naming split.
+  - [x] 2.9.2 Reloader-driven Pod restart on Secret rename is acceptable pre-launch (no service users).
+
+**EXTRA (marginal touch-ups, audit-identified):**
+- [x] Updated `k8s/namespaces/otel-collector/base/deployment.yaml:11` comment to reference `zitadel-api` Deployment.
+- [x] Updated `src/gcp/components/zitadel-monitoring.ts:160` runbook hint to reference `deployment/zitadel-api`.
 
 ## 3. Dev overlay updates (`k8s/namespaces/zitadel/overlays/dev/`)
 
-- [ ] 3.1 `kustomization.yaml`:
-  - [ ] 3.1.1 Patch `target.name` entries: `zitadel` → `zitadel-api`; `zitadel-login` → `zitadel-web`.
-  - [ ] 3.1.2 Reference `deployment-web-patch.yaml` instead of `deployment-login-patch.yaml`.
-  - [ ] 3.1.3 Add a new patch entry pointing at `httproute-patch.yaml` (new file, see 3.4).
+- [x] 3.1 `kustomization.yaml`:
+  - [x] 3.1.1 Patch `target.name` entries: `zitadel` → `zitadel-api`; `zitadel-login` → `zitadel-web`.
+  - [x] 3.1.2 Referenced `deployment-web-patch.yaml` instead of `deployment-login-patch.yaml`.
+  - [x] 3.1.3 Added new patch entry for `httproute-patch.yaml`.
 
-- [ ] 3.2 `deployment-patch.yaml`:
-  - [ ] 3.2.1 `metadata.name`: `zitadel` → `zitadel-api`.
+- [x] 3.2 `deployment-patch.yaml`:
+  - [x] 3.2.1 `metadata.name`: `zitadel` → `zitadel-api`.
 
-- [ ] 3.3 `deployment-login-patch.yaml` → rename file to `deployment-web-patch.yaml`:
-  - [ ] 3.3.1 `git mv`.
-  - [ ] 3.3.2 `metadata.name`: `zitadel-login` → `zitadel-web`.
+- [x] 3.3 `deployment-login-patch.yaml` → renamed to `deployment-web-patch.yaml`:
+  - [x] 3.3.1 `git mv` executed.
+  - [x] 3.3.2 `metadata.name`: `zitadel-login` → `zitadel-web`. Header comment refreshed.
 
-- [ ] 3.4 NEW: `httproute-patch.yaml`:
-  - [ ] 3.4.1 Create with `metadata.name: zitadel-route`, `spec.hostnames: [auth.dev.liverty-music.app]`.
+- [x] 3.4 NEW: `httproute-patch.yaml` — created with `metadata.name: zitadel-route`, `spec.hostnames: [auth.dev.liverty-music.app]`, explanatory comment.
 
-- [ ] 3.5 `pdb-patch.yaml`:
-  - [ ] 3.5.1 Both PDB `metadata.name`s renamed (`zitadel` → `zitadel-api`; `zitadel-login` → `zitadel-web`).
+- [x] 3.5 `pdb-patch.yaml`: both PDB `metadata.name`s renamed. Header comment refreshed to reference `deployment-web-patch.yaml`.
 
-- [ ] 3.6 (no changes) `configmap-patch.env`, `cronjob-restart-zitadel.yaml` — unaffected by rename, dev-only.
+- [x] 3.6 **CORRECTED — `cronjob-restart-zitadel.yaml` DID need updates** (original task incorrectly marked as "no changes"). Updates applied:
+  - Header comment: `kubectl rollout restart deploy/zitadel` → `deploy/zitadel-api`.
+  - RBAC `resourceNames: ["zitadel"]` → `["zitadel-api"]` (the pinned-resource grant must follow the rename).
+  - CronJob args: `deployment/zitadel` → `deployment/zitadel-api`.
+  - `configmap-patch.env` unaffected (confirmed).
 
 ## 4. Prod overlay creation (NEW: `k8s/namespaces/zitadel/overlays/prod/`)
 
-- [ ] 4.1 Create directory `overlays/prod/`.
+- [x] 4.1 Directory `overlays/prod/` created.
 
-- [ ] 4.2 NEW: `kustomization.yaml`:
-  - [ ] 4.2.1 `namespace: zitadel`.
-  - [ ] 4.2.2 `resources: [../../base]` — **does NOT include `cronjob-restart-zitadel.yaml`** (dev-only band-aid).
-  - [ ] 4.2.3 `patches`: reference `deployment-api-patch.yaml`, `deployment-web-patch.yaml`, `httproute-patch.yaml`.
-  - [ ] 4.2.4 (Decision: no `configMapGenerator` merge for prod yet — prod-specific config values are out of scope of this change; that's part of prod provisioning prep.)
+- [x] 4.2 NEW: `kustomization.yaml`:
+  - [x] 4.2.1 `namespace: zitadel`.
+  - [x] 4.2.2 `resources: [../../base]`; `cronjob-restart-zitadel.yaml` explicitly NOT imported (verified via render: prod has no `zitadel-restart` resources).
+  - [x] 4.2.3 `patches`: references `deployment-api-patch.yaml`, `deployment-web-patch.yaml`, `httproute-patch.yaml`.
+  - [x] 4.2.4 No `configMapGenerator` merge for prod (deferred to prod-provisioning change).
 
-- [ ] 4.3 NEW: `deployment-api-patch.yaml`:
-  - [ ] 4.3.1 `metadata.name: zitadel-api`.
-  - [ ] 4.3.2 `spec.replicas: 2` (matches base; explicit for symmetry with dev patch shape and clarity for future tuning).
-  - [ ] 4.3.3 `spec.template.spec.nodeSelector.cloud.google.com/gke-spot: "true"`.
+- [x] 4.3 NEW: `deployment-api-patch.yaml`:
+  - [x] 4.3.1 `metadata.name: zitadel-api`.
+  - [x] 4.3.2 **REVISED** — `replicas` field NOT set in patch (inherits base `replicas: 2` after the section-2 drift fix). Explicit patch was originally planned but is redundant with the base value.
+  - [x] 4.3.3 Spot-pool nodeSelector applied.
 
-- [ ] 4.4 NEW: `deployment-web-patch.yaml`:
-  - [ ] 4.4.1 `metadata.name: zitadel-web`.
-  - [ ] 4.4.2 `spec.replicas: 2`.
-  - [ ] 4.4.3 `spec.template.spec.nodeSelector.cloud.google.com/gke-spot: "true"`.
+- [x] 4.4 NEW: `deployment-web-patch.yaml`:
+  - [x] 4.4.1 `metadata.name: zitadel-web`.
+  - [x] 4.4.2 Same as 4.3.2: replicas inherits base, no patch needed.
+  - [x] 4.4.3 Spot-pool nodeSelector applied.
 
-- [ ] 4.5 NEW: `httproute-patch.yaml`:
-  - [ ] 4.5.1 `metadata.name: zitadel-route`.
-  - [ ] 4.5.2 `spec.hostnames: [auth.liverty-music.app]`.
+- [x] 4.5 NEW: `httproute-patch.yaml`:
+  - [x] 4.5.1 `metadata.name: zitadel-route`.
+  - [x] 4.5.2 `spec.hostnames: [auth.liverty-music.app]`.
 
-- [ ] 4.6 (Decision: no `pdb-patch.yaml` in prod — base `minAvailable: 1` is the desired value.)
+- [x] 4.6 No `pdb-patch.yaml` in prod (verified: base `minAvailable: 1` flows through; render confirms).
 
 ## 5. ArgoCD prod Application
 
-- [ ] 5.1 NEW: `k8s/argocd-apps/prod/zitadel.yaml`:
-  - [ ] 5.1.1 Mirror `k8s/argocd-apps/dev/zitadel.yaml` exactly except `spec.source.path: k8s/namespaces/zitadel/overlays/prod`.
-  - [ ] 5.1.2 `syncPolicy.automated.prune: true`, `selfHeal: true`, `syncOptions: [CreateNamespace=true, ServerSideApply=true]`.
-- [ ] 5.2 If `k8s/argocd-apps/prod/` does not exist yet, create the directory (this change introduces it).
+- [x] 5.1 NEW: `k8s/argocd-apps/prod/zitadel.yaml` created.
+  - [x] 5.1.1 Mirror of `k8s/argocd-apps/dev/zitadel.yaml`, with `spec.source.path: k8s/namespaces/zitadel/overlays/prod`.
+  - [x] 5.1.2 `syncPolicy.automated.prune: true`, `selfHeal: true`, `syncOptions: [CreateNamespace=true, ServerSideApply=true]`.
+- [x] 5.2 New directory `k8s/argocd-apps/prod/` introduced by this change.
 
 ## 6. Verification (local)
 
-- [ ] 6.1 `kubectl kustomize k8s/namespaces/zitadel/base` — must render without `hostnames` on HTTPRoute and with the renamed Deployments/Services/PDBs/HealthCheckPolicies.
-- [ ] 6.2 `kubectl kustomize k8s/namespaces/zitadel/overlays/dev` — must render with `hostnames: [auth.dev.liverty-music.app]`, `replicas: 1` patches, the `cronjob-restart-zitadel` CronJob, and the new resource names.
-- [ ] 6.3 `kubectl kustomize k8s/namespaces/zitadel/overlays/prod` — must render with `hostnames: [auth.liverty-music.app]`, `replicas: 2`, spot nodeSelector, the new resource names, and NO `restart-zitadel` CronJob.
-- [ ] 6.4 `make lint-k8s` — passes.
-- [ ] 6.5 `make lint-ts` — passes (sanity check; Pulumi side untouched by this change).
-- [ ] 6.6 `make check` — full pre-commit suite passes.
+- [x] 6.1 `kubectl kustomize k8s/namespaces/zitadel/base` — renders cleanly. HTTPRoute has no `hostnames`; Deployments/Services/PDBs/HCPs use new names; ExternalSecret `zitadel-web-pat` mirrors GSM `zitadel-login-pat`.
+- [x] 6.2 `kubectl kustomize k8s/namespaces/zitadel/overlays/dev` — renders with `hostnames: [auth.dev.liverty-music.app]`, `replicas: 1`, `cronjob-restart-zitadel` resources (SA/Role/RoleBinding/CronJob), new resource names.
+- [x] 6.3 `kubectl kustomize k8s/namespaces/zitadel/overlays/prod` — renders with `hostnames: [auth.liverty-music.app]`, `replicas: 2`, spot nodeSelector, new resource names, no `restart-zitadel` CronJob.
+- [~] 6.4 **Partial** — `make lint-k8s` fails on the unrelated `argocd` dev overlay due to a local `helm` CLI compatibility issue (`helm version -c --short`: unknown flag). Zitadel-only verification passed: `kube-linter lint /tmp/rendered-zitadel --config .kube-linter.yaml` → "No lint errors found!"; `./scripts/check-spot-nodeselector.sh /tmp/rendered-zitadel` → "OK: All workloads have Spot VM nodeSelector." Full `make lint-k8s` should be retried in CI where helm is wired up.
+- [x] 6.5 `make lint-ts` — clean (biome + tsc on 44 files).
+- [x] 6.6 `make check` — clean (lint-ts + 40 tests pass).
 
 ## 7. Cutover (dev only — prod waits on prereqs)
 

--- a/openspec/changes/k8s-naming-cleanup/tasks.md
+++ b/openspec/changes/k8s-naming-cleanup/tasks.md
@@ -1,0 +1,148 @@
+# Tasks
+
+## 1. Repo-wide audit (find every reference)
+
+- [ ] 1.1 `git grep -nE '\bzitadel(-login)?\b'` across the cloud-provisioning repo to list every reference to the old names. Bucket the hits:
+  - K8s manifests (in-scope)
+  - Pulumi source (`src/**`) — likely some `MachineUser.userName` references; check whether they should also rename
+  - Comments / docs (in-scope, opportunistic clean-up)
+  - Tests / fixtures
+- [ ] 1.2 Confirm `backend` Go source has NO hardcoded reference to the Service hostname `zitadel.zitadel.svc.cluster.local` (it uses public URL per `self-hosted-zitadel` requirements; verify).
+- [ ] 1.3 Confirm `frontend` source has NO hardcoded reference to either name.
+- [ ] 1.4 Decide whether `MachineUser.userName: zitadel` (if any) is in or out of scope; default: out — Pulumi resource names are an internal artifact, the K8s rename is independent.
+
+## 2. Base manifest renames (`k8s/namespaces/zitadel/base/`)
+
+- [ ] 2.1 `deployment-api.yaml`:
+  - [ ] 2.1.1 `metadata.name`: `zitadel` → `zitadel-api`
+  - [ ] 2.1.2 `metadata.labels.app`: keep `zitadel`; `component`: keep `api` (already correct)
+  - [ ] 2.1.3 `spec.selector.matchLabels` / `spec.template.metadata.labels`: keep `app: zitadel, component: api`
+  - [ ] 2.1.4 Container `name`: `zitadel` → `api`
+  - [ ] 2.1.5 Update header comment (the `enableServiceLinks: false` block at L30-37): change `ZITADEL_PORT` → `ZITADEL_API_PORT` in the explanatory text; note that after rename, the Viper-config conflict no longer materializes but the flag stays as defensive insurance.
+  - [ ] 2.1.6 Verify the `podAntiAffinity.matchLabels` (`app: zitadel, component: api`) still references the labels (labels are unchanged, only resource name changes).
+
+- [ ] 2.2 `deployment-login.yaml` → rename file to `deployment-web.yaml`:
+  - [ ] 2.2.1 `git mv` the file.
+  - [ ] 2.2.2 `metadata.name`: `zitadel-login` → `zitadel-web`
+  - [ ] 2.2.3 `metadata.labels.component`: `login` → `web`
+  - [ ] 2.2.4 `spec.selector.matchLabels.component` / pod template `component`: `login` → `web`
+  - [ ] 2.2.5 Container `name`: `zitadel-login` → `web`
+  - [ ] 2.2.6 **Remove the stale header comment block at L37-38** (`ZITADEL_API_URL points at the in-cluster API Service...`).
+  - [ ] 2.2.7 Verify image path stays `ghcr.io/zitadel/zitadel-login` (image name reflects upstream artifact, NOT the container/Deployment name; this is intentional per spec rationale).
+  - [ ] 2.2.8 Update `topologyKey` / `podAntiAffinity matchLabels.component`: `login` → `web`.
+
+- [ ] 2.3 `service-api.yaml`:
+  - [ ] 2.3.1 `metadata.name`: `zitadel` → `zitadel-api`
+  - [ ] 2.3.2 `spec.selector.component`: keep `api` (already correct).
+
+- [ ] 2.4 `service-login.yaml` → rename file to `service-web.yaml`:
+  - [ ] 2.4.1 `git mv` the file.
+  - [ ] 2.4.2 `metadata.name`: `zitadel-login` → `zitadel-web`
+  - [ ] 2.4.3 `spec.selector.component`: `login` → `web`.
+
+- [ ] 2.5 `httproute.yaml`:
+  - [ ] 2.5.1 **Remove `spec.hostnames` field entirely** (moved to overlays per design decision 1).
+  - [ ] 2.5.2 `backendRefs[0].name` (Login UI rule): `zitadel-login` → `zitadel-web`
+  - [ ] 2.5.3 `backendRefs[1].name` (catch-all rule): `zitadel` → `zitadel-api`
+  - [ ] 2.5.4 Add comment on the catch-all `/` rule explaining that `hostnames` is set per-overlay to scope this rule to the Zitadel hostname only.
+
+- [ ] 2.6 `pdb.yaml`:
+  - [ ] 2.6.1 First PDB `metadata.name`: `zitadel` → `zitadel-api`; `selector.matchLabels.component`: keep `api`.
+  - [ ] 2.6.2 Second PDB `metadata.name`: `zitadel-login` → `zitadel-web`; `selector.matchLabels.component`: `login` → `web`.
+
+- [ ] 2.7 `healthcheckpolicy.yaml`:
+  - [ ] 2.7.1 First policy `metadata.name`: `zitadel-api-policy` (already correct).
+  - [ ] 2.7.2 First policy `targetRef.name`: `zitadel` → `zitadel-api`.
+  - [ ] 2.7.3 Second policy `metadata.name`: `zitadel-login-policy` → `zitadel-web-policy`.
+  - [ ] 2.7.4 Second policy `targetRef.name`: `zitadel-login` → `zitadel-web`.
+  - [ ] 2.7.5 Second policy `labels.component`: `login` → `web`.
+
+- [ ] 2.8 `kustomization.yaml`:
+  - [ ] 2.8.1 Resource list: `deployment-login.yaml` → `deployment-web.yaml`; `service-login.yaml` → `service-web.yaml`.
+
+- [ ] 2.9 `external-secret-login-pat.yaml` (verify):
+  - [ ] 2.9.1 Check if this ExternalSecret targets a K8s Secret consumed by `zitadel-web` (was `zitadel-login`). If the secret name encodes the consumer, decide whether to rename the secret too (likely IN scope: `zitadel-login-pat` → `zitadel-web-pat`). If yes, follow through in the mount in `deployment-web.yaml` and the ExternalSecret resource itself.
+  - [ ] 2.9.2 If renaming the K8s Secret triggers a Reloader-driven Pod restart, that's fine pre-launch.
+
+## 3. Dev overlay updates (`k8s/namespaces/zitadel/overlays/dev/`)
+
+- [ ] 3.1 `kustomization.yaml`:
+  - [ ] 3.1.1 Patch `target.name` entries: `zitadel` → `zitadel-api`; `zitadel-login` → `zitadel-web`.
+  - [ ] 3.1.2 Reference `deployment-web-patch.yaml` instead of `deployment-login-patch.yaml`.
+  - [ ] 3.1.3 Add a new patch entry pointing at `httproute-patch.yaml` (new file, see 3.4).
+
+- [ ] 3.2 `deployment-patch.yaml`:
+  - [ ] 3.2.1 `metadata.name`: `zitadel` → `zitadel-api`.
+
+- [ ] 3.3 `deployment-login-patch.yaml` → rename file to `deployment-web-patch.yaml`:
+  - [ ] 3.3.1 `git mv`.
+  - [ ] 3.3.2 `metadata.name`: `zitadel-login` → `zitadel-web`.
+
+- [ ] 3.4 NEW: `httproute-patch.yaml`:
+  - [ ] 3.4.1 Create with `metadata.name: zitadel-route`, `spec.hostnames: [auth.dev.liverty-music.app]`.
+
+- [ ] 3.5 `pdb-patch.yaml`:
+  - [ ] 3.5.1 Both PDB `metadata.name`s renamed (`zitadel` → `zitadel-api`; `zitadel-login` → `zitadel-web`).
+
+- [ ] 3.6 (no changes) `configmap-patch.env`, `cronjob-restart-zitadel.yaml` — unaffected by rename, dev-only.
+
+## 4. Prod overlay creation (NEW: `k8s/namespaces/zitadel/overlays/prod/`)
+
+- [ ] 4.1 Create directory `overlays/prod/`.
+
+- [ ] 4.2 NEW: `kustomization.yaml`:
+  - [ ] 4.2.1 `namespace: zitadel`.
+  - [ ] 4.2.2 `resources: [../../base]` — **does NOT include `cronjob-restart-zitadel.yaml`** (dev-only band-aid).
+  - [ ] 4.2.3 `patches`: reference `deployment-api-patch.yaml`, `deployment-web-patch.yaml`, `httproute-patch.yaml`.
+  - [ ] 4.2.4 (Decision: no `configMapGenerator` merge for prod yet — prod-specific config values are out of scope of this change; that's part of prod provisioning prep.)
+
+- [ ] 4.3 NEW: `deployment-api-patch.yaml`:
+  - [ ] 4.3.1 `metadata.name: zitadel-api`.
+  - [ ] 4.3.2 `spec.replicas: 2` (matches base; explicit for symmetry with dev patch shape and clarity for future tuning).
+  - [ ] 4.3.3 `spec.template.spec.nodeSelector.cloud.google.com/gke-spot: "true"`.
+
+- [ ] 4.4 NEW: `deployment-web-patch.yaml`:
+  - [ ] 4.4.1 `metadata.name: zitadel-web`.
+  - [ ] 4.4.2 `spec.replicas: 2`.
+  - [ ] 4.4.3 `spec.template.spec.nodeSelector.cloud.google.com/gke-spot: "true"`.
+
+- [ ] 4.5 NEW: `httproute-patch.yaml`:
+  - [ ] 4.5.1 `metadata.name: zitadel-route`.
+  - [ ] 4.5.2 `spec.hostnames: [auth.liverty-music.app]`.
+
+- [ ] 4.6 (Decision: no `pdb-patch.yaml` in prod — base `minAvailable: 1` is the desired value.)
+
+## 5. ArgoCD prod Application
+
+- [ ] 5.1 NEW: `k8s/argocd-apps/prod/zitadel.yaml`:
+  - [ ] 5.1.1 Mirror `k8s/argocd-apps/dev/zitadel.yaml` exactly except `spec.source.path: k8s/namespaces/zitadel/overlays/prod`.
+  - [ ] 5.1.2 `syncPolicy.automated.prune: true`, `selfHeal: true`, `syncOptions: [CreateNamespace=true, ServerSideApply=true]`.
+- [ ] 5.2 If `k8s/argocd-apps/prod/` does not exist yet, create the directory (this change introduces it).
+
+## 6. Verification (local)
+
+- [ ] 6.1 `kubectl kustomize k8s/namespaces/zitadel/base` — must render without `hostnames` on HTTPRoute and with the renamed Deployments/Services/PDBs/HealthCheckPolicies.
+- [ ] 6.2 `kubectl kustomize k8s/namespaces/zitadel/overlays/dev` — must render with `hostnames: [auth.dev.liverty-music.app]`, `replicas: 1` patches, the `cronjob-restart-zitadel` CronJob, and the new resource names.
+- [ ] 6.3 `kubectl kustomize k8s/namespaces/zitadel/overlays/prod` — must render with `hostnames: [auth.liverty-music.app]`, `replicas: 2`, spot nodeSelector, the new resource names, and NO `restart-zitadel` CronJob.
+- [ ] 6.4 `make lint-k8s` — passes.
+- [ ] 6.5 `make lint-ts` — passes (sanity check; Pulumi side untouched by this change).
+- [ ] 6.6 `make check` — full pre-commit suite passes.
+
+## 7. Cutover (dev only — prod waits on prereqs)
+
+- [ ] 7.1 Merge PR. ArgoCD dev Application picks up the change.
+- [ ] 7.2 Observe ArgoCD UI: `zitadel` Application transitions through `OutOfSync` while old resources prune and new ones materialize. ArgoCD `prune: true` removes the old `zitadel` / `zitadel-login` Deployments/Services/etc.
+- [ ] 7.3 Verify dev pods come up cleanly:
+  - `kubectl get -n zitadel deploy` → `zitadel-api`, `zitadel-web`.
+  - `kubectl get -n zitadel svc` → `zitadel-api`, `zitadel-web`.
+  - `kubectl get -n zitadel pdb` → both renamed.
+  - `kubectl get -n zitadel httproute` → hostname is `auth.dev.liverty-music.app`.
+  - `kubectl logs -n zitadel deploy/zitadel-api -c api` returns Zitadel startup logs.
+- [ ] 7.4 Smoke test the auth endpoint: `curl -s https://auth.dev.liverty-music.app/.well-known/openid-configuration | jq .issuer` returns `https://auth.dev.liverty-music.app`.
+- [ ] 7.5 Confirm `zitadel` ArgoCD prod Application appears with `OutOfSync` / `Missing` status — this is the expected interim state until prod prereqs (Cloud SQL DB, GSM secrets, ESC env, GCP cert map binding) are provisioned. Document the known-OutOfSync state in the PR description.
+
+## 8. Follow-ups to track (not in this change)
+
+- [ ] 8.1 Prod prereqs change: Pulumi-side Cloud SQL DB / IAM user / GSM secrets / ESC env for prod Zitadel. Once landed, prod ArgoCD Application transitions to `Healthy`.
+- [ ] 8.2 `concert-data-store` namespace naming audit (deferred from this change).
+- [ ] 8.3 Backend/frontend HTTPRoute consistency review (no `hostnames`, no `/` catch-all rule) — separate Gateway-routing design discussion.

--- a/openspec/changes/k8s-naming-cleanup/tasks.md
+++ b/openspec/changes/k8s-naming-cleanup/tasks.md
@@ -113,7 +113,7 @@
   - [x] 4.2.1 `namespace: zitadel`.
   - [x] 4.2.2 `resources: [../../base]`; `cronjob-restart-zitadel.yaml` explicitly NOT imported (verified via render: prod has no `zitadel-restart` resources).
   - [x] 4.2.3 `patches`: references `deployment-api-patch.yaml`, `deployment-web-patch.yaml`, `httproute-patch.yaml`.
-  - [x] 4.2.4 No `configMapGenerator` merge for prod (deferred to prod-provisioning change).
+  - [x] 4.2.4 **REVISED** — `configMapGenerator` merge IS needed: `base/configmap.env` carries env-specific values (`ZITADEL_EXTERNALDOMAIN`, `ZITADEL_DATABASE_POSTGRES_USER_USERNAME`, `ZITADEL_DATABASE_POSTGRES_ADMIN_USERNAME` all dev-flavored). Added `overlays/prod/configmap-patch.env` overriding these to prod equivalents; kustomization references it via `configMapGenerator.behavior: merge`. Same env-leak-from-base pattern as design Decision #1 (hostname).
 
 - [x] 4.3 NEW: `deployment-api-patch.yaml`:
   - [x] 4.3.1 `metadata.name: zitadel-api`.
@@ -124,6 +124,7 @@
   - [x] 4.4.1 `metadata.name: zitadel-web`.
   - [x] 4.4.2 Same as 4.3.2: replicas inherits base, no patch needed.
   - [x] 4.4.3 Spot-pool nodeSelector applied.
+  - [x] 4.4.4 **ADDED (post-review)** — `ZITADEL_API_URL` env var override on the `web` container. Base hardcodes the dev URL (`https://auth.dev.liverty-music.app`); without this patch, the prod Login UI would call the dev domain → 404 from InstanceDomains mismatch → SSR 500. Same env-leak-from-base pattern as the HTTPRoute hostname.
 
 - [x] 4.5 NEW: `httproute-patch.yaml`:
   - [x] 4.5.1 `metadata.name: zitadel-route`.
@@ -142,7 +143,7 @@
 
 - [x] 6.1 `kubectl kustomize k8s/namespaces/zitadel/base` — renders cleanly. HTTPRoute has no `hostnames`; Deployments/Services/PDBs/HCPs use new names; ExternalSecret `zitadel-web-pat` mirrors GSM `zitadel-login-pat`.
 - [x] 6.2 `kubectl kustomize k8s/namespaces/zitadel/overlays/dev` — renders with `hostnames: [auth.dev.liverty-music.app]`, `replicas: 1`, `cronjob-restart-zitadel` resources (SA/Role/RoleBinding/CronJob), new resource names.
-- [x] 6.3 `kubectl kustomize k8s/namespaces/zitadel/overlays/prod` — renders with `hostnames: [auth.liverty-music.app]`, `replicas: 2`, spot nodeSelector, new resource names, no `restart-zitadel` CronJob.
+- [x] 6.3 `kubectl kustomize k8s/namespaces/zitadel/overlays/prod` — renders with `hostnames: [auth.liverty-music.app]`, `replicas: 2`, spot nodeSelector, new resource names, no `zitadel-restart` CronJob, and `ZITADEL_API_URL=https://auth.liverty-music.app`.
 - [~] 6.4 **Partial** — `make lint-k8s` fails on the unrelated `argocd` dev overlay due to a local `helm` CLI compatibility issue (`helm version -c --short`: unknown flag). Zitadel-only verification passed: `kube-linter lint /tmp/rendered-zitadel --config .kube-linter.yaml` → "No lint errors found!"; `./scripts/check-spot-nodeselector.sh /tmp/rendered-zitadel` → "OK: All workloads have Spot VM nodeSelector." Full `make lint-k8s` should be retried in CI where helm is wired up.
 - [x] 6.5 `make lint-ts` — clean (biome + tsc on 44 files).
 - [x] 6.6 `make check` — clean (lint-ts + 40 tests pass).


### PR DESCRIPTION
## 🔗 Related Issue

N/A — openspec-driven change. Tracking artifact: `openspec/changes/k8s-naming-cleanup/`.

## 📝 Summary of Changes

**OpenSpec change `k8s-naming-cleanup`** — rename the Zitadel namespace's K8s resources to the platform-wide `<role>-<tier>` convention and scaffold a `prod` Kustomize overlay so that prod inherits the canonical names from the start. Companion implementation PR lands in `liverty-music/cloud-provisioning`.

### Why

`kubectl get -n zitadel deploy` currently returns `zitadel` and `zitadel-login` (upstream Helm defaults). The rest of the platform — backend, frontend, atlas, ESO, reloader, argocd, cloudflared — follows `<role>-<tier>` (e.g., `server` / `server-svc`). The zitadel namespace is the odd one out, and the doubly-`zitadel` in-cluster DNS (`zitadel.zitadel.svc.cluster.local`) costs triage time.

Bundling the `prod` overlay scaffold with the rename avoids prod inheriting old names and immediately churning, since prod ArgoCD hasn't synced yet.

### Decisions captured in `design.md`

| Question | Decision |
|---|---|
| Hostname per-env | Both `dev` and `prod` overlays patch `hostnames`; base omits the field. The `/` catch-all rule makes the hostname filter load-bearing. |
| Prod replicas + node pool | `replicas: 2` + spot. Base `podAntiAffinity` (hostname topology) ensures different-host placement; PDB `minAvailable: 1` caps voluntary disruption at 1. Acceptable pre-launch — revisit when SLO matters. |
| ArgoCD prod Application | Created in this change with `automated.prune + selfHeal`. `OutOfSync` is the natural progress signal until prod prereqs (Cloud SQL DB, GSM secrets, ESC env, GCP cert map) land. |
| Container short-naming | `api` and `web` (matches Deployment `<role>-<tier>` while staying log-readable). Sidecars (`cloud-sql-proxy`, `bootstrap-uploader`) keep their existing names. |
| Stale comment cleanup | `deployment-login.yaml:37-38` stale `ZITADEL_API_URL points at in-cluster Service` comment (leftover from before cloud-provisioning#214) dropped during file rename. |
| Service-link env-var rationale | Updated to reflect post-rename state — `ZITADEL_API_PORT` has no matching uint16 config field, so the original Viper collision no longer applies; flag stays defensively. |

### Spec deltas (`zitadel-self-hosted-deployment` capability)

- **MODIFIED** Two-Container Deployment with Path-Based Routing — resource names + a new HealthCheckPolicy scenario.
- **MODIFIED** Login V2 UI Calls Zitadel API via Public URL — clarifies that the rename doesn't affect the public-URL requirement (cluster-internal hostname is by design unused).
- **MODIFIED** Resilient Scheduling on Shared Spot Node Pool — prod now explicitly applies the Spot nodeSelector while inheriting base replica count and PDB.
- **ADDED** Per-Environment Overlay Topology — codifies that base has no `hostnames`, both overlays patch the env-specific hostname, prod omits the dev-only `cronjob-restart-zitadel`, and the prod ArgoCD Application is wired with `automated.prune + selfHeal` from day one.

### Out of scope (tracked, not blocking)

- Prod Pulumi resources (Cloud SQL DB / IAM user / GSM secrets / ESC env for prod Zitadel) — flagged as prerequisite; `OutOfSync` until landed.
- `concert-data-store` namespace naming audit (similar drift may exist).
- Backend / frontend HTTPRoute consistency (no `hostnames`, no `/` catch-all rule) — separate Gateway-routing design discussion.

## ✅ Self-Checklist

- [x] I have linked the related issue. (N/A — openspec-driven; artifact is `openspec/changes/k8s-naming-cleanup/`.)
- [x] I have updated the relevant documentation. (proposal/design/specs/tasks under `openspec/changes/`)
- [x] I have run `buf lint` and `buf format` locally and all checks have passed. (No `.proto` files changed; pre-commit hooks verify on commit.)
- [x] My proto definitions follow the project's style guidelines and validation rules. (No proto changes in this PR.)
- [x] Breaking changes have been justified and documented if applicable. (None — this is a docs-only specification change.)
