### PR TITLE
openspec: amend k8s-naming-cleanup with prod env-override scenarios

### DIFF
--- a/openspec/changes/k8s-naming-cleanup/specs/zitadel-self-hosted-deployment/spec.md
+++ b/openspec/changes/k8s-naming-cleanup/specs/zitadel-self-hosted-deployment/spec.md
@@ -105,6 +105,15 @@ The HTTPRoute `hostnames` field SHALL NOT appear in `base/httproute.yaml`; inste
 - **AND** the rendered `zitadel-config` ConfigMap SHALL have `ZITADEL_EXTERNALDOMAIN: auth.liverty-music.app`
 - **AND** the rendered `zitadel-config` ConfigMap SHALL have `ZITADEL_DATABASE_POSTGRES_USER_USERNAME: zitadel@liverty-music-prod.iam`
 - **AND** the rendered `zitadel-config` ConfigMap SHALL have `ZITADEL_DATABASE_POSTGRES_ADMIN_USERNAME: zitadel@liverty-music-prod.iam`
+- **AND** the rendered `zitadel` ServiceAccount SHALL have `annotations."iam.gke.io/gcp-service-account": zitadel@liverty-music-prod.iam.gserviceaccount.com`
+- **AND** the rendered `zitadel-api` Deployment's `cloud-sql-proxy` container SHALL have its positional instance-connection-name arg set to `liverty-music-prod:asia-northeast2:postgres-osaka` (not the dev value)
+
+#### Scenario: Dev-only DB grant Job stays out of prod
+
+- **WHEN** `kubectl kustomize k8s/namespaces/zitadel/overlays/prod` is executed
+- **THEN** the rendered output SHALL NOT contain a Job named `zitadel-db-grant` (that Job lives in `overlays/dev/` because it hardcodes the dev Cloud SQL instance and dev IAM SA username)
+- **WHEN** `kubectl kustomize k8s/namespaces/zitadel/overlays/dev` is executed
+- **THEN** the rendered output SHALL contain the `zitadel-db-grant` Job
 
 #### Scenario: Base HTTPRoute has no hostnames field
 

--- a/openspec/changes/k8s-naming-cleanup/tasks.md
+++ b/openspec/changes/k8s-naming-cleanup/tasks.md
@@ -119,6 +119,7 @@
   - [x] 4.3.1 `metadata.name: zitadel-api`.
   - [x] 4.3.2 **REVISED** — `replicas` field NOT set in patch (inherits base `replicas: 2` after the section-2 drift fix). Explicit patch was originally planned but is redundant with the base value.
   - [x] 4.3.3 Spot-pool nodeSelector applied.
+  - [x] 4.3.4 **ADDED (post-review)** — `cloud-sql-proxy` container `args` override pointing at `liverty-music-prod:asia-northeast2:postgres-osaka`. Base hardcodes the dev instance connection name; without this patch, prod API pods would proxy to the dev DB. Strategic merge replaces the full `args` list since the field has no mergeKey.
 
 - [x] 4.4 NEW: `deployment-web-patch.yaml`:
   - [x] 4.4.1 `metadata.name: zitadel-web`.
@@ -131,6 +132,10 @@
   - [x] 4.5.2 `spec.hostnames: [auth.liverty-music.app]`.
 
 - [x] 4.6 No `pdb-patch.yaml` in prod (verified: base `minAvailable: 1` flows through; render confirms).
+
+- [x] 4.7 **ADDED (post-review)** — `overlays/prod/serviceaccount-patch.yaml` + kustomization wiring. Base annotates the `zitadel` SA with the dev Workload Identity GCP SA (`zitadel@liverty-music-dev.iam.gserviceaccount.com`); prod patch overrides to `zitadel@liverty-music-prod.iam.gserviceaccount.com`. Same env-leak-from-base pattern.
+
+- [x] 4.8 **ADDED (post-review)** — `job-grant-db.yaml` moved out of base into `overlays/dev/`. The Job hardcodes the dev Cloud SQL instance + the dev IAM SA usernames in its proxy args and SQL grants; making it overlay-only keeps base clean and prevents prod from accidentally running grants against dev resources. Base `kustomization.yaml` updated to drop the resource and add an explanatory comment; dev `kustomization.yaml` now imports it directly.
 
 ## 5. ArgoCD prod Application
 


### PR DESCRIPTION
## 🔗 Related Issue

Follow-up to [#451](https://github.com/liverty-music/specification/pull/451) (merged). Companion implementation: [liverty-music/cloud-provisioning#251](https://github.com/liverty-music/cloud-provisioning/pull/251).

## 📝 Summary of Changes

Amends the `k8s-naming-cleanup` openspec change with three additional prod-overlay env-override fixes that surfaced during cloud-provisioning#251 review. All three follow the same env-leak-from-base pattern that design Decision #1 codified for the HTTPRoute hostname; this PR just captures them in the spec deltas to keep documentation in sync with the implementation.

### Scenario amendments (`zitadel-self-hosted-deployment`)

- **MODIFIED** "Prod overlay overrides env-specific values from base": extended to assert two more prod-overlay overrides:
  - ServiceAccount `iam.gke.io/gcp-service-account` annotation → `zitadel@liverty-music-prod.iam.gserviceaccount.com` (was dev SA).
  - `zitadel-api` Deployment's `cloud-sql-proxy` container positional instance-connection-name arg → `liverty-music-prod:asia-northeast2:postgres-osaka` (was dev instance).
- **ADDED** "Dev-only DB grant Job stays out of prod": the `zitadel-db-grant` Job hardcodes the dev Cloud SQL instance in its proxy args and the dev IAM SA username in three places of the SQL block. The Job has been moved from `base/` into `overlays/dev/` (same exclusion pattern as `cronjob-restart-zitadel.yaml`); prod will need its own equivalent when prod prereqs (Cloud SQL prod instance, IAM user, postgres-admin-password GSM secret) are provisioned.

### Tasks updates

Added subtasks 4.3.4 (cloud-sql-proxy args override), 4.7 (ServiceAccount patch), 4.8 (job-grant-db move) under the prod overlay section to document the three fixes.

## ✅ Self-Checklist

- [x] I have linked the related issue. (Follows up #451.)
- [x] I have updated the relevant documentation. (Spec deltas + tasks.)
- [x] I have run `buf lint` and `buf format` locally. (No `.proto` changes; pre-commit hook verifies.)
- [x] My proto definitions follow the project's style guidelines and validation rules. (No proto changes.)
- [x] Breaking changes have been justified and documented if applicable. (Docs-only.)
