### PR TITLE
chore(openspec): archive improve-bubble-tap-feel + sync canonical specs

### DIFF
--- a/openspec/changes/archive/2026-05-31-improve-bubble-tap-feel/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-31-improve-bubble-tap-feel/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-31

--- a/openspec/changes/archive/2026-05-31-improve-bubble-tap-feel/design.md
+++ b/openspec/changes/archive/2026-05-31-improve-bubble-tap-feel/design.md
@@ -1,0 +1,106 @@
+## Context
+
+The discovery page renders artist bubbles on an HTML5 Canvas with Matter.js physics. Tapping a bubble triggers three things today:
+
+1. **Audio** — `AudioEngine.playTap(hue)` synthesizes a tone with bare `OscillatorNode`s (`triangle` + optional `sine` overtone), at a **fixed** frequency (`osc.frequency.setValueAtTime(freq, t)`), where `freq` is the bubble hue quantized to a major pentatonic scale. A rapid-tap combo climbs the scale. `playLanding(hue)` plays a softer tone an octave down when absorption completes.
+2. **Press feedback** — `TapEffects.addPress` squashes the bubble horizontally for ~70ms, then fires a callback.
+3. **Absorption** — `AbsorptionAnimator` shrinks the bubble and flies it into the orb along a Bézier path with a comet trail, spawning ~15 generic dissolve particles (hue 220–280) near the orb at 85% progress.
+
+Two problems:
+
+- **Sound**: a constant-pitch pure oscillator quantized to a scale is, by construction, a chiptune beep. The timbre — not the note choice — is what reads as "mechanical / retro game".
+- **Visual**: the dominant motion is "absorbed into the orb", never "burst". There is no pop.
+
+Constraints carried forward:
+- Frontend-only change; no proto/backend/BSR work.
+- No recorded audio assets — synthesis stays fully procedural so pitch can keep deriving from hue.
+- Must respect `prefers-reduced-motion` and the existing mute/volume settings.
+- Web Audio is the only sound API; the AudioContext is created lazily inside a user gesture (`unlock`).
+
+## Goals / Non-Goals
+
+**Goals:**
+- Make the tap SE read as a crisp, satisfying two-part "pu-chu" pop rather than a retro beep. (During in-app tuning the per-bubble pentatonic pitch and rapid-tap combo were intentionally dropped in favor of a single identical pop — see D3.)
+- Make the bubble visibly **burst** on tap (strong: dense luminous color-droplet spray + bright rupture ring + light bloom), then continue into the existing absorption-into-orb so the color-injection metaphor survives.
+- Keep latency low (tap feedback must remain perceptually immediate) and CPU bounded (voice cap, particle pool reuse).
+
+**Non-Goals:**
+- Introducing recorded audio samples or an audio asset pipeline.
+- Changing the orb color-injection behavior, stage-effect escalation, or absorption trajectory itself.
+- Touching any screen other than discovery, or any backend/proto surface.
+- Adding a new audio settings surface (mute/volume behavior is unchanged).
+
+## Decisions
+
+### D1: Procedural synthesis, not a recorded sample
+
+Keep `AudioEngine` fully procedural. The fixed "pu-chu" pop is built from several very short, tightly-scheduled layers (a low thump, a delayed downward chirp, a noise breath) with millisecond-level envelopes — synthesis gives precise control over those transients with zero asset weight, which suits a PWA.
+
+*Alternative considered:* one high-quality recorded "pop" sample. Rejected — adds an asset to manage and ship for a PWA, and the crisp two-part pop is fully achievable in synthesis (see D2). (Procedural also kept the door open during the by-ear tuning that converged on the final character.)
+
+### D2: Fixed "pu-chu" pop = plosive thump + delayed downward chirp + noise breath
+
+> **Iteration note.** The voice was tuned by ear in the running app. An ascending
+> glide read as a mechanical "blip"; a fast downward drop read as a dull "pon";
+> a resonant up-curl read as a wet "puryu" but then as a thin "chu". The version
+> that landed is a **two-part fixed pop**, below. Each tap plays this identical
+> pop — see D3 for why the musical mapping was dropped.
+
+Build the pop from two short layered voices per tap:
+
+- **"pu" thump (low, first).** A `sine` near ~160Hz with a quick downward drop and a short decay (~30ms), carrying the plosive noise breath. This is the lippy front of the pop.
+- **"chu" chirp (high, a beat later).** A `triangle` near ~820Hz whose pitch drops fast from above (start ≈ 2.4× the target) onto the target via `frequency.exponentialRampToValueAtTime`, through a **lightly** resonant low-pass (`Q ≈ 1.5`, so dry/crisp — not wet). Scheduled ~22ms after the "pu" (via a per-voice `delay`) so the ear hears two distinct parts.
+- **Noise breath.** A very short (~9ms) low-pass-filtered (~2kHz, lippy not bright) white-noise burst at the "pu" attack. Buffer generated once and cached.
+- **Amplitude envelopes.** Near-instant attack, short percussive decays (~30ms "pu", ~45ms "chu"), `exponentialRampToValueAtTime` to near-zero — crisp, no sustained tail.
+
+`spawnVoice` is "osc → (optional lowpass) → gain → master" with optional pitch-drop, cutoff sweep, `Q`, `delay`, and a noise layer. The voice cap (`MAX_VOICES`) and `onended` cleanup are retained; the noise source self-disconnects.
+
+*Alternatives considered (all auditioned in-app):* ascending glide (mechanical blip), pure downward drop (dull "pon"), resonant wet up-curl (wet "puryu" / thin "chu"). The two-part "pu-chu" was the one that read as a crisp, satisfying pop.
+
+### D3: No musical scale, no combo — every tap is the same pop
+
+The original hue→pentatonic pitch mapping and the rapid-tap combo are **removed**. During tuning it became clear that a single identical pop feels cleaner and punchier for this tap interaction than a melodic mapping, and the user explicitly chose "all taps the same SE". Consequently `PENTATONIC`, the MIDI/scale helpers, `advanceCombo`, the combo/overtone state, and the exported `hueToPentatonicPitch` are deleted. `playTap(hue)` ignores its `hue` argument (kept only to preserve the `IAudioEngine` signature and the call site).
+
+### D4: `playLanding` is a fixed low settle
+
+The post-absorption "settle" tone is a soft, low fixed `sine` "boop" that settles downward in pitch. It no longer derives from the bubble's hue and omits the noise breath — consistent with the fixed-pop direction.
+
+### D5: Visual — "burst, then absorb" (Plan B), strong burst
+
+Re-stage the tap so the bubble pops in place before the existing absorption runs. New ordering in `dna-orb-canvas.ts` `handleInteraction`:
+
+```
+tap
+ ├─ emitTapFeedback(hue)        // audio (pu-chu pop) + haptic — immediate, unchanged call site
+ ├─ TapEffects: BURST
+ │    1. over-inflation   scale 1.0 → ~1.15 over ~40ms   (membrane tension before rupture)
+ │    2. rupture ring     bright ring + additive light bloom at the burst point
+ │    3. droplet spray    15–20 LUMINOUS droplets at the TAP POINT, tinted with the
+ │                        BUBBLE'S hue, emitted immediately, outward + gravity arc, fade
+ ├─ physics.removeBubble
+ └─ onBurstPeak → AbsorptionAnimator.startAbsorption(...)   // existing comet→orb→injectColor
+```
+
+- The current `addPress` **horizontal squash** is replaced by the **over-inflation** anticipation (a bubble at its tension limit swells, then ruptures). The existing `onRelease` callback contract (fire after the anticipation pre-roll to start absorption) is preserved — only the visual and timing change.
+- The **rupture ring** is a brighter, faster variant of the existing ripple drawn at the burst radius, plus an **additive light bloom** (white→hue radial gradient, `globalCompositeOperation = 'lighter'`) so the burst reads as a pop of light against the dark canvas.
+- The **droplet spray** reuses `AbsorptionAnimator.spawnDissolveParticles`, retuned into a `spawnBurst`: spawn at the **tap point** (not at 85% near the orb), **immediately** (not at 85% progress), tinted with the **bubble's hue** (not fixed 220–280), denser (15–20), slightly larger, with a small downward gravity term so droplets arc like flung water. Burst droplets render **luminously** (additive glow halo + white-hot core) so they read as sparks of light, not flat same-color dots.
+- After the burst peak, the **existing** absorption (shrink + comet trail + `injectColor` + shockwave) runs unchanged, so "the artist's color flies into your orb" is intact.
+
+*Alternative considered:* Plan A (pure burst, no absorption) — rejected because it discards the orb color-injection metaphor that `dna-orb-color-injection` and stage escalation depend on. Plan C (burst + thin single color streak) — viable but a bigger rewrite of the absorption visual; deferred.
+
+### D6: Accessibility & settings unchanged in contract
+
+`prefers-reduced-motion` suppresses the burst (over-inflation, ring, spray) exactly as it suppresses ripple/press today, falling straight through to absorption (which already has its own reduced-motion handling). Mute/volume continue to gate all audio via the master gain. No new settings surface.
+
+## Risks / Trade-offs
+
+- **Synthesized pop may not feel organic enough** → Mitigated by tuning the constants by ear in the running app until the "pu-chu" landed; the constants are named and grouped at the top of `audio-engine.ts` so further tuning is cheap. If synthesis ever can't land the feel, D1 (a recorded sample) can be revisited.
+- **Multiple short voices + noise source per tap raise per-tap cost** → Bounded by the existing `MAX_VOICES` cap; the noise buffer is generated once and reused. Rapid tapping is the worst case and stays within the voice cap.
+- **Denser, immediate droplet spray adds canvas draw load on low-end mobile** → Reuse the existing particle pool (no new allocations per tap), cap droplet count (≤20), and short lifetimes. Burst is fully suppressed under reduced-motion.
+- **Audio timing glitches if envelopes overlap** → Use `exponentialRampToValueAtTime` with a small floor (avoid 0 for exponential ramps, as the code does with `0.0001`) and schedule all ramps relative to the voice's start time at spawn.
+- **Tests asserting the old pentatonic / squash behavior break** → Resolved: pentatonic unit tests were removed with the mapping; `audio-engine` tests now cover the pure `glideStartFreq` drop math, and `dna-orb`/tap-effect tests cover burst-before-absorb staging, luminous-droplet hue at the tap point, and reduced-motion suppression.
+
+## Open Questions
+
+- The exact tuned millisecond/Hz constants (`PLOSIVE_FREQ`, `CHU_DELAY`, `POP_FREQ`, decays, cutoffs, `NOISE_*`) were dialed in by ear and are grouped at the top of `audio-engine.ts` for easy future adjustment; the spec fixes the *behavior* (fixed two-part "pu-chu" pop, no scale/combo), not the constants.
+- Whether haptics should also change cadence to match the burst — left as-is (out of scope).

