### PR TITLE
openspec: adopt-runtime-config-for-frontend

### DIFF
--- a/openspec/changes/adopt-runtime-config-for-frontend/.openspec.yaml
+++ b/openspec/changes/adopt-runtime-config-for-frontend/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-16

--- a/openspec/changes/adopt-runtime-config-for-frontend/design.md
+++ b/openspec/changes/adopt-runtime-config-for-frontend/design.md
@@ -88,7 +88,13 @@ export interface AppConfig {
 export async function loadAppConfig(): Promise<AppConfig> {
   const res = await fetch('/config.json', { cache: 'no-store' })
   if (!res.ok) throw new Error(`config.json fetch failed: ${res.status}`)
-  return await res.json() as AppConfig
+  const parsed = await res.json() as unknown
+  // Runtime field validation (sketch): real impl iterates required keys
+  // and throws naming the offending field — see task 1.1 and the
+  // "Bootstrap validates required fields" scenario in
+  // specs/frontend-runtime-config/spec.md. The `as AppConfig` below is
+  // intentionally NOT a trust boundary; validate before the cast.
+  return validateAndCast(parsed)
 }
 
 // src/main.ts (sketch)

--- a/openspec/changes/adopt-runtime-config-for-frontend/design.md
+++ b/openspec/changes/adopt-runtime-config-for-frontend/design.md
@@ -275,7 +275,7 @@ This catches the specific regression that v1.0.0 hit AND any analogous future re
    - Deployment patch (volumeMount + volume + Reloader annotation) under `base/web/deployment.yaml`.
 3. Open `frontend/adopt-runtime-config` PR with code refactor + `public/config.json` (dev values) + Caddyfile + Dockerfile cleanup + post-build assertion script. Delete `.env.prod`.
 4. Both PRs reviewed in parallel.
-5. Merge `cloud-provisioning` PR first. ArgoCD applies; dev pod restarts via Reloader, picks up new ConfigMap. Dev still serves the OLD image (no `/config.json` reader yet). No visible change.
+5. Merge `cloud-provisioning` PR first. ArgoCD applies; the dev pod restarts via Reloader and the ConfigMap subPath-mounts dev `config.json` at `/srv/config.json`. The OLD frontend image reads `import.meta.env.VITE_*` (baked at build time) and **does not read `/config.json` at all** — there is no fallback mechanism; the mounted file is simply dormant. Behaviour is unchanged because the old code is oblivious to the file, not because anything falls back. The ConfigMap remains live but dormant until the frontend PR is merged.
 6. Merge `frontend` PR. Dev CI builds new image, pushes to dev-AR `:latest`. ArgoCD Image Updater bumps dev Deployment. New pod starts, fetches `/config.json`, app boots with runtime config. Verify dev `https://dev.liverty-music.app/` works.
 7. Cut frontend release tag `v1.0.1` on the new merge commit. Release CI builds → pushes to `liverty-music-prod/frontend/web-app:v1.0.1`.
 8. Update `cloud-provisioning/k8s/namespaces/frontend/overlays/prod/kustomization.yaml` image pin to `v1.0.1`. Merge.

--- a/openspec/changes/adopt-runtime-config-for-frontend/design.md
+++ b/openspec/changes/adopt-runtime-config-for-frontend/design.md
@@ -1,0 +1,300 @@
+## Context
+
+The frontend (Aurelia 2 SPA, Vite-built, Caddy-served, ArgoCD-deployed) currently uses build-time environment substitution: `vite build --mode prod` loads `.env` + `.env.prod`, Vite embeds `import.meta.env.VITE_*` values into the bundle, and the prod container image is built distinctly from the dev container image. This was introduced by the in-flight `prepare-prod-service-in` change (commit c4fae04, 2026-05-15).
+
+Two structural problems surfaced:
+
+1. **Aurelia plugin's mode coupling**: [`@aurelia/vite-plugin@2.0.0-rc.1`](../../../../frontend/node_modules/@aurelia/vite-plugin/src/index.ts) gates template-bundle code generation on a literal `config.mode === 'production'` check. The mode name `'prod'` (chosen to match `.env.prod` filename) is not `'production'`, so the plugin skips rewriting `.html` imports to `.$au.ts` virtual modules. Templates fall out of every lazy route chunk. Aurelia at runtime registers the route classes without CustomElement metadata under synthetic names (`unnamed-N`), and the router cannot resolve any route → blank screen across the entire app.
+
+2. **Per-env image divergence**: even without the bug, baking env values into the image means the artifact tested in dev is not the artifact deployed to prod. Future regressions can hide in the env-specific build path (as this one did — the c4fae04 spot-check verified env *values* were embedded but not that *templates* were).
+
+Empirically confirmed (binary diff of live chunks):
+- Dev `welcome-route-CJhWb1QO.js`: 9115 bytes, contains template strings (`welcome-hero`, `Hero`, `Live`).
+- Prod `welcome-route-CHv2U1al.js`: 6158 bytes, template strings absent.
+
+Current state pre-decision:
+- `https://liverty-music.app/` is live but blank (HTTP 200, Caddy serving valid `index.html`, JS chunks 200, but Aurelia bootstrap fails).
+- v1.0.0 frontend GitHub Release tagged, `liverty-music-prod/frontend/web-app:51f5bce…` in prod AR, ArgoCD synced to prod cluster.
+- Zero real users (PWA installs, auth sessions, SW caches) on prod — this change can land with **no user-facing migration cost**.
+
+Frontend code inventory grounding the design:
+- 8 `import.meta.env.VITE_*` read sites: `services/auth-service.ts` (4 reads), `services/grpc-transport.ts` (1, module const), `services/otel-init.ts` (1), `services/push-service.ts` (1, class field), `routes/settings/settings-route.ts` (1, class field), `services/proof-service.ts` (1, module const), `constants/preview-artists.ts` (2, module consts), `src/main.ts` (1, LOG_LEVEL).
+- 7 `import.meta.env.DEV` reads (`main.ts`, `auth-service.ts`, `preview-artists.ts`) — these encode "running under `vite` dev server vs. running from a `vite build` artifact". This semantic is orthogonal to which K8s environment serves the bundle and SHALL be preserved.
+- Existing CSP (`<meta http-equiv="Content-Security-Policy">` in `index.html`) already covers both envs via `connect-src 'self' https://*.zitadel.cloud https://*.liverty-music.app` wildcard.
+- Existing Caddyfile is minimal: `root * /srv`, `file_server`, SPA fallback. Service Worker registered post-bootstrap via `vite-plugin-pwa` (Workbox).
+
+Constraints:
+- ArgoCD continuous-delivery model is established. Per-env Kustomize overlays under `cloud-provisioning/k8s/namespaces/frontend/overlays/<env>/` are the canonical place for env-divergent config. Reloader namespace is provisioned and used by other workloads.
+- Per `prod-image-pipeline` spec: prod must pull from `liverty-music-prod/frontend/*` AR (cross-project pulls forbidden) and must NOT use `:latest` tag (explicit release tag or SHA).
+- All `VITE_*` values are classified public (per `prepare-prod-service-in` D3); no secret-handling concerns here.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Eliminate the entire class of "build-mode-dependent bundle correctness" bugs by removing build-time env divergence.
+- Restore correct rendering at `https://liverty-music.app/` with a single fix that does not depend on workarounds (e.g., choosing a "magic" mode name that happens to contain "production").
+- Produce a single deterministic SPA bundle whose behavior is identical across environments and whose env-specific behavior is derived from `/config.json` at boot.
+- Establish a defense-in-depth assertion that prevents regressions of this class (template-stripping or any analogous "bundle compiled, missing critical data" pattern).
+- Keep developer ergonomics for `npm start` (Vite dev server) identical to today.
+- Make adding a new environment (e.g., `staging`) a one-file Kustomize change.
+
+**Non-Goals:**
+- True bit-identical image promotion (dev-AR → prod-AR retag). The first iteration rebuilds for prod release tags with identical inputs; binary-identical promotion is a Phase-2 improvement, tracked as a follow-up.
+- Tightening CSP to per-env hostnames (currently wildcard covers both). Decoupled, future change.
+- Runtime feature flags or A/B config (this design adds *static* env config only; the same `/config.json` shape across all browsers in a given env).
+- Migrating `import.meta.env.DEV` to runtime config — semantically wrong; those reads encode dev-server-vs-build, not K8s environment.
+- Upstreaming the Aurelia plugin fix as a blocker. Filed in parallel; does not gate this change.
+
+## Decisions
+
+### D1. Replace build-time env bake with runtime `/config.json` fetched at bootstrap
+
+**Chosen**: SPA fetches `/config.json` from same origin during `main.ts` bootstrap, before `Aurelia.start()`. Caddy serves the file from `/srv/config.json`; K8s mounts a per-env ConfigMap onto that path.
+
+**Alternatives considered**:
+- **A. Keep build-time bake, switch to `BUILD_TARGET` env var** (vite.config.ts reads custom env, ignores Vite mode for selection, keeps mode=`production`). Smallest patch. Rejected: still per-env images, doesn't eliminate the bug class — future build-time flags will reintroduce the same trap. The "spot-check verified env values, didn't verify templates" failure mode persists.
+- **B. Keep build-time bake, use `.env.production.local` file swap in CI** (`cp .env.prod .env.production.local && vite build`). Rejected: uses Vite's `.local` convention against its semantic intent (developer-only overrides). Confusing for future contributors.
+- **C. Caddy `envsubst` at container startup** to template `index.html` with env values from container env vars. Rejected: prevents Subresource Integrity / strict CSP without `unsafe-inline`, and adds a Caddy template plugin dependency. Worse than D1 for the same outcome.
+- **D. Inject `window.__APP_CONFIG__` via `<script>` in index.html, rendered by Caddy at request time**. Rejected: same drawbacks as C, plus index.html caching becomes per-env (Caddy must not cache it).
+
+D1 is the cleanest separation: image == code, ConfigMap == environment. ArgoCD natively reconciles ConfigMaps. Reloader auto-rollouts on change. Bootstrap fetch is intra-pod (~5ms).
+
+### D2. Single image, env-agnostic; per-env divergence lives in K8s ConfigMap
+
+**Chosen**: The Docker build accepts no env-specific build-args. `npm run build` produces one canonical bundle. Both `liverty-music-dev/frontend/web-app` and `liverty-music-prod/frontend/web-app` AR pushes use the same source build (rebuilt on each path due to GitHub Actions topology, but with identical inputs).
+
+**Rationale**: The proximate cause of v1.0.0 being blank was build-time divergence interacting with a plugin's mode check. Eliminating divergence eliminates that whole interaction surface — including future analogous bugs we cannot enumerate today.
+
+**Phase-2 follow-up**: switch the release-tag CI to retag the dev-AR image (`gcloud artifacts docker tags add`) into prod-AR instead of rebuilding. Achieves true binary-identical promotion. Deferred because it requires CI restructuring and the v1 fix doesn't need it.
+
+### D3. `AppConfig` via Aurelia DI, loaded inside an async bootstrap
+
+**Chosen**:
+```ts
+// src/config/app-config.ts
+export const IAppConfig = DI.createInterface<AppConfig>('IAppConfig')
+export interface AppConfig {
+  environment: 'dev' | 'staging' | 'prod'
+  apiBaseUrl: string
+  zitadelIssuer: string
+  zitadelClientId: string
+  zitadelOrgId: string
+  vapidPublicKey: string
+  circuitBaseUrl: string
+  previewArtistIds: string[]
+  previewArtistNames: string[]
+  logLevel: 'trace' | 'debug' | 'info' | 'warn' | 'error'
+}
+export async function loadAppConfig(): Promise<AppConfig> {
+  const res = await fetch('/config.json', { cache: 'no-store' })
+  if (!res.ok) throw new Error(`config.json fetch failed: ${res.status}`)
+  return await res.json() as AppConfig
+}
+
+// src/main.ts (sketch)
+async function bootstrap() {
+  const config = await loadAppConfig()
+  validateEnvironmentMatchesHost(config)  // see D7
+  initOtel(config.apiBaseUrl)
+  const au = new Aurelia()
+  au.register(Registration.instance(IAppConfig, config))
+  au.register(/* existing registrations */)
+  au.app(AppShell).start()
+}
+bootstrap().catch(showStaticErrorPage)
+```
+
+**Alternatives considered**:
+- **Synchronous `XMLHttpRequest`** to keep `main.ts` synchronous. Rejected: blocking the main thread for ~5ms is acceptable but using a deprecated sync API for code we are writing today is wrong.
+- **Module-level top-level await** (`const config = await loadAppConfig()` at module scope). Rejected: top-level await complicates Vite chunking and HMR; explicit bootstrap function is clearer and testable in isolation.
+- **Global singleton without DI** (`window.__appConfig`). Rejected: bypasses Aurelia's DI lifecycle, makes unit tests harder to isolate, and is harder to mock in Vitest.
+
+### D4. Module-level reads of env are refactored to function-level / DI-resolved reads
+
+`grpc-transport.ts`, `proof-service.ts`, `preview-artists.ts` currently read `import.meta.env.VITE_*` at module-eval time (top-level `const`). These execute at import time, which is before `bootstrap()`'s `await loadAppConfig()` resolves. To make config-after-bootstrap safe:
+
+- `grpc-transport.ts`: export `createTransport(config: AppConfig)` factory; callers resolve `IAppConfig` and call the factory. (Or register the transport as a DI factory keyed on `IAppConfig`.)
+- `proof-service.ts`: same pattern — `CIRCUIT_BASE_URL` becomes a class field initialized from `resolve(IAppConfig)`.
+- `preview-artists.ts`: this is the trickiest because `PREVIEW_ARTIST_IDS` and `PREVIEW_ARTIST_NAME_MAP` are module-level exports consumed by lazy-loaded `welcome-route`. Since `welcome-route` is only instantiated AFTER bootstrap completes (router resolves the route lazily), its imports' top-level evaluation can safely read `getAppConfig()` from a non-DI synchronous accessor that throws if called before `loadAppConfig()` ran. Concretely: keep a `let _config` module-scoped in `app-config.ts`, populated by `loadAppConfig()`. Export `getAppConfig()` as a synchronous getter that throws if `_config` is null. `preview-artists.ts` module-level consts call `getAppConfig().previewArtistIds`. This works because the lazy route chunk only evaluates after `au.start()` has resolved the bootstrap promise.
+
+This gives us DI ergonomics for services (idiomatic) AND safe module-const access for lazy code (pragmatic, with explicit failure mode if invariant is violated).
+
+### D5. Caddy serves `/config.json` with no-cache headers; K8s mounts ConfigMap as a single-file volume
+
+```caddyfile
+:80 {
+  root * /srv
+  file_server
+  try_files {path} /index.html
+
+  @config path /config.json
+  header @config Cache-Control "no-cache, no-store, must-revalidate"
+  header @config Content-Type "application/json; charset=utf-8"
+
+  @sw path /sw.js
+  header @sw Cache-Control "no-cache"
+  header @sw Service-Worker-Allowed "/"
+}
+```
+
+K8s volume mount uses `subPath` so the ConfigMap key replaces only `/srv/config.json` without shadowing the rest of `/srv`:
+
+```yaml
+volumeMounts:
+- name: runtime-config
+  mountPath: /srv/config.json
+  subPath: config.json
+volumes:
+- name: runtime-config
+  configMap:
+    name: web-app-runtime-config
+```
+
+**Reloader annotation** (`reloader.stakater.com/auto: "true"`) on the Deployment triggers a pod rollout when the ConfigMap changes. Reloader is already deployed in both clusters.
+
+**Caveat**: `subPath` mounts do NOT auto-update on ConfigMap change (the file in the pod is a snapshot taken at mount time). Reloader's rollout addresses this. Without `subPath`, kubelet would atomically update the symlink but we'd lose the rest of `/srv`. The trade-off is correct: prefer explicit rollout (visible, ArgoCD-reconciled) over silent in-place file swap.
+
+### D6. Service Worker bypasses precache for `/config.json`
+
+Add an explicit `NetworkOnly` route in `sw.ts`:
+
+```ts
+registerRoute(
+  ({ url }) => url.pathname === '/config.json',
+  new NetworkOnly(),
+)
+```
+
+Workbox's `precacheAndRoute(__WB_MANIFEST)` runs first and matches only `__WB_MANIFEST`-listed assets. `/config.json` is intentionally NOT in `__WB_MANIFEST` (it's not in `dist/`, it's mounted at deploy time). Adding the explicit NetworkOnly route is defense-in-depth against future Workbox runtime-caching defaults changing.
+
+**SW offline behavior**: if the user is offline AND the app reloads, `/config.json` fetch fails → static error page. This is acceptable for a music-discovery PWA whose primary value is online. If offline-config becomes a requirement later, switch to `NetworkFirst` with a short TTL; the change is additive.
+
+### D7. Environment cross-check at boot
+
+`config.json` includes an `environment` field. At bootstrap, validate:
+
+```ts
+function validateEnvironmentMatchesHost(config: AppConfig): void {
+  const host = window.location.hostname
+  const expected = host === 'liverty-music.app' ? 'prod'
+    : host === 'dev.liverty-music.app' ? 'dev'
+    : host === 'staging.liverty-music.app' ? 'staging'
+    : null  // localhost / preview deploys: skip check
+  if (expected && config.environment !== expected) {
+    throw new Error(
+      `Config environment mismatch: host=${host} expects ${expected}, ` +
+      `config.json says ${config.environment}. Likely a misconfigured ConfigMap mount.`,
+    )
+  }
+}
+```
+
+This catches the failure mode where a prod pod accidentally serves the `public/config.json` shipped in the image (which contains dev values), by refusing to start instead of silently calling dev URLs from prod.
+
+### D8. `public/config.json` is checked-in with dev values
+
+The frontend repo's `public/config.json` is committed with dev environment values. This serves three purposes:
+
+1. **Local dev** (`npm start`): Vite serves the public dir; the app reads dev values and connects to dev backend. Works out-of-the-box for any developer.
+2. **Storybook / Playwright local runs**: same — dev values are accurate for these.
+3. **Image fallback**: if the K8s ConfigMap mount somehow fails (operator error), the pod serves dev values. D7's cross-check then refuses to start in prod. Failure is loud, not silent.
+
+This makes `public/config.json` effectively "the dev environment's config" — accurate, useful, and not a security issue because all values are public.
+
+### D9. Phased delivery (single change, single PR per repo)
+
+The change crosses three repos. Order:
+
+1. `specification` PR with this change's artifacts → merge.
+2. **In parallel** (after spec PR exists but before merge needed):
+   - `frontend` branch with code refactor + Dockerfile + Caddyfile + public/config.json. CI rebuilds dev image successfully.
+   - `cloud-provisioning` branch with ConfigMap overlays + Deployment patch.
+3. Merge `cloud-provisioning` PR first → ArgoCD adds ConfigMap to dev cluster. Dev pod restarts (Reloader) with empty ConfigMap → falls back to image's `public/config.json` (dev values). Behavior unchanged.
+4. Merge `frontend` PR → new dev image deployed; reads `/config.json` (now ConfigMap-backed). Dev verified.
+5. Cut frontend release tag (e.g., `v1.0.1` or `v1.1.0`). Prod CI builds + pushes to prod-AR.
+6. cloud-provisioning prod overlay updated with new image tag + prod ConfigMap. Manual `pulumi up --stack prod` if any IaC change (none expected). ArgoCD syncs prod.
+7. Post-deploy smoke E2E runs against `https://liverty-music.app/`.
+
+Rollback at any step: revert the offending repo PR. The change is additive in cloud-provisioning (adding ConfigMap doesn't break anything if the image isn't using it yet), so step ordering is forgiving.
+
+### D10. Defense-in-depth: post-build template-presence assertion
+
+Add `frontend/scripts/verify-build-templates.ts` invoked from CI after `npm run build`:
+
+```ts
+// Asserts that every route chunk contains template-derived strings.
+// If a chunk has compiled successfully but its template was stripped
+// (the regression class we just hit), this script fails.
+const routeChunks = glob('dist/assets/*-route-*.js')
+const requiredMarkers: Record<string, string> = {
+  'welcome-route': 'welcome-hero',
+  'dashboard-route': 'dashboard',
+  // ... one well-known template-derived string per route
+}
+for (const [routePrefix, marker] of Object.entries(requiredMarkers)) {
+  const chunk = routeChunks.find(c => c.includes(routePrefix))
+  if (!chunk || !readFileSync(chunk, 'utf-8').includes(marker)) {
+    throw new Error(`Route chunk for ${routePrefix} missing template marker '${marker}'`)
+  }
+}
+```
+
+This catches the specific regression that v1.0.0 hit AND any analogous future regression (HTML import path changing, plugin version bump, etc.). Runs in <100ms, no flakiness.
+
+## Risks / Trade-offs
+
+- **[Risk] Bootstrap-time `/config.json` fetch failure renders the app unable to start** → Mitigation: Caddy serves the file from the same pod (mount, not network), so failure modes are limited to ConfigMap mount errors caught at K8s reconciliation. The shape-validation in `loadAppConfig()` plus D7's environment cross-check fail fast with a static error page that tells the operator exactly what's wrong.
+- **[Risk] PWA offline scenario: user with no network can't bootstrap** → Mitigation: explicit non-goal for this change. If/when offline-tolerant config is needed, switch SW route from `NetworkOnly` to `NetworkFirst` with a short TTL. Additive change.
+- **[Risk] Module-level const reads in `preview-artists.ts` could break if a developer adds an early-import** → Mitigation: D4's `getAppConfig()` throws on premature access. The error message explicitly directs to `loadAppConfig()` in `main.ts`. Add a unit test that imports `preview-artists.ts` without bootstrapping and asserts the throw.
+- **[Risk] ConfigMap content (committed to Git in `cloud-provisioning`) drifts from `.env` in frontend repo when developers add a new `VITE_*`** → Mitigation: TypeScript `AppConfig` interface is the source of truth. Schema validation in `loadAppConfig()` rejects missing-required-field at boot. CI runs the dev image against a dev ConfigMap pre-deploy; missing fields fail there.
+- **[Risk] `subPath` ConfigMap mount caveat (no live update)** → Mitigation: Reloader annotation triggers explicit pod rollout. This is actually preferable (ArgoCD/audit-visible) to silent in-place file swap.
+- **[Risk] Rebuilding for prod release means dev-built and prod-built images differ at the bit level (different timestamps, perhaps minor non-determinism in dependency order)** → Mitigation: functionally identical, since inputs (source + lockfile) are identical. Phase-2 follow-up addresses true bit-identity via dev-AR → prod-AR retag.
+- **[Trade-off] Bootstrap adds one network round-trip before Aurelia.start()** → Cost: ~5ms intra-pod. Imperceptible. Could be avoided by inlining config into `index.html` (rejected in D1.C/D for index.html caching reasons).
+- **[Trade-off] `public/config.json` contains dev hostnames committed to the repo** → No change vs. today (those values already in `.env` and `.env.prod`, all public per D3 of `prepare-prod-service-in`).
+- **[Trade-off] Existing CSP is wildcard-broad to cover both envs** → Pre-existing condition. Tightening CSP requires either runtime CSP generation (Caddy template) or per-env image (which we're explicitly removing). Deferred.
+
+## Migration Plan
+
+**Pre-conditions** (verify before starting):
+- `prepare-prod-service-in` change is acknowledged as superseded for its build-time bake portions (its prod-AR/Workload-Identity work remains in force).
+- Reloader is healthy in both dev and prod clusters (`kubectl get pods -n reloader`).
+- v1.0.0 prod is in current broken state (blank screen); no user impact to coordinate.
+
+**Steps** (matches D9 ordering):
+
+1. Merge `specification/adopt-runtime-config-for-frontend` PR.
+2. Open `cloud-provisioning/adopt-runtime-config-frontend` PR adding:
+   - `k8s/namespaces/frontend/overlays/dev/configmap.yaml`
+   - `k8s/namespaces/frontend/overlays/prod/configmap.yaml`
+   - Deployment patch (volumeMount + volume + Reloader annotation) under `base/web/deployment.yaml`.
+3. Open `frontend/adopt-runtime-config` PR with code refactor + `public/config.json` (dev values) + Caddyfile + Dockerfile cleanup + post-build assertion script. Delete `.env.prod`.
+4. Both PRs reviewed in parallel.
+5. Merge `cloud-provisioning` PR first. ArgoCD applies; dev pod restarts via Reloader, picks up new ConfigMap. Dev still serves the OLD image (no `/config.json` reader yet). No visible change.
+6. Merge `frontend` PR. Dev CI builds new image, pushes to dev-AR `:latest`. ArgoCD Image Updater bumps dev Deployment. New pod starts, fetches `/config.json`, app boots with runtime config. Verify dev `https://dev.liverty-music.app/` works.
+7. Cut frontend release tag `v1.0.1` on the new merge commit. Release CI builds → pushes to `liverty-music-prod/frontend/web-app:v1.0.1`.
+8. Update `cloud-provisioning/k8s/namespaces/frontend/overlays/prod/kustomization.yaml` image pin to `v1.0.1`. Merge.
+9. ArgoCD syncs prod. New pod fetches ConfigMap-backed `/config.json` (prod values). Verify `https://liverty-music.app/` renders.
+10. Run post-deploy smoke E2E (Playwright) against prod URL.
+11. Archive this change in OpenSpec; update specs/ tree.
+
+**Rollback**:
+- After step 5 (cloud-provisioning merged): trivial revert — image still old, ConfigMap unused.
+- After step 6 (frontend merged to dev): revert frontend PR; dev pod redeploys old image. ConfigMap orphaned but harmless.
+- After step 9 (prod): revert cloud-provisioning image pin to previous tag (whatever was working — but note v1.0.0 is broken, so there's no good earlier prod baseline to revert to; rollback in prod means "fix forward").
+
+**Verification at each step**:
+- Step 5: `kubectl describe configmap web-app-runtime-config -n frontend` shows expected data.
+- Step 6: `curl https://dev.liverty-music.app/config.json` returns dev values; `dev.liverty-music.app` loads with expected dashboard content.
+- Step 9: same against prod URL; environment field equals `prod`.
+
+## Open Questions
+
+1. **Should we file the upstream `@aurelia/vite-plugin` PR as a hard prerequisite or parallel deliverable?** → Recommended: parallel. This change doesn't depend on the upstream fix (we sidestep the bug entirely by keeping mode='production'). Upstream PR improves the ecosystem; merge timing is independent.
+
+2. **Should the post-build template-presence assertion be a hard CI fail or a warning during a soak period?** → Recommended: hard fail from day one. The script is deterministic and the bug it guards against is severe (full-app failure). No reason to allow regressions through.
+
+3. **Phase 2 timing for true binary-identical image promotion (dev-AR → prod-AR retag)** → Out of scope for this change. Track as a follow-up issue. Likely triggered by: staging environment introduction OR a security audit requiring "tested image == deployed image" attestation.
+
+4. **Should the `circuitBaseUrl` be moved out of `AppConfig` since it's optional (some envs may not have ZK circuits)?** → Resolution: keep in `AppConfig` as required-string; for envs without circuits set to empty string and have `ProofService` no-op when empty. Simpler than optional-field handling and the value is always known at deploy time.
+
+5. **How do we ensure the ConfigMap content stays in sync with the `AppConfig` TypeScript interface?** → Acceptable for v1: TypeScript interface is single source of truth, `loadAppConfig()` validates shape, missing fields fail loud on bootstrap. Long-term option (not in scope): generate a JSON Schema from TS and validate ConfigMap content in cloud-provisioning CI. Track as follow-up.

--- a/openspec/changes/adopt-runtime-config-for-frontend/proposal.md
+++ b/openspec/changes/adopt-runtime-config-for-frontend/proposal.md
@@ -1,0 +1,55 @@
+## Why
+
+The current frontend bakes per-environment values (`VITE_API_BASE_URL`, `VITE_ZITADEL_*`, `VITE_VAPID_PUBLIC_KEY`, etc.) into the Vite-built SPA bundle via `.env.prod` loaded by `vite build --mode prod`. This approach is structurally fragile and **already produced a Sev-1 regression**: the v1.0.0 prod release renders a blank page at `https://liverty-music.app/` because `@aurelia/vite-plugin@2.0.0-rc.1` literal-checks `mode === 'production'` when bundling component templates ([node_modules/@aurelia/vite-plugin/src/index.ts:64](frontend/node_modules/@aurelia/vite-plugin/src/index.ts#L64)) — any non-`'production'` mode name silently strips templates from lazy route chunks, leaving Aurelia unable to resolve any route (`AUR3174 Failed to resolve VR(component:'unnamed-20')`).
+
+This vulnerability exists in every per-env build that uses a non-`production` mode name. The same class of bug will recur for any future build-time flag that interacts with Vite's `mode`. We have a **single non-recurring window** to fix it cleanly: prod is tagged `v1.0.0` but has zero users (blank page, no PWA installs, no auth sessions, no cached service workers). After service-in, migrating away from build-time env baking becomes 10× more expensive because of installed PWAs, cached SWs, and live user sessions that would need coordinated invalidation.
+
+## What Changes
+
+- **BREAKING (internal-only, pre-service-in)**: Replace build-time `.env.prod` bake with **runtime config injection** via `/config.json` served by Caddy from a K8s ConfigMap mounted per environment.
+- Single container image promoted across environments (dev/prod) — image binary is env-agnostic. Per-env divergence moves to ConfigMap content under `cloud-provisioning/k8s/namespaces/frontend/overlays/<env>/`.
+- New `AppConfig` DI token + async bootstrap that fetches and validates `/config.json` before `Aurelia.start()`. All 8 `import.meta.env.VITE_*` read sites migrate to `resolve(IAppConfig)`.
+- `import.meta.env.DEV` / `PROD` / `MODE` reads (5 sites) are NOT migrated — they retain their original semantics ("`vite` dev server vs `vite build` output") and are env-agnostic.
+- Remove `.env.prod` from the frontend repo and `VITE_MODE` build-arg from the Dockerfile. Vite mode stays `'production'` always — Aurelia plugin's template bundling path stays deterministic.
+- Add post-build assertion in CI: every route chunk MUST contain HTML-template-derived strings (defense against a future analogous regression).
+- Add post-deploy smoke E2E (Playwright) that hits the live URL and asserts non-empty DOM + correct `environment` field in `/config.json`.
+- File upstream issue / PR on `@aurelia/vite-plugin` to use `config.command === 'build'` instead of literal mode check.
+
+## Capabilities
+
+### New Capabilities
+- `frontend-runtime-config`: Defines the runtime configuration contract for the frontend SPA — the `/config.json` schema, the bootstrap load order, the validation/cross-check guards (environment field vs. window hostname), Service-Worker pass-through rules for the config endpoint, and the contract between the SPA bundle and the per-environment K8s ConfigMap.
+
+### Modified Capabilities
+- `prod-image-pipeline`: The "Frontend prod build SHALL bake env-prod values into the SPA bundle" requirement is REMOVED. Replaced by an invariant that the frontend image SHALL be env-agnostic at the bundle level. The release-triggered prod-AR push requirement is preserved but its `.env.prod` bake-time assertion is replaced with a "no env-divergent strings in bundle" assertion.
+- `frontend-hosting`: Adds requirements for Caddy to serve `/config.json` with no-cache headers, for the Deployment to mount a per-env ConfigMap volume at `/srv/config.json` (with Reloader annotation for rollout-on-change), and for the Service Worker to bypass the precache for `/config.json`.
+
+## Impact
+
+**Affected repos**:
+- `frontend` (largest surface): `src/main.ts` (async bootstrap), new `src/config/app-config.ts`, 8 service/route/constant files migrated to DI, `src/sw.ts` (NetworkOnly route for `/config.json`), `Caddyfile` (cache headers), `Dockerfile` (drop `VITE_MODE`), `public/config.json` (dev fallback), delete `.env.prod`.
+- `cloud-provisioning`: New `ConfigMap` per overlay (`overlays/dev/`, `overlays/prod/`), Deployment volumeMount patch in `namespaces/frontend/base/web/deployment.yaml`, Reloader annotation. No Pulumi changes (ConfigMap content lives in Kustomize, same as other static config).
+- `specification`: This change.
+
+**Affected CI**:
+- `frontend/.github/workflows/push-image.yaml`: Drop `VITE_MODE` build-arg from prod path. Both push and release paths build with identical inputs. Optional follow-up: switch to dev-AR → prod-AR retag (true build-once-promote); deferred to Phase 2.
+- New job: post-build template-presence assertion (defense-in-depth).
+- New job: post-deploy smoke E2E.
+
+**Affected dependencies**:
+- `@aurelia/vite-plugin@2.0.0-rc.1`: unchanged; upstream issue/PR filed as parallel deliverable.
+- `oidc-client-ts`, `@connectrpc/connect-web`, OTel SDK: API_BASE_URL / ZITADEL_ISSUER / etc. now sourced from `AppConfig` at construction time rather than at module-eval time.
+
+**User-facing impact**:
+- Pre-service-in (v1.0.0 prod is blank, no real users). Zero session/cookie/SW invalidation cost.
+- After this change: blank-page regression fixed; prod renders normally.
+- Bootstrap adds ~5ms (intra-pod fetch to Caddy) — imperceptible.
+
+**CSP**:
+- No changes. Existing `connect-src 'self' https://*.zitadel.cloud https://*.liverty-music.app` already covers both dev and prod hosts via wildcard. Tightening CSP per-env is a future concern, decoupled from this change.
+
+**Security posture**:
+- All `VITE_*` values are already classified as public by SPA convention (per the archived `prepare-prod-service-in` design D3). No new secret surface introduced. ConfigMap content is committed to Git under `cloud-provisioning`, same trust boundary as today's `.env`.
+
+**Coordination with `prepare-prod-service-in`**:
+- `prepare-prod-service-in` is in-flight in a worktree; this change SUPERSEDES the build-time portions of its D2 (`.env.prod` overlay) and D3 (env values committed to repo) while preserving its prod AR / Workload Identity / image-pin portions. The two changes will reconcile at merge time — this change is authored against `main` and is independent of `prepare-prod-service-in`'s merge order.

--- a/openspec/changes/adopt-runtime-config-for-frontend/specs/frontend-hosting/spec.md
+++ b/openspec/changes/adopt-runtime-config-for-frontend/specs/frontend-hosting/spec.md
@@ -53,7 +53,7 @@ The Kubernetes Deployment for the `web-app` container SHALL mount a ConfigMap vo
 
 ### Requirement: Post-deploy smoke verification SHALL assert the SPA renders
 
-After any deploy that updates the frontend image or ConfigMap in any environment, an automated post-deploy smoke check SHALL fetch the environment's homepage URL, load it in a headless browser (Playwright), and assert that the rendered DOM is non-empty and that the SPA's first-screen UI element is present. This catches blank-page regressions agnostic of root cause.
+After any deploy that updates the frontend image or ConfigMap in any environment, an automated post-deploy smoke check SHALL fetch the environment's homepage URL, load it in a headless browser (Playwright), and assert that the rendered DOM is non-empty and that the SPA's first-screen UI element is present. This catches blank-page regressions agnostic of root cause. The smoke run SHALL be bounded by a wall-clock timeout (60 seconds default) so that a hanging deploy fails closed rather than indefinitely blocking the pipeline.
 
 #### Scenario: Smoke check asserts non-empty rendered DOM
 
@@ -70,6 +70,6 @@ After any deploy that updates the frontend image or ConfigMap in any environment
 #### Scenario: Smoke failure blocks promotion
 
 - **WHEN** a deploy to a non-prod environment triggers the smoke check
-- **AND** any smoke assertion fails
+- **AND** any smoke assertion fails OR the smoke run exceeds its wall-clock timeout
 - **THEN** the deploy workflow SHALL be marked failed
 - **AND** the promotion of the same artifact to the next environment SHALL NOT proceed automatically

--- a/openspec/changes/adopt-runtime-config-for-frontend/specs/frontend-hosting/spec.md
+++ b/openspec/changes/adopt-runtime-config-for-frontend/specs/frontend-hosting/spec.md
@@ -42,7 +42,7 @@ The Kubernetes Deployment for the `web-app` container SHALL mount a ConfigMap vo
 
 - **WHEN** inspecting the rendered `web-app` Deployment in any environment overlay
 - **THEN** the Deployment metadata SHALL include the annotation `reloader.stakater.com/auto: "true"`
-- **AND** when the `web-app-runtime-config` ConfigMap is updated in-cluster, Reloader SHALL initiate a rolling restart of the Deployment within 30 seconds
+- **AND** the cluster's deployed Reloader operator SHALL be responsible for issuing the rolling restart when `web-app-runtime-config` changes. Precise rollout latency is determined by the operator's configured reconciliation interval (typically tens of seconds) and is an operational expectation rather than a CI-testable assertion. See `Risks / Trade-offs` in the proposing change for the live-update caveat behind this mechanism.
 
 #### Scenario: Pod is healthy with the mounted config
 

--- a/openspec/changes/adopt-runtime-config-for-frontend/specs/frontend-hosting/spec.md
+++ b/openspec/changes/adopt-runtime-config-for-frontend/specs/frontend-hosting/spec.md
@@ -1,0 +1,75 @@
+# frontend-hosting Specification
+
+## ADDED Requirements
+
+### Requirement: Caddy SHALL serve `/config.json` with no-cache headers
+
+The Caddy web server in the frontend container SHALL serve `/config.json` from the document root (`/srv/config.json`) with `Cache-Control: no-cache, no-store, must-revalidate` and `Content-Type: application/json; charset=utf-8` response headers. This ensures that ConfigMap updates (followed by pod rollout) propagate to clients on the next page load without depending on cache busting at the URL level.
+
+#### Scenario: Caddyfile defines the /config.json header rule
+
+- **WHEN** inspecting `frontend/Caddyfile`
+- **THEN** a matcher SHALL be defined for `path /config.json`
+- **AND** the matcher SHALL set `Cache-Control` to a value containing `no-cache`
+- **AND** the matcher SHALL set `Content-Type` to `application/json; charset=utf-8` (the file extension default also produces JSON, but the explicit header guards against future mount-source changes)
+
+#### Scenario: Live response carries the headers
+
+- **WHEN** running `curl -I https://<env>.liverty-music.app/config.json` (or the apex for prod)
+- **THEN** the response status SHALL be `200`
+- **AND** the `Cache-Control` header SHALL contain `no-cache`
+- **AND** the `Content-Type` header SHALL be `application/json` (charset suffix permitted)
+
+### Requirement: Frontend Deployment SHALL mount a per-environment runtime-config ConfigMap
+
+The Kubernetes Deployment for the `web-app` container SHALL mount a ConfigMap volume at `/srv/config.json` using a `subPath` mount, sourced from a ConfigMap named `web-app-runtime-config` in the same namespace. Each environment overlay under `cloud-provisioning/k8s/namespaces/frontend/overlays/<env>/` SHALL define this ConfigMap with the values appropriate for that environment. The Deployment SHALL carry a Reloader annotation so that ConfigMap changes trigger a rolling restart.
+
+#### Scenario: Base Deployment declares the volume and volumeMount
+
+- **WHEN** inspecting `cloud-provisioning/k8s/namespaces/frontend/base/web/deployment.yaml` (or an equivalent base patch)
+- **THEN** the `caddy` container SHALL declare a `volumeMounts` entry with `name: runtime-config`, `mountPath: /srv/config.json`, and `subPath: config.json`
+- **AND** the pod template SHALL declare a `volumes` entry with `name: runtime-config` sourced from a ConfigMap with `name: web-app-runtime-config`
+
+#### Scenario: Per-environment overlay defines the ConfigMap
+
+- **WHEN** inspecting `cloud-provisioning/k8s/namespaces/frontend/overlays/<env>/` for each env in `{dev, prod}` (and `staging` if/when introduced)
+- **THEN** a ConfigMap named `web-app-runtime-config` SHALL exist (defined inline in `configmap.yaml` or via `configMapGenerator`)
+- **AND** the ConfigMap SHALL have a `config.json` key whose value parses as JSON
+- **AND** the parsed JSON SHALL conform to the AppConfig schema declared in the `frontend-runtime-config` capability
+- **AND** the `environment` field SHALL match the overlay's environment identifier (`dev` → `dev`, `prod` → `prod`)
+
+#### Scenario: Reloader annotation triggers rollout on ConfigMap change
+
+- **WHEN** inspecting the rendered `web-app` Deployment in any environment overlay
+- **THEN** the Deployment metadata SHALL include the annotation `reloader.stakater.com/auto: "true"`
+- **AND** when the `web-app-runtime-config` ConfigMap is updated in-cluster, Reloader SHALL initiate a rolling restart of the Deployment within 30 seconds
+
+#### Scenario: Pod is healthy with the mounted config
+
+- **WHEN** a pod from this Deployment is running
+- **AND** `kubectl exec` into the container reads `/srv/config.json`
+- **THEN** the file content SHALL equal the `config.json` value from the ConfigMap (modulo trailing whitespace)
+- **AND** `curl localhost/config.json` from inside the pod SHALL return the same content with the headers defined in the "Caddy SHALL serve `/config.json` with no-cache headers" requirement
+
+### Requirement: Post-deploy smoke verification SHALL assert the SPA renders
+
+After any deploy that updates the frontend image or ConfigMap in any environment, an automated post-deploy smoke check SHALL fetch the environment's homepage URL, load it in a headless browser (Playwright), and assert that the rendered DOM is non-empty and that the SPA's first-screen UI element is present. This catches blank-page regressions agnostic of root cause.
+
+#### Scenario: Smoke check asserts non-empty rendered DOM
+
+- **WHEN** the smoke check loads `https://<env-host>/` after a deploy
+- **AND** waits for `networkidle` (or equivalent stabilization signal)
+- **THEN** `document.body.innerText.trim()` SHALL be non-empty
+- **AND** at least one element matching the welcome route's first-screen selector (e.g., `.welcome-hero` or `[data-screen-1]`) SHALL be present in the DOM
+
+#### Scenario: Smoke check validates /config.json environment field
+
+- **WHEN** the smoke check fetches `https://<env-host>/config.json` after a deploy
+- **THEN** the response's `environment` field SHALL equal the expected environment for that host (`dev` for `dev.liverty-music.app`, `prod` for `liverty-music.app`)
+
+#### Scenario: Smoke failure blocks promotion
+
+- **WHEN** a deploy to a non-prod environment triggers the smoke check
+- **AND** any smoke assertion fails
+- **THEN** the deploy workflow SHALL be marked failed
+- **AND** the promotion of the same artifact to the next environment SHALL NOT proceed automatically

--- a/openspec/changes/adopt-runtime-config-for-frontend/specs/frontend-runtime-config/spec.md
+++ b/openspec/changes/adopt-runtime-config-for-frontend/specs/frontend-runtime-config/spec.md
@@ -1,0 +1,126 @@
+# frontend-runtime-config Specification
+
+## ADDED Requirements
+
+### Requirement: Frontend SPA SHALL load environment configuration from `/config.json` at bootstrap
+
+The Aurelia 2 frontend SPA SHALL fetch a same-origin `/config.json` file during application bootstrap and use the parsed values as the source of truth for all environment-divergent configuration (API base URL, OIDC issuer/client/org IDs, VAPID public key, ZK circuit base URL, log level, preview artist data, and the environment identifier). The fetch SHALL complete before `Aurelia.start()` is invoked, so that all services and route components receive the resolved configuration via dependency injection on first construction. The SPA SHALL NOT read these values from `import.meta.env.VITE_*` at runtime in shipped production builds.
+
+#### Scenario: Bootstrap blocks on config fetch before Aurelia starts
+
+- **WHEN** the SPA is loaded in a browser
+- **THEN** the bootstrap entry point SHALL invoke `fetch('/config.json', { cache: 'no-store' })` before constructing the Aurelia application instance
+- **AND** SHALL await the fetch and JSON parse to completion
+- **AND** SHALL only call `Aurelia.start()` (or equivalent) after the parsed configuration is available
+- **AND** SHALL register the parsed configuration as a DI singleton accessible to all services
+
+#### Scenario: Bundle contains no env-divergent VITE_ values
+
+- **WHEN** searching any JavaScript chunk in the built `dist/` output for strings matching `https://api\.(dev\.)?liverty-music\.app`, `https://auth\.(dev\.)?liverty-music\.app`, the dev OIDC `client_id`, the prod OIDC `client_id`, the dev VAPID public key, or the prod VAPID public key
+- **THEN** zero occurrences SHALL be found in any of those patterns
+- **AND** the only origin-specific URL that MAY appear in chunks SHALL be `window.location.origin`-derived (e.g., redirect URIs constructed at runtime)
+
+#### Scenario: All eight legacy VITE_ read sites are migrated
+
+- **WHEN** running `grep -rn 'import\.meta\.env\.VITE_' frontend/src`
+- **THEN** the result SHALL be empty
+- **AND** the corresponding values SHALL be obtained from the `AppConfig` DI token instead
+
+#### Scenario: import.meta.env.DEV reads are preserved
+
+- **WHEN** running `grep -rn 'import\.meta\.env\.\(DEV\|PROD\|MODE\)' frontend/src`
+- **THEN** the result MAY contain reads
+- **AND** every such read SHALL encode "running under `vite` dev server vs. running from a `vite build` artifact" — not "which deployed environment serves this bundle"
+
+### Requirement: `/config.json` SHALL conform to the AppConfig schema
+
+The runtime configuration document SHALL be a JSON object whose top-level shape exactly matches the TypeScript `AppConfig` interface declared in `frontend/src/config/app-config.ts`. The interface SHALL be the single source of truth for the contract between the SPA bundle and any environment that serves `/config.json`. The schema fields SHALL include: `environment` (one of `dev | staging | prod`), `apiBaseUrl` (absolute https URL), `zitadelIssuer` (absolute https URL), `zitadelClientId` (non-empty string), `zitadelOrgId` (non-empty string), `vapidPublicKey` (non-empty string), `circuitBaseUrl` (string, MAY be empty when ZK circuits are unavailable in the environment), `previewArtistIds` (string array), `previewArtistNames` (string array, same length as `previewArtistIds`), and `logLevel` (one of `trace | debug | info | warn | error`).
+
+#### Scenario: Bootstrap validates required fields
+
+- **WHEN** `/config.json` is fetched and parsed
+- **AND** any of `apiBaseUrl`, `zitadelIssuer`, `zitadelClientId`, `vapidPublicKey`, `environment` is missing, empty, or not a string of the expected shape
+- **THEN** bootstrap SHALL throw an error naming the offending field
+- **AND** the SPA SHALL NOT call `Aurelia.start()`
+- **AND** the page SHALL render a minimal static error notice that surfaces the validation failure to the user
+
+#### Scenario: Optional fields tolerate empty strings
+
+- **WHEN** `circuitBaseUrl` is an empty string in the parsed config
+- **THEN** bootstrap SHALL succeed
+- **AND** the `ProofService` (or equivalent ZK-using service) SHALL treat the empty value as "circuits unavailable in this environment" and disable ZK features accordingly
+
+### Requirement: Bootstrap SHALL cross-check the configured environment against the page host
+
+The SPA SHALL refuse to start if the `environment` field in `/config.json` is inconsistent with `window.location.hostname` for the well-known production hostnames. This guards against the failure mode in which a misconfigured deployment serves the image's bundled fallback config in a production-tier environment.
+
+#### Scenario: Production host with dev config refuses to start
+
+- **WHEN** the page is loaded at `https://liverty-music.app/` (production apex)
+- **AND** `/config.json` has `environment` field equal to `dev` or `staging`
+- **THEN** bootstrap SHALL throw an error naming the mismatch
+- **AND** the SPA SHALL NOT call `Aurelia.start()`
+- **AND** the rendered error page SHALL state the expected and actual environment values
+
+#### Scenario: Localhost or preview hostname skips the check
+
+- **WHEN** the page is loaded at `http://localhost`, `http://127.0.0.1`, or any hostname not in the well-known production list
+- **THEN** bootstrap SHALL skip the host-vs-environment check
+- **AND** SHALL proceed with whatever `environment` value is in `/config.json`
+
+### Requirement: A checked-in `public/config.json` SHALL provide dev defaults
+
+The frontend repository SHALL maintain a `public/config.json` file at the root of the Vite public directory containing dev environment values. This file serves three purposes: (1) it makes `npm start` (the Vite dev server) work without external configuration, (2) it provides accurate values for Storybook and local Playwright runs, and (3) it acts as an in-image fallback that — combined with the environment cross-check — produces a loud failure mode if a per-environment ConfigMap mount is missing in a non-dev cluster.
+
+#### Scenario: Public config.json contains dev values
+
+- **WHEN** inspecting `frontend/public/config.json`
+- **THEN** the file SHALL exist
+- **AND** its `environment` field SHALL equal `dev`
+- **AND** its `apiBaseUrl` SHALL equal `https://api.dev.liverty-music.app`
+- **AND** its `zitadelIssuer` SHALL equal `https://auth.dev.liverty-music.app`
+
+#### Scenario: Public config.json is served by Vite dev server
+
+- **WHEN** running `npm start` and requesting `http://localhost:9000/config.json`
+- **THEN** the response status SHALL be `200`
+- **AND** the body SHALL be the JSON content of `public/config.json`
+
+### Requirement: The Service Worker SHALL bypass any cache for `/config.json`
+
+The Workbox-based Service Worker SHALL include an explicit `NetworkOnly` route for the `/config.json` request, so that ConfigMap updates (followed by pod rollout) are picked up by subsequent navigations without depending on cache-busting URLs. The runtime config endpoint SHALL NOT be included in the precache manifest (`__WB_MANIFEST`).
+
+#### Scenario: SW route exists for /config.json
+
+- **WHEN** inspecting `frontend/src/sw.ts`
+- **THEN** a `registerRoute` call SHALL exist that matches `url.pathname === '/config.json'`
+- **AND** the strategy SHALL be `NetworkOnly`
+
+#### Scenario: /config.json is not precached
+
+- **WHEN** inspecting the built `dist/sw.js`'s `__WB_MANIFEST` array
+- **THEN** no entry SHALL have a URL ending in `/config.json`
+
+#### Scenario: Online reload picks up new ConfigMap content
+
+- **WHEN** the ConfigMap is updated and pods restart (via Reloader)
+- **AND** an online client reloads the page
+- **THEN** the SPA SHALL fetch the new `/config.json` content directly from Caddy via the SW pass-through
+- **AND** the new values SHALL take effect for the lifetime of the new page load
+
+### Requirement: Bootstrap failures SHALL surface a static error page
+
+When any failure occurs between the page load and `Aurelia.start()` (network failure on `/config.json`, JSON parse error, schema validation failure, or environment cross-check failure), the SPA SHALL replace the document body with a minimal static error page that identifies the failure category and (in non-production environments) the underlying error message. The error page SHALL NOT depend on any Aurelia-provided UI primitive.
+
+#### Scenario: Network failure on /config.json shows error page
+
+- **WHEN** `/config.json` fetch returns a non-2xx status or fails with a network error
+- **THEN** the document body SHALL be replaced with a static error block
+- **AND** the block SHALL include the literal text "App failed to start" or equivalent
+- **AND** the block SHALL include the HTTP status or error class for diagnosis
+
+#### Scenario: Schema validation failure shows error page
+
+- **WHEN** `/config.json` parses successfully but fails the required-field validation
+- **THEN** the document body SHALL be replaced with the static error block
+- **AND** the block SHALL name the offending field

--- a/openspec/changes/adopt-runtime-config-for-frontend/specs/frontend-runtime-config/spec.md
+++ b/openspec/changes/adopt-runtime-config-for-frontend/specs/frontend-runtime-config/spec.md
@@ -34,25 +34,27 @@ The Aurelia 2 frontend SPA SHALL fetch a same-origin `/config.json` file during 
 
 ### Requirement: `/config.json` SHALL conform to the AppConfig schema
 
-The runtime configuration document SHALL be a JSON object whose top-level shape exactly matches the TypeScript `AppConfig` interface declared in `frontend/src/config/app-config.ts`. The interface SHALL be the single source of truth for the contract between the SPA bundle and any environment that serves `/config.json`. The schema fields SHALL include: `environment` (one of `dev | staging | prod`), `apiBaseUrl` (absolute https URL), `zitadelIssuer` (absolute https URL), `zitadelClientId` (non-empty string), `zitadelOrgId` (non-empty string), `vapidPublicKey` (non-empty string), `circuitBaseUrl` (string, MAY be empty when ZK circuits are unavailable in the environment), `previewArtistIds` (string array), `previewArtistNames` (string array, same length as `previewArtistIds`), and `logLevel` (one of `trace | debug | info | warn | error`).
+The runtime configuration document SHALL be a JSON object whose top-level shape exactly matches the TypeScript `AppConfig` interface declared in `frontend/src/config/app-config.ts`. The interface SHALL be the single source of truth for the contract between the SPA bundle and any environment that serves `/config.json`. The schema fields SHALL include: `environment` (one of `dev | staging | prod`), `apiBaseUrl` (absolute https URL), `zitadelIssuer` (absolute https URL), `zitadelClientId` (non-empty string), `zitadelOrgId` (non-empty string), `vapidPublicKey` (non-empty string), `circuitBaseUrl` (string, MAY be empty when ZK circuits are unavailable in the environment), `previewArtistIds` (string array), `previewArtistNames` (string array, same length as `previewArtistIds`), and `logLevel` (one of `trace | debug | info | warn | error`). All fields except `circuitBaseUrl` (which MAY be empty) and the two `previewArtist*` arrays (which MAY be empty) are required-and-non-empty; the spec's "MAY be empty" carve-outs are exhaustive.
 
 #### Scenario: Bootstrap validates required fields
 
 - **WHEN** `/config.json` is fetched and parsed
-- **AND** any of `apiBaseUrl`, `zitadelIssuer`, `zitadelClientId`, `vapidPublicKey`, `environment` is missing, empty, or not a string of the expected shape
+- **AND** any of `apiBaseUrl`, `zitadelIssuer`, `zitadelClientId`, `zitadelOrgId`, `vapidPublicKey`, `environment`, or `logLevel` is missing, empty, or not a string of the expected shape
 - **THEN** bootstrap SHALL throw an error naming the offending field
 - **AND** the SPA SHALL NOT call `Aurelia.start()`
 - **AND** the page SHALL render a minimal static error notice that surfaces the validation failure to the user
 
-#### Scenario: Optional fields tolerate empty strings
+#### Scenario: Empty-string `circuitBaseUrl` disables ZK features
 
-- **WHEN** `circuitBaseUrl` is an empty string in the parsed config
-- **THEN** bootstrap SHALL succeed
-- **AND** the `ProofService` (or equivalent ZK-using service) SHALL treat the empty value as "circuits unavailable in this environment" and disable ZK features accordingly
+- **WHEN** `circuitBaseUrl` is present in the parsed config but is the empty string
+- **THEN** bootstrap SHALL succeed (the field is required-present but MAY be empty per the schema)
+- **AND** the `ProofService` (or equivalent ZK-using service) SHALL treat the empty value as "circuits unavailable in this environment" and disable ZK features at the call sites without attempting any circuit fetch
 
 ### Requirement: Bootstrap SHALL cross-check the configured environment against the page host
 
-The SPA SHALL refuse to start if the `environment` field in `/config.json` is inconsistent with `window.location.hostname` for the well-known production hostnames. This guards against the failure mode in which a misconfigured deployment serves the image's bundled fallback config in a production-tier environment.
+The SPA SHALL refuse to start if the `environment` field in `/config.json` is inconsistent with `window.location.hostname` for the well-known production-tier hostnames (`liverty-music.app` → `prod`, `dev.liverty-music.app` → `dev`, `staging.liverty-music.app` → `staging`). This guards against the failure mode in which a misconfigured deployment serves the image's bundled fallback config in a production-tier environment.
+
+The `staging` environment is reserved/forward-looking: the `AppConfig.environment` union includes it and the host map MUST include `staging.liverty-music.app`, but no Kubernetes overlay or hostname currently maps to `staging` (introduced when the staging cluster is provisioned by a future change). The cross-check requirement holds whether or not the staging cluster exists yet.
 
 #### Scenario: Production host with dev config refuses to start
 
@@ -62,9 +64,22 @@ The SPA SHALL refuse to start if the `environment` field in `/config.json` is in
 - **AND** the SPA SHALL NOT call `Aurelia.start()`
 - **AND** the rendered error page SHALL state the expected and actual environment values
 
+#### Scenario: Staging host with non-staging config refuses to start
+
+- **WHEN** the page is loaded at `https://staging.liverty-music.app/`
+- **AND** `/config.json` has `environment` field equal to `dev` or `prod`
+- **THEN** bootstrap SHALL throw an error naming the mismatch
+- **AND** the SPA SHALL NOT call `Aurelia.start()`
+
+#### Scenario: Staging host with staging config passes
+
+- **WHEN** the page is loaded at `https://staging.liverty-music.app/`
+- **AND** `/config.json` has `environment` field equal to `staging`
+- **THEN** the host cross-check SHALL pass and bootstrap SHALL proceed
+
 #### Scenario: Localhost or preview hostname skips the check
 
-- **WHEN** the page is loaded at `http://localhost`, `http://127.0.0.1`, or any hostname not in the well-known production list
+- **WHEN** the page is loaded at `http://localhost`, `http://127.0.0.1`, or any hostname not in the well-known production-tier list
 - **THEN** bootstrap SHALL skip the host-vs-environment check
 - **AND** SHALL proceed with whatever `environment` value is in `/config.json`
 

--- a/openspec/changes/adopt-runtime-config-for-frontend/specs/frontend-runtime-config/spec.md
+++ b/openspec/changes/adopt-runtime-config-for-frontend/specs/frontend-runtime-config/spec.md
@@ -50,6 +50,14 @@ The runtime configuration document SHALL be a JSON object whose top-level shape 
 - **THEN** bootstrap SHALL succeed (the field is required-present but MAY be empty per the schema)
 - **AND** the `ProofService` (or equivalent ZK-using service) SHALL treat the empty value as "circuits unavailable in this environment" and disable ZK features at the call sites without attempting any circuit fetch
 
+#### Scenario: `previewArtistIds` and `previewArtistNames` length mismatch is rejected
+
+- **WHEN** `/config.json` parses successfully
+- **AND** `previewArtistIds.length` does not equal `previewArtistNames.length`
+- **THEN** bootstrap SHALL throw an error naming the length-mismatch invariant
+- **AND** the SPA SHALL NOT call `Aurelia.start()`
+- **AND** the rendered error page SHALL state the observed lengths so the operator can correct the ConfigMap
+
 ### Requirement: Bootstrap SHALL cross-check the configured environment against the page host
 
 The SPA SHALL refuse to start if the `environment` field in `/config.json` is inconsistent with `window.location.hostname` for the well-known production-tier hostnames (`liverty-music.app` → `prod`, `dev.liverty-music.app` → `dev`, `staging.liverty-music.app` → `staging`). This guards against the failure mode in which a misconfigured deployment serves the image's bundled fallback config in a production-tier environment.

--- a/openspec/changes/adopt-runtime-config-for-frontend/specs/frontend-runtime-config/spec.md
+++ b/openspec/changes/adopt-runtime-config-for-frontend/specs/frontend-runtime-config/spec.md
@@ -62,7 +62,7 @@ The runtime configuration document SHALL be a JSON object whose top-level shape 
 
 The SPA SHALL refuse to start if the `environment` field in `/config.json` is inconsistent with `window.location.hostname` for the well-known production-tier hostnames (`liverty-music.app` → `prod`, `dev.liverty-music.app` → `dev`, `staging.liverty-music.app` → `staging`). This guards against the failure mode in which a misconfigured deployment serves the image's bundled fallback config in a production-tier environment.
 
-The `staging` environment is reserved/forward-looking: the `AppConfig.environment` union includes it and the host map MUST include `staging.liverty-music.app`, but no Kubernetes overlay or hostname currently maps to `staging` (introduced when the staging cluster is provisioned by a future change). The cross-check requirement holds whether or not the staging cluster exists yet.
+> **Note on staging**: `staging` is reserved/forward-looking. The `AppConfig.environment` union includes it AND the host map MUST include `staging.liverty-music.app` so that the SPA bundle is ready for staging the moment a cluster is provisioned — but no Kubernetes overlay or hostname currently maps to `staging`. **The staging-host scenarios below are aspirational placeholders, not blocking acceptance criteria for the initial implementation.** Implementers MAY treat the staging scenarios as forward-looking documentation; they become enforceable acceptance criteria when a `staging` overlay is added in a follow-up change. The other (dev / prod) scenarios in this requirement ARE blocking.
 
 #### Scenario: Production host with dev config refuses to start
 

--- a/openspec/changes/adopt-runtime-config-for-frontend/specs/prod-image-pipeline/spec.md
+++ b/openspec/changes/adopt-runtime-config-for-frontend/specs/prod-image-pipeline/spec.md
@@ -1,0 +1,68 @@
+# prod-image-pipeline Specification
+
+## REMOVED Requirements
+
+### Requirement: Frontend prod build SHALL bake env-prod values into the SPA bundle
+
+**Reason**: Build-time env baking is structurally fragile (it caused the v1.0.0 blank-screen Sev-1 by interacting with `@aurelia/vite-plugin`'s literal `mode === 'production'` check) and produces per-environment images whose runtime behavior cannot be verified against a single artifact. The new model fetches `/config.json` at bootstrap from a per-environment K8s ConfigMap, eliminating build-time env divergence entirely.
+
+**Migration**: Per-environment values move out of `frontend/.env.prod` (deleted) and into `cloud-provisioning/k8s/namespaces/frontend/overlays/<env>/configmap.yaml`. The frontend image SHALL be built with no env-specific build-args. See the new `frontend-runtime-config` capability for the runtime config contract and the new ADDED requirement below for the env-agnostic bundle invariant.
+
+## ADDED Requirements
+
+### Requirement: Frontend prod image SHALL be env-agnostic at the bundle level
+
+The frontend container image SHALL be built with no env-specific build-args, so that the bundle's JavaScript chunks contain no environment-divergent literals (no hardcoded dev or prod hostnames, no OIDC client IDs, no VAPID public keys, no environment flags other than Vite's `import.meta.env.DEV` / `PROD` / `MODE` which encode "vite dev server vs. vite build artifact"). Per-environment values SHALL be sourced exclusively from `/config.json` served at request time. This invariant SHALL be asserted by CI on every build.
+
+#### Scenario: Bundle contains no env-divergent hostnames
+
+- **WHEN** searching every JavaScript chunk in the built `dist/` output (excluding `public/config.json` which is the bundled fallback) for substrings of dev or prod hostnames (`api.dev.liverty-music.app`, `api.liverty-music.app`, `auth.dev.liverty-music.app`, `auth.liverty-music.app`)
+- **THEN** zero matches SHALL be found in any chunk's compiled JavaScript
+
+#### Scenario: Bundle contains no OIDC client IDs
+
+- **WHEN** searching every JavaScript chunk for the literal dev OIDC client_id (`371355407710421859`) or the literal prod OIDC client_id (`373015520582107291`)
+- **THEN** zero matches SHALL be found
+
+#### Scenario: Image build receives no env-specific build-arg
+
+- **WHEN** inspecting `frontend/Dockerfile`
+- **THEN** no `ARG VITE_MODE` declaration SHALL exist
+- **AND** the `npm run build` command SHALL NOT receive a `--mode` flag
+
+#### Scenario: Same image SHA can be deployed to multiple environments
+
+- **WHEN** the same image (by digest) is pulled by a `frontend` namespace pod in any of dev, staging, or prod clusters
+- **AND** the pod's ConfigMap mount serves a `/config.json` for its target environment
+- **THEN** the SPA SHALL function correctly in that environment without any image-level change
+
+## MODIFIED Requirements
+
+### Requirement: Frontend prod image build SHALL be triggered by GitHub Release tags
+
+The frontend `push-image.yaml` workflow SHALL build and push to `liverty-music-prod/frontend/web-app` Artifact Registry only when triggered by a published GitHub Release. The build SHALL be env-agnostic (per the "Frontend prod image SHALL be env-agnostic at the bundle level" requirement) — the same Dockerfile inputs are used whether the workflow's trigger is `push: branches: [main]` (dev path) or `release: types: [published]` (prod path). The image SHALL be tagged with the release's tag and with the commit SHA. The existing dev path (push-to-main → `liverty-music-dev/frontend/web-app:latest,:<sha>`) SHALL be preserved.
+
+#### Scenario: Push to main triggers dev-only frontend build
+
+- **WHEN** a commit is pushed to `liverty-music/frontend:main`
+- **THEN** the workflow SHALL push only to `liverty-music-dev/frontend/web-app`
+- **AND** SHALL NOT push to `liverty-music-prod/frontend/web-app`
+
+#### Scenario: GitHub Release publish triggers prod frontend build
+
+- **WHEN** a GitHub Release is published in `liverty-music/frontend` with tag `vX.Y.Z`
+- **THEN** the workflow SHALL push to `liverty-music-prod/frontend/web-app`
+- **AND** the image SHALL carry tag `vX.Y.Z` and the commit SHA
+
+#### Scenario: Prod and dev builds use identical Dockerfile inputs
+
+- **WHEN** comparing the `docker build` invocations of the dev push path and the release prod path
+- **THEN** neither invocation SHALL pass a `--build-arg VITE_MODE` (or any other env-specific build-arg)
+- **AND** the Dockerfile evaluation SHALL produce functionally identical `/srv/*` content for both paths, modulo timestamps and other non-deterministic build metadata
+
+#### Scenario: Post-build template-presence assertion gates both paths
+
+- **WHEN** either the dev push path or the release prod path runs `npm run build`
+- **THEN** a post-build assertion step SHALL run `scripts/verify-build-templates.ts` (or equivalent)
+- **AND** the step SHALL fail the workflow if any route chunk under `dist/assets/*-route-*.js` does not contain its expected template-derived marker string
+- **AND** the workflow SHALL refuse to push the image if the assertion fails

--- a/openspec/changes/adopt-runtime-config-for-frontend/tasks.md
+++ b/openspec/changes/adopt-runtime-config-for-frontend/tasks.md
@@ -85,4 +85,14 @@
 
 ## 10. Archive
 
-- [ ] 10.1 After tasks 1–8 verified in dev + prod, mark this change complete and prepare an archive PR per the repo's openspec-sync-specs pattern (move `openspec/changes/adopt-runtime-config-for-frontend/` to `openspec/changes/archive/<date>-adopt-runtime-config-for-frontend/` and merge the spec deltas into `openspec/specs/`)
+- [ ] 10.1 After tasks 1–8 verified in dev + prod, mark this change complete and prepare an archive PR per the repo's openspec-sync-specs pattern (move `openspec/changes/adopt-runtime-config-for-frontend/` to `openspec/changes/archive/<date>-adopt-runtime-config-for-frontend/`).
+- [ ] 10.2 Merge spec deltas into canonical `openspec/specs/`:
+  - **Add** new `openspec/specs/frontend-runtime-config/spec.md` (full file from this change's `specs/frontend-runtime-config/spec.md`).
+  - **Edit** `openspec/specs/prod-image-pipeline/spec.md`:
+    - DELETE the requirement "Frontend prod build SHALL bake env-prod values into the SPA bundle" with all three of its scenarios (Prod build resolves API endpoints to prod hostnames; Prod build uses prod SPA OIDC client_id; Prod build uses info-level logging).
+    - REPLACE the requirement "Frontend prod image build SHALL be triggered by GitHub Release tags" with the MODIFIED version from this change (drops the `.env.prod` bake-time assertion, adds the env-agnostic-build + identical-Dockerfile-inputs scenarios + post-build template-presence gate scenario).
+    - ADD the new requirement "Frontend prod image SHALL be env-agnostic at the bundle level" with all four of its scenarios.
+  - **Edit** `openspec/specs/frontend-hosting/spec.md`:
+    - APPEND the three new ADDED requirements: "Caddy SHALL serve `/config.json` with no-cache headers"; "Frontend Deployment SHALL mount a per-environment runtime-config ConfigMap"; "Post-deploy smoke verification SHALL assert the SPA renders".
+    - The existing "Caddyfile configuration" requirement remains; its scenarios are unchanged in shape (no scenario deletion).
+- [ ] 10.3 Run `openspec validate` against the merged canonical specs to confirm no orphan references remain (e.g., the `.env.prod` string in any spec file).

--- a/openspec/changes/adopt-runtime-config-for-frontend/tasks.md
+++ b/openspec/changes/adopt-runtime-config-for-frontend/tasks.md
@@ -66,9 +66,9 @@
 
 ## 8. Coordinated rollout
 
-- [ ] 8.1 Merge specification PR (this change) — captures the contract
-- [ ] 8.2 Open cloud-provisioning PR (tasks 6.x) — review in parallel
-- [ ] 8.3 Open frontend PR (tasks 1.x–5.x, 7.x) — review in parallel
+- [x] 8.1 Merge specification PR (this change) — captures the contract — _PR open: liverty-music/specification#486; merge user-gated after CI passes_
+- [x] 8.2 Open cloud-provisioning PR (tasks 6.x) — review in parallel — _liverty-music/cloud-provisioning#275_
+- [x] 8.3 Open frontend PR (tasks 1.x–5.x, 7.x) — review in parallel — _liverty-music/frontend#358_
 - [ ] 8.4 Merge cloud-provisioning PR first → ArgoCD applies, dev pod restarts via Reloader, ConfigMap mounted but old image still ignores it. Verify dev still works as today
 - [ ] 8.5 Merge frontend PR → dev CI builds new image, ArgoCD Image Updater bumps dev Deployment. Verify `https://dev.liverty-music.app/` loads and `curl https://dev.liverty-music.app/config.json` returns dev values
 - [ ] 8.6 Cut frontend release `v1.0.1` (or appropriate semver) on the new merge commit on `main` HEAD. Verify release CI builds and pushes to `liverty-music-prod/frontend/web-app:v1.0.1,:<sha>`

--- a/openspec/changes/adopt-runtime-config-for-frontend/tasks.md
+++ b/openspec/changes/adopt-runtime-config-for-frontend/tasks.md
@@ -1,0 +1,88 @@
+## 1. Frontend — runtime config plumbing
+
+- [x] 1.1 Create `frontend/src/config/app-config.ts` exporting: `AppConfig` interface, `IAppConfig` DI token, `loadAppConfig()` async loader (with required-field validation), `getAppConfig()` synchronous accessor (throws if pre-bootstrap), `validateEnvironmentMatchesHost(config)` for production-host cross-check
+- [x] 1.2 Write unit tests (`app-config.spec.ts`): valid config resolves; missing required field throws with field name in error; environment-vs-host mismatch throws; `getAppConfig()` throws before `loadAppConfig()` is called
+- [x] 1.3 Refactor `frontend/src/main.ts` to an async `bootstrap()` function: call `loadAppConfig()`, then `validateEnvironmentMatchesHost(config)`, then `initOtel(config.apiBaseUrl)`, then construct Aurelia + register `IAppConfig` instance, then `au.start()`. Wrap with `.catch(showStaticErrorPage)`
+- [x] 1.4 Add a `showStaticErrorPage(err)` helper in `main.ts` (or a sibling module) that replaces `document.body.innerHTML` with a minimal error block per the `frontend-runtime-config` spec
+- [x] 1.5 Migrate `frontend/src/services/auth-service.ts`: `createSettings()` accepts `AppConfig`; `AuthService` constructor resolves `IAppConfig` and passes it to `createSettings()`. Replace all 4 `import.meta.env.VITE_*` reads. Keep `import.meta.env.DEV` reads unchanged
+- [x] 1.6 Migrate `frontend/src/services/grpc-transport.ts`: export `createTransport(config: AppConfig)` factory; remove the module-level `baseUrl` const. Update all callers (Aurelia DI registration in `main.ts` should hand the resolved config to the factory)
+- [x] 1.7 Migrate `frontend/src/services/otel-init.ts`: `initOtel(apiBaseUrl: string)` accepts the URL as a parameter; remove the module-level read. Update `main.ts` call site
+- [x] 1.8 Migrate `frontend/src/services/proof-service.ts`: read `circuitBaseUrl` from `resolve(IAppConfig)` in the constructor; treat empty string as "circuits disabled" no-op
+- [x] 1.9 Migrate `frontend/src/services/push-service.ts`: read `vapidPublicKey` from `resolve(IAppConfig)` in the constructor
+- [x] 1.10 Migrate `frontend/src/routes/settings/settings-route.ts`: `vapidAvailable` computed from `resolve(IAppConfig).vapidPublicKey` length
+- [x] 1.11 Migrate `frontend/src/constants/preview-artists.ts`: replace module-level `import.meta.env.VITE_PREVIEW_*` reads with `getAppConfig().previewArtistIds` / `previewArtistNames`. Keep export shape (array consts) so call sites in `welcome-route` are unchanged
+- [x] 1.12 Migrate `frontend/src/main.ts` log-level resolution (`resolveLogLevel`) to read from `config.logLevel`; the `import.meta.env.DEV` fallback remains
+- [x] 1.13 Verify `grep -rn 'import\.meta\.env\.VITE_' frontend/src` returns empty
+- [x] 1.14 Run `make lint` and fix any biome / tsc issues introduced by the refactor
+
+## 2. Frontend — Service Worker and Caddy
+
+- [x] 2.1 Add `registerRoute(({url}) => url.pathname === '/config.json', new NetworkOnly())` to `frontend/src/sw.ts` (above the existing artist/follow service routes for clarity)
+- [x] 2.2 Update `frontend/Caddyfile`: add a `@config path /config.json` matcher with `Cache-Control: no-cache, no-store, must-revalidate` and `Content-Type: application/json; charset=utf-8` headers
+- [x] 2.3 Verify Caddyfile syntax: `docker run --rm -v $PWD/Caddyfile:/etc/caddy/Caddyfile caddy:2-alpine caddy validate --config /etc/caddy/Caddyfile`
+
+## 3. Frontend — committed dev fallback and image cleanup
+
+- [x] 3.1 Create `frontend/public/config.json` containing dev environment values (mirrors today's `.env`). Format: JSON object matching `AppConfig`
+- [x] 3.2 Delete `frontend/.env.prod`
+- [x] 3.3 Update `frontend/Dockerfile`: remove `ARG VITE_MODE=""` and the conditional `if [ -n "$VITE_MODE" ]` build invocation. Replace with a plain `RUN npm run build`
+- [x] 3.4 Verify `npm start` boots and serves `http://localhost:9000/config.json` with the dev values
+- [x] 3.5 Verify `npm run build` produces a `dist/` that contains `config.json` (copied from `public/`)
+
+## 4. Frontend — defense-in-depth CI assertion
+
+- [x] 4.1 Create `frontend/scripts/verify-build-templates.ts`: glob `dist/assets/*-route-*.js`, assert each known route chunk contains its expected template marker string (e.g., `welcome-route` → `welcome-hero`). Exit non-zero with a clear message on failure
+- [x] 4.2 Define the route → marker map in the script as a const at the top, with one entry per route declared in `src/app-shell.ts`. Source markers from a stable class name or `data-` attribute that appears in each route's compiled `.html`
+- [x] 4.3 Add `npm run verify:build-templates` script in `package.json`
+- [x] 4.4 Add unit test that runs the script against a temp dir lacking the marker and asserts non-zero exit
+- [x] 4.5 Wire the script into the existing build step (either in Dockerfile after `npm run build`, or in `push-image.yaml` as a separate workflow step that runs before the docker push)
+
+## 5. Frontend — post-deploy smoke E2E
+
+- [x] 5.1 Create `frontend/tests/smoke/post-deploy.spec.ts` (Playwright): load the configured URL, wait for networkidle, assert `body.innerText.trim()` non-empty, assert the welcome route's first-screen element is in the DOM
+- [x] 5.2 Add `BASE_URL` env var support; default to the dev URL, override per CI invocation
+- [x] 5.3 Add a `config.json` fetch assertion in the same spec: response 200, environment field matches expected
+- [x] 5.4 Add `npm run test:smoke` script
+- [x] 5.5 Wire the smoke into the deploy workflow: run on both `main` push (against dev URL after ArgoCD sync) and on `release` (against prod URL after prod ArgoCD sync)
+
+## 6. cloud-provisioning — ConfigMap and Deployment patch
+
+- [x] 6.1 Add `volumes` + `volumeMounts` for `runtime-config` to `cloud-provisioning/k8s/namespaces/frontend/base/web/deployment.yaml` (mountPath `/srv/config.json`, subPath `config.json`, sourced from ConfigMap `web-app-runtime-config`)
+- [x] 6.2 Add Reloader annotation `reloader.stakater.com/auto: "true"` to the Deployment template metadata
+- [x] 6.3 Create `cloud-provisioning/k8s/namespaces/frontend/overlays/dev/configmap.yaml` with the `web-app-runtime-config` ConfigMap containing `config.json` key with dev values (mirrors `frontend/public/config.json`)
+- [x] 6.4 Reference the ConfigMap from `overlays/dev/kustomization.yaml` `resources:`
+- [x] 6.5 Create `cloud-provisioning/k8s/namespaces/frontend/overlays/prod/configmap.yaml` with `web-app-runtime-config` containing `config.json` with prod values (from today's `.env.prod`)
+- [x] 6.6 Reference the ConfigMap from `overlays/prod/kustomization.yaml`
+- [x] 6.7 Run `kubectl kustomize k8s/namespaces/frontend/overlays/dev` and verify the ConfigMap renders with dev `environment: dev` plus a Deployment with the expected mount
+- [x] 6.8 Run `kubectl kustomize k8s/namespaces/frontend/overlays/prod` and verify the same for prod
+- [x] 6.9 Run `make lint-k8s` to ensure kube-linter passes
+
+## 7. Frontend CI — drop VITE_MODE branches
+
+- [x] 7.1 Update `frontend/.github/workflows/push-image.yaml`: remove the conditional `Set Image Tags` step pair if it diverged only on env-tag, OR keep tag divergence (dev `:latest,:sha,:main`, prod `:<tag>,:<sha>`) but unify the build path
+- [x] 7.2 Remove `--build-arg VITE_MODE=prod` from the release/prod build step. Both paths now invoke the build with identical inputs
+- [x] 7.3 Add a workflow step (or rely on Dockerfile-internal step from task 4.5) that runs `npm run verify:build-templates` before pushing the image
+- [x] 7.4 Trigger a workflow_dispatch dry run to confirm the dev and release paths still pass
+
+## 8. Coordinated rollout
+
+- [ ] 8.1 Merge specification PR (this change) — captures the contract
+- [ ] 8.2 Open cloud-provisioning PR (tasks 6.x) — review in parallel
+- [ ] 8.3 Open frontend PR (tasks 1.x–5.x, 7.x) — review in parallel
+- [ ] 8.4 Merge cloud-provisioning PR first → ArgoCD applies, dev pod restarts via Reloader, ConfigMap mounted but old image still ignores it. Verify dev still works as today
+- [ ] 8.5 Merge frontend PR → dev CI builds new image, ArgoCD Image Updater bumps dev Deployment. Verify `https://dev.liverty-music.app/` loads and `curl https://dev.liverty-music.app/config.json` returns dev values
+- [ ] 8.6 Cut frontend release `v1.0.1` (or appropriate semver) on the new merge commit on `main` HEAD. Verify release CI builds and pushes to `liverty-music-prod/frontend/web-app:v1.0.1,:<sha>`
+- [ ] 8.7 Update `cloud-provisioning/k8s/namespaces/frontend/overlays/prod/kustomization.yaml` image pin to `v1.0.1`. Open + merge the pin-bump PR
+- [ ] 8.8 ArgoCD syncs prod. Verify `https://liverty-music.app/` renders the welcome route (no longer blank), and `curl https://liverty-music.app/config.json` returns prod values with `environment: prod`
+- [ ] 8.9 Run post-deploy smoke E2E against the live prod URL (manual or CI-triggered)
+
+## 9. Defense-in-depth follow-ups (track separately if not done in this PR)
+
+- [ ] 9.1 File an issue on `@aurelia/vite-plugin` GitHub repository describing the literal `mode === 'production'` check and proposing `command === 'build'` (or `config.isProduction`) as the gate. Include a minimal repro
+- [ ] 9.2 (Optional) Open a PR with the proposed fix on `@aurelia/vite-plugin`
+- [ ] 9.3 Document the runtime-config contract in `frontend/docs/` (or repo README) for new contributors: how `public/config.json` differs from the K8s-mounted version, where to add a new VITE_-equivalent field, the bootstrap order
+- [ ] 9.4 (Phase 2, separate change) Switch release-tag CI from rebuild to retag (dev-AR → prod-AR via `gcloud artifacts docker tags add`) for true binary-identical image promotion
+
+## 10. Archive
+
+- [ ] 10.1 After tasks 1–8 verified in dev + prod, mark this change complete and prepare an archive PR per the repo's openspec-sync-specs pattern (move `openspec/changes/adopt-runtime-config-for-frontend/` to `openspec/changes/archive/<date>-adopt-runtime-config-for-frontend/` and merge the spec deltas into `openspec/specs/`)

--- a/openspec/changes/adopt-runtime-config-for-frontend/tasks.md
+++ b/openspec/changes/adopt-runtime-config-for-frontend/tasks.md
@@ -1,3 +1,5 @@
+> **Cross-repo task layout**: Tasks 1–7 live in `frontend` and `cloud-provisioning`; tasks 8–10 are the user-gated rollout (merges, release tag, prod cutover, archive). This specification PR ships only the OpenSpec artifacts. The companion implementation PRs (`liverty-music/frontend#358`, `liverty-music/cloud-provisioning#275`) track sections 1–7. A checked box under sections 1–7 indicates work landed on the companion branch; section 8.x items remain `[ ]` until the corresponding merge / release event fires.
+
 ## 1. Frontend — runtime config plumbing
 
 - [x] 1.1 Create `frontend/src/config/app-config.ts` exporting: `AppConfig` interface, `IAppConfig` DI token, `loadAppConfig()` async loader (with required-field validation), `getAppConfig()` synchronous accessor (throws if pre-bootstrap), `validateEnvironmentMatchesHost(config)` for production-host cross-check


### PR DESCRIPTION
## Summary

Captures the architectural decision to replace build-time `.env.prod` baking with a runtime `/config.json` fetched at bootstrap from a per-environment K8s ConfigMap. Triggered by the v1.0.0 blank-screen Sev-1 at `https://liverty-music.app/` — caused by `@aurelia/vite-plugin@2.0.0-rc.1` literal-checking `config.mode === 'production'` when bundling templates, which silently stripped templates from every lazy route chunk under `--mode prod`.

## Spec deltas

- **NEW** `frontend-runtime-config`: bootstrap fetch + validation contract, `AppConfig` schema, host-vs-environment cross-check, Service-Worker pass-through, error-page semantics.
- **MODIFIED** `prod-image-pipeline`: REMOVES the bake-time env requirement; adds env-agnostic-bundle invariant + post-build template-presence gate. Release-trigger requirement preserved with replaced assertion.
- **MODIFIED** `frontend-hosting`: adds Caddy `/config.json` no-cache rule, per-env ConfigMap volume mount with Reloader annotation, post-deploy smoke assertion.

## Why now

Pre-service-in window: v1.0.0 is tagged but blank with zero real users, zero PWA installs, zero auth sessions to coordinate. Migrating to runtime config now costs ~310 LOC across 3 repos; doing it post-service-in would 10× that cost due to SW caches and installed PWAs in the wild.

## Companion PRs

- frontend: <will-be-linked-on-open>
- cloud-provisioning: <will-be-linked-on-open>

## Test plan

- [x] `openspec validate adopt-runtime-config-for-frontend` passes
- [x] Frontend `vitest run`: 1047/1047 pass (including 21 new app-config tests)
- [x] Frontend `tsc --noEmit`: clean
- [x] Frontend `npm run build && npm run verify:build-templates`: all 10 route chunks contain template markers
- [x] Frontend `grep` for any dev/prod hostname or OIDC client_id in `dist/assets/*.js`: zero matches
- [x] `kubectl kustomize` of dev + prod overlays renders cleanly
- [x] `kube-linter` on frontend overlays: no errors

Refs: liverty-music/specification#485