### PR TITLE
feat(openspec): add claude-review-check-run change

### DIFF
--- a/openspec/changes/claude-review-check-run/.openspec.yaml
+++ b/openspec/changes/claude-review-check-run/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-15

--- a/openspec/changes/claude-review-check-run/design.md
+++ b/openspec/changes/claude-review-check-run/design.md
@@ -1,0 +1,125 @@
+## Context
+
+Today every liverty-music repo runs a `claude-code-review.yml` workflow that calls `anthropics/claude-code-action@v1` with the `code-review@claude-code-plugins` plugin and the `--comment` flag, producing a sticky PR comment. The four YAML files are nearly identical; any behavior change touches four PRs.
+
+Direct review of `action.yml` and the plugin source confirmed two limitations:
+
+- `anthropics/claude-code-action@v1` exposes **no native input** for submitting a formal PR review (`APPROVE` / `REQUEST_CHANGES`). The full input set (34 entries) covers triggers, allowed tools, model, secrets, and signing — nothing maps to the GitHub Review API.
+- The `code-review` plugin's `allowed-tools` declaration is `Bash(gh pr comment:*)` + `mcp__github_inline_comment__create_inline_comment` only. It does not include `gh pr review`, so it cannot produce a verdict review even if instructed to.
+
+Branch protection and repo provisioning for all liverty-music repos are managed in `cloud-provisioning/src/github/components/{organization.ts,repository.ts}` and `cloud-provisioning/src/index.ts` via `@pulumi/github`. `GitHubOrganizationComponent` creates repos under an `if (env === 'prod')` guard; `BranchProtection` inside `GitHubRepositoryComponent` is gated by `if (environment === 'prod')` as well. The existing `requiredStatusCheckContexts` on every repo is `['CI Success']` (added by archive `2026-03-27-enforce-required-ci-checks`). `ANTHROPIC_API_KEY` is already provisioned as an `ActionsOrganizationSecret` with `visibility: 'all'`, so it is automatically available to any new repo in the org.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Surface Claude's review verdict as a green/red signal that is visible in the PR list and the PR Checks panel without opening the PR.
+- Make the failing verdict block merges where appropriate (Required Status Check).
+- Eliminate four-way duplication of the workflow YAML.
+- Preserve the existing multi-agent review quality of `code-review@claude-code-plugins` (do not rewrite the plugin's analysis logic).
+- Stay aligned with the prevailing pattern used by GitHub Copilot Code Review, CodeRabbit, Qodo, and Sentry Seer.
+
+**Non-Goals:**
+
+- Replacing the official `anthropics/claude[bot]` GitHub App with a custom App so that AI reviews could count toward Required Approvals. The community consensus is that bot identities should not satisfy human-reviewer requirements; this proposal explicitly does **not** pursue that path.
+- Tagging the reusable workflow as `@v1` on day one. Initial callers reference `@main`; a versioned release is deferred until the workflow has been stable across all four repos for ~1 month.
+- Adding inline-comment generation beyond what `code-review --comment` already produces.
+- Migrating other CI workflows (deploy, lint, atlas-ci) to a reusable workflow at the same time. The scope is the Claude review only.
+
+## Decisions
+
+### 1. Publish the verdict as a GitHub Check Run, not as a formal PR review
+
+A formal `APPROVE` / `REQUEST_CHANGES` review was the user's initial mental model but is **not** the path the community has converged on.
+
+- GitHub Copilot Code Review explicitly always leaves a `Comment` review, never `Approve` or `Request changes`, citing the desire to prevent bot reviews from bypassing required-reviewer protections.
+- CodeRabbit, Qodo, and Sentry Seer all post comments and (optionally) Check Runs, but do not submit formal review verdicts.
+- A bot-issued `REQUEST_CHANGES` review requires a dismiss-or-counter-review every time the author re-pushes, which generates ongoing operator friction; a Check Run is naturally overwritten by the next run.
+- A bot author cannot approve its own PR; for repos that auto-create PRs (Renovate-style), the approve path would silently break.
+
+Publishing a `Claude review` Check Run achieves the same green/red visibility, plugs into branch protection's Required Status Check mechanism, leaves the human approval flow untouched, and aligns with the rest of the ecosystem.
+
+**Alternative considered**: Have Claude itself call `gh pr review --approve` / `--request-changes`. Rejected for the reasons above and because the existing plugin's `allowed-tools` does not include `gh pr review`, forcing us to either fork the plugin or replace it with a hand-rolled prompt that re-implements the multi-agent quality gate.
+
+**Alternative considered**: Improve the sticky comment header with a ✅/⚠️ glyph and stop there. Rejected because that does not put the signal in the PR list view and cannot be used as a merge gate.
+
+### 2. Host the reusable workflow in a new `liverty-music/.github` repo
+
+A `workflow_call` reusable workflow needs a stable address. The conventional GitHub home for org-wide community files (and shared workflows) is a repo literally named `.github` under the org. It is publicly referenceable by callers in the same org with no special token handling, and future org-wide files (`CONTRIBUTING.md`, SECURITY policy, issue templates) can live in the same place.
+
+**Alternative considered**: Hosting it inside `specification` repo. Rejected because it conflates the protobuf API contract scope with CI tooling and complicates the spec repo's release tag cadence.
+
+**Alternative considered**: A dedicated `liverty-music/shared-workflows` repo. Acceptable but introduces an extra repo before there is a second reusable workflow to justify it. We can split later if the `.github` repo accumulates too many concerns.
+
+### 3. Use the existing `code-review@claude-code-plugins` plugin and add a small wrapper
+
+The plugin already orchestrates multiple specialist agents (haiku/sonnet/opus) with built-in false-positive gating. Re-implementing that in a custom prompt would regress review quality. Instead, the reusable workflow keeps the plugin invocation as `Step 1` and adds two further steps:
+
+1. Claude writes `/tmp/claude-verdict.json` with `{ "verdict": "pass" }` or `{ "verdict": "fail", "count": N, "summary": "<one-line>" }` — a deterministic 1-line contract chosen over parsing the comment body (resilient to plugin output changes).
+2. An `actions/github-script@v7` step reads the JSON and calls `checks.create` with `conclusion: success | failure | neutral`, `name: 'Claude review'`.
+
+If the verdict file is missing (Claude failed to write it), the Check Run conclusion is `neutral` so that the lack of signal is distinguishable from a real pass or fail.
+
+**Alternative considered**: Parse the sticky comment with a regex (`/No issues found/`). Rejected because the comment text is plugin-owned and may evolve, while we control the verdict JSON contract.
+
+### 4. Verdict-to-conclusion mapping
+
+| Claude verdict             | Check Run `conclusion` | UI signal | Blocks merge (if required) |
+|---|---|---|---|
+| `pass`                     | `success`              | ✅ green  | No                          |
+| `fail`                     | `failure`              | ❌ red    | Yes                         |
+| missing / unparseable JSON | `neutral`              | ⚪ neutral | No                          |
+
+`neutral` for missing verdicts means workflow plumbing issues do not block merges; they are visible but require manual triage rather than emergency override.
+
+### 5. Pilot in `specification` before rolling out
+
+`specification` has lower commit velocity than `backend` / `frontend`, so a misfire affects fewer in-flight PRs. After 1–2 weeks of stable operation (verdict file missing rate, false-positive rate, dismissal-via-admin frequency), add `'Claude review'` to the other three repos' `requiredStatusCheckContexts` in a follow-up Pulumi PR.
+
+The Pulumi change to add `Claude review` for the other three repos is in scope of this change's `tasks.md` (under a Step 5 follow-up section) but can be executed as a separate PR after pilot validation.
+
+### 6. Bypass policy: admin override only
+
+`Allow specified actors to bypass required pull request reviews` stays **off** — no service-account-shaped escape hatch. When Claude misfires, a repo admin uses the standard `Allow administrators to bypass configured protections` toggle (or the per-PR override) to merge. This keeps the policy boundary cleanly at "human admin override".
+
+### 7. Anthropic API key
+
+`ANTHROPIC_API_KEY` already exists as an `ActionsOrganizationSecret` (`visibility: 'all'`). The new `.github` repo automatically inherits it; no Pulumi change is required for secret distribution. The caller workflows pass `secrets: inherit` to forward it into the reusable workflow.
+
+## Risks / Trade-offs
+
+**[Risk] Claude does not write `/tmp/claude-verdict.json`** → the Check Run is `neutral`, which does not block merges. Reviewers may not notice that the verdict was never produced.
+
+→ **Mitigation**: The Check Run title is `'No verdict produced'` for the neutral case. After ~5 PRs we will measure the missing rate; if it exceeds ~5%, strengthen the prompt (e.g., require the JSON to be emitted before declaring success) or add a stdout-log-based fallback parser.
+
+**[Risk] Plugin output format drifts** → the `--comment` post may break, but the verdict JSON contract is ours.
+
+→ **Mitigation**: The Check Run depends only on the JSON, not the comment text. Plugin drift affects the comment body but not the verdict signal.
+
+**[Risk] Pilot-phase false positives block legitimate PRs** → `specification` is the smallest-blast-radius pilot target, and admin override is documented as the escape hatch.
+
+→ **Mitigation**: Repo admin can bypass via the standard branch-protection admin toggle. We will track override frequency during pilot and tune the prompt if needed before rolling out.
+
+**[Risk] `prod` stack deployment is required twice** → once to create `liverty-music/.github` and add `'Claude review'` to `specification`, and again (later) to extend `'Claude review'` to the other three repos.
+
+→ **Mitigation**: Standard operating procedure. Both deployments are small, reviewable Pulumi PRs with explicit user-approved `pulumi up -s prod`.
+
+**[Risk] Reusable workflow referenced as `@main`** → the four callers consume the tip of `main` in the `.github` repo, so a broken workflow change immediately affects all repos.
+
+→ **Mitigation**: Acceptable during pilot (one caller). Before rolling out to all four repos, decide whether to switch to `@v1` tag pinning. Tracked in the change's open questions / Step 6.
+
+## Migration Plan
+
+1. Land the Pulumi PR (`cloud-provisioning`): creates `liverty-music/.github` repo and extends `specification`'s `requiredStatusCheckContexts` to `['CI Success', 'Claude review']`. Merge → dev auto-deploys (no GitHub-side effect because both changes are inside the `env === 'prod'` guards) → run `pulumi up -s prod` to apply.
+2. Clone newly-created `liverty-music/.github`, land the reusable workflow PR.
+3. Land the `specification` caller PR (replaces `claude-code-review.yml` with the `~12-line caller). At this point the pilot is live: the next PR to `specification` produces a `Claude review` Check Run, and a failing verdict blocks merge.
+4. Operate for 1–2 weeks; collect verdict statistics (missing rate, failure rate, admin overrides).
+5. If stable, land the second Pulumi PR adding `'Claude review'` to `backend` / `frontend` / `cloud-provisioning` `requiredStatusCheckContexts`; land the three caller PRs.
+6. (Deferred) After ~1 month of stability on all four repos, tag `liverty-music/.github` `v1.0.0` and bump callers from `@main` to `@v1`.
+
+**Rollback**: Either remove `'Claude review'` from `requiredStatusCheckContexts` (Pulumi PR + `pulumi up -s prod`) — the Check Run still publishes but no longer blocks merges — or revert the caller workflow to the previous direct invocation. The new `.github` repo and reusable workflow can remain unused indefinitely.
+
+## Open Questions
+
+- **When to cut `v1` tag?** Plan is "1 month stable across all four repos". Could be earlier if no drift is observed.
+- **Should we capture verdict statistics centrally?** A future enhancement could append verdict JSON to a long-lived log (e.g., a status-summary issue or a small Google Sheet) for false-positive trend analysis. Out of scope for this change.

--- a/openspec/changes/claude-review-check-run/proposal.md
+++ b/openspec/changes/claude-review-check-run/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+The Claude code-review GitHub Action currently runs in all four repos (`backend`, `frontend`, `specification`, `cloud-provisioning`) but only posts a sticky PR comment. The verdict is invisible from the PR list view and cannot gate merges, so reviewers must open every PR to discover whether Claude flagged issues. The workflow YAML is also duplicated four times, so any change to the review behavior requires four PRs.
+
+Investigation found that `anthropics/claude-code-action@v1` exposes no native input for submitting a formal PR review (`APPROVE` / `REQUEST_CHANGES`), and the `code-review@claude-code-plugins` plugin is designed for comment-only operation. The community-aligned alternative — used by GitHub Copilot Code Review, CodeRabbit, Qodo, and Sentry Seer — is to emit a GitHub **Check Run** with `success` / `failure` / `neutral` conclusion. Check Runs give green/red visibility, can be made a Required Status Check to block merges, and do not interfere with the human approval flow (avoiding the required-reviewer bypass concern that motivates Copilot to refuse formal reviews).
+
+## What Changes
+
+- Add a new reusable workflow (`workflow_call`) that runs `code-review@claude-code-plugins --comment` and then publishes a `Claude review` GitHub Check Run whose `conclusion` reflects the verdict (`success` when zero high-signal issues, `failure` when any issue, `neutral` if the verdict cannot be produced).
+- Host the reusable workflow in a new `liverty-music/.github` org-wide repo so all four repos call into the same source of truth.
+- Each repo's `claude-code-review.yml` becomes a ~12-line caller that forwards a repo-specific `additional_focus` input and inherits org secrets.
+- Add `Claude review` to `requiredStatusCheckContexts` in branch protection so failing Check Runs block merges. Pilot in `specification` first, then roll out to the other three repos.
+- Bypass policy: admin override only (no `Allow specified actors to bypass` entries).
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `ci-optimization`: Add requirements describing the Claude review reusable workflow, the Check Run verdict contract, and the branch-protection requirement that gates merges on the `Claude review` check.
+
+## Impact
+
+- **New repo**: `liverty-music/.github` (created via Pulumi in `cloud-provisioning/src/github/components/organization.ts`; `RepositoryName` enum extended).
+- **cloud-provisioning/src/index.ts**: Add `'Claude review'` to `specification` repo's `requiredStatusCheckContexts` (pilot). After validation, also add to `backend`, `frontend`, and `cloud-provisioning`.
+- **liverty-music/.github/.github/workflows/claude-review.yml**: New reusable workflow.
+- **{backend,frontend,specification,cloud-provisioning}/.github/workflows/claude-code-review.yml**: Replaced with a ~12-line caller. Spec repo first (pilot); others after.
+- **Deployment**: Requires `pulumi up -s prod` because both `GitHubOrganizationComponent` (new repo) and `BranchProtection` (Required Status Check) are gated by `environment === 'prod'`.
+- **Tracking issue**: [liverty-music/specification#474](https://github.com/liverty-music/specification/issues/474).
+- **Related prior change**: archive `2026-03-27-enforce-required-ci-checks` (established the `'CI Success'` Required Status Check pattern).

--- a/openspec/changes/claude-review-check-run/specs/ci-optimization/spec.md
+++ b/openspec/changes/claude-review-check-run/specs/ci-optimization/spec.md
@@ -1,0 +1,76 @@
+## ADDED Requirements
+
+### Requirement: Claude code review runs via a single org-wide reusable workflow
+All four liverty-music repositories (`backend`, `frontend`, `specification`, `cloud-provisioning`) SHALL invoke Claude code review through a reusable workflow hosted at `liverty-music/.github/.github/workflows/claude-review.yml` (`workflow_call`). Each repository's own `.github/workflows/claude-code-review.yml` SHALL be a caller-only workflow that forwards `secrets: inherit` and optionally provides a repo-specific `additional_focus` input. The reusable workflow SHALL invoke `code-review@claude-code-plugins` with the `--comment` flag and `anthropics/claude-code-action@v1`.
+
+#### Scenario: PR is opened in any liverty-music repo
+- **WHEN** a pull request is opened or updated in `backend`, `frontend`, `specification`, or `cloud-provisioning`
+- **THEN** the repo's `claude-code-review.yml` SHALL call `liverty-music/.github/.github/workflows/claude-review.yml` via `uses:` rather than running Claude inline
+
+#### Scenario: Claude review behavior needs updating
+- **WHEN** the Claude review prompt, plugin version, or verdict logic needs to change
+- **THEN** the change SHALL be made in `liverty-music/.github/.github/workflows/claude-review.yml` and SHALL take effect on all four repos without modifying individual repo workflows
+
+### Requirement: Claude review publishes its verdict as a GitHub Check Run
+The reusable workflow SHALL create a GitHub Check Run named exactly `Claude review` on the pull request's head commit. The Check Run `conclusion` SHALL be derived from a `/tmp/claude-verdict.json` file that Claude writes after posting its sticky comment.
+
+The verdict-to-conclusion mapping SHALL be:
+
+| Verdict JSON | `conclusion` |
+|---|---|
+| `{ "verdict": "pass" }` | `success` |
+| `{ "verdict": "fail", "count": N, "summary": "..." }` | `failure` |
+| File missing or unparseable | `neutral` |
+
+The workflow SHALL NOT submit a formal pull request review (`APPROVE` or `REQUEST_CHANGES`) for the verdict. Only the sticky comment (posted by the plugin) and the Check Run are produced.
+
+#### Scenario: Claude finds no high-signal issues
+- **WHEN** Claude review completes and writes `{ "verdict": "pass" }` to `/tmp/claude-verdict.json`
+- **THEN** the workflow SHALL create a `Claude review` Check Run with `conclusion: success`
+- **AND** the Check Run output title SHALL be `No issues found`
+
+#### Scenario: Claude finds high-signal issues
+- **WHEN** Claude review completes and writes `{ "verdict": "fail", "count": N, "summary": "<text>" }` to `/tmp/claude-verdict.json`
+- **THEN** the workflow SHALL create a `Claude review` Check Run with `conclusion: failure`
+- **AND** the Check Run output title SHALL be `N issue(s) found`
+
+#### Scenario: Claude does not produce a verdict file
+- **WHEN** `/tmp/claude-verdict.json` is missing after the Claude step completes
+- **THEN** the workflow SHALL create a `Claude review` Check Run with `conclusion: neutral`
+- **AND** the Check Run output title SHALL be `No verdict produced`
+
+#### Scenario: Claude review never submits a formal PR review
+- **WHEN** any Claude review run completes (pass, fail, or neutral)
+- **THEN** `gh pr view --json reviews` SHALL NOT show a review authored by Claude with state `APPROVED` or `CHANGES_REQUESTED`
+
+### Requirement: `Claude review` is enforced as a Required Status Check via Pulumi
+For every liverty-music repository whose `GitHubRepositoryComponent` participates in Claude review, `cloud-provisioning/src/index.ts` SHALL include `'Claude review'` in `requiredStatusCheckContexts` alongside the existing `'CI Success'`. Branch protection is applied only when the Pulumi stack environment is `prod`, so the Required Status Check is effective only after `pulumi up -s prod`.
+
+A failing or pending `Claude review` Check Run SHALL block merging on the protected branch. Repo administrators retain the standard branch-protection admin-override capability; no other bypass actors are configured.
+
+#### Scenario: PR has a failing Claude review Check Run
+- **WHEN** a pull request is open with `Claude review` Check Run `conclusion: failure`
+- **AND** all other Required Status Checks pass
+- **THEN** the PR's merge button SHALL be disabled for non-admin users
+
+#### Scenario: PR has a neutral Claude review Check Run
+- **WHEN** a pull request is open with `Claude review` Check Run `conclusion: neutral`
+- **AND** all other Required Status Checks pass
+- **THEN** the PR's merge button SHALL be enabled (neutral does not block)
+
+#### Scenario: Repo admin merges despite failing Claude review
+- **WHEN** a repository administrator opens the merge dialog on a PR with `Claude review` `conclusion: failure`
+- **THEN** the admin SHALL be able to merge via the standard branch-protection administrator-override path
+
+### Requirement: Claude review pilots on `specification` before all-repo rollout
+The first deployment of the new reusable workflow + Required Status Check SHALL enable `'Claude review'` in `requiredStatusCheckContexts` for the `specification` repository only. The other three repos (`backend`, `frontend`, `cloud-provisioning`) SHALL retain `requiredStatusCheckContexts: ['CI Success']` until the pilot has run for at least one calendar week without persistent false-positive issues.
+
+#### Scenario: Initial deployment after pilot Pulumi PR
+- **WHEN** the first Pulumi PR introducing this change has been applied to `prod`
+- **THEN** only the `specification` repo's branch protection SHALL include `'Claude review'` in `requiredStatusCheckContexts`
+- **AND** `backend`, `frontend`, `cloud-provisioning` SHALL still have `requiredStatusCheckContexts: ['CI Success']`
+
+#### Scenario: Pilot graduates to full rollout
+- **WHEN** the pilot has run for at least one calendar week without unmitigated false-positive issues
+- **THEN** a follow-up Pulumi PR SHALL add `'Claude review'` to `requiredStatusCheckContexts` for `backend`, `frontend`, and `cloud-provisioning`
+- **AND** each of those three repos SHALL have its `.github/workflows/claude-code-review.yml` replaced with a caller of the reusable workflow before that Pulumi PR is deployed to `prod`

--- a/openspec/changes/claude-review-check-run/tasks.md
+++ b/openspec/changes/claude-review-check-run/tasks.md
@@ -1,0 +1,54 @@
+## 1. Pulumi PR (cloud-provisioning) — pilot
+
+- [ ] 1.1 In `cloud-provisioning/src/github/config.ts`, add `DOT_GITHUB = '.github'` to the `RepositoryName` enum
+- [ ] 1.2 In `cloud-provisioning/src/github/components/organization.ts`, create a `new github.Repository(RepositoryName.DOT_GITHUB, { ...defaultRepositoryArgs, name: '.github', description: 'Org-wide community files and reusable workflows' })` (no template) and include it in `this.repositories`
+- [ ] 1.3 In `cloud-provisioning/src/index.ts`, update the `specification` `GitHubRepositoryComponent` call to set `requiredStatusCheckContexts: ['CI Success', 'Claude review']`
+- [ ] 1.4 Run `make check` in cloud-provisioning to ensure lint passes
+- [ ] 1.5 Run `pulumi preview -s prod` and verify the diff shows: (a) create `liverty-music/.github` repo, (b) update `specification` branch protection to require `Claude review`
+- [ ] 1.6 Open the cloud-provisioning PR (base: `main`, branch: `474-claude-review-check-run`); reference issue #474
+- [ ] 1.7 After PR merge, `pulumi up -s prod` from Pulumi Cloud Deployments console (user-approved); confirm `liverty-music/.github` exists via `gh repo view liverty-music/.github` and `specification` branch protection lists `Claude review` via `gh api repos/liverty-music/specification/branches/main/protection`
+
+## 2. Reusable workflow in `liverty-music/.github`
+
+- [ ] 2.1 Clone the newly-created `liverty-music/.github` repo locally
+- [ ] 2.2 Create branch `474-claude-review-check-run` (or `add-claude-review-reusable-workflow` since the repo is new and may not yet enforce issue-number branch naming)
+- [ ] 2.3 Add `.github/workflows/claude-review.yml` per `design.md` Decision 3 (Step 1 plugin invocation → Step 2 verdict file read → Step 3 `actions/github-script@v7` `checks.create` with name `Claude review`)
+- [ ] 2.4 Declare `workflow_call` inputs (`additional_focus: string, default ''`) and required secret (`ANTHROPIC_API_KEY`)
+- [ ] 2.5 Declare permissions: `contents: read`, `pull-requests: write`, `issues: read`, `id-token: write`, `checks: write`
+- [ ] 2.6 Open PR; merge to `main` (no CI checks expected on this new repo yet — no caller exists)
+
+## 3. Specification caller workflow (pilot)
+
+- [ ] 3.1 In the specification worktree, replace `.github/workflows/claude-code-review.yml` contents with a ~12-line caller: `uses: liverty-music/.github/.github/workflows/claude-review.yml@main`, `secrets: inherit`, `with.additional_focus: "Protobuf style (Google AIP), buf.validate annotations, backward compatibility"`
+- [ ] 3.2 Preserve the existing `on: pull_request` trigger types (`opened, synchronize, ready_for_review, reopened`)
+- [ ] 3.3 Commit on branch `474-claude-review-check-run`; this branch already has the OpenSpec change artifacts in `openspec/changes/claude-review-check-run/`
+- [ ] 3.4 Open the specification PR referencing issue #474
+
+## 4. Pilot verification
+
+- [ ] 4.1 Create a clean test PR (e.g., README typo fix) in `specification`; confirm `Claude review` Check Run appears with `conclusion: success`
+- [ ] 4.2 Create a deliberately broken test PR (e.g., a CLAUDE.md violation or obvious bug); confirm `Claude review` Check Run appears with `conclusion: failure` and that the merge button is blocked for non-admin users
+- [ ] 4.3 Verify admin override path: log in as admin, confirm the merge dialog offers the bypass option on the failing PR; do NOT actually merge unless cleanup is acceptable
+- [ ] 4.4 Inspect `/tmp/claude-verdict.json` write success rate across the first ~5 real PRs (via Actions logs). If missing rate exceeds ~5%, strengthen the prompt before proceeding to Step 5
+- [ ] 4.5 Operate the pilot for at least 1 calendar week; track false-positive rate and admin override frequency
+
+## 5. Roll out to remaining repos (after pilot passes)
+
+- [ ] 5.1 In `backend/.github/workflows/claude-code-review.yml`, replace with caller using `additional_focus: "Go conventions, error handling (no silent fails), table-driven tests, pgx usage"`
+- [ ] 5.2 In `frontend/.github/workflows/claude-code-review.yml`, replace with caller using `additional_focus: "Aurelia 2 patterns, CUBE CSS methodology, INP optimization, semantic HTML"`
+- [ ] 5.3 In `cloud-provisioning/.github/workflows/claude-code-review.yml`, replace with caller using `additional_focus: "Pulumi best practices, K8s manifest conventions, IAM least privilege"`
+- [ ] 5.4 Open separate PRs per repo (or one stacked rollout PR, depending on team preference)
+- [ ] 5.5 After all three caller PRs are merged to `main`, open a second Pulumi PR in cloud-provisioning adding `'Claude review'` to `requiredStatusCheckContexts` for `backend`, `frontend`, `cloud-provisioning` in `src/index.ts`
+- [ ] 5.6 Run `pulumi preview -s prod`; confirm only branch protection contexts change for the three repos
+- [ ] 5.7 Merge Pulumi PR; run `pulumi up -s prod`; verify branch protection updates via `gh api repos/liverty-music/<repo>/branches/main/protection` for each of the three repos
+
+## 6. (Deferred) Cut `@v1` tag
+
+- [ ] 6.1 After ~1 month of stable operation across all four repos with no major drift, cut tag `v1.0.0` on `liverty-music/.github`
+- [ ] 6.2 Update each of the four caller workflows to reference `@v1` instead of `@main`
+- [ ] 6.3 Document the tag-bump process (Conventional Commits + manual tag, or release-please) in the `liverty-music/.github` README
+
+## 7. Documentation
+
+- [ ] 7.1 Add a brief README section to `liverty-music/.github` explaining the reusable workflow's contract (`additional_focus` input, `Claude review` Check Run name, verdict JSON format)
+- [ ] 7.2 Mention the Claude review Required Status Check + admin-override path in the developer onboarding doc (or equivalent) so non-admin contributors know what to do when a misfire blocks their PR


### PR DESCRIPTION
## 🔗 Related Issue

Closes #474

## 📝 Summary of Changes

OpenSpec proposal for moving the Claude code-review GitHub Action from comment-only to a **GitHub Check Run** that publishes `success` / `failure` / `neutral` on every PR. The reusable workflow itself is hosted in a new `liverty-music/.github` repo (managed by Pulumi) so all four repos share a single source of truth.

### Motivation

- Today's `claude-code-review.yml` (present in `backend` / `frontend` / `specification` / `cloud-provisioning`) only posts a sticky PR comment. The verdict is invisible from the PR list view and cannot gate merges.
- The YAML is duplicated four times — any behavior change requires four PRs.
- Investigation confirmed `anthropics/claude-code-action@v1` exposes **no native input** for submitting a formal PR review, and the `code-review@claude-code-plugins` plugin is comment-only by design.
- GitHub Copilot Code Review, CodeRabbit, Qodo, and Sentry Seer all converge on the **Check Run pattern** rather than letting bots submit formal `APPROVE` / `REQUEST_CHANGES` reviews. Copilot's docs explicitly call out that bot-issued formal reviews would bypass required-reviewer protections.

### Technical approach

- Reusable workflow at `liverty-music/.github/.github/workflows/claude-review.yml` (`workflow_call`) keeps the existing `code-review --comment` invocation and adds two steps: Claude writes `/tmp/claude-verdict.json` with a deterministic 1-line contract, then `actions/github-script@v7` calls `checks.create` with `name: 'Claude review'` and a conclusion derived from the verdict.
- Verdict → conclusion mapping: `pass → success`, `fail → failure`, missing JSON → `neutral`.
- New repo `liverty-music/.github` is created via Pulumi (`cloud-provisioning/src/github/components/organization.ts`).
- `'Claude review'` is added to `requiredStatusCheckContexts` in `cloud-provisioning/src/index.ts` — pilot in `specification` first, then roll out to the other three repos after ~1 week of stable operation.
- Bypass policy: **admin override only**.

See `openspec/changes/claude-review-check-run/`:
- [`proposal.md`](./openspec/changes/claude-review-check-run/proposal.md) — Why & What
- [`design.md`](./openspec/changes/claude-review-check-run/design.md) — 7 numbered decisions with alternatives considered, risks/trade-offs, migration plan
- [`specs/ci-optimization/spec.md`](./openspec/changes/claude-review-check-run/specs/ci-optimization/spec.md) — 4 ADDED requirements with scenarios
- [`tasks.md`](./openspec/changes/claude-review-check-run/tasks.md) — 7 sections / 27 tracked tasks (Pulumi PR → reusable workflow → caller → pilot verification → full rollout → `@v1` tag → docs)

### Out of scope

- Replacing the official `anthropics/claude[bot]` GitHub App with a custom App so AI reviews could count toward Required Approvals (community consensus is bot identities should not satisfy human-reviewer requirements; the design explicitly avoids this).
- Migrating other CI workflows (deploy, lint, atlas-ci) to a reusable workflow at the same time.
- Tagging `@v1` on day one — initial callers reference `@main`.

### Related prior change

Archive [`2026-03-27-enforce-required-ci-checks`](./openspec/changes/archive/2026-03-27-enforce-required-ci-checks/) established the `'CI Success'` Required Status Check pattern; this change extends `requiredStatusCheckContexts` to include `'Claude review'`.

## ✅ Self-Checklist

- [x] I have linked the related issue.
- [x] I have updated the relevant documentation (e.g., `README.md`) if needed.
- [x] I have run `buf lint` and `buf format` locally and all checks have passed.
- [x] My proto definitions follow the project's style guidelines and validation rules.
- [x] Breaking changes have been justified and documented if applicable.