--- a/openspec/changes/archive/2026-05-31-improve-bubble-tap-feel/proposal.md
+++ b/openspec/changes/archive/2026-05-31-improve-bubble-tap-feel/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+The recently shipped discovery-page bubble tap feedback does not feel the way it should. The sound effect is synthesized from bare oscillators at a fixed pitch quantized to a pentatonic scale, which produces a mechanical retro-game "beep" rather than the crisp, satisfying pop a bubble should make. The visual effect, meanwhile, animates the bubble being *absorbed* into the central orb (shrink + comet trail) — it never *bursts*. Both miss the tactile delight that makes the core "collect artists by tapping bubbles" loop feel good, so this directly affects the quality of the MVP onboarding experience.
+
+## What Changes
+
+- Replace the tap sound effect with a single fixed, crisp "pu-chu" pop, synthesized procedurally via Web Audio. During iteration the per-bubble pentatonic pitch mapping and rapid-tap combo were intentionally dropped — every tap now plays the same pop, which feels cleaner than the musical mapping for this interaction:
+  - A low, lippy plosive "pu" thump (with a filtered-noise breath) fires first.
+  - A short, dry high "chu" chirp — a fast downward pitch drop through a lightly resonant low-pass — fires a short beat later, so the pop reads as two distinct parts.
+  - Short percussive decays keep it crisp; low resonance keeps it dry, not wet/wobbly.
+  - Replace the post-absorption "settle" with a soft, low fixed landing tone.
+- Change the bubble tap visual from "absorb only" to "burst, then absorb": the bubble visibly pops in place (brief over-inflation → bright rupture ring + additive light bloom → outward spray of luminous color droplets) before the existing color-injection absorption continues toward the orb. The orb color-injection metaphor is preserved.
+- Continue to respect `prefers-reduced-motion` (burst suppressed) and the existing mute/volume settings.
+
+## Capabilities
+
+### New Capabilities
+- `discovery-tap-sonic-feedback`: Defines the procedural sound-effect behavior for tapping artist bubbles on the discovery page — a single fixed two-part "pu-chu" pop (low plosive thump + delayed high downward chirp, noise breath, dry percussive timbre, identical on every tap with no scale/combo), the post-absorption landing tone, and respect for mute/volume preferences.
+
+### Modified Capabilities
+- `artist-discovery-dna-orb-ui`: The "Bubble Absorption Animation" requirement changes so that tapping a bubble first plays a burst (over-inflation → bright rupture ring + additive light bloom → luminous color-droplet spray at the tap point) and then proceeds into the existing absorption-into-orb animation, rather than going straight to absorption.
+
+## Impact
+
+- Frontend only (`frontend/`); no proto, backend, or BSR changes.
+- Affected code:
+  - `src/services/audio-engine.ts` — `spawnVoice` (pitch envelope + low-pass + noise transient), `playTap`, `playLanding`.
+  - `src/components/dna-orb/tap-effects.ts` — the press/squash feedback becomes over-inflation + rupture ring.
+  - `src/components/dna-orb/absorption-animator.ts` — dissolve-particle spawn reused/retuned as the burst spray (tap point, bubble hue, immediate, denser).
+  - `src/components/dna-orb/dna-orb-canvas.ts` — orchestration order of tap → burst → absorb.
+- No new audio assets; synthesis stays fully procedural.
+- Scope excludes recorded audio samples, any non-discovery screens, and backend/proto work.

