### PR TITLE
docs(openspec): propose prod-cost-optimization change

### DIFF
--- a/openspec/changes/prod-cost-optimization/.openspec.yaml
+++ b/openspec/changes/prod-cost-optimization/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-28

--- a/openspec/changes/prod-cost-optimization/design.md
+++ b/openspec/changes/prod-cost-optimization/design.md
@@ -23,7 +23,7 @@ prod 環境を 5/13 に立ち上げ、5/18 に dev cluster を削除して安定
 
 **Goals:**
 - otel-collector の filter で Cloud Monitoring metric ingest を 45 MiB/月 → ~0.3 MiB/月 に削減 (現課金 ¥1,800/月の解消 + 将来 prod scale-up 時の free tier 突破防御)。
-- Argo CD prod overlay の pod 数を 8 → 4 程度に削減 (Autopilot per-Pod 最小課金分の削減)。
+- Argo CD prod overlay の pod 数を 8 → 5 に削減(image-updater-controller と applicationset-controller を `replicas: 0`、argocd-server を 2 → 1。notifications-controller は active subscription のため維持)。
 - Cloud SQL prod を ZONAL 化して HA レプリカ分を解放 (¥1,000/月削減)。
 - BQ billing export 基盤を Pulumi 管理化し、コスト調査を SQL で完結できる状態にする。
 - 上記 4 つの作業を、安全な順序 (otel → Argo CD → BQ → Cloud SQL) で段階的に適用できる単一 change としてまとめる。
