### PR TITLE
docs(openspec): propose remove-passkey-capture-path

### DIFF
--- a/openspec/changes/remove-passkey-capture-path/design.md
+++ b/openspec/changes/remove-passkey-capture-path/design.md
@@ -8,7 +8,7 @@ This is a pure-removal change. There are no new components, no new capabilities,
 
 **Goals:**
 
-- Bring the spec into alignment with reality on self-hosted dev Zitadel: the passkey capture path no longer functions, so the requirement that mandates its retention should be removed.
+- Bring **both** affected capability specs into alignment with reality on self-hosted dev Zitadel. `e2e-auth-testing` retires the `Existing Passkey Capture Path Retained` requirement (the script the requirement names no longer functions). `identity-management` MODIFIES `Provision Password-Based E2E Test User in Dev Zitadel` to drop the "distinct from the existing passkey-only test user" phrasing and REMOVES `Test User Coexists with Passkey User` (the coexistence requirement asserts a user state that does not exist).
 - Eliminate dead code (`frontend/scripts/capture-auth-state.ts`) and misleading documentation (`AGENTS.md` + `.auth/README.md` references to a wiped user).
 - Leave a clear forward-pointer for any future WebAuthn / passkey CI regression testing need.
 
@@ -63,9 +63,9 @@ This is a pure-removal change. There are no new components, no new capabilities,
 
 Pure removal — no migration of state or runtime data. Specification PR + frontend PR can land in either order:
 
-1. `specification` PR REMOVES the requirement and adds this change's artifacts.
+1. `specification` PR REMOVES `Existing Passkey Capture Path Retained` from `e2e-auth-testing`, MODIFIES `Provision Password-Based E2E Test User in Dev Zitadel` and REMOVES `Test User Coexists with Passkey User` from `identity-management`, and adds this change's artifacts (`proposal.md`, this `design.md`, `tasks.md`, the two spec deltas under `specs/`).
 2. `frontend` PR `git rm`s the script + simplifies the docs.
-3. After both merge, `/opsx:archive remove-passkey-capture-path` folds the REMOVED delta into the main `e2e-auth-testing/spec.md` (decrementing its requirement count by 1).
+3. After both merge, `/opsx:archive remove-passkey-capture-path` folds both deltas into main: `e2e-auth-testing/spec.md` loses one requirement; `identity-management/spec.md` updates one requirement in place and loses another.
 
 **Rollback**: revert both PR merges. The spec requirement comes back, the script comes back from git history, the docs revert. The dead path is restored, but functionally nothing changes because the user it targets is still gone — rollback only undoes the cleanup.
 

