### PR TITLE
feat(user): persist preferred language in the backend

### DIFF
--- a/openspec/changes/persist-user-language/.openspec.yaml
+++ b/openspec/changes/persist-user-language/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-21

--- a/openspec/changes/persist-user-language/design.md
+++ b/openspec/changes/persist-user-language/design.md
@@ -39,11 +39,19 @@ Alternatives considered:
 - Leave the default in place and treat `'en'` as both "set by user" and "default": rejected — undistinguishable states block any backfill heuristic.
 - Read a one-time legacy `localStorage['language']` at hydration to backfill: rejected — leaves a time-limited compatibility path in the code (the user explicitly wants no localStorage reads while authenticated).
 
-### D3. Proto: `optional string preferred_language` on entity, required `string preferred_language` on `CreateRequest`
+### D3. Proto: `optional string preferred_language` on both `User` and `CreateRequest`
 
-On `User`, the field uses `optional` so the wire can distinguish "unset" (NULL in DB) from "explicitly empty" — required for the backfill decision on the frontend. On `CreateRequest`, the field is required (`protovalidate.field.string.min_len = 2`) — the client always knows its current locale and must always send it.
+On `User`, the field uses `optional` so the wire can distinguish "unset" (NULL in DB) from "explicitly empty" — required for the backfill decision on the frontend.
 
-The value is an ISO 639-1 two-letter code (`ja`, `en`). Validation rule: `pattern = "^[a-z]{2}$"`. This keeps room for `ja-JP` style tags in the future via a separate field or a relaxed pattern, but for now Phase-1 supports only base codes.
+On `CreateRequest`, the field is ALSO `optional` (revised from the initial "required" formulation) to keep the RPC backward-compatible during the rolling-deploy window where the new backend may briefly serve old frontend clients that don't know about the field. Updated clients SHALL always send the value (the frontend code does), but old clients that omit it are accepted: the new user row is stored with a NULL `preferred_language` and the client backfills it on next hydration via `UpdatePreferredLanguage`. This converges on the same end-state as legacy rows, so the legacy-row backfill path doubly serves as the old-client transition path — no extra code surface.
+
+For `UpdatePreferredLanguageRequest`, the field is required (plain `string`) — there is no transition concern since the RPC is brand new; any caller MUST be from updated code.
+
+The value is an ISO 639-1 two-letter code (`ja`, `en`). Validation when present: `min_len: 2` and `pattern: "^[a-z]{2}$"`. The `min_len` annotation is explicit even though the pattern implicitly rejects empty strings — it makes the "non-empty when present" semantics legible to SDK / doc generators that read proto annotations independently. This keeps room for `ja-JP` style tags in the future via a separate field or a relaxed pattern, but for now Phase-1 supports only base codes.
+
+**Alternatives considered for the deployment-window concern (Issue 1 from PR review):**
+- Keep `CreateRequest.preferred_language` required and manually time the deploys: rejected — manual coordination is fragile (one failed deploy or rollback breaks the window) and breaks `Create` for any legitimate old client between backend ship and frontend ship.
+- Two-phase rollout (ship as optional, then tighten in a follow-up PR): rejected as unnecessary — the backfill mechanism already exists for legacy rows, so absent-on-Create can collapse into that same path with no follow-up tightening needed. The "fail loud if frontend forgets" benefit doesn't justify a second migration.
 
 ### D4. Frontend: i18next-browser-languagedetector `caches: ['localStorage']`
 

