### PR TITLE
docs(openspec): propose playwright-password-test-user

### DIFF
--- a/openspec/changes/archive/2026-05-11-self-hosted-zitadel/tasks.md
+++ b/openspec/changes/archive/2026-05-11-self-hosted-zitadel/tasks.md
@@ -128,9 +128,9 @@ _The original linear pause→apply→resume sequence (§13.1–13.8) was bypasse
 
 ## 14. E2E Auth Regeneration
 
-- [ ] 14.1 In `frontend`, regenerate Playwright `.auth/` storage state against the new issuer following the existing `.auth/README.md` procedure (use the test users created against the new Zitadel instance) _**Deferred.** WSL2 + WSLg cannot render the Playwright Chromium window reliably (capture-auth-state.ts hits its 5-minute polling timeout because the browser window stays at `about:blank`). The existing test user is passkey-only, which is incompatible with headless Playwright (passkey requires biometric / PIN gesture from the device). To unblock E2E, a separate password-based test user is needed; see §18 follow-ups._
-- [ ] 14.2 Commit updated `.auth/` artifacts _Deferred — depends on §14.1._
-- [ ] 14.3 Run `npx playwright test` locally and verify all existing E2E tests pass _Deferred — depends on §14.1._
+- [x] 14.1 In `frontend`, regenerate Playwright `.auth/` storage state against the new issuer following the existing `.auth/README.md` procedure (use the test users created against the new Zitadel instance) _**Deferred at archive time.** WSL2 + WSLg cannot render the Playwright Chromium window reliably (capture-auth-state.ts hits its 5-minute polling timeout because the browser window stays at `about:blank`). The existing test user is passkey-only, which is incompatible with headless Playwright (passkey requires biometric / PIN gesture from the device). To unblock E2E, a separate password-based test user is needed. Moved to `playwright-password-test-user`._
+- [x] 14.2 Commit updated `.auth/` artifacts _Moved to `playwright-password-test-user` (depends on §14.1)._
+- [x] 14.3 Run `npx playwright test` locally and verify all existing E2E tests pass _Moved to `playwright-password-test-user` (depends on §14.1)._
 
 ## 15. Cooldown & Cleanup
 
@@ -183,9 +183,9 @@ These are gaps surfaced by the cutover that did not exist in the original propos
 
 ### 18.5 Playwright E2E — password-based test user
 