--- a/openspec/changes/remove-passkey-capture-path/design.md
+++ b/openspec/changes/remove-passkey-capture-path/design.md
@@ -1,0 +1,74 @@
+## Context
+
+`playwright-password-test-user` (archived 2026-05-14) folded an `Existing Passkey Capture Path Retained` requirement into main `e2e-auth-testing/spec.md`. The Implementation Deltas section of that change's `design.md` already documented why the requirement was operationally vacuous on the active self-hosted dev Zitadel and queued THIS change as the loop-closer.
+
+This is a pure-removal change. There are no new components, no new capabilities, no new infrastructure. The "design" question is therefore not "how do we build something" but "what are the trade-offs in removing it, and what do we explicitly defer".
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Bring the spec into alignment with reality on self-hosted dev Zitadel: the passkey capture path no longer functions, so the requirement that mandates its retention should be removed.
+- Eliminate dead code (`frontend/scripts/capture-auth-state.ts`) and misleading documentation (`AGENTS.md` + `.auth/README.md` references to a wiped user).
+- Leave a clear forward-pointer for any future WebAuthn / passkey CI regression testing need.
+
+**Non-Goals:**
+
+- Re-provisioning a passkey test user on the self-hosted dev Zitadel. The next change that needs passkey coverage should design the approach from scratch (virtual authenticator) rather than restore the deleted lineage.
+- Cleaning up the inert `pepperoni9+playwright-1@gmail.com` row in the Zitadel Cloud tenant. Cloud retention is governed by `self-hosted-zitadel §15.1` / `§18.10` (indefinite no-cost rollback escape hatch); the user has no DNS, no OIDC traffic, and no operational impact. A future Cloud-decommission change can fold the cleanup in.
+- Touching the password capture path. The `Password-Based Storage State Capture Path`, `Test-User Credential File Gitignored`, and the user-type-agnostic `Playwright MCP Authenticated Session` / `StorageState Capture Script` / `StorageState Gitignore` requirements remain unchanged and continue to describe the live capability correctly.
+
+## Decisions
+
+### D1: REMOVE rather than MODIFY the retired requirement
+
+**Choice**: Treat this as a normative behavioural change (REMOVED in the delta), not a documentation refresh (MODIFIED with caveats).
+
+**Alternatives considered**:
+
+- **MODIFY the requirement** to say "the script is retained for future passkey re-provisioning". Rejected — there is no committed re-provisioning plan, and the spec should not invent one to justify keeping dead code.
+- **Leave the spec as-is and only update frontend docs**. Rejected — the spec is the source of truth on the capability; letting it drift from the live code (no script, no user) defeats the point of having one.
+
+**Rationale**: REMOVED with a clear `Reason:` + `Migration:` block is the honest formulation. The capability narrows by one requirement; downstream consumers (developers, agents, future changes) get a clean signal that the path is intentionally gone.
+
+### D2: Do not preempt the future WebAuthn-testing design
+
+**Choice**: Do not author a placeholder `Future Passkey CI Regression Testing` requirement now. The REMOVED block's `Migration:` text points at virtual authenticator as the likely direction if/when the need surfaces — that's the limit of what this change commits to.
+
+**Alternatives considered**:
+
+- **Add an ADDED requirement reserving the design space** ("the system SHOULD support virtual-authenticator-based WebAuthn testing"). Rejected — speculative; commits the project to building something nobody asked for and that would constrain the eventual design.
+
+**Rationale**: Spec hygiene. Don't pollute the capability with placeholders for unrequested work.
+
+### D3: Cloud-tenant user cleanup deferred
+
+**Choice**: Leave the user row on the Zitadel Cloud tenant untouched. Document the deferral in `proposal.md` Out-of-scope and this design.md Goals/Non-Goals.
+
+**Alternatives considered**:
+
+- **Delete the Cloud user as part of this change**. Rejected — the Cloud tenant retention decision is upstream of any single user-cleanup task. If/when an `archive-zitadel-cloud-tenant`-class change reopens, the user-cleanup belongs there. Folding it in here would split the Cloud-tenant retention question across two changes.
+
+**Rationale**: Scope discipline. The user is inert (no DNS, no OIDC traffic, no cost); deferring its cleanup costs nothing.
+
+## Risks / Trade-offs
+
+| Risk | Mitigation |
+|---|---|
+| A future developer needs to QA the passkey login UX manually and finds the script gone. | The `.auth/README.md` "Historical note" footer points at the deleted script's history + virtual-authenticator as the future direction. Restoring the script from git history is a single `git show <sha>:scripts/capture-auth-state.ts > scripts/capture-auth-state.ts` away if someone really needs the headed flow on a display-capable host. |
+| `playwright-password-test-user`'s recently-archived "Existing Passkey Capture Path Retained" requirement is REMOVED only ~hours after it was added. The change history will show the path was retained, then immediately retired. | This is the honest record. The retention was a hedge made during a busier change; the verify pass on that change surfaced the issue (W1) and this change resolves it. The git log narrative ("retained → discovered vacuous → removed") is readable and informative. |
+| If the Cloud tenant is ever decommissioned and the `pepperoni9+playwright-1@gmail.com` user along with it, an entry will exist in git history that some future grep may surface confusingly. | The `.auth/README.md` Historical note documents why. Future grep readers will find the explanation in the same paragraph that mentions the user name. |
+
+## Migration Plan
+
+Pure removal — no migration of state or runtime data. Specification PR + frontend PR can land in either order:
+
+1. `specification` PR REMOVES the requirement and adds this change's artifacts.
+2. `frontend` PR `git rm`s the script + simplifies the docs.
+3. After both merge, `/opsx:archive remove-passkey-capture-path` folds the REMOVED delta into the main `e2e-auth-testing/spec.md` (decrementing its requirement count by 1).
+
+**Rollback**: revert both PR merges. The spec requirement comes back, the script comes back from git history, the docs revert. The dead path is restored, but functionally nothing changes because the user it targets is still gone — rollback only undoes the cleanup.
+
+## Open Questions
+
+None. The Cloud-tenant cleanup question is closed by D3 (deferred). The future-WebAuthn-testing question is closed by D2 (not preempted). The script-deletion question is closed by D1 (REMOVE, not MODIFY).

