### PR TITLE
docs(openspec): propose complete-zitadel-prod-pulumi-stack

### DIFF
--- a/openspec/changes/complete-zitadel-prod-pulumi-stack/.openspec.yaml
+++ b/openspec/changes/complete-zitadel-prod-pulumi-stack/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-14

--- a/openspec/changes/complete-zitadel-prod-pulumi-stack/design.md
+++ b/openspec/changes/complete-zitadel-prod-pulumi-stack/design.md
@@ -1,0 +1,200 @@
+## Context
+
+The prior change `enable-zitadel-prod-pulumi-provider` (archived 2026-05-14) wired the Zitadel Pulumi provider + the `backend-app` machine user into prod via a single `BackendMachineKeyComponent`. That delivered backend ↔ Zitadel JWT auth (programmatic), but left **9 of the dev `Zitadel` class's 12 Zitadel-side components** unwired for prod. Concretely, today's prod state:
+
+- No browser user (operator or end-user) can sign in. `https://auth.liverty-music.app/ui/console` returns 401 — there's no `login-client` PAT for the `zitadel-web` Pod to authenticate to Zitadel.
+- No verification emails go out. There's no `SmtpConfig` + activation against the prod Zitadel instance.
+- The frontend SPA on `https://liverty-music.app` has no `ApplicationOidc` client to redirect to.
+- Access tokens issued by prod Zitadel lack the `email` claim — the backend's `ValidateIdentity` code path fails closed when `email` is absent.
+
+The dev path proves out the full topology: one `Zitadel` class instantiating Provider + admin org (imported) + product org + Project + Frontend + Smtp + ActionsV2 + MachineUser(backend-app) + LoginClient + GoogleAdminIdp + AdminOrgConfig + HumanAdmin + E2eTestUser, in a strict dependency order. Prod needs the same set minus `E2eTestUserComponent` (E2E test infra is a separate concern, scoped to a follow-up after launch).
+
+The existing dev `Zitadel` class throws on `env !== 'dev'` deliberately — it bakes in the assumption that the instance can be addressed via a single `ZitadelArgs` bundle. Re-using the class for prod would require either (a) loosening the env guard, (b) duplicating it as `ZitadelProd`, or (c) extracting a new top-level component that internally wires the 9 leaf components without touching dev's class. The constraint that the `src/index.ts` dispatch line stays thin (per `CLAUDE.md` "Main entry point dispatching to GCP and GitHub components") and that dev URNs must not churn drives the choice.
+
+Stakeholders:
+- **Operator** (`pannpers@pannpers.dev`): needs Console access to the prod instance via Google SSO.
+- **End users** (prod fan accounts): need the SPA's OIDC sign-in + sign-up flow to work, including email verification.
+- **Backend service**: depends on the `email` claim being present in access tokens (hardened by the cutover-incident chain in dev).
+- **Zitadel-web Pod**: currently `ContainerCreating`, blocked waiting on `zitadel-web-pat` K8s Secret (synced from GSM `zitadel-login-pat` by ESO).
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Reach dev parity for the prod Zitadel application-level stack: end-user OIDC sign-in via SPA, sign-up email verification, operator Console access via Google SSO, access tokens carrying `email`.
+- Land all 9 missing components in a single coherent Pulumi unit so the prod cutover is atomic — partial states (e.g., admin LoginPolicy without the Google IdP) would lock operators out mid-cutover.
+- Zero URN churn on dev. Dev's `Zitadel` class stays verbatim; existing dev URNs continue to map 1:1 to the same resources.
+- Keep the `src/index.ts` prod block as one dispatch line, parallel to dev's `new Zitadel(...)` line.
+- Preserve blast-radius separation (per the archived `enable-zitadel-prod-pulumi-provider` D2): `backend-app` lives in product org with ORG_USER_MANAGER, operator identities (pulumi-admin, login-client, IAM_OWNERs) live in admin org.
+
+**Non-Goals:**
+
+- `E2eTestUserComponent` for prod. E2E tests run against dev exclusively today; prod E2E is a follow-up scoped post-launch as `enable-zitadel-prod-e2e-user`.
+- Refactoring dev's `Zitadel` class into a shared base. The 13-component dev assembly stays unchanged. The new prod class is a *parallel* assembly, not a refactor of the dev one.
+- Cross-repo follow-ups: backend Atlas migration prod overlay, frontend `.env.prod` + CI/CD branch→env mapping. Those are tracked in separate repo PRs.
+- Pulumi-managed adoption of operational-debt IAM bindings (`cloudsql.client`, cross-project AR IAM, ESO refresh tuning). Carried forward from the archived `enable-zitadel-prod-pulumi-provider` follow-ups.
+- The Cloudflare apex `liverty-music.app` A record (out of scope per `prod-environment-bootstrap` design D2).
+
+## Decisions
+
+### D1 — Extract `ZitadelProdStackComponent` as a top-level wrapper; do NOT mutate dev's `Zitadel` class
+
+**Decision:** Create a new `ZitadelProdStackComponent extends pulumi.ComponentResource` at `src/zitadel/components/zitadel-prod-stack.ts`. It internally instantiates the 9 leaf components in the same dependency order dev's class uses, parallel to how `BackendMachineKeyComponent` today wraps `MachineUserComponent` + the product-org `Org` + the GSM Secret bundle. The prod block in `src/index.ts` becomes a single `new ZitadelProdStackComponent(...)` line, replacing today's `new BackendMachineKeyComponent(...)` line.
+
+**Rationale:**
+
+- **Zero dev URN churn.** Dev's `new Zitadel(...)` line and the 13 child URNs underneath it stay byte-identical. The new prod stack lives in a separate URN namespace (`zitadel:liverty-music:ZitadelProdStack$...`), so dev's preview shows `0 to do` for Zitadel even after this change merges.
+- **Thin dispatch line preserved.** `src/index.ts` keeps the "dispatch only" shape per `CLAUDE.md`. Anything else (env-specific ESC pulls, two-org wiring, conditional E2E user) lives inside the component.
+- **Atomic blast radius.** Wrapping the 9 components in a `ComponentResource` means a single `pulumi destroy --target` (in some recovery scenario) cleans the entire prod Zitadel stack at once, instead of leaving partial state across 9 leaves. Matches the recovery model in `docs/runbooks/pulumi-state-recovery.md`.
+- **Alternative considered (rejected): refactor dev's `Zitadel` class to be env-parameterized.** Cost: every dev resource URN changes (the env guard removal + arg signature change), forcing a Pulumi state migration on dev. Benefit: one class instead of two. Net: not worth it given dev is settled and prod adoption is the constrained path.
+- **Alternative considered (rejected): instantiate the 9 leaf components directly from `src/index.ts`'s prod block.** Cost: 9-line block in `index.ts` violates the thin-dispatch principle; future cross-component refactors touch `index.ts` instead of staying scoped. Benefit: no new wrapper class. Net: rejected because the same pattern already exists for backend-app via `BackendMachineKeyComponent`, so adding a second wrapper is the consistent path.
+
+### D2 — Bring the prod `admin` org into Pulumi state via one-time `pulumi import`
+
+**Decision:** The prod `admin` org is auto-created by Zitadel's first-instance bootstrap (driven by `ZITADEL_FIRSTINSTANCE_ORG_NAME=admin` in the configmap, already merged via the `prod-k8s-manifests` change). Before the first `pulumi up --stack prod` of this change, the operator runs once:
+
+```bash
+pulumi import zitadel:index/org:Org admin <prod-admin-org-id> --stack prod
+```
+
+The org id is fetched via the Zitadel admin API using the bootstrap-uploaded `pulumi-admin` JWT (the `zitadel-machine-key-for-pulumi-admin` GSM secret already exists in prod). Documented as a pre-flight step in tasks.md §1.
+
+**Rationale:**
+
+- **Cannot `new zitadel.Org('admin', ...)` from Pulumi.** Zitadel does not expose a creation API that idempotently adopts an existing org by name; a second `Org` create would either fail or duplicate. The bootstrap-created org has the `IsDefault=true` flag set by Zitadel itself.
+- **`protect: true` is mandatory on the resulting resource.** `pulumi destroy` against the imported admin org would lock all operators out — the `pulumi-admin` MachineUser the provider authenticates as lives inside it. Mirrors the dev path (`src/zitadel/index.ts` line 214).
+- **Alternative considered (rejected): write a Pulumi dynamic resource that discovers the admin org id via the Zitadel admin API on every preview/up.** Cost: extra API roundtrip every preview, dynamic resource state churn, and the prod admin org id is stable (never re-bootstraps), so a one-time import is the simpler answer. Benefit: no operator-visible pre-flight step. Net: rejected; the dev path uses the same one-time-import shape.
+
+### D3 — Bundle all 9 components in this single change instead of merging them one-by-one
+
+**Decision:** Land Frontend + Smtp + ActionsV2 + LoginClient + GoogleAdminIdp + AdminOrgConfig + HumanAdmin + ProjectComponent + admin-org import in one Pulumi `up`. Do not split into 9 PRs.
+
+**Rationale:**
+
+- **Inter-component dependencies create unsafe intermediate states.** Examples:
+  - `AdminOrgConfigComponent` sets `LoginPolicy.userLogin=false`. Without `GoogleAdminIdpComponent` (referenced by the same policy via `idps=[googleIdpId]`), the admin org has no usable sign-in method and the operator is locked out of `/ui/console`.
+  - `HumanAdminComponent` provisions `pannpers` and pre-links the Google sub via `ZitadelUserIdpLink`. Without the Google IdP in the admin org's LoginPolicy, the link is referenced but unreachable.
+  - `FrontendComponent` creates `ApplicationOidc` + product-org `LoginPolicy`. Without the policy, the SPA's redirect succeeds at the OIDC layer but the Login V2 UI presents an empty sign-in form (no userLogin, no IdPs, no passkey).
+- **`pulumi up --stack prod` is a manual operator action.** Bundling means one operator-attended deployment, one preview review, one verification window. Splitting means 9.
+- **Alternative considered (rejected): bundle only the inter-dependent quartet (Frontend + Smtp + LoginClient + ActionsV2) and ship the admin org cluster (GoogleIdp + AdminOrgConfig + HumanAdmin) in a follow-up.** Cost: leaves Console operator-locked for a deployment cycle and forces a second `pulumi import` window. Benefit: smaller preview. Net: rejected — the components are tightly coupled.
+- **Alternative considered (rejected): land the admin-org-side stack first (so Console works), then end-user-side.** Cost: end-user sign-up emails stay broken between cuts, observable as silent failures in prod sign-up. Benefit: operator can debug from Console mid-cutover. Net: marginal benefit, rejected.
+
+### D4 — Wrap `getSecretVersionAccessOutput` results and `MachineKey.keyDetails` in `pulumi.secret()` consistently across all 9 components
+
+**Decision:** Every code path inside `ZitadelProdStackComponent` that reads `zitadel-machine-key-for-pulumi-admin` from GSM (for the Provider's `jwtProfileJson`, for the `SmtpActivation` dynamic-resource Zitadel admin-API call, for `HumanAdminComponent`'s dynamic admin-API call) MUST wrap the result in `pulumi.secret()`. Same rule for the `MachineKey.keyDetails` output emitted by `LoginClientComponent` (the new login-client PAT) and any other Zitadel `Output<string>` carrying credential bytes.
+
+**Rationale:**
+
+- **`@pulumi/gcp`'s `getSecretVersionAccessOutput` does NOT mark its output secret.** The dev path's `src/zitadel/index.ts:170` and `BackendMachineKeyComponent`'s round-2 review fix both prove this: without an explicit `pulumi.secret()` wrap, the RSA private key embedded in the JWT-profile JSON surfaces in `pulumi preview` output (including Pulumi Cloud PR previews), CI logs, and Pulumi service state history.
+- **`@pulumiverse/zitadel`'s `MachineKey.keyDetails` is a plain `Output<string>`.** Same leak risk for any newly-issued JWT-profile keys (none expected from this change's 9 components beyond `loginClientToken` for the PAT, but the rule applies uniformly).
+- Same protection pattern as `BackendMachineKeyComponent` (`src/zitadel/components/backend-machine-key.ts:109-116, 170`).
+
+### D5 — Defer `E2eTestUserComponent` to a separate follow-up change
+
+**Decision:** Do not provision the prod E2E test user in this change. Track as a follow-up `enable-zitadel-prod-e2e-user`.
+
+**Rationale:**
+
+- **E2E test infra is operationally distinct.** The dev E2E user requires Playwright credentials in ESC (`pulumiConfig.zitadel.e2eTestUser.password`), a CI/CD job to capture session state from `auth.dev.liverty-music.app`, and the `.auth/` directory convention (per memory `reference_e2e_auth.md`). Prod E2E adds: separate test-tenant decision (do we test against real prod data or a side namespace?), GitOps wiring for the prod `.auth/` capture job, and prod-data-leakage risk review.
+- **None of the 9 components in this change depend on it.** Removing E2E from scope shrinks the preview, reduces ESC seeding (no `e2eTestUser.password` needed), and avoids tying the operator-unblock and end-user-unblock outcomes to a test-infra decision.
+- **Alternative considered (rejected): include with a feature flag.** Cost: dead code in prod state until activated. Benefit: pre-provision the GSM Secret shell. Net: rejected — adds complexity without unblocking anything.
+
+### D6 — Admin org keeps `isDefault: true`; product org `isDefault: false`
+
+**Decision:** When the prod admin org is imported, its `IsDefault=true` flag (set by the bootstrap) is preserved in Pulumi state. The new product org is created with `isDefault: false`. Mirrors dev exactly.
+
+**Rationale:**
+
+- **Console routing depends on the default org's `LoginPolicy`.** Empirically verified in dev (per `src/zitadel/index.ts:193-207` comment): Zitadel's Console OIDC AuthN does not include an `org_id`, so Login V2 uses the **default org's own LoginPolicy**. If the product org were default, Console would hit the passkey + register policy and the Google sign-in button would never appear. Making `admin` the default routes Console to the Google-IdP path.
+- **End-user OIDC traffic from the SPA is unaffected** because the `ApplicationOidc` client owned by the `liverty-music` Project (product org) carries that org's id in its AuthN context. Zitadel resolves the client_id to the product org regardless of the default flag.
+
+### D7 — Out-of-band: Google Cloud Console OAuth 2.0 Web Application client for prod
+
+**Decision:** Before the first `pulumi up --stack prod` of this change, the operator manually creates a Google Cloud Console OAuth 2.0 Web Application client for prod (separate from the dev client). Authorized redirect URI: `https://auth.liverty-music.app/ui/v2/login/login/callback`. The resulting `client_id` and `client_secret` are seeded into `liverty-music/prod` ESC via `esc env set pulumiConfig.zitadel.googleAdminIdp.clientId ...` (and `.clientSecret ... --secret`).
+
+**Rationale:**
+
+- **Google OAuth clients are not Pulumi-managed.** No Google API supports IaC creation of OAuth clients on a Google Cloud project — the Cloud Console GUI is the only path. Same constraint applied to dev (the dev Google client exists out-of-band).
+- **Why a separate client (not reuse dev's):** distinct authorized redirect URIs (dev's `auth.dev.liverty-music.app` vs. prod's `auth.liverty-music.app`) and credential separation (a dev client_secret leak shouldn't compromise prod operator sign-in).
+
+### D8 — Use the `api-client.ts` dynamic resource (not a Pulumi-managed `zitadel.*` resource) for the human admin's IdP link
+
+**Decision:** `HumanAdminComponent` provisions `pannpers@pannpers.dev` as a `zitadel.HumanUser` (Pulumi-managed) + grants `IAM_OWNER` via an instance-level `OrgMember`, then uses the existing `dynamic/user-idp-link.ts` dynamic resource (backed by `dynamic/api-client.ts`) to link the local user to the prod Google IdP.
+
+**Rationale:**
+
+- **`@pulumiverse/zitadel` does not expose user→IdP link as a managed resource.** The dev path uses the same dynamic resource. Re-using it for prod is a straight reuse — no new code paths.
+- **Why pre-link instead of relying on first-sign-in auto-link:** the admin org's LoginPolicy disables auto-create (`allowRegister=false`) and userLogin (`userLogin=false`). Without a pre-existing link, the operator's first Console sign-in resolves to "no matching local user" and Login V2 returns an error. Pre-linking via the dynamic resource guarantees the first `/ui/console` sign-in succeeds.
+- The dynamic resource consumes the admin JWT (`zitadel-machine-key-for-pulumi-admin`) to call the Zitadel Management API. The JWT is read from GSM via `getSecretVersionAccessOutput` and wrapped in `pulumi.secret()` per D4.
+
+### D9 — Store the `login-client` PAT in GSM as `zitadel-login-pat`; ESO mirrors to K8s; Reloader rolls `zitadel-web`
+
+**Decision:** `LoginClientComponent` creates the `login-client` MachineUser + instance-level `IAM_LOGIN_CLIENT` role + `PersonalAccessToken`. The component writes the PAT to a new GSM Secret `zitadel-login-pat` (Pulumi-created + version + IAM binding for the ESO Workload Identity SA). The existing K8s overlay for `zitadel-web` already references `zitadel-web-pat` via ExternalSecret; ESO maps GSM `zitadel-login-pat` → K8s `zitadel-web-pat` Secret, and Reloader rolls the Deployment.
+
+**Rationale:**
+
+- **`zitadel-web` Pod is currently `ContainerCreating`, blocked on the missing K8s Secret.** Naming the GSM Secret `zitadel-login-pat` matches the convention used in `prod-k8s-manifests` ExternalSecret CRs (per archived spec). The same pattern as the dev path (`src/zitadel/index.ts` lines 279-284 plus the dev k8s overlay).
+- **Why GSM (not direct K8s Secret):** the dev path uses GSM + ESO; deviating in prod would create a divergent ops contract. GSM also provides audit logging of PAT access via Cloud Logging.
+
+## Risks / Trade-offs
+
+| Risk | Mitigation |
+|---|---|
+| **Admin-org `pulumi import` fails** (wrong org id, bootstrap not yet run, JWT not in GSM) → first `pulumi up --stack prod` of this change can't proceed | tasks.md §1 explicitly fetches the org id via `curl` against the Zitadel admin API as a pre-flight step; documented prerequisite. |
+| **Out-of-band Google OAuth client not created** before `pulumi up --stack prod` → `GoogleAdminIdpComponent` create fails on bad credentials | tasks.md §2 lists the Google Cloud Console URL + redirect URI to create the client before the deploy. ESC seeding for `googleAdminIdp.clientId/clientSecret` is also pre-flight. |
+| **Postmark SMTP activation fails** (dynamic resource calls the Zitadel admin API's `_activate` endpoint) → sign-up emails still don't go out | Same dev path is proven; the dynamic resource `dynamic/smtp-activation.ts` retries on transient failures. Verification step in tasks.md §10 sends a smoke email to the operator inbox. |
+| **`ZitadelUserIdpLink` (dynamic resource) failure on first deploy** leaves `pannpers` un-linked → operator can't sign in to Console | tasks.md §10 smoke-tests Console sign-in immediately after `pulumi up`. If link failed, re-run the dynamic resource (idempotent) via `pulumi up --target zitadel:liverty-music:ZitadelProdStack$...$pannpers-idp-link`. |
+| **Admin LoginPolicy ordering hazard:** if `AdminOrgConfigComponent` applies *before* `GoogleAdminIdpComponent`, the policy references a non-existent IdP id and Pulumi-graph cycle creates rollback complexity | The component's `dependsOn: [googleAdminIdp.idp]` explicit dependency forces ordering. Mirrors dev's wiring exactly. |
+| **`SmtpConfig` activation pre-empts an instance-level default config** → existing dev SMTP configuration would be unaffected, but if prod was pre-seeded out-of-band with a different SMTP config, the dynamic activation could conflict | `tasks.md §1` pre-flight checks the Zitadel admin API for existing SMTP configs and documents a manual cleanup step if any are present. |
+| **ESC seeding leak risk:** copy-paste of `clientSecret` or `pulumiJwtProfileJson` outside `esc env set --secret` would persist in shell history | tasks.md §2 explicitly uses `--secret` flag on every secret-marked value and instructs the operator to source values from a secure password manager, not shell history. |
+| **`pulumi up --stack prod` is manual** (per `CLAUDE.md` "Pulumi Deployments (Automated)") → no auto-deploy on PR merge → window between PR merge and deployment leaves prod docs/state out-of-sync | Explicit step in tasks.md to manually trigger from Pulumi Cloud console. Verified state in archive step. |
+
+## Migration Plan
+
+**Phase 1 — Pre-flight (out-of-band):**
+
+1. Create the prod Google OAuth 2.0 Web Application client in Google Cloud Console. Authorized redirect URI: `https://auth.liverty-music.app/ui/v2/login/login/callback`.
+2. Seed ESC `liverty-music/prod`:
+   - `pulumiConfig.zitadel.googleAdminIdp.clientId` (plaintext)
+   - `pulumiConfig.zitadel.googleAdminIdp.clientSecret` (secret-marked)
+   - `pulumiConfig.zitadel.adminGoogleSubs.pannpers` (same `sub` claim as dev — pannpers@pannpers.dev; secret-marked for consistency)
+   - `pulumiConfig.zitadel.pulumiJwtProfileJson` (admin JWT for HumanAdminComponent's dynamic resource; secret-marked)
+3. Fetch the prod admin-org-id via the Zitadel admin API using the bootstrap-uploaded `pulumi-admin` JWT. Verify the bootstrap-uploader sidecar has completed by checking the `zitadel-machine-key-for-pulumi-admin` GSM Secret has a non-empty `latest` version.
+
+**Phase 2 — Pulumi import (one-time):**
+
+```bash
+pulumi import zitadel:index/org:Org admin <prod-admin-org-id> --stack prod
+```
+
+Verify the import added the resource to state without churn; commit the resulting `Pulumi.prod.yaml` if any pinned URN refs were emitted.
+
+**Phase 3 — Deploy:**
+
+1. PR merges to `main` after CI passes (PR triggers `pulumi preview` only on prod; verify preview matches expected ~25 new resources).
+2. Operator manually triggers `pulumi up --stack prod` from Pulumi Cloud console: https://app.pulumi.com/pannpers/liverty-music/prod/deployments
+3. Watch the deploy logs for any of the 5 known-risk components (admin LoginPolicy, SMTP activation, IdP link, login-client PAT, frontend ApplicationOidc).
+
+**Phase 4 — Verification (per tasks.md §10):**
+
+1. SPA sign-in flow: visit `https://liverty-music.app`, complete OIDC redirect, verify the prod Login V2 UI presents passkey + username/password, complete a test sign-up, verify the verification email arrives via Postmark.
+2. Operator Console sign-in: visit `https://auth.liverty-music.app/ui/console`, click "Sign in with Google", complete OAuth, verify resolution to `pannpers@pannpers.dev` with IAM_OWNER role.
+3. Backend smoke test: capture a token from the SPA flow, decode JWT claims, verify `email` claim is present (proves ActionsV2 webhook is wired and firing on the prod `preaccesstoken` flow).
+4. ESO refresh: `kubectl get externalsecret -n zitadel zitadel-web-secrets -o yaml` — verify `Status=Ready` and the synced K8s Secret `zitadel-web-pat` has a non-empty token.
+5. Reloader rolls `zitadel-web` Deployment; Pod transitions from `ContainerCreating` to `Running` (1/1 Ready).
+
+**Rollback Strategy:**
+
+- **Partial deploy failure (e.g., SMTP activation fails):** Pulumi's normal rollback semantics apply for the failing leaf; other leaves stay provisioned. Re-run `pulumi up` after fixing the underlying cause (most failures are upstream transient — Zitadel API rate limit, GSM secret access race).
+- **Total rollback (extreme):** `pulumi destroy --target <ZitadelProdStackComponent URN> --stack prod` from a fresh `pulumi up` baseline. Per `docs/runbooks/pulumi-state-recovery.md`, the `--target` flag scopes destroy to the component subtree. The admin org's `protect: true` flag survives any partial destroy, preventing operator lock-out.
+- **Admin LoginPolicy lockout (operator cannot sign in to Console):** the `pulumi-admin` MachineUser path always works (bypasses LoginPolicy); operator can re-run `pulumi up` to restore the policy from state.
+
+## Open Questions
+
+- **OQ1: Should the `loginClientToken` be issued with an expiry?** Dev currently issues it without expiration (per `LoginClientComponent`). Prod could mirror, but a 90d rotation cycle (with the GSM SecretVersion rotation pattern) would limit blast radius if the K8s Secret leaks. **Provisional answer:** mirror dev (no expiry) for this change; track rotation as an operational-debt follow-up after the prod stack is verified end-to-end. The rotation tooling would apply to dev simultaneously.
+
+- **OQ2: Does prod need a different `humanAdmin` set than dev?** Dev has only `pannpers@pannpers.dev`. Prod could add a second IAM_OWNER (e.g., a co-founder or oncall delegate) for break-glass redundancy. **Provisional answer:** ship with `pannpers` only — matches dev parity and avoids scope creep. Adding a second admin is a one-line component change in a follow-up.
+
+- **OQ3: Should `SmtpComponent`'s `from` address differ between dev and prod?** Dev uses a `noreply@dev.liverty-music.app` convention. Prod's natural default is `noreply@liverty-music.app`. **Provisional answer:** the `SmtpComponent` already env-routes the from address via the `domain` argument it receives; prod will inherit `auth.liverty-music.app` → `noreply@liverty-music.app` automatically, no override needed.
+
+- **OQ4: Will the Cloudflare apex `liverty-music.app` A record be in place before this change deploys?** SPA sign-up flow verification (Phase 4 §1) requires the apex domain to resolve to the prod Gateway. **Provisional answer:** this is a separate concern tracked under `prod-environment-bootstrap` design D2 (Cloudflare DNS out-of-band). Verification in Phase 4 §1 will fail if the A record isn't live, but that's a documentation/comms issue with no scope inside this change.

--- a/openspec/changes/complete-zitadel-prod-pulumi-stack/design.md
+++ b/openspec/changes/complete-zitadel-prod-pulumi-stack/design.md
@@ -1,6 +1,6 @@
 ## Context
 
-The prior change `enable-zitadel-prod-pulumi-provider` (archived 2026-05-14) wired the Zitadel Pulumi provider + the `backend-app` machine user into prod via a single `BackendMachineKeyComponent`. That delivered backend ↔ Zitadel JWT auth (programmatic), but left **9 of the dev `Zitadel` class's 12 Zitadel-side components** unwired for prod. Concretely, today's prod state:
+The prior change `enable-zitadel-prod-pulumi-provider` (archived 2026-05-14) wired the Zitadel Pulumi provider + the `backend-app` machine user into prod via a single `BackendMachineKeyComponent`. That delivered backend ↔ Zitadel JWT auth (programmatic), but left **9 of the dev `Zitadel` class's 13 Zitadel-side components** unwired for prod. Concretely, today's prod state:
 
 - No browser user (operator or end-user) can sign in. `https://auth.liverty-music.app/ui/console` returns 401 — there's no `login-client` PAT for the `zitadel-web` Pod to authenticate to Zitadel.
 - No verification emails go out. There's no `SmtpConfig` + activation against the prod Zitadel instance.
@@ -79,14 +79,19 @@ The org id is fetched via the Zitadel admin API using the bootstrap-uploaded `pu
 - **Alternative considered (rejected): bundle only the inter-dependent quartet (Frontend + Smtp + LoginClient + ActionsV2) and ship the admin org cluster (GoogleIdp + AdminOrgConfig + HumanAdmin) in a follow-up.** Cost: leaves Console operator-locked for a deployment cycle and forces a second `pulumi import` window. Benefit: smaller preview. Net: rejected — the components are tightly coupled.
 - **Alternative considered (rejected): land the admin-org-side stack first (so Console works), then end-user-side.** Cost: end-user sign-up emails stay broken between cuts, observable as silent failures in prod sign-up. Benefit: operator can debug from Console mid-cutover. Net: marginal benefit, rejected.
 
-### D4 — Wrap `getSecretVersionAccessOutput` results and `MachineKey.keyDetails` in `pulumi.secret()` consistently across all 9 components
+### D4 — Wrap secret-bearing `Output<string>` values in `pulumi.secret()` at the earliest producer / wrapper boundary
 
-**Decision:** Every code path inside `ZitadelProdStackComponent` that reads `zitadel-machine-key-for-pulumi-admin` from GSM (for the Provider's `jwtProfileJson`, for the `SmtpActivation` dynamic-resource Zitadel admin-API call, for `HumanAdminComponent`'s dynamic admin-API call) MUST wrap the result in `pulumi.secret()`. Same rule for the `MachineKey.keyDetails` output emitted by `LoginClientComponent` (the new login-client PAT) and any other Zitadel `Output<string>` carrying credential bytes.
+**Decision:** Every Pulumi `Output<string>` carrying credential bytes MUST be wrapped in `pulumi.secret()` at the earliest place it surfaces. Concretely:
+
+1. **GSM read at plan time:** `getSecretVersionAccessOutput({ secret: 'zitadel-machine-key-for-pulumi-admin' })` results are wrapped immediately inside `BackendMachineKeyComponent` (producer) and exposed as `BackendMachineKeyComponent.adminJwt` for sibling reuse (SMTP activation, ActionsV2 Target/Execution, HumanAdmin IdP-link dynamic resources).
+2. **Zitadel `MachineKey.keyDetails`:** wrapped inside `BackendMachineKeyComponent` when writing the SecretVersion (`pulumi.secret(this.machineUser.keyDetails)`), and AGAIN at the `ZitadelProdStackComponent` boundary when exposed as `machineKeyDetails` (so the value is masked in this ComponentResource's `registerOutputs(...)` state record).
+3. **Zitadel `PersonalAccessToken.token`:** wrapped at the `ZitadelProdStackComponent` boundary when exposed as `loginClientToken` (the inner `LoginClientComponent.token` is the upstream-supported plain Output<string>, kept unwrapped to preserve the dev contract). Downstream `Gcp.esoOnlySecrets` ALSO wraps defensively when writing the SecretVersion, so the value is secret-marked at every state-touching point.
 
 **Rationale:**
 
 - **`@pulumi/gcp`'s `getSecretVersionAccessOutput` does NOT mark its output secret.** The dev path's `src/zitadel/index.ts:170` and `BackendMachineKeyComponent`'s round-2 review fix both prove this: without an explicit `pulumi.secret()` wrap, the RSA private key embedded in the JWT-profile JSON surfaces in `pulumi preview` output (including Pulumi Cloud PR previews), CI logs, and Pulumi service state history.
-- **`@pulumiverse/zitadel`'s `MachineKey.keyDetails` is a plain `Output<string>`.** Same leak risk for any newly-issued JWT-profile keys (none expected from this change's 9 components beyond `loginClientToken` for the PAT, but the rule applies uniformly).
+- **`@pulumiverse/zitadel`'s `MachineKey.keyDetails` and `PersonalAccessToken.token` are plain `Output<string>`** — neither is auto-marked secret by the provider. Both surface in the owning ComponentResource's `registerOutputs(...)` state record if exposed unwrapped.
+- **Wrapper-boundary wrap protects against intermediate component-graph traversal.** `ZitadelProdStackComponent.registerOutputs({ loginClientToken, machineKeyDetails })` writes to Pulumi state; without the wrap, the values would surface in this ComponentResource's outputs even if the downstream SecretVersion consumer-site wrap exists.
 - Same protection pattern as `BackendMachineKeyComponent` (`src/zitadel/components/backend-machine-key.ts:109-116, 170`).
 
 ### D5 — Defer `E2eTestUserComponent` to a separate follow-up change
@@ -146,7 +151,7 @@ The org id is fetched via the Zitadel admin API using the bootstrap-uploaded `pu
 | **`ZitadelUserIdpLink` (dynamic resource) failure on first deploy** leaves `pannpers` un-linked → operator can't sign in to Console | tasks.md §10 smoke-tests Console sign-in immediately after `pulumi up`. If link failed, re-run the dynamic resource (idempotent) via `pulumi up --target zitadel:liverty-music:ZitadelProdStack$...$pannpers-idp-link`. |
 | **Admin LoginPolicy ordering hazard:** if `AdminOrgConfigComponent` applies *before* `GoogleAdminIdpComponent`, the policy references a non-existent IdP id and Pulumi-graph cycle creates rollback complexity | The component's `dependsOn: [googleAdminIdp.idp]` explicit dependency forces ordering. Mirrors dev's wiring exactly. |
 | **`SmtpConfig` activation pre-empts an instance-level default config** → existing dev SMTP configuration would be unaffected, but if prod was pre-seeded out-of-band with a different SMTP config, the dynamic activation could conflict | `tasks.md §1` pre-flight checks the Zitadel admin API for existing SMTP configs and documents a manual cleanup step if any are present. |
-| **ESC seeding leak risk:** copy-paste of `clientSecret` or `pulumiJwtProfileJson` outside `esc env set --secret` would persist in shell history | tasks.md §2 explicitly uses `--secret` flag on every secret-marked value and instructs the operator to source values from a secure password manager, not shell history. |
+| **ESC seeding leak risk:** copy-paste of `clientSecret` outside `esc env set --secret` would persist in shell history | tasks.md §2 explicitly uses `--secret` flag on every secret-marked value and instructs the operator to source values from a secure password manager, not shell history. |
 | **`pulumi up --stack prod` is manual** (per `CLAUDE.md` "Pulumi Deployments (Automated)") → no auto-deploy on PR merge → window between PR merge and deployment leaves prod docs/state out-of-sync | Explicit step in tasks.md to manually trigger from Pulumi Cloud console. Verified state in archive step. |
 
 ## Migration Plan
@@ -158,7 +163,7 @@ The org id is fetched via the Zitadel admin API using the bootstrap-uploaded `pu
    - `pulumiConfig.zitadel.googleAdminIdp.clientId` (plaintext)
    - `pulumiConfig.zitadel.googleAdminIdp.clientSecret` (secret-marked)
    - `pulumiConfig.zitadel.adminGoogleSubs.pannpers` (same `sub` claim as dev — pannpers@pannpers.dev; secret-marked for consistency)
-   - `pulumiConfig.zitadel.pulumiJwtProfileJson` (admin JWT for HumanAdminComponent's dynamic resource; secret-marked)
+   - No separate ESC entry for the admin JWT. `HumanAdminComponent`'s dynamic-resource Zitadel Management API call sources the JWT inside `ZitadelProdStackComponent` from GSM `zitadel-machine-key-for-pulumi-admin` via `getSecretVersionAccessOutput` (wrapped in `pulumi.secret()`), routed through `BackendMachineKeyComponent.adminJwt` for sibling re-use.
 3. Fetch the prod admin-org-id via the Zitadel admin API using the bootstrap-uploaded `pulumi-admin` JWT. Verify the bootstrap-uploader sidecar has completed by checking the `zitadel-machine-key-for-pulumi-admin` GSM Secret has a non-empty `latest` version.
 
 **Phase 2 — Pulumi import (one-time):**

--- a/openspec/changes/complete-zitadel-prod-pulumi-stack/proposal.md
+++ b/openspec/changes/complete-zitadel-prod-pulumi-stack/proposal.md
@@ -1,0 +1,51 @@
+## Why
+
+The prior change `enable-zitadel-prod-pulumi-provider` extracted `BackendMachineKeyComponent` for prod, covering only 3 of the 13 components the dev `Zitadel` class instantiates (Provider, productOrg, MachineUserComponent for backend-app). Post-deployment investigation surfaced **9 additional components** that the prod stack still needs before end users can sign in and operators can manage the system. The current prod state: backend ↔ Zitadel JWT auth works (programmatic), but **no human or end-user can sign in via browser**, **no verification emails go out**, and **the Console is operator-locked**.
+
+This change closes those remaining 9 components in a single coherent Pulumi unit so the prod stack reaches dev parity for application-level auth. The 10th component, `E2eTestUserComponent`, is intentionally deferred — E2E test infra is a separate concern, scoped to a follow-up after launch.
+
+## What Changes
+
+- **NEW**: Refactor dev's `Zitadel` class so the 9 components below can be instantiated for prod *without* duplicating the SaaS-only assumptions baked into the existing class. The cleanest path (per design D1) is to extract a new top-level `ZitadelProdStackComponent` that internally wires the 9 components in dependency order, parallel to how `BackendMachineKeyComponent` already does. Dev keeps its existing `Zitadel` class verbatim; no URN churn on dev.
+- **NEW**: Pulumi-managed import of the prod `admin` org (auto-created by first-boot bootstrap via `ZITADEL_FIRSTINSTANCE_ORG_NAME=admin`). One-time `pulumi import zitadel:index/org:Org admin <admin-org-id>` so admin-org-side resources (login policy, human admin, login client) can attach.
+- **NEW**: `ProjectComponent` (`zitadel.Project` named `liverty-music`) in the prod product org. The frontend SPA's `ApplicationOidc` lives under this project.
+- **NEW**: `FrontendComponent` for prod — creates the `ApplicationOidc` OIDC client (PKCE flow, JWT access tokens) + product-org `LoginPolicy` (passkey + username/password, `userLogin=true`, `allowRegister=true`).
+- **NEW**: `SmtpComponent` for prod — Postmark SMTP config + activation (the dynamic resource that calls the Zitadel admin API's `_activate` endpoint). Required for sign-up verification emails.
+- **NEW**: `LoginClientComponent` for prod — `login-client` MachineUser in admin org + instance-level `IAM_LOGIN_CLIENT` role + PAT. Backed-by GSM secret `zitadel-login-pat`. Required for the `zitadel-web` (Login V2 UI) container to authenticate to the prod Zitadel API; without it, the Console login page returns 401 and end-user login flow stalls at the UI layer.
+- **NEW**: `ActionsV2Component` for prod — `zitadel.Target` (REST webhook to backend's `/pre-access-token` endpoint) + `Execution` binding on the `preaccesstoken` flow. Without this, access tokens issued by prod Zitadel lack the `email` claim, which the backend's `ValidateIdentity` code path *requires* (the backend fails closed when `email` is absent — matches the dev behavior the cutover incident chain hardened).
+- **NEW**: `GoogleAdminIdpComponent` for prod — instance-level `IdpGoogle` keyed on a separate prod Google OAuth Web client (NOT the dev client). The OAuth client itself is created out-of-band in Google Cloud Console; this change consumes its credentials via ESC.
+- **NEW**: `AdminOrgConfigComponent` for prod — admin-org `LoginPolicy` (`userLogin=false`, `allowRegister=false`, `idps=[googleIdpId]`) + instance-level `DefaultLoginPolicy` mirroring it. Confines Console sign-in to the Google IdP path.
+- **NEW**: `HumanAdminComponent` for prod — provisions `pannpers@pannpers.dev` as an `IAM_OWNER` HumanUser in the prod admin org, pre-linked to the prod Google IdP via `ZitadelUserIdpLink` (uses the `dynamic/api-client.ts` admin-API client because the user→IdP link is not exposed as a Pulumi-managed Zitadel resource).
+- **NEW**: `cloud-provisioning/src/index.ts` prod block — replaces the current single `new BackendMachineKeyComponent(...)` line with a single `new ZitadelProdStackComponent(...)` line that wraps the 9 components above + the existing 3 (Provider/productOrg/MachineUser). The dispatch line stays thin per CLAUDE.md.
+- **NEW**: Prod ESC seeding — new entries in `liverty-music/prod` ESC environment: `pulumiConfig.zitadel.googleAdminIdp.clientId` (plaintext) + `pulumiConfig.zitadel.googleAdminIdp.clientSecret` (secret-marked, prod Google OAuth client), and `pulumiConfig.zitadel.adminGoogleSubs.pannpers` (secret-marked, same `sub` claim as dev — pannpers@pannpers.dev). The Postmark API token is already in `liverty-music/prod` ESC at `pulumiConfig.postmark.serverApiToken`. The admin JWT consumed by `HumanAdminComponent`'s dynamic resource is sourced inside `ZitadelProdStackComponent` from GSM `zitadel-machine-key-for-pulumi-admin` via `getSecretVersionAccessOutput` — no separate ESC entry.
+- **OUT OF SCOPE**: `E2eTestUserComponent` (CI test infra; tracked as a follow-up `enable-zitadel-prod-e2e-user`). Backend Atlas migration prod overlay (separate backend-repo PR). Frontend `.env.prod` + CI/CD branch→env mapping (separate frontend-repo PR). The 3 operational-debt items from `enable-zitadel-prod-pulumi-provider` archive (cloudsql.client Pulumi adoption, cross-project AR IAM Pulumi adoption, ESO refresh tuning) — separate follow-ups. The Cloudflare apex `liverty-music.app` A record (Pulumi out of scope by `prod-environment-bootstrap` design D2).
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `zitadel-self-hosted-deployment`: ADD 3 new requirements covering the full prod application stack (end-user OIDC application, operator console sign-in path, SMTP activation). MODIFY the existing "Bootstrap Admin Machine Key Stored in Secret Manager" requirement narrative to reference both dev and prod and add a scenario asserting both stacks produce the full set of Zitadel-side resources after this change.
+
+## Impact
+
+- **`cloud-provisioning/src/zitadel/components/`**: NEW component file `zitadel-prod-stack.ts` (top-level ComponentResource wrapping the 9 leaf components). The 9 leaf component files (`frontend.ts`, `smtp.ts`, `actions-v2.ts`, `login-client.ts`, `google-admin-idp.ts`, `admin-org-config.ts`, `human-admin.ts`, plus `project` + `adminOrg` instantiations) stay verbatim — used by both dev's `Zitadel` class and the new prod wrapper.
+- **`cloud-provisioning/src/index.ts`**: prod block becomes one `new ZitadelProdStackComponent(...)` instantiation (replacing the current `new BackendMachineKeyComponent(...)`). Dev `if (env === 'dev')` block unchanged.
+- **Prod Pulumi state after `pulumi up --stack prod`**: ~20-25 new resources. Concretely:
+  - 1 `zitadel.Org` imported (admin) — `protect: true`
+  - 1 `zitadel.Project` (liverty-music)
+  - 1 `zitadel.ApplicationOidc` + 1 product-org `LoginPolicy` (FrontendComponent)
+  - 1 `zitadel.SmtpConfig` + 1 `ZitadelSmtpActivation` dynamic resource (SmtpComponent)
+  - 1 `zitadel.Target` + 1 `zitadel.Execution` (ActionsV2Component)
+  - 1 `zitadel.MachineUser` `login-client` + 1 instance member + 1 `zitadel.PersonalAccessToken` + 1 GSM `Secret`/`SecretVersion`/`SecretIamMember` for `zitadel-login-pat` (LoginClientComponent)
+  - 1 `zitadel.IdpGoogle` (instance-level, GoogleAdminIdpComponent)
+  - 1 admin-org `LoginPolicy` + 1 instance `DefaultLoginPolicy` (AdminOrgConfigComponent)
+  - 1 `zitadel.HumanUser` (pannpers) + 1 instance member granting IAM_OWNER + 1 `ZitadelUserIdpLink` dynamic resource (HumanAdminComponent)
+- **`liverty-music/prod` ESC**: 3 new pulumiConfig entries (plaintext `googleAdminIdp.clientId`; secret-marked `googleAdminIdp.clientSecret` and `adminGoogleSubs.pannpers`). No `pulumiJwtProfileJson` entry — admin JWT is sourced from GSM at plan time inside the component.
+- **Out-of-band prerequisite**: a Google Cloud Console OAuth 2.0 Web Application client for prod (`https://auth.liverty-music.app/ui/v2/login/login/callback` redirect URI). Created manually before the first `pulumi up --stack prod` of this change; client_id + secret seeded into ESC.
+- **Operational unblocks**: after this change deploys, (a) the SPA on `liverty-music.app` can complete OIDC sign-in against prod Zitadel; (b) sign-up verification emails go out via Postmark; (c) backend access tokens include the `email` claim; (d) `pannpers@pannpers.dev` can sign in to `https://auth.liverty-music.app/ui/console` via Google. The `zitadel-web` Pod (currently in `ContainerCreating` waiting for `zitadel-web-pat` K8s Secret) transitions to `Running` once ESO syncs the new `zitadel-login-pat` GSM Secret.
+- **Cost**: zero net infra cost. The 25 new resources are all Zitadel-API-level (no GCP compute) except the `zitadel-login-pat` GSM Secret+Version+IAM (sub-cent/mo). Postmark traffic is per-email; expected band ~$0.20-2/mo for the first months of prod sign-ups.
+- **Risk**: the `pulumi import` step for the admin org is a one-time operation that needs the operator to fetch the prod admin-org-id first (via the Zitadel admin API using the bootstrap-uploaded JWT). Documented in tasks.md §1 pre-flight.

--- a/openspec/changes/complete-zitadel-prod-pulumi-stack/specs/zitadel-self-hosted-deployment/spec.md
+++ b/openspec/changes/complete-zitadel-prod-pulumi-stack/specs/zitadel-self-hosted-deployment/spec.md
@@ -1,0 +1,154 @@
+## ADDED Requirements
+
+### Requirement: Prod Zitadel Application Stack Provisioned by Pulumi
+
+The Pulumi `prod` stack SHALL provision the full Zitadel application stack required for end-user OIDC sign-in, end-user sign-up email verification, operator Console sign-in, and access-token email-claim propagation, in addition to the backend MachineKey already provisioned by `BackendMachineKeyComponent`. Specifically, the prod stack SHALL contain Pulumi-managed resources for:
+
+1. The prod `admin` org (brought into state via a one-time `pulumi import zitadel:index/org:Org admin <prod-admin-org-id>`), with `isDefault: true` (preserved from the bootstrap) and `protect: true`.
+2. A `zitadel.Project` named `liverty-music` in the product org.
+3. An `ApplicationOidc` for the frontend SPA (PKCE flow, JWT access tokens) and a product-org `LoginPolicy` (passkey + username/password sign-in, `userLogin=true`, `allowRegister=true`).
+4. A `SmtpConfig` (Postmark backend) and a dynamic-resource `SmtpActivation` that calls Zitadel's admin API `_activate` endpoint.
+5. An instance-level Actions V2 `Target` (REST webhook to the backend's `/pre-access-token` endpoint) and an `Execution` binding on the `preaccesstoken` flow.
+6. A `login-client` `MachineUser` (in the admin org), an instance-level `IAM_LOGIN_CLIENT` role grant, a `PersonalAccessToken` (PAT), and a GSM Secret `zitadel-login-pat` (Pulumi-created Secret + SecretVersion + IAM binding for the ESO Workload Identity SA) carrying the PAT for the in-cluster `zitadel-web` Pod.
+7. An instance-level `IdpGoogle` (admin Google IdP) keyed on a separate prod Google OAuth Web Application client (distinct from the dev client).
+8. An admin-org `LoginPolicy` (`userLogin=false`, `allowRegister=false`, `idps=[googleIdpId]`) and an instance-level `DefaultLoginPolicy` mirroring it.
+9. A `HumanUser` `pannpers@pannpers.dev` in the admin org with `IAM_OWNER` granted via an instance-level `OrgMember`, pre-linked to the prod Google IdP via a dynamic-resource `ZitadelUserIdpLink`.
+
+The prod stack SHALL NOT provision an `E2eTestUserComponent` (deferred to a follow-up change). The dev stack SHALL retain its existing 13-component `Zitadel` class verbatim; this requirement adds parallel prod-side provisioning, not a refactor of dev's assembly.
+
+**Rationale**: The prior `enable-zitadel-prod-pulumi-provider` change covered only the backend MachineKey, leaving prod with no browser sign-in path (operator or end-user), no sign-up email verification, and no access-token email claim. This requirement closes those gaps atomically — partial states (e.g., admin LoginPolicy without the Google IdP) would lock operators out mid-cutover. The 9-component bundle matches dev's proven topology minus E2E test infra, which is intentionally deferred so test-tenant decisions can be made after prod stack verification.
+
+#### Scenario: Prod stack contains the full application stack after apply
+
+- **WHEN** `pulumi up --stack prod` completes successfully against the change introducing this requirement
+- **THEN** the prod Pulumi state SHALL contain exactly one `zitadel.Org` named `admin` with `isDefault: true` and `protect: true`
+- **AND** exactly one `zitadel.Org` named `liverty-music` (product org) with `isDefault: false`
+- **AND** exactly one `zitadel.Project` named `liverty-music` in the product org
+- **AND** exactly one `zitadel.ApplicationOidc` for the frontend SPA (PKCE flow, scopes including `email`)
+- **AND** exactly one product-org `LoginPolicy` with `userLogin=true` and `allowRegister=true`
+- **AND** exactly one `zitadel.SmtpConfig` and exactly one dynamic-resource `ZitadelSmtpActivation`
+- **AND** exactly one `zitadel.Target` (REST webhook to the backend's `/pre-access-token` endpoint) and exactly one `zitadel.Execution` on the `preaccesstoken` flow
+- **AND** exactly one `login-client` `zitadel.MachineUser` in the admin org with an instance-level `IAM_LOGIN_CLIENT` role grant
+- **AND** exactly one `zitadel.PersonalAccessToken` for the `login-client` MachineUser
+- **AND** exactly one `gcp.secretmanager.Secret` named `zitadel-login-pat` (with at least one enabled SecretVersion and an IAM accessor binding for the ESO Workload Identity SA)
+- **AND** exactly one instance-level `zitadel.IdpGoogle`
+- **AND** exactly one admin-org `LoginPolicy` with `userLogin=false`, `allowRegister=false`, and `idps=[googleIdpId]`
+- **AND** exactly one instance-level `zitadel.DefaultLoginPolicy` mirroring the admin-org `LoginPolicy`
+- **AND** exactly one `zitadel.HumanUser` for `pannpers@pannpers.dev` in the admin org with instance-level `IAM_OWNER`
+- **AND** exactly one dynamic-resource `ZitadelUserIdpLink` linking the `pannpers` HumanUser to the prod Google IdP
+
+#### Scenario: Prod stack does NOT contain an E2E test user (deferred)
+
+- **WHEN** the prod Pulumi state is exported after this change is applied
+- **THEN** it SHALL NOT contain any `E2eTestUserComponent` ComponentResource
+- **AND** it SHALL NOT contain any `zitadel.HumanUser` whose `email` matches the dev E2E test user convention
+
+#### Scenario: Operator can sign in to prod Console via Google IdP
+
+- **WHEN** the operator visits `https://auth.liverty-music.app/ui/console` after the prod stack is applied
+- **THEN** the Login V2 UI SHALL present a "Sign in with Google" button (sourced from the admin-org `LoginPolicy.idps`)
+- **AND** completing the Google OAuth flow with `pannpers@pannpers.dev` SHALL resolve to the `pannpers` HumanUser via the pre-linked `ZitadelUserIdpLink`
+- **AND** the resulting Console session SHALL have IAM_OWNER authority at the instance level
+
+#### Scenario: End user can complete OIDC sign-up via SPA with email verification
+
+- **WHEN** an end user visits `https://liverty-music.app` after the prod stack is applied and chooses sign-up
+- **THEN** the SPA SHALL redirect to the prod Zitadel `ApplicationOidc` authorize endpoint
+- **AND** the Login V2 UI SHALL present passkey + username/password sign-up (sourced from the product-org `LoginPolicy`)
+- **AND** completing sign-up SHALL trigger a verification email sent via Postmark SMTP (sourced from the activated `SmtpConfig`)
+- **AND** verifying the email SHALL allow the user to sign in and obtain an access token containing the `email` claim (sourced from the Actions V2 `preaccesstoken` flow execution against the backend webhook)
+
+### Requirement: Prod ZitadelProdStackComponent Wraps the Nine Leaf Components
+
+The prod Pulumi stack SHALL implement the 9 components listed in the previous requirement via a single top-level `pulumi.ComponentResource` named `ZitadelProdStackComponent` (URN `zitadel:liverty-music:ZitadelProdStack`), which SHALL internally instantiate the 9 leaf components in dependency order. The `src/index.ts` prod block SHALL be a single `new ZitadelProdStackComponent(...)` invocation that replaces the prior `new BackendMachineKeyComponent(...)` line; the new component SHALL internally wrap the backend MachineKey provisioning logic so the existing `zitadel-machine-key-for-backend-app` GSM Secret + IAM binding are preserved (no destroy-replace, no URN churn for those subordinate resources).
+
+**Rationale**: A top-level wrapper preserves the thin-dispatch shape of `src/index.ts` (per `CLAUDE.md` "Main entry point dispatching to GCP and GitHub components") while keeping dev's `Zitadel` class verbatim — no dev URN churn. A `ComponentResource` also enables atomic `pulumi destroy --target` semantics for recovery: a single target removes the entire prod Zitadel application stack subtree, instead of leaving partial state across 9 leaves.
+
+#### Scenario: Prod index.ts dispatches via a single component
+
+- **WHEN** `cloud-provisioning/src/index.ts` is inspected for the prod-environment branch
+- **THEN** it SHALL contain exactly one `new ZitadelProdStackComponent(...)` instantiation
+- **AND** it SHALL NOT contain any direct instantiations of `FrontendComponent`, `SmtpComponent`, `ActionsV2Component`, `LoginClientComponent`, `GoogleAdminIdpComponent`, `AdminOrgConfigComponent`, `HumanAdminComponent`, `zitadel.Project`, or the imported `zitadel.Org('admin', ...)` outside of `ZitadelProdStackComponent`
+- **AND** the prior `new BackendMachineKeyComponent(...)` line SHALL no longer appear at the `index.ts` top level (its responsibility is absorbed into `ZitadelProdStackComponent`)
+
+#### Scenario: Backend MachineKey resources keep their URNs after the wrap
+
+- **WHEN** `pulumi preview --stack prod` runs against the change introducing `ZitadelProdStackComponent`
+- **THEN** the `zitadel-machine-key-for-backend-app` GSM Secret, SecretVersion, and IAM accessor binding SHALL NOT be marked for delete or replace
+- **AND** the existing backend `MachineUser`, `MachineKey`, and `OrgMember` resources SHALL NOT be marked for delete or replace
+- **AND** any URN change SHALL be expressed via Pulumi `aliases: [{ name: 'old-urn' }]` rather than a destroy-replace cycle (per the `reference_pulumi_aliases_urn_rename.md` operating rule)
+
+### Requirement: Prod LoginClient PAT Stored in GSM as zitadel-login-pat
+
+The prod Pulumi stack SHALL persist the `login-client` `PersonalAccessToken` to a Pulumi-managed `gcp.secretmanager.Secret` named `zitadel-login-pat` in project `liverty-music-prod`, with at least one enabled SecretVersion containing the PAT value (wrapped in `pulumi.secret()` before being passed to the SecretVersion's `secretData` argument) and an IAM accessor binding granting `roles/secretmanager.secretAccessor` to the ESO Workload Identity SA (`k8s-external-secrets@liverty-music-prod.iam.gserviceaccount.com`). The in-cluster `zitadel-web` Pod consumes this PAT via an `ExternalSecret` that mirrors the GSM Secret into a K8s Secret named `zitadel-web-pat`; Reloader rolls the `zitadel-web` Deployment on the K8s Secret change.
+
+**Rationale**: Without a `login-client` PAT, the `zitadel-web` (Login V2 UI) container's `ZITADEL_SERVICE_USER_TOKEN_FILE` is unmounted and the Pod stays in `ContainerCreating`. The Console login page returns 401 and the end-user sign-in flow stalls at the UI layer. The `pulumi.secret()` wrap is required because the `@pulumiverse/zitadel` provider's `PersonalAccessToken.token` output is a plain `Output<string>` — without the wrap, the PAT would surface in plaintext in Pulumi state history. GSM-mediated delivery (rather than a direct K8s Secret) matches the dev path and provides audit logging via Cloud Logging.
+
+#### Scenario: GSM Secret created and accessible to ESO
+
+- **WHEN** `pulumi up --stack prod` completes for the change introducing this requirement
+- **THEN** the GSM Secret `zitadel-login-pat` (project `liverty-music-prod`) SHALL exist with at least one enabled SecretVersion
+- **AND** the SecretVersion's `secretData` SHALL have been written via a Pulumi `pulumi.secret()`-wrapped value (so the PAT does not appear in plaintext in Pulumi state history)
+- **AND** an IAM accessor binding (`roles/secretmanager.secretAccessor`) SHALL grant access to `k8s-external-secrets@liverty-music-prod.iam.gserviceaccount.com`
+
+#### Scenario: zitadel-web Pod transitions to Running after ESO sync
+
+- **WHEN** ESO syncs the GSM Secret `zitadel-login-pat` into the K8s Secret `zitadel-web-pat` (namespace `zitadel`)
+- **AND** Reloader rolls the `zitadel-web` Deployment
+- **THEN** the `zitadel-web` Pod SHALL transition from `ContainerCreating` to `Running` (1/1 Ready)
+- **AND** the `zitadel-web` container SHALL successfully read the PAT from the file mounted at `ZITADEL_SERVICE_USER_TOKEN_FILE`
+
+### Requirement: Prod Google OAuth Web Client Provisioned Out-of-Band
+
+The prod Google OAuth 2.0 Web Application client (consumed by `GoogleAdminIdpComponent` as `clientId` + `clientSecret`) SHALL be created manually in Google Cloud Console (project `liverty-music-prod`) as a pre-flight step before the first `pulumi up --stack prod` of the change introducing this requirement. The client SHALL be distinct from the dev Google OAuth client (separate `client_id`, separate `client_secret`) and SHALL list `https://auth.liverty-music.app/ui/v2/login/login/callback` as an authorized redirect URI. The resulting credentials SHALL be seeded into ESC `liverty-music/prod` as `pulumiConfig.zitadel.googleAdminIdp.clientId` (plaintext) and `pulumiConfig.zitadel.googleAdminIdp.clientSecret` (secret-marked). The prod Pulumi stack SHALL consume these via Pulumi config; no Pulumi-managed `gcp.iap.*` or other IaC mechanism SHALL be used to create the OAuth client.
+
+**Rationale**: No Google API supports IaC creation of OAuth clients on a Google Cloud project — the Cloud Console GUI is the only path. A distinct prod client preserves blast-radius separation (a dev client_secret leak must not compromise prod operator sign-in) and matches the dev path's out-of-band creation pattern.
+
+#### Scenario: Prod OAuth client distinct from dev
+
+- **WHEN** the prod Google OAuth client and the dev Google OAuth client are inspected in Google Cloud Console
+- **THEN** they SHALL have distinct `client_id` values
+- **AND** the prod client's authorized redirect URIs SHALL include `https://auth.liverty-music.app/ui/v2/login/login/callback`
+- **AND** SHALL NOT include any `auth.dev.liverty-music.app` URI
+
+#### Scenario: ESC seeded before first pulumi up
+
+- **WHEN** the operator runs `esc env get liverty-music/prod` before the first `pulumi up --stack prod` of the change introducing this requirement
+- **THEN** `pulumiConfig.zitadel.googleAdminIdp.clientId` SHALL be a non-empty string
+- **AND** `pulumiConfig.zitadel.googleAdminIdp.clientSecret` SHALL be a non-empty string marked secret
+- **AND** `pulumiConfig.zitadel.adminGoogleSubs.pannpers` SHALL be a non-empty string (the Google `sub` claim for the human admin, secret-marked)
+- **AND** `pulumiConfig.postmark.serverApiToken` SHALL be a non-empty string marked secret (already seeded during the dev cutover; re-used for prod with no separate value)
+- **AND** the admin JWT used by `HumanAdminComponent`'s dynamic-resource API call SHALL NOT require a separate ESC entry — it is sourced inside `ZitadelProdStackComponent` from GSM `zitadel-machine-key-for-pulumi-admin` at plan time via `getSecretVersionAccessOutput` (wrapped in `pulumi.secret()`) and routed through `BackendMachineKeyComponent.adminJwt`
+
+## MODIFIED Requirements
+
+### Requirement: Bootstrap Admin Machine Key Stored in Secret Manager
+
+On first startup of an empty database, Zitadel SHALL create an initial admin machine user by consuming `ZITADEL_FIRSTINSTANCE_*` environment variables, write the resulting JWT-profile JSON key to a shared `emptyDir` pod volume, and a `bootstrap-uploader` sidecar container co-located in the same Zitadel API Pod SHALL upload that key to GCP Secret Manager as `zitadel-machine-key-for-pulumi-admin`; subsequent Pulumi stack applies SHALL read the key from Secret Manager as the `jwtProfileJson` for the Zitadel provider. This lifecycle SHALL apply identically in both the dev and prod stacks. After the `complete-zitadel-prod-pulumi-stack` change is applied, both stacks SHALL produce the full set of Zitadel-side resources — admin org (imported), product org (`liverty-music`), Project, Frontend ApplicationOidc, SmtpConfig + activation, Actions V2 Target + Execution, login-client MachineUser + PAT + GSM Secret, Google IdP, admin-org and instance LoginPolicies, human admin (with IdP link), and backend MachineKey + GSM Secret. The dev stack SHALL additionally produce the E2E test user (`E2eTestUserComponent`); the prod stack SHALL NOT produce an E2E test user (deferred to a follow-up change).
+
+**Rationale**: This closes the bootstrap chicken-and-egg — Pulumi needs admin credentials to configure Zitadel, but admin credentials only exist after Zitadel has bootstrapped itself. Shifting the boundary into the cluster avoids manual human steps. A separate Kubernetes `Job` cannot share an `emptyDir` volume with the Zitadel Deployment Pod (volumes are Pod-scoped), so the uploader runs as a sidecar container inside the Zitadel API Pod where the shared volume is naturally accessible. The sidecar idles after the upload (`tail -f /dev/null`) so the Pod stays ready and the upload is idempotent across Pod restarts (it skips re-uploading when the stored GSM version already matches).
+
+The GSM name `zitadel-machine-key-for-pulumi-admin` follows the platform-wide convention `zitadel-machine-key-for-<principal>`, where `<principal>` is the Pulumi `MachineUser` resource id. The legacy name `zitadel-admin-sa-key` was renamed because (1) it did not encode the binding between the GSM secret and the owning Zitadel principal, and (2) the principal label `admin` did not match the Pulumi `MachineUser` resource id `pulumi-admin`.
+
+After the `complete-zitadel-prod-pulumi-stack` change extends prod coverage to dev parity (minus E2E test infra), both stacks SHALL reach the same baseline of Zitadel-side resource counts. The admin org's `IsDefault=true` flag (set by the bootstrap) SHALL be preserved in both stacks; the prod admin org is brought into Pulumi state via a one-time `pulumi import zitadel:index/org:Org admin <prod-admin-org-id>`, while the dev admin org has been Pulumi-managed via the same import pattern since the original dev cutover.
+
+#### Scenario: First boot writes the admin key
+
+- **WHEN** the Zitadel API container starts against an empty database
+- **THEN** `ZITADEL_FIRSTINSTANCE_MACHINEKEYPATH` SHALL point to a path on an `emptyDir` volume mounted into both the Zitadel container and the `bootstrap-uploader` sidecar container in the same Pod
+- **AND** Zitadel SHALL write a JSON key file at that path
+- **AND** the `bootstrap-uploader` sidecar container in the same Pod SHALL upload the file to GCP Secret Manager secret `zitadel-machine-key-for-pulumi-admin`
+- **AND** the `bootstrap-uploader` sidecar SHALL unlink the key file from the shared `emptyDir` after a successful GSM upload, so the org-admin private key does not persist in the volume for the Pod's lifetime where any future co-located container with the same `volumeMount` could read it
+
+#### Scenario: Subsequent boots skip bootstrap
+
+- **WHEN** Zitadel starts against an already-initialized database
+- **THEN** the `ZITADEL_FIRSTINSTANCE_*` environment variables SHALL be ignored
+- **AND** the existing admin machine user and key in Secret Manager SHALL remain unchanged
+
+#### Scenario: Both stacks reach Zitadel-side parity after the prod stack change
+
+- **WHEN** `pulumi up` has been run for both the dev stack and the prod stack against the change introducing this requirement (`complete-zitadel-prod-pulumi-stack`)
+- **THEN** each stack's resulting Pulumi state SHALL contain the admin org (imported with `protect: true`), the `liverty-music` product org, a `zitadel.Project`, a frontend `ApplicationOidc` + product-org `LoginPolicy`, a `SmtpConfig` + `ZitadelSmtpActivation`, an Actions V2 `Target` + `Execution`, a `login-client` `MachineUser` + instance role + `PersonalAccessToken` + GSM `zitadel-login-pat`, an instance-level `IdpGoogle`, an admin-org `LoginPolicy` + instance `DefaultLoginPolicy`, a `HumanUser` for the human admin + instance `IAM_OWNER` member + `ZitadelUserIdpLink`, and a backend `MachineUser` + `MachineKey` + GSM `zitadel-machine-key-for-backend-app`
+- **AND** the dev stack SHALL additionally contain an `E2eTestUserComponent` (HumanUser + permanent-password dynamic resource)
+- **AND** the prod stack SHALL NOT contain an `E2eTestUserComponent`

--- a/openspec/changes/complete-zitadel-prod-pulumi-stack/tasks.md
+++ b/openspec/changes/complete-zitadel-prod-pulumi-stack/tasks.md
@@ -1,0 +1,95 @@
+## 1. Pre-Flight (Out-of-Band, Before First `pulumi up --stack prod`)
+
+- [ ] 1.1 Verify the prod `bootstrap-uploader` sidecar has completed: `gcloud secrets versions list zitadel-machine-key-for-pulumi-admin --project liverty-music-prod` SHALL return at least one ENABLED version.
+- [ ] 1.2 Fetch the prod admin-org-id via the Zitadel admin API: write the GSM `zitadel-machine-key-for-pulumi-admin` JSON to a tmp file, exchange it for an access token at `https://auth.liverty-music.app/oauth/v2/token` (JWT-bearer grant), then `GET /admin/v1/orgs` and record the org id where `name == "admin"`. Keep the access token only in shell history scrubbed of the secret.
+- [ ] 1.3 Check the prod Zitadel admin API for any existing `SmtpConfig`: `GET /admin/v1/smtp`. If a pre-seeded config exists from out-of-band setup, document it and decide whether to keep, replace, or remove it before §6 of this plan runs.
+- [ ] 1.4 Create the prod Google OAuth 2.0 Web Application client in Google Cloud Console (project `liverty-music-prod`). Authorized redirect URI: `https://auth.liverty-music.app/ui/v2/login/login/callback`. Record `client_id` + `client_secret` to a secure password manager.
+- [ ] 1.5 Confirm `pannpers@pannpers.dev`'s Google `sub` claim is the same numeric string in use by the dev stack (look up dev's `pulumiConfig.zitadel.adminGoogleSubs.pannpers` value). The `sub` is account-scoped and identical across all Google OAuth clients for the same account.
+
+## 2. ESC Seeding (`liverty-music/prod`)
+
+- [ ] 2.1 `esc env set liverty-music/prod pulumiConfig.zitadel.googleAdminIdp.clientId "<prod-client-id>"` (plaintext).
+- [ ] 2.2 `esc env set liverty-music/prod pulumiConfig.zitadel.googleAdminIdp.clientSecret "<prod-client-secret>" --secret`.
+- [ ] 2.3 `esc env set liverty-music/prod pulumiConfig.zitadel.adminGoogleSubs.pannpers "<pannpers-google-sub>" --secret`.
+- [ ] 2.4 Verify Postmark API token already present at `pulumiConfig.postmark.serverApiToken` (set during the dev cutover; same token used for both envs).
+- [ ] 2.5 `esc env get liverty-music/prod` and confirm all 3 new entries resolve with the expected secret-marking. (Implementation note: `pulumiJwtProfileJson` ESC entry is NOT needed — `HumanAdminComponent`'s dynamic resource consumes the admin JWT routed through `BackendMachineKeyComponent.adminJwt` inside `ZitadelProdStackComponent`, sourced from GSM `zitadel-machine-key-for-pulumi-admin` at plan time.)
+
+## 3. One-Time Pulumi Import of Admin Org
+
+- [ ] 3.1 In `cloud-provisioning/` directory, run `pulumi stack select prod`.
+- [ ] 3.2 `pulumi import zitadel:index/org:Org admin <prod-admin-org-id>` — the resource name `admin` MUST match the value used in the new `ZitadelProdStackComponent` source (so the import attaches to the right Pulumi resource).
+- [ ] 3.3 Verify the import added the resource to state without churn: `pulumi stack export | jq '.deployment.resources[] | select(.type == "zitadel:index/org:Org")'` SHALL return the admin org with `isDefault: true` and `protect: true`.
+
+## 4. New ZitadelProdStackComponent — Skeleton + Provider
+
+- [x] 4.1 Create `cloud-provisioning/src/zitadel/components/zitadel-prod-stack.ts`. Export class `ZitadelProdStackComponent extends pulumi.ComponentResource`. URN namespace: `zitadel:liverty-music:ZitadelProdStack`.
+- [x] 4.2 Define `ZitadelProdStackComponentArgs` interface: `env: Environment`, `gcpProject: pulumi.Input<string>`, `postmarkServerApiToken: string`, `googleAdminIdpClientId: pulumi.Input<string>`, `googleAdminIdpClientSecret: pulumi.Input<string>` (secret-wrapped upstream), `pannpersGoogleSub: pulumi.Input<string>`. (Design pivot: no separate `pulumiJwtProfileJson` arg — admin JWT comes from `BackendMachineKeyComponent.adminJwt`, re-exposed for sibling components.)
+- [x] 4.3 Re-use the admin-JWT read from inside `BackendMachineKeyComponent` (added a public `adminJwt: pulumi.Output<string>` property) instead of fetching twice. The `CRITICAL` `pulumi.secret()` wrap invariant is enforced inside `BackendMachineKeyComponent` (was already there).
+- [x] 4.4 Provider creation happens inside `BackendMachineKeyComponent` (re-used as a sub-component). `ZitadelProdStackComponent` uses `this.backendMachineKey.provider` for all 9 leaves.
+
+## 5. New ZitadelProdStackComponent — Admin Org (Imported) + Product Org + Project
+
+- [x] 5.1 Declare the admin org as a Pulumi resource (`new zitadel.Org('admin', { name: 'admin', isDefault: true }, { provider, protect: true, parent: this })`). Matches the imported state from §3.2.
+- [x] 5.2 Product org is created inside `BackendMachineKeyComponent` (already existing — `zitadel.Org('liverty-music', { isDefault: false })`). Re-used as `this.backendMachineKey.productOrg`.
+- [x] 5.3 Create the `zitadel.Project` named `liverty-music` in the product org. Mirror dev's `Zitadel.project` constructor args verbatim.
+- [x] 5.4 Design pivot: backend MachineKey + productOrg URNs preserved by re-using `BackendMachineKeyComponent` as a sub-component (with `parent: this` + `aliases: [{ parent: pulumi.rootStackResource }]`). Aliases on the parent propagate to all children — verify via `pulumi preview --stack prod` that no resource is marked for replace.
+
+## 6. New ZitadelProdStackComponent — Frontend + Smtp + Actions V2
+
+- [x] 6.1 Instantiate `FrontendComponent` with `env`, `orgId: productOrg.id`, `projectId: project.id`, `provider`, `parent: this`. Creates `ApplicationOidc` + product-org `LoginPolicy`.
+- [x] 6.2 Instantiate `SmtpComponent` with `env`, `serverApiToken: postmarkServerApiToken`, `provider`, `domain: zitadelDomainMap[env]`, `jwtProfileJson: <secret-wrapped admin JWT>`, `parent: this`. Creates `SmtpConfig` + `ZitadelSmtpActivation` dynamic resource.
+- [x] 6.3 Instantiate `ActionsV2Component` with `domain`, `jwtProfileJson`, `preAccessTokenEndpoint: \`${BACKEND_WEBHOOK_BASE_URL}${PRE_ACCESS_TOKEN_PATH}\``, `provider`, `parent: this`. Creates `Target` + `Execution`.
+
+## 7. New ZitadelProdStackComponent — Login Client + GSM Secret for PAT
+
+- [x] 7.1 Instantiate `LoginClientComponent` with `orgId: adminOrg.id`, `provider`, `parent: this`. Creates the `login-client` `MachineUser` + instance `IAM_LOGIN_CLIENT` role + `PersonalAccessToken`.
+- [x] 7.2 Design pivot: GSM `zitadel-login-pat` Secret + Version + ESO IAM binding are NOT created inside `ZitadelProdStackComponent`. Instead `loginClientToken` is surfaced and routed via `src/index.ts` → `Gcp({ ..., zitadelLoginPat })` → `KubernetesComponent.esoOnlySecrets`. Matches the dev path exactly; one code path for both envs.
+- [x] 7.3 (Subsumed by 7.2.) The `pulumi.secret()` wrap on the PAT value happens inside `Gcp.KubernetesComponent.esoOnlySecrets` (`pulumi.secret(zitadelLoginPat)` in `src/gcp/index.ts:270`).
+- [x] 7.4 (Subsumed by 7.2.) The ESO IAM binding is created inside `Gcp.KubernetesComponent` for `esoOnlySecrets` entries (`src/gcp/components/kubernetes.ts:268-277`).
+
+## 8. New ZitadelProdStackComponent — Google IdP + LoginPolicies + Human Admin
+
+- [x] 8.1 Instantiate `GoogleAdminIdpComponent` with `clientId: googleAdminIdpClientId`, `clientSecret: googleAdminIdpClientSecret`, `provider`, `parent: this`. Creates instance-level `IdpGoogle`.
+- [x] 8.2 Instantiate `AdminOrgConfigComponent` with `adminOrgId: adminOrg.id`, `googleIdpId: googleAdminIdp.idp.id`, `provider`, `consoleUrl`, `parent: this`. (Added `consoleUrl` arg to `AdminOrgConfigComponent` — optional, defaults to dev URL for dev-callsite back-compat; prod passes `https://auth.liverty-music.app/ui/console`.)
+- [x] 8.3 Instantiate `HumanAdminComponent` with `adminOrgId: adminOrg.id`, `email: 'pannpers@pannpers.dev'`, `firstName: 'Kyosuke'`, `lastName: 'Hamada'`, `googleIdpId: googleAdminIdp.idp.id`, `googleSub: pannpersGoogleSub`, `domain`, `jwtProfileJson`, `provider`, `parent: this`. Creates `HumanUser` + instance `IAM_OWNER` `OrgMember` + dynamic `ZitadelUserIdpLink`.
+
+## 9. Backend MachineKey Absorption — Reuse via Composition (NOT Delete)
+
+- [x] 9.1 Design pivot: keep `cloud-provisioning/src/zitadel/components/backend-machine-key.ts` AS-IS (with the addition of one public `adminJwt` property for sibling re-use). `BackendMachineKeyComponent` is instantiated INSIDE `ZitadelProdStackComponent` with `parent: this` — composition over inlining. This minimizes URN churn (one alias on `BackendMachineKeyComponent` propagates to all children) and avoids re-minting the lifecycle-sensitive backend `MachineKey` JWT (re-mint would cascade the §13.15 `Errors.AuthNKey.NotFound` failure).
+- [x] 9.2 Single `aliases: [{ parent: pulumi.rootStackResource }]` on `BackendMachineKeyComponent` covers the parent change. Pulumi's alias propagation re-anchors all child URNs (MachineUser, MachineKey, OrgMember, Secret, SecretVersion, IAM binding) without per-resource alias. Verify in §11.1 `pulumi preview --stack prod` that NONE of these are marked for replace.
+- [x] 9.3 (Cancelled — `backend-machine-key.ts` stays. The "delete + inline" path in the original tasks would have forced per-resource aliases across 7 inner resources and increased the destroy-replace risk.)
+- [x] 9.4 Update `cloud-provisioning/src/index.ts`: replace `import { BackendMachineKeyComponent } from './zitadel/components/backend-machine-key.js'` with `import { ZitadelProdStackComponent } from './zitadel/components/zitadel-prod-stack.js'`. (Internal re-import inside `zitadel-prod-stack.ts` preserves the `BackendMachineKeyComponent` usage point.)
+
+## 10. Wire ZitadelProdStackComponent in `src/index.ts`
+
+- [x] 10.1 Replace the existing `new BackendMachineKeyComponent('backend-app-prod', ...)` line in the prod-environment branch of `src/index.ts` with a single `new ZitadelProdStackComponent('liverty-music', ...)` instantiation. (Also removed the standalone `if (env === 'prod') { new BackendMachineKeyComponent(...) }` block — the wrapper now creates that resource subtree internally.)
+- [x] 10.2 Re-use the existing `zitadelConfig = config.requireSecretObject<...>('zitadel')` object. Three values consumed in the prod branch: `googleAdminIdp.clientId`, `googleAdminIdp.clientSecret`, `adminGoogleSubs.pannpers`. (No separate `pulumiJwtProfileJson` — see §2.5 note.)
+- [x] 10.3 The `ZitadelProdStackComponent` constructor receives the three ESC values via `zitadelConfig.apply(...)` (matches the dev call site shape). `loginClientToken` is forwarded into `Gcp` via the `zitadelLoginPat` slot.
+- [x] 10.4 `make lint-ts` passes (biome + tsc).
+
+## 11. Pulumi Preview + Deploy
+
+- [ ] 11.1 In `cloud-provisioning/` directory, run `pulumi preview --stack prod --diff`. Verify: ~20-25 new resources are created (the 9 new components + their leaves); NO resource is marked for replace or destroy; the admin org appears as imported (no churn); the backend MachineKey stack's URNs are stable (alias-mapped).
+- [ ] 11.2 Run `rm -rf node_modules package-lock.json && npm install` if any `package.json` changes were introduced (per memory `feedback_npm_lockfile_clean_install.md`).
+- [ ] 11.3 Commit + push the changes; open a PR to `main`; wait for `pulumi preview` PR check (preview-only on prod per `CLAUDE.md` "Pulumi Deployments (Automated)"). Address any CI failures.
+- [ ] 11.4 After PR approval + merge, manually trigger `pulumi up --stack prod` from the Pulumi Cloud console: https://app.pulumi.com/pannpers/liverty-music/prod/deployments. Watch deploy logs for SMTP activation, IdP link, login-client PAT, frontend ApplicationOidc.
+
+## 12. Smoke Tests (Post-Deploy)
+
+- [ ] 12.1 SPA sign-in flow: open `https://liverty-music.app` in a fresh browser, complete OIDC redirect, verify the prod Login V2 UI presents passkey + username/password sign-in.
+- [ ] 12.2 Sign-up email verification: complete a test sign-up with a real-but-disposable inbox; verify the verification email arrives via Postmark (check Postmark dashboard if the email doesn't arrive within 60s).
+- [ ] 12.3 Operator Console sign-in: open `https://auth.liverty-music.app/ui/console` in a fresh browser; click "Sign in with Google"; complete OAuth as `pannpers@pannpers.dev`; verify Console resolves to that user with IAM_OWNER role.
+- [ ] 12.4 Backend access-token email claim: capture a token from the SPA sign-in flow (`localStorage.getItem('access_token')` via DevTools); decode JWT claims via `jwt.io` or `jq`; verify `email` claim is present and matches the signed-in user's email.
+- [ ] 12.5 ESO sync verification: `kubectl get externalsecret -n zitadel zitadel-web-secrets -o yaml --context prod`. Verify `Status=Ready` and the synced K8s Secret `zitadel-web-pat` has a non-empty token.
+- [ ] 12.6 `zitadel-web` Pod healthy: `kubectl get pods -n zitadel --context prod`. The `zitadel-web` Pod SHALL be `Running` (1/1 Ready), transitioning out of the previous `ContainerCreating` state.
+
+## 13. Documentation + Memory
+
+- [ ] 13.1 Update `cloud-provisioning/CLAUDE.md` if any prod-specific operating rule changed (e.g., new GSM Secret names, new ESC paths). Likely just a one-line note pointing at this archived change.
+- [ ] 13.2 If the operator-attended workflow in §1 (admin-org-id discovery via curl) turns into a recurring break-glass step, add a short runbook at `cloud-provisioning/docs/runbooks/zitadel-admin-org-discovery.md` and link from `CLAUDE.md`.
+- [ ] 13.3 Run `openspec validate complete-zitadel-prod-pulumi-stack --strict` and confirm no spec-graph regressions.
+
+## 14. Archive
+
+- [ ] 14.1 Run `/opsx:archive complete-zitadel-prod-pulumi-stack` only after `openspec status complete-zitadel-prod-pulumi-stack --json` reports `isComplete: true` and all §11 + §12 + §13 tasks are checked.
+- [ ] 14.2 Per `reference_openspec_archive_pattern.md`: bundle the doc-fixes, delta→main spec sync (via `/opsx:archive`'s sync prompt), and git mv into a single archive PR.


### PR DESCRIPTION
## Summary

- Propose `complete-zitadel-prod-pulumi-stack` — close the **9 unwired Pulumi Zitadel components** for prod so end-user OIDC sign-in, sign-up email verification, operator Google-IdP Console access, and access-token email-claim injection all work end-to-end. Today (post-`enable-zitadel-prod-pulumi-provider`) only the backend ↔ Zitadel JWT auth (programmatic) is live.
- The 9 components: admin-org `pulumi import`, `Project`, `Frontend`, `Smtp`, `ActionsV2`, `LoginClient`, `GoogleAdminIdp`, `AdminOrgConfig`, `HumanAdmin`. `E2eTestUserComponent` deferred to follow-up `enable-zitadel-prod-e2e-user`.
- Single bundled change because partial states are unsafe (e.g., admin `LoginPolicy` without `GoogleAdminIdp` locks operators out mid-cutover).
- Implementation PR: liverty-music/cloud-provisioning (separate PR, follows this one).

## Artifacts

- [proposal.md](openspec/changes/complete-zitadel-prod-pulumi-stack/proposal.md)
- [design.md](openspec/changes/complete-zitadel-prod-pulumi-stack/design.md) — 9 decisions, 8 risks, 4-phase migration plan, 4 open questions
- [specs/zitadel-self-hosted-deployment/spec.md](openspec/changes/complete-zitadel-prod-pulumi-stack/specs/zitadel-self-hosted-deployment/spec.md) — 4 ADDED requirements + 1 MODIFIED (dev↔prod parity statement)
- [tasks.md](openspec/changes/complete-zitadel-prod-pulumi-stack/tasks.md) — 14 sections covering pre-flight, ESC seeding, admin-org `pulumi import`, the component implementation, deploy, smoke tests, archive

## Test plan

- [x] `openspec validate complete-zitadel-prod-pulumi-stack --strict` passes
- [ ] CI green
- [ ] Reviewer sign-off