--- a/openspec/changes/archive/2026-05-31-improve-bubble-tap-feel/specs/artist-discovery-dna-orb-ui/spec.md
+++ b/openspec/changes/archive/2026-05-31-improve-bubble-tap-feel/specs/artist-discovery-dna-orb-ui/spec.md
@@ -1,0 +1,71 @@
+## MODIFIED Requirements
+
+### Requirement: Bubble Absorption Animation
+The system SHALL provide satisfying visual feedback when users select artists by first bursting the tapped bubble in place and then animating its color into the DNA Orb, with accumulating visual intensity and comet trail effects.
+
+#### Scenario: Artist selection bursts then absorbs
+
+- **WHEN** a user taps an artist bubble
+- **THEN** the bubble SHALL first play a burst effect at the tap point (see "Bubble Burst On Tap") before the absorption animation begins
+- **AND** after the burst, the bubble SHALL shrink and trace a path toward the DNA Orb at the bottom
+- **AND** the bubble SHALL be absorbed into the orb with a dissolve effect
+- **AND** if comet trail is enabled by the current stage level, the bubble SHALL leave a colored trail along its path
+- **AND** on absorption completion, the orb SHALL trigger a shockwave ring (if enabled by stage level)
+- **AND** the orb's color SHALL incorporate the absorbed bubble's hue
+
+#### Scenario: Color injection uses bubble's existing hue
+- **WHEN** a bubble is absorbed into the orb
+- **THEN** `OrbRenderer.injectColor` SHALL be called with the same hue used to render that bubble's gradient
+- **AND** 10-15 particles SHALL be replaced with the injected hue (with +/- 20 degree random variance)
+- **AND** `swirlIntensity` SHALL spike to 1.0 for a transient visual burst
+- **AND** the hue SHALL be appended to the color palette for use by orbital particles and light rays
+
+#### Scenario: Orb visual evolution with stage-level escalation
+- **WHEN** the user follows more artists
+- **THEN** the orb's visual presentation SHALL be determined by `getStageParams(followCount)` from `stage-effects.ts`
+- **AND** the orb radius, orbital count, light ray count, breathing amplitude, and ground glow SHALL all be driven by the returned `StageParams`
+- **AND** each follow SHALL produce a visibly distinct escalation in effects
+
+#### Scenario: First follow has maximum visual impact
+- **WHEN** the user follows their first artist (followCount goes from 0 to 1)
+- **THEN** the orb radius SHALL increase from 60 to 68
+- **AND** the breathing pulse SHALL begin
+- **AND** the visible particle count SHALL increase noticeably
+
+#### Scenario: Effective swirl combines base and transient
+- **WHEN** the orb animation loop runs
+- **THEN** `baseIntensity` SHALL be computed as `1 - 1 / (1 + followCount * 0.5)` (diminishing returns curve)
+- **AND** the particle speed multiplier SHALL be `1 + (baseIntensity + swirlIntensity) * 2`
+- **AND** `swirlIntensity` SHALL decay over ~1000ms as before
+- **AND** `baseIntensity` SHALL NOT decay within the same page session
+
+## ADDED Requirements
+
+### Requirement: Bubble Burst On Tap
+
+When a user taps an artist bubble, the system SHALL play a burst effect that makes the bubble visibly pop in place before the absorption-into-orb animation continues, providing tactile "pop" feedback while preserving the orb color-injection metaphor.
+
+#### Scenario: Bubble over-inflates then ruptures
+
+- **WHEN** a user taps an artist bubble
+- **THEN** the bubble SHALL briefly over-inflate (scale up beyond its rest size) as a short anticipation before rupturing
+- **AND** a bright rupture ring plus an additive light bloom SHALL flash open at the burst point so the burst reads as a pop of light
+- **AND** the over-inflation SHALL replace the previous horizontal squash anticipation
+
+#### Scenario: Burst sprays luminous droplets in the bubble's hue
+
+- **WHEN** the bubble ruptures
+- **THEN** a spray of droplet particles (on the order of 15–20) SHALL be emitted immediately at the tap point
+- **AND** the droplets SHALL be tinted with the tapped bubble's own hue but rendered luminously (additive glow with a white-hot core) so they read as sparks of light rather than flat same-color dots
+- **AND** the droplets SHALL travel outward with a slight downward gravity so they arc like flung liquid, then fade out
+
+#### Scenario: Burst hands off to absorption
+
+- **WHEN** the burst anticipation reaches its peak
+- **THEN** the existing absorption animation SHALL start (shrink, comet trail, color injection, shockwave) so the artist's color still flies into the orb
+
+#### Scenario: Reduced motion suppresses the burst
+
+- **WHEN** the user has `prefers-reduced-motion` enabled and taps a bubble
+- **THEN** the over-inflation, rupture ring, and droplet spray SHALL be suppressed
+- **AND** the interaction SHALL proceed directly to absorption, consistent with the existing reduced-motion handling