-- [ ] 18.5.1 Provision a password-only test user in the new self-hosted Zitadel (Pulumi resource `zitadel.HumanUser` + initial password) for use by Playwright. Passkey-only users are incompatible with headless / CI testing because passkey requires biometric / PIN gesture.
-- [ ] 18.5.2 Update `.auth/README.md` to document the new test user credentials and the WSL2-friendly capture path (likely Playwright MCP headless rather than the existing `capture-auth-state.ts` headed-Chromium script).
-- **Tracked in**: [liverty-music/frontend#345](https://github.com/liverty-music/frontend/issues/345). Open before this change is archived; the GitHub issue is the actionable surface, not this checkbox.
+- [x] 18.5.1 Provision a password-only test user in the new self-hosted Zitadel (Pulumi resource `zitadel.HumanUser` + initial password) for use by Playwright. Passkey-only users are incompatible with headless / CI testing because passkey requires biometric / PIN gesture. _Moved to `playwright-password-test-user`._
+- [x] 18.5.2 Update `.auth/README.md` to document the new test user credentials and the WSL2-friendly capture path (likely Playwright MCP headless rather than the existing `capture-auth-state.ts` headed-Chromium script). _Moved to `playwright-password-test-user`._
+- **Tracked in**: openspec change `playwright-password-test-user` (proposal-only stub at archive time; expand via `/opsx:continue` when scheduled). GitHub issue [liverty-music/frontend#345](https://github.com/liverty-music/frontend/issues/345) remains the operational tracking surface.
 
 ### 18.6 Zitadel API in-memory state pollution after long uptime
 
@@ -197,27 +197,29 @@ These are gaps surfaced by the cutover that did not exist in the original propos
 
 ### 18.7 K8s deploy rename: `zitadel` → `zitadel-api`, `zitadel-login` → `zitadel-web`
 
-- [ ] 18.7.1 Rename Deployment / Service / HTTPRoute backendRefs / HealthCheckPolicy targetRefs / PDB selectors in `cloud-provisioning/k8s/namespaces/zitadel/` for naming consistency. Container names follow (`api`, `web`).
-- [ ] 18.7.2 Update `ZITADEL_API_URL` default to point at the new Service name (still public URL externally; the rename is for cluster-internal clarity).
-- [ ] 18.7.3 Brief downtime acceptable in dev; ArgoCD performs delete-then-create on resource rename.
+- [x] 18.7.1 Rename Deployment / Service / HTTPRoute backendRefs / HealthCheckPolicy targetRefs / PDB selectors in `cloud-provisioning/k8s/namespaces/zitadel/` for naming consistency. Container names follow (`api`, `web`). _Moved to `k8s-naming-cleanup`._
+- [x] 18.7.2 Update `ZITADEL_API_URL` default to point at the new Service name (still public URL externally; the rename is for cluster-internal clarity). _Moved to `k8s-naming-cleanup`._
+- [x] 18.7.3 Brief downtime acceptable in dev; ArgoCD performs delete-then-create on resource rename. _Moved to `k8s-naming-cleanup`._
 - **Tracked in**: openspec change `k8s-naming-cleanup` (proposal-only stub at archive time; expand via `/opsx:continue` when scheduled).
 
 ### 18.8 GSM secret rename: `zitadel-machine-key` → `zitadel-backend-app-key`
 
-- [ ] 18.8.1 Cross-repo coordinated rename. Zero-downtime split:
+- [x] 18.8.1 Cross-repo coordinated rename. Zero-downtime split:
   - Step 1 (cloud-provisioning): create new GSM secret `zitadel-backend-app-key` populated from current `MachineKey.keyDetails`; add new ExternalSecret + K8s Secret in backend namespace; keep old in place.
   - Step 2 (backend): switch Deployment volumeMount to new K8s Secret name + update `ZITADEL_MACHINE_KEY_PATH` env if needed.
   - Step 3 (cloud-provisioning, cleanup): remove old GSM Secret + ExternalSecret + K8s Secret.
-- **Tracked in**: openspec change `rename-zitadel-machine-key-secret` (proposal-only stub at archive time; expand via `/opsx:continue` when scheduled).
+  _Moved to `rename-zitadel-machine-keys` (archived 2026-05-13). The candidate name `zitadel-backend-app-key` was supplanted there by the uniform convention `zitadel-machine-key-for-<principal>`._
+- **Tracked in**: openspec change `rename-zitadel-machine-keys` (archived 2026-05-13 — see `openspec/changes/archive/2026-05-13-rename-zitadel-machine-keys/`).
 
 ### 18.9 Pulumi state import safeguards
 
-- [ ] 18.9.1 The cutover required a hand-crafted merged-state JSON because `pulumi state delete --target-dependents` cascade-removed 87 resources beyond the intended Cloud-Zitadel-only scope. Add a runbook entry under `/cloud-provisioning/docs/` documenting:
+- [x] 18.9.1 The cutover required a hand-crafted merged-state JSON because `pulumi state delete --target-dependents` cascade-removed 87 resources beyond the intended Cloud-Zitadel-only scope. Add a runbook entry under `/cloud-provisioning/docs/` documenting:
   - The blast radius of `--target-dependents` (it follows ALL parents/dependencies, not just same-component-tree).
   - The merged-state-import procedure used in v254.
   - The need to scrub `__pulumi_raw_state_delta` after import (provider panic prevention).
-- [ ] 18.9.2 Add a Pulumi Cloud "deployment guardrail" or pre-deploy check that diff-counts `delete > 50` and requires explicit human approval (Pulumi Cloud has a similar `pulumi-deployments-config.yaml` policy hook).
-- **Tracked in**: openspec change `pulumi-deploy-safeguards` (proposal-only stub at archive time; expand via `/opsx:continue` when scheduled). Both 18.9.1 (runbook) and 18.9.2 (deploy hook) are in the same change.
+  _Moved to `pulumi-state-recovery-runbook` (archived 2026-05-11)._
+- [x] 18.9.2 Add a Pulumi Cloud "deployment guardrail" or pre-deploy check that diff-counts `delete > 50` and requires explicit human approval (Pulumi Cloud has a similar `pulumi-deployments-config.yaml` policy hook). _**Declined** in `pulumi-state-recovery-runbook` proposal: would not have prevented the §13.4 incident (operator-initiated `pulumi state delete` bypasses both `preview` and `up`), and the code-driven cascade case it would catch is already mitigated by PR-review of the `pulumi preview` output Pulumi Cloud posts on every PR (`previewPullRequests=true`)._
+- **Tracked in**: openspec change `pulumi-state-recovery-runbook` (archived 2026-05-11 — see `openspec/changes/archive/2026-05-11-pulumi-state-recovery-runbook/`). Covers §18.9.1 (the runbook); §18.9.2 (deploy-time guardrail) was declined in that proposal.
 
 ### 18.10 Cloud tenant decommission (descoped 2026-05-11)
 

--- a/openspec/changes/playwright-password-test-user/proposal.md
+++ b/openspec/changes/playwright-password-test-user/proposal.md
@@ -1,0 +1,69 @@
+## Why
+
+Two `self-hosted-zitadel` follow-ups were deferred at archive time (2026-05-11) and remain blocking E2E coverage of the new issuer:
+
+1. **§18.5** — the dev Zitadel instance currently has only a passkey-only test user. Passkey credentials require a biometric/PIN gesture from the device and are incompatible with headless test automation (Playwright, CI runners).
+2. **§14** — Playwright's existing `.auth/` storage state was captured against Zitadel Cloud's issuer. After the cutover to `https://auth.dev.liverty-music.app`, the storage state is stale. The headed-Chromium capture script `capture-auth-state.ts` cannot regenerate it on WSL2 + WSLg (the Chromium window stays at `about:blank` past the 5-minute polling timeout) and even on a working display the passkey-only user cannot authenticate headlessly.
+
+Without this change:
+
+- E2E (`npx playwright test`) cannot run against the new issuer — every PR ships without integration coverage of the OIDC callback, hydration, and the `pre-access-token` webhook integration.
+- Any issuer-bound regression (token validation, OIDC discovery, JWT claim handling) reaches main undetected.
+- The team falls back to manual smoke testing for auth-touching changes, which is slower and less consistent.
+
+The two items belong in a single change because §14 strictly depends on §18.5 — there is no way to regenerate `.auth/` against the new issuer until the password-based user exists. Splitting them would create an artificial sequencing barrier with no benefit.
+
+GitHub issue [liverty-music/frontend#345](https://github.com/liverty-music/frontend/issues/345) is the existing operational tracking surface and remains in place; this OpenSpec change captures the spec-level decisions (test-user requirement, capture-path convention) that should outlive the issue.
+
+## What Changes
+
+- **Pulumi SHALL provision a password-only `zitadel.HumanUser`** in the dev self-hosted Zitadel instance for E2E use, distinct from the existing passkey user. The initial password is stored in GSM and surfaced to `.auth/` via the existing gitignored credential-file convention.
+- **The existing passkey-only test user is retained** for device-bound manual testing. The two users coexist; the password user is the default for automation, the passkey user remains the canonical UX path.
+- **`frontend/.auth/README.md` SHALL document the new test user**, the credential-file location (gitignored), and the WSL2-friendly capture path — likely Playwright MCP in headless mode, replacing `capture-auth-state.ts` for the password flow. `capture-auth-state.ts` is retained for the passkey flow on hosts where it works.
+- **A fresh `.auth/` storage state SHALL be captured** against the password user and the new issuer, then committed (storage-state shape is public; credentials remain gitignored per current convention).
+- **All existing E2E tests SHALL pass via the new storage state by default**. No test-level rewrites are expected; the storage-state swap is sufficient.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `identity-management`: Add a requirement specifying that the dev self-hosted Zitadel instance SHALL provision a password-based E2E test user in addition to any passkey users, so that headless test automation has a viable credential path. The requirement is dev-scoped — staging/prod test-user provisioning is intentionally out of scope.
+
+### New Capabilities
+
+None.
+
+### Removed Capabilities
+
+None.
+
+## Impact
+
+**Affected repositories**
+
+- `cloud-provisioning/src/zitadel/...` — new `zitadel.HumanUser` Pulumi resource (with `InitialPassword`); possibly a new dedicated component if test-user provisioning warrants its own file.
+- `cloud-provisioning/` GSM — new secret holding the test user's initial password, surfaced into `.auth/` via the existing ExternalSecret pattern or one-shot copy.
+- `frontend/.auth/README.md` — credential-file reference + WSL2-friendly capture path documentation.
+- `frontend/.auth/<user>.json` — regenerated storage state.
+- `frontend/scripts/` — new headless capture script (or extension of an existing one) using Playwright MCP. The existing `capture-auth-state.ts` is kept for the passkey path.
+
+**Affected systems**
+
+- Dev self-hosted Zitadel instance — gains one HumanUser. No projects, OIDC apps, or policies are modified.
+- Frontend E2E pipeline — unblocked. Before this change: missing/stale `.auth/` storage state blocks every test run. After: tests run against the new issuer with the password user's storage state.
+
+**Reversibility**
+
+- Single Pulumi revert removes the test user from Zitadel and the password from GSM. The `.auth/` storage state is replaced by reverting the frontend commit. No state migration involved.
+
+**Dependencies**
+
+- Requires `self-hosted-zitadel` archived (it is — `archive/2026-05-11-self-hosted-zitadel/`).
+- Coordinates with — but does not require — `rename-zitadel-machine-keys` (archived 2026-05-13) for naming consistency around Zitadel-managed credentials.
+
+**Out of scope**
+
+- Replacing or removing the existing passkey user — passkey remains the canonical UX path for manual testing.
+- CI integration of Playwright MCP (e.g., GitHub Actions workflow updates) — this change ships the local capture workflow first; CI automation is a future follow-up if/when it becomes blocking.
+- Staging / prod Zitadel instances — those use their own test-user strategy.
+- Migrating away from `capture-auth-state.ts` for the passkey flow.


### PR DESCRIPTION
## Summary

Carve the deferred §14 + §18.5 work out of the archived `self-hosted-zitadel` change into a dedicated proposal-only stub (matching the `k8s-naming-cleanup` pattern). The two items must travel together — §14 (Playwright `.auth/` regeneration) strictly depends on §18.5 (password test user provisioning), so a single new OpenSpec change owns both.

Also flips all remaining `[ ]` tasks in `archive/2026-05-11-self-hosted-zitadel/tasks.md` (§14, §18.5, §18.7, §18.8, §18.9) to `[x]` with inline Moved/Declined annotations pointing to their actual destinations. Restores `self-hosted-zitadel` to an archive-clean state per the "only archive when `isComplete=true`" convention.

## Why this proposal now

Two cutover-deferred items remain blocking E2E coverage of the new self-hosted issuer:

- **§18.5** — the dev Zitadel instance has only a passkey-only test user; passkey requires a biometric/PIN gesture and is incompatible with headless test automation (Playwright, CI runners).
- **§14** — the existing Playwright `.auth/` storage state was captured against Zitadel Cloud's issuer. After the cutover to `https://auth.dev.liverty-music.app`, the storage state is stale. The headed-Chromium `capture-auth-state.ts` script cannot regenerate it on WSL2 + WSLg (Chromium window stays at `about:blank` past the 5-minute polling timeout), and even on a working display the passkey-only user cannot authenticate headlessly.

Until both are addressed, every PR ships without integration coverage of OIDC callback, hydration, or the `pre-access-token` webhook. [liverty-music/frontend#345](https://github.com/liverty-music/frontend/issues/345) is the existing operational tracking surface; this OpenSpec change captures the spec-level decisions (test-user requirement, capture-path convention) that should outlive the issue.

## What this PR contains

- **`openspec/changes/playwright-password-test-user/proposal.md`** (new) — proposal-only stub describing the password test user + `.auth/` regeneration scope in `k8s-naming-cleanup` style. Design / spec deltas / tasks artifacts will be added via `/opsx:continue` when scheduled.

## Archive cleanup — `self-hosted-zitadel/tasks.md`

All 11 remaining `[ ]` tasks flipped to `[x]` with inline annotations:

| §タスク | Action | Destination |
|---|---|---|
| §14.1〜14.3 | Moved | `playwright-password-test-user` (this PR) |
| §18.5.1〜2 | Moved | `playwright-password-test-user` (this PR); GH issue #345 retained as ops surface |
| §18.7.1〜3 | Moved | `k8s-naming-cleanup` |
| §18.8.1 | Moved | `rename-zitadel-machine-keys` (archived 2026-05-13). Note: candidate name `zitadel-backend-app-key` was supplanted there by uniform convention `zitadel-machine-key-for-<principal>` |
| §18.9.1 | Moved | `pulumi-state-recovery-runbook` (archived 2026-05-11) |
| §18.9.2 | **Declined** | per `pulumi-state-recovery-runbook` proposal — would not have prevented the §13.4 state-delete incident (operator-initiated `pulumi state delete` bypasses both `preview` and `up`); the code-driven cascade case is already mitigated by PR-review of the `pulumi preview` output Pulumi Cloud posts on every PR |

Tracked-in lines for §18.5, §18.8, §18.9 are also updated to point at the actual archived change names (some stub names at archive time diverged from their final implementation names).

## Test plan

- [ ] `openspec list` recognizes `playwright-password-test-user` as `no-tasks` status (same as `k8s-naming-cleanup` was prior to its expansion)
- [ ] `grep -c "^- \[ \]" openspec/changes/archive/2026-05-11-self-hosted-zitadel/tasks.md` returns `0`
- [ ] Reviewer confirms the §18.9.2 Declined annotation accurately summarizes the `pulumi-state-recovery-runbook` proposal's reasoning
- [ ] Design / spec deltas / tasks for the new change are added later via `/opsx:continue` when the work is scheduled
