### PR TITLE
refactor(workflows): use reusable Claude review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -3,43 +3,10 @@ name: Claude Code Review
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review, reopened]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
 
 jobs:
-  claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
-
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
-      issues: read
-      id-token: write
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-
-      - name: Run Claude Code Review
-        id: claude-review
-        uses: anthropics/claude-code-action@v1
-        with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
-          plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }} --comment'
-          claude_args: '--allowedTools "Bash(gh pr *),Bash(gh api *),Bash(git *),Write"'
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
-
+  review:
+    uses: liverty-music/.github/.github/workflows/claude-review.yml@main
+    secrets: inherit
+    with:
+      additional_focus: "Protobuf style (Google AIP), buf.validate annotations, backward compatibility"

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -4,6 +4,17 @@ on:
   pull_request:
     types: [opened, synchronize, ready_for_review, reopened]
 
+# Permissions are inherited by the reusable workflow's job and intersected
+# with its own workflow-level declarations. Set them here in the caller so
+# the called job has everything it needs (sticky/inline comment, Claude
+# action OIDC, Check Run publish).
+permissions:
+  contents: read
+  pull-requests: write
+  issues: read
+  id-token: write
+  checks: write
+
 jobs:
   review:
     uses: liverty-music/.github/.github/workflows/claude-review.yml@main


### PR DESCRIPTION
## 🔗 Related Issue

Refs: #474

(Not closing — this is Section 3 of OpenSpec change [`claude-review-check-run`](https://github.com/liverty-music/specification/tree/main/openspec/changes/claude-review-check-run). Backend / frontend / cloud-provisioning callers follow after pilot verification.)

## 📝 Summary of Changes

Replace the inline Claude Code review workflow with a thin caller of the new reusable workflow at [`liverty-music/.github/.github/workflows/claude-review.yml@main`](https://github.com/liverty-music/.github/blob/main/.github/workflows/claude-review.yml) (merged in [liverty-music/.github#1](https://github.com/liverty-music/.github/pull/1)).

### Before

`.github/workflows/claude-code-review.yml` was a 45-line inline workflow that ran `anthropics/claude-code-action@v1` with `claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}` and posted a sticky PR comment via `code-review --comment`. No green/red signal in the PR list view; no merge gate.

### After

The workflow is now a 12-line caller of the reusable workflow:

```yaml
jobs:
  review:
    uses: liverty-music/.github/.github/workflows/claude-review.yml@main
    secrets: inherit
    with:
      additional_focus: "Protobuf style (Google AIP), buf.validate annotations, backward compatibility"
```

The reusable workflow:

1. Runs `code-review@claude-code-plugins` against this PR.
2. Posts the existing detailed sticky comment.
3. Publishes a **`Claude review`** GitHub Check Run with conclusion derived from Claude's verdict:
   - `pass` → `success` ✅
   - `fail` → `failure` ❌ (blocks merge — see below)
   - missing → `neutral` ⚪

### Auth change

Switches from `CLAUDE_CODE_OAUTH_TOKEN` (per-repo, manually set 2026-02-24) to `ANTHROPIC_API_KEY` (Pulumi-managed `ActionsOrganizationSecret` with `visibility: 'all'`). Forwarded via `secrets: inherit`. The old per-repo OAuth token is no longer used by this workflow and can be revoked after rollout to all four repos (a separate cleanup task, not done here).

### Merge gating

`Claude review` is now a **Required Status Check** for this repo (set via Pulumi in [liverty-music/cloud-provisioning#267](https://github.com/liverty-music/cloud-provisioning/pull/267), applied to prod in v161). A failing `Claude review` Check Run blocks merge; admin override remains available.

## 🧪 Test plan

This PR itself becomes the **first pilot exercise** of the new workflow:

- [ ] On open, `Claude review` Check Run appears alongside `CI Success` in the PR status panel.
- [ ] Since this is a clean, well-scoped refactor, expect `conclusion: success` and merge to be unblocked.
- [ ] Inline / sticky comment behavior matches the previous workflow (no regression).

Follow-up pilot exercises (Section 4 of [`tasks.md`](https://github.com/liverty-music/specification/blob/main/openspec/changes/claude-review-check-run/tasks.md)):

- [ ] Deliberately broken PR → expect `conclusion: failure` and merge blocked for non-admin.
- [ ] Admin override path works on the failing PR.
- [ ] `/tmp/claude-verdict.json` write success rate ≥ 95% over first ~5 PRs.

## ✅ Self-Checklist

- [x] I have linked the related issue.
- [x] I have updated the relevant documentation (the OpenSpec change is the design doc; no proto changes).
- [x] I have run `buf lint` and `buf format` locally and all checks have passed (no proto changes; n/a).
- [x] My proto definitions follow the project's style guidelines and validation rules (n/a; workflow-only change).
- [x] Breaking changes have been justified and documented if applicable (none — output behavior is additive: existing sticky comment preserved, new Check Run added).