--- a/openspec/changes/archive/2026-05-31-improve-bubble-tap-feel/specs/discovery-tap-sonic-feedback/spec.md
+++ b/openspec/changes/archive/2026-05-31-improve-bubble-tap-feel/specs/discovery-tap-sonic-feedback/spec.md
@@ -1,0 +1,58 @@
+## ADDED Requirements
+
+### Requirement: Bubble Tap Sound Character
+
+The discovery page SHALL play a single fixed two-part "pu-chu" pop sound effect when a user taps an artist bubble, synthesized procedurally via the Web Audio API (no recorded audio assets), such that the tap reads as a crisp, satisfying bubble pop rather than a retro-game tone. Every tap SHALL sound identical — there is no musical scale, no per-bubble pitch, and no combo.
+
+#### Scenario: Tap plays a fixed pop on every tap
+
+- **WHEN** a user taps an artist bubble and audio is unlocked and not muted
+- **THEN** the system SHALL play the same fixed pop regardless of which bubble is tapped
+- **AND** the pop SHALL NOT vary in pitch with the bubble's hue or with how rapidly taps occur
+
+#### Scenario: Pop is a low "pu" thump followed by a high "chu" chirp
+
+- **WHEN** the tap pop is synthesized
+- **THEN** a low-pitched plosive "pu" thump SHALL fire first
+- **AND** a higher-pitched "chu" chirp SHALL fire a short beat later (on the order of ~20ms) so the pop reads as two distinct parts
+- **AND** the "chu" chirp's pitch SHALL drop quickly from above onto its target pitch (a fast downward chirp animated with a Web Audio frequency ramp, not held constant)
+
+#### Scenario: Pop has a plosive noise breath
+
+- **WHEN** the "pu" thump begins
+- **THEN** a short low-pass-filtered noise burst SHALL be layered at its attack to provide the lippy plosive onset
+
+#### Scenario: Pop timbre is dry and percussive
+
+- **WHEN** the pop plays
+- **THEN** each voice's amplitude SHALL rise quickly and decay to near-silence within a short interval (a short percussive tail, not a sustained tone)
+- **AND** the low-pass resonance SHALL be low so the pop reads as dry and crisp rather than wet or wobbly
+
+### Requirement: Landing Tone On Absorption
+
+When a tapped bubble completes its absorption into the orb, the system SHALL play a soft, low fixed settle ("landing") tone.
+
+#### Scenario: Absorption completion plays a settle tone
+
+- **WHEN** a bubble finishes being absorbed into the orb
+- **THEN** the system SHALL play a soft, low fixed tone that settles downward in pitch
+- **AND** the tone SHALL be the same on every absorption (it does not derive from the bubble's hue) and SHALL omit the plosive noise breath
+
+### Requirement: Sound Respects Mute and Volume Settings
+
+The tap and landing sounds SHALL honor the user's existing mute and volume preferences and the browser autoplay policy.
+
+#### Scenario: Muted user taps a bubble
+
+- **WHEN** the user has muted sound and taps a bubble
+- **THEN** no audible tap or landing tone SHALL be produced
+
+#### Scenario: Volume preference applied
+
+- **WHEN** the user has set a volume level
+- **THEN** the tap and landing tones SHALL be scaled to that level via the master output
+
+#### Scenario: Audio unlocked within a user gesture
+
+- **WHEN** audio has not yet been unlocked by a user gesture
+- **THEN** no AudioContext SHALL be forcibly started outside a gesture, consistent with the existing lazy-unlock behavior

--- a/openspec/changes/archive/2026-05-31-improve-bubble-tap-feel/tasks.md
+++ b/openspec/changes/archive/2026-05-31-improve-bubble-tap-feel/tasks.md
@@ -1,0 +1,26 @@
+## 1. Audio: fixed "pu-chu" pop (`src/services/audio-engine.ts`)
+
+- [x] 1.1 Add a cached white-noise `AudioBuffer` generated once on the engine (reused for every tap breath)
+- [x] 1.2 Extend `ToneOptions` to support an optional pitch drop (start ratio + duration), an optional low-pass cutoff sweep (start/end cutoff, Q), and a per-voice start `delay`
+- [x] 1.3 Rework `spawnVoice` graph to `osc → (optional lowpass) → gain → master`; schedule a downward `frequency.exponentialRampToValueAtTime`; honor the start `delay`
+- [x] 1.4 Add an optional short filtered-noise breath layer (`AudioBufferSourceNode → lowpass → fast-decay gain → master`) fired at the voice's start time, self-disconnecting on end
+- [x] 1.5 Build `playTap` as a single fixed two-part "pu-chu" pop — a low lippy plosive thump (with noise breath) then a delayed (~22ms) high downward `triangle` chirp through a lightly-resonant low-pass — ignoring `hue` so every tap is identical
+- [x] 1.6 Remove the pentatonic mapping, rapid-tap combo, and overtone (pivoted to one fixed pop): delete `PENTATONIC`/MIDI-scale helpers, `advanceCombo`/combo state, and the exported `hueToPentatonicPitch`
+- [x] 1.7 Update `playLanding` to a soft, low fixed settle tone (downward `sine` "boop"; no hue derivation, no noise breath)
+- [x] 1.8 Confirm mute/volume gating and lazy `unlock` behavior are unchanged
+
+## 2. Visual: burst then absorb (`src/components/dna-orb/`)
+
+- [x] 2.1 In `tap-effects.ts`, replace the horizontal-squash press with an over-inflation anticipation (scale ~1.0 → ~1.15 over ~40ms) that still fires the `onRelease`/peak callback to start absorption
+- [x] 2.2 In `tap-effects.ts`, add a bright rupture ring plus an additive light bloom (`globalCompositeOperation = 'lighter'`) that flash open at the burst point
+- [x] 2.3 In `absorption-animator.ts`, add `spawnBurst` (reusing the particle pool): emit at the tap point, immediately, tinted with the bubble's hue, denser (15–20), slightly larger, with downward gravity, and render luminously (additive glow halo + white-hot core)
+- [x] 2.4 In `dna-orb-canvas.ts` `handleInteraction`, re-order to: tap feedback (audio+haptic) → burst (over-inflation + rupture ring/light bloom + luminous droplet spray) → on burst peak start existing absorption (comet trail + `injectColor` + shockwave)
+- [x] 2.5 Ensure `prefers-reduced-motion` suppresses over-inflation, rupture ring/bloom, and droplet spray and falls straight through to absorption
+
+## 3. Tests & verification
+
+- [x] 3.1 `audio-engine` unit tests cover the pure `glideStartFreq` drop math (start above target, positive, proportional); the pentatonic tests were removed with the mapping. (The imperative Web Audio graph is verified by typecheck and in-app, since jsdom has no AudioContext and the engine resolves DI in its constructor.)
+- [x] 3.2 Update/extend `dna-orb` / tap-effect unit tests: assert burst-before-absorb staging, luminous droplet spray uses the bubble hue at the tap point with a white-hot core, and reduced-motion suppresses the burst
+- [x] 3.3 Run `make check` (Biome lint + format + typecheck + vitest) and fix any failures
+- [x] 3.4 Verify by ear and eye in the running app (local backend + `npm start`): every tap plays the same crisp "pu-chu" pop, and the bubble visibly bursts (luminous spray + light bloom) before its color flies into the orb. Audio constants tuned by ear to the approved character.
+- [x] 3.5 Verify reduced-motion and muted paths behave correctly in the running app

--- a/openspec/specs/artist-discovery-dna-orb-ui/spec.md
+++ b/openspec/specs/artist-discovery-dna-orb-ui/spec.md
@@ -41,11 +41,12 @@ The system SHALL provide a gamified artist discovery interface using a "DNA Extr
 ---
 
 ### Requirement: Bubble Absorption Animation
-The system SHALL provide satisfying visual feedback when users select artists by animating bubbles into the DNA Orb, with accumulating visual intensity and comet trail effects.
+The system SHALL provide satisfying visual feedback when users select artists by first bursting the tapped bubble in place and then animating its color into the DNA Orb, with accumulating visual intensity and comet trail effects.
 
-#### Scenario: Artist selection with absorption effect
+#### Scenario: Artist selection bursts then absorbs
 - **WHEN** a user taps an artist bubble
-- **THEN** the bubble SHALL shrink and trace a path toward the DNA Orb at the bottom
+- **THEN** the bubble SHALL first play a burst effect at the tap point (see "Bubble Burst On Tap") before the absorption animation begins
+- **AND** after the burst, the bubble SHALL shrink and trace a path toward the DNA Orb at the bottom
 - **AND** the bubble SHALL be absorbed into the orb with a dissolve effect
 - **AND** if comet trail is enabled by the current stage level, the bubble SHALL leave a colored trail along its path
 - **AND** on absorption completion, the orb SHALL trigger a shockwave ring (if enabled by stage level)
@@ -76,6 +77,32 @@ The system SHALL provide satisfying visual feedback when users select artists by
 - **AND** the particle speed multiplier SHALL be `1 + (baseIntensity + swirlIntensity) * 2`
 - **AND** `swirlIntensity` SHALL decay over ~1000ms as before
 - **AND** `baseIntensity` SHALL NOT decay within the same page session
+
+---
+
+### Requirement: Bubble Burst On Tap
+When a user taps an artist bubble, the system SHALL play a burst effect that makes the bubble visibly pop in place before the absorption-into-orb animation continues, providing tactile "pop" feedback while preserving the orb color-injection metaphor.
+
+#### Scenario: Bubble over-inflates then ruptures
+- **WHEN** a user taps an artist bubble
+- **THEN** the bubble SHALL briefly over-inflate (scale up beyond its rest size) as a short anticipation before rupturing
+- **AND** a bright rupture ring plus an additive light bloom SHALL flash open at the burst point so the burst reads as a pop of light
+- **AND** the over-inflation SHALL replace the previous horizontal squash anticipation
+
+#### Scenario: Burst sprays luminous droplets in the bubble's hue
+- **WHEN** the bubble ruptures
+- **THEN** a spray of droplet particles (on the order of 15–20) SHALL be emitted immediately at the tap point
+- **AND** the droplets SHALL be tinted with the tapped bubble's own hue but rendered luminously (additive glow with a white-hot core) so they read as sparks of light rather than flat same-color dots
+- **AND** the droplets SHALL travel outward with a slight downward gravity so they arc like flung liquid, then fade out
+
+#### Scenario: Burst hands off to absorption
+- **WHEN** the burst anticipation reaches its peak
+- **THEN** the existing absorption animation SHALL start (shrink, comet trail, color injection, shockwave) so the artist's color still flies into the orb
+
+#### Scenario: Reduced motion suppresses the burst
+- **WHEN** the user has `prefers-reduced-motion` enabled and taps a bubble
+- **THEN** the over-inflation, rupture ring, and droplet spray SHALL be suppressed
+- **AND** the interaction SHALL proceed directly to absorption, consistent with the existing reduced-motion handling
 
 ---
 

--- a/openspec/specs/discovery-tap-sonic-feedback/spec.md
+++ b/openspec/specs/discovery-tap-sonic-feedback/spec.md
@@ -1,0 +1,62 @@
+# Discovery Tap Sonic Feedback
+
+## Purpose
+
+This capability defines the procedural sound effect played when a user taps an artist bubble on the discovery page. It specifies a single fixed, crisp two-part "pu-chu" pop (synthesized via the Web Audio API, no recorded assets), the soft settle tone on absorption completion, and respect for the user's mute/volume preferences and the browser autoplay policy.
+
+---
+
+## Requirements
+
+### Requirement: Bubble Tap Sound Character
+
+The discovery page SHALL play a single fixed two-part "pu-chu" pop sound effect when a user taps an artist bubble, synthesized procedurally via the Web Audio API (no recorded audio assets), such that the tap reads as a crisp, satisfying bubble pop rather than a retro-game tone. Every tap SHALL sound identical — there is no musical scale, no per-bubble pitch, and no combo.
+
+#### Scenario: Tap plays a fixed pop on every tap
+- **WHEN** a user taps an artist bubble and audio is unlocked and not muted
+- **THEN** the system SHALL play the same fixed pop regardless of which bubble is tapped
+- **AND** the pop SHALL NOT vary in pitch with the bubble's hue or with how rapidly taps occur
+
+#### Scenario: Pop is a low "pu" thump followed by a high "chu" chirp
+- **WHEN** the tap pop is synthesized
+- **THEN** a low-pitched plosive "pu" thump SHALL fire first
+- **AND** a higher-pitched "chu" chirp SHALL fire a short beat later (on the order of ~20ms) so the pop reads as two distinct parts
+- **AND** the "chu" chirp's pitch SHALL drop quickly from above onto its target pitch (a fast downward chirp animated with a Web Audio frequency ramp, not held constant)
+
+#### Scenario: Pop has a plosive noise breath
+- **WHEN** the "pu" thump begins
+- **THEN** a short low-pass-filtered noise burst SHALL be layered at its attack to provide the lippy plosive onset
+
+#### Scenario: Pop timbre is dry and percussive
+- **WHEN** the pop plays
+- **THEN** each voice's amplitude SHALL rise quickly and decay to near-silence within a short interval (a short percussive tail, not a sustained tone)
+- **AND** the low-pass resonance SHALL be low so the pop reads as dry and crisp rather than wet or wobbly
+
+---
+
+### Requirement: Landing Tone On Absorption
+
+When a tapped bubble completes its absorption into the orb, the system SHALL play a soft, low fixed settle ("landing") tone.
+
+#### Scenario: Absorption completion plays a settle tone
+- **WHEN** a bubble finishes being absorbed into the orb
+- **THEN** the system SHALL play a soft, low fixed tone that settles downward in pitch
+- **AND** the tone SHALL be the same on every absorption (it does not derive from the bubble's hue) and SHALL omit the plosive noise breath
+
+---
+
+### Requirement: Sound Respects Mute and Volume Settings
+
+The tap and landing sounds SHALL honor the user's existing mute and volume preferences and the browser autoplay policy.
+
+#### Scenario: Muted user taps a bubble
+- **WHEN** the user has muted sound and taps a bubble
+- **THEN** no audible tap or landing tone SHALL be produced
+
+#### Scenario: Volume preference applied
+- **WHEN** the user has set a volume level
+- **THEN** the tap and landing tones SHALL be scaled to that level via the master output
+
+#### Scenario: Audio unlocked within a user gesture
+- **WHEN** audio has not yet been unlocked by a user gesture
+- **THEN** no AudioContext SHALL be forcibly started outside a gesture, consistent with the existing lazy-unlock behavior


### PR DESCRIPTION
Refs: liverty-music/frontend#386

## Summary

Archive the completed `improve-bubble-tap-feel` OpenSpec change and sync its delta specs into the canonical specs.

- **New capability** `discovery-tap-sonic-feedback` — fixed two-part "pu-chu" tap pop, fixed landing tone, mute/volume respect.
- **Modified** `artist-discovery-dna-orb-ui` — "Bubble Absorption Animation" now bursts the bubble in place before absorbing; new "Bubble Burst On Tap" requirement (over-inflation, rupture ring + light bloom, luminous droplets, reduced-motion suppression).
- Change moved to `openspec/changes/archive/2026-05-31-improve-bubble-tap-feel/`.

No proto changes. Implementation: liverty-music/frontend#386.