### PR TITLE
docs(openspec): propose refactor-unify-env-dispatch

### DIFF
--- a/openspec/changes/refactor-unify-env-dispatch/.openspec.yaml
+++ b/openspec/changes/refactor-unify-env-dispatch/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-15

--- a/openspec/changes/refactor-unify-env-dispatch/design.md
+++ b/openspec/changes/refactor-unify-env-dispatch/design.md
@@ -1,0 +1,241 @@
+## Context
+
+`cloud-provisioning` has three architectural debts that compound each other:
+
+1. **Two parallel "prod-only" Zitadel wrapper classes**: `BackendMachineKeyComponent` (one-component prod wrapper from `enable-zitadel-prod-pulumi-provider`, archived 2026-05-14) and `ZitadelProdStackComponent` (nine-component prod wrapper from `complete-zitadel-prod-pulumi-stack`, merged but never deployed). Each clones the dev `Zitadel` class with a subset of components. The 9-component instantiation block is almost byte-identical between dev's `Zitadel` and prod's `ZitadelProdStackComponent` — every Zitadel-side change must be applied in two places, with no compiler-level guarantee they stay in sync. The pattern was an over-application of "BackendMachineKeyComponent is a parallel class" to a 9-component context where the duplication cost crossed acceptable threshold.
+
+2. **`if (env === 'dev') { ... }` blocks where ternary / env-keyed map would suffice**: scattered through `frontend.ts`, `kubernetes.ts`, `gcp/index.ts`, `index.ts`, `e2e-test-user.ts`. The leaf components already accept `env` and switch internally via `Record<Environment, T>` maps (`baseDomainMap`, `zitadelDomainMap`, `senderAddressMap`). The wrappers fight that grain by re-doing env-dispatch at the call-site.
+
+3. **Stale staging code paths**: `staging` branches exist in `network.ts` (Cloud NAT block), `kubernetes.ts` (staging cluster block), env-keyed maps. No staging stack exists today; the staging code has never been exercised by `pulumi up`. Per the user's clarification, **staging is dropped from the near-term plan**.
+
+The trigger for this cleanup: while operator-deploying `complete-zitadel-prod-pulumi-stack` for prod, two compound problems surfaced — (a) `pulumi import` CLI required a pre-existing provider URN that the wrapper class hadn't yet materialized (hotfix #261 worked around with `import:` resource option), and (b) the parallel-class pattern made the divergence between dev and prod hard to reason about, leading to a runaway-spec-divergence cluster (redirect URI mismatch, fabricated ESC entries, etc.). The user's explicit pre-launch directive — *"破壊的な変更をするのはサービスイン前のこのタイミングが最適です"* — makes this the right moment for a destructive cleanup.
+
+Stakeholders:
+- **Operator** (`pannpers@pannpers.dev`): wants a clean codebase to maintain going forward; tolerates a 2-5 min prod auth outage pre-launch in exchange.
+- **Future contributors**: benefit from a single source of truth for Zitadel topology (the unified `Zitadel` class) and the principle "`if (env === ...)` only for fundamental structural differences like DNS".
+- **Pulumi state**: prod loses 9 URNs and gains ~30 new URNs in a single apply. Dev is byte-identical.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Delete `BackendMachineKeyComponent` and `ZitadelProdStackComponent`. Unify into the existing `Zitadel` class with env guards relaxed.
+- Drop `staging` from the `Environment` type and all code paths. Cloud NAT block in `network.ts` is **commented out** (not deleted) because near-future re-introduction is anticipated.
+- Establish the **canonical pattern**: env-driven differences expressed via ternary or env-keyed `Record<Environment, T>` map. `if (env === ...)` is reserved for *structural* differences — fundamentally different resource types (Autopilot vs Standard cluster, DNS-provider routing, folder-create vs StackReference-import).
+- Apply dev-only observability + cost-guardrail resources to all envs by removing the inner `if (env === 'dev')` guards. The outer guards (`gcpConfig.monitoring?.slackNotificationChannels`, `gcpConfig.billingAlertEmail`) still control whether the resources materialize — ESC seeding is the gate, not a code branch.
+- Extract `sharedClusterConfig` from the K8s cluster blocks to eliminate copy-paste of network/IAM/Gateway config across Autopilot and Standard.
+- Fix discovered bugs: `MonitoringComponent` clusterName hardcoded to dev's `standard-cluster-osaka` (prod would target the wrong cluster); staging cluster missing `gatewayApiConfig` + `monitoringConfig` (dormant bug since staging is never deployed, but worth fixing on the way out).
+
+**Non-Goals:**
+
+- Carry Pulumi `aliases` to preserve old prod URNs. Per user direction, simpler code is preferred over zero-downtime migration. The 2-5 min prod auth outage is acceptable pre-launch.
+- Refactor the dev `Zitadel` class's internal structure. Other than removing the `env !== 'dev'` guard and adding the `e2eTestUser` conditional, the class stays as-is. Dev URNs remain byte-identical.
+- ESC seeding (Slack channel ID, billing alert email). Operator-attended pre-flight; documented in tasks.md.
+- Cross-repo follow-ups carried forward from `complete-zitadel-prod-pulumi-stack`: backend Atlas migration prod overlay, frontend `.env.prod`, Cloudflare apex A record.
+- E2eTestUserComponent for prod (still deferred per `enable-zitadel-prod-e2e-user` plan).
+
+## Decisions
+
+### D1 — Drop `staging` from the `Environment` type; comment out the Cloud NAT block for future re-introduction
+
+**Decision:** `Environment = 'dev' | 'staging' | 'prod'` → `Environment = 'dev' | 'prod'`. All `if (env === 'staging')` blocks deleted (or commented out where re-introduction is anticipated). The `staging` cluster block in `kubernetes.ts:725-776` is **deleted** outright (staging cluster has never been deployed and its code has dormant bugs). The Cloud NAT block in `network.ts:200-228` is **commented out** with a TODO referencing the conditions under which it should be re-enabled (private nodes returning to prod, or staging stack adoption).
+
+**Rationale:**
+
+- No staging stack exists today and no near-term plan to add one.
+- Keeping unreached staging branches with subtle bugs (missing `gatewayApiConfig`, missing `monitoringConfig`, etc.) is worse than deleting them — the next dev to add staging will fix them anyway and may be confused by the partially-broken existing code.
+- Cloud NAT specifically is anticipated to return when (a) prod migrates to private nodes (currently public for cost reasons; flip "when real users arrive" per `docs/PROD_BOOTSTRAP_DECISIONS.md` D6), or (b) staging is reintroduced. Commenting it out — rather than deleting — preserves the block as ready-to-uncomment scaffolding while keeping the active codebase env-clean.
+- **Alternative considered (rejected): keep `Environment` union as-is, only delete the if-branches.** Cost: `Record<Environment, T>` maps still need `staging` entries (drift risk). TypeScript exhaustiveness checks still surface `staging` cases. The user explicitly asked for "条件分岐を一緒に削除", which only works if the type is also tightened. Net: tighten the type.
+
+### D2 — Delete the two parallel Zitadel wrapper classes; unify into the existing `Zitadel` class
+
+**Decision:** Delete `BackendMachineKeyComponent` and `ZitadelProdStackComponent` files. Remove the `if (env !== 'dev')` throw from `Zitadel`'s constructor. Move the prod-side `adminOrg` import-id from a class-specific hardcode to a shared `adminOrgIdMap: Record<Environment, string>` consumed via ternary inside the unified class.
+
+**Rationale:**
+
+- The 9 components instantiated in `ZitadelProdStackComponent` are byte-identical (modulo arg names) to those instantiated in `Zitadel`. The duplication has no functional benefit and creates drift risk on every future Zitadel-side change.
+- The `if (env !== 'dev')` throw was a defensive guard from when `Zitadel` was the dev-only cutover artifact (per `add-zitadel-console-admin-via-google-idp`, archived 2026-05-08). Post-cutover, dev's component leaves are all env-parameterized via maps and component args — removing the guard surfaces no behavioral risk.
+- The `BackendMachineKeyComponent` justification ("prod needs only backend-app, parallel class keeps it minimal") was a reasonable judgment when prod needed 1 component. It does not scale to 9 components, and the precedent it set ("parallel class for env") propagated to `ZitadelProdStackComponent`'s anti-pattern.
+- **Alternative considered (rejected): keep `BackendMachineKeyComponent` as a "compose-over-inline" sub-component inside `Zitadel`.** This was the original `complete-zitadel-prod-pulumi-stack` D9 decision. Cost: still requires `parent: this` + `aliases: [{ parent: pulumi.rootStackResource }]` plumbing on the inner class, plus a `backendMachineKey.adminJwt` re-export hack to share the GSM read. Benefit: would preserve some prod state URNs. Net: rejected because the user explicitly preferred simpler code (D3 below) over state preservation.
+
+### D3 — Destroy + recreate prod state (no `aliases`); accept 2-5 min auth outage
+
+**Decision:** Do not carry Pulumi `aliases: [{ parent: pulumi.rootStackResource }, { name: 'old-name' }]` to preserve the 9 prod URNs currently deployed under `BackendMachineKeyComponent`. The first `pulumi up --stack prod` of this change destroys those 9 resources and recreates them under the unified `Zitadel` class's URNs (with dev-style naming: provider `liverty-music-provider`, machine-user-component `liverty-music`).
+
+**Rationale:**
+
+- Per user explicit direction: *"alias については、一度、削除して作り直すのでもOK。コードがシンプルになってメンテナンス性が高い方法を優先して"* — simpler code is preferred over state preservation.
+- The alias-based approach would have required ~9 alias entries scattered through `Zitadel` class plumbing, plus careful handling of name changes that don't fit Pulumi's alias-on-parent-propagation model (provider name change `zitadel-prod` → `liverty-music-provider`, MachineUserComponent name change `backend-app-prod` → `liverty-music` — both require explicit `name` aliases that do not propagate to children).
+- **Pre-launch traffic shape**: prod has zero real users today. The 2-5 min window where the `backend` Pod's mounted JWT-profile JSON points at an invalidated `MachineKey.kid` produces error logs but no user-facing impact. ESO re-syncs the new GSM SecretVersion (~1 min), Reloader rolls the backend Deployment (~1 min), Pods boot with the new JWT (~30 sec).
+- **Risk if accepted post-launch**: would NOT be acceptable. This is the destructive-pre-launch window working in our favor.
+- **Alternative considered (rejected): preserve URNs via aliases.** Cost: ~50 lines of alias plumbing in the unified `Zitadel` class, fragile to future Pulumi version changes, has to be removed in a follow-up PR after the first apply lands (per Pulumi guidance). Benefit: zero prod auth outage. Net: rejected on the user's explicit code-simplicity preference.
+
+### D4 — Apply dev-only resources to all envs by removing inner `if (env === 'dev')` guards; outer ESC presence checks remain
+
+**Decision:** Three resources currently dev-only inside `gcp/index.ts` lose their `if (environment === 'dev')` guards:
+
+- `ZitadelMonitoringComponent` (latency p99 + JWT error rate alerts + connection-pool dashboard)
+- `gcp.billing.Budget` (`dev-cost-budget` → renamed `cost-budget`)
+- `MonitoringComponent`'s `ZitadelMonitoringComponent` sub-instantiation
+
+Plus one in `src/index.ts`: `SecretsComponent` instantiation loses its `if (env === 'dev' || env === 'prod')` allowlist (only two envs exist now, so the guard is no-op anyway — drop it for clarity).
+
+The OUTER guards remain:
+- `if (gcpConfig.monitoring?.slackNotificationChannels)` — gates the whole `MonitoringComponent` chain on Slack ESC seeding
+- `if (gcpConfig.billingAlertEmail)` — gates the `gcp.billing.Budget` on the alert-email ESC seeding
+
+These outer guards now serve a single purpose: "is this env's ESC seeded with the required value?" — pure data-driven, no env hardcoding.
+
+**Rationale:**
+
+- The dev thresholds in `ZitadelMonitoringComponent` are deliberately generous (50× over steady-state for latency p99, 10 errors / 60s for JWT). They will not page on the pre-launch prod traffic shape; if they become noisy later, threshold tuning is a separate concern.
+- The billing budget needs DIFFERENT amount values per env (dev: ¥3000, prod: TBD by operator). However, the dev billing budget is currently *dormant* — `gcpConfig.billingAlertEmail` is unset in dev ESC, so the inner `if` evaluates false and no Budget resource exists in dev state today. Refactoring to "all envs" is effectively no-op until ESC is seeded. When seeded, the budget amount is read from `gcpConfig.budgetAmountJpy` (new field) — per-env value seeded by operator.
+- **`MonitoringComponent` parameterization for env-correct cluster targeting**: `gcp/index.ts:324-327` currently hardcodes `clusterLocation: ${Regions.Osaka}-a` (zonal — dev-only) and `clusterName: standard-cluster-osaka` (dev-only). For prod the cluster is regional (`asia-northeast2`) and named `autopilot-cluster-osaka`. Without parameterization, prod alerts would silently target log entries from the dev cluster — a real bug. The fix is two new env-keyed maps in `constants.ts`-equivalent location (or inline ternaries):
+  ```ts
+  const clusterNameByEnv: Record<Environment, string> = {
+    dev: `standard-cluster-${RegionNames.Osaka}`,
+    prod: `autopilot-cluster-${RegionNames.Osaka}`,
+  }
+  const clusterLocationByEnv: Record<Environment, string> = {
+    dev: `${Regions.Osaka}-a`,   // zonal
+    prod: Regions.Osaka,         // regional
+  }
+  ```
+
+### D5 — Extract `sharedClusterConfig` for K8s cluster declarations; keep `if (env === 'dev')` only for the structural mode difference
+
+**Decision:** Pull out a module-level `sharedClusterConfig` const containing fields identical across all envs (network, subnet, ipAllocationPolicy, workloadIdentityConfig, releaseChannel, costManagementConfig, gatewayApiConfig). Spread it into both the dev (Standard) and prod (Autopilot) cluster declarations. Extract a further `sharedAutopilotConfig` const (extends `sharedClusterConfig` with `enableAutopilot: true`, `location: region` regional, `deletionProtection: true`, `clusterAutoscaling.autoProvisioningDefaults`, `monitoringConfig` with `enableComponents: ['SYSTEM_COMPONENTS']` + `managedPrometheus.enabled: true`).
+
+The `if (env === 'dev')` / `else` (= prod) structural branch remains because:
+- Dev uses Standard mode + a separate `gcp.container.NodePool` resource that does not exist in Autopilot
+- Prod uses Autopilot mode with `databaseEncryption.state: 'ENCRYPTED'` (CMEK), Standard cannot have this set
+- The mutually exclusive sets of valid config knobs (`removeDefaultNodePool` / `initialNodeCount` for Standard; `enableAutopilot` for Autopilot) cannot collapse into a single Pulumi resource declaration
+
+**Rationale:**
+
+- The structural difference (Autopilot vs Standard) is genuinely the kind the user said `if` is justified for — different resource graphs, not just different config values.
+- The duplicated SHARED config (network, subnet, IAM, Gateway, etc.) is what should be extracted. Future env-level additions (e.g., a new `costManagementConfig` flag) only have to be added in one place.
+
+### D6 — `places.googleapis.com` API enabled in all envs
+
+**Decision:** Remove the `if (environment === 'dev') apisToEnable.push('places.googleapis.com')` guard. Add the API to the base `apisToEnable` list unconditionally.
+
+**Rationale:**
+
+- API enablement in GCP is free until first call — enabling Places API in prod is zero-cost when prod doesn't call it.
+- Per user direction: *"prod にも同じリソースを作成して... 条件を削除して"* — uniform principle. The stale comment claiming "gcp-cost-guardrails" justification is removed (no such mechanism exists).
+- **Alternative considered (rejected): leave as dev-only.** Cost: more `if`-branch clutter, and the comment is misleading. Net: rejected.
+
+### D7 — Comment out (not delete) the staging Cloud NAT block; delete the staging cluster block
+
+**Decision:** The staging-only Cloud NAT scaffolding in `network.ts:200-228` is **commented out** (with a clearly-labeled TODO comment explaining re-enable conditions). The staging-only cluster block in `kubernetes.ts:725-776` is **deleted** outright.
+
+**Rationale (per user direction):**
+
+- Cloud NAT will likely return — either when (a) prod's `enablePrivateNodes: true` flip happens post-launch (Cloud NAT becomes mandatory for private-node clusters to reach the internet), or (b) staging is reintroduced. The user said *"近い将来導入するのでコメントアウトがいいかも"*. Commenting out preserves the working block as ready-to-uncomment.
+- The staging cluster block has dormant bugs (missing `gatewayApiConfig`, missing `monitoringConfig`, missing CMEK) and is largely a copy of the (now-modernized) prod block. Future staging adoption is better served by writing fresh from the unified `sharedClusterConfig` than from a partially-broken legacy.
+- **Alternative considered (rejected): delete both.** Cost: Cloud NAT re-introduction will require recreating from git history. Benefit: cleaner active codebase. Net: rejected for Cloud NAT (user direction); accepted for the cluster block (it's been a worse copy than the alternative).
+
+### D8 — Naming conventions: prod resources adopt dev's names; no per-env name suffixes
+
+**Decision:** Under the unified `Zitadel` class, prod resources adopt dev's naming:
+- Provider: `liverty-music-provider` (was `zitadel-prod` in prod state)
+- MachineUserComponent: `liverty-music` (was `backend-app-prod` in prod state)
+- Other component instantiations: same name across envs (the `name` arg passed to the `Zitadel` class — `'liverty-music'`)
+
+The billing budget is renamed `cost-budget` (from `dev-cost-budget`) — env is implicit via Pulumi stack scoping, not encoded in the resource name.
+
+**Rationale:**
+
+- Pulumi resource URNs are scoped by stack — `urn:pulumi:dev::...::Type::name` and `urn:pulumi:prod::...::Type::name` are distinct even when name is the same. Suffixing the name with `-dev` / `-prod` is redundant.
+- Simpler `grep` story for future maintainers — same name across envs means the same code path produces the same shape in every stack.
+- **Alternative considered (rejected): env-suffixed names everywhere.** Cost: more boilerplate, harder to grep for "the prod Provider resource". Benefit: explicit env disambiguation in log lines (mild). Net: rejected, Pulumi state already disambiguates by stack.
+
+### D9 — Pre-flight ESC seeding is operator pre-condition, not a Pulumi resource
+
+**Decision:** Two new ESC values must be seeded by the operator before the unified `Zitadel` class + Monitoring stack produces the full intended end-state in prod:
+
+- `pulumiConfig.gcp.monitoring.slackNotificationChannels.alertBackend` — Slack channel ID for backend ERROR log alerts. Created out-of-band via the Slack OAuth flow + GCP Console (per the existing `MonitoringComponentArgs.slackNotificationChannelIds` docstring: *"API requires Slack OAuth flow that is not IaC-friendly"*).
+- `pulumiConfig.gcp.billingAlertEmail` — recipient for Cloud Billing Budget alerts. Currently absent in BOTH dev and prod ESC; the dev billing budget has been dormant since inception. Operator decides whether to seed in this change cycle or defer.
+
+The Pulumi code reads these via the existing `gcpConfig.monitoring?.slackNotificationChannels` and `gcpConfig.billingAlertEmail` optional-chain guards. The refactor itself does not require these values to be present — without them, the relevant resources remain unmaterialized (same as today), but the code is no longer env-hardcoded.
+
+**Rationale:**
+
+- These are operator-attended steps (one requires the Slack OAuth UI, the other a deliberate budget-alert-email decision). Documenting them as pre-flight tasks keeps the code change pure and reviewable.
+
+### D10 — Supersede `complete-zitadel-prod-pulumi-stack`; archive at this change's archive step
+
+**Decision:** The OpenSpec change `complete-zitadel-prod-pulumi-stack` (active in `openspec/changes/`, never deployed to prod state) is superseded by THIS change. As part of this change's archive step, the operator marks the remaining `complete-zitadel-prod-pulumi-stack` tasks (§1-3 pre-flight, §11-12 deploy / smoke, §13-14 docs / archive) as "superseded — replaced by `refactor-unify-env-dispatch`", then archives `complete-zitadel-prod-pulumi-stack` with a date-prefix archive directory name. No `pulumi up` is ever run against `complete-zitadel-prod-pulumi-stack`'s coded form.
+
+**Rationale:**
+
+- The `complete-zitadel-prod-pulumi-stack` change correctly identified the 9-component prod gap but chose a parallel-class pattern that this change retrospectively rejects. Its proposal/design/specs remain useful historical context but its tasks are no longer the path forward.
+- Per memory `feedback_openspec_archive_when_done.md`, `/opsx:archive` requires `isComplete: true`. The remaining tasks need to be marked done (with "superseded" notes) before archive succeeds. Acceptable because the *intent* of those tasks is realized by this change.
+- Archive PR will bundle: (a) updating `complete-zitadel-prod-pulumi-stack/tasks.md` to mark remaining tasks as superseded, (b) running `/opsx:archive complete-zitadel-prod-pulumi-stack` to move the directory to `archive/`, (c) running `/opsx:archive refactor-unify-env-dispatch` itself.
+
+## Risks / Trade-offs
+
+| Risk | Mitigation |
+|---|---|
+| **Prod backend → Zitadel JWT auth fails for 2-5 min during `pulumi up`** (D3) — destroy of old `MachineKey.kid` invalidates the JWT in the currently-mounted K8s Secret; new JWT propagates via GSM → ESO → Reloader → Pod restart. | Pre-launch prod has zero real users. Operator monitors backend logs; expects `Errors.AuthNKey.NotFound` until ESO sync + Pod restart completes. Documented as expected behavior in tasks.md §smoke-tests. |
+| **Pulumi state-level orphan resources** if `pulumi up` is interrupted mid-destroy — the 9 old prod resources could be partially destroyed but not yet recreated, leaving Zitadel-side artifacts (e.g., the productOrg) referenced by destroyed Pulumi state. | Re-running `pulumi up --stack prod` after interruption recreates the missing leaves. If Zitadel-side orphans accumulate (e.g., productOrg created in Zitadel but Pulumi state lost), the operator manually deletes them via the Zitadel admin API before re-running. Acceptable manual cleanup window. |
+| **Resource name collision on recreate** — if Pulumi's destroy doesn't fully complete before create (e.g., GSM Secret soft-deletion), the new create might error on "resource already exists". | The GSM Secret resource has `deletionPolicy: 'DELETE'` (already in code) → hard delete on destroy. Zitadel resources (Org, MachineUser, MachineKey) have no soft-delete equivalent. Risk window is small. |
+| **Staging re-introduction friction** — type narrowed to `'dev' \| 'prod'`; `Record<Environment, T>` maps lose `staging` entries; staging cluster block deleted. | When staging is re-introduced, the operator (a) adds `'staging'` back to the union, (b) repopulates the env-keyed maps, (c) writes a fresh staging cluster block from `sharedAutopilotConfig`. The reintroduction is more work than today, but the result is correct (vs. today's partially-broken staging stub). |
+| **Cloud NAT comment-out drift** — commented-out code can rot; references it makes (NetworkConfig.Osaka.masterCidr, etc.) might break silently. | TODO comment includes explicit re-enable instructions + required ESC seeds. Periodic review (e.g., as part of `enable-private-prod-nodes` future change) re-validates the commented block. If it becomes too stale, delete and rewrite — same outcome as today. |
+| **`adminOrgIdMap` requires per-env admin-org-id hardcoded in source** — dev's `371280364565496672` and prod's `372892288692584603` are now both in `constants.ts`. If a Zitadel DB wipe + re-bootstrap happens, the org-id changes and the constant must be updated. | Same risk as today's `ZITADEL_DEV_ADMIN_ORG_ID`. The new map makes the prod entry visible alongside dev, so the dual-update is easier to remember. Comment on the const explains the discovery procedure. |
+| **`MonitoringComponent` alert filters now correctly target prod cluster** — change in alert behavior on first prod deploy (was effectively no-op due to dev cluster name mismatch). | Expected behavior. Operator validates alerts route to the configured Slack/Chat channel via a smoke-test alert trigger. |
+| **`complete-zitadel-prod-pulumi-stack` supersession archive failure** — `/opsx:archive` requires `isComplete: true`. The remaining tasks need manual mark-as-done with "superseded" notes. | Documented archive procedure in tasks.md. Acceptable manual step. |
+
+## Migration Plan
+
+**Phase 1 — Code refactor (this change's PR)**
+
+1. Open feature branch `refactor-unify-env-dispatch` in cloud-provisioning. Apply all code modifications per the task list.
+2. `make lint-ts` passes locally.
+3. Open PR. Pulumi preview runs on dev (expected: no diff — the unified `Zitadel` class produces identical state to today's dev) and prod (expected: 9 destroys + ~30 creates + 1 update on `kubernetes-cluster` if `MonitoringComponent` becomes active for prod).
+4. Review + merge.
+
+**Phase 2 — Operator pre-flight (out-of-band, optional)**
+
+- (Optional, can skip in this cycle) Create prod Slack channel + seed `pulumiConfig.gcp.monitoring.slackNotificationChannels.alertBackend` in prod ESC.
+- (Optional, can skip in this cycle) Decide budget alert email + budget amount; seed `pulumiConfig.gcp.billingAlertEmail` + `pulumiConfig.gcp.budgetAmountJpy` (new field) for both envs.
+
+Skipping these means `MonitoringComponent` + `gcp.billing.Budget` resources stay unmaterialized in prod (same as today's dev situation). The Zitadel application stack still deploys cleanly.
+
+**Phase 3 — `pulumi up --stack prod` (manual)**
+
+- Trigger from Pulumi Cloud console: https://app.pulumi.com/pannpers/liverty-music/prod/deployments
+- Watch destroy + recreate sequence for the 9 BackendMachineKey$... resources.
+- Expected: 2-5 min window where backend Pod auth fails. ESO syncs new GSM Secret, Reloader rolls Pod, auth resumes.
+
+**Phase 4 — Smoke tests**
+
+(Inherited from `complete-zitadel-prod-pulumi-stack/tasks.md §12` — same six tests, just executed against the new state.)
+
+1. SPA OIDC sign-in at `https://liverty-music.app`
+2. Sign-up email verification arrives via Postmark
+3. Operator Google IdP Console sign-in at `https://auth.liverty-music.app/ui/console`
+4. JWT `email` claim present in SPA-issued access token
+5. `kubectl get externalsecret -n zitadel zitadel-web-secrets` reports `Status=Ready`
+6. `zitadel-web` Pod is `Running` (1/1 Ready)
+
+**Phase 5 — Archive supersession**
+
+1. Mark all remaining `openspec/changes/complete-zitadel-prod-pulumi-stack/tasks.md` items as `[x]` with comment `# superseded by refactor-unify-env-dispatch`.
+2. Run `/opsx:archive complete-zitadel-prod-pulumi-stack` — moves to `openspec/changes/archive/YYYY-MM-DD-complete-zitadel-prod-pulumi-stack/`.
+3. Run `/opsx:archive refactor-unify-env-dispatch` — moves to `openspec/changes/archive/YYYY-MM-DD-refactor-unify-env-dispatch/`.
+4. Archive PR bundles both moves + delta→main spec sync.
+
+**Rollback Strategy**
+
+- If Phase 3 fails partway: re-run `pulumi up --stack prod`. The destroy + recreate is idempotent — Pulumi resumes from the failed step.
+- If Zitadel-side orphans accumulate (e.g., productOrg created without Pulumi state): operator deletes via Zitadel admin API using `pulumi-admin` MachineUser JWT.
+- If the refactor itself is rejected mid-deploy: revert the PR. Prod state stays partially migrated; manual cleanup of leaked resources required. **Likelihood is low** because dev preview already validates the unified class shape.
+
+## Open Questions
+
+- **OQ1: Should `budgetAmountJpy` be a new field in `GcpConfig` or a separate top-level ESC path?** The existing `gcpConfig` shape is mostly secrets-or-IDs; adding a plaintext budget amount is consistent. Recommendation: extend `GcpConfig` with `budgetAmountJpy?: string` (string for consistency with existing `currencyCode: 'JPY', units: '3000'` shape).
+- **OQ2: Should the staging cluster block deletion include the `masterCidr` constant from `NetworkConfig.Osaka`?** The constant is referenced only by the deleted staging block. Recommendation: leave the constant (the prod private-nodes flip will need it). Add a comment "currently unused; will be referenced by future enable-private-prod-nodes change".
+- **OQ3: Does the supersession of `complete-zitadel-prod-pulumi-stack` affect any open PRs or external references?** As of authoring time, PR #468 (spec) and PR #260 + #261 (cloud-provisioning) are all merged. The merged code still references `BackendMachineKeyComponent` + `ZitadelProdStackComponent`, which this change deletes. No external PRs reference these classes. Recommendation: document the merge-then-delete sequence in the supersession archive note.
+- **OQ4: Should `Cloud NAT comment-out` include a NetworkConfig `masterCidr` reference comment, since masterCidr was previously only referenced by the now-commented-out and now-deleted blocks?** Tied to OQ2 — keep the constant, add a "future re-use" comment.

--- a/openspec/changes/refactor-unify-env-dispatch/design.md
+++ b/openspec/changes/refactor-unify-env-dispatch/design.md
@@ -38,7 +38,7 @@ Stakeholders:
 
 ### D1 — Drop `staging` from the `Environment` type; comment out the Cloud NAT block for future re-introduction
 
-**Decision:** `Environment = 'dev' | 'staging' | 'prod'` → `Environment = 'dev' | 'prod'`. All `if (env === 'staging')` blocks deleted (or commented out where re-introduction is anticipated). The `staging` cluster block in `kubernetes.ts:725-776` is **deleted** outright (staging cluster has never been deployed and its code has dormant bugs). The Cloud NAT block in `network.ts:200-228` is **commented out** with a TODO referencing the conditions under which it should be re-enabled (private nodes returning to prod, or staging stack adoption).
+**Decision:** `Environment = 'dev' | 'staging' | 'prod'` → `Environment = 'dev' | 'prod'`. All `if (env === 'staging')` blocks deleted (or commented out where re-introduction is anticipated). The `staging` cluster block in `kubernetes.ts:725-776` is **deleted** outright (staging cluster has never been deployed and its code has dormant bugs). The Cloud NAT block in `network.ts:193-228` (including the leading explanatory comment at line 193 so the commented-out block stays self-documenting) is **commented out** with a TODO referencing the conditions under which it should be re-enabled (private nodes returning to prod, or staging stack adoption).
 
 **Rationale:**
 
@@ -90,6 +90,7 @@ These outer guards now serve a single purpose: "is this env's ESC seeded with th
 
 - The dev thresholds in `ZitadelMonitoringComponent` are deliberately generous (50× over steady-state for latency p99, 10 errors / 60s for JWT). They will not page on the pre-launch prod traffic shape; if they become noisy later, threshold tuning is a separate concern.
 - The billing budget needs DIFFERENT amount values per env (dev: ¥3000, prod: TBD by operator). However, the dev billing budget is currently *dormant* — `gcpConfig.billingAlertEmail` is unset in dev ESC, so the inner `if` evaluates false and no Budget resource exists in dev state today. Refactoring to "all envs" is effectively no-op until ESC is seeded. When seeded, the budget amount is read from `gcpConfig.budgetAmountJpy` (new field) — per-env value seeded by operator.
+- **Resource renames (two of them, both env-prefix removal)**: `dev-cost-budget` → `cost-budget` and `dev-billing-alert-email` → `billing-alert-email`. Env-prefix removal follows D8 (Pulumi stack URN already disambiguates env). Pulumi state impact: zero — both resources are currently DORMANT in dev state (the inner `if (gcpConfig.billingAlertEmail)` evaluates false today, so neither resource exists in any stack state), so the rename triggers no destroy+create operation. If the operator seeds `billingAlertEmail` in ESC *after* the refactor lands, the resources are created under the new (un-prefixed) names directly.
 - **`MonitoringComponent` parameterization for env-correct cluster targeting**: `gcp/index.ts:324-327` currently hardcodes `clusterLocation: ${Regions.Osaka}-a` (zonal — dev-only) and `clusterName: standard-cluster-osaka` (dev-only). For prod the cluster is regional (`asia-northeast2`) and named `autopilot-cluster-osaka`. Without parameterization, prod alerts would silently target log entries from the dev cluster — a real bug. The fix is two new env-keyed maps in `constants.ts`-equivalent location (or inline ternaries):
   ```ts
   const clusterNameByEnv: Record<Environment, string> = {
@@ -128,7 +129,7 @@ The `if (env === 'dev')` / `else` (= prod) structural branch remains because:
 
 ### D7 — Comment out (not delete) the staging Cloud NAT block; delete the staging cluster block
 
-**Decision:** The staging-only Cloud NAT scaffolding in `network.ts:200-228` is **commented out** (with a clearly-labeled TODO comment explaining re-enable conditions). The staging-only cluster block in `kubernetes.ts:725-776` is **deleted** outright.
+**Decision:** The staging-only Cloud NAT scaffolding in `network.ts:193-228` (including the leading explanatory comment at line 193 so the commented-out block stays self-documenting) is **commented out** (with a clearly-labeled TODO comment explaining re-enable conditions). The staging-only cluster block in `kubernetes.ts:725-776` is **deleted** outright.
 
 **Rationale (per user direction):**
 

--- a/openspec/changes/refactor-unify-env-dispatch/proposal.md
+++ b/openspec/changes/refactor-unify-env-dispatch/proposal.md
@@ -1,0 +1,70 @@
+## Why
+
+The `cloud-provisioning` codebase has accumulated three classes of env-dispatch anti-patterns that compound maintenance cost:
+
+1. **Parallel "prod-only" classes**: `ZitadelProdStackComponent` (from `complete-zitadel-prod-pulumi-stack`) and `BackendMachineKeyComponent` (from `enable-zitadel-prod-pulumi-provider`) each clone the dev `Zitadel` class with subset config. The 9-component instantiation block in each is almost byte-identical, drift-prone, and forces every future Zitadel-side change to be applied in two places.
+2. **Inline `if (env === 'dev')` blocks where ternaries / env-keyed maps suffice**: scattered through `frontend.ts` (localhost redirect URIs), `kubernetes.ts` (places API), `gcp/index.ts` (billing budget + ZitadelMonitoring), `index.ts` (SecretsComponent), `zitadel/components/e2e-test-user.ts` (env guard). The leaf components already accept `env` and switch via `Record<Environment, T>` maps internally — the wrappers fight that grain.
+3. **Stale staging code paths**: `staging` branches exist in `network.ts` (Cloud NAT), `kubernetes.ts` (staging cluster block), `constants.ts` (env-keyed maps), `smtp.ts` (sender address map). No staging stack exists today and none is planned in the near term, so the staging code is unreached and unreached-tested. The user-clarified policy: **staging is dropped from the near-term plan**; keep Cloud NAT only as commented-out scaffolding for likely future re-introduction.
+
+Discovered during attempted operator-deploy of `complete-zitadel-prod-pulumi-stack`: the parallel-class pattern blocked us via two separate problems — (a) Pulumi `pulumi import` CLI required a pre-existing provider URN that didn't exist for the wrapped prod component (hotfix #261 worked around with `import:` resource option), and (b) the duplicated 9-component instantiation made the divergence between dev and prod hard to reason about and led to a runaway-spec-divergence cluster (redirect URI mismatch, ESC entries fabricated, etc.). The user's pre-launch directive — *"破壊的な変更をするのはサービスイン前のこのタイミングが最適です"* — makes this the right moment for a destructive cleanup.
+
+This change supersedes `complete-zitadel-prod-pulumi-stack` (which was merged but has never been deployed to prod state). The prod Zitadel application stack will be delivered by THIS change instead, with the unified `Zitadel` class as the single source of truth.
+
+## What Changes
+
+### Code deletions
+
+- **DELETE** `cloud-provisioning/src/zitadel/components/zitadel-prod-stack.ts` (~370 lines)
+- **DELETE** `cloud-provisioning/src/zitadel/components/backend-machine-key.ts` (~210 lines)
+- **DELETE** staging-specific cluster block in `cloud-provisioning/src/gcp/components/kubernetes.ts` (lines 725-776)
+- **COMMENT OUT** (not delete) the staging-only Cloud NAT block in `cloud-provisioning/src/gcp/components/network.ts` (lines 193-228) — re-introduction is planned in the near future when private nodes return to prod or when staging stack is created. Inline TODO with re-enable instructions.
+
+### Code modifications
+
+- **MODIFY** `cloud-provisioning/src/config.ts`: `Environment = 'dev' | 'prod'` (drop `'staging'`).
+- **MODIFY** `cloud-provisioning/src/zitadel/index.ts`: remove the `if (env !== 'dev')` throw guard; `Zitadel` class supports all envs. Inline ternary for the `adminOrg.import` value (`adminOrgIdMap[env]`). Conditional create of `E2eTestUserComponent` only when `env === 'dev'`.
+- **MODIFY** `cloud-provisioning/src/zitadel/constants.ts`: drop `staging` entry from `baseDomainMap` and `zitadelDomainMap`; replace scalar `ZITADEL_DEV_ADMIN_ORG_ID` with `adminOrgIdMap: Record<Environment, string>` covering both dev and prod admin-org-ids.
+- **MODIFY** `cloud-provisioning/src/zitadel/components/frontend.ts`: localhost redirect URIs via ternary spread (`...(env === 'dev' ? ['http://localhost:9000/auth/callback'] : [])`), not `if` push.
+- **MODIFY** `cloud-provisioning/src/zitadel/components/e2e-test-user.ts`: remove the `if (env !== 'dev')` throw guard and docstring "Dev-only" callout — the caller (`Zitadel` class) gates instantiation via `if (env === 'dev')`, the component itself is env-agnostic.
+- **MODIFY** `cloud-provisioning/src/zitadel/components/smtp.ts`: drop `staging` from `senderAddressMap`.
+- **MODIFY** `cloud-provisioning/src/zitadel/components/zitadel-monitoring.ts`: docstring update — remove "Dev-only" callout; the component now runs in all envs.
+- **MODIFY** `cloud-provisioning/src/gcp/components/network.ts`: comment out staging Cloud NAT block (re-enable instructions in comment); simplify `buildZoneTopology` to `prod` vs `dev` 2-way branch (was `prod` vs `dev/staging`); update comments throughout.
+- **MODIFY** `cloud-provisioning/src/gcp/components/kubernetes.ts`: delete staging cluster block; extract `sharedClusterConfig` (network, subnet, ipAllocationPolicy, workloadIdentityConfig, releaseChannel, costManagementConfig, gatewayApiConfig) and `sharedAutopilotConfig` (extends `sharedClusterConfig` with Autopilot-specific shared fields) into module-level consts; spread into each cluster declaration. Places API enabled for all envs via ternary spread (was `if (env === 'dev')`). Drop stale "gcp-cost-guardrails" comment.
+- **MODIFY** `cloud-provisioning/src/gcp/components/postgres.ts`, `src/gcp/components/project.ts`: standardize inline `'dev' | 'staging' | 'prod'` type annotations to import `Environment` from `config.ts`.
+- **MODIFY** `cloud-provisioning/src/gcp/index.ts`: remove `if (environment === 'dev')` guard around `ZitadelMonitoringComponent`; remove the same guard around billing budget (rename resource from `dev-cost-budget` to `cost-budget` — name is naturally env-scoped via Pulumi stack). Parameterize `MonitoringComponent` instantiation: `clusterName` + `clusterLocation` driven by env-keyed map (`clusterNameByEnv`, `clusterLocationByEnv`) so log-based alerts target the correct cluster in each env.
+- **MODIFY** `cloud-provisioning/src/index.ts`: collapse the dev/prod Zitadel dispatch into a single `new Zitadel('liverty-music', { env, ... })` line; remove the explicit `if (env === 'dev' || env === 'prod')` allowlist on `SecretsComponent` (apply to all envs — there are only dev and prod now); both `zitadelMachineKey` and `zitadelLoginPat` flow through `Gcp` for both envs (the prod path's `BackendMachineKeyComponent`-owned GSM Secret is replaced by `Gcp.KubernetesComponent.esoOnlySecrets`, matching the dev pattern).
+
+### Pulumi state migration: destroy + recreate (no aliases)
+
+The currently-deployed prod state from `enable-zitadel-prod-pulumi-provider` (commit `47b1b47`, deployed 2026-05-14) places the backend MachineKey subtree under `BackendMachineKeyComponent`. After this refactor it lives under the unified `Zitadel` class with dev-style naming (`liverty-music-provider`, `MachineUserComponent("liverty-music")`). Per the user's explicit guidance — *"alias については、一度、削除して作り直すのでもOK。コードがシンプルになってメンテナンス性が高い方法を優先して"* — this change does NOT carry Pulumi `aliases` to preserve the old URNs. The 9 prod-side resources are destroyed and recreated under the new URNs on the first `pulumi up --stack prod` of this change.
+
+Practical impact: a 2-5 minute window during the prod apply where backend → Zitadel JWT auth fails (old `MachineKey.kid` invalidated before the new one propagates through GSM → ESO → K8s Secret → Reloader → Pod restart). Pre-launch prod has zero real users; the impact is bounded to error logs.
+
+### Operator pre-flight (out of scope for code, in scope for tasks.md)
+
+Prod ESC must be seeded with two additional values before the first `pulumi up --stack prod` of this change unlocks `MonitoringComponent` + `ZitadelMonitoringComponent` end-to-end:
+
+- `pulumiConfig.gcp.monitoring.slackNotificationChannels.alertBackend` — Slack channel ID (created out-of-band in GCP Console because the API requires Slack OAuth; same pattern as `liverty-music-dev` already uses).
+- `pulumiConfig.gcp.billingAlertEmail` — recipient for Cloud Billing Budget alerts (decide threshold; recommend not seeding `dev` either, since current `dev` ESC also lacks this and the dev budget is currently dormant — so the refactor is no-op until ESC is seeded).
+
+These are documented as pre-flight tasks. The code change without them produces a clean preview (the inner `if (gcpConfig.monitoring?.slackNotificationChannels)` and `if (gcpConfig.billingAlertEmail)` guards remain).
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `zitadel-self-hosted-deployment`: **REMOVE** the requirement "Prod Backend MachineKey Component Authenticates with Bootstrap-Uploaded Admin JWT" — its content is absorbed into a unified requirement covering both envs. **REMOVE** the requirement "Backend MachineUser Placed in Product Org, Not the First-Boot Admin Org" — superseded by a unified product-org requirement applied to all envs. **MODIFY** several existing requirements to drop "dev only" / "prod scope" language and reflect dev-prod parity. **ADD** a requirement establishing the "unified `Zitadel` class for all envs" pattern as the canonical implementation.
+
+## Impact
+
+- **`cloud-provisioning/src/` net diff**: ~580 lines deleted, ~250 lines modified, ~50 lines added (sharedClusterConfig, adminOrgIdMap, env-keyed monitoring maps).
+- **Dev Pulumi state**: zero churn. The unified `Zitadel` class is byte-identical to today's dev class with the `env !== 'dev'` throw removed. Dev URNs do not change.
+- **Prod Pulumi state**: 9 `BackendMachineKey$...` resources destroyed; ~30 new `Zitadel$...` resources created (the 9 originals re-created under new URNs + Project + Frontend + Smtp + ActionsV2 + LoginClient + GoogleAdminIdp + AdminOrgConfig + HumanAdmin + admin-org import + GSM `zitadel-login-pat` Secret bundle). The admin org is imported via `import:` resource option (same id `372892288692584603` already discovered).
+- **Operational unblocks** after deploy: prod SPA OIDC sign-in, sign-up email verification, operator Google IdP Console access, JWT `email` claim, prod ZitadelMonitoring (latency p99 + JWT error rate alerts), prod billing budget (once ESC seeded).
+- **Operator-attended window**: 2-5 minutes prod backend ↔ Zitadel auth failure during destroy-recreate; pre-launch prod is no-traffic, impact is bounded to error logs.
+- **Supersession bookkeeping**: `openspec/changes/complete-zitadel-prod-pulumi-stack/` (active, never deployed) is archived as part of this change's archive step with a clear `superseded by refactor-unify-env-dispatch` note. The redirect-URI doc errors and `pulumi import` CLI workaround in that change become historical context; this change's spec delta is the new source of truth.
+- **Out of scope**: backend Atlas migration prod overlay, frontend `.env.prod`, Cloudflare apex `liverty-music.app` A record (carried forward from `complete-zitadel-prod-pulumi-stack` proposal — same separate-PR follow-ups). E2eTestUserComponent for prod (still deferred per the original `enable-zitadel-prod-e2e-user` plan). Staging stack adoption (out of near-term plan; Cloud NAT scaffolding preserved as commented-out for easy re-introduction).

--- a/openspec/changes/refactor-unify-env-dispatch/specs/zitadel-self-hosted-deployment/spec.md
+++ b/openspec/changes/refactor-unify-env-dispatch/specs/zitadel-self-hosted-deployment/spec.md
@@ -1,0 +1,171 @@
+## ADDED Requirements
+
+### Requirement: Single Unified Zitadel Class Across All Environments
+
+The Pulumi `cloud-provisioning` codebase SHALL provision the Zitadel application stack via a **single** `Zitadel` class (`src/zitadel/index.ts`) used by every Pulumi stack. The class SHALL accept an `env: Environment` argument and SHALL handle all environment-specific behavior internally via ternary expressions and `Record<Environment, T>` constant maps. Parallel "prod-only" or "env-specific" wrapper classes (e.g., `BackendMachineKeyComponent`, `ZitadelProdStackComponent`) SHALL NOT exist; the call-site in `src/index.ts` SHALL invoke `new Zitadel(name, { env, ... })` once, without env-branching.
+
+**Rationale**: The previous parallel-class pattern (`BackendMachineKeyComponent` from `enable-zitadel-prod-pulumi-provider`, `ZitadelProdStackComponent` from `complete-zitadel-prod-pulumi-stack`) duplicated the 9-component Zitadel topology across two near-identical class definitions. Every future Zitadel-side change had to be applied in both places with no compiler-level synchronization guarantee. The leaf components already accept `env` and switch behavior internally via env-keyed maps (`baseDomainMap`, `zitadelDomainMap`, `senderAddressMap`); the wrappers fought that grain. A single class with env-aware internals fits the established leaf-component pattern and eliminates the drift hazard.
+
+#### Scenario: Single Zitadel class instantiation in src/index.ts
+
+- **WHEN** `cloud-provisioning/src/index.ts` is inspected
+- **THEN** it SHALL contain exactly one `new Zitadel(...)` instantiation
+- **AND** the instantiation SHALL NOT be wrapped in an `if (env === ...)` branch
+- **AND** no other `zitadel:liverty-music:*` ComponentResource wrapping the 9 Zitadel leaf components SHALL exist
+
+#### Scenario: Env-driven differences via map / ternary, not branching wrapper
+
+- **WHEN** the `Zitadel` class constructor handles an environment-specific value (admin org id, redirect URI, sender address, etc.)
+- **THEN** the value SHALL be sourced from a `Record<Environment, T>` map (e.g., `adminOrgIdMap`, `baseDomainMap`) consulted via `[env]` indexing
+- **AND/OR** the value SHALL be a ternary expression (`env === 'dev' ? X : Y`)
+- **AND** the class SHALL NOT have its own `if (env === 'dev')` / `if (env === 'prod')` top-level dispatch (env-conditional leaf-component instantiation such as `if (env === 'dev') this.e2eTestUser = ...` is acceptable when the leaf component is truly env-scoped, but the wrapper structure itself is uniform)
+
+#### Scenario: Zero dev URN churn after unification
+
+- **WHEN** `pulumi preview --stack dev` runs after this requirement is implemented
+- **THEN** the preview SHALL show zero changes to existing Zitadel-side resource URNs in dev state
+- **AND** the `Zitadel` class internal structure SHALL be byte-equivalent to its pre-refactor form modulo the removal of the `env !== 'dev'` throw guard and the addition of env-conditional `E2eTestUserComponent` creation
+
+### Requirement: Env-Driven Configuration Uses Maps or Ternaries, Not Top-Level If-Branches
+
+The Pulumi `cloud-provisioning` codebase SHALL express environment-specific configuration values via `Record<Environment, T>` constant maps or inline ternary expressions. Top-level `if (env === 'dev')` / `if (env === 'prod')` branches in component constructors or in `src/index.ts` SHALL be reserved for **structurally different resource shapes** — i.e., cases where the env difference produces fundamentally different Pulumi resource types or resource graphs that cannot be expressed as parameter differences on the same resource declaration.
+
+Examples of structural differences (where `if` IS justified):
+- DNS topology: prod uses Cloudflare for the apex + Cloud DNS for subdomains; non-prod uses Cloud DNS only with a single zone (`src/gcp/components/network.ts`)
+- K8s cluster mode: dev uses Standard cluster + separate NodePool resource; prod uses Autopilot cluster with mutually-exclusive config knobs (`src/gcp/components/kubernetes.ts`)
+- Organization folder: prod creates a new folder; non-prod imports via `StackReference` (`src/gcp/components/project.ts`)
+- GitHub organization-level config: prod stack owns the GitHub org-level resources to avoid cross-stack conflict (`src/index.ts`)
+
+Examples of NON-structural differences (where ternary / map SHALL replace `if`):
+- Environment-specific redirect URIs (add localhost only for dev)
+- Environment-specific OAuth client values
+- Environment-specific admin org ids
+- Environment-specific Postmark sender addresses
+- Conditional API enablement of harmless APIs
+
+**Rationale**: The `if`-as-default pattern leads to code drift across env branches because each branch carries an independent copy of the surrounding configuration. Centralizing env-keyed differences in maps and inline ternaries forces the env-specific value to be the ONLY thing that varies, making divergence visible at the point of value selection rather than spread across duplicated blocks.
+
+#### Scenario: Per-env redirect URIs use ternary spread, not if-push
+
+- **WHEN** `FrontendComponent` constructs `redirectUris` for the SPA's `ApplicationOidc`
+- **THEN** dev-only localhost URIs SHALL be added via ternary spread (`...(env === 'dev' ? ['http://localhost:9000/auth/callback'] : [])`)
+- **AND** an `if (env === 'dev')` block that calls `redirectUris.push(...)` SHALL NOT appear
+
+#### Scenario: Per-env admin org id sourced from env-keyed map
+
+- **WHEN** the `Zitadel` class imports the admin org via `zitadel.Org('admin', ...)` resource option `import:`
+- **THEN** the import id SHALL be `adminOrgIdMap[env]` where `adminOrgIdMap: Record<Environment, string>` lives in `src/zitadel/constants.ts`
+- **AND** no per-env scalar constant (such as a legacy `ZITADEL_DEV_ADMIN_ORG_ID`) SHALL be referenced
+
+#### Scenario: places.googleapis.com enabled in all environments
+
+- **WHEN** `src/gcp/components/kubernetes.ts` builds the `apisToEnable` list
+- **THEN** `places.googleapis.com` SHALL be included unconditionally (no env-gated `apisToEnable.push`)
+- **AND** API enablement SHALL incur zero recurring cost when the API is not called (justified by GCP's enablement-is-free / per-call-is-paid pricing)
+
+### Requirement: Backend MachineUser Lives in Product Org Across All Environments
+
+The Pulumi `Zitadel` class SHALL create the backend `MachineUser` (with `ORG_USER_MANAGER` role grant via `OrgMember`) inside a **Pulumi-managed product org** named `liverty-music`, in every environment. Pulumi SHALL NOT create or manage the first-boot admin org (auto-created by Zitadel via `ZITADEL_FIRSTINSTANCE_ORG_NAME`) as a creation; the admin org SHALL be brought into Pulumi state via the `import:` resource option using an environment-keyed admin-org-id map (`adminOrgIdMap`), without per-env wrapper classes or per-env scalar constants.
+
+**Rationale**: The first-boot admin org holds operator identities — `pulumi-admin` (IaC break-glass), `login-client` (Login V2 PAT host), and any human IAM_OWNER admins. Granting the backend `MachineUser` `ORG_USER_MANAGER` in that org would let the runtime backend Pod create, suspend, or modify those operator identities — a privilege-escalation foothold from a compromised backend Pod to the IaC/admin tier. Placing `backend-app` in a separate Pulumi-managed product org confines `ORG_USER_MANAGER` to end-user principals. This rule applied to dev from the original cutover (`add-zitadel-console-admin-via-google-idp`) and was extended to prod in `enable-zitadel-prod-pulumi-provider` with the prod-specific `BackendMachineKeyComponent`. The unified `Zitadel` class makes the rule env-agnostic: same code path, same Pulumi resource shapes, env-specific values only via maps.
+
+#### Scenario: backend-app MachineUser lives in product org (any env)
+
+- **WHEN** `pulumi up` is applied to any env (`dev` or `prod`)
+- **THEN** the resulting Pulumi state SHALL contain exactly one `zitadel.Org` resource named `liverty-music` (the product org)
+- **AND** the backend `zitadel.MachineUser` resource SHALL reference `productOrg.id`, NOT the admin org's id
+- **AND** the `zitadel.OrgMember` granting `ORG_USER_MANAGER` SHALL also scope to `productOrg.id`
+
+#### Scenario: Admin org imported via inline import: resource option, env-keyed id
+
+- **WHEN** the `Zitadel` class instantiates `new zitadel.Org('admin', ...)` for any env
+- **THEN** the resource SHALL declare `protect: true`
+- **AND** SHALL declare `isDefault: true` (matching the bootstrap-set flag)
+- **AND** SHALL declare `import: adminOrgIdMap[env]` to bind to the pre-existing bootstrap-created admin org
+- **AND** the `adminOrgIdMap` SHALL contain at minimum a `dev` entry and a `prod` entry, each set to the respective env's admin-org-id as discovered post-bootstrap via `POST /admin/v1/orgs/_search`
+
+#### Scenario: Provider sourced from GSM admin JWT in all envs
+
+- **WHEN** the `Zitadel` class instantiates `new zitadel.Provider(...)` for any env
+- **THEN** `jwtProfileJson` SHALL be a `pulumi.secret()`-wrapped `Output<string>` produced by `gcp.secretmanager.getSecretVersionAccessOutput` against the GSM Secret `zitadel-machine-key-for-pulumi-admin` in the env's GCP project
+- **AND** the env's `domain` SHALL be `zitadelDomainMap[env]`
+- **AND** no per-env wrapper class SHALL pre-process or shadow this Provider construction
+
+### Requirement: Cost Guardrails and Observability Applied to All Environments
+
+The Pulumi `cloud-provisioning` codebase SHALL instantiate `ZitadelMonitoringComponent` and `gcp.billing.Budget` in every environment (`dev` and `prod`). Materialization of these resources at apply time SHALL be gated by the presence of their required ESC configuration (`gcpConfig.monitoring?.slackNotificationChannels` for the monitoring chain; `gcpConfig.billingAlertEmail` for the budget), not by env-hardcoded branches.
+
+**Rationale**: The previous `if (environment === 'dev')` guard around `ZitadelMonitoringComponent` and the billing budget was a pre-prod decision rationalized as "thresholds tuned for dev, would page on prod". Empirically the thresholds (50× headroom on latency p99, 10 errors / 60s on JWT validation) are generous enough for pre-launch prod traffic. Re-tuning is a future operational concern; gating on env at code level prevents the operator from enabling prod alerts via ESC seeding without a code change. The new pattern: code is env-uniform, materialization is ESC-driven.
+
+#### Scenario: ZitadelMonitoringComponent runs in all envs when Slack channel ESC seeded
+
+- **WHEN** `pulumiConfig.gcp.monitoring.slackNotificationChannels.alertBackend` is seeded in an env's ESC
+- **THEN** `pulumi up` for that env SHALL create the `ZitadelMonitoringComponent` resources (latency p99 alert, JWT error rate alert, connection-pool dashboard)
+- **AND** no `if (environment === 'dev')` code branch SHALL gate the instantiation
+
+#### Scenario: Billing budget materializes when ESC seeded, any env
+
+- **WHEN** `gcpConfig.billingAlertEmail` is set in an env's ESC
+- **THEN** `pulumi up` for that env SHALL create a `gcp.billing.Budget` resource named `cost-budget` (env scoping is via Pulumi stack URN, not the resource name)
+- **AND** the budget amount SHALL be sourced from `gcpConfig.budgetAmountJpy` (new field, env-specific value)
+
+#### Scenario: MonitoringComponent targets the env's actual cluster
+
+- **WHEN** `MonitoringComponent` instantiates log-based alert policies
+- **THEN** the `clusterName` and `clusterLocation` arguments SHALL be sourced from env-keyed maps (e.g., `clusterNameByEnv`, `clusterLocationByEnv`)
+- **AND** the resolved values SHALL match the cluster actually deployed in that env (dev: `standard-cluster-osaka` / `asia-northeast2-a`; prod: `autopilot-cluster-osaka` / `asia-northeast2`)
+- **AND** no per-cluster name SHALL be hardcoded to a single env's value
+
+## REMOVED Requirements
+
+### Requirement: Backend MachineUser Placed in Product Org, Not the First-Boot Admin Org
+
+**Reason**: Superseded by the new general-form requirement "Backend MachineUser Lives in Product Org Across All Environments" (ADDED above). The removed requirement was written in `enable-zitadel-prod-pulumi-provider` with prod-specific language ("Pulumi `BackendMachineKeyComponent` (or equivalent) SHALL ...") that constrained the implementation choice to a parallel wrapper class. The new general-form requirement applies env-agnostically and does not constrain the implementation to a particular wrapper.
+
+**Migration**: Implementations satisfying the removed requirement automatically satisfy the new general-form requirement, as the rule itself (product-org placement of backend `MachineUser` + ORG_USER_MANAGER) is preserved. The constraint that was relaxed is the implementation shape: the unified `Zitadel` class replaces the prod-specific `BackendMachineKeyComponent` while continuing to honor the org-placement rule.
+
+### Requirement: Prod Backend MachineKey Component Authenticates with Bootstrap-Uploaded Admin JWT
+
+**Reason**: The `BackendMachineKeyComponent` (the subject of this requirement) is deleted by this change. Its responsibilities — fetching the admin JWT from GSM via `getSecretVersionAccessOutput`, wrapping it in `pulumi.secret()`, configuring the `zitadel.Provider` — are absorbed into the unified `Zitadel` class and apply to all envs uniformly. The new ADDED requirement "Backend MachineUser Lives in Product Org Across All Environments" scenarios `Admin org imported via inline import: resource option, env-keyed id` and `Provider sourced from GSM admin JWT in all envs` together cover all the operational invariants the removed requirement encoded.
+
+**Migration**: The `pulumi.secret()` wrap, the GSM data source, and the failure-on-missing-version behavior are all preserved in the unified `Zitadel` class. Implementations migrating from `BackendMachineKeyComponent` SHALL:
+1. Delete the `BackendMachineKeyComponent` file.
+2. Remove the `env !== 'dev'` throw guard from the `Zitadel` class.
+3. Source the admin JWT inside the unified class (it was already there pre-refactor for dev; remove the env guard so the same code path runs in prod).
+4. Accept the prod state migration cost: the previous `BackendMachineKey$...` URNs are destroyed and recreated under `Zitadel$...` URNs on the first prod `pulumi up`. Brief backend-auth outage (~2-5 min pre-launch).
+
+## MODIFIED Requirements
+
+### Requirement: Bootstrap Admin Machine Key Stored in Secret Manager
+
+On first startup of an empty database, Zitadel SHALL create an initial admin machine user by consuming `ZITADEL_FIRSTINSTANCE_*` environment variables, write the resulting JWT-profile JSON key to a shared `emptyDir` pod volume, and a `bootstrap-uploader` sidecar container co-located in the same Zitadel API Pod SHALL upload that key to GCP Secret Manager as `zitadel-machine-key-for-pulumi-admin`; subsequent Pulumi stack applies SHALL read the key from Secret Manager as the `jwtProfileJson` for the Zitadel provider. This lifecycle SHALL apply identically across all environments (`dev` and `prod`).
+
+Per the `Single Unified Zitadel Class Across All Environments` requirement, the JWT read + Provider construction live inside one shared `Zitadel` class consumed by all Pulumi stacks. No per-env wrapper class (`BackendMachineKeyComponent`, `ZitadelProdStackComponent`) shall mediate this lifecycle.
+
+**Rationale**: This closes the bootstrap chicken-and-egg — Pulumi needs admin credentials to configure Zitadel, but admin credentials only exist after Zitadel has bootstrapped itself. Shifting the boundary into the cluster avoids manual human steps. A separate Kubernetes `Job` cannot share an `emptyDir` volume with the Zitadel Deployment Pod (volumes are Pod-scoped), so the uploader runs as a sidecar container inside the Zitadel API Pod where the shared volume is naturally accessible. The sidecar idles after the upload (`tail -f /dev/null`) so the Pod stays ready and the upload is idempotent across Pod restarts (it skips re-uploading when the stored GSM version already matches).
+
+The GSM name `zitadel-machine-key-for-pulumi-admin` follows the platform-wide convention `zitadel-machine-key-for-<principal>`, where `<principal>` is the Pulumi `MachineUser` resource id. The legacy name `zitadel-admin-sa-key` was renamed because (1) it did not encode the binding between the GSM secret and the owning Zitadel principal, and (2) the principal label `admin` did not match the Pulumi `MachineUser` resource id `pulumi-admin`.
+
+The unified `Zitadel` class refactor (`refactor-unify-env-dispatch`) deletes the prod-specific `BackendMachineKeyComponent` that previously mediated this for prod. The unified class re-runs the same GSM read + Provider construction in both envs from a single code path; the `pulumi.secret()` wrap that protects the embedded RSA private key from leaking into preview/state/log output is enforced once in the unified class and inherited by all envs.
+
+#### Scenario: First boot writes the admin key
+
+- **WHEN** the Zitadel API container starts against an empty database
+- **THEN** `ZITADEL_FIRSTINSTANCE_MACHINEKEYPATH` SHALL point to a path on an `emptyDir` volume mounted into both the Zitadel container and the `bootstrap-uploader` sidecar container in the same Pod
+- **AND** Zitadel SHALL write a JSON key file at that path
+- **AND** the `bootstrap-uploader` sidecar container in the same Pod SHALL upload the file to GCP Secret Manager secret `zitadel-machine-key-for-pulumi-admin`
+- **AND** the `bootstrap-uploader` sidecar SHALL unlink the key file from the shared `emptyDir` after a successful GSM upload, so the org-admin private key does not persist in the volume for the Pod's lifetime where any future co-located container with the same `volumeMount` could read it
+
+#### Scenario: Subsequent boots skip bootstrap
+
+- **WHEN** Zitadel starts against an already-initialized database
+- **THEN** the `ZITADEL_FIRSTINSTANCE_*` environment variables SHALL be ignored
+- **AND** the existing admin machine user and key in Secret Manager SHALL remain unchanged
+
+#### Scenario: Unified Zitadel class reads admin JWT in all envs
+
+- **WHEN** `pulumi up` runs for any env after the `refactor-unify-env-dispatch` change is applied
+- **THEN** the JWT is read via `gcp.secretmanager.getSecretVersionAccessOutput` against the env-scoped `zitadel-machine-key-for-pulumi-admin` GSM Secret
+- **AND** the read result is wrapped in `pulumi.secret()` inside the unified `Zitadel` class
+- **AND** the wrapped value is passed to `new zitadel.Provider(...).jwtProfileJson`
+- **AND** no env-specific wrapper class mediates this construction

--- a/openspec/changes/refactor-unify-env-dispatch/specs/zitadel-self-hosted-deployment/spec.md
+++ b/openspec/changes/refactor-unify-env-dispatch/specs/zitadel-self-hosted-deployment/spec.md
@@ -26,42 +26,32 @@ The Pulumi `cloud-provisioning` codebase SHALL provision the Zitadel application
 - **THEN** the preview SHALL show zero changes to existing Zitadel-side resource URNs in dev state
 - **AND** the `Zitadel` class internal structure SHALL be byte-equivalent to its pre-refactor form modulo the removal of the `env !== 'dev'` throw guard and the addition of env-conditional `E2eTestUserComponent` creation
 
-### Requirement: Env-Driven Configuration Uses Maps or Ternaries, Not Top-Level If-Branches
+### Requirement: Per-Environment Configuration Values Sourced From Env-Keyed Map
 
-The Pulumi `cloud-provisioning` codebase SHALL express environment-specific configuration values via `Record<Environment, T>` constant maps or inline ternary expressions. Top-level `if (env === 'dev')` / `if (env === 'prod')` branches in component constructors or in `src/index.ts` SHALL be reserved for **structurally different resource shapes** — i.e., cases where the env difference produces fundamentally different Pulumi resource types or resource graphs that cannot be expressed as parameter differences on the same resource declaration.
+Environment-keyed configuration values that vary across stacks (admin org ids, redirect URI lists, sender addresses, cluster names for monitoring filters, etc.) SHALL be expressed as `Record<Environment, T>` constant maps and looked up via `[env]` indexing, OR as inline ternary expressions on `env`. Per-env scalar constants (such as a legacy `ZITADEL_DEV_ADMIN_ORG_ID` covering only one env) SHALL NOT be used when a corresponding value is needed for additional envs.
 
-Examples of structural differences (where `if` IS justified):
-- DNS topology: prod uses Cloudflare for the apex + Cloud DNS for subdomains; non-prod uses Cloud DNS only with a single zone (`src/gcp/components/network.ts`)
-- K8s cluster mode: dev uses Standard cluster + separate NodePool resource; prod uses Autopilot cluster with mutually-exclusive config knobs (`src/gcp/components/kubernetes.ts`)
-- Organization folder: prod creates a new folder; non-prod imports via `StackReference` (`src/gcp/components/project.ts`)
-- GitHub organization-level config: prod stack owns the GitHub org-level resources to avoid cross-stack conflict (`src/index.ts`)
+**Rationale**: Localizing env-keyed differences in a single map forces the env-specific value to be the only thing that varies. Future env additions update the map; future env removals delete an entry. The alternative — duplicating surrounding code per-env branch — has historically led to drift (e.g., the `MonitoringComponent` clusterName hardcoded to a dev-only value, which silently routed prod alerts to the wrong cluster).
 
-Examples of NON-structural differences (where ternary / map SHALL replace `if`):
-- Environment-specific redirect URIs (add localhost only for dev)
-- Environment-specific OAuth client values
-- Environment-specific admin org ids
-- Environment-specific Postmark sender addresses
-- Conditional API enablement of harmless APIs
+**Out-of-scope for this requirement** (not a SHALL): general code-style preferences such as "use ternary spread over `if-push`" for array construction. Those are coding conventions tracked outside the capability spec, because their verifiability depends on judgment calls that no spec scenario can pin down.
 
-**Rationale**: The `if`-as-default pattern leads to code drift across env branches because each branch carries an independent copy of the surrounding configuration. Centralizing env-keyed differences in maps and inline ternaries forces the env-specific value to be the ONLY thing that varies, making divergence visible at the point of value selection rather than spread across duplicated blocks.
-
-#### Scenario: Per-env redirect URIs use ternary spread, not if-push
-
-- **WHEN** `FrontendComponent` constructs `redirectUris` for the SPA's `ApplicationOidc`
-- **THEN** dev-only localhost URIs SHALL be added via ternary spread (`...(env === 'dev' ? ['http://localhost:9000/auth/callback'] : [])`)
-- **AND** an `if (env === 'dev')` block that calls `redirectUris.push(...)` SHALL NOT appear
-
-#### Scenario: Per-env admin org id sourced from env-keyed map
+#### Scenario: Admin org id sourced from env-keyed map
 
 - **WHEN** the `Zitadel` class imports the admin org via `zitadel.Org('admin', ...)` resource option `import:`
 - **THEN** the import id SHALL be `adminOrgIdMap[env]` where `adminOrgIdMap: Record<Environment, string>` lives in `src/zitadel/constants.ts`
+- **AND** the map SHALL contain entries for every env in `Environment` type union (at minimum `dev` + `prod`)
 - **AND** no per-env scalar constant (such as a legacy `ZITADEL_DEV_ADMIN_ORG_ID`) SHALL be referenced
+
+#### Scenario: MonitoringComponent cluster targeting via env-keyed map
+
+- **WHEN** `MonitoringComponent` is instantiated for any env
+- **THEN** its `clusterName` and `clusterLocation` arguments SHALL be sourced from env-keyed maps (e.g., `clusterNameByEnv`, `clusterLocationByEnv`) or inline ternaries
+- **AND** the resolved values SHALL match the cluster actually deployed in that env (dev: `standard-cluster-osaka` / `asia-northeast2-a`; prod: `autopilot-cluster-osaka` / `asia-northeast2`)
+- **AND** no per-cluster name SHALL be hardcoded to a single env's value
 
 #### Scenario: places.googleapis.com enabled in all environments
 
 - **WHEN** `src/gcp/components/kubernetes.ts` builds the `apisToEnable` list
 - **THEN** `places.googleapis.com` SHALL be included unconditionally (no env-gated `apisToEnable.push`)
-- **AND** API enablement SHALL incur zero recurring cost when the API is not called (justified by GCP's enablement-is-free / per-call-is-paid pricing)
 
 ### Requirement: Backend MachineUser Lives in Product Org Across All Environments
 

--- a/openspec/changes/refactor-unify-env-dispatch/tasks.md
+++ b/openspec/changes/refactor-unify-env-dispatch/tasks.md
@@ -1,0 +1,93 @@
+## 1. Type + Constants Refactor
+
+- [ ] 1.1 `src/config.ts`: narrow `Environment = 'dev' | 'prod' | 'staging'` to `Environment = 'dev' | 'prod'`.
+- [ ] 1.2 `src/zitadel/constants.ts`: drop `staging` entry from `baseDomainMap` and `zitadelDomainMap`.
+- [ ] 1.3 `src/zitadel/constants.ts`: add `adminOrgIdMap: Record<Environment, string>` exporting `{ dev: '371280364565496672', prod: '372892288692584603' }` (values discovered post-bootstrap via Zitadel admin API, documented in earlier archived changes). Remove the now-superseded `ZITADEL_DEV_ADMIN_ORG_ID` scalar.
+- [ ] 1.4 `src/zitadel/components/smtp.ts`: drop `staging` entry from `senderAddressMap`.
+- [ ] 1.5 Across `src/gcp/components/postgres.ts`, `src/gcp/components/project.ts`, `src/gcp/components/kubernetes.ts`, `src/gcp/index.ts`: replace inline `'dev' | 'staging' | 'prod'` type annotations with `Environment` imported from `config.ts`.
+
+## 2. Delete Parallel Zitadel Wrapper Classes
+
+- [ ] 2.1 Delete `src/zitadel/components/zitadel-prod-stack.ts` (entire file).
+- [ ] 2.2 Delete `src/zitadel/components/backend-machine-key.ts` (entire file).
+- [ ] 2.3 Verify no other source files reference the deleted symbols: `grep -rn "ZitadelProdStackComponent\|BackendMachineKeyComponent" src/ test/` returns empty (modulo comments / migration notes if any are retained).
+
+## 3. Refactor the Unified Zitadel Class
+
+- [ ] 3.1 `src/zitadel/index.ts`: remove the `if (env !== 'dev')` throw guard in the constructor.
+- [ ] 3.2 `src/zitadel/index.ts`: change `this.adminOrg = new zitadel.Org('admin', ...)` to include `import: adminOrgIdMap[env]` in the resource options.
+- [ ] 3.3 `src/zitadel/index.ts`: change `this.e2eTestUser = new E2eTestUserComponent(...)` to be gated by `if (env === 'dev')` (or equivalent ternary if the property type allows `undefined`). Document the gate as "E2E test user is dev-only by product decision, not env-dispatch anti-pattern".
+- [ ] 3.4 `src/zitadel/components/e2e-test-user.ts`: remove the `if (env !== 'dev')` throw guard and update the docstring to remove the "Dev-only: the caller must guard..." callout.
+- [ ] 3.5 `src/zitadel/components/zitadel-monitoring.ts`: update the docstring to remove "Dev-only" language; document that the component runs in all envs and threshold tuning is a future operational concern.
+
+## 4. Refactor Inline Env-Conditional Blocks
+
+- [ ] 4.1 `src/zitadel/components/frontend.ts`: replace the `if (env === 'dev') redirectUris.push(...)` block with a ternary spread inside the initializer: `const redirectUris = [\`https://${domain}/auth/callback\`, ...(env === 'dev' ? ['http://localhost:9000/auth/callback'] : [])]`. Same for `postLogoutRedirectUris`.
+- [ ] 4.2 `src/gcp/components/kubernetes.ts`: replace `if (environment === 'dev') apisToEnable.push('places.googleapis.com')` with unconditional inclusion: `const apisToEnable: GoogleApis[] = ['container.googleapis.com', 'places.googleapis.com']`. Remove the stale "gcp-cost-guardrails" comment.
+- [ ] 4.3 `src/index.ts`: collapse the dev/prod Zitadel dispatch (lines 78-125) to a single `const zitadel = new Zitadel('liverty-music', { env, gcpProjectId: \`${brandId}-${env}\`, ... })`. Drop the `let zitadelMachineKey / zitadelLoginPat` declarations — assign directly: `const zitadelMachineKey = zitadel.machineKeyDetails; const zitadelLoginPat = zitadel.loginClientToken`.
+- [ ] 4.4 `src/index.ts`: remove the explicit `if (env === 'dev' || env === 'prod')` allowlist on `SecretsComponent` (only two envs exist now after Phase 1; the guard is no-op).
+
+## 5. Remove Dev-Only Resource Guards in gcp/index.ts
+
+- [ ] 5.1 `src/gcp/index.ts`: remove the `if (environment === 'dev')` guard around `ZitadelMonitoringComponent` instantiation. The component runs in any env that has Slack channel ESC seeded.
+- [ ] 5.2 `src/gcp/index.ts`: remove the `if (environment === 'dev')` guard around the billing budget. Rename the resource from `dev-cost-budget` to `cost-budget` and `dev-billing-alert-email` to `billing-alert-email`. Add a new optional field `gcpConfig.budgetAmountJpy` (string, e.g., `'3000'`); replace the hardcoded `units: '3000'` with `units: gcpConfig.budgetAmountJpy ?? '3000'` so dev's existing budget shape stays the same.
+- [ ] 5.3 `src/gcp/index.ts`: parameterize `MonitoringComponent` cluster targeting. Add inline ternaries (or module-level `Record<Environment, string>` maps) for `clusterName` (dev: `standard-cluster-osaka`, prod: `autopilot-cluster-osaka`) and `clusterLocation` (dev: `asia-northeast2-a` zonal, prod: `asia-northeast2` regional). Pass the env-resolved values into `new MonitoringComponent({...})`.
+- [ ] 5.4 `src/gcp/components/project.ts` (GcpConfig interface): add `budgetAmountJpy?: string` field per task 5.2.
+
+## 6. K8s Cluster Refactor (shared config extraction + staging removal)
+
+- [ ] 6.1 `src/gcp/components/kubernetes.ts`: delete the trailing staging cluster block (lines 725-776). The new constructor falls through `if (env === 'dev') { ...Standard... } else { ...Autopilot prod... }`.
+- [ ] 6.2 `src/gcp/components/kubernetes.ts`: extract `sharedClusterConfig` as a const inside the constructor (after `this.subnet` is created so it can reference `this.subnet.id`). Fields: `network: networkId`, `subnetwork: this.subnet.id`, `ipAllocationPolicy: { clusterSecondaryRangeName: 'pods-range', servicesSecondaryRangeName: 'services-range' }`, `workloadIdentityConfig: { workloadPool: pulumi.interpolate\`${project.projectId}.svc.id.goog\` }`, `releaseChannel: { channel: 'REGULAR' }`, `costManagementConfig: { enabled: true }`, `gatewayApiConfig: { channel: 'CHANNEL_STANDARD' }`.
+- [ ] 6.3 `src/gcp/components/kubernetes.ts`: extract `sharedAutopilotConfig` as a const that spreads `sharedClusterConfig` and adds Autopilot-specific shared fields: `enableAutopilot: true`, `location: region`, `deletionProtection: true`, `clusterAutoscaling: { autoProvisioningDefaults: { serviceAccount: gkeNodeSa.email } }`, `monitoringConfig: { enableComponents: ['SYSTEM_COMPONENTS'], managedPrometheus: { enabled: true } }`.
+- [ ] 6.4 `src/gcp/components/kubernetes.ts`: rewrite the prod Autopilot cluster declaration to spread `sharedAutopilotConfig` and add only the prod-specific `databaseEncryption: { state: 'ENCRYPTED', keyName: etcdCmekKeyName }`. The 50-line block of explicit field assignments shrinks to a ~10-line block.
+- [ ] 6.5 `src/gcp/components/kubernetes.ts`: rewrite the dev Standard cluster declaration to spread `sharedClusterConfig` and add only the Standard-specific fields (`location: \`${region}-a\``, `deletionProtection: false`, `removeDefaultNodePool: true`, `initialNodeCount: 1`, `privateClusterConfig: { enablePrivateNodes: false, enablePrivateEndpoint: false }`, `monitoringConfig: { enableComponents: ['SYSTEM_COMPONENTS'], managedPrometheus: { enabled: false } }`, `loggingConfig: { enableComponents: ['SYSTEM_COMPONENTS', 'WORKLOADS'] }`). The separate `gcp.container.NodePool` spot pool resource stays unchanged.
+
+## 7. Network Refactor
+
+- [ ] 7.1 `src/gcp/components/network.ts`: **comment out** the staging Cloud NAT block (lines 200-228) with a TODO comment explaining the re-enable conditions: (a) prod migrates to `enablePrivateNodes: true` (NAT becomes mandatory), or (b) staging stack is reintroduced. Include re-enable instructions: uncomment, restore `staging` to `Environment` type, repopulate `senderAddressMap.staging` etc.
+- [ ] 7.2 `src/gcp/components/network.ts`: simplify `buildZoneTopology` from `prod` vs `dev/staging` 2-branch to `prod` vs `dev` 2-branch. Update the surrounding comments to remove "dev/staging" references.
+- [ ] 7.3 `src/gcp/components/network.ts`: update the `if (environment !== 'prod')` blocks (Postmark Cloud DNS records) — the logic stays the same (only one non-prod env now, `dev`), but the comments can be tightened.
+
+## 8. Verify + Lint
+
+- [ ] 8.1 In `cloud-provisioning/`, run `make lint-ts` — biome + tsc must pass clean.
+- [ ] 8.2 `grep -rn "staging" src/` returns only the commented-out Cloud NAT TODO + docstring references documenting why it's commented out. No active code path references `staging`.
+- [ ] 8.3 `grep -rn "BackendMachineKeyComponent\|ZitadelProdStackComponent" src/` returns empty.
+- [ ] 8.4 `grep -rEn "if \(env" src/` review remaining results: each `if` SHALL be either a structurally-justified branch (cluster mode, DNS provider, folder create vs StackReference, GitHub org-level resources) or the documented `if (env === 'dev')` for `E2eTestUserComponent` instantiation.
+
+## 9. Operator Pre-flight (out-of-band, optional; can defer)
+
+- [ ] 9.1 (Optional) Create a Slack channel for prod backend ERROR log alerts; complete the Slack OAuth flow in GCP Console; record the channel ID.
+- [ ] 9.2 (Optional) `esc env set liverty-music/prod pulumiConfig.gcp.monitoring.slackNotificationChannels.alertBackend "<channel-id>"`. Without this seed, `MonitoringComponent` + `ZitadelMonitoringComponent` stay unmaterialized in prod (same as today; the refactor is no-op for these resources until ESC is seeded).
+- [ ] 9.3 (Optional) Decide budget alert email + per-env amount; `esc env set liverty-music/dev pulumiConfig.gcp.billingAlertEmail "<email>"`, `esc env set liverty-music/dev pulumiConfig.gcp.budgetAmountJpy "3000"`; same for prod with a higher amount (recommend 10000 JPY).
+
+## 10. Pulumi Preview + Deploy
+
+- [ ] 10.1 In `cloud-provisioning/`, push the feature branch. Wait for CI: Pulumi preview runs on both dev and prod.
+- [ ] 10.2 **Dev preview**: expected = ZERO Zitadel resource changes (the unified class is byte-equivalent to today's dev Zitadel class). Any monitoring/budget changes only appear if §9 ESC seeds were applied to dev.
+- [ ] 10.3 **Prod preview**: expected = 9 destroys (`BackendMachineKey$...` subtree) + ~30 creates (unified Zitadel stack + GSM `zitadel-login-pat` + admin org via `import:`) + 1 update on `kubernetes-cluster` (esoOnlySecrets adding `zitadel-login-pat`). NO replaces on backend-app's GSM Secret (it's destroy+create with a new resource name — actually with destroy+create at the SAME GSM Secret name, the underlying GSM hard-deletes and recreates).
+- [ ] 10.4 Operator reviews the prod preview output. Highlight the 9 destroys — ensure the backend MachineKey is among them (this triggers the 2-5 min auth outage on apply).
+- [ ] 10.5 Merge the PR. The dev `pulumi up` runs automatically via Pulumi Cloud Deployments.
+- [ ] 10.6 **Dev verify**: `pulumi stack output --stack dev` shows no Zitadel changes. Backend auth in dev unchanged.
+- [ ] 10.7 **Prod manual deploy**: trigger `pulumi up --stack prod` from Pulumi Cloud console (https://app.pulumi.com/pannpers/liverty-music/prod/deployments). Watch the destroy + recreate sequence.
+- [ ] 10.8 During prod apply: expect backend → Zitadel auth errors (`Errors.AuthNKey.NotFound`) for 2-5 min. ESO syncs new GSM Secret (~1 min); Reloader rolls backend Deployment (~1 min); new Pods boot with new JWT (~30 sec); auth resumes.
+
+## 11. Smoke Tests (prod post-deploy)
+
+- [ ] 11.1 SPA OIDC sign-in: open `https://liverty-music.app` in a fresh browser, complete OIDC redirect, verify the prod Login V2 UI presents passkey + username/password.
+- [ ] 11.2 Sign-up email verification: complete a test sign-up with a disposable inbox; verify the verification email arrives via Postmark within 60s.
+- [ ] 11.3 Operator Console: open `https://auth.liverty-music.app/ui/console`, click "Sign in with Google", complete OAuth as `pannpers@pannpers.dev`, verify Console resolves with IAM_OWNER.
+- [ ] 11.4 JWT email claim: capture an SPA-issued access token (`localStorage.getItem('access_token')` via DevTools), decode JWT payload, verify `email` claim is present.
+- [ ] 11.5 ESO sync: `kubectl get externalsecret -n zitadel zitadel-web-secrets -o yaml --context prod` → `Status=Ready`; `kubectl get secret -n zitadel zitadel-web-pat --context prod` returns non-empty data.
+- [ ] 11.6 `zitadel-web` Pod: `kubectl get pods -n zitadel --context prod` → `Running` (1/1 Ready), transitioning out of any prior `ContainerCreating` state.
+- [ ] 11.7 Backend Pod auth: `kubectl logs -n backend deployment/server --context prod` shows no recent `Errors.AuthNKey.NotFound`; backend Connect-RPC calls succeed.
+
+## 12. Documentation + Archive
+
+- [ ] 12.1 If §9 was deferred, update `cloud-provisioning/CLAUDE.md` with a note that prod observability + budget are not yet enabled (require ESC seeding when ready).
+- [ ] 12.2 Mark all remaining tasks in `openspec/changes/complete-zitadel-prod-pulumi-stack/tasks.md` as `[x]` with the comment `# superseded by refactor-unify-env-dispatch`. (Required because `/opsx:archive` validates `isComplete: true`.)
+- [ ] 12.3 Run `openspec validate complete-zitadel-prod-pulumi-stack --strict`. Should pass with all tasks marked done.
+- [ ] 12.4 Run `/opsx:archive complete-zitadel-prod-pulumi-stack` (decline the delta→main spec sync prompt — its requirements are superseded; do NOT propagate to main spec).
+- [ ] 12.5 Run `openspec validate refactor-unify-env-dispatch --strict`.
+- [ ] 12.6 Run `/opsx:archive refactor-unify-env-dispatch`. Accept the delta→main spec sync prompt — this change's delta IS the new source of truth for the affected requirements.
+- [ ] 12.7 Bundle both archives + main spec sync into the archive PR per memory `reference_openspec_archive_pattern.md`.

--- a/openspec/changes/refactor-unify-env-dispatch/tasks.md
+++ b/openspec/changes/refactor-unify-env-dispatch/tasks.md
@@ -44,7 +44,7 @@
 
 ## 7. Network Refactor
 
-- [ ] 7.1 `src/gcp/components/network.ts`: **comment out** the staging Cloud NAT block (lines 200-228) with a TODO comment explaining the re-enable conditions: (a) prod migrates to `enablePrivateNodes: true` (NAT becomes mandatory), or (b) staging stack is reintroduced. Include re-enable instructions: uncomment, restore `staging` to `Environment` type, repopulate `senderAddressMap.staging` etc.
+- [ ] 7.1 `src/gcp/components/network.ts`: **comment out** the staging Cloud NAT block (lines 193-228, including the leading explanatory comment at line 193 so the commented-out block stays self-documenting) with a TODO comment explaining the re-enable conditions: (a) prod migrates to `enablePrivateNodes: true` (NAT becomes mandatory), or (b) staging stack is reintroduced. Include re-enable instructions: uncomment, restore `staging` to `Environment` type, repopulate `senderAddressMap.staging` etc.
 - [ ] 7.2 `src/gcp/components/network.ts`: simplify `buildZoneTopology` from `prod` vs `dev/staging` 2-branch to `prod` vs `dev` 2-branch. Update the surrounding comments to remove "dev/staging" references.
 - [ ] 7.3 `src/gcp/components/network.ts`: update the `if (environment !== 'prod')` blocks (Postmark Cloud DNS records) — the logic stays the same (only one non-prod env now, `dev`), but the comments can be tightened.
 
@@ -54,6 +54,8 @@
 - [ ] 8.2 `grep -rn "staging" src/` returns only the commented-out Cloud NAT TODO + docstring references documenting why it's commented out. No active code path references `staging`.
 - [ ] 8.3 `grep -rn "BackendMachineKeyComponent\|ZitadelProdStackComponent" src/` returns empty.
 - [ ] 8.4 `grep -rEn "if \(env" src/` review remaining results: each `if` SHALL be either a structurally-justified branch (cluster mode, DNS provider, folder create vs StackReference, GitHub org-level resources) or the documented `if (env === 'dev')` for `E2eTestUserComponent` instantiation.
+- [ ] 8.5 **Invariant: `pulumi.secret()` wrap on GSM admin JWT read**: verify the unified `Zitadel` class's GSM `getSecretVersionAccessOutput(...).apply(v => v.secretData)` result is wrapped in `pulumi.secret(...)` BEFORE being passed to `new zitadel.Provider(...).jwtProfileJson`. `grep -A2 "getSecretVersionAccessOutput" src/zitadel/index.ts` must show `pulumi.secret(...)` on the surrounding lines.
+- [ ] 8.6 **Verify ExternalSecret deletion policy for backend GSM Secret**: read `cloud-provisioning/k8s/namespaces/backend/base/server/external-secret.yaml` (or the equivalent overlay). The `spec.target.deletionPolicy` field controls what ESO does to the K8s Secret if the upstream GSM Secret becomes briefly unavailable during destroy/recreate. If `deletionPolicy: Delete`, the K8s Secret is deleted on upstream-not-found → backend Pod loses its mounted JWT file → backend boot fails. If `deletionPolicy: Retain` (default), the K8s Secret persists with stale-but-valid data through the destroy window → safer. Document the actual value in the PR description before the prod apply. If `Delete`, halt the prod apply and switch to `Retain` in a preceding K8s manifest PR.
 
 ## 9. Operator Pre-flight (out-of-band, optional; can defer)
 
@@ -64,13 +66,22 @@
 ## 10. Pulumi Preview + Deploy
 
 - [ ] 10.1 In `cloud-provisioning/`, push the feature branch. Wait for CI: Pulumi preview runs on both dev and prod.
-- [ ] 10.2 **Dev preview**: expected = ZERO Zitadel resource changes (the unified class is byte-equivalent to today's dev Zitadel class). Any monitoring/budget changes only appear if §9 ESC seeds were applied to dev.
-- [ ] 10.3 **Prod preview**: expected = 9 destroys (`BackendMachineKey$...` subtree) + ~30 creates (unified Zitadel stack + GSM `zitadel-login-pat` + admin org via `import:`) + 1 update on `kubernetes-cluster` (esoOnlySecrets adding `zitadel-login-pat`). NO replaces on backend-app's GSM Secret (it's destroy+create with a new resource name — actually with destroy+create at the SAME GSM Secret name, the underlying GSM hard-deletes and recreates).
-- [ ] 10.4 Operator reviews the prod preview output. Highlight the 9 destroys — ensure the backend MachineKey is among them (this triggers the 2-5 min auth outage on apply).
+- [ ] 10.2 **Dev preview verification** (claim: zero Zitadel resource changes): the dev preview output SHALL show zero `+ create`, `~ update`, `- delete`, or `+- replace` on any `zitadel:*` or `gcp:secretmanager/*::zitadel-*` URN. Quote the full preview's Resource Changes block in the PR description (or attach as a comment). If the dev preview shows ANY Zitadel-side changes, halt — investigate before any prod apply. The unified class is supposed to be byte-equivalent to today's dev Zitadel class modulo the env guard removal + e2eTestUser conditional + adminOrg `import:` resource option (the last of which is a *one-time hint* that Pulumi ignores once the resource is in state, but a fresh preview against unchanged state should NOT show drift).
+- [ ] 10.3 **Prod preview verification** (claim: 9 destroys + ~30 creates + 1 update). Specifically check:
+  - The 9 `BackendMachineKey$...` URNs are marked `- delete` (not `+- replace`).
+  - The new admin org line MUST show `+ create (import)` with the prod admin-org-id `372892288692584603`. If it shows plain `+ create` without `(import)`, Pulumi will attempt to create a NEW admin org named `admin` in Zitadel — abort, fix the `import:` option resolution, re-preview.
+  - `kubernetes-cluster` shows a single `~ update` (esoOnlySecrets list grows by 1 entry for `zitadel-login-pat`).
+  - No backend-app GSM SecretVersion shows `+- replace` — should be plain `- delete` (under the old Pulumi URN `BackendMachineKey$...`) then `+ create` (under the new Pulumi URN `Zitadel$...`). Two distinct naming layers: (a) the Pulumi logical resource URN CHANGES (new parent type, no `aliases` per D3); (b) the underlying GCP Secret Manager `secretId` stays the SAME (`zitadel-machine-key-for-backend-app`), so the GSM secret is hard-deleted from GCP and immediately recreated with the same GCP identifier in the same apply.
+- [ ] 10.4 Operator reviews the prod preview output and quotes the full Resource Changes block in the PR description before approving the apply.
 - [ ] 10.5 Merge the PR. The dev `pulumi up` runs automatically via Pulumi Cloud Deployments.
 - [ ] 10.6 **Dev verify**: `pulumi stack output --stack dev` shows no Zitadel changes. Backend auth in dev unchanged.
-- [ ] 10.7 **Prod manual deploy**: trigger `pulumi up --stack prod` from Pulumi Cloud console (https://app.pulumi.com/pannpers/liverty-music/prod/deployments). Watch the destroy + recreate sequence.
-- [ ] 10.8 During prod apply: expect backend → Zitadel auth errors (`Errors.AuthNKey.NotFound`) for 2-5 min. ESO syncs new GSM Secret (~1 min); Reloader rolls backend Deployment (~1 min); new Pods boot with new JWT (~30 sec); auth resumes.
+- [ ] 10.7 **Prod manual deploy — staged target-apply for safety** (per devil's advocate review C3): instead of a single open-ended `pulumi up --stack prod`, the operator MAY target the destroy phase first via `pulumi destroy --target 'urn:pulumi:prod::liverty-music::zitadel:liverty-music:BackendMachineKey$**' --target-dependents` (or equivalent URN glob in the Pulumi Cloud console's targeted-update UI). Then re-preview to confirm the destroy is clean. Then run an untargeted `pulumi up --stack prod` to create the new unified `Zitadel$...` subtree.
+  - **Alternative**: single untargeted apply if the dev preview was clean and the prod preview shows no surprises. The single-apply path saves operator time but couples the two halves into one transaction — if the destroy half partially fails, the create half does not run and the operator must `pulumi up` again from the partially-destroyed state.
+- [ ] 10.8 **During prod apply**: expect backend → Zitadel auth errors (`Errors.AuthNKey.NotFound`) for 2-5 min. ESO syncs new GSM Secret (~1 min — depends on ExternalSecret `refreshInterval`; verify in §8.6); Reloader rolls backend Deployment (~1 min); new Pods boot with new JWT (~30 sec); auth resumes.
+- [ ] 10.9 **Rollback plan if Phase 10.7 fails partway** (per devil's advocate review C3): If destroy-phase fails (e.g., Zitadel admin API rejects an OrgMember delete), the old MachineKey may already be invalidated but the new one not yet created. Operator actions:
+  - Re-run `pulumi up --stack prod`. Pulumi's destroy+create is idempotent — destroyed resources stay destroyed, missing creates are added.
+  - If the new admin org `import:` fails because the previous admin org `protect: true` flag from the deleted state lingers in the Zitadel-side state (unlikely; `protect` is a Pulumi-side flag, not Zitadel-side), unblock by re-running with `--target` exclusion of the admin org until the rest of the stack settles.
+  - **Zitadel-side data loss risk**: destroying `zitadel.Org('liverty-music')` cascade-deletes the contained productOrg's projects, machine users, applications inside the Zitadel DB. In current prod state, the productOrg contains only the backend-app MachineUser trio (PR #260's planned additions were never deployed). The cascade is bounded. The new productOrg's resources are recreated by the same apply, with fresh internal Zitadel ids — backend Pod's JWT references the new MachineUser+MachineKey via the GSM Secret. No external system caches productOrg ids.
 
 ## 11. Smoke Tests (prod post-deploy)
 
@@ -85,9 +96,18 @@
 ## 12. Documentation + Archive
 
 - [ ] 12.1 If §9 was deferred, update `cloud-provisioning/CLAUDE.md` with a note that prod observability + budget are not yet enabled (require ESC seeding when ready).
-- [ ] 12.2 Mark all remaining tasks in `openspec/changes/complete-zitadel-prod-pulumi-stack/tasks.md` as `[x]` with the comment `# superseded by refactor-unify-env-dispatch`. (Required because `/opsx:archive` validates `isComplete: true`.)
-- [ ] 12.3 Run `openspec validate complete-zitadel-prod-pulumi-stack --strict`. Should pass with all tasks marked done.
-- [ ] 12.4 Run `/opsx:archive complete-zitadel-prod-pulumi-stack` (decline the delta→main spec sync prompt — its requirements are superseded; do NOT propagate to main spec).
+- [ ] 12.2 **Supersession bookkeeping for `complete-zitadel-prod-pulumi-stack`** (per devil's advocate review C9 — do NOT fake-check the unfinished `[ ]` tasks because that pollutes the audit trail with false "done" claims). Approach:
+  - Create a new file `openspec/changes/complete-zitadel-prod-pulumi-stack/SUPERSEDED.md` at the change root, stating:
+    - This change was merged (spec PR #468) but never deployed to prod Pulumi state.
+    - It is **abandoned**, not completed. Tasks marked `[ ]` were not performed.
+    - The intent of those tasks (close the 9-component prod Zitadel gap) is realized by `refactor-unify-env-dispatch` via a different implementation shape (unified `Zitadel` class instead of `ZitadelProdStackComponent` wrapper).
+    - Date of supersession + commit SHA reference.
+  - In `openspec/changes/complete-zitadel-prod-pulumi-stack/tasks.md`, add a header note (under the top-level `## 1.` heading) pointing to `SUPERSEDED.md`. Do NOT change task `[ ]` markers.
+- [ ] 12.3 `/opsx:archive complete-zitadel-prod-pulumi-stack` may fail `isComplete: true` check because tasks are still `[ ]`. Workaround options (pick one in order of preference):
+  - **(a) Use `--force` flag** if `openspec archive` supports it.
+  - **(b) Move the change directory manually**: `mv openspec/changes/complete-zitadel-prod-pulumi-stack openspec/changes/archive/YYYY-MM-DD-complete-zitadel-prod-pulumi-stack` (preserving `.openspec.yaml` and `SUPERSEDED.md`). Skip the openspec CLI archive flow for this change.
+  - **(c) If neither works**, file a `/opsx:openspec-cli-feature-request` issue for "supersede a change without marking tasks done" and use option (b) in the meantime.
+- [ ] 12.4 **Do NOT sync `complete-zitadel-prod-pulumi-stack`'s delta to main spec**. Its requirements (4 ADDED, 1 MODIFIED) are superseded by THIS change's spec delta. Syncing would propagate now-incorrect prod-specific requirements into main spec.
 - [ ] 12.5 Run `openspec validate refactor-unify-env-dispatch --strict`.
 - [ ] 12.6 Run `/opsx:archive refactor-unify-env-dispatch`. Accept the delta→main spec sync prompt — this change's delta IS the new source of truth for the affected requirements.
-- [ ] 12.7 Bundle both archives + main spec sync into the archive PR per memory `reference_openspec_archive_pattern.md`.
+- [ ] 12.7 Bundle both archive moves + the SUPERSEDED.md creation + the THIS-change main spec sync into one archive PR per memory `reference_openspec_archive_pattern.md`.


### PR DESCRIPTION
## Summary

Proposes a single OpenSpec change `refactor-unify-env-dispatch` that consolidates three classes of env-dispatch anti-patterns in `cloud-provisioning/`:

1. **Delete two parallel "prod-only" Zitadel wrapper classes** (`BackendMachineKeyComponent`, `ZitadelProdStackComponent`). Unify into the existing `Zitadel` class with env guards relaxed — single source of truth for the 9-component Zitadel topology across all envs.
2. **Drop `staging` from the `Environment` type** and all dormant code paths. Staging stack does not exist and is not in near-term plans. Cloud NAT block in `network.ts` is **commented out** (not deleted) because near-future re-introduction is anticipated.
3. **Convert `if (env === 'dev')` blocks to ternary / env-keyed map** wherever the difference is configuration, not structure. Apply previously dev-only resources (`ZitadelMonitoringComponent`, `gcp.billing.Budget`, places API) to all envs via outer ESC-presence guards. Extract `sharedClusterConfig` from K8s cluster blocks.

## Why this is being proposed now

Two convergent forces:
- **Pre-launch destructive-change window**: user explicit guidance — *"破壊的な変更をするのはサービスイン前のこのタイミングが最適です"* — prod has zero real users today; large refactors carry minimal user impact.
- **Live trigger**: while operator-deploying `complete-zitadel-prod-pulumi-stack` (merged 2026-05-14 in PR #468), the parallel-class pattern blocked us via two separate problems: (a) `pulumi import` CLI required a pre-existing provider URN that the wrapper class hadn't materialized (hotfix #261 worked around with `import:` resource option), and (b) the duplicated 9-component instantiation led to a spec-divergence cluster (wrong redirect URI in 4 places, fabricated `pulumiJwtProfileJson` ESC entry, etc.). The simpler fix is to delete the parallel class entirely.

## Supersession

This change **supersedes** the active OpenSpec change `complete-zitadel-prod-pulumi-stack` (merged but never deployed to prod state). The supersession is captured in design D10 + tasks §12. The original change's proposal/design remain useful historical context; its specific implementation choices (parallel-class pattern, hotfix `import:` workaround) are absorbed into this change with a different shape.

## Key design decisions (full rationale in design.md)

- **D1**: Drop staging; comment out Cloud NAT
- **D2**: Delete `BackendMachineKeyComponent` + `ZitadelProdStackComponent`
- **D3**: Skip Pulumi `aliases` for prod state; accept 2-5 min auth outage on `pulumi up --stack prod` (destroy + recreate of the 9 prod resources under new URNs)
- **D4**: All envs get observability + budget; outer ESC guards control materialization
- **D5**: Extract `sharedClusterConfig` from K8s blocks; keep `if (env === 'dev')` only for structural cluster-mode divergence
- **D6**: Enable `places.googleapis.com` in all envs (harmless)
- **D7**: Comment out staging Cloud NAT; delete staging cluster block
- **D8**: Prod resources adopt dev's naming (Pulumi stack scoping handles env disambiguation)
- **D9**: ESC seeding (Slack channel, billing email) is operator pre-flight, not part of this code change
- **D10**: Supersede `complete-zitadel-prod-pulumi-stack` at archive step

## Impact

- **Dev Pulumi state**: zero churn. The unified `Zitadel` class is byte-equivalent to today's dev class with the `env !== 'dev'` throw removed. Dev URNs do not change.
- **Prod Pulumi state**: 9 `BackendMachineKey$...` resources destroyed; ~30 new `Zitadel$...` resources created on first `pulumi up --stack prod` of this change.
- **Prod operational impact**: 2-5 min window where backend → Zitadel JWT auth fails during destroy-recreate. Pre-launch prod has zero real users; impact bounded to error logs.

## Artifacts

- [proposal.md](openspec/changes/refactor-unify-env-dispatch/proposal.md)
- [design.md](openspec/changes/refactor-unify-env-dispatch/design.md) — D1-D10 decisions, 8 risks, 5-phase migration plan, 4 open questions
- [specs/zitadel-self-hosted-deployment/spec.md](openspec/changes/refactor-unify-env-dispatch/specs/zitadel-self-hosted-deployment/spec.md) — 4 ADDED + 2 REMOVED + 1 MODIFIED
- [tasks.md](openspec/changes/refactor-unify-env-dispatch/tasks.md) — 12 sections, 64 tasks

## Test plan

- [x] `openspec validate refactor-unify-env-dispatch --strict` passes
- [ ] CI green
- [ ] Reviewer sign-off
- [ ] (post-merge) Implementation PR in `cloud-provisioning` with `make lint-ts` passing + Pulumi preview shows expected destroy+create on prod