--- a/openspec/changes/remove-passkey-capture-path/proposal.md
+++ b/openspec/changes/remove-passkey-capture-path/proposal.md
@@ -25,6 +25,7 @@ The Cloud tenant where the user was originally provisioned is retained indefinit
 ### Modified Capabilities
 
 - `e2e-auth-testing`: one requirement REMOVED (`Existing Passkey Capture Path Retained`). No requirements added or otherwise modified. The remaining requirements (Playwright MCP Authenticated Session, StorageState Capture Script, StorageState Gitignore, Password-Based Storage State Capture Path, Test-User Credential File Gitignored) continue to describe the password capture path correctly — the first three are credential-type-agnostic and the last two were added by `playwright-password-test-user`.
+- `identity-management`: one requirement MODIFIED (`Provision Password-Based E2E Test User in Dev Zitadel`, dropping the "distinct from the existing passkey-only test user" phrase from the statement and rationale) and one requirement REMOVED (`Test User Coexists with Passkey User`). Both were added by `playwright-password-test-user`. After the deltas land, `identity-management` has a single normative source for the dev E2E test user (the modified `Provision Password-Based E2E Test User in Dev Zitadel` requirement) and no surviving references to the wiped passkey user.
 
 ### New Capabilities
 
@@ -39,6 +40,7 @@ None at the capability level — only one requirement within `e2e-auth-testing` 
 **Affected repositories**
 
 - `specification/openspec/specs/e2e-auth-testing/spec.md`: one requirement folded out via archive's delta-sync.
+- `specification/openspec/specs/identity-management/spec.md`: one requirement MODIFIED in place + one folded out via archive's delta-sync.
 - `frontend/scripts/capture-auth-state.ts`: deleted (~90 lines).
 - `frontend/AGENTS.md`: "Playwright MCP" section trimmed (~10 lines net).
 - `frontend/.auth/README.md`: dual-user matrix collapsed to single-user procedure (~30 lines net).

--- a/openspec/changes/remove-passkey-capture-path/proposal.md
+++ b/openspec/changes/remove-passkey-capture-path/proposal.md
@@ -24,7 +24,7 @@ The Cloud tenant where the user was originally provisioned is retained indefinit
 
 ### Modified Capabilities
 
-- `e2e-auth-testing`: one requirement REMOVED (`Existing Passkey Capture Path Retained`). No requirements added or otherwise modified. The capability narrows to password-only on its remaining requirements (Password-Based Storage State Capture Path, Test-User Credential File Gitignored).
+- `e2e-auth-testing`: one requirement REMOVED (`Existing Passkey Capture Path Retained`). No requirements added or otherwise modified. The remaining requirements (Playwright MCP Authenticated Session, StorageState Capture Script, StorageState Gitignore, Password-Based Storage State Capture Path, Test-User Credential File Gitignored) continue to describe the password capture path correctly — the first three are credential-type-agnostic and the last two were added by `playwright-password-test-user`.
 
 ### New Capabilities
 

