### PR TITLE
docs(readme): rename title from scaffold template

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Protobuf Scaffold
+# liverty-music/specification
 
 A repository for managing application entity and API definitions using Protocol Buffers with Buf Schema Registry (BSR) for remote code generation.
 


### PR DESCRIPTION
## 🔗 Related Issue

Refs: #474

(Test PR — will be merged or closed depending on Claude review verdict; serves as **Section 4.1 pilot verification** of OpenSpec change `claude-review-check-run`.)

## 📝 Summary of Changes

Minimal documentation fix: replace the leftover `# Protobuf Scaffold` title (inherited from the `protobuf-scaffold` template repo when this repo was bootstrapped via Pulumi) with the actual repository name `liverty-music/specification`.

The README body already refers to "this repository" without naming it, so no other content needs updating.

## 🧪 Why this PR exists

This is the **first real PR** running through the new reusable Claude review workflow + Required Status Check pipeline introduced by the `claude-review-check-run` OpenSpec change.

Expected outcome:
- `Claude review` Check Run posts with `conclusion: success` (no high-signal issues)
- `CI Success` passes (buf-checks-skip because no proto changes)
- Merge button enabled

If observed, this validates Section 4.1 of [`tasks.md`](https://github.com/liverty-music/specification/blob/main/openspec/changes/claude-review-check-run/tasks.md):
> 4.1 Create a clean test PR (e.g., README typo fix) in `specification`; confirm `Claude review` Check Run appears with `conclusion: success`

## ✅ Self-Checklist

- [x] I have linked the related issue.
- [x] I have updated the relevant documentation (this PR _is_ the doc update).
- [x] No proto changes; `buf lint` / `buf format` / `buf breaking` skipped via path filter.
- [x] No breaking changes.