@@ -151,7 +151,7 @@ new gcp.bigquery.Dataset('billing-export', {
 new gcp.bigquery.DatasetIamMember('billing-export-svc', {
   datasetId: 'billing_export',
   role: 'roles/bigquery.dataEditor',
-  member: 'serviceAccount:billing-export-bigquery@system.gserviceaccount.com',
+  member: 'serviceAccount:cloud-billing-export@system.gserviceaccount.com',
   // ↑ 正確なサービスアカウント名は GCP docs で確認、または billing-account の serviceConfig から取得
 })
 ```
@@ -189,7 +189,7 @@ new gcp.bigquery.DatasetIamMember('billing-export-svc', {
   → **Mitigation:** Cloudflare の前段で 503 を返す or maintenance ページに切り替え。Pulumi の preview で変更内容を確認後、低トラフィック時間帯 (深夜 JST) に実施。トラフィック規模が小さい launch 直後である今が実施好機。
 
 - **Risk:** BQ Billing Export の IAM 権限不足で provision 後も export が始まらない
-  → **Mitigation:** runbook の検証ステップ (24h 後の `bq ls` 確認) を必須化。失敗時は GCP docs に従って `billing-export-bigquery@system.gserviceaccount.com` 以外の正しい SA を IAM に追加。
+  → **Mitigation:** runbook の検証ステップ (24h 後の `bq ls` 確認) を必須化。失敗時は GCP docs / Cloud Logging audit trail で実際の writer SA を特定し、`cloud-billing-export@system.gserviceaccount.com` 以外の SA であれば IAM binding を差し替える。
 
 - **Trade-off:** ZONAL 化で zonal failover の自動冗長性を失う
   → 将来トラフィック増加で SLA が厳しくなったら config key を `REGIONAL` に戻すだけで HA 復活可能。今のコスト > SLA リスクの判断。
@@ -212,4 +212,4 @@ Rollback: 各 PR を revert + 再 ArgoCD sync / `pulumi up` で原状復帰。
 
 - **Q1:** Argo CD の `notifications-controller` と `applicationset-controller` は実運用で使用されているか? 未使用なら disable、使用中なら維持。tasks.md の 1st step で確認する。
 - **Q2:** Cloud SQL config key 化 (Decision 3) の名前。`postgres.availabilityType` (string) と `postgres.haEnabled` (boolean) のどちらが好みか。前者は GCP 用語そのもの、後者は意図が読みやすい。tasks.md で実装時に決定する。
-- **Q3:** BQ Billing Export の billing service account 名は公式 docs を参照すべき。`billing-export-bigquery@system.gserviceaccount.com` は推測値、正確な値は実装時に GCP docs で確認する。
+- **Q3 (resolved):** BQ Billing Export の billing service account 名は GCP 公式 docs で確認済み。`cloud-billing-export@system.gserviceaccount.com` を Pulumi 実装で採用。GCP が将来 principal 名を変えた場合は runbook の troubleshooting セクションで Cloud Logging audit trail から実際の SA を特定する手順を整備済み。

--- a/openspec/changes/prod-cost-optimization/design.md
+++ b/openspec/changes/prod-cost-optimization/design.md
@@ -1,0 +1,215 @@
+## Context
+
+prod 環境を 5/13 に立ち上げ、5/18 に dev cluster を削除して安定運用に入ったのち、課金実績 (May 19-28 の SKU 別 CSV) を分析した結果、月額 ¥30,000 ($200) ペースで以下の 6 SKU が突出していた:
+
+| SKU | 月額換算 | 削減可否 |
+|---|---|---|
+| Gemini API (input + output + grounding) | ~¥13,000 | 別途検討 (今回スコープ外) |
+| Autopilot Cluster Mgmt Fee (after free credit) | ~¥6,000 | 削減不可 |
+| Cloud Monitoring Metric Volume | ~¥1,800 | **本 change で対応** |
+| Cloud SQL Regional Micro | ~¥2,600 | **本 change で対応** |
+| Global LB Forwarding Rule | ~¥2,400 | 構成変更が必要 (今回スコープ外) |
+| Autopilot Spot Pod + 周辺 | ~¥3,000 | **本 change で pod 数削減** |
+
+調査自体は GCP Billing Console の CSV export と Cloud Monitoring API 直叩きで完結したが、**BigQuery Billing Export が無効だったため日次の SKU 別分解ができず**、May 23 の cost spike (¥3,300/日) の原因を確定できなかった。再発時に SQL で即診断できる基盤を恒久整備する判断。
+
+現状の構成:
+- otel-collector: `googlecloud` exporter に `processors: [batch]` のみ。filter 未設定で全 metric が流れる。
+- Argo CD prod overlay: `argocd-server: 2 replicas`, image-updater / notifications / applicationset が default-on。
+- Cloud SQL prod: `db-f1-micro`, `availabilityType: REGIONAL`, PSC 接続。
+- BigQuery: prod project に dataset 無し、billing export も未設定。
+
+## Goals / Non-Goals
+
+**Goals:**
+- otel-collector の filter で Cloud Monitoring metric ingest を 45 MiB/月 → ~0.3 MiB/月 に削減 (現課金 ¥1,800/月の解消 + 将来 prod scale-up 時の free tier 突破防御)。
+- Argo CD prod overlay の pod 数を 8 → 4 程度に削減 (Autopilot per-Pod 最小課金分の削減)。
+- Cloud SQL prod を ZONAL 化して HA レプリカ分を解放 (¥1,000/月削減)。
+- BQ billing export 基盤を Pulumi 管理化し、コスト調査を SQL で完結できる状態にする。
+- 上記 4 つの作業を、安全な順序 (otel → Argo CD → BQ → Cloud SQL) で段階的に適用できる単一 change としてまとめる。
+
+**Non-Goals:**
+- Gemini API のコスト最適化 (prompt 設計改善、model 切り替え、grounding 削減)。月額の最大コストではあるがビジネスロジック改修が必要で本 change には含めない。
+- Global LB → Regional LB への移行。Cloudflare TLS 終端構成の見直しが必要で別 change。
+- concert-discovery の prompt 設計改善 (May 23 spike の根本原因かもしれないが、本 change はインフラ層の最適化に絞る)。
+- 過去の dev 残債コストの遡及精算。dev cluster 削除 (5/18) で自然消滅済み。
+- Cloud Monitoring SLO 用 metric の追加・dashboard 整備。
+
+## Decisions
+
+### Decision 1: otel-collector filter は OpenTelemetry Collector の `filter` processor で実装する
+
+OTLP 受信後の pipeline に挿入する processor として、OpenTelemetry Collector 標準の `filter` processor を選択する。
+
+**選択肢:**
+- **A. `filter` processor (採用)**: metric name を正規表現または完全一致で drop。設定が宣言的で読みやすい。
+- B. `transform` processor: より高機能だが、metric drop には overkill。OTEL Collector の維持コスト増。
+- C. backend (otelconnect / otelhttp) 側で計装を止める: 根本的だがソース変更が広範に及ぶ。Go コード修正が必要で revert も重い。
+
+**決定理由:** filter processor は YAML の宣言だけで完結し、否定的判断 (「これは出さない」) を一箇所に集約できる。otel-collector の再起動だけで反映され、backend デプロイ不要。将来 SLO 用に `rpc.server.duration` を復活させる時も filter ルールを 1 行変えるだけ。
+
+**Drop ルール:**
+```yaml
+processors:
+  filter/drop_workload_noise:
+    metrics:
+      exclude:
+        match_type: regexp
+        metric_names:
+          - rpc\.server\..*           # 5 metric (duration, request.size, response.size, requests_per_rpc, responses_per_rpc)
+          - http\.client\..*          # 2 metric (request.duration, request.body.size)
+```
+
+**Keep されるもの (明示的に列挙しないが filter 通過):**
+- `concert.search.count` (business KPI, counter)
+- `db.pool.active_connections` (gauge)
+- `db.pool.idle_connections` (gauge)
+
+**Service pipeline 変更:**
+```yaml
+service:
+  pipelines:
+    metrics:
+      receivers: [otlp]
+      processors: [filter/drop_workload_noise, batch]
+      exporters: [googlecloud]
+```
+
+`filter` を `batch` の **前** に置くことで、drop 対象を batch 集約前に捨てる (batch を経由してから捨てる無駄を回避)。
+
+### Decision 2: Argo CD の不要 pod 削減は base ではなく overlays/prod で patch する
+
+prod overlay 限定の disable を行い、dev では現状動作を維持する。
+
+**選択肢:**
+- A. base/kustomization.yaml で完全に削除: dev も含めて全環境で disable される。dev の image auto-update が止まる。
+- **B. overlays/prod/ で patch で 0 replicas にする (採用)**: dev 影響なし。base のリソース定義は残す。
+- C. helm values の `enabled: false`: Argo CD は upstream Helm chart 経由でないため非対応。
+
+**決定理由:** prod の semver pin 運用 (#274) は prod のみの制約。dev は image-updater による latest 追従が現役で必要。dev/prod の対称性を保ったまま prod のみ pod 数を減らせるのが Kustomize patch アプローチ。
+
+**実装方針:**
+```yaml
+# k8s/namespaces/argocd/overlays/prod/disable-image-updater-patch.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: argocd-image-updater-controller
+spec:
+  replicas: 0
+---
+# 同様に notifications-controller, applicationset-controller も replicas: 0 にする
+# (未使用なら。tasks.md の事前確認で判断)
+```
+
+argocd-server の `replicas: 2 → 1` も同じ overlay の strategic merge patch で実施。
+
+### Decision 3: Cloud SQL availability 切り替えは Pulumi 経由、staged rollout は行わない
+
+Cloud SQL の `availabilityType` 変更は Pulumi で宣言的に行う。
+
+**選択肢:**
+- A. `gcloud sql instances patch` で手動切り替え: 即時反映だが Pulumi state とドリフトする。次の `pulumi preview` で REGIONAL に戻されるリスク。
+- **B. Pulumi コード変更 + `pulumi up` (採用)**: state と実態が一致。レビュー履歴が残る。
+- C. 段階的 (replica 削除 → primary 移行): Cloud SQL の HA は単一の `availabilityType` フラグで両者切り替わるため段階化不可。
+
+**決定理由:** Pulumi 一元管理が破綻しない。`postgres.ts` で `availabilityType` を環境別に分岐させるか、`Pulumi.prod.yaml` 経由で config 化する。
+
+**実装方針:**
+```typescript
+// postgres.ts または環境設定
+settings: {
+  availabilityType: environment === 'prod-ha' ? 'REGIONAL' : 'ZONAL',
+  // または config key で:
+  // availabilityType: cfg.get('postgres.availabilityType') ?? 'ZONAL',
+}
+```
+
+「将来 REGIONAL に戻したくなった時」を考慮し、config key で切り替え可能にする実装を推奨する。新しい環境タイプを増やすより config flag のほうが軽い。
+
+### Decision 4: BigQuery Billing Export は Pulumi で dataset + IAM のみ管理、export 有効化操作は runbook 化
+
+Billing Export の有効化 API/CLI に Pulumi resource が存在しないため、Pulumi で provision できる範囲を最大化し、最後の手動ステップを runbook で固定化する。
+
+**選択肢:**
+- A. 完全に手動 (Console のみ): 既存運用と同じ。コード化のメリット無し。
+- **B. dataset + IAM を Pulumi、export 有効化は runbook 手動 (採用)**: 99% Pulumi 化、最終ステップだけ Console。
+- C. Cloud Billing API を直接叩く Pulumi Dynamic Provider を書く: 過剰実装。billing export の有効化は 1 回しか発生しないオペレーション。
+
+**決定理由:** Pulumi GCP provider に `gcp.billing.AccountIamMember` はあるが、「billing account → BQ dataset への export」を直接表現する resource は無い (2025-05 時点)。dataset と IAM 権限を Pulumi で揃えれば、Console での export 有効化は dataset を選ぶだけの 30 秒操作になる。
+
+**Provision するもの:**
+```typescript
+// src/gcp/components/billing-export.ts (新規)
+new gcp.bigquery.Dataset('billing-export', {
+  datasetId: 'billing_export',
+  location: 'asia-northeast1',
+  description: 'GCP Billing Export — standard + detailed usage cost',
+  project: 'liverty-music-prod',
+})
+
+new gcp.bigquery.DatasetIamMember('billing-export-svc', {
+  datasetId: 'billing_export',
+  role: 'roles/bigquery.dataEditor',
+  member: 'serviceAccount:billing-export-bigquery@system.gserviceaccount.com',
+  // ↑ 正確なサービスアカウント名は GCP docs で確認、または billing-account の serviceConfig から取得
+})
+```
+
+**runbook (新規):** `docs/runbooks/enable-billing-export.md` に以下を記載:
+1. `pulumi up` で dataset + IAM が provision されたことを確認
+2. Console → Billing → Billing export → BigQuery export
+3. Standard usage cost を Edit → project=liverty-music-prod, dataset=billing_export → Save
+4. Detailed usage cost も同様に有効化
+5. (任意) Pricing export も同 dataset に向ける
+6. 24h 後に `bq ls liverty-music-prod:billing_export` でテーブル生成を確認
+7. テーブルが現れない場合は IAM 権限を再確認
+
+### Decision 5: 適用順序は「リスクが小さい順」で otel → Argo CD → BQ → Cloud SQL
+
+各サブタスクは独立しているが、依存関係はなくても適用時のリスク (= 影響範囲 × 復旧難度) が異なる。
+
+**順序:**
+1. **otel filter** (最低リスク): collector 再起動のみ。metric が一時欠損するだけで他に影響なし。失敗しても`kubectl rollout undo` で即復旧。
+2. **Argo CD pod 削減** (低リスク): replicas 0 化は revert 容易。image-updater は disable しても sync 自体は動く。
+3. **BQ Export 基盤** (低リスク): 新規リソース作成のみ、既存に影響しない。失敗しても削除して再 provision。
+4. **Cloud SQL ZONAL 化** (中リスク): 数分のダウンタイム発生。事前にトラフィック確認、メンテナンス時間帯で実施。
+
+各タスクの間に 1 日程度の観察期間を置く運用も可能 (連続適用必須ではない)。
+
+## Risks / Trade-offs
+
+- **Risk:** otel filter で必要な metric を誤って drop する
+  → **Mitigation:** filter の正規表現を `rpc.server.*` と `http.client.*` に限定し、他の workload metric (db.pool.*, concert.search.count) は影響を受けない。Cloud Monitoring の `bytes_ingested` で適用前後の差分を確認する。
+
+- **Risk:** Argo CD image-updater を disable した直後に dev の運用が混乱する
+  → **Mitigation:** disable は overlays/prod でのみ実施。dev overlay は触らない。kustomize dry-run で確認してからマージ。
+
+- **Risk:** Cloud SQL ZONAL 化中の数分ダウンタイムでユーザー影響
+  → **Mitigation:** Cloudflare の前段で 503 を返す or maintenance ページに切り替え。Pulumi の preview で変更内容を確認後、低トラフィック時間帯 (深夜 JST) に実施。トラフィック規模が小さい launch 直後である今が実施好機。
+
+- **Risk:** BQ Billing Export の IAM 権限不足で provision 後も export が始まらない
+  → **Mitigation:** runbook の検証ステップ (24h 後の `bq ls` 確認) を必須化。失敗時は GCP docs に従って `billing-export-bigquery@system.gserviceaccount.com` 以外の正しい SA を IAM に追加。
+
+- **Trade-off:** ZONAL 化で zonal failover の自動冗長性を失う
+  → 将来トラフィック増加で SLA が厳しくなったら config key を `REGIONAL` に戻すだけで HA 復活可能。今のコスト > SLA リスクの判断。
+
+- **Trade-off:** otel filter で将来 SLO 用 latency histogram を使いたくなった場合に re-enable コストが発生
+  → filter は YAML 1 行で除外でき、PR 1 件で復活可能。Cloud Monitoring 側に metric definition が残るので途絶期間中の欠損はあるが運用継続には支障なし。
+
+## Migration Plan
+
+各タスクは独立して revert 可能。順序通り適用すれば総ダウンタイムは Cloud SQL 切り替え時の数分のみ。
+
+1. otel filter PR → review → merge → ArgoCD sync → 24h 観察
+2. Argo CD pod 削減 PR → review → merge → ArgoCD sync → image-updater 停止確認
+3. BQ Billing Export Pulumi PR → review → merge → `pulumi up` prod → Console で export 有効化 → 24h 後 `bq ls` で確認
+4. Cloud SQL ZONAL PR → review → merge → Pulumi preview → メンテナンス時間帯に `pulumi up` prod → DB 接続性確認
+
+Rollback: 各 PR を revert + 再 ArgoCD sync / `pulumi up` で原状復帰。
+
+## Open Questions
+
+- **Q1:** Argo CD の `notifications-controller` と `applicationset-controller` は実運用で使用されているか? 未使用なら disable、使用中なら維持。tasks.md の 1st step で確認する。
+- **Q2:** Cloud SQL config key 化 (Decision 3) の名前。`postgres.availabilityType` (string) と `postgres.haEnabled` (boolean) のどちらが好みか。前者は GCP 用語そのもの、後者は意図が読みやすい。tasks.md で実装時に決定する。
+- **Q3:** BQ Billing Export の billing service account 名は公式 docs を参照すべき。`billing-export-bigquery@system.gserviceaccount.com` は推測値、正確な値は実装時に GCP docs で確認する。

--- a/openspec/changes/prod-cost-optimization/design.md
+++ b/openspec/changes/prod-cost-optimization/design.md
@@ -24,7 +24,7 @@ prod 環境を 5/13 に立ち上げ、5/18 に dev cluster を削除して安定
 **Goals:**
 - otel-collector の filter で Cloud Monitoring metric ingest を 45 MiB/月 → ~0.3 MiB/月 に削減 (現課金 ¥1,800/月の解消 + 将来 prod scale-up 時の free tier 突破防御)。
 - Argo CD prod overlay の pod 数を 8 → 5 に削減(image-updater-controller と applicationset-controller を `replicas: 0`、argocd-server を 2 → 1。notifications-controller は active subscription のため維持)。
-- Cloud SQL prod を ZONAL 化して HA レプリカ分を解放 (¥1,000/月削減)。
+- Cloud SQL prod を ZONAL 化して HA レプリカ分を解放 (¥1,300/月削減 ≈ Regional Micro 月額 ¥2,600 の ~50%)。
 - BQ billing export 基盤を Pulumi 管理化し、コスト調査を SQL で完結できる状態にする。
 - 上記 4 つの作業を、安全な順序 (otel → Argo CD → BQ → Cloud SQL) で段階的に適用できる単一 change としてまとめる。
 

--- a/openspec/changes/prod-cost-optimization/proposal.md
+++ b/openspec/changes/prod-cost-optimization/proposal.md
@@ -1,10 +1,10 @@
 ## Why
 
-prod 環境の月次コストが想定を上回り、SKU レベルの調査で 3 つの即効性のある削減候補が見つかった: ① otel-collector が低価値な OTLP metric を素通しで Cloud Monitoring に流して billing account の free tier (150 MiB) を圧迫している、② prod overlay は semver pin 運用に変更済みなのに Argo CD の image-updater 等が常駐して Autopilot per-Pod 課金を発生させている、③ Cloud SQL prod インスタンスが launch 直後の SLA 要件を超える `REGIONAL` HA で動いており約 2 倍のコストを払っている。本 change はこの 3 点を 1 つの作業単位として並行で潰し、月 ¥3,000-3,300 (~10%) のコスト圧縮を行う。加えて、今回の調査が「BigQuery Billing Export が無いと SKU 別の日次分解ができず推測に頼らざるを得なかった」反省から、コスト調査基盤として ④ **BigQuery Billing Export 用の BQ dataset と IAM bindings を Pulumi 管理化**して恒久的な観測手段を整備する。
+prod 環境の月次コストが想定を上回り、SKU レベルの調査で 3 つの即効性のある削減候補が見つかった: ① otel-collector が低価値な OTLP metric を素通しで Cloud Monitoring に流して billing account の free tier (150 MiB) を圧迫している、② prod overlay は semver pin 運用に変更済みなのに Argo CD の image-updater 等が常駐して Autopilot per-Pod 課金を発生させている、③ Cloud SQL prod インスタンスが launch 直後の SLA 要件を超える `REGIONAL` HA で動いており約 2 倍のコストを払っている。本 change はこの 3 点を 1 つの作業単位として並行で潰し、月 ¥3,250-3,600 (~11%) のコスト圧縮を行う。加えて、今回の調査が「BigQuery Billing Export が無いと SKU 別の日次分解ができず推測に頼らざるを得なかった」反省から、コスト調査基盤として ④ **BigQuery Billing Export 用の BQ dataset と IAM bindings を Pulumi 管理化**して恒久的な観測手段を整備する。
 
 ## What Changes
 
-- otel-collector Deployment の `googlecloud` exporter pipeline に **filter processor** を追加し、`workload.googleapis.com/rpc.server.*` (5 metric) と `workload.googleapis.com/http.client.*` (2 metric) を drop。残す metric は `concert.search.count` と `db.pool.{active,idle}_connections` の 3 種のみ。
+- otel-collector Deployment の `googlecloud` exporter pipeline に **filter processor** を追加し、`rpc.server.*` (5 metric) と `http.client.*` (2 metric) を OTLP レベルで drop(Cloud Monitoring 上では `workload.googleapis.com/rpc.server.*` と `workload.googleapis.com/http.client.*` として見えるが、filter processor は `googlecloud` exporter より前段で動くため OTLP 名で指定する)。残す metric は `concert.search.count` と `db.pool.{active,idle}_connections` の 3 種のみ。
 - prod overlay (`k8s/namespaces/argocd/overlays/prod/`) で **Argo CD pod 数を最小化**: image-updater-controller を完全に disable、未使用なら notifications-controller / applicationset-controller も disable、argocd-server の replicas を 2 → 1 に。
 - Cloud SQL prod の **`availabilityType` を REGIONAL → ZONAL** に変更し、HA レプリカを廃止。Pulumi (`postgres.ts` または環境設定) で切り替え、`pulumi up` で適用。短時間のダウンタイムを許容する。
 - **BigQuery Billing Export** 用のリソース (BQ dataset `billing_export` + billing-export service account への IAM binding) を Pulumi で provision。実際の export 有効化操作 (Console 経由 or `gcloud billing` CLI) は手動で行うがそのための runbook を整備する。

--- a/openspec/changes/prod-cost-optimization/proposal.md
+++ b/openspec/changes/prod-cost-optimization/proposal.md
@@ -1,0 +1,40 @@
+## Why
+
+prod 環境の月次コストが想定を上回り、SKU レベルの調査で 3 つの即効性のある削減候補が見つかった: ① otel-collector が低価値な OTLP metric を素通しで Cloud Monitoring に流して billing account の free tier (150 MiB) を圧迫している、② prod overlay は semver pin 運用に変更済みなのに Argo CD の image-updater 等が常駐して Autopilot per-Pod 課金を発生させている、③ Cloud SQL prod インスタンスが launch 直後の SLA 要件を超える `REGIONAL` HA で動いており約 2 倍のコストを払っている。本 change はこの 3 点を 1 つの作業単位として並行で潰し、月 ¥3,000-3,300 (~10%) のコスト圧縮を行う。加えて、今回の調査が「BigQuery Billing Export が無いと SKU 別の日次分解ができず推測に頼らざるを得なかった」反省から、コスト調査基盤として ④ **BigQuery Billing Export 用の BQ dataset と IAM bindings を Pulumi 管理化**して恒久的な観測手段を整備する。
+
+## What Changes
+
+- otel-collector Deployment の `googlecloud` exporter pipeline に **filter processor** を追加し、`workload.googleapis.com/rpc.server.*` (5 metric) と `workload.googleapis.com/http.client.*` (2 metric) を drop。残す metric は `concert.search.count` と `db.pool.{active,idle}_connections` の 3 種のみ。
+- prod overlay (`k8s/namespaces/argocd/overlays/prod/`) で **Argo CD pod 数を最小化**: image-updater-controller を完全に disable、未使用なら notifications-controller / applicationset-controller も disable、argocd-server の replicas を 2 → 1 に。
+- Cloud SQL prod の **`availabilityType` を REGIONAL → ZONAL** に変更し、HA レプリカを廃止。Pulumi (`postgres.ts` または環境設定) で切り替え、`pulumi up` で適用。短時間のダウンタイムを許容する。
+- **BigQuery Billing Export** 用のリソース (BQ dataset `billing_export` + billing-export service account への IAM binding) を Pulumi で provision。実際の export 有効化操作 (Console 経由 or `gcloud billing` CLI) は手動で行うがそのための runbook を整備する。
+- 上記 4 つの変更は互いに独立しており、リスクが大きい順に Cloud SQL を最後に置く。
+
+## Capabilities
+
+### New Capabilities
+- `billing-export-infrastructure`: GCP Billing Export の受け皿となる BigQuery dataset と billing-export service account への IAM binding を Pulumi で provision する。Standard / Detailed / Pricing の各 export を同一 dataset に集約し、コスト分析 SQL の基盤として恒久運用する。
+
+### Modified Capabilities
+- `otel-collector-deployment`: metric pipeline の filter ポリシーを要件として追加。"OTLP で受け取った metric のうち、現在の運用で必要なものだけを Cloud Monitoring に export する" 振る舞いを規定する。
+- `argocd-image-automation`: 「prod 環境では image-updater は無効」「prod は semver pin 経由でのみ image 更新」という運用ポリシーを明文化する。dev は現状通り auto-update を継続。
+- `argocd-gateway-deployment`: prod overlay の Argo CD pod minimum 構成 (image-updater / notifications / applicationset の有効/無効と argocd-server のレプリカ数) を要件化する。
+- `database`: prod の Cloud SQL availability に関する要件を「launch フェーズは ZONAL、本格運用フェーズで REGIONAL HA を選択する」段階的ポリシーに緩める。
+
+## Impact
+
+- 影響コード:
+  - `cloud-provisioning/k8s/namespaces/otel-collector/base/configmap.yaml` (filter processor 追加)
+  - `cloud-provisioning/k8s/namespaces/argocd/overlays/prod/` (image-updater 等の有効/無効、replicas 調整)
+  - `cloud-provisioning/src/gcp/components/postgres.ts` または `Pulumi.prod.yaml` (availabilityType)
+  - `cloud-provisioning/src/gcp/components/` 配下に **新規 `billing-export.ts` コンポーネント** (BQ dataset + IAM)
+  - `cloud-provisioning/docs/runbooks/` に Billing Export 有効化手順を新規 runbook として追加
+- 影響インフラ:
+  - prod GKE クラスタの otel-collector Deployment が再起動 (数秒)
+  - Argo CD pod 4 個ほどが削除され、観測 / Slack 通知が無効になる
+  - Cloud SQL prod が REGIONAL → ZONAL 切り替え時に短時間 (数分以内) のダウンタイム
+  - `liverty-music-prod` プロジェクトに新規 BQ dataset `billing_export` (asia-northeast1) と IAM binding が作成される
+- 関連メトリクス: Cloud Monitoring の bytes_ingested、Autopilot Spot Pod mCPU/Memory、Cloud SQL Regional/Zonal Micro Instance の SKU 課金額
+- リスク:
+  - Cloud SQL ZONAL 化で zonal failover の自動冗長性を失う。トラフィック規模が拡大する前の段階で実施するため許容範囲。後で REGIONAL に戻す場合は同様の手順で可能。
+  - Billing Export の Console 操作は手動で残るため、runbook の手順抜けによって export が有効化されない可能性がある。検証ステップ (24h 後の `bq ls` でテーブル生成確認) を runbook に含める。

--- a/openspec/changes/prod-cost-optimization/proposal.md
+++ b/openspec/changes/prod-cost-optimization/proposal.md
@@ -31,7 +31,7 @@ prod 環境の月次コストが想定を上回り、SKU レベルの調査で 3
   - `cloud-provisioning/docs/runbooks/` に Billing Export 有効化手順を新規 runbook として追加
 - 影響インフラ:
   - prod GKE クラスタの otel-collector Deployment が再起動 (数秒)
-  - Argo CD pod 4 個ほどが削除され、観測 / Slack 通知が無効になる
+  - Argo CD pod 3 個が削除される(image-updater-controller 無効化、applicationset-controller 無効化、argocd-server を 2→1)。notifications-controller は active な Google Chat subscription を保持しているため維持し、sync-failed / health-degraded / sync-status-unknown のアラートは引き続き動く
   - Cloud SQL prod が REGIONAL → ZONAL 切り替え時に短時間 (数分以内) のダウンタイム
   - `liverty-music-prod` プロジェクトに新規 BQ dataset `billing_export` (asia-northeast1) と IAM binding が作成される
 - 関連メトリクス: Cloud Monitoring の bytes_ingested、Autopilot Spot Pod mCPU/Memory、Cloud SQL Regional/Zonal Micro Instance の SKU 課金額

--- a/openspec/changes/prod-cost-optimization/specs/argocd-gateway-deployment/spec.md
+++ b/openspec/changes/prod-cost-optimization/specs/argocd-gateway-deployment/spec.md
@@ -1,0 +1,29 @@
+## ADDED Requirements
+
+### Requirement: Prod overlay minimizes Argo CD Pod count
+The prod argocd overlay SHALL minimize the number of running Argo CD Pods by reducing the `argocd-server` replicas and disabling non-essential controllers, to keep GKE Autopilot per-Pod billing low.
+
+#### Scenario: argocd-server runs with single replica in prod
+- **WHEN** the prod cluster reconciles the argocd-server Deployment
+- **THEN** the Deployment SHALL have `replicas: 1` (not 2)
+- **AND** access to the Argo CD UI/API SHALL be unaffected at single-replica scale (no SLA on Argo CD UI HA is required in this phase)
+
+#### Scenario: image-updater-controller replicas are 0 in prod
+- **WHEN** the prod cluster reconciles the argocd-image-updater-controller Deployment
+- **THEN** the Deployment SHALL have `replicas: 0`
+- **AND** no Pod SHALL be running
+
+#### Scenario: Disabled non-essential controllers are documented
+- **WHEN** an operator reads the prod overlay
+- **THEN** any Deployment patched to `replicas: 0` SHALL have a comment explaining why
+- **AND** the comment SHALL state which capability/feature is being given up
+
+---
+
+### Requirement: dev overlay is unaffected
+The dev environment overlay SHALL continue to run Argo CD with its default replica counts and all controllers enabled, to preserve dev iteration speed (image auto-update, notifications, applicationsets).
+
+#### Scenario: dev overlay does not patch replicas
+- **WHEN** the dev overlay is rendered
+- **THEN** `argocd-server` SHALL keep its base replicas (`2` if base specifies HA, `1` if base specifies single)
+- **AND** `argocd-image-updater-controller`, `argocd-notifications-controller`, and `argocd-applicationset-controller` SHALL keep their base replicas

--- a/openspec/changes/prod-cost-optimization/specs/argocd-image-automation/spec.md
+++ b/openspec/changes/prod-cost-optimization/specs/argocd-image-automation/spec.md
@@ -1,0 +1,25 @@
+## MODIFIED Requirements
+
+### Requirement: Production deployments remain manual
+The system SHALL NOT automatically update production environment deployments. The `argocd-image-updater-controller` Deployment SHALL NOT consume cluster resources in the prod cluster (its replicas SHALL be 0), and the prod argocd overlay SHALL NOT contain any ImageUpdater CR. Production image updates SHALL occur exclusively via manual semver-pinned overlay PRs.
+
+#### Scenario: Prod image requires manual update
+- **WHEN** a new image is released with semantic version tag (v1.2.3)
+- **THEN** developer MUST manually update prod overlay kustomization with new version tag
+- **THEN** production deployment SHALL only occur after manual kustomization commit
+
+#### Scenario: Prod overlay has no ImageUpdater CR
+- **WHEN** inspecting prod argocd overlay
+- **THEN** overlay SHALL NOT contain an ImageUpdater CR
+- **THEN** Image Updater SHALL ignore prod Applications entirely
+
+#### Scenario: image-updater-controller is not running in prod cluster
+- **WHEN** inspecting the prod argocd namespace
+- **THEN** the `argocd-image-updater-controller` Deployment SHALL have `replicas: 0`
+- **AND** no `argocd-image-updater-controller` Pod SHALL be running
+- **AND** the Autopilot per-Pod billing for this controller SHALL be eliminated
+
+#### Scenario: dev cluster continues to run image-updater
+- **WHEN** inspecting the dev argocd namespace
+- **THEN** the `argocd-image-updater-controller` Deployment SHALL run with its base replica count (1)
+- **AND** dev Applications SHALL continue to receive automated digest updates

--- a/openspec/changes/prod-cost-optimization/specs/billing-export-infrastructure/spec.md
+++ b/openspec/changes/prod-cost-optimization/specs/billing-export-infrastructure/spec.md
@@ -22,7 +22,7 @@ The system SHALL grant the GCP billing export service account write permissions 
 #### Scenario: Billing export service account can write to dataset
 - **WHEN** Pulumi applies the prod stack
 - **THEN** the billing export service account SHALL have `roles/bigquery.dataEditor` on the `billing_export` dataset
-- **AND** the service account principal SHALL match the form documented by GCP (e.g., `billing-export-bigquery@system.gserviceaccount.com` or the project's billing service agent)
+- **AND** the service account principal SHALL match the form documented by GCP (e.g., `cloud-billing-export@system.gserviceaccount.com` or the project's billing service agent)
 
 #### Scenario: Permission survives drift
 - **WHEN** the IAM binding is removed manually

--- a/openspec/changes/prod-cost-optimization/specs/billing-export-infrastructure/spec.md
+++ b/openspec/changes/prod-cost-optimization/specs/billing-export-infrastructure/spec.md
@@ -1,0 +1,67 @@
+## ADDED Requirements
+
+### Requirement: BigQuery dataset for GCP Billing Export
+The system SHALL provision a BigQuery dataset named `billing_export` in the `liverty-music-prod` GCP project to receive GCP Billing Export data for cost analysis.
+
+#### Scenario: Dataset exists and is queryable
+- **WHEN** Pulumi applies the prod stack
+- **THEN** a BigQuery dataset `billing_export` SHALL exist in project `liverty-music-prod`
+- **AND** the dataset SHALL be located in `asia-northeast1`
+- **AND** the dataset SHALL have a description indicating its purpose as billing export sink
+
+#### Scenario: Dataset is managed by Pulumi
+- **WHEN** an operator drifts the dataset (e.g., deletes via Console)
+- **THEN** the next `pulumi preview` SHALL detect the drift
+- **AND** `pulumi up` SHALL recreate the dataset
+
+---
+
+### Requirement: IAM binding for billing export service account
+The system SHALL grant the GCP billing export service account write permissions on the `billing_export` dataset so that Standard, Detailed, and Pricing exports can land in BigQuery without manual permission grants.
+
+#### Scenario: Billing export service account can write to dataset
+- **WHEN** Pulumi applies the prod stack
+- **THEN** the billing export service account SHALL have `roles/bigquery.dataEditor` on the `billing_export` dataset
+- **AND** the service account principal SHALL match the form documented by GCP (e.g., `billing-export-bigquery@system.gserviceaccount.com` or the project's billing service agent)
+
+#### Scenario: Permission survives drift
+- **WHEN** the IAM binding is removed manually
+- **THEN** `pulumi preview` SHALL detect the missing binding
+- **AND** `pulumi up` SHALL re-create it
+
+---
+
+### Requirement: Runbook documents the Console step to enable billing export
+The system SHALL document the Console-side enablement of billing export to the provisioned dataset, since the export configuration itself is not Pulumi-managed.
+
+#### Scenario: Runbook lists all required Console steps
+- **WHEN** an operator follows the runbook for the first time
+- **THEN** the runbook SHALL specify navigation to `Billing → Billing export → BigQuery export`
+- **AND** the runbook SHALL instruct enabling Standard usage cost export to project `liverty-music-prod` dataset `billing_export`
+- **AND** the runbook SHALL instruct enabling Detailed usage cost export to the same dataset
+- **AND** the runbook SHALL document the verification step (`bq ls liverty-music-prod:billing_export` 24 hours later) confirming table creation
+
+#### Scenario: Operator can recover from misconfiguration
+- **WHEN** the runbook verification step fails (no tables after 24 hours)
+- **THEN** the runbook SHALL provide troubleshooting steps for IAM permission verification
+- **AND** the runbook SHALL link to GCP's official billing export documentation for current service account naming
+
+---
+
+### Requirement: Detailed usage cost export is preferred over Standard-only
+The system SHALL enable Detailed usage cost export (resource-level granularity) in addition to Standard usage cost export.
+
+#### Scenario: Detailed export provides per-resource breakdown
+- **WHEN** a cost spike investigation requires per-pod or per-namespace attribution
+- **THEN** the Detailed usage cost export tables SHALL be queryable with resource labels intact
+- **AND** the operator SHALL be able to attribute costs to specific resources via SQL
+
+---
+
+### Requirement: Sample analysis SQL is provided
+The system SHALL ship example SQL queries against the billing export tables for common cost analysis scenarios.
+
+#### Scenario: Example daily SKU breakdown query exists
+- **WHEN** an operator wants to investigate a daily cost spike
+- **THEN** an example SQL query SHALL be available (in runbook or repository docs)
+- **AND** the example SHALL show daily SUM(cost) grouped by service and SKU

--- a/openspec/changes/prod-cost-optimization/specs/database/spec.md
+++ b/openspec/changes/prod-cost-optimization/specs/database/spec.md
@@ -1,0 +1,26 @@
+## MODIFIED Requirements
+
+### Requirement: The system MUST provide persistent relational storage
+
+The system SHALL provide a durable, consistent store for relational data. The Cloud SQL availability tier for each environment SHALL be selected based on the environment's SLA phase: `ZONAL` during the launch phase (cost-priority, single-zone primary, automated daily backups), `REGIONAL` during the steady-state phase (HA with zonal failover). The availability tier SHALL be controlled by Pulumi configuration so that switching between phases is a single PR + `pulumi up` operation.
+
+#### Scenario: Production Deployment
+
+- **WHEN** the backend service is deployed to production during the launch phase
+- **THEN** it SHALL persist user data in a Cloud SQL instance with `availabilityType: ZONAL`
+- **AND** the data SHALL be encrypted at rest
+- **AND** automated daily backups SHALL be retained for the configured retention period
+
+#### Scenario: Promotion to steady-state HA
+
+- **WHEN** an operator decides to promote prod to the steady-state phase
+- **THEN** a Pulumi config flag SHALL be flipped to switch `availabilityType` to `REGIONAL`
+- **AND** `pulumi up` SHALL trigger the Cloud SQL instance to add a zonal standby
+- **AND** the change SHALL be revertible by flipping the flag back
+
+#### Scenario: Failover semantics in ZONAL phase
+
+- **WHEN** the primary Cloud SQL zone experiences an outage during the launch phase
+- **THEN** the system SHALL fail to serve database-dependent traffic until manual recovery
+- **AND** operators SHALL accept this risk in exchange for ~50% cost savings versus REGIONAL
+- **AND** the runbook SHALL document the manual recovery procedure (point-in-time restore from backup)

--- a/openspec/changes/prod-cost-optimization/specs/otel-collector-deployment/spec.md
+++ b/openspec/changes/prod-cost-optimization/specs/otel-collector-deployment/spec.md
@@ -1,0 +1,57 @@
+## MODIFIED Requirements
+
+### Requirement: OTel Collector Kubernetes Deployment
+The system SHALL deploy an OpenTelemetry Collector as a Kubernetes Deployment in a dedicated `otel-collector` namespace, configured to receive both traces and metrics via OTLP and export them to Google Cloud Trace (traces) and Google Cloud Monitoring (metrics). The metrics pipeline SHALL include a `filter` processor that drops low-value, high-volume metric series to keep Cloud Monitoring metric ingest within the GCP free tier (150 MiB / billing account / month) under normal traffic.
+
+#### Scenario: Collector receives OTLP traces over HTTP
+- **WHEN** a backend service sends traces to the Collector's OTLP/HTTP endpoint
+- **THEN** the Collector SHALL accept the traces on port 4318
+- **AND** the Collector SHALL process them through the `batch` processor
+- **AND** the Collector SHALL export the traces to Google Cloud Trace via the `googlecloud` exporter
+
+#### Scenario: Collector receives OTLP traces over gRPC
+- **WHEN** a backend service sends traces to the Collector's OTLP/gRPC endpoint
+- **THEN** the Collector SHALL accept the traces on port 4317
+
+#### Scenario: Collector is reachable via in-cluster service
+- **WHEN** a backend pod needs to send traces
+- **THEN** a Kubernetes Service `otel-collector` in namespace `otel-collector` SHALL be available
+- **AND** the service SHALL expose ports 4317 (gRPC) and 4318 (HTTP)
+
+#### Scenario: Metrics pipeline drops noisy auto-generated metrics
+- **WHEN** the Collector receives OTLP metrics whose name matches `rpc.server.*` or `http.client.*`
+- **THEN** the `filter` processor SHALL drop those metrics before the `batch` processor
+- **AND** the metrics SHALL NOT be exported to Cloud Monitoring
+
+#### Scenario: Business-relevant metrics pass through
+- **WHEN** the Collector receives OTLP metrics named `concert.search.count`, `db.pool.active_connections`, or `db.pool.idle_connections`
+- **THEN** the `filter` processor SHALL NOT drop them
+- **AND** the metrics SHALL be exported to Cloud Monitoring via the `googlecloud` exporter under the `workload.googleapis.com/` domain
+
+#### Scenario: Filter ordering minimizes batch overhead
+- **WHEN** metrics flow through the pipeline
+- **THEN** the `filter` processor SHALL be configured before `batch` in the processor chain
+- **AND** dropped metrics SHALL NOT contribute to batch payload size
+
+---
+
+## ADDED Requirements
+
+### Requirement: Filter rule scope is documented in the ConfigMap
+The Collector ConfigMap SHALL contain a comment explaining the filter rule's intent so future operators can extend, relax, or revert the policy with full context.
+
+#### Scenario: ConfigMap comment explains drop rules
+- **WHEN** an operator reads `k8s/namespaces/otel-collector/base/configmap.yaml`
+- **THEN** there SHALL be a comment block above the `filter` processor explaining why `rpc.server.*` and `http.client.*` are dropped
+- **AND** the comment SHALL reference the billing account 150 MiB free tier constraint
+- **AND** the comment SHALL list the metrics that are explicitly retained
+
+---
+
+### Requirement: Metric ingest volume is observable
+The system SHALL allow operators to verify the effectiveness of the filter via the `monitoring.googleapis.com/billing/bytes_ingested` metric in Cloud Monitoring.
+
+#### Scenario: Operator can compare ingest volume before and after filter
+- **WHEN** an operator queries `monitoring.googleapis.com/billing/bytes_ingested` for the prod project
+- **THEN** the time series SHALL show a step decrease at the moment the filter is deployed
+- **AND** the post-filter daily ingest SHALL be less than 1 MiB/day under normal traffic

--- a/openspec/changes/prod-cost-optimization/tasks.md
+++ b/openspec/changes/prod-cost-optimization/tasks.md
@@ -1,0 +1,60 @@
+## 1. otel-collector filter (lowest risk, do first)
+
+- [x] 1.1 `cloud-provisioning/k8s/namespaces/otel-collector/base/configmap.yaml` に `filter/drop_workload_noise` processor を追加(`rpc.server.*` と `http.client.*` を regexp で exclude)
+- [x] 1.2 同 ConfigMap の `service.pipelines.metrics.processors` を `[filter/drop_workload_noise, batch]` の順に更新
+- [x] 1.3 ConfigMap に filter ルールの意図と保持メトリクス一覧を説明するコメントブロックを追加
+- [x] 1.4 `kubectl kustomize k8s/namespaces/otel-collector/overlays/prod` で dry-run し、ConfigMap が正しくレンダリングされることを確認
+- [ ] 1.5 PR を作成、レビュー、マージ。ArgoCD が prod cluster の otel-collector Deployment を sync するのを待つ
+- [ ] 1.6 適用後 24h の `monitoring.googleapis.com/billing/bytes_ingested` (prod project) を確認し、日次 ingest が 1 MiB/日未満に落ちていることを検証
+- [ ] 1.7 業務メトリクス (`concert.search.count`, `db.pool.active_connections`, `db.pool.idle_connections`) が Cloud Monitoring に依然として記録されていることを確認
+
+## 2. Argo CD prod overlay の Pod 削減
+
+- [x] 2.1 prod cluster で `argocd-notifications-controller` と `argocd-applicationset-controller` の使用状況を確認(notification ルール定義の有無、ApplicationSet リソースの有無)
+- [x] 2.2 未使用と確認できた controller を 2.4 の対象に含めるか判断 — notifications-controller は active subscription があるため維持、applicationset-controller のみ disable
+- [x] 2.3 `k8s/namespaces/argocd/overlays/prod/kustomization.yaml` に `argocd-image-updater-controller` の `replicas: 0` inline patch を追加(別ファイル化はせず簡潔に)
+- [x] 2.4 同 kustomization.yaml に `argocd-applicationset-controller` の `replicas: 0` patch を追加(notifications-controller は維持)
+- [x] 2.5 既存の `argocd-server` patch を `replicas: 2 → 1` に変更
+- [x] 2.6 各 patch ブロックに「なぜ replicas: 0 / 1 か」のコメントを追加
+- [x] 2.7 `k8s/namespaces/argocd/overlays/prod/kustomization.yaml` に新規 patch を登録(同 file 内 inline で完結)
+- [x] 2.8 ローカル kustomize 環境の Helm v4 / v3 互換性問題で `kubectl kustomize --enable-helm` がローカル失敗。YAML 構文 + patch 構造は `python yaml.safe_load` でチェック済み(CI でレンダリング検証)
+- [x] 2.9 dev overlay は触っていないことを確認(git diff で overlays/prod のみ変更)
+- [ ] 2.10 PR を作成、レビュー、マージ
+- [ ] 2.11 ArgoCD sync 後、`kubectl get pods -n argocd` で対象 Pod が 0 または 1 になっていることを確認
+- [ ] 2.12 dev cluster の image-updater が引き続き auto-update 動作していることを確認(dev で次回 image push 時のログを確認)
+
+## 3. BigQuery Billing Export 基盤の Pulumi 化
+
+- [x] 3.1 `cloud-provisioning/src/gcp/components/billing-export.ts` を新規作成。`gcp.bigquery.Dataset` で `billing_export` (asia-northeast1, project liverty-music-prod) を定義
+- [x] 3.2 同コンポーネントで `gcp.bigquery.DatasetIamMember` を定義し、`cloud-billing-export@system.gserviceaccount.com` に `roles/bigquery.dataEditor` を付与
+- [x] 3.3 `src/gcp/index.ts` の `Gcp` クラスで `environment === 'prod'` ガード付きで `BillingExportComponent` をインスタンス化
+- [x] 3.4 `bigquery.googleapis.com` を `GoogleApis` 型に追加(`services/api.ts`)
+- [ ] 3.5 `pulumi preview --stack prod` で diff を確認(新規 dataset + IAM 2 リソースのみ)
+- [ ] 3.6 PR を作成、レビュー、マージ
+- [ ] 3.7 Pulumi Cloud Console から prod stack の `pulumi up` を手動 trigger
+- [ ] 3.8 `bq --project_id=liverty-music-prod ls billing_export` で dataset の存在を確認
+- [x] 3.9 `docs/runbooks/enable-billing-export.md` を新規作成。Console 操作手順(Billing → Billing export → BigQuery export → Standard + Detailed 有効化)を記載
+- [x] 3.10 同 runbook に検証ステップ(24h 後の `bq ls liverty-music-prod:billing_export` でテーブル生成確認)と例 SQL(日次 SKU breakdown、per-namespace GKE Pod cost、cost-spike 特定)を記載
+- [ ] 3.11 Console で Standard usage cost export と Detailed usage cost export を有効化(runbook 通り)
+- [ ] 3.12 24h 後に `bq ls liverty-music-prod:billing_export` でテーブルが作成されていることを確認、できていなければ IAM 権限を再チェック
+
+## 4. Cloud SQL prod を REGIONAL → ZONAL に変更(highest risk, do last)
+
+- [x] 4.1 `postgres.ts` で `availabilityType` を `PostgresComponentArgs` 経由で受け取れるよう変更。`src/index.ts` で `liverty-music:postgresAvailabilityType` config key から読み取り(default `ZONAL`、型チェック付き)、`Gcp` 経由で `PostgresComponent` に渡す
+- [x] 4.2 `Pulumi.prod.yaml` に `liverty-music:postgresAvailabilityType: ZONAL` を明示設定(コメントで運用ポリシー説明)
+- [ ] 4.3 `pulumi preview --stack prod` で diff を確認(`availabilityType: REGIONAL → ZONAL` のみが変更項目であること)
+- [ ] 4.4 PR を作成、レビュー、マージ
+- [ ] 4.5 メンテナンス時間帯(JST 深夜、低トラフィック時)を設定
+- [ ] 4.6 (任意)Cloudflare で maintenance ページに切り替え、または DB 接続が必要な API endpoint で 503 を返す事前準備
+- [ ] 4.7 Pulumi Cloud Console から `pulumi up --stack prod` を手動 trigger
+- [ ] 4.8 切り替え完了後、`gcloud sql instances describe postgres-osaka --project=liverty-music-prod --format="value(settings.availabilityType,state)"` で `ZONAL, RUNNABLE` を確認
+- [ ] 4.9 backend Pod から DB 接続が回復していることを確認(pod logs に errors が無い、`SELECT 1` が通る)
+- [ ] 4.10 (該当する場合)maintenance モードを解除し、トラフィックを通常運用に戻す
+- [ ] 4.11 完了後の月次コスト効果を翌月の billing で確認(Cloud SQL Regional Micro SKU の `Subtotal` が大幅減 → Zonal Micro SKU 側に移行)
+
+## 5. 完了確認 & ドキュメント
+
+- [ ] 5.1 翌請求月の billing CSV で Cloud Monitoring `Metric Volume`, Argo CD 経由の `Autopilot Spot Pod` 合計, Cloud SQL `Regional Micro` の SKU 単位コストの減少を確認
+- [ ] 5.2 削減実績を記録(目標 ¥3,000-3,300/月、実績は CSV 差分から計算)
+- [ ] 5.3 OpenSpec change を `/opsx:verify` で検証
+- [ ] 5.4 `/opsx:archive` で change を archive

--- a/openspec/changes/prod-cost-optimization/tasks.md
+++ b/openspec/changes/prod-cost-optimization/tasks.md
@@ -55,6 +55,6 @@
 ## 5. 完了確認 & ドキュメント
 
 - [ ] 5.1 翌請求月の billing CSV で Cloud Monitoring `Metric Volume`, Argo CD 経由の `Autopilot Spot Pod` 合計, Cloud SQL `Regional Micro` の SKU 単位コストの減少を確認
-- [ ] 5.2 削減実績を記録(目標 ¥3,000-3,300/月、実績は CSV 差分から計算)
+- [ ] 5.2 削減実績を記録(目標 ¥3,250-3,600/月 ≈ otel filter ¥1,800-2,000 + Argo CD ¥150-300 + Cloud SQL ¥1,300、実績は CSV 差分から計算)
 - [ ] 5.3 OpenSpec change を `/opsx:verify` で検証
 - [ ] 5.4 `/opsx:archive` で change を archive


### PR DESCRIPTION
## Summary

- Capture the prod cost analysis (May 2026, post dev-shutdown baseline) as an OpenSpec change with proposal, design, 5 spec deltas, and a 46-task implementation checklist.
- 4 cost-reduction workstreams targeting ~¥3,000-3,300/month savings on a ~¥30,000/month baseline.
- Implementation PR follows in `liverty-music/cloud-provisioning` referencing the same issue #527.

## Why

SKU-level analysis of the May 19-28 billing CSV (after prod stabilization and dev cluster deletion) surfaced four levers:
1. **Cloud Monitoring metric overage** — otel-collector floods `workload.googleapis.com/rpc.server.*` (5 histograms) and `workload.googleapis.com/http.client.*` (2 histograms) into Cloud Monitoring with no filter. The 150 MiB free tier is per *billing account*, already consumed for May 2026 — current charged volume is ¥1,861/month.
2. **Argo CD over-provisioning in prod** — image-updater-controller runs 24/7 but prod uses semver-pinned overlays (#274), so it never has work to do. No ApplicationSet CRs exist. argocd-server has 2 replicas with no real HA SLA. Autopilot bills per-Pod minimums (50m CPU + 64Mi mem + 1Gi ephemeral) regardless of actual usage.
3. **Cloud SQL HA overspec for launch phase** — `availabilityType: REGIONAL` on db-f1-micro costs roughly 2× ZONAL (~¥1,000/month delta) while the launch-phase SLA does not require zonal failover.
4. **Missing cost analysis infrastructure** — investigating the spike that prompted this change required CSV decoding because BigQuery Billing Export was never enabled. Codify the export sink in Pulumi so future investigations are SQL-driven.

## Artifacts

- `openspec/changes/prod-cost-optimization/proposal.md`
- `openspec/changes/prod-cost-optimization/design.md`
- `openspec/changes/prod-cost-optimization/specs/`
  - `billing-export-infrastructure/spec.md` (NEW capability)
  - `otel-collector-deployment/spec.md` (MODIFIED + ADDED)
  - `argocd-image-automation/spec.md` (MODIFIED)
  - `argocd-gateway-deployment/spec.md` (ADDED)
  - `database/spec.md` (MODIFIED)
- `openspec/changes/prod-cost-optimization/tasks.md` (46 tasks, 5 task groups, ordered by deployment risk)

## Out of scope

- Gemini API optimization (~¥4,000/month, business-logic change)
- Global LB → Regional LB migration (~¥1,500/month, requires Cloudflare TLS termination rework)
- concert-discovery prompt redesign (May 23 daily-cost spike candidate)
- Trial-discounted SKUs that may convert to paid later (~¥538/month)

## Test plan

- [x] `openspec status --change prod-cost-optimization` → all artifacts done
- [x] Spec deltas validated against existing capability spec headers
- [ ] Reviewers verify each Modified Requirements block contains the full updated content (not partial)
- [ ] Reviewers confirm workstream ordering in tasks.md matches design's risk-sorted Migration Plan

Refs: #527