--- a/openspec/changes/remove-passkey-capture-path/proposal.md
+++ b/openspec/changes/remove-passkey-capture-path/proposal.md
@@ -1,0 +1,63 @@
+## Why
+
+The just-archived `playwright-password-test-user` change ([archive/2026-05-14-playwright-password-test-user/](../archive/2026-05-14-playwright-password-test-user/)) shipped an `Existing Passkey Capture Path Retained` requirement on the `e2e-auth-testing` capability — the spec mandates that `frontend/scripts/capture-auth-state.ts` remain unchanged so a developer on a display-capable host can drive the headed OIDC flow with the existing passkey test user.
+
+That requirement is **operationally vacuous on the active self-hosted dev Zitadel**: the passkey user the scenario implicitly references — `pepperoni9+playwright-1@gmail.com` — is a Zitadel-Cloud-era Self-Registration user that was wiped by `self-hosted-zitadel §10`'s `truncate_users_for_zitadel_migration` Atlas migration and was never re-provisioned on self-hosted. The script is now dead code: it loads Chromium, redirects to `/loginname`, fills the email, and Zitadel returns `user not found`.
+
+Three concrete harms follow from leaving it as-is:
+
+1. **Misleading docs**: `frontend/AGENTS.md` (the canonical agent-facing entry point) and `frontend/.auth/README.md` both name `pepperoni9+playwright-1@gmail.com` as the passkey path's test user. A new developer or agent following the docs will sink 5–10 minutes diagnosing "user not found" before realising the documented user doesn't exist on the active issuer.
+2. **Spec drift**: `e2e-auth-testing` requires the script's retention, but no scenario in any capability requires Zitadel to host the user the script targets. The requirement and the surrounding reality have diverged; the spec is no longer a credible source of truth on this capability.
+3. **Dead code**: `scripts/capture-auth-state.ts` plus the `npx tsx scripts/capture-auth-state.ts` invocation it implies clutters the repo without any path to working. Its existence prolongs the "maybe someone is using this?" ambiguity that retiring it removes.
+
+The Cloud tenant where the user was originally provisioned is retained indefinitely per `self-hosted-zitadel §15.1` / `§18.10` as a no-cost rollback escape hatch — but DNS does not point at Cloud, no OIDC traffic reaches it, and rollback is no longer a planned action. The user on the Cloud tenant is inert.
+
+## What Changes
+
+- **Remove** the `Existing Passkey Capture Path Retained` requirement from `e2e-auth-testing/spec.md` (REMOVED with a clear `Migration:` line pointing operators at the password capture path).
+- **Delete** `frontend/scripts/capture-auth-state.ts`.
+- **Revise** `frontend/AGENTS.md` "Playwright MCP (Authenticated E2E Testing)" section to a single-user, password-only table. Drop all `pepperoni9+playwright-1@gmail.com` references; keep the password-flow procedure intact.
+- **Revise** `frontend/.auth/README.md` to drop the dual-user / passkey columns and sections. Keep the password-flow procedure, rotation protocol, and gitignore conventions.
+- **Leave the Cloud tenant user untouched.** It is inert (no DNS, no OIDC traffic) and the Cloud tenant retention is a separate operational decision (`self-hosted-zitadel §15.1`). If a future change consolidates the Cloud-tenant decommission, it can clean up the user as part of that scope.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `e2e-auth-testing`: one requirement REMOVED (`Existing Passkey Capture Path Retained`). No requirements added or otherwise modified. The capability narrows to password-only on its remaining requirements (Password-Based Storage State Capture Path, Test-User Credential File Gitignored).
+
+### New Capabilities
+
+None.
+
+### Removed Capabilities
+
+None at the capability level — only one requirement within `e2e-auth-testing` is removed.
+
+## Impact
+
+**Affected repositories**
+
+- `specification/openspec/specs/e2e-auth-testing/spec.md`: one requirement folded out via archive's delta-sync.
+- `frontend/scripts/capture-auth-state.ts`: deleted (~90 lines).
+- `frontend/AGENTS.md`: "Playwright MCP" section trimmed (~10 lines net).
+- `frontend/.auth/README.md`: dual-user matrix collapsed to single-user procedure (~30 lines net).
+
+**Affected systems**
+
+- None at runtime. Dev Zitadel state unchanged. The Cloud tenant user remains in place (inert).
+
+**Reversibility**
+
+- Single revert of both PR merges restores the script and docs. The `e2e-auth-testing` requirement can be re-added in a follow-up change if a future need surfaces (e.g., CI WebAuthn regression testing via virtual authenticator — a separate design problem, not a fork of the current script's lineage).
+
+**Dependencies**
+
+- Requires `playwright-password-test-user` archived (it is — `archive/2026-05-14-playwright-password-test-user/`).
+- Does not interact with `archive-zitadel-cloud-tenant` (descoped per `self-hosted-zitadel §18.10` — tenant retained indefinitely).
+
+**Out of scope**
+
+- Cloud-tenant cleanup of `pepperoni9+playwright-1@gmail.com` (would belong in a future Cloud-decommission change, not here).
+- Virtual-authenticator approach to passkey regression testing (separate design problem; out of scope until / unless the need surfaces).
+- Retiring any other dev-only test fixture or seed user.

--- a/openspec/changes/remove-passkey-capture-path/specs/e2e-auth-testing/spec.md
+++ b/openspec/changes/remove-passkey-capture-path/specs/e2e-auth-testing/spec.md
@@ -1,0 +1,9 @@
+## REMOVED Requirements
+
+### Requirement: Existing Passkey Capture Path Retained
+
+**Reason**: The passkey user the requirement implicitly relies on (`pepperoni9+playwright-1@gmail.com`, a Zitadel-Cloud-era Self-Registration user) was wiped from the dev Zitadel by `self-hosted-zitadel §10`'s `truncate_users_for_zitadel_migration` Atlas migration and was never re-provisioned on self-hosted. The script (`frontend/scripts/capture-auth-state.ts`) is therefore dead code against the active dev Zitadel issuer — it opens Chromium, drives the OIDC flow to `/loginname`, and Zitadel returns "user not found". Retaining the requirement misrepresents the state of the capability.
+
+**Migration**: Use the `Password-Based Storage State Capture Path` requirement on the same capability instead — `npm run auth:capture:password` in the `frontend` repo. The password user is Pulumi-managed on the dev Zitadel (`liverty-music/cloud-provisioning` `E2eTestUserComponent`) and the script is headless / WSL2-compatible.
+
+If a future need for actual WebAuthn / passkey CI regression testing surfaces, that is a new design problem (Chrome DevTools virtual authenticator via `webAuthn.addVirtualAuthenticator` + Pulumi-managed device-bound enrollment) — not a fork of the deleted script's lineage. A new requirement (and likely a new component on the cloud-provisioning side) should be designed in a follow-up change.

--- a/openspec/changes/remove-passkey-capture-path/specs/identity-management/spec.md
+++ b/openspec/changes/remove-passkey-capture-path/specs/identity-management/spec.md
@@ -4,7 +4,7 @@
 
 The dev self-hosted Zitadel instance SHALL provision, via Pulumi, a password-based `zitadel.HumanUser` for E2E test automation. The provisioning SHALL be gated to the `dev` Pulumi stack and SHALL NOT execute in any other stack.
 
-**Rationale**: Headless test automation cannot drive a passkey-only login flow (passkey requires a biometric / PIN gesture from a registered device). A Pulumi-managed password-based user provides a credential path the headless capture script can drive end-to-end, unblocking E2E coverage of the post-cutover self-hosted issuer. (Earlier wording referenced "distinct from the existing passkey-only test user" — that wording was inherited from the original `playwright-password-test-user` change but no passkey-only test user exists on the active self-hosted dev Zitadel; the Zitadel-Cloud-era Self-Registration user was wiped by `self-hosted-zitadel §10` and never re-provisioned. See change `remove-passkey-capture-path` for the cleanup record.)
+**Rationale**: Headless test automation cannot drive a passkey-only login flow (passkey requires a biometric / PIN gesture from a registered device). A Pulumi-managed password-based user provides a credential path the headless capture script can drive end-to-end, unblocking E2E coverage of the post-cutover self-hosted issuer. (Earlier wording referenced "distinct from the existing passkey-only test user" — that wording was inherited from the original `playwright-password-test-user` change but no passkey-only test user exists on the active self-hosted dev Zitadel; the Zitadel-Cloud-era Self-Registration user was wiped by `self-hosted-zitadel §10` and never re-provisioned.)
 
 #### Scenario: Pulumi apply on dev stack provisions the test user
 

--- a/openspec/changes/remove-passkey-capture-path/specs/identity-management/spec.md
+++ b/openspec/changes/remove-passkey-capture-path/specs/identity-management/spec.md
@@ -1,0 +1,44 @@
+## MODIFIED Requirements
+
+### Requirement: Provision Password-Based E2E Test User in Dev Zitadel
+
+The dev self-hosted Zitadel instance SHALL provision, via Pulumi, a password-based `zitadel.HumanUser` for E2E test automation. The provisioning SHALL be gated to the `dev` Pulumi stack and SHALL NOT execute in any other stack.
+
+**Rationale**: Headless test automation cannot drive a passkey-only login flow (passkey requires a biometric / PIN gesture from a registered device). A Pulumi-managed password-based user provides a credential path the headless capture script can drive end-to-end, unblocking E2E coverage of the post-cutover self-hosted issuer. (Earlier wording referenced "distinct from the existing passkey-only test user" — that wording was inherited from the original `playwright-password-test-user` change but no passkey-only test user exists on the active self-hosted dev Zitadel; the Zitadel-Cloud-era Self-Registration user was wiped by `self-hosted-zitadel §10` and never re-provisioned. See change `remove-passkey-capture-path` for the cleanup record.)
+
+#### Scenario: Pulumi apply on dev stack provisions the test user
+
+- **WHEN** `pulumi up` runs on the `dev` stack
+- **THEN** a `zitadel.HumanUser` resource SHALL be created in the self-hosted Zitadel instance with a recognizable display name and an email under the dev domain
+- **AND** the user SHALL have `InitialPassword` set from the ESC value `pulumiConfig.zitadel.e2eTestUser.password` (read via `config.requireSecretObject`)
+- **AND** the user SHALL have `isEmailVerified` set to `true` — without this flag Zitadel injects an email-verification step into the OIDC flow that the headless capture script cannot handle
+- **AND** the user SHALL have no second-factor (TOTP / SMS / passkey) enrollment
+
+#### Scenario: Non-dev stacks do not provision the test user
+
+- **WHEN** `pulumi up` runs on any stack other than `dev`
+- **THEN** the Pulumi program SHALL NOT instantiate the test-user component (today via the outer `if (env === "dev")` check that gates the entire `Zitadel` composition; see Tasks §1.6/§1.8)
+- **AND** no `zitadel.HumanUser` resource for `e2e-test-password` SHALL appear in the preview diff
+- **AND** the component-internal synthesis guard (`if (env !== "dev") throw …`) and the parent `Zitadel` class guard remain in place as defensive depth — if the outer `if (env === "dev")` check is removed in a future refactor, either guard SHALL throw with a clear "dev-only" error message before any Zitadel API call is made
+
+#### Scenario: `initialPassword` changes do not trigger silent replacement
+
+- **WHEN** an operator changes the ESC value `pulumiConfig.zitadel.e2eTestUser.password`
+- **AND** `pulumi preview --stack dev` is run on the next deploy
+- **THEN** the preview SHALL show NO change to the e2e-test-user `zitadel.HumanUser` resource (the `ignoreChanges: ['initialPassword']` directive on the resource hides the diff)
+- **AND** the captured Playwright `storageState.json` SHALL remain valid until the operator explicitly forces a replacement
+
+#### Scenario: Intentional rotation requires an explicit replace
+
+- **WHEN** an operator runs `pulumi up --replace <urn-of-e2e-test-user>` on the dev stack
+- **THEN** the preview SHALL clearly indicate the replacement (`-/+ create replacement`)
+- **AND** after apply, the new HumanUser SHALL use the latest ESC `initialPassword` value
+- **AND** the operator is then responsible for re-mirroring `.auth/password.md` and re-running the headless capture script to regenerate `.auth/storageState.json`
+
+## REMOVED Requirements
+
+### Requirement: Test User Coexists with Passkey User
+
+**Reason**: The requirement asserts "the existing passkey-only user SHALL still be present in Zitadel and unchanged", but on the active self-hosted dev Zitadel there is no passkey-only test user. The user the requirement refers to (`pepperoni9+playwright-1@gmail.com`) was a Zitadel-Cloud-era Self-Registration account that was wiped by `self-hosted-zitadel §10`'s `truncate_users_for_zitadel_migration` Atlas migration and was never re-provisioned. The requirement therefore mandates a state that does not exist; retaining it puts main specs in direct contradiction with the `Existing Passkey Capture Path Retained` removal in `e2e-auth-testing/spec.md` (this same change) and with the reality of the live dev Zitadel.
+
+**Migration**: None required at the system level — there was nothing to coexist with. The `Provision Password-Based E2E Test User in Dev Zitadel` requirement (MODIFIED in this same delta to drop the "distinct from the existing passkey-only test user" phrasing) remains the single normative source of truth for the dev E2E test user. If a future need for a parallel passkey-based test user surfaces (e.g., for virtual-authenticator-driven WebAuthn regression testing), a new requirement should be authored in that change rather than restoring this one.

--- a/openspec/changes/remove-passkey-capture-path/tasks.md
+++ b/openspec/changes/remove-passkey-capture-path/tasks.md
@@ -1,0 +1,26 @@
+## 1. Frontend cleanup
+
+- [ ] 1.1 `git rm frontend/scripts/capture-auth-state.ts` — delete the dead headed-Chromium passkey capture script
+- [ ] 1.2 Revise `frontend/AGENTS.md` "Playwright MCP (Authenticated E2E Testing)" section to a single-user (password) table. Drop all `pepperoni9+playwright-1@gmail.com` references; preserve the password-flow procedure (ESC retrieval + `npm run auth:capture:password`) intact. Remove the WSL2 caveat for the passkey path (no longer relevant).
+- [ ] 1.3 Revise `frontend/.auth/README.md` to drop the dual-user / passkey sections (host-suitability table collapses to one row; "Falling back to the passkey flow" section deleted). Keep the password-flow setup procedure, rotation protocol, and gitignore conventions.
+- [ ] 1.4 `make lint` passes (biome + stylelint + brand-vocabulary + tsc)
+
+## 2. Spec sync
+
+- [ ] 2.1 The `e2e-auth-testing` spec delta in this change defines a single REMOVED requirement ("Existing Passkey Capture Path Retained") with a clear `Reason:` + `Migration:` block. No additional spec edits are required — the rest of `e2e-auth-testing` (Playwright MCP Authenticated Session, StorageState Capture Script, StorageState Gitignore, Password-Based Storage State Capture Path, Test-User Credential File Gitignored) stays intact and continues to describe the password capture path correctly
+
+## 3. Verification
+
+- [ ] 3.1 After both PRs merge: confirm `frontend/scripts/capture-auth-state.ts` is gone on `main` and `npm run auth:capture:password` still completes end-to-end on WSL2 + WSLg with "Smoke test PASSED"
+- [ ] 3.2 `openspec validate remove-passkey-capture-path` passes locally
+- [ ] 3.3 `openspec list --json` shows the change with `isComplete=true` after tasks are ticked
+
+## 4. Out of scope (do NOT include in this change)
+
+- [ ] 4.1 Cloud-tenant cleanup of `pepperoni9+playwright-1@gmail.com` — Cloud tenant retention is governed by `self-hosted-zitadel §15.1` / `§18.10` (retained indefinitely as no-cost rollback escape hatch). User is inert (no DNS, no OIDC traffic). Folded into a future Cloud-decommission change if and when one is opened. This task exists in tasks.md only as an explicit "do not do here" marker for the implementer
+
+## 5. Archive prep
+
+- [ ] 5.1 `openspec validate remove-passkey-capture-path` passes
+- [ ] 5.2 `openspec status --change remove-passkey-capture-path --json` reports `isComplete=true`
+- [ ] 5.3 `/opsx:archive remove-passkey-capture-path`

--- a/openspec/changes/remove-passkey-capture-path/tasks.md
+++ b/openspec/changes/remove-passkey-capture-path/tasks.md
@@ -7,7 +7,8 @@
 
 ## 2. Spec sync
 
-- [ ] 2.1 The `e2e-auth-testing` spec delta in this change defines a single REMOVED requirement ("Existing Passkey Capture Path Retained") with a clear `Reason:` + `Migration:` block. No additional spec edits are required — the rest of `e2e-auth-testing` (Playwright MCP Authenticated Session, StorageState Capture Script, StorageState Gitignore, Password-Based Storage State Capture Path, Test-User Credential File Gitignored) stays intact and continues to describe the password capture path correctly
+- [ ] 2.1 The `e2e-auth-testing` spec delta in this change defines a single REMOVED requirement ("Existing Passkey Capture Path Retained") with a clear `Reason:` + `Migration:` block. The remaining `e2e-auth-testing` requirements (Playwright MCP Authenticated Session, StorageState Capture Script, StorageState Gitignore, Password-Based Storage State Capture Path, Test-User Credential File Gitignored) stay intact and continue to describe the password capture path correctly
+- [ ] 2.2 The `identity-management` spec delta in this change defines (a) a REMOVED requirement ("Test User Coexists with Passkey User") with a clear `Reason:` + `Migration:` block — the passkey user it requires to remain present does not exist on the active dev Zitadel; and (b) a MODIFIED of the "Provision Password-Based E2E Test User in Dev Zitadel" requirement dropping the "distinct from the existing passkey-only test user" phrasing inherited from `playwright-password-test-user`. After the archive folds these in, `identity-management` no longer references the wiped passkey user
 
 ## 3. Verification
 

--- a/openspec/changes/remove-passkey-capture-path/tasks.md
+++ b/openspec/changes/remove-passkey-capture-path/tasks.md
@@ -18,7 +18,7 @@
 
 ## 4. Out of scope (do NOT include in this change)
 
-- [ ] 4.1 Cloud-tenant cleanup of `pepperoni9+playwright-1@gmail.com` — Cloud tenant retention is governed by `self-hosted-zitadel §15.1` / `§18.10` (retained indefinitely as no-cost rollback escape hatch). User is inert (no DNS, no OIDC traffic). Folded into a future Cloud-decommission change if and when one is opened. This task exists in tasks.md only as an explicit "do not do here" marker for the implementer
+- 4.1 Cloud-tenant cleanup of `pepperoni9+playwright-1@gmail.com` — Cloud tenant retention is governed by `self-hosted-zitadel §15.1` / `§18.10` (retained indefinitely as no-cost rollback escape hatch). User is inert (no DNS, no OIDC traffic). Folded into a future Cloud-decommission change if and when one is opened. This bullet exists in tasks.md only as an explicit "do not do here" marker for the implementer — formatted as a plain bullet (not `- [ ]`) so the `isComplete` calculation does not gate on it
 
 ## 5. Archive prep
 


### PR DESCRIPTION
## Summary

Propose `remove-passkey-capture-path` — the loop-closer for the **W1** finding documented in [`playwright-password-test-user`'s Implementation Deltas](https://github.com/liverty-music/specification/tree/main/openspec/changes/archive/2026-05-14-playwright-password-test-user/design.md).

The just-archived `playwright-password-test-user` folded an `Existing Passkey Capture Path Retained` requirement into main `e2e-auth-testing/spec.md`. The script the requirement names (`frontend/scripts/capture-auth-state.ts`) is unchanged, BUT the passkey user it implicitly targets (`pepperoni9+playwright-1@gmail.com`, a Zitadel-Cloud-era Self-Registration user) was wiped by `self-hosted-zitadel §10`'s `truncate_users_for_zitadel_migration` and was never re-provisioned on the self-hosted dev Zitadel. The script is dead code.

## What this change does

- **Specification (this PR)**: REMOVE the `Existing Passkey Capture Path Retained` requirement from `e2e-auth-testing/spec.md` via the standard REMOVED delta, with a clear `Reason:` + `Migration:` block pointing operators at the password capture path.
- **Frontend (companion PR — to be opened separately)**:
  - `git rm scripts/capture-auth-state.ts`
  - collapse `AGENTS.md` "Playwright MCP" section to a single-user (password) table
  - collapse `.auth/README.md` to a single-user procedure
- **Cloud tenant cleanup**: explicitly OUT OF SCOPE. The Cloud tenant is retained indefinitely per `self-hosted-zitadel §15.1` / `§18.10`; the inert user there can be cleaned up in a future Cloud-decommission change.

## Capabilities

- `e2e-auth-testing` MODIFIED: 1 REMOVED requirement. The remaining requirements on the capability (Playwright MCP Authenticated Session, StorageState Capture Script, StorageState Gitignore, Password-Based Storage State Capture Path, Test-User Credential File Gitignored) continue to describe the password capture path correctly.

## Test plan

- [x] `openspec validate remove-passkey-capture-path` passes locally
- [ ] Companion frontend PR (script `git rm` + docs trim) lands in parallel
- [ ] After both PRs merge: `openspec status --change remove-passkey-capture-path --json` reports `isComplete=true`
- [ ] After verification: `/opsx:archive remove-passkey-capture-path` (separate archive PR)
