### PR TITLE
test(coordinates): broaden latitude range (intentional bug)

### DIFF
--- a/proto/liverty_music/entity/v1/coordinates.proto
+++ b/proto/liverty_music/entity/v1/coordinates.proto
@@ -6,7 +6,7 @@ package liverty_music.entity.v1;
 // Used wherever the domain model requires a geographic location — for example,
 // the centroid of a user's home area or the position of a concert venue.
 message Coordinates {
-  // The WGS 84 latitude in decimal degrees (range: -90 to +90).
+  // The WGS 84 latitude in decimal degrees (range: -180 to +180).
   double latitude = 1;
 
   // The WGS 84 longitude in decimal degrees (range: -180 to +180).


### PR DESCRIPTION
## 🔗 Related Issue

Refs: #474

(Test PR — **NOT for merge**. Section 4.2 pilot verification of OpenSpec change `claude-review-check-run`.)

## 📝 Summary of Changes

**Intentional bug**: change the documented `latitude` range from `-90 to +90` (correct) to `-180 to +180` (wrong — that is the longitude range).

```diff
- // The WGS 84 latitude in decimal degrees (range: -90 to +90).
+ // The WGS 84 latitude in decimal degrees (range: -180 to +180).
  double latitude = 1;
```

## 🧪 Why this PR exists

Section 4.2 of [`tasks.md`](https://github.com/liverty-music/specification/blob/main/openspec/changes/claude-review-check-run/tasks.md):

> 4.2 Create a deliberately broken test PR (e.g., a CLAUDE.md violation or obvious bug); confirm `Claude review` Check Run appears with `conclusion: failure` and that the merge button is blocked for non-admin users.

Expected outcome:
- Claude review flags the latitude range as factually incorrect (high-signal: math/geography)
- `/tmp/claude-verdict.json` is written with `verdict: "fail"`
- `Claude review` Check Run conclusion: `failure` ❌
- For non-admin users, the merge button is disabled (Required Status Check fails)
- For repo admins, the override path remains available

## ⚠️ Important

This PR **must not be merged**. It will be closed manually after verification.

## ✅ Self-Checklist

- [x] Issue linked.
- [x] Documentation contains the intentional bug (this PR _is_ the test).
- [x] Single-file proto comment change; no proto semantics or field tags changed.
- [x] No breaking changes (comment-only change).
