### PR TITLE
docs(openspec): honor-thread-resolution → drop Claude review Check Run (Option B)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -3,6 +3,8 @@ name: Claude Code Review
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review, reopened]
+  pull_request_review_thread:
+    types: [resolved, unresolved]
 
 # Permissions are inherited by the reusable workflow's job and intersected
 # with its own workflow-level declarations. Set them here in the caller so

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -19,5 +19,13 @@ permissions:
 
 jobs:
   review:
+    if: ${{ github.event_name == 'pull_request' }}
     uses: liverty-music/.github/.github/workflows/claude-review.yml@main
+    secrets: inherit
+
+  recompute-verdict:
+    if: ${{ github.event_name == 'pull_request_review_thread' }}
+    uses: liverty-music/.github/.github/workflows/claude-review.yml@main
+    with:
+      verdict_only: true
     secrets: inherit

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -3,8 +3,6 @@ name: Claude Code Review
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review, reopened]
-  pull_request_review_thread:
-    types: [resolved, unresolved]
 
 # Permissions are inherited by the reusable workflow's job and intersected
 # with its own workflow-level declarations. Set them here in the caller so
@@ -19,13 +17,5 @@ permissions:
 
 jobs:
   review:
-    if: ${{ github.event_name == 'pull_request' }}
     uses: liverty-music/.github/.github/workflows/claude-review.yml@main
-    secrets: inherit
-
-  recompute-verdict:
-    if: ${{ github.event_name == 'pull_request_review_thread' }}
-    uses: liverty-music/.github/.github/workflows/claude-review.yml@main
-    with:
-      verdict_only: true
     secrets: inherit

--- a/openspec/changes/honor-thread-resolution-in-claude-review-check/design.md
+++ b/openspec/changes/honor-thread-resolution-in-claude-review-check/design.md
@@ -99,24 +99,63 @@ on:
 
 **Alternative considered:** Use `pull_request_review.types: [submitted]`. Rejected because it fires on every review submission (formal review or comment batch), not on resolve, and the count step is decoupled from review submissions.
 
-### Decision 3: Guard the `Run Claude review` step with `if: github.event_name == 'pull_request'`
+### Decision 3: Split caller into two jobs; reusable workflow accepts a `verdict_only` input
 
-Inside the reusable workflow, the `anthropics/claude-code-action@v1` step is gated:
+Rather than gating the expensive step inside the reusable workflow with `if: github.event_name == 'pull_request'`, gate at the **caller job level** with an explicit `verdict_only` input on the reusable workflow. The caller has two jobs that each invoke the reusable, one per triggering event:
 
 ```yaml
-- name: Run Claude review
-  id: claude
-  if: github.event_name == 'pull_request'
-  uses: anthropics/claude-code-action@v1
-  with: ...
+# caller workflow (each of the 4 repos)
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+  pull_request_review_thread:
+    types: [resolved, unresolved]
+
+jobs:
+  review:
+    if: ${{ github.event_name == 'pull_request' }}
+    uses: liverty-music/.github/.github/workflows/claude-review.yml@main
+    secrets: inherit
+
+  recompute-verdict:
+    if: ${{ github.event_name == 'pull_request_review_thread' }}
+    uses: liverty-music/.github/.github/workflows/claude-review.yml@main
+    with:
+      verdict_only: true
+    secrets: inherit
 ```
 
-The count step and publish step remain ungated (`if: always()` for the count, no conditional for publish).
+The reusable workflow declares the new input and gates the LLM step against it:
+
+```yaml
+# .github/workflows/claude-review.yml
+on:
+  workflow_call:
+    inputs:
+      verdict_only:
+        type: boolean
+        required: false
+        default: false
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN:
+        required: true
+
+jobs:
+  review:
+    steps:
+      - name: Run Claude review
+        if: ${{ !inputs.verdict_only }}
+        uses: anthropics/claude-code-action@v1
+      # count + publish steps run regardless
+```
 
 **Why:**
 
 - Resolve clicks should recompute the verdict cheaply. Re-running Claude on every resolve click would (a) burn Anthropic API tokens for no signal change, (b) likely re-post the same nits the maintainer just resolved, creating a cycle.
 - The count step's input (the set of review threads) is independent of whether Claude just ran — it queries the live PR state — so skipping Claude on thread events still produces a correct count.
+- The split-job + `verdict_only` input pattern makes the contract explicit. A caller declares "this is a recompute-only run" via the input rather than relying on `github.event_name` inside the reusable. This is easier to reason about and easier to extend (e.g., future `workflow_dispatch` trigger can also pass `verdict_only: true`).
+
+**Alternative considered:** Gate the expensive step inside the reusable with `if: github.event_name == 'pull_request'`. Rejected because (a) it implicitly couples the reusable to event-name semantics rather than exposing an explicit input contract, (b) it makes the caller's intent harder to read — you have to know how the reusable interprets event names, (c) any future trigger (e.g., `workflow_dispatch`) needs to be added to the reusable's `if` expression rather than just passing `verdict_only: true` at the call site.
 
 **Alternative considered:** Run Claude on every trigger and rely on the skip-on-repeat upstream behavior to be cheap. Rejected because skip-on-repeat is not free (the action still spins up, reads the diff, and decides to skip), and skip-on-repeat is itself a known-unreliable behavior under model degradation.
 

--- a/openspec/changes/honor-thread-resolution-in-claude-review-check/design.md
+++ b/openspec/changes/honor-thread-resolution-in-claude-review-check/design.md
@@ -160,7 +160,7 @@ See `proposal.md` "Deployment ordering". Summary:
 5. Open a normal follow-up PR on any repo to confirm: Claude review posts inline comments (if any), no `Claude review` Check Run is created, merge gating is `CI Success` only.
 6. Archive this change.
 
-**Rollback:** Re-apply `'Claude review'` to `requiredStatusCheckContexts` via Pulumi AND restore the `.github` reusable workflow to its pre-#7 state. The Check Run resumes with the GraphQL-`isResolved` logic from `.github#6`. Rollback restores the bug behavior (stuck failures from non-code-resolved threads) but is operationally safe.
+**Rollback (order is the inverse of the forward migration):** Restore the `.github` reusable workflow to its pre-#7 state **first** — so the `Claude review` Check Run resumes being created — then re-apply `'Claude review'` to `requiredStatusCheckContexts` via Pulumi (`pulumi up -s prod`). Reversing this order (Pulumi-first) re-creates the same un-mergeable window the forward plan avoided: Pulumi would require a check the workflow no longer produces. The Check Run resumes with the GraphQL-`isResolved` logic from `.github#6`. Rollback restores the bug behavior (stuck failures from non-code-resolved threads) but is operationally safe.
 
 ## Open Questions
 