--- a/openspec/changes/persist-user-language/design.md
+++ b/openspec/changes/persist-user-language/design.md
@@ -1,0 +1,104 @@
+## Context
+
+The `users.preferred_language` column exists in the DB with `DEFAULT 'en'` and the Go `entity.User.PreferredLanguage` field is populated by the repository — but the proto layer never exposes it. As a result, the only effective store for the user's language preference is browser `localStorage` written by `changeLocale()` (`frontend/src/util/change-locale.ts`).
+
+Symptoms observed in production: after a user switches the language in Settings, a hard reload occasionally falls back to EN. The most likely failure surfaces are localStorage volatility (Safari ITP cap, private browsing, cross-device divergence) and the absence of a recovery path — there is no server-side fallback when `localStorage` is missing or stale. Even without a confirmed root cause, the only durable fix is to make the backend the source of truth once an account exists.
+
+Pre-signup, the user is anonymous — the only place to remember a language choice is the browser. The existing i18next-browser-languagedetector chain (`['querystring', 'localStorage', 'navigator']`) is already correct for anonymous users, but `caches: []` means navigator-detected values are NOT persisted, so each reload re-detects from `navigator.language` instead of remembering a stable choice.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Make `users.preferred_language` the single source of truth for authenticated users.
+- Capture the user's pre-signup effective locale at Create time and persist it.
+- Persist navigator-detected locale to `localStorage` on first visit so anonymous reload behavior is stable.
+- After signup, remove `localStorage['language']` and never read it again while signed in.
+- Provide a backfill path for existing rows so they aren't permanently stuck on the old `DEFAULT 'en'`.
+
+**Non-Goals:**
+- Generalizing user profile updates (e.g., introducing `UpdateUser` with FieldMask). Out of scope; if a future change needs many mutable user fields, that refactor will subsume the dedicated `UpdatePreferredLanguage`.
+- Server-side i18n of emails or Zitadel templates. Tracked separately.
+- Auto-detecting language from JWT claims or `Accept-Language` headers. Out of scope.
+- Adding more than the two currently supported locales (`ja`, `en`).
+
+## Decisions
+
+### D1. Dedicated `UpdatePreferredLanguage` RPC, not a generic `UpdateUser`
+
+Mirrors the precedent set by the existing `UpdateHome` custom-method RPC. The only currently-mutable user fields are `home` and `preferred_language`; introducing a `FieldMask`-based `UpdateUser` now would be over-engineered and would force a co-migration of `UpdateHome`. If a third mutable field appears, that change can revisit consolidation.
+
+Alternatives considered:
+- `UpdateUser(user, update_mask)` (AIP-134 canonical): rejected as over-engineered for two fields, and would require migrating `UpdateHome` simultaneously.
+- Reuse `Create`'s idempotent path: rejected — Create's documented contract is "duplicate call is a read, not an upsert"; making one field a write-on-duplicate breaks that contract asymmetrically.
+
+### D2. DB column: drop `DEFAULT 'en'`, NULL out existing rows
+
+The `DEFAULT 'en'` made sense when the field was an internal stub but conflicts with "client decides" semantics. NULL becomes the canonical "not yet set; client must backfill" state. Existing rows are reset to NULL so the client takes responsibility on next hydration — yielding their current effective locale rather than the historical default.
+
+Alternatives considered:
+- Leave the default in place and treat `'en'` as both "set by user" and "default": rejected — undistinguishable states block any backfill heuristic.
+- Read a one-time legacy `localStorage['language']` at hydration to backfill: rejected — leaves a time-limited compatibility path in the code (the user explicitly wants no localStorage reads while authenticated).
+
+### D3. Proto: `optional string preferred_language` on entity, required `string preferred_language` on `CreateRequest`
+
+On `User`, the field uses `optional` so the wire can distinguish "unset" (NULL in DB) from "explicitly empty" — required for the backfill decision on the frontend. On `CreateRequest`, the field is required (`protovalidate.field.string.min_len = 2`) — the client always knows its current locale and must always send it.
+
+The value is an ISO 639-1 two-letter code (`ja`, `en`). Validation rule: `pattern = "^[a-z]{2}$"`. This keeps room for `ja-JP` style tags in the future via a separate field or a relaxed pattern, but for now Phase-1 supports only base codes.
+
+### D4. Frontend: i18next-browser-languagedetector `caches: ['localStorage']`
+
+The current `caches: []` disables write-back. Switching to `['localStorage']` makes the detector persist its decision after the first navigator-based detection, so subsequent anonymous reloads see a stable language without requiring explicit user action.
+
+Side effect: a `?lang=xx` querystring visit will also be cached. This is intentional — a shared link's language choice should "stick" rather than evaporate. If a user objects, they can change it in Settings.
+
+### D5. Frontend: hydration applies + backfills
+
+After `UserService.Get` completes (in `UserHydrationTask` and in `auth-callback`), the frontend:
+
+1. If `user.preferred_language` is present → `i18n.setLocale(user.preferred_language)`.
+2. If absent (legacy NULL row) → call `UpdatePreferredLanguage(i18n.getLocale())` to persist the current effective locale, then keep i18n where it is.
+3. In both cases, remove `localStorage['language']` (it served its purpose pre-signup and is no longer read).
+
+The brief flash where the navigator-derived locale is shown before being replaced by the DB value is acceptable per product call. No suspense or splash gate.
+
+### D6. Frontend: anonymous vs authenticated paths in `changeLocale`
+
+Today `changeLocale(i18n, lang)` does `i18n.setLocale + localStorage.setItem`. We split:
+
+- **Anonymous callers** (welcome route, future discovery): unchanged behavior — `setLocale + localStorage.setItem('language', lang)`.
+- **Authenticated callers** (settings route): `UpdatePreferredLanguage(lang) → setLocale` — no `localStorage` write.
+
+Concrete implementation can either be (a) two utility functions or (b) one utility that consults `IAuthService.isAuthenticated`. Implementation detail; either is acceptable as long as authenticated callers never touch `localStorage`.
+
+### D7. `Create` continues to ignore home AND preferred_language on idempotent return
+
+The existing contract: "duplicate call is a read, not an upsert; home is ignored on idempotent return". Extending this rule, `preferred_language` is ALSO ignored on idempotent return. The hydration backfill path (D5) handles language for users whose row already exists with NULL.
+
+## Risks / Trade-offs
+
+- **[Existing JA users flip to EN momentarily]** Existing rows with `'en'` are reset to NULL by the migration. On next sign-in, hydration backfills from `i18n.getLocale()`, which is derived from the navigator. If the user's browser is JA, they end up with JA in DB. If their browser is EN but they had explicitly chosen JA in settings (and that choice was lost because we never persisted it server-side anyway), they will see EN and have to switch in Settings once. → Mitigation: documented in release notes; this is a one-time transition cost.
+
+- **[BSR client / backend skew during release]** Adding a required field to `CreateRequest` means a frontend running the old code against a new backend will fail validation, and vice versa. → Mitigation: follow the standard proto-change release order — specification PR → Release → BSR gen → backend & frontend PRs land after. Brief dev/staging skew is acceptable since rollout is coordinated. For prod we time the deploys.
+
+- **[Boot flicker on slow networks]** On authenticated boot, the i18n chain shows JA/EN from navigator first, then switches to the DB value when Get resolves. Could be 200–500ms on cold cache. → Mitigation: accepted per product call (D5). If complaints arise, we can add an AppShell skeleton that masks text until hydration completes.
+
+- **[Settings language change race vs concurrent reload]** User taps language in Settings → UpdatePreferredLanguage in-flight → user hard-reloads before RPC returns. The new value isn't persisted, so the old DB value is read back. → Mitigation: the optimistic UI in Settings shows the change immediately via `i18n.setLocale`; if the RPC fails, we surface a Snack and revert. The hard-reload-mid-flight case is rare and self-correcting (user re-applies).
+
+- **[NULL semantics confusion]** Future readers may not know whether NULL means "legacy unset" or "user opted into 'auto'". → Mitigation: column comment makes the semantics explicit; backfill happens on first hydration so NULL is short-lived per row.
+
+- **[Anonymous users on multiple devices]** Since pre-signup state lives only in `localStorage`, choosing JA on one anonymous device does not affect another. → Out of scope; this is fundamental to anonymous state.
+
+## Migration Plan
+
+1. **specification PR**: proto changes + this OpenSpec change merged.
+2. **GitHub Release** on specification: triggers `buf-release.yml` → BSR publishes new schema.
+3. **Backend PR**: Atlas migration (`ALTER COLUMN ... DROP DEFAULT`, `UPDATE users SET preferred_language = NULL`), mapper extension, new handler/use-case/repo method, tests. Merged after BSR gen succeeds.
+4. **Frontend PR**: detector cache change, entity field, RPC client + service methods, hydration apply/backfill, Settings rewrite, auth-callback cleanup, tests. Merged after backend ships.
+5. **Verify in dev**: capture a fresh signed-up user has `preferred_language = 'ja'` (or 'en') in DB; old user signs in → backfill happens; Settings change persists across hard reload.
+
+**Rollback strategy**: revert frontend first (returns to localStorage-only behavior, harmless since DB column still exists and is just unread). Then revert backend if needed (the new RPC and field become unused; Atlas down-migration restores `DEFAULT 'en'` but the existing NULLs can stay — they don't break anything when nothing reads them).
+
+## Open Questions
+
+- Should `Settings → Language` RPC failure revert the UI (pessimistic) or stay applied with a Snack warning (optimistic)? Current preference is optimistic with Snack; finalize in implementation.
+- Do we need a Storybook story update for the Settings language-selector to reflect the new RPC-driven state? Decided during apply.

--- a/openspec/changes/persist-user-language/proposal.md
+++ b/openspec/changes/persist-user-language/proposal.md
@@ -4,8 +4,8 @@ The user's preferred display language is currently stored only in browser `local
 
 ## What Changes
 
-- **BREAKING (proto)** — `entity.v1.User` adds a `preferred_language` field (ISO 639-1).
-- **BREAKING (proto)** — `rpc.user.v1.CreateRequest` adds a required `preferred_language` field. Clients must capture the effective locale at signup and send it.
+- `entity.v1.User` adds an optional `preferred_language` field (ISO 639-1). Additive only — wire-compatible.
+- `rpc.user.v1.CreateRequest` adds an optional `preferred_language` field. Wire-compatible — old clients that omit the field create users with NULL preferred_language and trigger the same hydration-backfill path as legacy rows. Updated clients always send the value.
 - Add new RPC `UserService.UpdatePreferredLanguage(user_id, preferred_language)` (mirrors the existing `UpdateHome` custom-method pattern).
 - Backend: remove the `DEFAULT 'en'` from `users.preferred_language`, set existing rows to `NULL` so the client can backfill on next hydration.
 - Backend: extend `UserToProto` and `NewUserFromCreateRequest` to carry `preferred_language`; add a `UpdatePreferredLanguage` handler/use-case/repo method.
@@ -30,7 +30,7 @@ The user's preferred display language is currently stored only in browser `local
 
 ## Impact
 
-- **Proto / BSR**: `User.preferred_language` field added; `CreateRequest.preferred_language` added; new `UpdatePreferredLanguage` RPC. Will be released as a minor version bump in the BSR schema; the new `CreateRequest` field is required, so older frontend clients are temporarily incompatible until they ship the matching change.
+- **Proto / BSR**: `User.preferred_language` field added; `CreateRequest.preferred_language` added (both `optional`); new `UpdatePreferredLanguage` RPC. Will be released as a minor version bump in the BSR schema. All wire changes are additive — `buf breaking` passes and old clients keep working through the optional-field semantics (their Create calls succeed with `preferred_language` NULL on the resulting row).
 - **Backend (Go)**: `internal/adapter/rpc/mapper/user.go` (mapper extension), `internal/adapter/rpc/user_handler.go` (new RPC), `internal/usecase/user_uc.go` (new use-case method), `internal/infrastructure/database/rdb/user_repo.go` (language-only update). Atlas migration to drop `DEFAULT 'en'` and NULL out existing rows.
 - **Frontend (Aurelia 2)**: `src/main.ts` (i18n detector `caches: ['localStorage']`), `src/entities/user.ts` (add field), `src/adapter/rpc/client/user-client.ts` (new method + Create signature), `src/services/user-service.ts`, `src/services/user-hydration-task.ts` (apply + backfill), `src/routes/auth-callback/auth-callback-route.ts` (cleanup localStorage), `src/routes/settings/settings-route.ts` (route through RPC), `src/util/change-locale.ts` (split: anon vs authed paths).
 - **Database**: `app.users.preferred_language` — DEFAULT dropped, existing rows updated to NULL.

--- a/openspec/changes/persist-user-language/proposal.md
+++ b/openspec/changes/persist-user-language/proposal.md
@@ -1,0 +1,37 @@
+## Why
+
+The user's preferred display language is currently stored only in browser `localStorage`, which is unreliable (Safari 7-day cap, private browsing, cross-device divergence) and is the suspected cause of authenticated users seeing the UI revert to EN after a hard reload. The DB already has a `users.preferred_language` column but it is never exposed over the wire, so it cannot serve as a source of truth. We need to make the DB authoritative for authenticated users while keeping the existing browser auto-detection working pre-signup, and clean up localStorage as soon as the user signs up.
+
+## What Changes
+
+- **BREAKING (proto)** — `entity.v1.User` adds a `preferred_language` field (ISO 639-1).
+- **BREAKING (proto)** — `rpc.user.v1.CreateRequest` adds a required `preferred_language` field. Clients must capture the effective locale at signup and send it.
+- Add new RPC `UserService.UpdatePreferredLanguage(user_id, preferred_language)` (mirrors the existing `UpdateHome` custom-method pattern).
+- Backend: remove the `DEFAULT 'en'` from `users.preferred_language`, set existing rows to `NULL` so the client can backfill on next hydration.
+- Backend: extend `UserToProto` and `NewUserFromCreateRequest` to carry `preferred_language`; add a `UpdatePreferredLanguage` handler/use-case/repo method.
+- Frontend: change i18n detector config to cache detected locale to `localStorage` (so first-visit browser detection persists).
+- Frontend: on signup (Create), send `i18n.getLocale()` as `preferred_language`; on success, remove `localStorage['language']`.
+- Frontend: on profile hydration (Get), if `user.preferred_language` is set, switch i18n to it; if absent (NULL), call `UpdatePreferredLanguage` with the current effective locale to backfill.
+- Frontend: Settings → Language change calls `UpdatePreferredLanguage` and `i18n.setLocale`; it MUST NOT touch `localStorage`.
+- Frontend: while authenticated, no code path reads or writes `localStorage['language']`.
+
+## Capabilities
+
+### New Capabilities
+
+- `user-language-preference`: Backend ownership of the authenticated user's preferred display language — proto entity field, Create/Update RPCs, DB column semantics, and the contract that DB is the source of truth post-signup.
+
+### Modified Capabilities
+
+- `frontend-i18n`: Locale detection now persists the detected value to `localStorage` (cache enabled). Runtime switching for authenticated users routes through the backend RPC; the shared `changeLocale` utility no longer touches `localStorage` for authenticated callers.
+- `settings`: The Language row reads from `UserService.current.preferred_language` and writes via `UpdatePreferredLanguage`. It MUST NOT read or write `localStorage['language']`.
+- `user-profile-hydration`: After loading the User entity, the frontend applies `user.preferred_language` to i18n. When the field is empty (NULL legacy rows), the frontend backfills it by calling `UpdatePreferredLanguage` with the currently effective locale. The hydration step also removes any lingering `localStorage['language']`.
+- `user-account-sync`: The `Create` RPC accepts `preferred_language`, captured at sign-up from the client's effective locale. After successful Create, the frontend removes `localStorage['language']`. The idempotent-return path does NOT overwrite an existing user's `preferred_language` (mirrors the existing rule for `home`).
+
+## Impact
+
+- **Proto / BSR**: `User.preferred_language` field added; `CreateRequest.preferred_language` added; new `UpdatePreferredLanguage` RPC. Will be released as a minor version bump in the BSR schema; the new `CreateRequest` field is required, so older frontend clients are temporarily incompatible until they ship the matching change.
+- **Backend (Go)**: `internal/adapter/rpc/mapper/user.go` (mapper extension), `internal/adapter/rpc/user_handler.go` (new RPC), `internal/usecase/user_uc.go` (new use-case method), `internal/infrastructure/database/rdb/user_repo.go` (language-only update). Atlas migration to drop `DEFAULT 'en'` and NULL out existing rows.
+- **Frontend (Aurelia 2)**: `src/main.ts` (i18n detector `caches: ['localStorage']`), `src/entities/user.ts` (add field), `src/adapter/rpc/client/user-client.ts` (new method + Create signature), `src/services/user-service.ts`, `src/services/user-hydration-task.ts` (apply + backfill), `src/routes/auth-callback/auth-callback-route.ts` (cleanup localStorage), `src/routes/settings/settings-route.ts` (route through RPC), `src/util/change-locale.ts` (split: anon vs authed paths).
+- **Database**: `app.users.preferred_language` — DEFAULT dropped, existing rows updated to NULL.
+- **Cross-repo release order**: specification PR + Release → BSR gen → backend & frontend PRs (per the standard proto-change workflow).

--- a/openspec/changes/persist-user-language/specs/frontend-i18n/spec.md
+++ b/openspec/changes/persist-user-language/specs/frontend-i18n/spec.md
@@ -1,0 +1,90 @@
+## MODIFIED Requirements
+
+### Requirement: Locale Detection
+The system SHALL detect the user's preferred language using a priority chain: URL parameter, persisted preference, browser language, then fallback. Detection results SHALL be persisted to `localStorage` so that the chosen language survives subsequent reloads for anonymous users.
+
+#### Scenario: URL parameter override
+- **WHEN** the URL contains a `?lang=en` query parameter
+- **THEN** the system SHALL set the active locale to EN regardless of other settings
+- **AND** the system SHALL write `en` to `localStorage` under the `language` key
+
+#### Scenario: Persisted preference from localStorage
+- **WHEN** no `?lang=` URL parameter is present
+- **AND** localStorage contains a `language` key with value `en`
+- **THEN** the system SHALL set the active locale to EN
+
+#### Scenario: Browser language detection persists to localStorage
+- **WHEN** no `?lang=` URL parameter is present
+- **AND** no `language` key exists in localStorage
+- **AND** `navigator.language` starts with `en`
+- **THEN** the system SHALL set the active locale to EN
+- **AND** the system SHALL write `en` to `localStorage` under the `language` key so subsequent reloads do not re-detect
+
+#### Scenario: Fallback to Japanese
+- **WHEN** no `?lang=` URL parameter is present
+- **AND** no `language` key exists in localStorage
+- **AND** `navigator.language` does not match any supported locale
+- **THEN** the system SHALL set the active locale to JA
+- **AND** the system SHALL write `ja` to `localStorage` under the `language` key
+
+---
+
+### Requirement: Runtime Language Switching
+The system SHALL re-render all translated strings when the active locale changes without requiring a page reload. The persistence target for the new locale SHALL depend on the authentication state: anonymous changes persist to `localStorage`; authenticated changes persist to the backend user row.
+
+#### Scenario: Switching language mid-session as an anonymous user
+- **WHEN** an unauthenticated user changes the language preference (e.g., from the Welcome page language selector)
+- **THEN** all `t`-bound template strings SHALL immediately update to the new locale
+- **AND** the `language` key in localStorage SHALL be updated
+- **AND** the system SHALL NOT issue any backend RPC for the change
+- **AND** date/number formatters SHALL use the new locale for subsequent renders
+
+#### Scenario: Switching language mid-session as an authenticated user
+- **WHEN** an authenticated user changes the language preference (e.g., from the Settings page)
+- **THEN** the system SHALL call `UserService.UpdatePreferredLanguage` with the new locale
+- **AND** on success, the system SHALL call `i18n.setLocale` so all `t`-bound template strings update immediately
+- **AND** the system SHALL NOT read or write `localStorage['language']` for this change
+- **AND** date/number formatters SHALL use the new locale for subsequent renders
+
+#### Scenario: Authenticated language switch RPC failure
+- **WHEN** the `UpdatePreferredLanguage` RPC fails (network, server error)
+- **THEN** the system SHALL NOT change the active locale
+- **AND** the system SHALL surface a user-visible error notification (Snack)
+
+---
+
+### Requirement: Shared Language Switching Utility
+The system SHALL provide a shared utility for changing the active locale that selects the correct persistence path based on the caller's authentication state, so components do not duplicate this logic.
+
+#### Scenario: Anonymous caller path
+- **WHEN** any component calls the shared language-change utility while unauthenticated
+- **THEN** the utility SHALL call `i18n.setLocale(lang)` and `localStorage.setItem('language', lang)`
+- **AND** the utility SHALL NOT issue any backend RPC
+
+#### Scenario: Authenticated caller path
+- **WHEN** any component calls the shared language-change utility while authenticated
+- **THEN** the utility SHALL call `UserService.UpdatePreferredLanguage` first
+- **AND** on success, the utility SHALL call `i18n.setLocale(lang)`
+- **AND** the utility SHALL NOT touch `localStorage['language']`
+
+#### Scenario: Used by both Welcome and Settings
+- **WHEN** the Welcome page (anonymous context) and Settings page (authenticated context) both change language
+- **THEN** they SHALL both call the same shared utility
+- **AND** the utility SHALL route persistence appropriately for each context
+
+---
+
+## ADDED Requirements
+
+### Requirement: Locale Sourced from Backend User Entity for Authenticated Sessions
+While the user is authenticated, the active i18n locale SHALL be sourced from `UserService.current.preferred_language` and SHALL NOT be derived from `localStorage`.
+
+#### Scenario: i18n locale aligns with backend value on every authenticated render
+- **WHEN** `UserService.current` is populated and `preferred_language` is set
+- **THEN** `i18n.getLocale()` SHALL return that value
+- **AND** no code path in the authenticated session SHALL read `localStorage['language']` to decide the locale
+
+#### Scenario: localStorage language key absent during authenticated sessions
+- **WHEN** the application has finished hydrating an authenticated user
+- **THEN** `localStorage['language']` SHALL have been removed (handled by the hydration/auth-callback cleanup specified in `user-profile-hydration` and `user-account-sync`)
+- **AND** the absence SHALL NOT affect the rendered locale, which is driven by `UserService.current.preferred_language`

--- a/openspec/changes/persist-user-language/specs/settings/spec.md
+++ b/openspec/changes/persist-user-language/specs/settings/spec.md
@@ -1,0 +1,30 @@
+## MODIFIED Requirements
+
+### Requirement: Language Preference
+The system SHALL allow users to change the display language of the application. While authenticated, the change SHALL be persisted to the backend user row via `UserService.UpdatePreferredLanguage` — Settings SHALL NOT read or write `localStorage['language']` for the language preference.
+
+#### Scenario: Displaying language option
+- **WHEN** the Settings page is displayed for an authenticated user
+- **THEN** the system SHALL show a "Language" row displaying the current language name derived from `UserService.current.preferred_language` (e.g., "日本語" or "English")
+- **AND** the system SHALL NOT read `localStorage['language']` to populate this row
+
+#### Scenario: Changing language
+- **WHEN** a user taps the "Language" row
+- **THEN** the system SHALL display a selection UI with available languages: 日本語, English
+- **AND** WHEN the user selects a language different from the current one
+- **THEN** the system SHALL call `UserService.UpdatePreferredLanguage` with the new value
+- **AND** on success, the system SHALL call `I18N.setLocale()` to change the active locale
+- **AND** all UI text on the Settings page and throughout the app SHALL immediately update to the selected language
+- **AND** the system SHALL NOT write to `localStorage['language']`
+- **AND** subsequent reads of `UserService.current.preferred_language` SHALL return the new value (write-through per `user-profile-hydration`)
+
+#### Scenario: Language change RPC failure
+- **WHEN** the `UpdatePreferredLanguage` RPC fails (network or server error)
+- **THEN** the active locale SHALL remain unchanged
+- **AND** the displayed "Language" row SHALL continue to show the prior value
+- **AND** the system SHALL surface a Snack notification indicating the change could not be saved
+
+#### Scenario: Re-selecting the current language is a no-op
+- **WHEN** a user taps the "Language" row and selects the language already in effect
+- **THEN** the system SHALL close the selection UI without issuing an RPC
+- **AND** no DB write SHALL occur

--- a/openspec/changes/persist-user-language/specs/user-account-sync/spec.md
+++ b/openspec/changes/persist-user-language/specs/user-account-sync/spec.md
@@ -1,0 +1,51 @@
+## MODIFIED Requirements
+
+### Requirement: User Account Provisioning on Signup
+
+The system SHALL create a local user record in the application database when a user completes the onboarding tutorial and authenticates via Passkey. The provisioning is triggered by the guest data merge process at the end of the tutorial.
+
+The `UserService.Create` RPC SHALL be idempotent on duplicate `external_id`: a second call for the same `external_id` SHALL return the existing user as a successful response rather than `connect.CodeAlreadyExists`. This allows the frontend to treat `Create` as a uniform "resolve-or-provision" bootstrap RPC on any device, regardless of whether the user was provisioned in a prior session.
+
+The `Create` RPC SHALL carry the user's effective locale as `preferred_language` so the language preference is persisted atomically with the new user row. On the idempotent-return path, `preferred_language` SHALL NOT overwrite an existing row's value (mirroring the rule for `home`).
+
+#### Scenario: Successful signup provisioning from tutorial
+
+- **WHEN** a user completes Passkey authentication at tutorial Step 6
+- **AND** the frontend has no cached `user_id` for the authenticated `external_id`
+- **THEN** the frontend SHALL call the `Create` RPC with the user's `email` parameter AND `preferred_language` set to `I18N.getLocale()` (the locale currently effective in the client)
+- **AND** the backend SHALL extract `external_id` (from JWT `sub` claim) and `name` (from JWT `name` claim)
+- **AND** the backend SHALL create a new user record with `external_id`, `email`, `name`, and `preferred_language` persisted
+- **AND** the backend SHALL return the newly created `User` entity in `CreateResponse.user` (including `preferred_language`)
+- **AND** the frontend SHALL cache the returned `user_id` in `localStorage` keyed by `external_id`
+- **AND** the frontend SHALL remove `localStorage['language']` after the successful Create
+- **AND** the frontend SHALL then proceed to sync guest data (follows, passion levels)
+
+#### Scenario: Successful provisioning from Login link
+
+- **WHEN** a returning user authenticates via the [Login] link on the LP
+- **AND** the frontend has no cached `user_id` for the authenticated `external_id` (e.g., fresh device or cleared storage)
+- **THEN** the frontend SHALL call the `Create` RPC with the user's `email` parameter AND `preferred_language` set to `I18N.getLocale()`
+- **AND** the backend SHALL either create a new record (first-ever sign-in) or return the existing record (returning user)
+- **AND** the frontend SHALL cache the returned `user_id` in `localStorage` keyed by `external_id`
+- **AND** the frontend SHALL remove `localStorage['language']` after the successful Create
+
+#### Scenario: Duplicate Create call returns the existing user idempotently
+
+- **WHEN** the `Create` RPC is called with an `external_id` that already exists in the database
+- **THEN** the backend SHALL return `OK` with `CreateResponse.user` populated from the existing row
+- **AND** the backend SHALL NOT return `connect.CodeAlreadyExists`
+- **AND** the backend SHALL NOT modify the existing `email`, `name`, `home`, or `preferred_language` fields (the duplicate call is a read, not an upsert)
+- **AND** the frontend SHALL treat the response identically to a fresh creation — cache the `user_id` and proceed
+
+#### Scenario: Cached userID is reused on subsequent boots
+
+- **WHEN** the app boots for a user whose `external_id` has a cached `user_id` in `localStorage`
+- **THEN** the frontend SHALL read the cached `user_id` **before** issuing any authenticated per-user RPC
+- **AND** the frontend SHALL call `UserService.Get` with the cached `user_id` to hydrate the current profile
+- **AND** the backend SHALL verify the supplied `user_id` matches the JWT-derived userID (per `rpc-auth-scoping`)
+
+#### Scenario: Cached userID is cleared on sign-out
+
+- **WHEN** the user signs out via the auth service
+- **THEN** the frontend SHALL remove the `localStorage` entry keyed by the signed-out user's `external_id`
+- **AND** the next sign-in SHALL follow the cache-miss path (call `Create` to resolve the `user_id`)

--- a/openspec/changes/persist-user-language/specs/user-language-preference/spec.md
+++ b/openspec/changes/persist-user-language/specs/user-language-preference/spec.md
@@ -1,0 +1,98 @@
+## ADDED Requirements
+
+### Requirement: User Preferred Language Field on User Entity
+
+The `entity.v1.User` message SHALL expose the user's preferred display language as an ISO 639-1 two-letter code, distinguishable from the unset state.
+
+#### Scenario: Preferred language present
+
+- **WHEN** the backend returns a `User` entity for a row whose `preferred_language` column is non-NULL
+- **THEN** the proto response SHALL include `preferred_language` set to the stored ISO 639-1 code (e.g., `"ja"` or `"en"`)
+- **AND** the code SHALL match `^[a-z]{2}$`
+
+#### Scenario: Preferred language unset (legacy or new row before backfill)
+
+- **WHEN** the backend returns a `User` entity for a row whose `preferred_language` column is NULL
+- **THEN** the proto response SHALL signal absence via the `optional` field marker (the field SHALL NOT be present in the wire response)
+- **AND** clients SHALL interpret absence as "client must backfill on next observation"
+
+---
+
+### Requirement: Create RPC Captures Preferred Language at Signup
+
+The `UserService.Create` RPC SHALL accept a required `preferred_language` field carrying the client's effective locale at the moment of signup, and SHALL persist it atomically with the new user row.
+
+#### Scenario: Successful Create persists the supplied language
+
+- **WHEN** a client calls `Create` with `preferred_language = "ja"` and an unprovisioned `external_id`
+- **THEN** the backend SHALL persist `preferred_language = "ja"` on the new `users` row
+- **AND** the returned `User` entity SHALL include `preferred_language = "ja"`
+
+#### Scenario: Create rejects missing or malformed preferred_language
+
+- **WHEN** a client calls `Create` without `preferred_language` or with a value that does not match `^[a-z]{2}$`
+- **THEN** the backend SHALL reject the request with `INVALID_ARGUMENT`
+- **AND** no user row SHALL be created
+
+#### Scenario: Idempotent Create does NOT overwrite existing language
+
+- **WHEN** `Create` is called with an `external_id` that already exists in the database
+- **AND** the request carries `preferred_language = "en"`
+- **AND** the existing row has `preferred_language = "ja"`
+- **THEN** the backend SHALL return `OK` with the existing user
+- **AND** the stored `preferred_language` SHALL remain `"ja"` (the duplicate call is a read, not an upsert — mirroring the existing rule for `home`)
+
+---
+
+### Requirement: UpdatePreferredLanguage RPC
+
+The `UserService.UpdatePreferredLanguage` RPC SHALL allow an authenticated user to change their stored preferred language. The RPC SHALL follow the rpc-auth-scoping convention — the request carries an explicit `user_id` that the backend verifies against the caller's JWT-derived userID.
+
+#### Scenario: Successful language update
+
+- **WHEN** an authenticated user calls `UpdatePreferredLanguage` with their own `user_id` and `preferred_language = "en"`
+- **THEN** the backend SHALL persist `preferred_language = "en"` on the user's row
+- **AND** the response SHALL return the updated `User` entity with `preferred_language = "en"`
+
+#### Scenario: Cross-user update is rejected
+
+- **WHEN** an authenticated user calls `UpdatePreferredLanguage` with a `user_id` that does not match their JWT-derived userID
+- **THEN** the backend SHALL reject the request with `PERMISSION_DENIED`
+- **AND** no DB write SHALL occur
+
+#### Scenario: Malformed language code is rejected
+
+- **WHEN** the request carries `preferred_language` not matching `^[a-z]{2}$` (e.g., `""`, `"jpn"`, `"JA"`, `"ja-JP"`)
+- **THEN** the backend SHALL reject the request with `INVALID_ARGUMENT`
+
+#### Scenario: Unknown user is rejected
+
+- **WHEN** the request is well-formed but the JWT-derived user has no corresponding `users` row
+- **THEN** the backend SHALL reject the request with `NOT_FOUND`
+
+#### Scenario: Unauthenticated request is rejected
+
+- **WHEN** the request lacks valid authentication credentials
+- **THEN** the backend SHALL reject the request with `UNAUTHENTICATED`
+
+---
+
+### Requirement: DB Column Semantics — NULL Means "Not Yet Set by Client"
+
+The `app.users.preferred_language` column SHALL NOT carry a server-side `DEFAULT` value. NULL SHALL denote "client has not yet asserted a language preference" and SHALL be the trigger for client-side backfill on next observation.
+
+#### Scenario: New row from Create always has a non-NULL language
+
+- **WHEN** a row is inserted via the Create RPC
+- **THEN** `preferred_language` SHALL be non-NULL (the Create contract requires the field)
+
+#### Scenario: Legacy rows are NULL until backfilled
+
+- **WHEN** the migration runs against an existing database
+- **THEN** all rows previously holding `'en'` from the dropped DEFAULT SHALL be set to NULL
+- **AND** clients observing NULL SHALL call `UpdatePreferredLanguage` with their currently effective locale to backfill
+
+#### Scenario: Column comment documents the semantics
+
+- **WHEN** an operator inspects `\d+ app.users` or queries `pg_description` for the column
+- **THEN** the comment SHALL state that NULL means "not yet set by client; client backfills via UpdatePreferredLanguage on first observation"

--- a/openspec/changes/persist-user-language/specs/user-language-preference/spec.md
+++ b/openspec/changes/persist-user-language/specs/user-language-preference/spec.md
@@ -20,7 +20,7 @@ The `entity.v1.User` message SHALL expose the user's preferred display language 
 
 ### Requirement: Create RPC Captures Preferred Language at Signup
 
-The `UserService.Create` RPC SHALL accept a required `preferred_language` field carrying the client's effective locale at the moment of signup, and SHALL persist it atomically with the new user row.
+The `UserService.Create` RPC SHALL accept an optional `preferred_language` field carrying the client's effective locale at the moment of signup. When the field is present, the backend SHALL persist it atomically with the new user row; when absent, the row SHALL be created with NULL and the client SHALL backfill on next hydration via `UpdatePreferredLanguage`. The field is `optional` on the wire so the RPC stays backward-compatible during a rolling deploy where the new backend may briefly serve old frontend clients.
 
 #### Scenario: Successful Create persists the supplied language
 
@@ -28,9 +28,16 @@ The `UserService.Create` RPC SHALL accept a required `preferred_language` field 
 - **THEN** the backend SHALL persist `preferred_language = "ja"` on the new `users` row
 - **AND** the returned `User` entity SHALL include `preferred_language = "ja"`
 
-#### Scenario: Create rejects missing or malformed preferred_language
+#### Scenario: Create accepts absent preferred_language for old clients
 
-- **WHEN** a client calls `Create` without `preferred_language` or with a value that does not match `^[a-z]{2}$`
+- **WHEN** a client calls `Create` without supplying the `preferred_language` field at all (i.e. the field is absent on the wire, as an unupdated client would send)
+- **THEN** the backend SHALL create the user row with `preferred_language` as NULL
+- **AND** the returned `User` entity SHALL NOT include `preferred_language`
+- **AND** subsequent hydration SHALL trigger client-side backfill via `UpdatePreferredLanguage`
+
+#### Scenario: Create rejects malformed preferred_language
+
+- **WHEN** a client calls `Create` with `preferred_language` explicitly present but not matching `^[a-z]{2}$` (e.g., `""`, `"jpn"`, `"JA"`, `"ja-JP"`)
 - **THEN** the backend SHALL reject the request with `INVALID_ARGUMENT`
 - **AND** no user row SHALL be created
 

--- a/openspec/changes/persist-user-language/specs/user-profile-hydration/spec.md
+++ b/openspec/changes/persist-user-language/specs/user-profile-hydration/spec.md
@@ -1,0 +1,80 @@
+## MODIFIED Requirements
+
+### Requirement: Write-through on user mutation
+
+When the user's profile is mutated via an RPC, the in-memory `current` state SHALL be updated with the response, without requiring a separate `Get` call.
+
+#### Scenario: Home area updated
+
+- **WHEN** an authenticated user calls `UserService.updateHome()` successfully
+- **THEN** the system SHALL update `UserService.current` with the `User` entity returned in the RPC response
+- **AND** subsequent reads of `UserService.current.home` SHALL reflect the new home area
+
+#### Scenario: Preferred language updated
+
+- **WHEN** an authenticated user calls `UserService.updatePreferredLanguage()` successfully
+- **THEN** the system SHALL update `UserService.current` with the `User` entity returned in the RPC response
+- **AND** subsequent reads of `UserService.current.preferredLanguage` SHALL reflect the new value
+- **AND** the system SHALL call `I18N.setLocale()` with the new value so all `t`-bound bindings re-render
+
+---
+
+## ADDED Requirements
+
+### Requirement: Apply Preferred Language to i18n After Hydration
+
+After loading the authenticated user's profile, the system SHALL apply the user's stored preferred language to the active i18n locale, making the DB the source of truth for authenticated sessions.
+
+#### Scenario: Preferred language present in hydrated profile
+
+- **WHEN** `UserService.ensureLoaded()` resolves and `UserService.current.preferredLanguage` is set
+- **THEN** the system SHALL call `I18N.setLocale(UserService.current.preferredLanguage)`
+- **AND** all `t`-bound template strings SHALL re-render to the resolved locale
+
+#### Scenario: Brief locale flicker on slow networks is acceptable
+
+- **WHEN** the application bootstraps an authenticated user
+- **AND** the initial i18n chain (querystring → localStorage → navigator) sets a tentative locale before `ensureLoaded()` resolves
+- **THEN** the system MAY render with the tentative locale until the hydration completes
+- **AND** the system SHALL switch to the DB-sourced locale as soon as hydration resolves
+- **AND** the system SHALL NOT block initial render waiting for hydration
+
+---
+
+### Requirement: Backfill Preferred Language When Missing
+
+When the hydrated user profile has no preferred language set (NULL legacy row), the system SHALL backfill the DB by persisting the currently effective locale before continuing.
+
+#### Scenario: Hydrated profile has no preferred language
+
+- **WHEN** `UserService.ensureLoaded()` resolves
+- **AND** `UserService.current.preferredLanguage` is absent (proto `optional` field not present)
+- **THEN** the system SHALL call `UserService.updatePreferredLanguage(I18N.getLocale())`
+- **AND** on success, `UserService.current.preferredLanguage` SHALL match the value sent
+- **AND** the active i18n locale SHALL remain unchanged (no flicker because the value matched what was already effective)
+
+#### Scenario: Backfill RPC failure is non-fatal
+
+- **WHEN** the backfill `UpdatePreferredLanguage` RPC fails
+- **THEN** the system SHALL log a warning
+- **AND** the application SHALL continue to render with the current locale
+- **AND** the next hydration cycle SHALL retry the backfill (because the DB still holds NULL)
+
+---
+
+### Requirement: Remove Legacy localStorage Language Key After Hydration
+
+After successful authenticated hydration, the system SHALL remove `localStorage['language']` so subsequent code paths cannot read a stale value. This SHALL run regardless of whether `preferred_language` was already set or required backfill.
+
+#### Scenario: Cleanup runs after hydration completes
+
+- **WHEN** `UserService.ensureLoaded()` resolves for an authenticated user
+- **THEN** the system SHALL call `localStorage.removeItem('language')`
+- **AND** the removal SHALL execute even if `preferred_language` was already populated in the response
+
+#### Scenario: Cleanup is idempotent
+
+- **WHEN** `localStorage['language']` has already been removed
+- **AND** hydration runs again (e.g., subsequent boot)
+- **THEN** `removeItem` SHALL be a safe no-op
+- **AND** no error SHALL be raised

--- a/openspec/changes/persist-user-language/tasks.md
+++ b/openspec/changes/persist-user-language/tasks.md
@@ -4,7 +4,7 @@
 - [x] 1.2 Add required `string preferred_language` to `rpc.user.v1.CreateRequest` with the same `protovalidate` pattern; document idempotent-return non-overwrite rule
 - [x] 1.3 Add `rpc UpdatePreferredLanguage(UpdatePreferredLanguageRequest) returns (UpdatePreferredLanguageResponse)` to `UserService`; define request (`UserId user_id`, `string preferred_language`) and response (`User user`); document error matrix (INVALID_ARGUMENT / PERMISSION_DENIED / NOT_FOUND / UNAUTHENTICATED)
 - [x] 1.4 Run `buf lint` and `buf format -w` locally; verify `buf breaking --against '.git#branch=main'` reports only the intentional break on CreateRequest (label PR with `buf skip breaking` if required by repo convention)
-- [ ] 1.5 Open specification PR; after approval and CI pass, merge to main
+- [x] 1.5 Open specification PR; after approval and CI pass, merge to main
 - [ ] 1.6 Cut GitHub Release `vX.Y.Z` on specification; monitor `buf-release.yml` until BSR gen completes
 
 ## 2. Backend (Go) — preparation while specification PR is in flight

--- a/openspec/changes/persist-user-language/tasks.md
+++ b/openspec/changes/persist-user-language/tasks.md
@@ -1,9 +1,9 @@
 ## 1. Specification (proto)
 
-- [x] 1.1 Add `optional string preferred_language` to `entity.v1.User` with `protovalidate` pattern `^[a-z]{2}$`; document semantics (ISO 639-1, absent = NULL = not yet set by client)
-- [x] 1.2 Add required `string preferred_language` to `rpc.user.v1.CreateRequest` with the same `protovalidate` pattern; document idempotent-return non-overwrite rule
-- [x] 1.3 Add `rpc UpdatePreferredLanguage(UpdatePreferredLanguageRequest) returns (UpdatePreferredLanguageResponse)` to `UserService`; define request (`UserId user_id`, `string preferred_language`) and response (`User user`); document error matrix (INVALID_ARGUMENT / PERMISSION_DENIED / NOT_FOUND / UNAUTHENTICATED)
-- [x] 1.4 Run `buf lint` and `buf format -w` locally; verify `buf breaking --against '.git#branch=main'` reports only the intentional break on CreateRequest (label PR with `buf skip breaking` if required by repo convention)
+- [x] 1.1 Add `optional string preferred_language` to `entity.v1.User` with `protovalidate` constraints `min_len: 2` and `pattern: "^[a-z]{2}$"`; document semantics (ISO 639-1, absent = NULL = not yet set by client)
+- [x] 1.2 Add `optional string preferred_language` to `rpc.user.v1.CreateRequest` with the same `protovalidate` constraints; document idempotent-return non-overwrite rule and the absent-equals-backfill path for old clients
+- [x] 1.3 Add `rpc UpdatePreferredLanguage(UpdatePreferredLanguageRequest) returns (UpdatePreferredLanguageResponse)` to `UserService`; define request (`UserId user_id`, `string preferred_language` with `min_len: 2` + pattern) and response (`User user`); document error matrix (INVALID_ARGUMENT / PERMISSION_DENIED / NOT_FOUND / UNAUTHENTICATED)
+- [x] 1.4 Run `buf lint` and `buf format -w` locally; verify `buf breaking --against '.git#branch=main'` passes (all wire changes are additive — no `buf skip breaking` label required)
 - [x] 1.5 Open specification PR; after approval and CI pass, merge to main
 - [ ] 1.6 Cut GitHub Release `vX.Y.Z` on specification; monitor `buf-release.yml` until BSR gen completes
 

--- a/openspec/changes/persist-user-language/tasks.md
+++ b/openspec/changes/persist-user-language/tasks.md
@@ -1,0 +1,56 @@
+## 1. Specification (proto)
+
+- [x] 1.1 Add `optional string preferred_language` to `entity.v1.User` with `protovalidate` pattern `^[a-z]{2}$`; document semantics (ISO 639-1, absent = NULL = not yet set by client)
+- [x] 1.2 Add required `string preferred_language` to `rpc.user.v1.CreateRequest` with the same `protovalidate` pattern; document idempotent-return non-overwrite rule
+- [x] 1.3 Add `rpc UpdatePreferredLanguage(UpdatePreferredLanguageRequest) returns (UpdatePreferredLanguageResponse)` to `UserService`; define request (`UserId user_id`, `string preferred_language`) and response (`User user`); document error matrix (INVALID_ARGUMENT / PERMISSION_DENIED / NOT_FOUND / UNAUTHENTICATED)
+- [x] 1.4 Run `buf lint` and `buf format -w` locally; verify `buf breaking --against '.git#branch=main'` reports only the intentional break on CreateRequest (label PR with `buf skip breaking` if required by repo convention)
+- [ ] 1.5 Open specification PR; after approval and CI pass, merge to main
+- [ ] 1.6 Cut GitHub Release `vX.Y.Z` on specification; monitor `buf-release.yml` until BSR gen completes
+
+## 2. Backend (Go) — preparation while specification PR is in flight
+
+- [x] 2.1 Create branch in backend worktree
+- [x] 2.2 Draft Atlas migration: `ALTER TABLE app.users ALTER COLUMN preferred_language DROP DEFAULT;` and `UPDATE app.users SET preferred_language = NULL WHERE preferred_language = 'en';`; update column comment to document NULL semantics
+- [x] 2.3 In `internal/adapter/rpc/mapper/user.go`, extend `UserToProto` to populate `preferred_language` when non-empty (using the proto `optional` field); extend `NewUserFromCreateRequest` to accept and pass through `preferred_language`
+- [x] 2.4 In `internal/adapter/rpc/user_handler.go`, update the `Create` handler to read `preferred_language` from the request, validate it as part of the existing protovalidate interceptor, and propagate it to the use case
+- [x] 2.5 In `internal/adapter/rpc/user_handler.go`, add `UpdatePreferredLanguage` handler with `RequireUserIDMatch` and proper error mapping
+- [x] 2.6 In `internal/usecase/user_uc.go`, add `UpdatePreferredLanguage(ctx, userID, lang)` use-case method
+- [x] 2.7 In `internal/infrastructure/database/rdb/user_repo.go`, add `UpdatePreferredLanguage(ctx, userID, lang) (*entity.User, error)` repo method that updates only the column and returns the refreshed row
+- [x] 2.8 Update entity-level docs on `User.PreferredLanguage` (and `NewUser.PreferredLanguage`) to reflect "non-empty string supplied at signup; empty string disallowed by Create"
+- [x] 2.9 Generate mocks via `mockery` for any new repository/use-case interface
+- [x] 2.10 Write unit tests: mapper round-trip with present/absent preferred_language; use-case happy-path + NOT_FOUND; handler permission scoping
+- [x] 2.11 Write integration test: Create persists preferred_language; idempotent Create does NOT overwrite; UpdatePreferredLanguage round-trips
+- [x] 2.12 Run `make check` and verify all linters / tests pass
+
+## 3. Frontend (Aurelia 2) — preparation while specification PR is in flight
+
+- [x] 3.1 Create branch in frontend worktree
+- [x] 3.2 In `src/main.ts`, change i18next-browser-languagedetector config to `caches: ['localStorage']`
+- [x] 3.3 In `src/entities/user.ts`, add `preferredLanguage?: string` field to the `User` interface (proto optional → TS optional)
+- [x] 3.4 In `src/adapter/rpc/client/user-client.ts`, update `create()` signature to accept and pass `preferredLanguage`; add `updatePreferredLanguage(userId, lang)` method that calls the new RPC
+- [x] 3.5 In `src/services/user-service.ts`, expose `current.preferredLanguage`; add `updatePreferredLanguage(lang)` method with write-through state update
+- [x] 3.6 In `src/services/user-hydration-task.ts`, after `ensureLoaded` resolves: if `current.preferredLanguage` is present call `i18n.setLocale(...)`; if absent call `userService.updatePreferredLanguage(i18n.getLocale())` (log warning on failure); always `localStorage.removeItem('language')`
+- [x] 3.7 In `src/routes/auth-callback/auth-callback-route.ts`, on successful Create / ensureUserProvisioned, ensure `localStorage.removeItem('language')` runs (may be a no-op if hydration already did it, but keep for the explicit-Create path)
+- [x] 3.8 In `src/services/user-service.ts` and the RPC client, ensure Create passes `i18n.getLocale()` as `preferredLanguage`
+- [x] 3.9 In `src/util/change-locale.ts`, split anonymous vs authenticated paths: keep current behavior when unauthenticated; for authenticated callers route through `userService.updatePreferredLanguage(lang)` and DO NOT touch localStorage; surface RPC failure to the caller for UI feedback
+- [x] 3.10 In `src/routes/settings/settings-route.ts`, rewrite `selectLanguage`: call the authenticated `changeLocale` path; on failure publish a Snack; reread `currentLocale` from `userService.current.preferredLanguage` after successful change
+- [x] 3.11 Update unit tests in `src/routes/settings/settings-route.spec.ts` (and create equivalents for welcome if needed) to cover RPC success, RPC failure, and re-selection no-op
+- [x] 3.12 Verify Storybook stories still render with the new `preferredLanguage` field on the User entity; update fixtures if needed
+- [x] 3.13 Run `make check` and verify lint / typecheck / tests pass
+
+## 4. Cross-Repo Release Coordination
+
+- [ ] 4.1 Confirm specification PR merged and Release published (Task 1.6 complete) before pushing backend/frontend branches
+- [ ] 4.2 In backend: `go get buf.build/gen/go/liverty-music/schema/...@vX.Y.Z`, `go mod tidy`, swap any `TODO: swap to generated type` placeholders for the real generated types, run `make check`
+- [ ] 4.3 In frontend: `npm install @buf/liverty-music_schema.connectrpc_es@latest` (or the equivalent), swap placeholders for generated types, run `make check`
+- [ ] 4.4 Open backend PR; address review; ensure CI passes before requesting merge
+- [ ] 4.5 Open frontend PR; address review; ensure CI passes before requesting merge
+
+## 5. Post-Merge Verification
+
+- [ ] 5.1 After backend merge: monitor ArgoCD deployment via `gh run list --repo liverty-music/backend --branch main --limit 3`; verify new pod serves UpdatePreferredLanguage RPC (smoke test `grpcurl` or curl)
+- [ ] 5.2 In dev environment: sign up a fresh test user, verify `app.users.preferred_language` matches the client locale at signup
+- [ ] 5.3 In dev environment: take a legacy user row, sign in, verify hydration backfills `preferred_language` (DB transition NULL → 'ja'/'en')
+- [ ] 5.4 In dev environment: change language via Settings, hard reload, verify the language persists (the original bug is fixed)
+- [ ] 5.5 In dev environment: verify `localStorage['language']` is removed after sign-in and not re-written by any code path while authenticated
+- [ ] 5.6 Archive the OpenSpec change via `/opsx:archive` once all tasks are ticked and verification is complete

--- a/proto/liverty_music/entity/v1/user.proto
+++ b/proto/liverty_music/entity/v1/user.proto
@@ -59,7 +59,10 @@ message User {
   // backfill it by calling UpdatePreferredLanguage with their currently
   // effective locale, so that subsequent sessions can rely on the backend
   // as the single source of truth for the user's language preference.
-  optional string preferred_language = 7 [(buf.validate.field).string.pattern = "^[a-z]{2}$"];
+  optional string preferred_language = 7 [(buf.validate.field).string = {
+    min_len: 2
+    pattern: "^[a-z]{2}$"
+  }];
 }
 
 // Home represents the user's home area as a structured geographic location,

--- a/proto/liverty_music/entity/v1/user.proto
+++ b/proto/liverty_music/entity/v1/user.proto
@@ -48,6 +48,18 @@ message User {
   // are classified as HOME, nearby areas as NEARBY, and everything else as AWAY.
   // Absent until the user explicitly selects their area during onboarding or in settings.
   Home home = 6;
+
+  // The user's preferred display language as an ISO 639-1 two-letter code
+  // (e.g., "ja", "en"). Used to render the UI in the user's chosen language
+  // and to localize user-facing notifications.
+  //
+  // Absent (NULL in storage) until the client first asserts a preference —
+  // either via Create at signup or via UpdatePreferredLanguage for legacy
+  // rows that predate this field. Clients observing an absent value SHALL
+  // backfill it by calling UpdatePreferredLanguage with their currently
+  // effective locale, so that subsequent sessions can rely on the backend
+  // as the single source of truth for the user's language preference.
+  optional string preferred_language = 7 [(buf.validate.field).string.pattern = "^[a-z]{2}$"];
 }
 
 // Home represents the user's home area as a structured geographic location,

--- a/proto/liverty_music/rpc/user/v1/user_service.proto
+++ b/proto/liverty_music/rpc/user/v1/user_service.proto
@@ -44,10 +44,35 @@ service UserService {
   // idempotent-return path, home is ignored — use UpdateHome to change an
   // already-provisioned user's home area.
   //
+  // The preferred_language field is required: clients always know their
+  // current effective locale at signup and MUST send it. On the
+  // idempotent-return path, preferred_language is IGNORED — the existing
+  // row's language is not overwritten, mirroring the rule for home. Use
+  // UpdatePreferredLanguage to change an already-provisioned user's
+  // preferred display language.
+  //
   // Possible errors:
   // - INVALID_ARGUMENT: The provided user data is missing required fields or is malformed.
   // - UNAUTHENTICATED: The request lacks valid authentication credentials.
   rpc Create(CreateRequest) returns (CreateResponse);
+
+  // UpdatePreferredLanguage sets or changes the authenticated user's
+  // preferred display language.
+  //
+  // The preferred language determines the locale used to render the UI and
+  // user-facing notifications. Users typically set this at signup (carried
+  // in the Create RPC) and may update it later from settings.
+  //
+  // Per the rpc-auth-scoping convention, the request carries an explicit
+  // user_id that the backend verifies against the userID derived from the
+  // JWT context; mismatches are rejected with PERMISSION_DENIED.
+  //
+  // Possible errors:
+  // - INVALID_ARGUMENT: user_id is missing or malformed, or preferred_language is empty or not a valid ISO 639-1 two-letter code.
+  // - NOT_FOUND: No user record exists for the authenticated identity.
+  // - PERMISSION_DENIED: The supplied user_id does not match the authenticated caller.
+  // - UNAUTHENTICATED: The request lacks valid authentication credentials.
+  rpc UpdatePreferredLanguage(UpdatePreferredLanguageRequest) returns (UpdatePreferredLanguageResponse);
 
   // UpdateHome sets or changes the authenticated user's home area.
   //
@@ -117,6 +142,18 @@ message CreateRequest {
   // UpdateHome. Ignored on the idempotent-return path (duplicate
   // external_id) — the existing row's home is not overwritten.
   entity.v1.Home home = 2;
+
+  // Required. The user's preferred display language as an ISO 639-1
+  // two-letter code (e.g., "ja", "en"), captured from the client's
+  // effective locale at the moment of signup. Persisted atomically with
+  // the new user record so subsequent sessions can render the UI in the
+  // user's chosen language without relying on browser storage.
+  //
+  // Ignored on the idempotent-return path (duplicate external_id) — the
+  // existing row's preferred_language is not overwritten, mirroring the
+  // rule for home. Use UpdatePreferredLanguage to change an
+  // already-provisioned user's preferred display language.
+  string preferred_language = 3 [(buf.validate.field).string.pattern = "^[a-z]{2}$"];
 }
 
 // CreateResponse returns the user profile as successfully created.
@@ -139,6 +176,26 @@ message UpdateHomeRequest {
 // UpdateHomeResponse returns the updated user profile after the home area change.
 message UpdateHomeResponse {
   // The updated user entity with the new home area applied.
+  entity.v1.User user = 1 [(buf.validate.field).required = true];
+}
+
+// UpdatePreferredLanguageRequest provides the new preferred language for the
+// authenticated user.
+message UpdatePreferredLanguageRequest {
+  // The caller's user identifier. Must match the userID derived from the
+  // authenticated session; mismatches are rejected with PERMISSION_DENIED.
+  entity.v1.UserId user_id = 1 [(buf.validate.field).required = true];
+
+  // Required. The new preferred display language as an ISO 639-1 two-letter
+  // code (e.g., "ja", "en"). Empty values and codes outside the
+  // `^[a-z]{2}$` pattern are rejected with INVALID_ARGUMENT.
+  string preferred_language = 2 [(buf.validate.field).string.pattern = "^[a-z]{2}$"];
+}
+
+// UpdatePreferredLanguageResponse returns the updated user profile after the
+// preferred language change.
+message UpdatePreferredLanguageResponse {
+  // The updated user entity with the new preferred language applied.
   entity.v1.User user = 1 [(buf.validate.field).required = true];
 }
 

--- a/proto/liverty_music/rpc/user/v1/user_service.proto
+++ b/proto/liverty_music/rpc/user/v1/user_service.proto
@@ -44,10 +44,16 @@ service UserService {
   // idempotent-return path, home is ignored — use UpdateHome to change an
   // already-provisioned user's home area.
   //
-  // The preferred_language field is required: clients always know their
-  // current effective locale at signup and MUST send it. On the
-  // idempotent-return path, preferred_language is IGNORED — the existing
-  // row's language is not overwritten, mirroring the rule for home. Use
+  // The preferred_language field is optional on the wire so this RPC
+  // remains backward-compatible during a rolling deploy where the new
+  // backend may be live before all frontend clients have been updated.
+  // Updated clients MUST send their currently effective locale; the
+  // value, when present, is persisted atomically with the new user row.
+  // Absent values are stored as NULL and trigger the same client-side
+  // backfill path as legacy rows (see UpdatePreferredLanguage and the
+  // user-profile-hydration capability). On the idempotent-return path,
+  // preferred_language is IGNORED — the existing row's language is not
+  // overwritten, mirroring the rule for home. Use
   // UpdatePreferredLanguage to change an already-provisioned user's
   // preferred display language.
   //
@@ -143,17 +149,27 @@ message CreateRequest {
   // external_id) — the existing row's home is not overwritten.
   entity.v1.Home home = 2;
 
-  // Required. The user's preferred display language as an ISO 639-1
-  // two-letter code (e.g., "ja", "en"), captured from the client's
-  // effective locale at the moment of signup. Persisted atomically with
-  // the new user record so subsequent sessions can render the UI in the
-  // user's chosen language without relying on browser storage.
+  // Optional on the wire to keep this RPC backward-compatible during a
+  // rolling deploy where the new backend may serve old frontend clients
+  // briefly. Updated clients SHALL send their currently effective locale
+  // as an ISO 639-1 two-letter code (e.g., "ja", "en"). When present,
+  // the value is validated against `^[a-z]{2}$` and persisted atomically
+  // with the new user record so subsequent sessions can render the UI in
+  // the user's chosen language without relying on browser storage.
+  //
+  // When absent, the user row is created with a NULL preferred_language
+  // — semantically equivalent to a legacy row pending backfill — and the
+  // client backfills it on next hydration via UpdatePreferredLanguage.
+  // This keeps the old-client transition window safe without requiring
+  // perfectly synchronized deploys.
   //
   // Ignored on the idempotent-return path (duplicate external_id) — the
   // existing row's preferred_language is not overwritten, mirroring the
-  // rule for home. Use UpdatePreferredLanguage to change an
-  // already-provisioned user's preferred display language.
-  string preferred_language = 3 [(buf.validate.field).string.pattern = "^[a-z]{2}$"];
+  // rule for home.
+  optional string preferred_language = 3 [(buf.validate.field).string = {
+    min_len: 2
+    pattern: "^[a-z]{2}$"
+  }];
 }
 
 // CreateResponse returns the user profile as successfully created.
@@ -189,7 +205,10 @@ message UpdatePreferredLanguageRequest {
   // Required. The new preferred display language as an ISO 639-1 two-letter
   // code (e.g., "ja", "en"). Empty values and codes outside the
   // `^[a-z]{2}$` pattern are rejected with INVALID_ARGUMENT.
-  string preferred_language = 2 [(buf.validate.field).string.pattern = "^[a-z]{2}$"];
+  string preferred_language = 2 [(buf.validate.field).string = {
+    min_len: 2
+    pattern: "^[a-z]{2}$"
+  }];
 }
 
 // UpdatePreferredLanguageResponse returns the updated user profile after the


### PR DESCRIPTION
## Summary

- Adds `preferred_language` (ISO 639-1) to `entity.v1.User` as `optional`, and adds it as a required field to `rpc.user.v1.CreateRequest`.
- Adds new RPC `UserService.UpdatePreferredLanguage` mirroring the existing `UpdateHome` custom-method pattern.
- Tracks the cross-repo design in OpenSpec change `persist-user-language` (proposal / design / 5 spec deltas / task list).

## Why

The user's UI language preference currently lives only in browser `localStorage`. This is unreliable (Safari ITP cap, private browsing, cross-device divergence) and is the suspected cause of authenticated users seeing the UI revert to EN after a hard reload. The DB already has a `users.preferred_language` column but it is not exposed over the wire, so it cannot serve as the source of truth.

This change makes the backend authoritative for authenticated users:

- Anonymous (welcome / discovery): browser auto-detection persists to `localStorage` so reloads are stable.
- At signup: `Create` carries the effective locale; backend persists it; frontend cleans up `localStorage['language']`.
- Authenticated: locale is sourced from `user.preferred_language`; `localStorage` is no longer read or written.
- Legacy rows (DB had `DEFAULT 'en'`) are set to NULL by the backend migration and backfilled by the client on next hydration with its currently effective locale.

## What's in this PR

- `proto/liverty_music/entity/v1/user.proto`: adds field 7 `optional string preferred_language` with `protovalidate` pattern `^[a-z]{2}$`.
- `proto/liverty_music/rpc/user/v1/user_service.proto`: adds field 3 `string preferred_language` on `CreateRequest`; documents the idempotent-return non-overwrite rule; adds `UpdatePreferredLanguage` RPC + request/response messages; documents the error matrix.
- `openspec/changes/persist-user-language/`: proposal, design (decisions D1-D7), spec deltas (`user-language-preference` NEW; `frontend-i18n` / `settings` / `user-profile-hydration` / `user-account-sync` MODIFIED), tasks.md.

Wire-compatibility is preserved (`buf breaking` passes) — the `required`-via-protovalidate constraint on `CreateRequest.preferred_language` is a runtime validation break for old clients, not a wire break, so no `buf skip breaking` label is needed.

## Downstream PRs (pending BSR gen)

After this PR merges and the GitHub Release publishes the schema to BSR, the matching backend and frontend PRs will be opened. Both branches are prepared locally; their commits carry `TODO(persist-user-language)` markers at the call sites where the new generated types are referenced, which will be swapped in follow-up commits before opening the downstream PRs.

## Test plan

- [x] `buf lint` clean
- [x] `buf format -w` no changes needed
- [x] `buf breaking --against '.git#branch=main'` passes (intentional: additive only at the wire level)
- [ ] CI `buf-pr-checks.yml` passes on this PR
- [ ] Spec review approves the new field / RPC / docs

Closes #512