### PR TITLE
Mechanize Claude review verdict (propose change + drop caller additional_focus)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -19,5 +19,3 @@ jobs:
   review:
     uses: liverty-music/.github/.github/workflows/claude-review.yml@main
     secrets: inherit
-    with:
-      additional_focus: "Protobuf style (Google AIP), buf.validate annotations, backward compatibility"

--- a/openspec/changes/mechanize-claude-review-verdict/.openspec.yaml
+++ b/openspec/changes/mechanize-claude-review-verdict/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-25

--- a/openspec/changes/mechanize-claude-review-verdict/design.md
+++ b/openspec/changes/mechanize-claude-review-verdict/design.md
@@ -1,0 +1,103 @@
+## Context
+
+The `Claude review` Check Run was introduced 2026-05-15 ([archive/2026-05-16-claude-review-check-run](../archive/2026-05-16-claude-review-check-run/)) to surface code-review verdicts in the PR list view and gate merges via Required Status Checks. The implementation asked the wrapping LLM agent — orchestrated by `anthropics/claude-code-action@v1` — to invoke the `/code-review:code-review` slash command, then write `/tmp/claude-verdict.json` containing a binary pass/fail verdict that a subsequent `actions/github-script` step mapped to a Check Run `conclusion`.
+
+Investigation conducted 2026-05-25 found that this design deviates from official `anthropics/claude-code-action` and `code-review` plugin patterns in six places (`additional_focus` free-text injection, factually-wrong "sticky comment" prompt wording, Step 1 / Step 2 wrapping, user-invented verdict-file mechanism, `--allowedTools` mismatch with the slash command's frontmatter, and unhandled skip-on-repeat behavior). Each deviation is independently documented in `anthropics/claude-code-action` issues (notably [#1087](https://github.com/anthropics/claude-code-action/issues/1087), [#590](https://github.com/anthropics/claude-code-action/issues/590), [anthropics/claude-code#19618](https://github.com/anthropics/claude-code/issues/19618)) and in academic literature on LLM confidence inflation under binary classification pressure ([arxiv 2602.17170](https://arxiv.org/pdf/2602.17170), [arxiv 2604.01457](https://arxiv.org/pdf/2604.01457)).
+
+The Anthropic model-serving incidents of 2026-05-18 to 2026-05-22 (multiple `Opus 4.7`, `Sonnet 4.6`, `Haiku 4.5` elevated-error events per [status.claude.com](https://status.claude.com/)) amplified the consequences of these deviations into user-visible symptoms: nit-level comment overload, "HIGH SIGNAL only" filter being ignored, and self-contradicting verdicts within a single PR's review loop. Plugin source confirms the `code-review` slash command itself has not changed since 2026-04-10, and `anthropics/claude-code-action` v1.0.133 (2026-05-23) only bumped the underlying SDK without behavior changes — so the regression locus is the user-side wrapper, with model wobble as the amplifier.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Eliminate binary pass/fail verdict pressure on the LLM (replace with deterministic post-step counting).
+- Restore alignment with official `anthropics/claude-code-action` invocation patterns (single-line `prompt:`, slash command standalone).
+- Preserve the `Claude review` Check Run name, the Required Status Check gating policy, and the pilot-then-rollout deployment posture (no Pulumi changes).
+- Reduce the prompt-injection surface (remove `additional_focus` free-text input).
+- Make the workflow's `--allowedTools` agree with the slash command's declared frontmatter, removing silent subagent failures.
+
+**Non-Goals:**
+
+- Fix the upstream skip-on-repeat behavior ([anthropics/claude-code#19618](https://github.com/anthropics/claude-code/issues/19618)). Mitigated by HEAD-SHA-scoped counting, not resolved.
+- Improve plugin output quality during Anthropic-side incidents (out of our control).
+- Migrate to the cloud-hosted "Code Review" product (`REVIEW.md`-based) on `claude.com`. Mentioned as a future option, not adopted here.
+- Change the Pulumi branch-protection contract or Required Status Check name.
+- Change per-repo `CLAUDE.md` files (the "Go conventions / pgx" content previously injected via `additional_focus` is already documented there).
+
+## Decisions
+
+### Decision 1: Mechanical comment counting replaces LLM-emitted verdict file
+
+The Check Run `conclusion` is derived in a bash post-step that calls `gh api repos/<owner>/<repo>/pulls/<N>/comments`, filters to comments whose `commit_id` equals the PR head SHA AND whose `user.login` indicates the Claude bot (e.g., `claude[bot]`), and counts the result. Zero comments → `success`. One or more → `failure`. Any error fetching → `neutral`.
+
+**Why:**
+
+- LLM-emitted binary verdicts are documented to suffer confidence inflation under fail-justifying prompts ([arxiv 2602.17170](https://arxiv.org/pdf/2602.17170)). Removing the LLM from the verdict path removes the inflation pressure entirely.
+- The post-step observes the same artifact a human reviewer sees on the PR (the inline comments). There is no second source of truth.
+- HEAD-SHA scoping prevents stale comments from prior pushes inflating the count — partially mitigating the skip-on-repeat scenario where the slash command exits early on subsequent pushes.
+
+**Alternative considered:** Use the action's `outputs.structured_output` with a `--json-schema`. Rejected because the `code-review` plugin emits a natural-language summary, not structured output, and changing the plugin is out of scope.
+
+**Alternative considered:** Use `track_progress: true` from the official examples. Rejected for the same reason — `track_progress` surfaces UI progress, not a machine-readable verdict.
+
+### Decision 2: Remove `additional_focus` input entirely
+
+The reusable workflow's `additional_focus` input is removed. Caller workflows drop their `with: additional_focus:` blocks. Per-repo review focus is expressed in each repo's `CLAUDE.md`.
+
+**Why:**
+
+- The `/code-review` slash command's only documented argument is `--comment`. `additional_focus` was injected as free-form text between Step 1 and Step 2 of the wrapper prompt — semantically identical to a prompt-injection pattern (per [OWASP guidance](https://owasp.org/www-community/attacks/PromptInjection)).
+- Under degraded models, the additional-focus text reads as "also flag X" rather than "ALSO use this as filter context", which directly opposes the plugin's "HIGH SIGNAL only" instruction and causes nit volume to spike.
+- The content previously injected ("Go conventions, error handling, table-driven tests, pgx usage" for backend; equivalents for other repos) is already in each repo's `CLAUDE.md`, which the slash command's CLAUDE.md-audit agents already read. There is no information loss.
+
+**Alternative considered:** Move `additional_focus` content into a per-repo `REVIEW.md`. Rejected because the open-source `code-review` plugin (which we use) reads `CLAUDE.md`, not `REVIEW.md` — `REVIEW.md` is a feature of the separate cloud-hosted Code Review product on `claude.com`.
+
+### Decision 3: Restore single-line `prompt:` and align `--allowedTools` with slash-command frontmatter
+
+The reusable workflow's `prompt:` becomes one line: `'/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }} --comment'`. The "Step 1 / Step 2" wrapping is removed. `claude_args.--allowedTools` adds `Bash(gh pr list:*)` to match the slash command's declared `allowed-tools` frontmatter; `Write` is removed (no verdict file to write).
+
+**Why:**
+
+- All 10 official examples in `anthropics/claude-code-action/examples/` and 8 use cases in `docs/solutions.md` invoke slash commands standalone, not wrapped in numbered steps.
+- The slash command has its own internal step-1-through-9 structure (`code-review.md`). Nesting an outer "Step 1 / Step 2" forces the wrapper agent to choose between solving outer steps and delegating to inner steps — a state of instruction conflict that fails first under model degradation.
+- `--allowedTools` per [anthropics/claude-code#37683](https://github.com/anthropics/claude-code/issues/37683) does not block tools; it only removes approval prompts. On CI runners with no human to approve, a missing tool from the allowlist causes subagent hang/timeout.
+
+### Decision 4: Check Run name, Required Status Check, and pilot/rollout posture unchanged
+
+The Check Run is still named `Claude review`. The Pulumi `requiredStatusCheckContexts` configuration in `cloud-provisioning/src/index.ts` is untouched. The conclusion vocabulary (`success` / `failure` / `neutral`) is unchanged.
+
+**Why:**
+
+- Branch-protection settings are environment-gated (`prod` only) and stable. Touching them widens blast radius and forces a Pulumi PR. The mechanical-counting change is workflow-only.
+- The conclusion semantics from the consumer's perspective (GitHub branch protection) are identical: `failure` blocks merge, `success` allows, `neutral` allows. Only the derivation mechanism inside the workflow changes.
+
+### Decision 5: Tracking issue created in `liverty-music/specification` before implementation
+
+A new tracking issue is created in `liverty-music/specification` ahead of any workflow PR, mirroring the prior `#474` precedent. The issue number is referenced in all PR commits per the liverty-music commit convention (`Refs: #<issue-number>`).
+
+**Why:**
+
+- The change spans four caller-repo PRs plus one `.github` repo PR. Without a single tracking issue, the audit trail fragments.
+
+## Risks / Trade-offs
+
+- **[Skip-on-repeat: second push gets no fresh review]** → Mitigation: HEAD-SHA scoping ensures `failure` doesn't persist from stale prior-push comments. If the second push fixes the issues from the first push, the count returns to zero and the Check Run flips to `success`. Trade-off: a second push that introduces NEW bugs won't be caught — accepted because this matches the plugin's documented behavior and is upstream-only fixable.
+- **[Bot-author detection brittleness]** → The post-step filters by `user.login` matching the Claude bot identity. If Anthropic changes the bot's GitHub identity (rename, app re-installation), the filter silently breaks → `success` despite issues posted. Mitigation: assert at least one of the filtered comments has the expected `user.type == "Bot"` or `user.login` pattern; fail to `neutral` rather than `success` if zero comments match BUT inline comments exist on the head SHA from any bot.
+- **[Comments from non-Claude bots on same PR]** → A different bot (Dependabot, Renovate) posting inline comments on the same PR head SHA could inflate the count. Mitigation: the `user.login` filter is exact-match to Claude's bot identity, not a generic "is a bot" check.
+- **[`gh api` rate limits or network errors]** → The post-step uses the workflow's `GITHUB_TOKEN`, which has generous limits, but transient errors are possible. Mitigation: on `gh api` non-zero exit, publish Check Run with `conclusion: neutral` and a summary indicating "verdict computation failed".
+- **[Loss of the "fail with summary text" UX]** → Previously the Check Run's `output.title` showed `N issue(s) found` derived from the LLM's verdict JSON. Mechanical counting still gives `N`, but the LLM-authored one-line `summary` field is gone. Mitigation: include the count in the title (`N issue(s) found`) and link to the PR inline-comments view in the `summary`. Acceptable degradation — the summary was rarely informative.
+
+## Migration Plan
+
+1. Create tracking issue in `liverty-music/specification` ("Mechanize Claude review verdict (decouple from LLM judgment)").
+2. Land the `.github` repo change first (reusable workflow at `liverty-music/.github/.github/workflows/claude-review.yml`). Because all four caller workflows reference `@main`, they will pick up the new reusable workflow on the next PR push.
+3. Land the four caller-repo changes (drop `with: additional_focus:`) in any order. Each is a single-file, single-block deletion.
+4. Validate on the `specification` repo (the original pilot target) by opening a small test PR. Confirm: single-line prompt is sent, slash command runs to completion, inline comments are posted (if applicable), Check Run conclusion matches comment count.
+5. After two successful PRs on `specification`, declare migration complete. Archive this change.
+
+**Rollback:** revert the merge commits in `liverty-music/.github` and the four caller repos. Branch protection is unchanged, so rollback restores the previous (broken-but-tolerated) state without any Pulumi action.
+
+## Open Questions
+
+- Should the `gh api` filter also exclude comments authored before the head SHA was pushed (in case `commit_id` ever lags)? Probably not — `commit_id` on the API response is authoritative — but to be confirmed during implementation by inspecting a real run's API output.
+- Is there value in publishing a sticky comment summarizing the verdict (for PR readers who don't expand the Check Run)? Defer; can be added later as a non-breaking enhancement.

--- a/openspec/changes/mechanize-claude-review-verdict/proposal.md
+++ b/openspec/changes/mechanize-claude-review-verdict/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+The current `Claude review` Check Run pipeline (introduced in [archive/2026-05-16-claude-review-check-run](../archive/2026-05-16-claude-review-check-run/)) asks the wrapping LLM agent to commit to a binary pass/fail verdict via `/tmp/claude-verdict.json`. Combined with an `additional_focus` free-text injection, a "Step 1 / Step 2" wrapper around the slash command, and a `--allowedTools` list that omits `Bash(gh pr list:*)`, this design has 6 documented deviations from `anthropics/claude-code-action` and `code-review` plugin official patterns. Under the Anthropic model-serving incidents of 2026-05-18 to 2026-05-22 (Opus 4.7 / Sonnet 4.6 / Haiku 4.5 elevated errors), these deviations produced nit-level comment overload, ignored "HIGH SIGNAL only" filter instructions, and self-contradicting verdicts inside a single review loop — symptoms that block PRs on noise rather than real issues.
+
+The fix is to decouple the verdict from LLM judgment: let Claude do only the review (post inline comments), and let a deterministic post-step count the comments Claude posted against the PR head SHA to derive the Check Run conclusion. This eliminates the confidence-inflation pressure that binary verdict prompts are known to induce, removes the prompt-injection surface that `additional_focus` opens, and restores the workflow to single-line slash-command invocation per the official examples.
+
+## What Changes
+
+- **BREAKING (spec-only)**: Remove the `Claude writes /tmp/claude-verdict.json` contract from `ci-optimization`. The Check Run `conclusion` is now derived from counting inline review comments authored by the Claude bot against the PR head SHA, computed in a post-step bash + `gh api` + `jq` pipeline.
+- **BREAKING (workflow API)**: Remove the `additional_focus` input from the reusable workflow `liverty-music/.github/.github/workflows/claude-review.yml`. Repo-specific review focus is expressed exclusively in each repo's `CLAUDE.md`.
+- Simplify the reusable workflow's `prompt:` from a multi-step structured prompt to the single-line slash-command invocation used pre-2026-05-15.
+- Correct the slash command's `--allowedTools` to match the `code-review` plugin's declared frontmatter (add `Bash(gh pr list:*)`), and remove tools no longer needed (`Write` for the verdict file).
+- Caller workflows in `backend`, `frontend`, `specification`, `cloud-provisioning` drop their `with: additional_focus:` blocks.
+- Branch-protection policy (Required Status Check on `Claude review`) is unchanged. The Check Run still publishes `success` / `failure` / `neutral` conclusions; only the derivation mechanism changes.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `ci-optimization`: Replace the verdict-file-driven Check Run requirement with a comment-count-driven requirement, and remove `additional_focus` from the reusable-workflow requirement.
+
+## Impact
+
+- **Affected repo**: `liverty-music/.github` (reusable workflow at `.github/workflows/claude-review.yml` — prompt, post-steps, and inputs all change).
+- **Affected caller workflows** (4 repos, ~1-line change each): `backend/.github/workflows/claude-code-review.yml`, `frontend/.github/workflows/claude-code-review.yml`, `specification/.github/workflows/claude-code-review.yml`, `cloud-provisioning/.github/workflows/claude-code-review.yml`.
+- **No Pulumi change**: `cloud-provisioning/src/index.ts` already adds `'Claude review'` to `requiredStatusCheckContexts`; the Check Run name and Required-Status-Check semantics are unchanged.
+- **No CLAUDE.md change required**: the "Go conventions / error handling / table-driven tests / pgx usage" content currently injected via `additional_focus` is already documented in `backend/CLAUDE.md` and the equivalent files in other repos.
+- **Tracking issue**: to be created in `liverty-music/specification` (next-available number) before implementation begins, per the liverty-music commit convention (`Refs: #<issue-number>`).
+- **Known residual issue**: the `code-review` plugin's skip-on-repeat behavior ([anthropics/claude-code#19618](https://github.com/anthropics/claude-code/issues/19618)) is out of scope; mitigated partially by HEAD-SHA-scoped counting (stale comments from prior pushes do not inflate the count).

--- a/openspec/changes/mechanize-claude-review-verdict/specs/ci-optimization/spec.md
+++ b/openspec/changes/mechanize-claude-review-verdict/specs/ci-optimization/spec.md
@@ -1,0 +1,61 @@
+## MODIFIED Requirements
+
+### Requirement: Claude code review runs via a single org-wide reusable workflow
+All four liverty-music repositories (`backend`, `frontend`, `specification`, `cloud-provisioning`) SHALL invoke Claude code review through a reusable workflow hosted at `liverty-music/.github/.github/workflows/claude-review.yml` (`workflow_call`). Each repository's own `.github/workflows/claude-code-review.yml` SHALL be a caller-only workflow that forwards `secrets: inherit`. The reusable workflow SHALL invoke `code-review@claude-code-plugins` with the `--comment` flag and `anthropics/claude-code-action@v1`, passing the slash command as a single-line `prompt:` without additional structured-prompt wrapping.
+
+The reusable workflow's `claude_args.--allowedTools` SHALL be aligned with the `code-review` plugin's declared `allowed-tools` frontmatter — at minimum including `Bash(gh pr list:*)`, `Bash(gh pr view:*)`, `Bash(gh pr diff:*)`, `Bash(gh pr comment:*)`, `Bash(gh issue view:*)`, `Bash(gh issue list:*)`, `Bash(gh search:*)`, and `mcp__github_inline_comment__create_inline_comment`. The reusable workflow SHALL NOT accept per-repo input parameters that inject free-form text into the prompt; per-repo review focus is expressed exclusively via each repo's `CLAUDE.md`.
+
+#### Scenario: PR is opened in any liverty-music repo
+- **WHEN** a pull request is opened or updated in `backend`, `frontend`, `specification`, or `cloud-provisioning`
+- **THEN** the repo's `claude-code-review.yml` SHALL call `liverty-music/.github/.github/workflows/claude-review.yml` via `uses:` rather than running Claude inline
+
+#### Scenario: Claude review behavior needs updating
+- **WHEN** the Claude review prompt, plugin version, or verdict logic needs to change
+- **THEN** the change SHALL be made in `liverty-music/.github/.github/workflows/claude-review.yml` and SHALL take effect on all four repos without modifying individual repo workflows
+
+#### Scenario: Caller workflow contains no prompt-injecting input
+- **WHEN** a caller workflow at `<repo>/.github/workflows/claude-code-review.yml` is inspected
+- **THEN** the `jobs.review.with:` block SHALL be absent (or empty), with no `additional_focus` or other free-form text inputs passed to the reusable workflow
+
+### Requirement: Claude review publishes its verdict as a GitHub Check Run
+The reusable workflow SHALL create a GitHub Check Run named exactly `Claude review` on the pull request's head commit. The Check Run `conclusion` SHALL be derived deterministically from the count of inline review comments that the Claude bot has posted against the pull request's head commit SHA, computed in a post-step that calls `gh api repos/<owner>/<repo>/pulls/<N>/comments` and filters by `commit_id == <head_sha>` AND `user.login == <claude bot identity>`.
+
+The conclusion mapping SHALL be:
+
+| Filtered comment count | `conclusion` |
+|---|---|
+| `0` | `success` |
+| `≥ 1` | `failure` |
+| `gh api` call fails or output unparseable | `neutral` |
+
+The Check Run output `title` SHALL be `No issues found` when `conclusion == success`, `N issue(s) found` when `conclusion == failure` (where `N` is the filtered comment count), and `Verdict could not be computed` when `conclusion == neutral`. The Check Run output `summary` SHALL link to the pull request's `Files changed` view.
+
+The verdict SHALL NOT be derived from an LLM-emitted artifact (such as a JSON file written by the Claude run). The Claude run is responsible only for posting inline review comments; the verdict is computed mechanically after the Claude run completes.
+
+The workflow SHALL NOT submit a formal pull request review (`APPROVE` or `REQUEST_CHANGES`) for the verdict. Only the inline comments (posted by the plugin) and the Check Run are produced.
+
+#### Scenario: Claude finds no high-signal issues
+- **WHEN** the Claude run completes and `gh api repos/.../pulls/<N>/comments` returns zero comments matching `commit_id == <head_sha>` AND `user.login == <claude bot identity>`
+- **THEN** the workflow SHALL create a `Claude review` Check Run with `conclusion: success`
+- **AND** the Check Run output title SHALL be `No issues found`
+
+#### Scenario: Claude posts inline comments against the PR head
+- **WHEN** the Claude run completes and `gh api repos/.../pulls/<N>/comments` returns `N ≥ 1` comments matching `commit_id == <head_sha>` AND `user.login == <claude bot identity>`
+- **THEN** the workflow SHALL create a `Claude review` Check Run with `conclusion: failure`
+- **AND** the Check Run output title SHALL be `N issue(s) found`
+
+#### Scenario: Verdict computation fails
+- **WHEN** the `gh api` call to fetch PR comments exits non-zero, or its output cannot be parsed as JSON
+- **THEN** the workflow SHALL create a `Claude review` Check Run with `conclusion: neutral`
+- **AND** the Check Run output title SHALL be `Verdict could not be computed`
+
+#### Scenario: Subsequent push fixes earlier-flagged issues
+- **WHEN** a PR initially has `conclusion: failure` from Claude comments on commit SHA `A`
+- **AND** a new commit SHA `B` is pushed that fixes the flagged issues (such that the slash command's skip-on-repeat behavior exits the Claude run without posting new comments)
+- **AND** no inline comments exist with `commit_id == B`
+- **THEN** the workflow on commit `B` SHALL create a `Claude review` Check Run with `conclusion: success`
+- **AND** the prior `failure` Check Run on commit `A` does not affect commit `B`'s conclusion
+
+#### Scenario: Claude review never submits a formal PR review
+- **WHEN** any Claude review run completes (success, failure, or neutral)
+- **THEN** `gh pr view --json reviews` SHALL NOT show a review authored by Claude with state `APPROVED` or `CHANGES_REQUESTED`

--- a/openspec/changes/mechanize-claude-review-verdict/tasks.md
+++ b/openspec/changes/mechanize-claude-review-verdict/tasks.md
@@ -1,0 +1,35 @@
+## 1. Preparation
+
+- [x] 1.1 Create tracking issue in `liverty-music/specification` titled `Mechanize Claude review verdict (decouple from LLM judgment)` and note its number for all subsequent commits (`Refs: #<N>`) — created as [#521](https://github.com/liverty-music/specification/issues/521)
+- [x] 1.2 Identify the Claude bot's GitHub `user.login` by inspecting an existing PR's inline comments via `gh api repos/liverty-music/specification/pulls/<recent-PR>/comments | jq '.[] | {login: .user.login, type: .user.type, commit_id}'`. Record the exact login string for use in the workflow filter. — confirmed via PR #520: `user.login == "claude[bot]"`, `user.type == "Bot"`
+
+## 2. Reusable workflow (`liverty-music/.github`)
+
+- [ ] 2.1 Create branch off `main` in the `.github` repo
+- [x] 2.2 Edit `.github/workflows/claude-review.yml`: remove the `inputs.additional_focus` block from `on.workflow_call`
+- [x] 2.3 Replace the multi-line `prompt:` value with the single-line form: `'/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }} --comment'`
+- [x] 2.4 Update `claude_args.--allowedTools` to add `Bash(gh pr list:*)` and remove `Write`
+- [x] 2.5 Delete the `Read verdict file` step
+- [x] 2.6 Add a new `Count Claude inline comments` step that calls `gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/comments`, filters by `commit_id == github.event.pull_request.head.sha` AND `user.login == <recorded login from 1.2>`, counts the result via `jq`, and writes the count to `$GITHUB_OUTPUT`. On `gh api` failure, write `count=-1` to signal `neutral`.
+- [x] 2.7 Update the `Publish Claude review Check Run` step: replace the verdict-JSON parsing with the count → conclusion mapping from the spec (`0 → success`, `≥1 → failure`, `-1 → neutral`). Set output `title` per the spec (`No issues found` / `N issue(s) found` / `Verdict could not be computed`). Set `summary` to link to the PR's Files changed view.
+- [ ] 2.8 Open PR; ensure CI passes; merge
+
+## 3. Caller workflows (4 repos)
+
+- [ ] 3.1 `liverty-music/specification`: remove `with: additional_focus:` block from `.github/workflows/claude-code-review.yml`; open PR; merge
+- [ ] 3.2 `liverty-music/backend`: remove `with: additional_focus:` block from `.github/workflows/claude-code-review.yml`; open PR; merge
+- [ ] 3.3 `liverty-music/frontend`: remove `with: additional_focus:` block from `.github/workflows/claude-code-review.yml`; open PR; merge
+- [ ] 3.4 `liverty-music/cloud-provisioning`: remove `with: additional_focus:` block from `.github/workflows/claude-code-review.yml`; open PR; merge
+
+## 4. Validation
+
+- [ ] 4.1 Open a small test PR on `liverty-music/specification` that intentionally contains no review-worthy issues. Confirm: Claude run completes, no inline comments are posted, `Claude review` Check Run conclusion is `success`, title is `No issues found`.
+- [ ] 4.2 Open a small test PR on `liverty-music/specification` that intentionally contains a CLAUDE.md violation (e.g., missing required field documentation). Confirm: Claude posts at least one inline comment, `Claude review` Check Run conclusion is `failure`, title shows the correct comment count.
+- [ ] 4.3 Push a fix commit to the failing test PR from 4.2. Confirm: the new head SHA has zero matching inline comments, the Check Run on the new SHA is `success` (even though the slash command may skip the actual review per the documented skip-on-repeat behavior).
+- [ ] 4.4 Verify that no formal PR review (`APPROVED` or `CHANGES_REQUESTED`) is created by Claude on any of the test PRs: `gh pr view <N> --json reviews --jq '.reviews[] | select(.author.login | test("claude"))'` returns nothing.
+- [ ] 4.5 Inspect a `gh api` output from one of the runs to confirm the `commit_id` and `user.login` filter matches reality. Adjust the workflow if the bot login differs from what was recorded in 1.2.
+
+## 5. Documentation and archive
+
+- [ ] 5.1 Confirm `make check` (or equivalent validation) passes on all four caller-repo PRs
+- [ ] 5.2 After two successful real (non-test) PRs land on `specification` with the new mechanism, run `/opsx:archive` to archive this change and apply the spec delta to `openspec/specs/ci-optimization/spec.md`


### PR DESCRIPTION
## Summary

This PR bundles two related changes:

1. **OpenSpec change proposal** `mechanize-claude-review-verdict` — documents the rationale, design, spec delta (`ci-optimization` MODIFIED, 2 Requirements), and tasks for decoupling the `Claude review` Check Run verdict from LLM judgment.
2. **Caller workflow update** — drops the `with: additional_focus: ...` block from `.github/workflows/claude-code-review.yml`, since the reusable workflow at `liverty-music/.github` no longer accepts that input.

## Why

The previous reusable workflow (introduced 2026-05-15) deviated from `anthropics/claude-code-action` and `code-review` plugin official patterns in six places. Under the Anthropic model-serving incidents of 2026-05-18 to 2026-05-22, those deviations surfaced as nit-level comment overload, "HIGH SIGNAL only" filter being ignored, and self-contradicting verdicts inside a single review loop.

See [`openspec/changes/mechanize-claude-review-verdict/design.md`](openspec/changes/mechanize-claude-review-verdict/design.md) for the full technical analysis and 5 design decisions.

## Companion PRs

- [liverty-music/.github#4](https://github.com/liverty-music/.github/pull/4) — reusable workflow rewrite (MERGED)
- liverty-music/backend — caller workflow strip (pending)
- liverty-music/frontend — caller workflow strip (pending)
- liverty-music/cloud-provisioning — caller workflow strip (pending)

## Test plan

- [ ] `openspec validate mechanize-claude-review-verdict` passes (verified locally)
- [ ] After this PR merges + first PR opened on this repo, observe the new mechanism produces a deterministic `Claude review` Check Run conclusion via comment counting (OpenSpec tasks 4.1–4.5)

## Refs

Closes #521 (after the four caller PRs land and validation completes per tasks 4.1–4.5)