--- a/openspec/changes/honor-thread-resolution-in-claude-review-check/design.md
+++ b/openspec/changes/honor-thread-resolution-in-claude-review-check/design.md
@@ -1,0 +1,180 @@
+## Context
+
+The `Claude review` Check Run was first introduced [2026-05-16](../archive/2026-05-16-claude-review-check-run/) (LLM-emitted verdict via `/tmp/claude-verdict.json`), then redesigned [2026-05-25](../mechanize-claude-review-verdict/) to derive its conclusion from a mechanical count of bot-authored inline comments scoped by `commit_id == HEAD_SHA`. The redesign correctly addressed the LLM confidence-inflation problem documented in that change's `design.md`.
+
+Two real-world PRs immediately exposed a second-order bug that the redesign's validation (`tasks.md` §4.3) did not probe. Frontend [`#367`](https://github.com/liverty-music/frontend/pull/367) and backend [`#305`](https://github.com/liverty-music/backend/pull/305) ran the full bot review cycle (17 rounds, 100+ inline comments accumulated), then the maintainer marked every thread `isResolved = true` via the standard GitHub UI. The `Claude review` Check Run stayed at `18 issue(s) found` (frontend) and `51 issue(s) found` (backend) — both PRs were merged via admin override.
+
+Root-cause investigation showed that GitHub's REST `/pulls/N/comments` field `commit_id` is not what the redesign assumed. It is **not** "the SHA the comment was posted against" (that field exists too, as `original_commit_id`); it is "the most recent SHA where the line being commented on is still present in the diff". GitHub re-evaluates every inline comment on every push and bumps `commit_id` forward if the line is unchanged. Therefore the filter `commit_id == HEAD_SHA` selects bot comments **still applicable to the current code** — which is a strict subset of "issues the reviewer hasn't acknowledged".
+
+The fix is to switch the resolution signal from `commit_id` (REST) to `isResolved` (GraphQL), which honors all three reviewer acknowledgement paths (UI resolve, code-change resolve, defended-via-reply-then-resolve).
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make `Claude review` Check Run honor GitHub-native thread resolution (the "Resolve conversation" button).
+- Continue to honor code-change resolution (covered by `isOutdated`).
+- Re-fire the Check Run on resolve/unresolve clicks so feedback is immediate, without forcing a no-op commit.
+- Avoid burning Anthropic API tokens (and re-posting nits) when the workflow is re-triggered by a resolve event.
+- Preserve every preserved property of `mechanize-claude-review-verdict`: Check Run name, conclusion vocabulary, branch-protection contract, caller-workflow surface area, no Pulumi changes.
+
+**Non-Goals:**
+
+- Fix the upstream `code-review` skip-on-repeat behavior ([anthropics/claude-code#19618](https://github.com/anthropics/claude-code/issues/19618)). Still mitigated, not resolved.
+- Add CODEOWNERS-based governance for who can resolve threads. The default GitHub trust model (anyone with write access) is consistent with branch-protection trust.
+- Add a `claude-review-acknowledged` label override. The `isResolved` mechanism already provides a per-thread acknowledgement affordance with the same authority surface; a label override would be redundant and would defeat the per-thread granularity.
+- Migrate to the cloud-hosted "Code Review" product on `claude.com`.
+
+## Decisions
+
+### Decision 1: GraphQL `reviewThreads` with `isResolved` and `isOutdated` filters replaces REST `commit_id` filter
+
+The reusable workflow's count step calls `gh api graphql` against:
+
+```graphql
+query($owner: String!, $repo: String!, $number: Int!) {
+  repository(owner: $owner, name: $repo) {
+    pullRequest(number: $number) {
+      reviewThreads(first: 100) {
+        pageInfo { hasNextPage }
+        nodes {
+          isResolved
+          isOutdated
+          comments(first: 1) {
+            nodes { author { __typename login } }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+The filter is:
+
+```jq
+[
+  .data.repository.pullRequest.reviewThreads.nodes[]
+  | select(.isResolved == false
+           and .isOutdated == false
+           and .comments.nodes[0].author.__typename == "Bot"
+           and .comments.nodes[0].author.login == "claude")
+] | length
+```
+
+**Bot identity note (verified 2026-05-28 against frontend#367):** GitHub's GraphQL Author interface returns bot login *without* the `[bot]` suffix (e.g., `"claude"`), unlike the REST API which returns `"claude[bot]"`. The `__typename == "Bot"` guard ensures we cannot be spoofed by a human GitHub user named "claude".
+
+**Why:**
+
+- `isResolved` reflects the standard GitHub UI affordance (the "Resolve conversation" button). Using it as the resolution signal aligns the Check Run with the reviewer's own mental model.
+- `isOutdated` is GitHub's authoritative judgment of "is this comment still applicable to the diff" — strictly broader and more accurate than the REST `commit_id` heuristic, since it also covers cases where the line was moved or its surrounding context changed.
+- `comments.nodes[0]` is the thread opener. GraphQL's default ordering for `comments` is chronological, so the first node is reliably the bot. (In our workflow Claude always opens threads; maintainer replies are never thread openers.)
+- `first: 100` keeps the query under GitHub's hard cap of 100 nodes per page and avoids cursor pagination complexity. Healthy PRs are far below this limit; see Decision 4.
+
+**Alternative considered:** Use the REST `/pulls/N/comments` endpoint and filter by `in_reply_to_id` and a separate "is thread resolved" lookup. Rejected because the REST API does not expose thread-resolved state — `isResolved` is a GraphQL-only concept on the `PullRequestReviewThread` object.
+
+**Alternative considered:** Use `original_commit_id` + a side-channel "issues acknowledged" registry. Rejected because GitHub already provides the registry as `reviewThreads.isResolved`.
+
+### Decision 2: Add `pull_request_review_thread` to caller-workflow `on:` triggers
+
+Each caller workflow at `<repo>/.github/workflows/claude-code-review.yml` adds:
+
+```yaml
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  pull_request_review_thread:
+    types: [resolved, unresolved]
+```
+
+**Why:**
+
+- Without this, clicking "Resolve conversation" does nothing observable to the Check Run — the failure persists until something else (manual re-run, no-op push) re-fires the workflow. That breaks the reviewer's expectation of immediate feedback.
+- GitHub fires `pull_request_review_thread` events with full `pull_request` context in the payload, so the reusable workflow's `github.event.pull_request.number` and `.head.sha` continue to work without changes.
+- `unresolved` is included so that re-opening a thread also recomputes the Check Run, restoring `failure` symmetrically.
+
+**Trigger documentation note (verified 2026-05-28):** The official GitHub Actions ["Events that trigger workflows" reference](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows) does NOT list `pull_request_review_thread` as a workflow trigger. The webhook event IS documented at the [webhook reference](https://docs.github.com/en/webhooks/webhook-events-and-payloads#pull_request_review_thread) with activity types `resolved` and `unresolved`. The Actions runtime supports this trigger even though the Actions docs are silent on it — verified by 11+ production workflows on GitHub using `on: pull_request_review_thread: types: [resolved, unresolved]` (e.g., [`akasper/plate_template/feedback-resolution-check.yml`](https://github.com/akasper/plate_template/blob/main/.github/workflows/feedback-resolution-check.yml), [`smart-village-solutions/sva-studio/bot-comment-governance.yml`](https://github.com/smart-village-solutions/sva-studio/blob/main/.github/workflows/bot-comment-governance.yml)). YAML schema validators (vscode-github-actions extension included) may flag this as an unknown property — false positive due to outdated schema.
+
+**Alternative considered:** Add only `pull_request_review_thread.types: [resolved]`. Rejected for asymmetry — unresolving must also reflect immediately, otherwise an accidentally-resolved-then-unresolved thread leaves the Check Run stuck on `success`.
+
+**Alternative considered:** Use `pull_request_review.types: [submitted]`. Rejected because it fires on every review submission (formal review or comment batch), not on resolve, and the count step is decoupled from review submissions.
+
+### Decision 3: Guard the `Run Claude review` step with `if: github.event_name == 'pull_request'`
+
+Inside the reusable workflow, the `anthropics/claude-code-action@v1` step is gated:
+
+```yaml
+- name: Run Claude review
+  id: claude
+  if: github.event_name == 'pull_request'
+  uses: anthropics/claude-code-action@v1
+  with: ...
+```
+
+The count step and publish step remain ungated (`if: always()` for the count, no conditional for publish).
+
+**Why:**
+
+- Resolve clicks should recompute the verdict cheaply. Re-running Claude on every resolve click would (a) burn Anthropic API tokens for no signal change, (b) likely re-post the same nits the maintainer just resolved, creating a cycle.
+- The count step's input (the set of review threads) is independent of whether Claude just ran — it queries the live PR state — so skipping Claude on thread events still produces a correct count.
+
+**Alternative considered:** Run Claude on every trigger and rely on the skip-on-repeat upstream behavior to be cheap. Rejected because skip-on-repeat is not free (the action still spins up, reads the diff, and decides to skip), and skip-on-repeat is itself a known-unreliable behavior under model degradation.
+
+### Decision 4: Fail-neutral on >100 threads (pagination overflow)
+
+If the GraphQL response's `pageInfo.hasNextPage == true`, the count step writes `count=-1` and the publish step emits `conclusion: neutral` with title `Verdict could not be computed (>100 threads)`.
+
+**Why:**
+
+- A PR with >100 review threads is unhealthy regardless of who authored them. Neither auto-passing nor auto-failing is meaningful; surface ambiguity and let humans investigate.
+- The highest observed count in production is 66 threads (backend#305), so 100 is a comfortable ceiling for healthy PRs.
+- Implementing cursor pagination would add ~15 lines of bash and a second `gh api` call; on a runaway PR it would just produce a high but uninformative count.
+
+### Decision 5: Bot-author detection unchanged (`user.login == "claude[bot]"`)
+
+The bot identity check is the same exact-match used in `mechanize-claude-review-verdict` task 1.2.
+
+**Why:**
+
+- Risk surface is unchanged from the predecessor change.
+- If Anthropic ever renames the bot identity, this filter silently produces `count=0` (success). Same risk as the predecessor; mitigated by the same logic — if zero threads match the filter but the GraphQL response had any bot threads from any author, that would warrant escalation. (Not implemented as code; documented as a known-unmonitored risk.)
+
+## Risks / Trade-offs
+
+- **[Stale `failure` until a re-trigger fires]** → After this change, clicking "Resolve conversation" re-fires the workflow, so the lag is bounded by GitHub's event delivery (<10s in practice). Before either workflow_dispatch or a commit could clear it. This is a strict improvement.
+
+- **[Resolve-as-mute by PR author]** → The default GitHub trust model lets the PR author resolve their own threads, which silences the bot's gate. This is consistent with the existing branch-protection trust (PR authors with write access can also approve merges via admin override). Documented as expected behavior in the migration plan; not a CODEOWNERS-enforced restriction. If this becomes a problem, a follow-up change can introduce a CODEOWNERS check.
+
+- **[Replay attack: maintainer resolves all threads, then bot re-reviews on next push and re-flags them]** → Acceptable. The bot is the source of truth on whether an issue still exists. If it re-flags, the maintainer can defend and re-resolve, or fix the code. The Check Run reflects the latest state.
+
+- **[`pull_request_review_thread` event delivery delay]** → GitHub does not document a delivery SLA. If the event is delayed or dropped, the Check Run stays stale until the next `pull_request` synchronize. Mitigation: nothing — the predecessor failure mode was worse (stuck permanently), so a brief stuck state on event drops is an acceptable degradation.
+
+- **[GraphQL rate limits]** → The default `GITHUB_TOKEN` has a 5,000-point/hour rate budget for GraphQL. This query is single-shot and ~2 points. Even pathological re-trigger volume (one resolve click per second) is well within budget.
+
+- **[>100 threads collapses to neutral, blocking the gate from concluding]** → The `requiredStatusCheckContexts` rule treats `neutral` as a pass (per GitHub's documented behavior). A PR that overflows would be merge-eligible despite an unreviewed state. Acceptable: this is a degenerate PR that needs human attention regardless.
+
+- **[Caller-workflow `on:` block change is required in 4 repos]** → Cannot be done purely in the reusable workflow because `on:` is owned by the caller. This makes the rollout a 5-PR fan-out instead of 1. Documented in the migration plan.
+
+## Migration Plan
+
+1. **Archive `mechanize-claude-review-verdict`** so its spec delta lands in canonical `openspec/specs/ci-optimization/spec.md`. The current canonical still describes the verdict-file mechanism — without archiving first, this change's MODIFIED requirement would target outdated text and create a delta-against-delta state.
+2. Create tracking issue in `liverty-music/specification` ("Honor thread resolution in Claude review Check Run").
+3. Land the `.github` repo change first (reusable workflow): GraphQL count step + Claude-run step guard. All four caller workflows reference `@main`, so they pick up the new logic on the next push.
+4. Land the four caller-repo changes (add `pull_request_review_thread` to `on:`). Order does not matter.
+5. **Validate** on a real PR by deliberately reproducing the bug-and-fix cycle:
+   - Open a PR that intentionally contains a CLAUDE.md violation.
+   - Confirm `Claude review` = `failure` with a non-zero count.
+   - Click "Resolve conversation" on each bot thread via the GitHub UI (no commit push).
+   - Confirm the workflow re-runs on `pull_request_review_thread.resolved`, and the Check Run flips to `success` within ~30s.
+   - Click "Unresolve" on one thread.
+   - Confirm the workflow re-runs and Check Run flips back to `failure` with count 1.
+6. (Optional) Land a documentation update in each repo's `CLAUDE.md` describing the resolve-to-clear flow.
+7. Archive this change.
+
+**Rollback:** Revert the merge commits in `liverty-music/.github` and the four caller repos. The Check Run returns to the (broken-but-tolerated) `commit_id == HEAD_SHA` behavior — but production has been operating in that broken state for the entire mechanize window, so rollback is safe.
+
+## Open Questions
+
+- Should the `Claude review` Check Run's summary link to the unresolved threads filter (`?reviewer=claude%5Bbot%5D` style) in addition to the Files-changed view? Defer; can be a non-breaking enhancement after the core fix lands.
+- Should the workflow also include `pull_request_review_thread.types: [outdated]`? GitHub does not currently document `outdated` as a `pull_request_review_thread` event subtype, so likely no. To be verified during implementation by inspecting webhook delivery on a real outdated event.
+- Should the `Run Claude review` step also be skipped on `workflow_dispatch` (manual recompute), or is keeping it gated to `pull_request` enough? Likely yes — `workflow_dispatch` is the natural "I want to force a recount without re-reviewing" trigger. To be confirmed once the workflow is functioning.

--- a/openspec/changes/honor-thread-resolution-in-claude-review-check/design.md
+++ b/openspec/changes/honor-thread-resolution-in-claude-review-check/design.md
@@ -1,219 +1,169 @@
 ## Context
 
-The `Claude review` Check Run was first introduced [2026-05-16](../archive/2026-05-16-claude-review-check-run/) (LLM-emitted verdict via `/tmp/claude-verdict.json`), then redesigned [2026-05-25](../mechanize-claude-review-verdict/) to derive its conclusion from a mechanical count of bot-authored inline comments scoped by `commit_id == HEAD_SHA`. The redesign correctly addressed the LLM confidence-inflation problem documented in that change's `design.md`.
+The `Claude review` Check Run was introduced 2026-05-15 ([archive/2026-05-16-claude-review-check-run](../archive/2026-05-16-claude-review-check-run/)) on the theory that the bot's review output should gate merges via Required Status Checks. Two subsequent changes ([mechanize](../archive/2026-05-28-mechanize-claude-review-verdict/), and the initial revisions of this change) tried to fix progressively-discovered bugs in the gating mechanism:
 
-Two real-world PRs immediately exposed a second-order bug that the redesign's validation (`tasks.md` §4.3) did not probe. Frontend [`#367`](https://github.com/liverty-music/frontend/pull/367) and backend [`#305`](https://github.com/liverty-music/backend/pull/305) ran the full bot review cycle (17 rounds, 100+ inline comments accumulated), then the maintainer marked every thread `isResolved = true` via the standard GitHub UI. The `Claude review` Check Run stayed at `18 issue(s) found` (frontend) and `51 issue(s) found` (backend) — both PRs were merged via admin override.
+| Iteration | Mechanism | Discovered failure mode | Outcome |
+|---|---|---|---|
+| 1 (2026-05-16) | LLM emits `/tmp/claude-verdict.json` | Binary-classification confidence inflation under degraded models ([arxiv 2602.17170](https://arxiv.org/pdf/2602.17170)) | Replaced by mechanize |
+| 2 (mechanize, 2026-05-25) | REST `commit_id == HEAD_SHA AND user.login == "claude[bot]"` filter | `commit_id` is auto-bumped forward on every push for still-applicable comments — does NOT mean "posted against this SHA"; misses UI Resolve and empty-commit pushes | Replaced by [.github#6](https://github.com/liverty-music/.github/pull/6) (merged) |
+| 3 (.github#6, 2026-05-28) | GraphQL `reviewThreads.isResolved == false AND comments.commit.oid == HEAD_SHA AND author.bot == claude` | Better, but no auto-recompute on UI Resolve clicks; this PR set out to add the recompute trigger | Being reverted by [.github#7](https://github.com/liverty-music/.github/pull/7) |
+| 4 (this change's initial design) | Split-job caller + `verdict_only` input + `pull_request_review_thread: [resolved, unresolved]` trigger | The `pull_request_review_thread` trigger is documented as a webhook event but silently disables ALL GitHub Actions triggers on the workflow (spurious push-event stub failures; no `pull_request` runs fire). Verified empirically against this PR's caller workflow changes, and confirmed by 11+ third-party production workflows on GitHub that use the same trigger and are all in `failure` state | Abandoned; this change pivots to Option B |
 
-Root-cause investigation showed that GitHub's REST `/pulls/N/comments` field `commit_id` is not what the redesign assumed. It is **not** "the SHA the comment was posted against" (that field exists too, as `original_commit_id`); it is "the most recent SHA where the line being commented on is still present in the diff". GitHub re-evaluates every inline comment on every push and bumps `commit_id` forward if the line is unchanged. Therefore the filter `commit_id == HEAD_SHA` selects bot comments **still applicable to the current code** — which is a strict subset of "issues the reviewer hasn't acknowledged".
+Investigation through iteration 4 surfaced a deeper question: is the gate even viable upstream? The answer is no:
 
-The fix is to switch the resolution signal from `commit_id` (REST) to `isResolved` (GraphQL), which honors all three reviewer acknowledgement paths (UI resolve, code-change resolve, defended-via-reply-then-resolve).
+- [`anthropics/claude-code-action`](https://github.com/anthropics/claude-code-action) (action v1) exposes no verdict, pass/fail, or Check Run output. The README and `docs/custom-automations.md` are silent on the topic.
+- All official examples ([`examples/`](https://github.com/anthropics/claude-code-action/tree/main/examples)) — including the three PR-review examples (`pr-review-comprehensive.yml`, `pr-review-filtered-authors.yml`, `pr-review-filtered-paths.yml`) — invoke the action and stop. None create a Check Run, none set workflow conclusion, none gate the merge.
+- The [`code-review`](https://github.com/anthropics/claude-code/blob/main/plugins/code-review/commands/code-review.md) slash command itself posts inline comments and a terminal summary — no verdict file, no structured output.
+
+The four-iteration accumulation is therefore not a series of bugs in a supported pattern; it is a series of user-side wrappers for a pattern upstream does not offer. Per the operating instruction "可能な限り構成をシンプルに / 場当たり的なハックは禁止", this change abandons the gate entirely and aligns with the upstream pattern.
 
 ## Goals / Non-Goals
 
 **Goals:**
 
-- Make `Claude review` Check Run honor GitHub-native thread resolution (the "Resolve conversation" button).
-- Continue to honor code-change resolution (covered by `isOutdated`).
-- Re-fire the Check Run on resolve/unresolve clicks so feedback is immediate, without forcing a no-op commit.
-- Avoid burning Anthropic API tokens (and re-posting nits) when the workflow is re-triggered by a resolve event.
-- Preserve every preserved property of `mechanize-claude-review-verdict`: Check Run name, conclusion vocabulary, branch-protection contract, caller-workflow surface area, no Pulumi changes.
+- Align the `Claude review` workflow with the official `anthropics/claude-code-action` pattern (`pr-review-comprehensive.yml`).
+- Remove the `Claude review` Check Run, its Pulumi-managed required-status-check enforcement, and all user-side counting / GraphQL / pagination / `verdict_only` logic.
+- Preserve `Claude review`'s ability to post inline review comments on PRs (advisory only).
+- Eliminate the operating-protocol conflict where the current broken gate forces admin-override merges to bypass branch protection.
 
 **Non-Goals:**
 
-- Fix the upstream `code-review` skip-on-repeat behavior ([anthropics/claude-code#19618](https://github.com/anthropics/claude-code/issues/19618)). Still mitigated, not resolved.
-- Add CODEOWNERS-based governance for who can resolve threads. The default GitHub trust model (anyone with write access) is consistent with branch-protection trust.
-- Add a `claude-review-acknowledged` label override. The `isResolved` mechanism already provides a per-thread acknowledgement affordance with the same authority surface; a label override would be redundant and would defeat the per-thread granularity.
-- Migrate to the cloud-hosted "Code Review" product on `claude.com`.
+- Replace the gate with a different gating mechanism (e.g., CODEOWNERS-enforced thread-resolution, GitHub App webhook bridge, scheduled recompute). Considered and rejected — see Decision 3.
+- Add or migrate to alternative review automation products (Anthropic's hosted Code Review at `claude.com`, third-party bots). Out of scope.
+- Change `CI Success` or any other existing required check.
+- Reorganize permissions on caller workflows (`checks: write` on each caller becomes unused after this change; harmless and deferred for future cleanup).
 
 ## Decisions
 
-### Decision 1: GraphQL `reviewThreads` with `isResolved` and `isOutdated` filters replaces REST `commit_id` filter
+### Decision 1: Revert the reusable workflow to the official `pr-review-comprehensive.yml` shape
 
-The reusable workflow's count step calls `gh api graphql` against:
-
-```graphql
-query($owner: String!, $repo: String!, $number: Int!) {
-  repository(owner: $owner, name: $repo) {
-    pullRequest(number: $number) {
-      reviewThreads(first: 100) {
-        pageInfo { hasNextPage }
-        nodes {
-          isResolved
-          isOutdated
-          comments(first: 1) {
-            nodes { author { __typename login } }
-          }
-        }
-      }
-    }
-  }
-}
-```
-
-The filter is:
-
-```jq
-[
-  .data.repository.pullRequest.reviewThreads.nodes[]
-  | select(.isResolved == false
-           and .isOutdated == false
-           and .comments.nodes[0].author.__typename == "Bot"
-           and .comments.nodes[0].author.login == "claude")
-] | length
-```
-
-**Bot identity note (verified 2026-05-28 against frontend#367):** GitHub's GraphQL Author interface returns bot login *without* the `[bot]` suffix (e.g., `"claude"`), unlike the REST API which returns `"claude[bot]"`. The `__typename == "Bot"` guard ensures we cannot be spoofed by a human GitHub user named "claude".
-
-**Why:**
-
-- `isResolved` reflects the standard GitHub UI affordance (the "Resolve conversation" button). Using it as the resolution signal aligns the Check Run with the reviewer's own mental model.
-- `isOutdated` is GitHub's authoritative judgment of "is this comment still applicable to the diff" — strictly broader and more accurate than the REST `commit_id` heuristic, since it also covers cases where the line was moved or its surrounding context changed.
-- `comments.nodes[0]` is the thread opener. GraphQL's default ordering for `comments` is chronological, so the first node is reliably the bot. (In our workflow Claude always opens threads; maintainer replies are never thread openers.)
-- `first: 100` keeps the query under GitHub's hard cap of 100 nodes per page and avoids cursor pagination complexity. Healthy PRs are far below this limit; see Decision 4.
-
-**Alternative considered:** Use the REST `/pulls/N/comments` endpoint and filter by `in_reply_to_id` and a separate "is thread resolved" lookup. Rejected because the REST API does not expose thread-resolved state — `isResolved` is a GraphQL-only concept on the `PullRequestReviewThread` object.
-
-**Alternative considered:** Use `original_commit_id` + a side-channel "issues acknowledged" registry. Rejected because GitHub already provides the registry as `reviewThreads.isResolved`.
-
-### Decision 2: Add `pull_request_review_thread` to caller-workflow `on:` triggers
-
-Each caller workflow at `<repo>/.github/workflows/claude-code-review.yml` adds:
+`liverty-music/.github/.github/workflows/claude-review.yml` becomes a single-job, single-step workflow:
 
 ```yaml
-on:
-  pull_request:
-    types: [opened, synchronize, reopened]
-  pull_request_review_thread:
-    types: [resolved, unresolved]
-```
+name: Reusable Claude Review
 
-**Why:**
-
-- Without this, clicking "Resolve conversation" does nothing observable to the Check Run — the failure persists until something else (manual re-run, no-op push) re-fires the workflow. That breaks the reviewer's expectation of immediate feedback.
-- GitHub fires `pull_request_review_thread` events with full `pull_request` context in the payload, so the reusable workflow's `github.event.pull_request.number` and `.head.sha` continue to work without changes.
-- `unresolved` is included so that re-opening a thread also recomputes the Check Run, restoring `failure` symmetrically.
-
-**Trigger documentation note (verified 2026-05-28):** The official GitHub Actions ["Events that trigger workflows" reference](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows) does NOT list `pull_request_review_thread` as a workflow trigger. The webhook event IS documented at the [webhook reference](https://docs.github.com/en/webhooks/webhook-events-and-payloads#pull_request_review_thread) with activity types `resolved` and `unresolved`. The Actions runtime supports this trigger even though the Actions docs are silent on it — verified by 11+ production workflows on GitHub using `on: pull_request_review_thread: types: [resolved, unresolved]` (e.g., [`akasper/plate_template/feedback-resolution-check.yml`](https://github.com/akasper/plate_template/blob/main/.github/workflows/feedback-resolution-check.yml), [`smart-village-solutions/sva-studio/bot-comment-governance.yml`](https://github.com/smart-village-solutions/sva-studio/blob/main/.github/workflows/bot-comment-governance.yml)). YAML schema validators (vscode-github-actions extension included) may flag this as an unknown property — false positive due to outdated schema.
-
-**Alternative considered:** Add only `pull_request_review_thread.types: [resolved]`. Rejected for asymmetry — unresolving must also reflect immediately, otherwise an accidentally-resolved-then-unresolved thread leaves the Check Run stuck on `success`.
-
-**Alternative considered:** Use `pull_request_review.types: [submitted]`. Rejected because it fires on every review submission (formal review or comment batch), not on resolve, and the count step is decoupled from review submissions.
-
-### Decision 3: Split caller into two jobs; reusable workflow accepts a `verdict_only` input
-
-Rather than gating the expensive step inside the reusable workflow with `if: github.event_name == 'pull_request'`, gate at the **caller job level** with an explicit `verdict_only` input on the reusable workflow. The caller has two jobs that each invoke the reusable, one per triggering event:
-
-```yaml
-# caller workflow (each of the 4 repos)
-on:
-  pull_request:
-    types: [opened, synchronize, ready_for_review, reopened]
-  pull_request_review_thread:
-    types: [resolved, unresolved]
-
-jobs:
-  review:
-    if: ${{ github.event_name == 'pull_request' }}
-    uses: liverty-music/.github/.github/workflows/claude-review.yml@main
-    secrets: inherit
-
-  recompute-verdict:
-    if: ${{ github.event_name == 'pull_request_review_thread' }}
-    uses: liverty-music/.github/.github/workflows/claude-review.yml@main
-    with:
-      verdict_only: true
-    secrets: inherit
-```
-
-The reusable workflow declares the new input and gates the LLM step against it:
-
-```yaml
-# .github/workflows/claude-review.yml
 on:
   workflow_call:
-    inputs:
-      verdict_only:
-        type: boolean
-        required: false
-        default: false
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN:
         required: true
 
+permissions:
+  contents: read
+  pull-requests: write
+  issues: read
+  id-token: write
+
 jobs:
   review:
+    runs-on: ubuntu-latest
     steps:
-      - name: Run Claude review
-        if: ${{ !inputs.verdict_only }}
-        uses: anthropics/claude-code-action@v1
-      # count + publish steps run regardless
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+      - uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          plugin_marketplaces: https://github.com/anthropics/claude-code.git
+          plugins: code-review@claude-code-plugins
+          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }} --comment'
+          claude_args: '--allowedTools "Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh issue view:*),Bash(gh issue list:*),Bash(gh search:*),mcp__github_inline_comment__create_inline_comment"'
+```
+
+Removed: the `verdict_only` input on `workflow_call`; the `Count unresolved Claude review threads` step; the `Publish Claude review Check Run` step; the `checks: write` permission; all pagination loop / GraphQL / jq logic.
+
+**Why:**
+
+- This is the exact shape of [`pr-review-comprehensive.yml`](https://github.com/anthropics/claude-code-action/blob/main/examples/pr-review-comprehensive.yml) with only two delta: (1) the `prompt` invokes the `code-review` slash command instead of inlining review instructions, matching how mechanize structured it; (2) `secrets.CLAUDE_CODE_OAUTH_TOKEN` is used rather than `secrets.ANTHROPIC_API_KEY` because liverty-music authenticates via Claude OAuth.
+- No custom code = no custom bugs. Future upstream improvements (e.g., if Anthropic adds a verdict mechanism) are picked up by bumping the action pin.
+
+**Alternative considered:** Keep the GraphQL-`isResolved` post-step but remove the Check Run creation, just for telemetry. Rejected — telemetry without a gate is unused information and still drags in pagination / filter logic that has to be maintained.
+
+### Decision 2: Drop `'Claude review'` from `requiredStatusCheckContexts` in Pulumi
+
+`cloud-provisioning/src/index.ts` updates all four `GitHubRepositoryComponent` invocations to `requiredStatusCheckContexts: ['CI Success']`. The Pilot-graduation comment on the `specification` entry is removed.
+
+**Why:**
+
+- If Decision 1 ships and the required check stays, every PR is permanently blocked — the `Claude review` Check Run is no longer created, so it can never turn green. Pulumi must lead Decision 1's deploy.
+- `'CI Success'` remains as the deterministic gate (lint, test, build, etc.). This is the same set of checks that gated PRs before the mechanize / honor-thread-resolution arc.
+
+### Decision 3: No replacement gating mechanism
+
+Considered and rejected:
+
+- **GitHub App webhook bridge**: A small App listening for `pull_request_review_thread` webhooks and triggering `repository_dispatch` events. Solves the auto-recompute problem but adds an external service to operate, a secret to manage, and rate-limit considerations. Disproportionate complexity for the value.
+- **`workflow_dispatch` manual recompute**: Add a manual "Recompute verdict" button to the Actions UI. Half-measure — the Check Run still exists, still needs the count logic, still has all the maintenance burden, in exchange for an affordance that humans rarely click. Worse total cost than just deleting the gate.
+- **CODEOWNERS-gated `isResolved` filter**: Only count threads resolved by a non-author CODEOWNER as truly resolved. Adds code complexity, governance subtleties, and doesn't solve the resolve-without-push problem.
+- **Periodic cron recompute**: A scheduled workflow that walks open PRs and updates Check Runs. Adds a cron, walks a quota, and produces stale-by-design results.
+
+The principled choice is: **bot review is advisory by nature; treat it as such.** Reviewers (human + automation) see comments and act on them; merge is gated on objective, deterministic checks.
+
+### Decision 4: Caller workflows on all four repos remain unchanged
+
+`.github/workflows/claude-code-review.yml` on `backend`, `frontend`, `specification`, `cloud-provisioning` keeps:
+
+```yaml
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+permissions:
+  contents: read
+  pull-requests: write
+  issues: read
+  id-token: write
+  checks: write   # unused after Decision 1; harmless, deferred for cleanup
+jobs:
+  review:
+    uses: liverty-music/.github/.github/workflows/claude-review.yml@main
+    secrets: inherit
 ```
 
 **Why:**
 
-- Resolve clicks should recompute the verdict cheaply. Re-running Claude on every resolve click would (a) burn Anthropic API tokens for no signal change, (b) likely re-post the same nits the maintainer just resolved, creating a cycle.
-- The count step's input (the set of review threads) is independent of whether Claude just ran — it queries the live PR state — so skipping Claude on thread events still produces a correct count.
-- The split-job + `verdict_only` input pattern makes the contract explicit. A caller declares "this is a recompute-only run" via the input rather than relying on `github.event_name` inside the reusable. This is easier to reason about and easier to extend (e.g., future `workflow_dispatch` trigger can also pass `verdict_only: true`).
+- The reusable workflow's `workflow_call` interface no longer accepts `verdict_only`. Caller workflows that don't pass that input continue to work — no breaking change for callers.
+- The shape matches the official `pr-review-comprehensive.yml` `on:` block exactly.
+- No need to add `pull_request_review_thread`, `workflow_dispatch`, or any other re-trigger affordance — there's no Check Run to recompute.
+- The `checks: write` permission becomes unused but is harmless. Cleaning it up across four repos is deferred to a follow-up tidy PR.
 
-**Alternative considered:** Gate the expensive step inside the reusable with `if: github.event_name == 'pull_request'`. Rejected because (a) it implicitly couples the reusable to event-name semantics rather than exposing an explicit input contract, (b) it makes the caller's intent harder to read — you have to know how the reusable interprets event names, (c) any future trigger (e.g., `workflow_dispatch`) needs to be added to the reusable's `if` expression rather than just passing `verdict_only: true` at the call site.
+### Decision 5: Document the historical arc in the spec delta but keep the canonical spec lean
 
-**Alternative considered:** Run Claude on every trigger and rely on the skip-on-repeat upstream behavior to be cheap. Rejected because skip-on-repeat is not free (the action still spins up, reads the diff, and decides to skip), and skip-on-repeat is itself a known-unreliable behavior under model degradation.
+The spec delta in this change rewrites the `Claude review publishes its verdict as a GitHub Check Run` requirement to a simpler "Claude review posts advisory inline comments" requirement, and removes the `Claude review is enforced as a Required Status Check via Pulumi` requirement and the pilot-rollout requirement.
 
-### Decision 4: Fail-neutral on >100 threads (pagination overflow)
-
-If the GraphQL response's `pageInfo.hasNextPage == true`, the count step writes `count=-1` and the publish step emits `conclusion: neutral` with title `Verdict could not be computed (>100 threads)`.
-
-**Why:**
-
-- A PR with >100 review threads is unhealthy regardless of who authored them. Neither auto-passing nor auto-failing is meaningful; surface ambiguity and let humans investigate.
-- The highest observed count in production is 66 threads (backend#305), so 100 is a comfortable ceiling for healthy PRs.
-- Implementing cursor pagination would add ~15 lines of bash and a second `gh api` call; on a runaway PR it would just produce a high but uninformative count.
-
-### Decision 5: Bot-author detection unchanged (`user.login == "claude[bot]"`)
-
-The bot identity check is the same exact-match used in `mechanize-claude-review-verdict` task 1.2.
+The why-trail (LLM verdict → REST `commit_id` → GraphQL `isResolved` → broken trigger → revert) is captured in this design.md and in the [issue #525](https://github.com/liverty-music/specification/issues/525) thread. It is NOT reproduced in the canonical spec — the spec describes the current state of the system, not the historical journey.
 
 **Why:**
 
-- Risk surface is unchanged from the predecessor change.
-- If Anthropic ever renames the bot identity, this filter silently produces `count=0` (success). Same risk as the predecessor; mitigated by the same logic — if zero threads match the filter but the GraphQL response had any bot threads from any author, that would warrant escalation. (Not implemented as code; documented as a known-unmonitored risk.)
+- Canonical specs that document failed approaches become "if-not, why-not" mazes that obscure the current contract.
+- The archive of `mechanize-claude-review-verdict` and this change's design.md jointly preserve the chronological record for anyone investigating the operating-protocol clash referenced in CLAUDE.md.
 
 ## Risks / Trade-offs
 
-- **[Stale `failure` until a re-trigger fires]** → After this change, clicking "Resolve conversation" re-fires the workflow, so the lag is bounded by GitHub's event delivery (<10s in practice). Before either workflow_dispatch or a commit could clear it. This is a strict improvement.
+- **[Loss of forced response to bot findings]** → Reviewers can now merge a PR with un-addressed Claude review comments. Mitigation: human reviewers should treat the bot's output as an input to their review, same as any other reviewer. The bot is advisory by nature ([upstream pattern](https://github.com/anthropics/claude-code-action/blob/main/examples/pr-review-comprehensive.yml)) and treating it otherwise — as we found over four iterations — fights the tool.
 
-- **[Resolve-as-mute by PR author]** → The default GitHub trust model lets the PR author resolve their own threads, which silences the bot's gate. This is consistent with the existing branch-protection trust (PR authors with write access can also approve merges via admin override). Documented as expected behavior in the migration plan; not a CODEOWNERS-enforced restriction. If this becomes a problem, a follow-up change can introduce a CODEOWNERS check.
+- **[Bot still spends Anthropic API budget on every PR push]** → No change from current state. If cost becomes a concern, separate work to add path/author filters (per [`pr-review-filtered-authors.yml`](https://github.com/anthropics/claude-code-action/blob/main/examples/pr-review-filtered-authors.yml) and [`pr-review-filtered-paths.yml`](https://github.com/anthropics/claude-code-action/blob/main/examples/pr-review-filtered-paths.yml)).
 
-- **[Replay attack: maintainer resolves all threads, then bot re-reviews on next push and re-flags them]** → Acceptable. The bot is the source of truth on whether an issue still exists. If it re-flags, the maintainer can defend and re-resolve, or fix the code. The Check Run reflects the latest state.
+- **[CLAUDE.md "NEVER skip hooks unless explicitly requested" guard becomes vacuous for Claude review]** → The guard applied because admin-override was the only way past the stuck Check Run. After this change there is no Check Run to override; the guard is unaffected for other checks (lint, test, signing). Update CLAUDE.md if the guard's existing wording specifically references Claude review (none observed at the time of writing).
 
-- **[`pull_request_review_thread` event delivery delay]** → GitHub does not document a delivery SLA. If the event is delayed or dropped, the Check Run stays stale until the next `pull_request` synchronize. Mitigation: nothing — the predecessor failure mode was worse (stuck permanently), so a brief stuck state on event drops is an acceptable degradation.
+- **[`permissions: checks: write` on each caller becomes unused]** → No functional impact. Defer cleanup to a tidy PR.
 
-- **[GraphQL rate limits]** → The default `GITHUB_TOKEN` has a 5,000-point/hour rate budget for GraphQL. This query is single-shot and ~2 points. Even pathological re-trigger volume (one resolve click per second) is well within budget.
-
-- **[>100 threads collapses to neutral, blocking the gate from concluding]** → The `requiredStatusCheckContexts` rule treats `neutral` as a pass (per GitHub's documented behavior). A PR that overflows would be merge-eligible despite an unreviewed state. Acceptable: this is a degenerate PR that needs human attention regardless.
-
-- **[Caller-workflow `on:` block change is required in 4 repos]** → Cannot be done purely in the reusable workflow because `on:` is owned by the caller. This makes the rollout a 5-PR fan-out instead of 1. Documented in the migration plan.
+- **[Pulumi deploy ordering risk]** → If `.github#7` merges before `pulumi up -s prod` is applied, every open PR becomes permanently un-mergeable. Deployment ordering documented in `proposal.md` "Deployment ordering" section and in the Pulumi PR description.
 
 ## Migration Plan
 
-1. **Archive `mechanize-claude-review-verdict`** so its spec delta lands in canonical `openspec/specs/ci-optimization/spec.md`. The current canonical still describes the verdict-file mechanism — without archiving first, this change's MODIFIED requirement would target outdated text and create a delta-against-delta state.
-2. Create tracking issue in `liverty-music/specification` ("Honor thread resolution in Claude review Check Run").
-3. Land the `.github` repo change first (reusable workflow): GraphQL count step + Claude-run step guard. All four caller workflows reference `@main`, so they pick up the new logic on the next push.
-4. Land the four caller-repo changes (add `pull_request_review_thread` to `on:`). Order does not matter.
-5. **Validate** on a real PR by deliberately reproducing the bug-and-fix cycle:
-   - Open a PR that intentionally contains a CLAUDE.md violation.
-   - Confirm `Claude review` = `failure` with a non-zero count.
-   - Click "Resolve conversation" on each bot thread via the GitHub UI (no commit push).
-   - Confirm the workflow re-runs on `pull_request_review_thread.resolved`, and the Check Run flips to `success` within ~30s.
-   - Click "Unresolve" on one thread.
-   - Confirm the workflow re-runs and Check Run flips back to `failure` with count 1.
-6. (Optional) Land a documentation update in each repo's `CLAUDE.md` describing the resolve-to-clear flow.
-7. Archive this change.
+See `proposal.md` "Deployment ordering". Summary:
 
-**Rollback:** Revert the merge commits in `liverty-music/.github` and the four caller repos. The Check Run returns to the (broken-but-tolerated) `commit_id == HEAD_SHA` behavior — but production has been operating in that broken state for the entire mechanize window, so rollback is safe.
+1. Merge [`cloud-provisioning#311`](https://github.com/liverty-music/cloud-provisioning/pull/311).
+2. Run `pulumi up -s prod`. Verify required checks via `gh api ...` on all four repos.
+3. Merge [`.github#7`](https://github.com/liverty-music/.github/pull/7).
+4. Merge this PR ([`specification#526`](https://github.com/liverty-music/specification/pull/526)).
+5. Open a normal follow-up PR on any repo to confirm: Claude review posts inline comments (if any), no `Claude review` Check Run is created, merge gating is `CI Success` only.
+6. Archive this change.
+
+**Rollback:** Re-apply `'Claude review'` to `requiredStatusCheckContexts` via Pulumi AND restore the `.github` reusable workflow to its pre-#7 state. The Check Run resumes with the GraphQL-`isResolved` logic from `.github#6`. Rollback restores the bug behavior (stuck failures from non-code-resolved threads) but is operationally safe.
 
 ## Open Questions
 
-- Should the `Claude review` Check Run's summary link to the unresolved threads filter (`?reviewer=claude%5Bbot%5D` style) in addition to the Files-changed view? Defer; can be a non-breaking enhancement after the core fix lands.
-- Should the workflow also include `pull_request_review_thread.types: [outdated]`? GitHub does not currently document `outdated` as a `pull_request_review_thread` event subtype, so likely no. To be verified during implementation by inspecting webhook delivery on a real outdated event.
-- Should the `Run Claude review` step also be skipped on `workflow_dispatch` (manual recompute), or is keeping it gated to `pull_request` enough? Likely yes — `workflow_dispatch` is the natural "I want to force a recount without re-reviewing" trigger. To be confirmed once the workflow is functioning.
+- Should we add path filters per [`pr-review-filtered-paths.yml`](https://github.com/anthropics/claude-code-action/blob/main/examples/pr-review-filtered-paths.yml) to skip review on cosmetic-only PRs (e.g., openspec doc changes)? Deferred — separate work, not blocking this change.
+- Should `permissions: checks: write` be removed from all four caller workflows? Deferred — harmless, tidy-PR.
+- If a future need arises to revisit gating, the principled path is to wait for an upstream feature (Anthropic-side Check Run support in `claude-code-action`) rather than to rebuild the wrapper. Open as a research watch.

--- a/openspec/changes/honor-thread-resolution-in-claude-review-check/proposal.md
+++ b/openspec/changes/honor-thread-resolution-in-claude-review-check/proposal.md
@@ -1,0 +1,49 @@
+## Why
+
+The predecessor change [`mechanize-claude-review-verdict`](../mechanize-claude-review-verdict/) correctly removed LLM-emitted verdict pressure by deriving the `Claude review` Check Run conclusion from a mechanical count of inline review comments. It chose `commit_id == HEAD_SHA AND user.login == "claude[bot]"` (REST `/pulls/N/comments`) as the resolution signal. That signal turned out to detect only **one** of the three resolution paths a reviewer can take, producing a permanent FAILURE state in real use.
+
+Specifically, `commit_id` on a review comment is **not** the SHA where the comment was originally posted — it is the most recent SHA where the comment is still applicable to the code. GitHub auto-updates it forward on every push as long as the commented line is unchanged. Therefore the predecessor filter is semantically `still-applicable-bot-comments-on-HEAD`, which excludes only the "code was rewritten over the line" case. It does not exclude:
+
+- A maintainer clicking **Resolve conversation** in the GitHub UI (`isResolved = true` does not change `commit_id`).
+- A defendable inline reply where the maintainer pushes back and resolves (same as above).
+- An empty / unrelated commit being pushed (every still-live comment's `commit_id` is bumped to the new HEAD — count is unchanged).
+
+This was observed on two production PRs that completed full 17-round bot review cycles:
+
+| PR | Threads resolved (UI) | Final Check Run | Final title |
+|---|---|---|---|
+| [`liverty-music/backend#305`](https://github.com/liverty-music/backend/pull/305) | 66 / 66 | `failure` | `51 issue(s) found` |
+| [`liverty-music/frontend#367`](https://github.com/liverty-music/frontend/pull/367) | 45 / 45 | `failure` | `18 issue(s) found` |
+
+Both PRs required **admin override** to merge, which directly conflicts with the `NEVER skip hooks unless explicitly requested` guard documented in CLAUDE.md. Left unfixed, this forces a choice between removing `Claude review` from `requiredStatusCheckContexts` (defeating the gate) or routinely bypassing branch protection (defeating the operating-protocol guard).
+
+The fix is to switch the resolution signal from REST-comment-`commit_id` to GraphQL **`reviewThreads.isResolved`** (plus `isOutdated` to retain the "code-change-resolved" path), and to re-trigger the workflow on `pull_request_review_thread` events so resolve clicks take effect without a manual re-push.
+
+## What Changes
+
+- **BREAKING (workflow logic)**: In `liverty-music/.github/.github/workflows/claude-review.yml`, replace the REST `/pulls/N/comments` + `commit_id == HEAD_SHA` filter with a GraphQL `reviewThreads(first: 100)` query filtering `isResolved == false AND isOutdated == false AND comments.nodes[0].author.login == "claude[bot]"`. Count remains the conclusion signal.
+- **ADD**: All four caller workflows (`backend`, `frontend`, `specification`, `cloud-provisioning`) MUST add `pull_request_review_thread` (types `resolved`, `unresolved`) to their `on:` triggers so resolve clicks recompute the Check Run.
+- **ADD**: Guard the expensive `anthropics/claude-code-action@v1` step in the reusable workflow with `if: github.event_name == 'pull_request'` so resolve-click re-triggers run only the cheap count + publish steps. Without this guard each resolve click would burn Anthropic API tokens and likely re-post nits.
+- **ADD**: On GraphQL `pageInfo.hasNextPage == true` (>100 threads), publish `conclusion: neutral`. A PR with that many threads is unhealthy regardless and should not be auto-gated either way.
+- **PRESERVED**: Check Run name (`Claude review`), conclusion vocabulary (`success` / `failure` / `neutral`), Required Status Check policy, no Pulumi changes, no `CLAUDE.md` content changes.
+- **PRESERVED**: All five decisions of `mechanize-claude-review-verdict` — verdict decoupled from LLM, `additional_focus` removed, single-line slash command, `--allowedTools` aligned, tracking-issue convention. This change supersedes only the implementation detail of how comments are counted; the thesis stands.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `ci-optimization`: Replace the `commit_id == HEAD_SHA`-driven comment-count requirement with an unresolved-`reviewThread`-count requirement; require caller workflows to fire on `pull_request_review_thread`; require the reusable workflow to skip the Claude run step on non-`pull_request` events.
+
+## Impact
+
+- **Affected repo**: `liverty-music/.github` (reusable workflow at `.github/workflows/claude-review.yml` — count step + step guard change).
+- **Affected caller workflows** (4 repos, ~3-line addition each): `backend/.github/workflows/claude-code-review.yml`, `frontend/.github/workflows/claude-code-review.yml`, `specification/.github/workflows/claude-code-review.yml`, `cloud-provisioning/.github/workflows/claude-code-review.yml`.
+- **No Pulumi change**: Branch protection is unchanged.
+- **CLAUDE.md update (optional, documentation-only)**: Add a one-line note in each repo's `CLAUDE.md` (or the workspace CLAUDE.md) clarifying that maintainers can clear `Claude review` failures by clicking "Resolve conversation" on the relevant threads, and that resolving a thread automatically recomputes the Check Run.
+- **Tracking issue**: To be created in `liverty-music/specification` (next-available number) before implementation. Per the liverty-music commit convention every commit footer is `Refs: #<issue-number>`.
+- **Predecessor dependency**: `mechanize-claude-review-verdict` MUST be archived before this change is applied (so its spec delta lands in canonical `openspec/specs/ci-optimization/spec.md` and this change's MODIFIED requirement targets the post-mechanize text). See [`design.md`](./design.md) §"Migration Plan" for the ordering.
+- **Known residual issue (unchanged from predecessor)**: The `code-review` plugin's skip-on-repeat behavior ([anthropics/claude-code#19618](https://github.com/anthropics/claude-code/issues/19618)) remains out of scope. Mitigation is unchanged — `isOutdated` excludes code-resolved threads, `isResolved` excludes UI-resolved threads, so a stale cache cannot inflate the count.

--- a/openspec/changes/honor-thread-resolution-in-claude-review-check/proposal.md
+++ b/openspec/changes/honor-thread-resolution-in-claude-review-check/proposal.md
@@ -1,32 +1,23 @@
 ## Why
 
-The predecessor change [`mechanize-claude-review-verdict`](../mechanize-claude-review-verdict/) correctly removed LLM-emitted verdict pressure by deriving the `Claude review` Check Run conclusion from a mechanical count of inline review comments. It chose `commit_id == HEAD_SHA AND user.login == "claude[bot]"` (REST `/pulls/N/comments`) as the resolution signal. That signal turned out to detect only **one** of the three resolution paths a reviewer can take, producing a permanent FAILURE state in real use.
+The predecessor change [`mechanize-claude-review-verdict`](../archive/2026-05-28-mechanize-claude-review-verdict/) tried to gate PR merges on `Claude review` Check Run output by mechanically counting inline comments. Two production PRs ([`liverty-music/backend#305`](https://github.com/liverty-music/backend/pull/305), [`liverty-music/frontend#367`](https://github.com/liverty-music/frontend/pull/367)) exposed that the chosen `commit_id == HEAD_SHA` REST filter detects only code-overwrite resolution, missing UI-resolve and "still-applicable-after-push" cases.
 
-Specifically, `commit_id` on a review comment is **not** the SHA where the comment was originally posted — it is the most recent SHA where the comment is still applicable to the code. GitHub auto-updates it forward on every push as long as the commented line is unchanged. Therefore the predecessor filter is semantically `still-applicable-bot-comments-on-HEAD`, which excludes only the "code was rewritten over the line" case. It does not exclude:
+This change initially proposed a layered fix: GraphQL `reviewThreads.isResolved` filtering + `pull_request_review_thread` re-trigger + split-job caller pattern + `verdict_only` reusable-workflow input. Investigation while implementing the fix revealed a deeper problem: **the entire pattern of using `Claude review` as a required status check is not supported by `anthropics/claude-code-action` upstream**, and every layer of the harness adds workarounds for upstream behavior it was never designed to provide.
 
-- A maintainer clicking **Resolve conversation** in the GitHub UI (`isResolved = true` does not change `commit_id`).
-- A defendable inline reply where the maintainer pushes back and resolves (same as above).
-- An empty / unrelated commit being pushed (every still-live comment's `commit_id` is bumped to the new HEAD — count is unchanged).
+Concretely:
 
-This was observed on two production PRs that completed full 17-round bot review cycles:
+- `anthropics/claude-code-action` exposes no Check Run / verdict / pass-fail output mechanism. Its [official examples](https://github.com/anthropics/claude-code-action/tree/main/examples) (`pr-review-comprehensive.yml`, `pr-review-filtered-authors.yml`, `pr-review-filtered-paths.yml`) all post inline comments only — none create a Check Run or gate the workflow.
+- The `code-review` slash command itself ([`anthropics/claude-code` plugins](https://github.com/anthropics/claude-code/blob/main/plugins/code-review/commands/code-review.md)) does not emit a verdict file or any structured pass/fail signal.
+- `pull_request_review_thread` is documented as a webhook event but **does not function as a GitHub Actions workflow trigger**. Empirical test (this change, 2026-05-28): adding `on: pull_request_review_thread:` to a caller workflow produces spurious push-event stub failures AND prevents the `pull_request` trigger from firing at all. Confirmed against 11+ third-party workflows on GitHub that use this trigger — all in `failure` state.
 
-| PR | Threads resolved (UI) | Final Check Run | Final title |
-|---|---|---|---|
-| [`liverty-music/backend#305`](https://github.com/liverty-music/backend/pull/305) | 66 / 66 | `failure` | `51 issue(s) found` |
-| [`liverty-music/frontend#367`](https://github.com/liverty-music/frontend/pull/367) | 45 / 45 | `failure` | `18 issue(s) found` |
-
-Both PRs required **admin override** to merge, which directly conflicts with the `NEVER skip hooks unless explicitly requested` guard documented in CLAUDE.md. Left unfixed, this forces a choice between removing `Claude review` from `requiredStatusCheckContexts` (defeating the gate) or routinely bypassing branch protection (defeating the operating-protocol guard).
-
-The fix is to switch the resolution signal from REST-comment-`commit_id` to GraphQL **`reviewThreads.isResolved`** (plus `isOutdated` to retain the "code-change-resolved" path), and to re-trigger the workflow on `pull_request_review_thread` events so resolve clicks take effect without a manual re-push.
+The accumulated user-side harness reached four iterations, each fixing the prior layer's bug while introducing new complexity (LLM verdict file → REST `commit_id` filter → GraphQL `isResolved` filter → split-job + `verdict_only` + broken trigger). Per the operating instruction "可能な限り構成をシンプルに / 場当たり的なハックは禁止", reset to the upstream pattern: `Claude review` becomes advisory-only.
 
 ## What Changes
 
-- **BREAKING (workflow logic)**: In `liverty-music/.github/.github/workflows/claude-review.yml`, replace the REST `/pulls/N/comments` + `commit_id == HEAD_SHA` filter with a GraphQL `reviewThreads(first: 100)` query filtering `isResolved == false AND isOutdated == false AND comments.nodes[0].author.login == "claude[bot]"`. Count remains the conclusion signal.
-- **ADD**: All four caller workflows (`backend`, `frontend`, `specification`, `cloud-provisioning`) MUST add `pull_request_review_thread` (types `resolved`, `unresolved`) to their `on:` triggers so resolve clicks recompute the Check Run.
-- **ADD**: Guard the expensive `anthropics/claude-code-action@v1` step in the reusable workflow with `if: github.event_name == 'pull_request'` so resolve-click re-triggers run only the cheap count + publish steps. Without this guard each resolve click would burn Anthropic API tokens and likely re-post nits.
-- **ADD**: On GraphQL `pageInfo.hasNextPage == true` (>100 threads), publish `conclusion: neutral`. A PR with that many threads is unhealthy regardless and should not be auto-gated either way.
-- **PRESERVED**: Check Run name (`Claude review`), conclusion vocabulary (`success` / `failure` / `neutral`), Required Status Check policy, no Pulumi changes, no `CLAUDE.md` content changes.
-- **PRESERVED**: All five decisions of `mechanize-claude-review-verdict` — verdict decoupled from LLM, `additional_focus` removed, single-line slash command, `--allowedTools` aligned, tracking-issue convention. This change supersedes only the implementation detail of how comments are counted; the thesis stands.
+- **BREAKING (workflow)**: Revert the reusable workflow `liverty-music/.github/.github/workflows/claude-review.yml` to the official [`pr-review-comprehensive.yml`](https://github.com/anthropics/claude-code-action/blob/main/examples/pr-review-comprehensive.yml) shape — a single job invoking `anthropics/claude-code-action@v1` with the `code-review` plugin and `--comment`. Remove the `Count unresolved Claude review threads` step, the `Publish Claude review Check Run` step, the `verdict_only` input, the `checks: write` permission, and all pagination / GraphQL / jq filtering logic.
+- **BREAKING (branch protection)**: Drop `'Claude review'` from `requiredStatusCheckContexts` on all four liverty-music repos (`backend`, `frontend`, `specification`, `cloud-provisioning`) in [`cloud-provisioning/src/index.ts`](https://github.com/liverty-music/cloud-provisioning/blob/main/src/index.ts). `'CI Success'` remains as the sole required check.
+- **PRESERVED (caller workflows)**: All four caller workflows at `<repo>/.github/workflows/claude-code-review.yml` keep their existing `on: pull_request: types: [opened, synchronize, ready_for_review, reopened]` trigger and single-job structure invoking the reusable workflow. No `pull_request_review_thread`, no split-jobs, no `verdict_only` plumbing. (The `permissions: checks: write` line on each caller becomes unused after the reusable stops creating Check Runs; treated as harmless and deferred for cleanup.)
+- **PRESERVED (review behavior)**: `Claude review` workflow still runs on every PR push, the bot still posts inline review comments. What changes is solely the gate: reviewers (human or otherwise) read the comments and decide what to act on; merge is no longer blocked by an automated comment count.
 
 ## Capabilities
 
@@ -36,14 +27,22 @@ The fix is to switch the resolution signal from REST-comment-`commit_id` to Grap
 
 ### Modified Capabilities
 
-- `ci-optimization`: Replace the `commit_id == HEAD_SHA`-driven comment-count requirement with an unresolved-`reviewThread`-count requirement; require caller workflows to fire on `pull_request_review_thread`; require the reusable workflow to skip the Claude run step on non-`pull_request` events.
+- `ci-optimization`: Remove the requirement that `Claude review` publishes a Check Run derived from comment counting. Remove the requirement that `Claude review` is enforced as a Required Status Check via Pulumi. Replace with an advisory-only requirement: Claude review posts inline comments; no Check Run is published; merge gating uses other deterministic checks.
 
 ## Impact
 
-- **Affected repo**: `liverty-music/.github` (reusable workflow at `.github/workflows/claude-review.yml` — count step + step guard change).
-- **Affected caller workflows** (4 repos, ~3-line addition each): `backend/.github/workflows/claude-code-review.yml`, `frontend/.github/workflows/claude-code-review.yml`, `specification/.github/workflows/claude-code-review.yml`, `cloud-provisioning/.github/workflows/claude-code-review.yml`.
-- **No Pulumi change**: Branch protection is unchanged.
-- **CLAUDE.md update (optional, documentation-only)**: Add a one-line note in each repo's `CLAUDE.md` (or the workspace CLAUDE.md) clarifying that maintainers can clear `Claude review` failures by clicking "Resolve conversation" on the relevant threads, and that resolving a thread automatically recomputes the Check Run.
-- **Tracking issue**: To be created in `liverty-music/specification` (next-available number) before implementation. Per the liverty-music commit convention every commit footer is `Refs: #<issue-number>`.
-- **Predecessor dependency**: `mechanize-claude-review-verdict` MUST be archived before this change is applied (so its spec delta lands in canonical `openspec/specs/ci-optimization/spec.md` and this change's MODIFIED requirement targets the post-mechanize text). See [`design.md`](./design.md) §"Migration Plan" for the ordering.
-- **Known residual issue (unchanged from predecessor)**: The `code-review` plugin's skip-on-repeat behavior ([anthropics/claude-code#19618](https://github.com/anthropics/claude-code/issues/19618)) remains out of scope. Mitigation is unchanged — `isOutdated` excludes code-resolved threads, `isResolved` excludes UI-resolved threads, so a stale cache cannot inflate the count.
+- **Affected repo: `liverty-music/.github`** — reusable workflow at `.github/workflows/claude-review.yml` is reverted to the minimal upstream shape ([#7](https://github.com/liverty-music/.github/pull/7)).
+- **Affected repo: `liverty-music/cloud-provisioning`** — Pulumi component invocations in `src/index.ts` drop `'Claude review'` from `requiredStatusCheckContexts` on all four `GitHubRepositoryComponent` entries ([#311](https://github.com/liverty-music/cloud-provisioning/pull/311)).
+- **No change required in caller workflows** (`backend`, `frontend`, `specification`, `cloud-provisioning` `.github/workflows/claude-code-review.yml`) — they already use the official `pull_request` trigger pattern.
+- **Tracking issue**: [`liverty-music/specification#525`](https://github.com/liverty-music/specification/issues/525).
+- **Predecessor archive**: `mechanize-claude-review-verdict` archived at [`archive/2026-05-28-mechanize-claude-review-verdict`](../archive/2026-05-28-mechanize-claude-review-verdict/). Its spec delta is in the current canonical `openspec/specs/ci-optimization/spec.md` and is being further modified by this change.
+- **Superseded PRs** (closed without merge): [`liverty-music/.github#5`](https://github.com/liverty-music/.github/pull/5) (verdict_only input version), [`liverty-music/backend#311`](https://github.com/liverty-music/backend/pull/311), [`liverty-music/frontend#371`](https://github.com/liverty-music/frontend/pull/371), [`liverty-music/cloud-provisioning#310`](https://github.com/liverty-music/cloud-provisioning/pull/310).
+- **Already merged (but being walked back by this change)**: [`liverty-music/.github#6`](https://github.com/liverty-music/.github/pull/6) merged the GraphQL-`isResolved` Check Run logic to `main`. This change's [.github#7](https://github.com/liverty-music/.github/pull/7) reverts it.
+
+## Deployment ordering
+
+1. Merge [cloud-provisioning#311](https://github.com/liverty-music/cloud-provisioning/pull/311) (Pulumi drops required check).
+2. User manually runs `pulumi up -s prod`. Verify via `gh api repos/liverty-music/<repo>/branches/main/protection --jq '.required_status_checks.contexts'` that `Claude review` is gone from all four repos.
+3. Only AFTER step 2 confirmed, merge [.github#7](https://github.com/liverty-music/.github/pull/7) (reusable workflow stops creating Check Run).
+4. Merge this specification PR ([#526](https://github.com/liverty-music/specification/pull/526)) — the OpenSpec proposal/design/spec/tasks for the change.
+5. Archive `honor-thread-resolution-in-claude-review-check` after the next normal PR proves the new state works (inline comments posted, no Check Run created, merge succeeds via `CI Success` only).

--- a/openspec/changes/honor-thread-resolution-in-claude-review-check/specs/ci-optimization/spec.md
+++ b/openspec/changes/honor-thread-resolution-in-claude-review-check/specs/ci-optimization/spec.md
@@ -1,92 +1,58 @@
 ## MODIFIED Requirements
 
-### Requirement: Claude review publishes its verdict as a GitHub Check Run
-The reusable workflow SHALL create a GitHub Check Run named exactly `Claude review` on the pull request's head commit. The Check Run `conclusion` SHALL be derived deterministically from the count of **unresolved review threads opened by the Claude bot**, computed in a post-step that calls `gh api graphql` against the pull request's `reviewThreads(first: 100)` field and filters by `isResolved == false` AND `isOutdated == false` AND (`comments.nodes[0].author.__typename == "Bot"` AND `comments.nodes[0].author.login == "claude"`).
+### Requirement: Claude review posts advisory inline comments on pull requests
+The reusable workflow `liverty-music/.github/.github/workflows/claude-review.yml` SHALL invoke `anthropics/claude-code-action@v1` with the `code-review@claude-code-plugins` plugin and the `--comment` argument so that Claude posts inline review comments on each pull request. The workflow SHALL NOT create a GitHub Check Run, SHALL NOT emit a verdict file, and SHALL NOT submit a formal pull request review (`APPROVED` or `CHANGES_REQUESTED`).
 
-The Check Run conclusion mapping SHALL be:
+The reusable workflow's `workflow_call` interface SHALL declare only the `CLAUDE_CODE_OAUTH_TOKEN` secret (no inputs). The workflow SHALL request permissions `contents: read`, `pull-requests: write`, `issues: read`, `id-token: write` — and SHALL NOT request `checks: write`.
 
-| Filtered thread count | `conclusion` |
-|---|---|
-| `0` | `success` |
-| `≥ 1` | `failure` |
-| GraphQL call fails, response is unparseable, or `pageInfo.hasNextPage == true` (>100 threads) | `neutral` |
-
-The Check Run output `title` SHALL be `No issues found` when `conclusion == success`, `N issue(s) found` when `conclusion == failure` (where `N` is the filtered thread count), and `Verdict could not be computed` when `conclusion == neutral` (the title MAY append `(>100 threads)` when the pagination-overflow branch is taken). The Check Run output `summary` SHALL link to the pull request's `Files changed` view.
-
-The verdict SHALL NOT be derived from an LLM-emitted artifact (such as a JSON file written by the Claude run), and SHALL NOT be derived from a REST-comments-`commit_id` filter. The Claude run is responsible only for posting inline review comments; the verdict is computed mechanically against live thread state after the count step completes.
-
-The workflow SHALL NOT submit a formal pull request review (`APPROVE` or `REQUEST_CHANGES`) for the verdict. Only the inline comments (posted by the plugin) and the Check Run are produced.
-
-#### Scenario: Claude finds no high-signal issues
-- **WHEN** the Claude run completes and zero `reviewThreads` match `isResolved == false AND isOutdated == false AND comments.nodes[0].author.__typename == "Bot" AND comments.nodes[0].author.login == "claude"`
-- **THEN** the workflow SHALL create a `Claude review` Check Run with `conclusion: success`
-- **AND** the Check Run output title SHALL be `No issues found`
-
-#### Scenario: Claude has open unresolved bot threads
-- **WHEN** the count step finds `N ≥ 1` `reviewThreads` matching the filter
-- **THEN** the workflow SHALL create a `Claude review` Check Run with `conclusion: failure`
-- **AND** the Check Run output title SHALL be `N issue(s) found`
-
-#### Scenario: Verdict computation fails
-- **WHEN** the `gh api graphql` call exits non-zero, OR its output cannot be parsed, OR `pageInfo.hasNextPage == true`
-- **THEN** the workflow SHALL create a `Claude review` Check Run with `conclusion: neutral`
-- **AND** the Check Run output title SHALL be `Verdict could not be computed`
-
-#### Scenario: Maintainer resolves a bot thread via the GitHub UI
-- **WHEN** a maintainer clicks "Resolve conversation" on a bot-opened thread
-- **THEN** GitHub SHALL fire a `pull_request_review_thread` event with `action: resolved`
-- **AND** the caller workflow SHALL re-invoke the reusable workflow
-- **AND** the count step SHALL recompute against live thread state
-- **AND** the Check Run on the head SHA SHALL be republished with the new count
-
-#### Scenario: Maintainer un-resolves a previously-resolved bot thread
-- **WHEN** a maintainer clicks "Unresolve conversation" on a previously-resolved bot thread
-- **THEN** the caller workflow SHALL re-invoke the reusable workflow on the `pull_request_review_thread.unresolved` event
-- **AND** the count step SHALL include that thread again
-- **AND** the Check Run SHALL reflect the higher count
-
-#### Scenario: Subsequent push fixes earlier-flagged issues by changing the lines
-- **WHEN** a PR initially has `conclusion: failure` from bot threads on commit SHA `A`
-- **AND** a new commit SHA `B` is pushed that edits or removes the flagged lines (such that GitHub marks the corresponding threads `isOutdated: true`)
-- **THEN** the workflow on commit `B` SHALL exclude those threads from the count
-- **AND** if no other unresolved bot threads remain, the Check Run SHALL be `conclusion: success`
-
-#### Scenario: Empty or unrelated commit is pushed without resolving any threads
-- **WHEN** a commit is pushed that does not touch any line referenced by an open bot thread, AND no threads are marked resolved
-- **THEN** every open bot thread remains `isResolved: false AND isOutdated: false`
-- **AND** the Check Run conclusion SHALL remain `failure` with the same count as before the push
-- **AND** the count SHALL NOT be inflated by the new HEAD SHA (the count is independent of `commit_id`)
-
-#### Scenario: Claude review never submits a formal PR review
-- **WHEN** any Claude review run completes (success, failure, or neutral)
-- **THEN** `gh pr view --json reviews` SHALL NOT show a review authored by Claude with state `APPROVED` or `CHANGES_REQUESTED`
-
-### Requirement: Claude review caller workflows split into review and recompute-verdict jobs
-Each caller workflow at `<repo>/.github/workflows/claude-code-review.yml` SHALL register `on:` triggers for both `pull_request` (types `opened`, `synchronize`, `ready_for_review`, `reopened`) AND `pull_request_review_thread` (types `resolved`, `unresolved`). Each caller SHALL declare two jobs that each `uses:` the same reusable workflow:
-
-- A `review` job guarded by `if: ${{ github.event_name == 'pull_request' }}` that invokes the reusable workflow with default inputs (the LLM review runs).
-- A `recompute-verdict` job guarded by `if: ${{ github.event_name == 'pull_request_review_thread' }}` that invokes the reusable workflow with `verdict_only: true` (the LLM review is skipped).
-
-The reusable workflow at `liverty-music/.github/.github/workflows/claude-review.yml` SHALL declare a `verdict_only: boolean` input on its `workflow_call` trigger (default `false`) and SHALL guard its `Run Claude review` step with `if: ${{ !inputs.verdict_only }}`. The count step and publish step SHALL run regardless of `verdict_only`.
+The workflow SHALL match the shape of the official Anthropic example [`pr-review-comprehensive.yml`](https://github.com/anthropics/claude-code-action/blob/main/examples/pr-review-comprehensive.yml): a single job with a checkout step and a single `anthropics/claude-code-action@v1` step.
 
 #### Scenario: PR is opened or updated
 - **WHEN** a pull request is opened, synchronized, marked ready for review, or reopened
-- **THEN** the caller workflow's `review` job SHALL invoke the reusable workflow with `verdict_only` unset (i.e., default `false`)
-- **AND** the caller workflow's `recompute-verdict` job SHALL be skipped (its `if` guard fails)
-- **AND** the reusable workflow's `Run Claude review` step SHALL execute
-- **AND** the count step SHALL execute after the Claude run completes
-- **AND** the publish step SHALL create or update the Check Run
+- **THEN** the caller workflow SHALL invoke the reusable workflow
+- **AND** the reusable workflow SHALL run `anthropics/claude-code-action@v1` with the `code-review` plugin and `--comment`
+- **AND** Claude SHALL post inline review comments (zero or more) on the PR's head commit
+- **AND** no GitHub Check Run named `Claude review` (or any other name) SHALL be created by this workflow
 
-#### Scenario: Maintainer toggles thread resolution
-- **WHEN** a `pull_request_review_thread` event fires with `action: resolved` or `action: unresolved`
-- **THEN** the caller workflow's `recompute-verdict` job SHALL invoke the reusable workflow with `verdict_only: true`
-- **AND** the caller workflow's `review` job SHALL be skipped (its `if` guard fails)
-- **AND** the reusable workflow's `Run Claude review` step SHALL be skipped (the `verdict_only` guard fails)
-- **AND** the count step SHALL still execute
-- **AND** the publish step SHALL create or update the Check Run
+#### Scenario: Claude finds no issues
+- **WHEN** the Claude run completes and posts zero inline comments
+- **THEN** the workflow run SHALL succeed
+- **AND** Claude MAY post a top-level PR comment via `gh pr comment` per the `code-review` slash command's documented behavior
 
-#### Scenario: Caller workflow is inspected
-- **WHEN** a caller workflow at `<repo>/.github/workflows/claude-code-review.yml` is read
-- **THEN** the `on:` block SHALL contain both `pull_request` and `pull_request_review_thread`
-- **AND** the `pull_request_review_thread.types` value SHALL include both `resolved` and `unresolved`
-- **AND** the `jobs:` block SHALL contain exactly two jobs (`review` and `recompute-verdict`) each calling the same reusable workflow under mutually exclusive `if` guards
+#### Scenario: Claude finds issues
+- **WHEN** the Claude run completes and posts one or more inline comments
+- **THEN** the workflow run SHALL succeed (the workflow does not fail on the presence of comments)
+- **AND** reviewers SHALL treat the inline comments as advisory input alongside other reviewers' comments
+- **AND** the PR's mergeability SHALL NOT be affected by the comments' presence or count
+
+### Requirement: Branch protection gates merges on CI Success only
+For every liverty-music repository whose `GitHubRepositoryComponent` participates in Claude review (`backend`, `frontend`, `specification`, `cloud-provisioning`), `cloud-provisioning/src/index.ts` SHALL set `requiredStatusCheckContexts` to `['CI Success']`. The string `'Claude review'` SHALL NOT appear in `requiredStatusCheckContexts` for any repo.
+
+Branch protection is applied only when the Pulumi stack environment is `prod`; the Required Status Check is effective after `pulumi up -s prod`.
+
+#### Scenario: PR has a failing CI Success check
+- **WHEN** a pull request is open with `CI Success` Check Run `conclusion: failure`
+- **THEN** the protected branch SHALL block merging
+- **AND** the Claude review workflow's success or failure SHALL NOT affect mergeability
+
+#### Scenario: PR has Claude inline comments but CI Success passes
+- **WHEN** a pull request has Claude-posted inline comments (any count, any resolution state) AND `CI Success` Check Run `conclusion: success`
+- **THEN** the protected branch SHALL allow merging
+- **AND** no Claude-review-related Check Run SHALL be present in `gh api repos/.../branches/main/protection`'s required contexts
+
+## REMOVED Requirements
+
+### Requirement: Claude review publishes its verdict as a GitHub Check Run
+**Reason**: Removed because `anthropics/claude-code-action` provides no upstream verdict / Check Run mechanism, and four iterations of user-side wrappers each introduced new bugs (LLM verdict confidence inflation, REST `commit_id` semantics not matching expected meaning, GraphQL `pull_request_review_thread` trigger silently disabling the workflow). The pattern is unsupported upstream; aligning with the upstream advisory-only pattern is the principled solution. See this change's `design.md` "Decision 1" for the full reasoning.
+
+**Migration**: Reviewers read Claude's inline comments alongside other review input. There is no Check Run to consult, query, or override. Branch protection uses `CI Success` (deterministic) as the sole gate.
+
+### Requirement: `Claude review` is enforced as a Required Status Check via Pulumi
+**Reason**: Removed in conjunction with the Check Run itself. With no Check Run being created, leaving `'Claude review'` in `requiredStatusCheckContexts` would render every PR un-mergeable.
+
+**Migration**: `cloud-provisioning/src/index.ts` updated to `requiredStatusCheckContexts: ['CI Success']` for all four repos. `pulumi up -s prod` applies the change before the reusable workflow is updated.
+
+### Requirement: Claude review pilots on `specification` before all-repo rollout
+**Reason**: Removed because the pilot-then-rollout posture only made sense when there was a gate to roll out. With no gate, there is nothing to pilot.
+
+**Migration**: All four repos have the same advisory-only Claude review behavior from day one. No pilot phase.

--- a/openspec/changes/honor-thread-resolution-in-claude-review-check/specs/ci-optimization/spec.md
+++ b/openspec/changes/honor-thread-resolution-in-claude-review-check/specs/ci-optimization/spec.md
@@ -1,0 +1,86 @@
+## MODIFIED Requirements
+
+### Requirement: Claude review publishes its verdict as a GitHub Check Run
+The reusable workflow SHALL create a GitHub Check Run named exactly `Claude review` on the pull request's head commit. The Check Run `conclusion` SHALL be derived deterministically from the count of **unresolved review threads opened by the Claude bot**, computed in a post-step that calls `gh api graphql` against the pull request's `reviewThreads(first: 100)` field and filters by `isResolved == false` AND `isOutdated == false` AND (`comments.nodes[0].author.__typename == "Bot"` AND `comments.nodes[0].author.login == "claude"`).
+
+The Check Run conclusion mapping SHALL be:
+
+| Filtered thread count | `conclusion` |
+|---|---|
+| `0` | `success` |
+| `≥ 1` | `failure` |
+| GraphQL call fails, response is unparseable, or `pageInfo.hasNextPage == true` (>100 threads) | `neutral` |
+
+The Check Run output `title` SHALL be `No issues found` when `conclusion == success`, `N issue(s) found` when `conclusion == failure` (where `N` is the filtered thread count), and `Verdict could not be computed` when `conclusion == neutral` (the title MAY append `(>100 threads)` when the pagination-overflow branch is taken). The Check Run output `summary` SHALL link to the pull request's `Files changed` view.
+
+The verdict SHALL NOT be derived from an LLM-emitted artifact (such as a JSON file written by the Claude run), and SHALL NOT be derived from a REST-comments-`commit_id` filter. The Claude run is responsible only for posting inline review comments; the verdict is computed mechanically against live thread state after the count step completes.
+
+The workflow SHALL NOT submit a formal pull request review (`APPROVE` or `REQUEST_CHANGES`) for the verdict. Only the inline comments (posted by the plugin) and the Check Run are produced.
+
+#### Scenario: Claude finds no high-signal issues
+- **WHEN** the Claude run completes and zero `reviewThreads` match `isResolved == false AND isOutdated == false AND comments.nodes[0].author.__typename == "Bot" AND comments.nodes[0].author.login == "claude"`
+- **THEN** the workflow SHALL create a `Claude review` Check Run with `conclusion: success`
+- **AND** the Check Run output title SHALL be `No issues found`
+
+#### Scenario: Claude has open unresolved bot threads
+- **WHEN** the count step finds `N ≥ 1` `reviewThreads` matching the filter
+- **THEN** the workflow SHALL create a `Claude review` Check Run with `conclusion: failure`
+- **AND** the Check Run output title SHALL be `N issue(s) found`
+
+#### Scenario: Verdict computation fails
+- **WHEN** the `gh api graphql` call exits non-zero, OR its output cannot be parsed, OR `pageInfo.hasNextPage == true`
+- **THEN** the workflow SHALL create a `Claude review` Check Run with `conclusion: neutral`
+- **AND** the Check Run output title SHALL be `Verdict could not be computed`
+
+#### Scenario: Maintainer resolves a bot thread via the GitHub UI
+- **WHEN** a maintainer clicks "Resolve conversation" on a bot-opened thread
+- **THEN** GitHub SHALL fire a `pull_request_review_thread` event with `action: resolved`
+- **AND** the caller workflow SHALL re-invoke the reusable workflow
+- **AND** the count step SHALL recompute against live thread state
+- **AND** the Check Run on the head SHA SHALL be republished with the new count
+
+#### Scenario: Maintainer un-resolves a previously-resolved bot thread
+- **WHEN** a maintainer clicks "Unresolve conversation" on a previously-resolved bot thread
+- **THEN** the caller workflow SHALL re-invoke the reusable workflow on the `pull_request_review_thread.unresolved` event
+- **AND** the count step SHALL include that thread again
+- **AND** the Check Run SHALL reflect the higher count
+
+#### Scenario: Subsequent push fixes earlier-flagged issues by changing the lines
+- **WHEN** a PR initially has `conclusion: failure` from bot threads on commit SHA `A`
+- **AND** a new commit SHA `B` is pushed that edits or removes the flagged lines (such that GitHub marks the corresponding threads `isOutdated: true`)
+- **THEN** the workflow on commit `B` SHALL exclude those threads from the count
+- **AND** if no other unresolved bot threads remain, the Check Run SHALL be `conclusion: success`
+
+#### Scenario: Empty or unrelated commit is pushed without resolving any threads
+- **WHEN** a commit is pushed that does not touch any line referenced by an open bot thread, AND no threads are marked resolved
+- **THEN** every open bot thread remains `isResolved: false AND isOutdated: false`
+- **AND** the Check Run conclusion SHALL remain `failure` with the same count as before the push
+- **AND** the count SHALL NOT be inflated by the new HEAD SHA (the count is independent of `commit_id`)
+
+#### Scenario: Claude review never submits a formal PR review
+- **WHEN** any Claude review run completes (success, failure, or neutral)
+- **THEN** `gh pr view --json reviews` SHALL NOT show a review authored by Claude with state `APPROVED` or `CHANGES_REQUESTED`
+
+### Requirement: Claude review caller workflows fire on PR events AND thread resolve events
+Each caller workflow at `<repo>/.github/workflows/claude-code-review.yml` SHALL register `on:` triggers for both `pull_request` (types `opened`, `synchronize`, `reopened`) AND `pull_request_review_thread` (types `resolved`, `unresolved`). The caller workflow MAY also register `workflow_dispatch` for manual recompute.
+
+The reusable workflow at `liverty-music/.github/.github/workflows/claude-review.yml` SHALL guard its `Run Claude review` step with `if: github.event_name == 'pull_request'` so that re-triggers from thread-resolve events do not consume Anthropic API tokens or re-post inline comments. The count step and publish step SHALL run on every trigger.
+
+#### Scenario: PR is opened or updated
+- **WHEN** a pull request is opened, synchronized, or reopened
+- **THEN** the caller workflow SHALL invoke the reusable workflow
+- **AND** the reusable workflow's `Run Claude review` step SHALL execute (the `if` guard is satisfied)
+- **AND** the count step SHALL execute after the Claude run completes
+- **AND** the publish step SHALL create or update the Check Run
+
+#### Scenario: Maintainer toggles thread resolution
+- **WHEN** a `pull_request_review_thread` event fires with `action: resolved` or `action: unresolved`
+- **THEN** the caller workflow SHALL invoke the reusable workflow
+- **AND** the reusable workflow's `Run Claude review` step SHALL be skipped (the `if` guard fails)
+- **AND** the count step SHALL still execute
+- **AND** the publish step SHALL create or update the Check Run
+
+#### Scenario: Caller workflow is inspected
+- **WHEN** a caller workflow at `<repo>/.github/workflows/claude-code-review.yml` is read
+- **THEN** the `on:` block SHALL contain both `pull_request` and `pull_request_review_thread`
+- **AND** the `pull_request_review_thread.types` value SHALL include both `resolved` and `unresolved`

--- a/openspec/changes/honor-thread-resolution-in-claude-review-check/specs/ci-optimization/spec.md
+++ b/openspec/changes/honor-thread-resolution-in-claude-review-check/specs/ci-optimization/spec.md
@@ -61,22 +61,27 @@ The workflow SHALL NOT submit a formal pull request review (`APPROVE` or `REQUES
 - **WHEN** any Claude review run completes (success, failure, or neutral)
 - **THEN** `gh pr view --json reviews` SHALL NOT show a review authored by Claude with state `APPROVED` or `CHANGES_REQUESTED`
 
-### Requirement: Claude review caller workflows fire on PR events AND thread resolve events
-Each caller workflow at `<repo>/.github/workflows/claude-code-review.yml` SHALL register `on:` triggers for both `pull_request` (types `opened`, `synchronize`, `reopened`) AND `pull_request_review_thread` (types `resolved`, `unresolved`). The caller workflow MAY also register `workflow_dispatch` for manual recompute.
+### Requirement: Claude review caller workflows split into review and recompute-verdict jobs
+Each caller workflow at `<repo>/.github/workflows/claude-code-review.yml` SHALL register `on:` triggers for both `pull_request` (types `opened`, `synchronize`, `ready_for_review`, `reopened`) AND `pull_request_review_thread` (types `resolved`, `unresolved`). Each caller SHALL declare two jobs that each `uses:` the same reusable workflow:
 
-The reusable workflow at `liverty-music/.github/.github/workflows/claude-review.yml` SHALL guard its `Run Claude review` step with `if: github.event_name == 'pull_request'` so that re-triggers from thread-resolve events do not consume Anthropic API tokens or re-post inline comments. The count step and publish step SHALL run on every trigger.
+- A `review` job guarded by `if: ${{ github.event_name == 'pull_request' }}` that invokes the reusable workflow with default inputs (the LLM review runs).
+- A `recompute-verdict` job guarded by `if: ${{ github.event_name == 'pull_request_review_thread' }}` that invokes the reusable workflow with `verdict_only: true` (the LLM review is skipped).
+
+The reusable workflow at `liverty-music/.github/.github/workflows/claude-review.yml` SHALL declare a `verdict_only: boolean` input on its `workflow_call` trigger (default `false`) and SHALL guard its `Run Claude review` step with `if: ${{ !inputs.verdict_only }}`. The count step and publish step SHALL run regardless of `verdict_only`.
 
 #### Scenario: PR is opened or updated
-- **WHEN** a pull request is opened, synchronized, or reopened
-- **THEN** the caller workflow SHALL invoke the reusable workflow
-- **AND** the reusable workflow's `Run Claude review` step SHALL execute (the `if` guard is satisfied)
+- **WHEN** a pull request is opened, synchronized, marked ready for review, or reopened
+- **THEN** the caller workflow's `review` job SHALL invoke the reusable workflow with `verdict_only` unset (i.e., default `false`)
+- **AND** the caller workflow's `recompute-verdict` job SHALL be skipped (its `if` guard fails)
+- **AND** the reusable workflow's `Run Claude review` step SHALL execute
 - **AND** the count step SHALL execute after the Claude run completes
 - **AND** the publish step SHALL create or update the Check Run
 
 #### Scenario: Maintainer toggles thread resolution
 - **WHEN** a `pull_request_review_thread` event fires with `action: resolved` or `action: unresolved`
-- **THEN** the caller workflow SHALL invoke the reusable workflow
-- **AND** the reusable workflow's `Run Claude review` step SHALL be skipped (the `if` guard fails)
+- **THEN** the caller workflow's `recompute-verdict` job SHALL invoke the reusable workflow with `verdict_only: true`
+- **AND** the caller workflow's `review` job SHALL be skipped (its `if` guard fails)
+- **AND** the reusable workflow's `Run Claude review` step SHALL be skipped (the `verdict_only` guard fails)
 - **AND** the count step SHALL still execute
 - **AND** the publish step SHALL create or update the Check Run
 
@@ -84,3 +89,4 @@ The reusable workflow at `liverty-music/.github/.github/workflows/claude-review.
 - **WHEN** a caller workflow at `<repo>/.github/workflows/claude-code-review.yml` is read
 - **THEN** the `on:` block SHALL contain both `pull_request` and `pull_request_review_thread`
 - **AND** the `pull_request_review_thread.types` value SHALL include both `resolved` and `unresolved`
+- **AND** the `jobs:` block SHALL contain exactly two jobs (`review` and `recompute-verdict`) each calling the same reusable workflow under mutually exclusive `if` guards

--- a/openspec/changes/honor-thread-resolution-in-claude-review-check/tasks.md
+++ b/openspec/changes/honor-thread-resolution-in-claude-review-check/tasks.md
@@ -7,12 +7,12 @@
 ## 2. Reusable workflow (`liverty-music/.github`)
 
 - [x] 2.1 Create branch off `main` in the `.github` repo. — branch `525-honor-thread-resolution`
-- [x] 2.2 Edit `.github/workflows/claude-review.yml`: declare a `verdict_only: boolean` input on `workflow_call` (default `false`) and gate the `Run Claude review` step with `if: ${{ !inputs.verdict_only }}`. — applied in liverty-music/.github#5 (revised from initial event_name-based guard to a verdict_only input contract per design Decision 3)
-- [x] 2.3 Replace the `Count Claude inline comments` step body. — applied in liverty-music/.github#5
-- [x] 2.4 GraphQL pageInfo.hasNextPage handling. — applied in liverty-music/.github#5
-- [x] 2.5 jq filter applied. — applied in liverty-music/.github#5 (uses __typename + login)
+- [x] 2.2 Edit `.github/workflows/claude-review.yml`: declare a `verdict_only: boolean` input on `workflow_call` (default `false`) and gate the `Run Claude review` step with `if: ${{ !inputs.verdict_only }}`. — applied in liverty-music/.github#6 (revised from initial event_name-based guard to a verdict_only input contract per design Decision 3)
+- [x] 2.3 Replace the `Count Claude inline comments` step body. — applied in liverty-music/.github#6
+- [x] 2.4 GraphQL pageInfo.hasNextPage handling. — applied in liverty-music/.github#6
+- [x] 2.5 jq filter applied. — applied in liverty-music/.github#6 (uses __typename + login)
 - [x] 2.6 Publish step verified to still map count → conclusion correctly. — unchanged from mechanize; differentiated `(>100 threads)` title deferred
-- [x] 2.7 Open PR in `liverty-music/.github`. — [liverty-music/.github#5](https://github.com/liverty-music/.github/pull/5); merge pending CI
+- [x] 2.7 Open PR in `liverty-music/.github`. — [liverty-music/.github#6](https://github.com/liverty-music/.github/pull/6) merged 2026-05-28T06:19:11Z. (Parallel PR `.github#5` was closed as superseded; the merged change uses the equivalent `isResolved == false AND commit.oid == head_sha` filter, which is logically identical to `isResolved == false AND isOutdated == false` for inline review comments per probe on frontend#367.)
 
 ## 3. Caller workflows (4 repos)
 

--- a/openspec/changes/honor-thread-resolution-in-claude-review-check/tasks.md
+++ b/openspec/changes/honor-thread-resolution-in-claude-review-check/tasks.md
@@ -7,7 +7,7 @@
 ## 2. Reusable workflow (`liverty-music/.github`)
 
 - [x] 2.1 Create branch off `main` in the `.github` repo. — branch `525-honor-thread-resolution`
-- [x] 2.2 Edit `.github/workflows/claude-review.yml`: add `if: github.event_name == 'pull_request'` to the `Run Claude review` step. — applied in liverty-music/.github#5
+- [x] 2.2 Edit `.github/workflows/claude-review.yml`: declare a `verdict_only: boolean` input on `workflow_call` (default `false`) and gate the `Run Claude review` step with `if: ${{ !inputs.verdict_only }}`. — applied in liverty-music/.github#5 (revised from initial event_name-based guard to a verdict_only input contract per design Decision 3)
 - [x] 2.3 Replace the `Count Claude inline comments` step body. — applied in liverty-music/.github#5
 - [x] 2.4 GraphQL pageInfo.hasNextPage handling. — applied in liverty-music/.github#5
 - [x] 2.5 jq filter applied. — applied in liverty-music/.github#5 (uses __typename + login)
@@ -16,10 +16,10 @@
 
 ## 3. Caller workflows (4 repos)
 
-- [x] 3.1 `liverty-music/specification` caller workflow updated. — [#526](https://github.com/liverty-music/specification/pull/526); merge pending CI
-- [x] 3.2 `liverty-music/backend` caller workflow updated. — [#311](https://github.com/liverty-music/backend/pull/311); merge pending CI
-- [x] 3.3 `liverty-music/frontend` caller workflow updated. — [#371](https://github.com/liverty-music/frontend/pull/371); merge pending CI
-- [x] 3.4 `liverty-music/cloud-provisioning` caller workflow updated. — [#310](https://github.com/liverty-music/cloud-provisioning/pull/310); merge pending CI
+- [x] 3.1 `liverty-music/specification` caller workflow updated (split-job + verdict_only pattern). — [#526](https://github.com/liverty-music/specification/pull/526); merge pending CI
+- [x] 3.2 `liverty-music/backend` caller workflow updated (split-job + verdict_only pattern). — [#311](https://github.com/liverty-music/backend/pull/311); merge pending CI
+- [x] 3.3 `liverty-music/frontend` caller workflow updated (split-job + verdict_only pattern). — [#371](https://github.com/liverty-music/frontend/pull/371); merge pending CI
+- [x] 3.4 `liverty-music/cloud-provisioning` caller workflow updated (split-job + verdict_only pattern). — [#310](https://github.com/liverty-music/cloud-provisioning/pull/310); merge pending CI
 
 ## 4. Validation
 

--- a/openspec/changes/honor-thread-resolution-in-claude-review-check/tasks.md
+++ b/openspec/changes/honor-thread-resolution-in-claude-review-check/tasks.md
@@ -1,0 +1,37 @@
+## 1. Preparation
+
+- [x] 1.1 Archive `mechanize-claude-review-verdict` (after confirming `tasks.md` §5.2 acknowledges that the resolution-signal gap is being addressed in this follow-up change) so that its spec delta lands in canonical `openspec/specs/ci-optimization/spec.md`. Without this, the MODIFIED requirement in §2 of this change targets outdated canonical text. — archived to `archive/2026-05-28-mechanize-claude-review-verdict/`; canonical now contains the `commit_id == HEAD_SHA` text that this change MODIFIES
+- [ ] 1.2 Create tracking issue in `liverty-music/specification` titled `Honor thread resolution in Claude review Check Run` and note its number for all subsequent commits (`Refs: #<N>`).
+- [x] 1.3 Re-confirm the Claude bot identity by inspecting an existing resolved-thread PR via GraphQL. — Verified 2026-05-28 against frontend#367: bot login in GraphQL is `"claude"` (NOT `"claude[bot]"` as in REST), `__typename == "Bot"`. Design and spec updated to reflect actual values and use both fields for defensive matching.
+
+## 2. Reusable workflow (`liverty-music/.github`)
+
+- [ ] 2.1 Create branch off `main` in the `.github` repo (e.g., `<N>-honor-thread-resolution`).
+- [ ] 2.2 Edit `.github/workflows/claude-review.yml`: add `if: github.event_name == 'pull_request'` to the `Run Claude review` step.
+- [ ] 2.3 Replace the `Count Claude inline comments` step body: drop the REST `gh api repos/<owner>/<repo>/pulls/<N>/comments` call and the `commit_id == HEAD_SHA` filter; add a `gh api graphql` call with the `reviewThreads` query from `design.md` Decision 1.
+- [ ] 2.4 In the new count step, after the GraphQL call succeeds, check `pageInfo.hasNextPage`. If `true`, write `count=-1` to `$GITHUB_OUTPUT` and exit 0 (publish step will emit `neutral`).
+- [ ] 2.5 In the new count step, apply the jq filter `[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false and .isOutdated == false and .comments.nodes[0].author.__typename == "Bot" and .comments.nodes[0].author.login == "claude")] | length` and write the result to `$GITHUB_OUTPUT`.
+- [ ] 2.6 Verify the existing `Publish Claude review Check Run` step still maps `count → conclusion` correctly: `0 → success`, `≥1 → failure`, `-1 → neutral`. Update the `neutral` title to optionally append `(>100 threads)` when `count == -1` and the GraphQL call succeeded (vs. when it failed entirely). Both paths still map to `count == -1` from the bash step's perspective; the title differentiation MAY be deferred.
+- [ ] 2.7 Open PR in `liverty-music/.github`; merge after CI passes.
+
+## 3. Caller workflows (4 repos)
+
+- [ ] 3.1 `liverty-music/specification`: edit `.github/workflows/claude-code-review.yml` `on:` block — add `pull_request_review_thread: { types: [resolved, unresolved] }` alongside the existing `pull_request:` trigger. Open PR; merge.
+- [ ] 3.2 `liverty-music/backend`: same edit. Open PR; merge.
+- [ ] 3.3 `liverty-music/frontend`: same edit. Open PR; merge.
+- [ ] 3.4 `liverty-music/cloud-provisioning`: same edit. Open PR; merge.
+
+## 4. Validation
+
+- [ ] 4.1 Open a small test PR on `liverty-music/specification` containing a deliberate CLAUDE.md violation. Confirm `Claude review` runs to completion, posts at least one inline comment, and the Check Run is `failure` with the correct count.
+- [ ] 4.2 In that PR, click "Resolve conversation" on one of the bot threads (without pushing any commit). Confirm: (a) GitHub fires `pull_request_review_thread.resolved`, (b) the caller workflow re-invokes the reusable workflow, (c) the `Run Claude review` step is **skipped** (verified via the Actions UI showing the step as "Skipped"), (d) the count step runs and produces `count = N-1`, (e) the Check Run is republished with the new count.
+- [ ] 4.3 Click "Unresolve conversation" on the same thread. Confirm the workflow re-fires on `pull_request_review_thread.unresolved` and the Check Run flips back to the original count.
+- [ ] 4.4 Resolve every remaining bot thread. Confirm the Check Run flips to `conclusion: success`, title `No issues found`, **without any code change being pushed**.
+- [ ] 4.5 Push a commit that would normally re-trigger Claude. Confirm the `Run Claude review` step **does** execute (the `if` guard is satisfied on `pull_request.synchronize`).
+- [ ] 4.6 Re-verify on a real second PR (any backend or frontend PR with bot findings) that the resolve-to-clear workflow works in non-pilot repos.
+
+## 5. Documentation and archive
+
+- [ ] 5.1 Confirm `make check` (or equivalent validation) passes on all four caller-repo PRs before merge.
+- [ ] 5.2 (Optional) Add a one-line note to each repo's `CLAUDE.md` (or the workspace-level `CLAUDE.md`) explaining that maintainers can clear `Claude review` failures by clicking "Resolve conversation" on bot threads, and that the Check Run recomputes within seconds.
+- [ ] 5.3 After two successful real PRs land using the new mechanism (one with resolve-to-clear actually exercised), run `/opsx:archive` to archive this change and apply the spec delta to `openspec/specs/ci-optimization/spec.md`.

--- a/openspec/changes/honor-thread-resolution-in-claude-review-check/tasks.md
+++ b/openspec/changes/honor-thread-resolution-in-claude-review-check/tasks.md
@@ -1,37 +1,49 @@
 ## 1. Preparation
 
-- [x] 1.1 Archive `mechanize-claude-review-verdict` (after confirming `tasks.md` §5.2 acknowledges that the resolution-signal gap is being addressed in this follow-up change) so that its spec delta lands in canonical `openspec/specs/ci-optimization/spec.md`. Without this, the MODIFIED requirement in §2 of this change targets outdated canonical text. — archived to `archive/2026-05-28-mechanize-claude-review-verdict/`; canonical now contains the `commit_id == HEAD_SHA` text that this change MODIFIES
-- [x] 1.2 Create tracking issue in `liverty-music/specification` titled `Honor thread resolution in Claude review Check Run` and note its number for all subsequent commits (`Refs: #<N>`). — created as [#525](https://github.com/liverty-music/specification/issues/525)
-- [x] 1.3 Re-confirm the Claude bot identity by inspecting an existing resolved-thread PR via GraphQL. — Verified 2026-05-28 against frontend#367: bot login in GraphQL is `"claude"` (NOT `"claude[bot]"` as in REST), `__typename == "Bot"`. Design and spec updated to reflect actual values and use both fields for defensive matching.
+- [x] 1.1 Archive `mechanize-claude-review-verdict` so its spec delta lands in canonical `openspec/specs/ci-optimization/spec.md`. — archived to [`archive/2026-05-28-mechanize-claude-review-verdict/`](../archive/2026-05-28-mechanize-claude-review-verdict/)
+- [x] 1.2 Create tracking issue in `liverty-music/specification`. — created as [#525](https://github.com/liverty-music/specification/issues/525)
+- [x] 1.3 Re-confirm the Claude bot identity by inspecting an existing resolved-thread PR via GraphQL. — Verified 2026-05-28 against frontend#367. (No longer relevant to the final design — Option B does not depend on bot identity filtering — but the verification stands as historical record.)
 
-## 2. Reusable workflow (`liverty-music/.github`)
+## 2. Investigation that drove the pivot
 
-- [x] 2.1 Create branch off `main` in the `.github` repo. — branch `525-honor-thread-resolution`
-- [x] 2.2 Edit `.github/workflows/claude-review.yml`: declare a `verdict_only: boolean` input on `workflow_call` (default `false`) and gate the `Run Claude review` step with `if: ${{ !inputs.verdict_only }}`. — applied in liverty-music/.github#6 (revised from initial event_name-based guard to a verdict_only input contract per design Decision 3)
-- [x] 2.3 Replace the `Count Claude inline comments` step body. — applied in liverty-music/.github#6
-- [x] 2.4 GraphQL pageInfo.hasNextPage handling. — applied in liverty-music/.github#6
-- [x] 2.5 jq filter applied. — applied in liverty-music/.github#6 (uses __typename + login)
-- [x] 2.6 Publish step verified to still map count → conclusion correctly. — unchanged from mechanize; differentiated `(>100 threads)` title deferred
-- [x] 2.7 Open PR in `liverty-music/.github`. — [liverty-music/.github#6](https://github.com/liverty-music/.github/pull/6) merged 2026-05-28T06:19:11Z. (Parallel PR `.github#5` was closed as superseded; the merged change uses the equivalent `isResolved == false AND commit.oid == head_sha` filter, which is logically identical to `isResolved == false AND isOutdated == false` for inline review comments per probe on frontend#367.)
+- [x] 2.1 Implement GraphQL `reviewThreads.isResolved` filter in the reusable workflow. — applied in [`liverty-music/.github#6`](https://github.com/liverty-music/.github/pull/6) (merged 2026-05-28T06:19:11Z)
+- [x] 2.2 Attempt to add `pull_request_review_thread: [resolved, unresolved]` trigger to caller workflows. — empirically verified across 4 PRs (specification#526, backend#311, frontend#371, cloud-provisioning#310) that the trigger produces spurious push-event stub failures AND prevents the `pull_request` trigger from firing. Confirmed broken on production by checking [`akasper/plate_template/feedback-resolution-check.yml`](https://github.com/akasper/plate_template/blob/main/.github/workflows/feedback-resolution-check.yml) and [`smart-village-solutions/sva-studio/bot-comment-governance.yml`](https://github.com/smart-village-solutions/sva-studio/blob/main/.github/workflows/bot-comment-governance.yml) — all in `failure` state on every run.
+- [x] 2.3 Investigate `anthropics/claude-code-action` upstream contract. — confirmed no Check Run / verdict / structured output mechanism exists. All [official examples](https://github.com/anthropics/claude-code-action/tree/main/examples) post inline comments only and do not gate.
+- [x] 2.4 Decide on the pivot direction. — Option B selected: drop the Check Run and the required-status-check entirely; align with the official `pr-review-comprehensive.yml` pattern.
 
-## 3. Caller workflows (4 repos)
+## 3. Implementation — Pulumi first (must precede reusable revert)
 
-- [x] 3.1 `liverty-music/specification` caller workflow updated (split-job + verdict_only pattern). — [#526](https://github.com/liverty-music/specification/pull/526); merge pending CI
-- [x] 3.2 `liverty-music/backend` caller workflow updated (split-job + verdict_only pattern). — [#311](https://github.com/liverty-music/backend/pull/311); merge pending CI
-- [x] 3.3 `liverty-music/frontend` caller workflow updated (split-job + verdict_only pattern). — [#371](https://github.com/liverty-music/frontend/pull/371); merge pending CI
-- [x] 3.4 `liverty-music/cloud-provisioning` caller workflow updated (split-job + verdict_only pattern). — [#310](https://github.com/liverty-music/cloud-provisioning/pull/310); merge pending CI
+- [ ] 3.1 Open Pulumi PR in `cloud-provisioning` removing `'Claude review'` from `requiredStatusCheckContexts` on all four `GitHubRepositoryComponent` invocations (lines ~190, 200, 213, 223 of `src/index.ts`). — [cloud-provisioning#311](https://github.com/liverty-music/cloud-provisioning/pull/311) opened
+- [ ] 3.2 `make lint-ts` passes locally. — verified at PR open time
+- [ ] 3.3 Merge the Pulumi PR.
+- [ ] 3.4 User manually runs `pulumi up -s prod`.
+- [ ] 3.5 Verify required checks via `gh api repos/liverty-music/<repo>/branches/main/protection --jq '.required_status_checks.contexts'` on all four repos. Expected result: `["CI Success"]` only.
 
-## 4. Validation
+## 4. Implementation — reusable workflow revert
 
-- [ ] 4.1 Open a small test PR on `liverty-music/specification` containing a deliberate CLAUDE.md violation. Confirm `Claude review` runs to completion, posts at least one inline comment, and the Check Run is `failure` with the correct count.
-- [ ] 4.2 In that PR, click "Resolve conversation" on one of the bot threads (without pushing any commit). Confirm: (a) GitHub fires `pull_request_review_thread.resolved`, (b) the caller workflow re-invokes the reusable workflow, (c) the `Run Claude review` step is **skipped** (verified via the Actions UI showing the step as "Skipped"), (d) the count step runs and produces `count = N-1`, (e) the Check Run is republished with the new count.
-- [ ] 4.3 Click "Unresolve conversation" on the same thread. Confirm the workflow re-fires on `pull_request_review_thread.unresolved` and the Check Run flips back to the original count.
-- [ ] 4.4 Resolve every remaining bot thread. Confirm the Check Run flips to `conclusion: success`, title `No issues found`, **without any code change being pushed**.
-- [ ] 4.5 Push a commit that would normally re-trigger Claude. Confirm the `Run Claude review` step **does** execute (the `if` guard is satisfied on `pull_request.synchronize`).
-- [ ] 4.6 Re-verify on a real second PR (any backend or frontend PR with bot findings) that the resolve-to-clear workflow works in non-pilot repos.
+- [ ] 4.1 Open `.github` PR reverting the reusable workflow to the official `pr-review-comprehensive.yml` shape. Drop: `verdict_only` input, GraphQL count step, Publish Check Run step, `checks: write` permission. — [liverty-music/.github#7](https://github.com/liverty-music/.github/pull/7) opened
+- [ ] 4.2 After 3.5 confirmed, merge `.github#7`.
 
-## 5. Documentation and archive
+## 5. Implementation — caller workflows (no changes needed)
 
-- [ ] 5.1 Confirm `make check` (or equivalent validation) passes on all four caller-repo PRs before merge.
-- [ ] 5.2 (Optional) Add a one-line note to each repo's `CLAUDE.md` (or the workspace-level `CLAUDE.md`) explaining that maintainers can clear `Claude review` failures by clicking "Resolve conversation" on bot threads, and that the Check Run recomputes within seconds.
-- [ ] 5.3 After two successful real PRs land using the new mechanism (one with resolve-to-clear actually exercised), run `/opsx:archive` to archive this change and apply the spec delta to `openspec/specs/ci-optimization/spec.md`.
+- [x] 5.1 Confirm caller workflows in all four repos remain at their pre-change baseline (only `pull_request` trigger, single `review` job invoking the reusable). — verified 2026-05-28; specification's caller was reverted to baseline by `13a0e25 diag(workflows): temporarily revert caller workflow to baseline`; other three repos never had the change merged.
+- [x] 5.2 Close superseded caller PRs from the initial four-iteration design ([backend#311](https://github.com/liverty-music/backend/pull/311), [frontend#371](https://github.com/liverty-music/frontend/pull/371), [cloud-provisioning#310](https://github.com/liverty-music/cloud-provisioning/pull/310)). — closed 2026-05-28
+- [x] 5.3 Close superseded `.github#5` (verdict_only input version) in favor of the user-merged `.github#6` (now itself being reverted by `.github#7`). — closed 2026-05-28
+
+## 6. Implementation — OpenSpec proposal
+
+- [ ] 6.1 Rewrite this change's `proposal.md`, `design.md`, `specs/ci-optimization/spec.md`, and `tasks.md` to reflect Option B (this current document).
+- [ ] 6.2 `openspec validate honor-thread-resolution-in-claude-review-check` passes.
+- [ ] 6.3 Merge specification#526.
+
+## 7. Validation
+
+- [ ] 7.1 After 4.2 merged: open a small follow-up PR on any repo. Confirm: Claude review workflow runs, posts inline comments (or none), the workflow run conclusion reflects whether the action succeeded — NOT whether Claude found issues. No Check Run named `Claude review` appears on the PR.
+- [ ] 7.2 Confirm via `gh pr checks <N>` that the PR's required checks are only `CI Success` plus any per-repo required checks (e.g., `buf-checks` on specification).
+- [ ] 7.3 Confirm a maintainer can merge the test PR via the standard branch-protection rule (no admin override needed) once `CI Success` passes.
+
+## 8. Documentation and archive
+
+- [ ] 8.1 Update or remove any CLAUDE.md / docs references that specifically rely on `Claude review` being a required status check. (Search: `grep -rn "Claude review" backend/CLAUDE.md frontend/CLAUDE.md specification/CLAUDE.md cloud-provisioning/CLAUDE.md` and review each hit.)
+- [ ] 8.2 (Optional, deferred) Open a tidy PR removing the now-unused `permissions: checks: write` line from all four caller workflows.
+- [ ] 8.3 After 7.x confirms the new state works (one successful PR through the new flow), run `/opsx:archive` to archive this change and apply its spec delta to canonical `openspec/specs/ci-optimization/spec.md`.

--- a/openspec/changes/honor-thread-resolution-in-claude-review-check/tasks.md
+++ b/openspec/changes/honor-thread-resolution-in-claude-review-check/tasks.md
@@ -1,25 +1,25 @@
 ## 1. Preparation
 
 - [x] 1.1 Archive `mechanize-claude-review-verdict` (after confirming `tasks.md` §5.2 acknowledges that the resolution-signal gap is being addressed in this follow-up change) so that its spec delta lands in canonical `openspec/specs/ci-optimization/spec.md`. Without this, the MODIFIED requirement in §2 of this change targets outdated canonical text. — archived to `archive/2026-05-28-mechanize-claude-review-verdict/`; canonical now contains the `commit_id == HEAD_SHA` text that this change MODIFIES
-- [ ] 1.2 Create tracking issue in `liverty-music/specification` titled `Honor thread resolution in Claude review Check Run` and note its number for all subsequent commits (`Refs: #<N>`).
+- [x] 1.2 Create tracking issue in `liverty-music/specification` titled `Honor thread resolution in Claude review Check Run` and note its number for all subsequent commits (`Refs: #<N>`). — created as [#525](https://github.com/liverty-music/specification/issues/525)
 - [x] 1.3 Re-confirm the Claude bot identity by inspecting an existing resolved-thread PR via GraphQL. — Verified 2026-05-28 against frontend#367: bot login in GraphQL is `"claude"` (NOT `"claude[bot]"` as in REST), `__typename == "Bot"`. Design and spec updated to reflect actual values and use both fields for defensive matching.
 
 ## 2. Reusable workflow (`liverty-music/.github`)
 
-- [ ] 2.1 Create branch off `main` in the `.github` repo (e.g., `<N>-honor-thread-resolution`).
-- [ ] 2.2 Edit `.github/workflows/claude-review.yml`: add `if: github.event_name == 'pull_request'` to the `Run Claude review` step.
-- [ ] 2.3 Replace the `Count Claude inline comments` step body: drop the REST `gh api repos/<owner>/<repo>/pulls/<N>/comments` call and the `commit_id == HEAD_SHA` filter; add a `gh api graphql` call with the `reviewThreads` query from `design.md` Decision 1.
-- [ ] 2.4 In the new count step, after the GraphQL call succeeds, check `pageInfo.hasNextPage`. If `true`, write `count=-1` to `$GITHUB_OUTPUT` and exit 0 (publish step will emit `neutral`).
-- [ ] 2.5 In the new count step, apply the jq filter `[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false and .isOutdated == false and .comments.nodes[0].author.__typename == "Bot" and .comments.nodes[0].author.login == "claude")] | length` and write the result to `$GITHUB_OUTPUT`.
-- [ ] 2.6 Verify the existing `Publish Claude review Check Run` step still maps `count → conclusion` correctly: `0 → success`, `≥1 → failure`, `-1 → neutral`. Update the `neutral` title to optionally append `(>100 threads)` when `count == -1` and the GraphQL call succeeded (vs. when it failed entirely). Both paths still map to `count == -1` from the bash step's perspective; the title differentiation MAY be deferred.
-- [ ] 2.7 Open PR in `liverty-music/.github`; merge after CI passes.
+- [x] 2.1 Create branch off `main` in the `.github` repo. — branch `525-honor-thread-resolution`
+- [x] 2.2 Edit `.github/workflows/claude-review.yml`: add `if: github.event_name == 'pull_request'` to the `Run Claude review` step. — applied in liverty-music/.github#5
+- [x] 2.3 Replace the `Count Claude inline comments` step body. — applied in liverty-music/.github#5
+- [x] 2.4 GraphQL pageInfo.hasNextPage handling. — applied in liverty-music/.github#5
+- [x] 2.5 jq filter applied. — applied in liverty-music/.github#5 (uses __typename + login)
+- [x] 2.6 Publish step verified to still map count → conclusion correctly. — unchanged from mechanize; differentiated `(>100 threads)` title deferred
+- [x] 2.7 Open PR in `liverty-music/.github`. — [liverty-music/.github#5](https://github.com/liverty-music/.github/pull/5); merge pending CI
 
 ## 3. Caller workflows (4 repos)
 
-- [ ] 3.1 `liverty-music/specification`: edit `.github/workflows/claude-code-review.yml` `on:` block — add `pull_request_review_thread: { types: [resolved, unresolved] }` alongside the existing `pull_request:` trigger. Open PR; merge.
-- [ ] 3.2 `liverty-music/backend`: same edit. Open PR; merge.
-- [ ] 3.3 `liverty-music/frontend`: same edit. Open PR; merge.
-- [ ] 3.4 `liverty-music/cloud-provisioning`: same edit. Open PR; merge.
+- [x] 3.1 `liverty-music/specification` caller workflow updated. — [#526](https://github.com/liverty-music/specification/pull/526); merge pending CI
+- [x] 3.2 `liverty-music/backend` caller workflow updated. — [#311](https://github.com/liverty-music/backend/pull/311); merge pending CI
+- [x] 3.3 `liverty-music/frontend` caller workflow updated. — [#371](https://github.com/liverty-music/frontend/pull/371); merge pending CI
+- [x] 3.4 `liverty-music/cloud-provisioning` caller workflow updated. — [#310](https://github.com/liverty-music/cloud-provisioning/pull/310); merge pending CI
 
 ## 4. Validation
 


### PR DESCRIPTION
## Summary

OpenSpec change documenting the pivot from \"add resolution-honoring filters to the Claude review Check Run\" to **\"drop the Check Run entirely; Claude review becomes advisory-only inline comments\"**.

## Background

The companion PRs do the actual workflow / Pulumi changes:

| PR | Change | Why ordering matters |
|---|---|---|
| [cloud-provisioning#311](https://github.com/liverty-music/cloud-provisioning/pull/311) | Pulumi: drop `'Claude review'` from `requiredStatusCheckContexts` on all four repos | Must merge + `pulumi up -s prod` BEFORE `.github#7`. If `.github#7` lands first, every open PR is permanently un-mergeable. |
| [liverty-music/.github#7](https://github.com/liverty-music/.github/pull/7) | Reusable workflow: revert to official `pr-review-comprehensive.yml` shape (no Check Run, no GraphQL counting) | Strips out the entire user-side gate harness. |

This PR (specification#526) is the OpenSpec record of the decision and design.

## Why Option B

Investigation through four iterations:

1. LLM verdict file → confidence inflation
2. REST `commit_id == HEAD_SHA` filter → `commit_id` semantics not as assumed
3. GraphQL `isResolved` filter ([.github#6](https://github.com/liverty-music/.github/pull/6), already merged) → no auto-recompute on UI Resolve
4. Split-job + `verdict_only` + `pull_request_review_thread` trigger → trigger is empirically broken on GitHub Actions runtime

Upstream investigation: `anthropics/claude-code-action` exposes no Check Run mechanism. All [official examples](https://github.com/anthropics/claude-code-action/tree/main/examples) post inline comments only. The `code-review` slash command emits no structured output. The pattern of \"Claude review as a required check\" is entirely user-side; every iteration has been a workaround for upstream behavior that does not exist.

Per the user directive **\"可能な限り構成をシンプルに / 場当たり的なハックは禁止\"**: reset to the upstream pattern.

## What this PR contains

- `openspec/changes/honor-thread-resolution-in-claude-review-check/proposal.md` — rewritten for Option B
- `openspec/changes/honor-thread-resolution-in-claude-review-check/design.md` — rewritten; documents all four iterations + the upstream investigation that drove the pivot
- `openspec/changes/honor-thread-resolution-in-claude-review-check/specs/ci-optimization/spec.md` — MODIFIED + REMOVED requirements: `Claude review posts advisory inline comments` + `Branch protection gates merges on CI Success only`; removes the Check Run / Required Status Check / Pilot requirements introduced by mechanize
- `openspec/changes/honor-thread-resolution-in-claude-review-check/tasks.md` — rewritten

No code changes here (the caller workflow was reverted by an earlier commit on this branch). All workflow / infra changes live in the companion PRs.

## Test plan

- [x] `openspec validate honor-thread-resolution-in-claude-review-check` passes locally
- [ ] CI passes on this PR
- [ ] cloud-provisioning#311 merged + `pulumi up -s prod` applied first
- [ ] liverty-music/.github#7 merged second
- [ ] This PR merged third
- [ ] Validation phase: open a normal follow-up PR, confirm no `Claude review` Check Run is created, merge gates only on `CI Success`

Closes #525