### PR TITLE
docs(openspec): propose enable-zitadel-prod-pulumi-provider (follow-up to #457)

### DIFF
--- a/openspec/changes/enable-zitadel-prod-pulumi-provider/.openspec.yaml
+++ b/openspec/changes/enable-zitadel-prod-pulumi-provider/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-14

--- a/openspec/changes/enable-zitadel-prod-pulumi-provider/design.md
+++ b/openspec/changes/enable-zitadel-prod-pulumi-provider/design.md
@@ -1,0 +1,132 @@
+## Context
+
+After the `prod-k8s-manifests` change deploy on 2026-05-14, the prod self-hosted Zitadel is running at `https://auth.liverty-music.app` (zitadel-api Pod 3/3 Ready, zitadel-web Pod 1/1 Ready, public OIDC issuer responding). The first-boot bootstrap-uploader sidecar populated `zitadel-machine-key-for-pulumi-admin` GSM Secret with version 1 at 11:12:47 UTC — this is the JWT-profile for the org-admin machine user that Zitadel auto-created during `start-from-init`.
+
+What didn't happen: the planned "second `pulumi up --stack prod`" did not create the backend MachineKey, because the Pulumi code that creates it (`MachineUserComponent`) is invoked only from inside the `Zitadel` class at [`src/zitadel/index.ts`](https://github.com/liverty-music/cloud-provisioning/blob/main/src/zitadel/index.ts), and that class is instantiated only when `env === 'dev'` at [`src/index.ts:74`](https://github.com/liverty-music/cloud-provisioning/blob/main/src/index.ts#L74). The original gate was correct for the SaaS Cloud-tenant Zitadel; it was not lifted when prod switched to self-hosted.
+
+The blast-radius separation that `prod-k8s-manifests` round-12 fix established (org-admin JWT → Pulumi only; backend uses a derived lower-privilege MachineKey) is correct — the gap is purely on the Pulumi side. Three GCP resources need to exist after this change runs successfully: the prod Zitadel `MachineUser`, the prod Zitadel `MachineKey`, and the GSM `Secret` + `SecretVersion` named `zitadel-machine-key-for-backend-app` (project `liverty-music-prod`).
+
+Backend Pods on prod are currently stuck in `ContainerCreating` waiting for that GSM Secret. The blocker chain is: this change merges → `pulumi up --stack prod` creates the 5 new resources → ESO syncs the new GSM Secret into the backend namespace → Reloader rolls the backend Deployment → backend Pods reach Running → backend → Zitadel auth path is live.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make `pulumi up --stack prod` create exactly the resources needed for the backend ↔ Zitadel auth path: prod Zitadel `MachineUser`, `MachineKey`, GSM `Secret` + `SecretVersion`, ESO accessor IAM binding.
+- Keep the blast-radius separation: the org-admin JWT (`zitadel-machine-key-for-pulumi-admin`) is consumed only by Pulumi at plan/apply time; the GSM SecretVersion that backend mounts is a *separate* JWT for a lower-privilege machine user with the `ORG_USER_MANAGER` role.
+- Reuse the dev pattern (`MachineUserComponent`) verbatim — same component, same role assignment, same JWT lifecycle. Differences should be configuration-only (provider URL, org ID, GCP project).
+- Land this change before any new feature work that depends on backend → Zitadel auth (currently blocked: backend Pods stuck in `ContainerCreating`).
+
+**Non-Goals:**
+
+- Wiring up the SaaS Zitadel feature set for prod: admin Google IDP (`googleAdminIdpClientId/Secret` ESC values), SMTP (Postmark), ActionsV2 webhooks, productOrg branding, e2e-test-user provisioning. These come when prod actually needs them — they are separate downstream changes.
+- Rotating the org-admin JWT (`zitadel-machine-key-for-pulumi-admin`). That key was minted by first-boot bootstrap, and the design intent is "effectively never expires" for the admin tier; rotation is a separate runbook.
+- Backfilling Pulumi-managed cross-project Artifact Registry IAM (manual `gcloud projects add-iam-policy-binding` was applied during the `prod-k8s-manifests` deploy — that gets adopted into Pulumi state in a *separate* change).
+- Wiring the backend-migrations Application's cross-repo dependency on the backend repo's `k8s/atlas/overlays/prod` (separate backend-repo PR).
+
+## Decisions
+
+### D1: Extract `BackendMachineKeyComponent` (Option B) over lifting the full `Zitadel` class gate (Option A)
+
+**Decision:** Extract a focused, top-level `BackendMachineKeyComponent` that takes minimal inputs (Zitadel provider, org ID, GSM project) and produces the four resources needed. Do NOT lift the env gate on the existing `Zitadel` class.
+
+**Why:**
+
+- The existing `Zitadel` class also creates `adminOrg`, `productOrg`, `frontend`, `smtp`, `actionsV2` resources that are NOT needed for prod and would either fail (Zitadel API rejects "admin" org create because it already exists from first-boot bootstrap) or create unwanted side effects (a second `productOrg` distinct from the first-boot org). Adding env conditionals throughout the `Zitadel` class would scatter the dev/prod split across multiple files.
+- The minimum component for prod is `Zitadel Provider + MachineUserComponent + GSM Secret + GSM SecretVersion + IAM binding`. Pulling that into a focused top-level component (parallel to `SecretsComponent`) keeps `src/index.ts` readable and makes the prod call site one expressive `new BackendMachineKeyComponent(...)` line.
+- `MachineUserComponent` already exists and is stable on dev. The refactor pulls it into the new top-level component as-is; dev's `Zitadel` class becomes the *caller* in dev, prod calls the new component directly. Zero risk to dev's existing behavior.
+
+**Alternative considered (Option A):** Lift the `env === 'dev'` gate on `new Zitadel(...)` and pass `env`-conditional skip flags into the class to disable `adminOrg`/`productOrg`/etc. for prod. Rejected — it broadens an already-complex class, and the prod path would still call the `Zitadel` class with most arguments set to `undefined`, which is confusing at the call site.
+
+### D2: Look up the "admin" org rather than create it
+
+**Decision:** The `BackendMachineKeyComponent` accepts the org ID as a *data input* (resolved via `zitadel.getOrg({ name: 'admin' }, { provider })`) — it does not create the org. The org was auto-created by first-boot via `ZITADEL_FIRSTINSTANCE_ORG_NAME=admin`; trying to `new zitadel.Org(...)` would conflict (the org already exists outside Pulumi state).
+
+**Why:** Aligns Pulumi state with the runtime reality. The first-boot org is owned by Zitadel itself; importing it as a Pulumi-managed resource would tightly couple Zitadel's bootstrap to Pulumi's state and create a destroy-cascade hazard (`pulumi destroy` on prod would attempt to delete the admin org, which is the same org the admin JWT belongs to — circular dependency).
+
+**Alternative considered:** `zitadel.Org` resource with `aliases:` pointing at an imported state. Rejected — the imported state has no Pulumi history, and the lifecycle (Zitadel-managed `firstInstance` vs Pulumi-managed) doesn't fit the alias-rename pattern.
+
+### D3: Provider configuration sources the admin JWT from GSM by URN reference, not by passing the secret value
+
+**Decision:** Configure the Zitadel provider with:
+
+```typescript
+const adminJwt = gcp.secretmanager.getSecretVersion({
+  project: 'liverty-music-prod',
+  secret: 'zitadel-machine-key-for-pulumi-admin',
+}, { provider: gcpProvider })
+
+const zitadelProvider = new zitadel.Provider('zitadel-prod', {
+  domain: 'auth.liverty-music.app',
+  insecure: false,
+  jwtProfileJson: adminJwt.then(v => v.secretData),
+})
+```
+
+The `jwtProfileJson` is a Pulumi `Output<string>` derived from a `getSecretVersion` data source, so it's never serialized to the Pulumi state for the secret itself (just the URN reference + checksum).
+
+**Why:** Avoids round-tripping the JWT through Pulumi config / ESC. The JWT was minted by first-boot bootstrap; the source of truth is GSM. Reading it via a `getSecretVersion` data source on each `pulumi up` ensures Pulumi always uses the current version.
+
+**Risk:** The admin JWT must exist before this code path runs (it does, after the `prod-k8s-manifests` bootstrap-uploader sidecar populates it on first boot — confirmed populated at 11:12:47 UTC 2026-05-14). If somehow the GSM Secret is deleted or the version is disabled, `pulumi up` will fail at preview time with a clear "secret not found" error rather than create a broken MachineUser.
+
+### D4: Effective forever expiration on the prod backend MachineKey
+
+**Decision:** Match dev's pattern verbatim — `expirationDate: '2099-01-01T00:00:00Z'`. The same rotation-runbook gap (no automated rotation today) exists for prod, and a short expiration would cause silent breakage. Comment in code references the dev rationale.
+
+**Why:** This is a known trade-off documented in `zitadel-self-hosted-deployment` spec. Adding rotation is a separate change. Until then, the long-expiration matches dev's stability profile; the alternative (e.g., 90-day expiration) would create operational risk in prod without an existing rotation mechanism.
+
+**Follow-up:** A `zitadel-machine-key-rotation` change introduces a Pulumi-managed rotation cadence + alerting on near-expiry; out of scope here.
+
+## Risks / Trade-offs
+
+- **[Risk] Pulumi `getOrg({ name: 'admin' })` returns a different org than expected** (e.g., if multiple orgs named "admin" exist or if Zitadel's name lookup is loose). → Mitigation: assert on the resolved org's `id` matches what the `zitadel-machine-key-for-pulumi-admin` JWT's `iss` claim expects. Add a runtime check in the component constructor that throws if the lookup returns >1 result or no result.
+
+- **[Risk] First `pulumi up --stack prod` after this change fails because the Zitadel provider can't reach `auth.liverty-music.app`** (e.g., DNS not yet propagating, certificate not yet active). → Mitigation: the prod-k8s-manifests deploy has already verified `auth.liverty-music.app/.well-known/openid-configuration` is live and trusted (the gateway+cert-map is healthy, confirmed via §10 of that change). If it's not, the failure is clear (HTTP error from Zitadel provider) and recoverable via a re-run after DNS/cert is fixed.
+
+- **[Risk] Backend Pod doesn't pick up the new GSM Secret because Reloader doesn't watch GSM directly** (ESO writes a K8s Secret, Reloader watches K8s Secrets — but the backend Deployment may not have the right Reloader annotation). → Mitigation: the backend base manifest already has `reloader.stakater.com/auto: "true"` (confirmed in `prod-k8s-manifests` round-12 D4 design). ESO → K8s Secret → Reloader → Deployment rollout chain has worked on dev for months.
+
+- **[Risk] After this change merges, `pulumi up --stack dev` introduces churn** (because the refactor moves `MachineUserComponent` out of the `Zitadel` class to a new top-level component). → Mitigation: use `aliases: [{ name: 'old-urn' }]` on the new component's `MachineKey` resource to inherit the existing URN, preventing create-replace-delete cycle on the dev MachineKey (which would mint a new key and break dev backend's authn until ESO re-syncs). Memory `reference_pulumi_aliases_urn_rename.md` is the canonical pattern.
+
+- **[Trade-off] No SaaS feature parity in prod for now.** Admin login via Google IDP, SMTP via Postmark, ActionsV2 webhooks — none of these work on prod yet. They are not blockers for the API server: backend ↔ Zitadel auth works via JWT-profile, end-users can self-register via Zitadel's default email/password flow without SMTP (Zitadel logs the verification link instead of emailing it — usable for staged prod testing). Productionizing the admin IDP + SMTP is a separate follow-up.
+
+- **[Trade-off] Effective forever MachineKey expiration carries operational risk.** A leaked JWT-profile cannot be expired without a rotation runbook. → Tracked as the future `zitadel-machine-key-rotation` change. Dev has lived with this trade-off; prod adopts the same posture.
+
+## Migration Plan
+
+1. **Pre-merge prep**:
+   - Confirm `auth.liverty-music.app/.well-known/openid-configuration` returns 200 with the Zitadel issuer payload (already verified during `prod-k8s-manifests` §10).
+   - Confirm `zitadel-machine-key-for-pulumi-admin` GSM Secret has ≥1 enabled version (already verified — version 1 since 11:12:47 UTC 2026-05-14).
+2. **PR + CI**:
+   - `pulumi preview --stack dev` shows the refactor's URN moves with `aliases:` set correctly — expect zero replacement (no resource recreation), only a metadata move in state.
+   - `pulumi preview --stack prod` shows ~5 resources to create: 1 `MachineUser`, 1 `MachineKey`, 1 GSM `Secret`, 1 `SecretVersion`, 1 IAM `SecretIamMember`. Plus 1 `Output` (parent ComponentResource).
+3. **Merge**:
+   - Merge triggers auto-deploy on dev (the URN move should be a no-op state-wise; backend behavior unchanged).
+   - Prod stays on manual trigger.
+4. **Pulumi up for prod (manual, post-merge)**:
+   - Trigger `pulumi up --stack prod` from Pulumi Cloud console.
+   - Pulumi authenticates to `https://auth.liverty-music.app` using the admin JWT from GSM.
+   - Creates the prod `MachineUser` + `MachineKey` in Zitadel.
+   - Writes the resulting JWT-profile JSON to GSM SecretVersion `zitadel-machine-key-for-backend-app`.
+   - Creates the IAM binding granting ESO read access.
+5. **Verification (post-Pulumi-up)**:
+   - `gcloud secrets versions list zitadel-machine-key-for-backend-app --project liverty-music-prod` returns ≥1 enabled version.
+   - ESO reconciles `zitadel-machine-key-for-backend-app` ExternalSecret in the backend namespace within ~30s.
+   - Reloader detects the new K8s Secret and rolls the backend Deployment.
+   - Backend Pods (`server-app`, `consumer-app`) transition from `ContainerCreating` to `Running` (~2-3 min total from `pulumi up` completion).
+   - `curl -I https://api.liverty-music.app/grpc.health.v1.Health/Check` returns 200.
+
+**Rollback strategy:** If the prod `pulumi up` fails partway:
+- Delete any partial resources via `pulumi destroy --target` on the specific URN.
+- Re-run after fixing the root cause.
+- The backend Pods staying in `ContainerCreating` is the same pre-state as before this change — no regression risk.
+
+## Open Questions
+
+- **OQ1:** Should the prod backend MachineKey live in the "admin" org (first-boot single-org), or should this change also create a separate `productOrg` for prod (matching dev's two-org structure)?
+  - *Default decision unless raised:* use the single "admin" org. Two-org separation buys nothing while there are no other product machine users; can be revisited when we have a real reason (e.g., distinct billing or audit boundary).
+
+- **OQ2:** Does the Zitadel `getOrg(name)` data source exist in the `@pulumiverse/zitadel` provider, or do we need to use a different lookup mechanism?
+  - *To verify during implementation:* check `@pulumiverse/zitadel` docs / source. If `getOrg` by name doesn't exist, use `getOrgs` + filter, or pass the org ID via ESC (least desirable — couples to a Zitadel-internal ID).
+
+- **OQ3:** Should we surface the new GSM Secret's resource name into the prod backend overlay's `ExternalSecret` *here*, or rely on the dev manifest pattern (which already references `zitadel-machine-key-for-backend-app` by name)?
+  - *Default decision unless raised:* the dev pattern is already the canonical reference (per `zitadel-self-hosted-deployment` spec line 164); prod's backend overlay inherits it via the base. No k8s changes needed in this PR — purely Pulumi side.

--- a/openspec/changes/enable-zitadel-prod-pulumi-provider/design.md
+++ b/openspec/changes/enable-zitadel-prod-pulumi-provider/design.md
@@ -4,7 +4,7 @@ After the `prod-k8s-manifests` change deploy on 2026-05-14, the prod self-hosted
 
 What didn't happen: the planned "second `pulumi up --stack prod`" did not create the backend MachineKey, because the Pulumi code that creates it (`MachineUserComponent`) is invoked only from inside the `Zitadel` class at [`src/zitadel/index.ts`](https://github.com/liverty-music/cloud-provisioning/blob/main/src/zitadel/index.ts), and that class is instantiated only when `env === 'dev'` at [`src/index.ts:74`](https://github.com/liverty-music/cloud-provisioning/blob/main/src/index.ts#L74). The original gate was correct for the SaaS Cloud-tenant Zitadel; it was not lifted when prod switched to self-hosted.
 
-The blast-radius separation that `prod-k8s-manifests` round-12 fix established (org-admin JWT → Pulumi only; backend uses a derived lower-privilege MachineKey) is correct — the gap is purely on the Pulumi side. Three GCP resources need to exist after this change runs successfully: the prod Zitadel `MachineUser`, the prod Zitadel `MachineKey`, and the GSM `Secret` + `SecretVersion` named `zitadel-machine-key-for-backend-app` (project `liverty-music-prod`).
+The blast-radius separation that `prod-k8s-manifests` round-12 fix established (org-admin JWT → Pulumi only; backend uses a derived lower-privilege MachineKey) is correct — the gap is purely on the Pulumi side. Five Pulumi resources need to exist after this change runs successfully: the prod Zitadel `MachineUser` and `MachineKey` (Zitadel-provider resources targeting `auth.liverty-music.app`), the GSM `Secret` named `zitadel-machine-key-for-backend-app`, its `SecretVersion`, and the `SecretIamMember` granting ESO read access (all three GCP resources in project `liverty-music-prod`).
 
 Backend Pods on prod are currently stuck in `ContainerCreating` waiting for that GSM Secret. The blocker chain is: this change merges → `pulumi up --stack prod` creates the 5 new resources → ESO syncs the new GSM Secret into the backend namespace → Reloader rolls the backend Deployment → backend Pods reach Running → backend → Zitadel auth path is live.
 
@@ -28,7 +28,7 @@ Backend Pods on prod are currently stuck in `ContainerCreating` waiting for that
 
 ### D1: Extract `BackendMachineKeyComponent` (Option B) over lifting the full `Zitadel` class gate (Option A)
 
-**Decision:** Extract a focused, top-level `BackendMachineKeyComponent` that takes minimal inputs (Zitadel provider, org ID, GSM project) and produces the four resources needed. Do NOT lift the env gate on the existing `Zitadel` class.
+**Decision:** Extract a focused, top-level `BackendMachineKeyComponent` that takes minimal inputs (Zitadel provider, org ID, GSM project) and produces the five resources needed (`MachineUser`, `MachineKey`, GSM `Secret`, GSM `SecretVersion`, `SecretIamMember`). Do NOT lift the env gate on the existing `Zitadel` class.
 
 **Why:**
 

--- a/openspec/changes/enable-zitadel-prod-pulumi-provider/proposal.md
+++ b/openspec/changes/enable-zitadel-prod-pulumi-provider/proposal.md
@@ -23,7 +23,11 @@ This change closes that gap: enables a prod-scoped `Zitadel` Pulumi instance tha
 
 ### Modified Capabilities
 
-- `zitadel-self-hosted-deployment`: extend the existing Bootstrap Admin Machine Key + Backend MachineKey Lifecycle requirements to cover **prod** (currently they reference dev's project/SA/connection name with the implicit assumption that an `env === 'dev'` gate exists Pulumi-side). The requirement narrative becomes env-agnostic, and the prod-specific values (project = `liverty-music-prod`, Zitadel API URL = `https://auth.liverty-music.app`, IAM SA = `zitadel@liverty-music-prod.iam`) are validated against the existing scenarios. No new requirements; existing requirements broaden to apply equally to dev + prod.
+- `zitadel-self-hosted-deployment`: 2 MODIFIED + 2 ADDED requirements.
+  - **MODIFIED** "Cloud SQL Database and IAM User Pre-Provisioned by Pulumi" and "Backend MachineKey Lifecycle Tied to Zitadel-Side Identity" — narratives become env-agnostic (`zitadel@liverty-music-${env}.iam`), and the latter gains a new scenario asserting both dev and prod stacks each produce their own `MachineKey` + GSM `Secret`/`SecretVersion`.
+  - **ADDED** "First-Boot Org Looked Up via Provider Data Source" — prohibits creating the admin org as a `zitadel.Org` resource when first-boot bootstrap auto-created it (destroy-cascade hazard); mandates a `zitadel.getOrg` data-source lookup.
+  - **ADDED** "Prod Backend MachineKey Component Authenticates with Bootstrap-Uploaded Admin JWT" — mandates the prod provider's `jwtProfileJson` is sourced from `gcp.secretmanager.getSecretVersion` on `zitadel-machine-key-for-pulumi-admin`, never from Pulumi config or ESC.
+  - Prod-specific values (project = `liverty-music-prod`, Zitadel API URL = `https://auth.liverty-music.app`, IAM SA = `zitadel@liverty-music-prod.iam`) are validated against the broadened scenarios.
 
 ## Impact
 

--- a/openspec/changes/enable-zitadel-prod-pulumi-provider/proposal.md
+++ b/openspec/changes/enable-zitadel-prod-pulumi-provider/proposal.md
@@ -1,0 +1,41 @@
+## Why
+
+The just-archived `prod-k8s-manifests` change deployed self-hosted Zitadel on prod (auth.liverty-music.app is live, the bootstrap-uploader sidecar populated `zitadel-machine-key-for-pulumi-admin` GSM Secret at 11:12:47 UTC 2026-05-14 on first boot). The design assumed a follow-up `pulumi up --stack prod` would then use that org-admin JWT to create the backend's lower-privilege `MachineKey` (a Zitadel API call) and write the result to a *separate* GSM Secret `zitadel-machine-key-for-backend-app` — which is what the backend Pod mounts at runtime.
+
+**That follow-up Pulumi code does not exist for prod.** The `Zitadel` class at [`src/zitadel/index.ts`](https://github.com/liverty-music/cloud-provisioning/blob/main/src/zitadel/index.ts) — which wraps the `MachineUserComponent` that creates the backend MachineKey — is currently gated to `env === 'dev'` at [`src/index.ts:74`](https://github.com/liverty-music/cloud-provisioning/blob/main/src/index.ts#L74). The original gate was correct for the SaaS Cloud-tenant Zitadel (`https://liverty-music.zitadel.cloud`); it was *not* lifted when prod switched to self-hosted in `prod-k8s-manifests`. As a result, the prod backend Pods are stuck in `ContainerCreating` waiting for `zitadel-machine-key-for-backend-app` that nothing creates.
+
+This change closes that gap: enables a prod-scoped `Zitadel` Pulumi instance that points at `https://auth.liverty-music.app` and runs the same `MachineUserComponent` → backend MachineKey → GSM SecretVersion flow that dev has.
+
+## What Changes
+
+- **NEW**: `src/index.ts` instantiates a prod-scoped `Zitadel` (or a leaner equivalent — see Design) that points its Zitadel provider at `https://auth.liverty-music.app` and authenticates with the `zitadel-machine-key-for-pulumi-admin` GSM SecretVersion (populated by the in-cluster bootstrap-uploader sidecar on first Zitadel API Pod boot). Currently this is gated `env === 'dev'`; the gate lifts.
+- **NEW**: Prod ESC values for the Zitadel-side seeds needed by the Pulumi provider — at minimum the `zitadelConfig` ESC structure (`googleAdminIdp.{clientId,clientSecret}`, `adminGoogleSubs.pannpers`, `e2eTestUser.password`). Either prod gets its own values or each input is made optional in the `Zitadel` class so prod can run with a subset (the minimum being whatever `MachineUserComponent` requires).
+- **NEW**: `MachineUserComponent` runs for prod and creates a `zitadel.MachineUser` + `zitadel.MachineKey` inside prod's Zitadel; Pulumi writes the resulting JWT-profile JSON to the GSM Secret `zitadel-machine-key-for-backend-app` (prod project).
+- **MODIFIED**: ESO's prod-scoped `backend` namespace `ExternalSecret` already references `zitadel-machine-key-for-backend-app` (inherited from the dev pattern via the k8s base); once the Pulumi side creates the GSM SecretVersion, ESO reconciles it into the backend Pod and Reloader rolls the Deployment.
+- **DESIGN DECISION**: Whether to instantiate the full `Zitadel` class for prod (which also tries to create `adminOrg`, `productOrg`, `frontend`, `smtp`, `actionsV2`) — most of which are *already* configured inside the self-hosted Zitadel via its own bootstrap and Pulumi shouldn't recreate them — or to refactor `MachineUserComponent` into a stand-alone top-level component that can be instantiated independently. Tracked in design.md.
+- **OUT OF SCOPE**: The `zitadel-machine-key-for-pulumi-admin` to `zitadel-machine-key-for-backend-app` *handoff* is the load-bearing flow. The full SaaS Zitadel feature set (Google admin IDP wiring, SMTP, ActionsV2 webhooks) is not in scope — that comes when prod actually needs admin login + email + custom auth actions, which is a separate change. This PR is the minimum to make backend → Zitadel runtime auth work.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `zitadel-self-hosted-deployment`: extend the existing Bootstrap Admin Machine Key + Backend MachineKey Lifecycle requirements to cover **prod** (currently they reference dev's project/SA/connection name with the implicit assumption that an `env === 'dev'` gate exists Pulumi-side). The requirement narrative becomes env-agnostic, and the prod-specific values (project = `liverty-music-prod`, Zitadel API URL = `https://auth.liverty-music.app`, IAM SA = `zitadel@liverty-music-prod.iam`) are validated against the existing scenarios. No new requirements; existing requirements broaden to apply equally to dev + prod.
+
+## Impact
+
+- **`cloud-provisioning/src/index.ts`**: lift the `env === 'dev'` gate around `new Zitadel(...)` (line 74-95) to include prod. Or replace the call with a leaner top-level `MachineUserComponent` instantiation for prod (cleaner, but requires refactoring the `Zitadel` class to expose what's needed).
+- **`cloud-provisioning/src/zitadel/`**: depending on design decision, either refactor `Zitadel` class to make non-MachineKey resources optional, OR extract `MachineUserComponent` to a top-level component.
+- **Prod ESC** (`liverty-music/prod` environment): add the `zitadelConfig` ESC structure with the prod values needed by the `Zitadel` class signature (TBD which inputs are required vs optional — see Design).
+- **Prod Pulumi state**: `pulumi up --stack prod` will create:
+  - 1 Zitadel `MachineUser` (in the prod self-hosted Zitadel API)
+  - 1 Zitadel `MachineKey`
+  - 1 GSM `Secret` (`zitadel-machine-key-for-backend-app`)
+  - 1 GSM `SecretVersion` (the JWT-profile JSON)
+  - 1 IAM `SecretIamMember` (ESO accessor on the new Secret)
+- **Backend Pod runtime**: currently `ContainerCreating` — flips to `Running` once ESO syncs the new GSM Secret into the backend namespace and Reloader rolls the Deployment.
+- **Risk**: Pulumi runs against the prod Zitadel API using the org-admin JWT — bugs in MachineUserComponent could create orphaned MachineUsers or grant excessive privileges. Mitigation: review the same code path that has been stable in dev (no architectural changes, just env propagation).
+- **Out of scope**: SaaS Zitadel admin IDP / SMTP / ActionsV2 for prod; backend-migrations Application's cross-repo dependency on the backend repo's `k8s/atlas/overlays/prod` (separate backend-repo PR); making the cross-project Artifact Registry IAM grant Pulumi-managed (manual `gcloud projects add-iam-policy-binding` was applied during the prod-k8s-manifests deploy — a separate Pulumi-side cleanup change should adopt it into state).

--- a/openspec/changes/enable-zitadel-prod-pulumi-provider/specs/zitadel-self-hosted-deployment/spec.md
+++ b/openspec/changes/enable-zitadel-prod-pulumi-provider/specs/zitadel-self-hosted-deployment/spec.md
@@ -1,0 +1,88 @@
+## MODIFIED Requirements
+
+### Requirement: Cloud SQL Database and IAM User Pre-Provisioned by Pulumi
+
+Pulumi SHALL create the `zitadel` database and the `zitadel@liverty-music-${env}.iam` Cloud SQL IAM user on the `postgres-osaka` instance (where `${env}` is `dev` or `prod`), grant the IAM user ownership of the `zitadel` database, and bind Workload Identity so that the Zitadel Kubernetes Service Account can impersonate the IAM user.
+
+#### Scenario: Database resources exist after Pulumi apply
+
+- **WHEN** the Pulumi stack is applied
+- **THEN** a database named `zitadel` SHALL exist on `postgres-osaka`
+- **AND** a Cloud SQL IAM user of type `CLOUD_IAM_SERVICE_ACCOUNT` named `zitadel@liverty-music-${env}.iam` SHALL exist (matching the stack's environment)
+- **AND** the IAM user SHALL own the `zitadel` database
+
+#### Scenario: Workload Identity binding exists
+
+- **WHEN** the Pulumi stack is applied
+- **THEN** the Kubernetes Service Account `zitadel` in namespace `zitadel` SHALL be bound to impersonate the GCP service account `zitadel@liverty-music-${env}.iam.gserviceaccount.com` (matching the stack's environment)
+
+### Requirement: Backend MachineKey Lifecycle Tied to Zitadel-Side Identity
+
+The backend's machine-user JWT private key (`zitadel-machine-key-for-backend-app` in GSM) SHALL track the `MachineKey` Pulumi resource's `keyDetails` output one-to-one. State drift between the Zitadel DB, the GSM SecretVersion, and the Pulumi state SHALL be treated as a critical incident — backend → Zitadel API auth fails with `Errors.AuthNKey.NotFound` whenever the kid in the GSM-mounted JSON key does not have a matching row in Zitadel's AuthNKey table. This lifecycle SHALL apply identically in dev and prod; both stacks SHALL produce a `MachineKey` resource and a corresponding GSM SecretVersion (`zitadel-machine-key-for-backend-app` in their respective GCP projects).
+
+**Rationale**: Discovered post-cutover when `ResendEmailVerification` returned `Errors.Internal (OIDC-AhX2u) parent: invalid signature (error fetching keys: Errors.AuthNKey.NotFound)`. The cause was a three-way drift after the cutover incident chain:
+
+1. Pulumi created a fresh self-hosted MachineKey at v252; GSM was updated with the new keyDetails.
+2. `pulumi state delete --target-dependents` cascade-removed the MachineKey state at v250.
+3. The merged-state import at v254 re-injected the v246 (Cloud-era) MachineKey output into Pulumi state.
+4. v258's SecretVersion replace pulled `secretData` from the (now stale) `MachineKey.keyDetails`, writing the Cloud-era key back into GSM. Zitadel DB still held the self-hosted key.
+
+The fix (cloud-provisioning#216) was to force-replace the `MachineKey` resource by changing `expirationDate` from the magic upstream-example value `2519-04-01T08:45:00Z` to a clean `2099-01-01T00:00:00Z`. Replacement re-runs the create flow, which produces a fresh `keyDetails` value that propagates through the dependency graph.
+
+The GSM name `zitadel-machine-key-for-backend-app` follows the platform-wide convention `zitadel-machine-key-for-<principal>`. The legacy name `zitadel-machine-key` was renamed because (1) it did not encode which Zitadel principal owned the key, ambiguity that directly cost triage time in the §13.15 incident chain, and (2) the platform now manages two Zitadel `MachineKey`s (`pulumi-admin` and `backend-app`) that need to be distinguishable at a glance.
+
+#### Scenario: keyId in GSM matches Zitadel DB
+
+- **WHEN** Pulumi state contains a `MachineKey` for a given user
+- **THEN** the `keyId` in the GSM SecretVersion's JSON SHALL match a row in Zitadel's AuthNKey table for that user
+- **AND** backend → Zitadel API JWT bearer auth SHALL succeed
+
+#### Scenario: Force-replace on detected drift
+
+- **WHEN** the operator detects keyId drift (e.g., via `Errors.AuthNKey.NotFound` in backend logs)
+- **THEN** the operator SHALL force-replace the Pulumi `MachineKey` resource by changing a non-cosmetic property (e.g., bumping `expirationDate` to a different valid value)
+- **AND** the resulting Pulumi apply SHALL produce a new `keyDetails` value, propagate it through the dependency graph, replace the GSM SecretVersion, sync ESO, and trigger Reloader-driven backend Pod restart
+
+#### Scenario: Both dev and prod produce a Backend MachineKey
+
+- **WHEN** `pulumi up` runs for the `dev` stack and again for the `prod` stack
+- **THEN** each stack's resulting Pulumi state SHALL contain exactly one `MachineKey` resource for the `backend-app` machine user
+- **AND** each stack's GSM project (`liverty-music-dev` and `liverty-music-prod` respectively) SHALL contain a Secret named `zitadel-machine-key-for-backend-app` with at least one enabled SecretVersion
+
+## ADDED Requirements
+
+### Requirement: First-Boot Org Looked Up via Provider Data Source
+
+Pulumi SHALL NOT create the Zitadel "admin" org as a `zitadel.Org` resource for any environment where the org is auto-created by Zitadel's first-boot bootstrap (i.e., where `ZITADEL_FIRSTINSTANCE_ORG_NAME` is set in the deployment's configmap). Instead, Pulumi SHALL look up the existing org by name via the Zitadel provider's data source and reference its `id` for downstream resources such as the backend `MachineUser`.
+
+**Rationale**: First-boot bootstrap creates the admin org outside Pulumi's state. Importing it as a Pulumi-managed resource creates a destroy-cascade hazard — `pulumi destroy` on the stack would attempt to delete the admin org, which is the same org the admin JWT belongs to, creating a circular dependency. Looking up the org as a data source (read-only) keeps Pulumi out of the org's lifecycle.
+
+#### Scenario: Pulumi state has no `zitadel.Org` resource named "admin"
+
+- **WHEN** the Pulumi stack is applied for an environment where first-boot bootstrap created the admin org (currently: prod)
+- **THEN** Pulumi state SHALL NOT contain a `zitadel.Org` resource with name "admin"
+- **AND** the backend `MachineUser` resource SHALL reference the org id resolved by a `zitadel.getOrg` (or equivalent) data source lookup
+
+#### Scenario: Org lookup is unambiguous
+
+- **WHEN** the data source `zitadel.getOrg({ name: 'admin' })` is invoked
+- **THEN** it SHALL return exactly one org
+- **AND** the component SHALL fail the Pulumi preview with a clear error message if the lookup returns zero or multiple results
+
+### Requirement: Prod Backend MachineKey Component Authenticates with Bootstrap-Uploaded Admin JWT
+
+The Pulumi `BackendMachineKeyComponent` (or equivalent top-level component) for the prod stack SHALL configure its Zitadel provider with `domain: 'auth.liverty-music.app'` and the `jwtProfileJson` SHALL be sourced from the GSM SecretVersion `zitadel-machine-key-for-pulumi-admin` (project `liverty-music-prod`) via a `gcp.secretmanager.getSecretVersion` data source — NOT from a Pulumi config or ESC value. The component SHALL fail Pulumi preview/up with a clear error if the GSM Secret has zero enabled versions.
+
+**Rationale**: The org-admin JWT is minted by Zitadel's first-boot bootstrap and uploaded to GSM by the in-cluster `bootstrap-uploader` sidecar — it is generated *after* Pulumi creates the GSM Secret shell, so it cannot be a Pulumi-config input at stack-create time. Reading it via a data source on each `pulumi up` ensures Pulumi always uses the current version and preserves the source-of-truth ordering (Zitadel → GSM → Pulumi-runtime, never Pulumi → JWT).
+
+#### Scenario: Provider configured from GSM data source
+
+- **WHEN** the prod Pulumi stack is applied
+- **THEN** the Zitadel provider's `jwtProfileJson` argument SHALL be a Pulumi `Output<string>` produced by a `gcp.secretmanager.getSecretVersion` data source pointing at the GSM Secret `zitadel-machine-key-for-pulumi-admin` in project `liverty-music-prod`
+- **AND** the JWT value SHALL NOT appear in the Pulumi stack's config nor in any ESC environment
+
+#### Scenario: Missing GSM secret fails fast
+
+- **WHEN** the prod Pulumi stack is applied and the GSM Secret `zitadel-machine-key-for-pulumi-admin` has zero enabled versions
+- **THEN** Pulumi preview SHALL fail with a clear "secret version not found" error referencing the missing GSM resource
+- **AND** no Zitadel MachineUser, MachineKey, or downstream GSM resource SHALL be created

--- a/openspec/changes/enable-zitadel-prod-pulumi-provider/tasks.md
+++ b/openspec/changes/enable-zitadel-prod-pulumi-provider/tasks.md
@@ -11,7 +11,7 @@
 - [ ] 2.2 Inside the new component, instantiate the existing `MachineUserComponent` (re-export from `./machine-user.js`) with the provided `orgId` + `zitadelProvider`. This re-uses the proven dev pattern verbatim.
 - [ ] 2.3 Inside the new component, write the `MachineKey.keyDetails` to GSM via:
       - `new gcp.secretmanager.Secret('zitadel-machine-key-for-backend-app', ...)` (project from args, secretId = `zitadel-machine-key-for-backend-app`, auto replication)
-      - `new gcp.secretmanager.SecretVersion(...)` (secretData = `MachineUser.keyDetails`, deletionPolicy DELETE)
+      - `new gcp.secretmanager.SecretVersion(...)` (secretData = `MachineKey.keyDetails`, deletionPolicy DELETE)
       - `new gcp.secretmanager.SecretIamMember(...)` (role `secretAccessor`, member = the ESO GSA email `k8s-external-secrets@${gcpProject}.iam.gserviceaccount.com`)
 - [ ] 2.4 Apply `aliases: [{ name: 'OLD_URN' }]` to the `MachineKey` resource in `BackendMachineKeyComponent` for the dev URN to preserve dev state after refactor — capture the current dev URN via `pulumi stack export --stack dev | jq '.deployment.resources[] | select(.type == "zitadel:index/machineKey:MachineKey")'`.
 

--- a/openspec/changes/enable-zitadel-prod-pulumi-provider/tasks.md
+++ b/openspec/changes/enable-zitadel-prod-pulumi-provider/tasks.md
@@ -1,0 +1,63 @@
+## 1. Pre-flight verification
+
+- [ ] 1.1 Confirm `auth.liverty-music.app/.well-known/openid-configuration` returns 200 with `issuer: https://auth.liverty-music.app`: `curl -s https://auth.liverty-music.app/.well-known/openid-configuration | jq -r '.issuer'`
+- [ ] 1.2 Confirm prod GSM has `zitadel-machine-key-for-pulumi-admin` with ≥1 enabled version: `gcloud secrets versions list zitadel-machine-key-for-pulumi-admin --project liverty-music-prod --filter='state=ENABLED'` returns ≥1 row
+- [ ] 1.3 Confirm prod cluster's zitadel-api Pod is 3/3 Ready: `kubectl --context gke_liverty-music-prod_asia-northeast2_autopilot-cluster-osaka get pods -n zitadel -l app=zitadel,component=api`
+- [ ] 1.4 Confirm Zitadel's "admin" org exists in prod by hitting the admin API once (curl test using the admin JWT) — verify the org id you'd get back via `zitadel.getOrg({ name: 'admin' })` will match what the bootstrap-uploaded JWT's `iss` claim points to (sanity check before relying on the data source).
+
+## 2. Extract `BackendMachineKeyComponent` (cloud-provisioning/src/zitadel/components/)
+
+- [ ] 2.1 Create `cloud-provisioning/src/zitadel/components/backend-machine-key.ts` defining `BackendMachineKeyComponent` (ComponentResource). Args: `{ env: 'dev' | 'prod', gcpProject: string, zitadelProvider: zitadel.Provider, orgId: pulumi.Input<string> }`. Outputs: the same `keyDetails: Output<string>` that the existing `MachineUserComponent` returns, plus the resulting GSM `Secret` + `SecretVersion` resource references.
+- [ ] 2.2 Inside the new component, instantiate the existing `MachineUserComponent` (re-export from `./machine-user.js`) with the provided `orgId` + `zitadelProvider`. This re-uses the proven dev pattern verbatim.
+- [ ] 2.3 Inside the new component, write the `MachineKey.keyDetails` to GSM via:
+      - `new gcp.secretmanager.Secret('zitadel-machine-key-for-backend-app', ...)` (project from args, secretId = `zitadel-machine-key-for-backend-app`, auto replication)
+      - `new gcp.secretmanager.SecretVersion(...)` (secretData = `MachineUser.keyDetails`, deletionPolicy DELETE)
+      - `new gcp.secretmanager.SecretIamMember(...)` (role `secretAccessor`, member = the ESO GSA email `k8s-external-secrets@${gcpProject}.iam.gserviceaccount.com`)
+- [ ] 2.4 Apply `aliases: [{ name: 'OLD_URN' }]` to the `MachineKey` resource in `BackendMachineKeyComponent` for the dev URN to preserve dev state after refactor — capture the current dev URN via `pulumi stack export --stack dev | jq '.deployment.resources[] | select(.type == "zitadel:index/machineKey:MachineKey")'`.
+
+## 3. Refactor `Zitadel` class to use the extracted component (cloud-provisioning/src/zitadel/index.ts)
+
+- [ ] 3.1 Replace the inline `new MachineUserComponent(...)` call inside the `Zitadel` class with a `new BackendMachineKeyComponent(...)` call. Keep the rest of `Zitadel` class behavior unchanged for dev.
+- [ ] 3.2 Verify `pulumi preview --stack dev` shows ZERO changes after the refactor (the `aliases:` move should be state-only — no resource recreation). If it shows replacement of the `MachineKey`, abort and fix the alias URN.
+
+## 4. Add prod call site (cloud-provisioning/src/index.ts)
+
+- [ ] 4.1 After the existing prod-enabled `SecretsComponent('zitadel-secrets', ...)` block at line ~119, add a NEW `env === 'prod'` block that:
+      - Reads `zitadel-machine-key-for-pulumi-admin` GSM SecretVersion via `gcp.secretmanager.getSecretVersion({ project: 'liverty-music-prod', secret: 'zitadel-machine-key-for-pulumi-admin' })`
+      - Creates a `zitadel.Provider('zitadel-prod', { domain: 'auth.liverty-music.app', jwtProfileJson })`
+      - Looks up the existing "admin" org via `zitadel.getOrg({ name: 'admin' }, { provider: zitadelProdProvider })`
+      - Instantiates `new BackendMachineKeyComponent('backend-app', { env: 'prod', gcpProject: 'liverty-music-prod', zitadelProvider, orgId: adminOrg.id })`
+- [ ] 4.2 Verify the `zitadel.getOrg` data source exists in the `@pulumiverse/zitadel` provider version pinned by `package.json`. If not, use `getOrgs` + filter (or fall back to passing the org id via a Pulumi config — least desirable).
+- [ ] 4.3 Add a runtime sanity check: `if (adminOrg.id is unknown OR returns empty) throw`. This catches the case where the data source lookup silently fails.
+
+## 5. Local validation
+
+- [ ] 5.1 `make lint-ts` in cloud-provisioning — must pass after the refactor + new prod block.
+- [ ] 5.2 `pulumi preview --stack dev` — expect ZERO changes (aliases preserve URN).
+- [ ] 5.3 `pulumi preview --stack prod` — expect ~5 resources to create: 1 `zitadel.MachineUser`, 1 `zitadel.MachineKey`, 1 `gcp.secretmanager.Secret`, 1 `gcp.secretmanager.SecretVersion`, 1 `gcp.secretmanager.SecretIamMember`. Plus parent ComponentResource.
+
+## 6. PR preparation
+
+- [ ] 6.1 Commit with Conventional Commits: `feat(infra): enable Zitadel prod Pulumi provider + backend MachineKey creation`.
+- [ ] 6.2 Open PR in `cloud-provisioning` referencing this OpenSpec change.
+- [ ] 6.3 Open companion PR in `specification` with this OpenSpec change (proposal + design + specs delta + tasks).
+- [ ] 6.4 Wait for Pulumi Cloud auto-preview on both stacks: dev shows zero changes; prod shows the expected ~5-resource creation.
+- [ ] 6.5 Wait for reviewer approval. Given this affects prod (creates Zitadel API objects + new GSM Secret), require explicit "approved" comment.
+
+## 7. Prod deployment (manual, after PR merge)
+
+- [ ] 7.1 Trigger `pulumi up --stack prod` from Pulumi Cloud console.
+- [ ] 7.2 Verify the prod-side resources created: `gcloud secrets versions list zitadel-machine-key-for-backend-app --project liverty-music-prod` returns ≥1 enabled version.
+- [ ] 7.3 ESO reconciles the new GSM SecretVersion to the backend namespace's K8s Secret within ~30s.
+- [ ] 7.4 Reloader picks up the new K8s Secret and rolls the backend Deployment.
+- [ ] 7.5 Backend Pods (`server-app`, `consumer-app`) transition from `ContainerCreating` to `Running`.
+- [ ] 7.6 Verify backend → Zitadel auth path is live: `curl -I https://api.liverty-music.app/grpc.health.v1.Health/Check` returns 200 (this exercises the gRPC health endpoint which is auth-exempt; for an auth-bearing test, hit any RPC that calls Zitadel, e.g. user info read).
+
+## 8. Archive
+
+- [ ] 8.1 Update this tasks.md + design.md with any incident notes from the live bootstrap (Pulumi-up duration, any data-source lookup quirks, observed backend Pod sync time).
+- [ ] 8.2 Run `openspec validate enable-zitadel-prod-pulumi-provider --strict`.
+- [ ] 8.3 Sync delta specs to main specs (`openspec/specs/zitadel-self-hosted-deployment/spec.md` — apply MODIFIED + ADDED operations).
+- [ ] 8.4 Move change directory: `git mv openspec/changes/enable-zitadel-prod-pulumi-provider openspec/changes/archive/YYYY-MM-DD-enable-zitadel-prod-pulumi-provider`.
+- [ ] 8.5 Commit + push + merge the archive PR.
+- [ ] 8.6 Now that backend is up, also archive the `prod-k8s-manifests` change (open its archive PR — it was deferred until backend reached Healthy).


### PR DESCRIPTION
## Summary

Follow-up to [liverty-music/specification#457](https://github.com/liverty-music/specification/pull/457) /
[cloud-provisioning#255](https://github.com/liverty-music/cloud-provisioning/pull/255)
(`prod-k8s-manifests`, merged 2026-05-14 as
1dcd7b5).

During the manual prod bootstrap, we discovered a gap: the Pulumi-side
`MachineUserComponent` (which creates the backend `MachineKey` via the
Zitadel API) lives inside the `Zitadel` class, and that class is gated
to `env === 'dev'` at [src/index.ts:74](https://github.com/liverty-music/cloud-provisioning/blob/main/src/index.ts#L74). The gate was correct
for SaaS Cloud-tenant Zitadel; it was not lifted when prod switched to
self-hosted. So the second `pulumi up --stack prod` (per the previous
change's Migration Plan §6) did NOT create
`zitadel-machine-key-for-backend-app` — prod backend Pods are stuck in
`ContainerCreating` waiting for that GSM Secret.

This proposal codifies the minimum Pulumi-side work to close the gap.

### Approach

**Option B** (chosen — see design D1): extract a focused top-level
`BackendMachineKeyComponent` (Provider + MachineUserComponent + GSM
Secret/Version/IAM). Avoids lifting the full `Zitadel` class gate, which
would also try to re-create the admin org that Zitadel auto-created at
first boot.

Three load-bearing design decisions:

- **D2**: Look up the existing "admin" org via `zitadel.getOrg({ name:
  'admin' })` data source rather than creating a `zitadel.Org` —
  destroy-cascade hazard if Pulumi owns the org the admin JWT belongs to.
- **D3**: Configure prod Zitadel provider with `jwtProfileJson` sourced
  from `gcp.secretmanager.getSecretVersion` on
  `zitadel-machine-key-for-pulumi-admin` — never round-trip the JWT
  through Pulumi config or ESC.
- **D4**: `aliases:` on the new component's `MachineKey` resource to
  preserve dev's existing URN through the refactor — zero churn on dev
  state.

### Modified capability

`zitadel-self-hosted-deployment` — 2 MODIFIED requirements broaden the
env language to be env-agnostic; 2 ADDED requirements codify the
first-boot-org-via-data-source pattern and the prod-provider-from-GSM
sourcing rule.

### Resources `pulumi up --stack prod` will create after implementation

- 1 `zitadel.MachineUser` (`backend-app` in prod's "admin" org)
- 1 `zitadel.MachineKey` (effective-forever expiration, matches dev pattern)
- 1 `zitadel.OrgMember` (ORG_USER_MANAGER role)
- 1 `gcp.secretmanager.Secret` (`zitadel-machine-key-for-backend-app`)
- 1 `gcp.secretmanager.SecretVersion` (JWT-profile JSON)
- 1 `gcp.secretmanager.SecretIamMember` (ESO read access)
- Parent ComponentResource

### Out of scope (separate follow-up changes)

- SaaS Zitadel feature wiring for prod (admin Google IDP, SMTP, ActionsV2)
- `backend-migrations` Application's cross-repo dependency on
  backend repo's `k8s/atlas/overlays/prod`
- Pulumi adoption of the manual cross-project Artifact Registry IAM
  grant (applied with `gcloud projects add-iam-policy-binding` during
  the `prod-k8s-manifests` deploy)
- A `zitadel-machine-key-rotation` change (rotation runbook + alerting)

## Test plan

- [ ] CI green (`openspec validate --strict` passes; `buf` skip applicable)
- [ ] Review of design D1-D4
- [ ] Review of MODIFIED requirements (env language broadening preserves
  all existing scenarios)
- [ ] Review of ADDED requirements (first-boot-org data source + prod
  provider from GSM)
- [ ] Open follow-up implementation PR in `cloud-provisioning` per
  `tasks.md` once this lands
