### PR TITLE
docs(settings): add fix-settings-layout OpenSpec change

### DIFF
--- a/openspec/changes/fix-settings-layout/design.md
+++ b/openspec/changes/fix-settings-layout/design.md
@@ -1,0 +1,77 @@
+# Design
+
+## Settings content slides under the fixed header
+
+### Root cause
+
+The route box is a 2-row grid (`auto 1fr`) with the `page-header` pinned to the
+`header` row and `main` in the `content` (`1fr`) row:
+
+```
+settings-route   block-size: 100%   (= app-shell viewport track minmax(0,1fr))
+└ display: grid  rows: auto / 1fr
+   ├─[header]  page-header           grid-area: header  (fixed)
+   └─[content] main                  1fr track, scroll container
+                ↑ grid item default min-block-size: auto
+                  → main refuses to shrink below content height
+                  → 1fr track grows to full content height
+                  → grid exceeds the route's 100% box
+                  → no overflow guard on :scope → content overflows upward,
+                    first card + section title end up behind page-header
+```
+
+`overflow-y: auto` on `main` cannot engage because the item never gets a
+height smaller than its content — the classic CSS min-size gotcha: a flex/grid
+item's automatic minimum size is `auto`, not `0`.
+
+### Sibling routes (the canonical pattern)
+
+| route       | `:scope` rows         | `main` overflow | `main` min-block-size | scroll element                        |
+|-------------|-----------------------|-----------------|-----------------------|---------------------------------------|
+| my-artists  | `auto 1fr`            | `hidden`        | `0`                   | inner child                           |
+| dashboard   | `auto minmax(0,1fr)`  | `hidden`        | `0`                   | inner child                           |
+| tickets     | `auto 1fr`            | `hidden`        | `0`                   | `.ticket-list` `flex:1; overflow-y:auto` |
+| discovery   | `auto 1fr`            | `hidden`        | (child `block-size:100%`) | inner child                       |
+| **settings**| `auto 1fr`            | **`auto`**      | **missing**           | `main` itself                         |
+
+### Decision
+
+Adopt the house pattern rather than the minimal one-liner:
+
+- `main`: `overflow: hidden; min-block-size: 0;` (shell, no scrolling itself).
+- Introduce an inner scroll container (`.settings-scroll`, `flex: 1;
+  overflow-y: auto;`) that holds the `<section>` list, with the existing
+  padding gutters.
+
+Rationale: the one-line fix (just add `min-block-size: 0` to the
+`overflow-y: auto` main) would also work visually, but keeping Settings
+structurally identical to its four siblings removes the divergence that caused
+the regression and prevents recurrence when the page is next edited.
+
+## CUBE CSS alignment
+
+- **Composition re-use:** the section list's vertical rhythm comes from the
+  existing `[ stack ]` composition primitive (compositions.css), grouped as
+  `[ settings-scroll ] [ stack ]`; the language list as
+  `[ language-list ] [ stack ]` with a `--stack-gap` exception for its tighter
+  rhythm. The block layer keeps only skin/scroll/gutters — it does NOT
+  re-declare `display`/`flex-direction`/`gap` (block wins over composition in
+  the `reset, tokens, global, composition, utility, block, exception` order, so
+  re-declaring would silently override the primitive).
+- **Bracket grouping:** drop `class="[ settings-divider ]"` (a lone block class
+  in brackets is meaningless). Use brackets only to group
+  `[ block ] [ composition ] [ utilities ]` by role, per `consent-route` (the
+  in-repo canonical, e.g. `class="[ consent-card ] [ flow ]"`).
+
+## Out of scope
+
+- The guest language-selector reactivity defect (selector highlight not
+  following the active locale after a guest change) is NOT addressed here. Its
+  root cause is the dual-owner guest/authed state model (`GuestService` vs
+  `UserService`); the proper fix is the GuestService dissolution refactor,
+  tracked as a separate change. Until that lands, the guest selector highlight
+  remains stale.
+- The PostHog CSP `Fetch API cannot load …eu.i.posthog.com` console errors seen
+  in the same devtools capture are a separate analytics/CSP concern.
+- No change to home-area selection, push, sound, consent, or account sections
+  beyond the composition/skin refactor needed for the layout fix.

--- a/openspec/changes/fix-settings-layout/proposal.md
+++ b/openspec/changes/fix-settings-layout/proposal.md
@@ -10,10 +10,11 @@ omits `min-block-size: 0`. As a grid item in the `1fr` content track its default
 `min-block-size: auto` prevents it from shrinking below its content height, so
 the track grows past the route's `100%` box, the grid overflows, and the content
 slides under the header. Every sibling route (my-artists, dashboard, tickets,
-discovery) sets `min-block-size: 0` on `main` and keeps `main` as an
-`overflow: hidden` shell with an inner scroll child — Settings is the only route
-that diverged. That divergence also left CUBE CSS drift in the page (composition
-re-implemented in the block layer; misused bracket grouping).
+discovery) keeps `main` as an `overflow: hidden` shell with an inner scroll
+child (using `min-block-size: 0` or a `block-size: 100%` child to bound the
+track) — Settings is the only route that diverged. That divergence also left
+CUBE CSS drift in the page (composition re-implemented in the block layer;
+misused bracket grouping).
 
 > Out of scope: the guest language-selector reactivity defect (the selector
 > highlight not following the active locale) is tracked separately and will be

--- a/openspec/changes/fix-settings-layout/proposal.md
+++ b/openspec/changes/fix-settings-layout/proposal.md
@@ -1,0 +1,58 @@
+## Why
+
+The Settings page ships with a layout regression: the first preferences card is
+clipped behind the fixed `page-header` — the PREFERENCES section title and the
+first rows (My Home Area, Language) render under the header instead of inside
+the scroll area.
+
+The Settings `main` is itself the scroll container (`overflow-y: auto`) but
+omits `min-block-size: 0`. As a grid item in the `1fr` content track its default
+`min-block-size: auto` prevents it from shrinking below its content height, so
+the track grows past the route's `100%` box, the grid overflows, and the content
+slides under the header. Every sibling route (my-artists, dashboard, tickets,
+discovery) sets `min-block-size: 0` on `main` and keeps `main` as an
+`overflow: hidden` shell with an inner scroll child — Settings is the only route
+that diverged. That divergence also left CUBE CSS drift in the page (composition
+re-implemented in the block layer; misused bracket grouping).
+
+> Out of scope: the guest language-selector reactivity defect (the selector
+> highlight not following the active locale) is tracked separately and will be
+> fixed as part of the GuestService dissolution refactor, not here.
+
+## What Changes
+
+- **Fix the scroll/layout regression.** Re-align Settings with the house scroll
+  pattern: `main` becomes an `overflow: hidden` shell with `min-block-size: 0`,
+  and an inner scroll container (`flex: 1; overflow-y: auto`) holds the section
+  list — matching my-artists / tickets / dashboard / discovery. The fixed
+  `page-header` stays pinned; the section list scrolls within the content area.
+- **Re-use CUBE composition primitives.** The vertical section list uses the
+  existing `[ stack ]` composition (compositions.css) for its rhythm instead of
+  re-declaring flex+gap in the block layer; the language list likewise.
+- **Correct CUBE bracket-grouping usage.** Remove the meaningless single-block
+  bracket wrapper `class="[ settings-divider ]"`; apply bracket grouping only
+  where it expresses `[ block ] [ composition ] [ utilities ]` role grouping.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `settings`: adds a layout/scroll requirement for the Settings page content
+  area (fixed header + scrollable list that does not overlap the header).
+
+## Impact
+
+- **Frontend only.** Touches `src/routes/settings/settings-route.{css,html}`.
+  No TypeScript/ViewModel, backend, proto, or DB changes; no new dependencies.
+- **CUBE CSS alignment.** Brings Settings in line with `cube-css-architecture`,
+  `cube-css-structural-rules`, and `cube-css-layer-constraints` (composition
+  re-use, layer placement, bracket grouping).
+- **Tests.** Visual/layout assertion that the first row is visible (not clipped
+  by the header). The existing `settings.auth.visual.spec.ts` screenshot
+  baseline will need to be refreshed.
+- **Ships to prod** as part of the normal frontend release (GitHub Release →
+  prod AR retag → cloud-provisioning prod pin bump).

--- a/openspec/changes/fix-settings-layout/specs/settings/spec.md
+++ b/openspec/changes/fix-settings-layout/specs/settings/spec.md
@@ -1,0 +1,29 @@
+## ADDED Requirements
+
+### Requirement: Settings Page Layout and Scroll
+
+The Settings page SHALL render a fixed page header and a vertically scrollable
+content area. The settings section list SHALL scroll within the content area
+without displacing or overlapping the fixed header, and the bottom navigation
+bar SHALL remain unaffected. The content scroll container SHALL follow the
+project's shared route scroll pattern: the content track grid item SHALL set
+`min-block-size: 0` so it can shrink within its track, and scrolling SHALL be
+owned by a scroll container whose minimum size does not prevent overflow.
+
+#### Scenario: First preferences row is visible on load
+- **WHEN** the Settings page loads
+- **THEN** the PREFERENCES section title and its first row ("My Home Area")
+  SHALL be visible within the content area
+- **AND** they SHALL NOT be clipped by or rendered behind the fixed page header
+
+#### Scenario: Section list scrolls within the content area
+- **WHEN** the settings content exceeds the available viewport height
+- **THEN** the section list SHALL scroll vertically within the content area
+- **AND** the page header SHALL remain pinned at the top
+- **AND** the bottom navigation bar SHALL remain pinned at the bottom
+
+#### Scenario: Content track item can shrink
+- **WHEN** the Settings route lays out its `header` / `content` grid
+- **THEN** the content-area grid item SHALL set `min-block-size: 0`
+- **AND** the scroll container SHALL engage `overflow-y: auto` rather than
+  expanding the grid track to full content height

--- a/openspec/changes/fix-settings-layout/tasks.md
+++ b/openspec/changes/fix-settings-layout/tasks.md
@@ -1,0 +1,42 @@
+# Tasks
+
+## 1. Layout / scroll fix
+
+- [x] 1.1 Refactor `settings-route.css` `main` to the house scroll pattern:
+      `overflow: hidden; min-block-size: 0;` and move scrolling to an inner
+      `.settings-scroll` container (`flex: 1; overflow-y: auto;`) holding the
+      `<section>` list, preserving the gutters.
+- [x] 1.2 Update `settings-route.html` so the section list lives inside the new
+      inner scroll container; keep `page-header` pinned outside it.
+- [ ] 1.3 Verify against siblings in-browser: first row (My Home Area) visible
+      on load, header not overlapped, list scrolls within the content area,
+      bottom nav unaffected. (Pending: run the app / refresh visual baseline.)
+
+## 2. CUBE CSS alignment
+
+- [x] 2.1 Use the `[ stack ]` composition for the section list and language list
+      rhythm instead of hand-rolled flex+gap; keep only skin in `@layer block`
+      and do NOT re-declare composition `display/flex/gap` (block wins over
+      composition in the cascade order).
+- [x] 2.2 Remove the single-block bracket wrapper `class="[ settings-divider ]"`;
+      apply bracket grouping only for `[ block ] [ composition ] [ utilities ]`.
+- [x] 2.3 `make lint` (biome + stylelint + cube-css lint plugin + typecheck)
+      clean — 0 errors. (Pre-existing `.settings-volume-slider` order warning
+      left untouched.)
+
+## 3. Tests
+
+- [x] 3.1 `make lint` + unit tests (`test/routes/settings-route.spec.ts`, 28)
+      green after the change (ViewModel untouched; CSS/HTML only).
+- [ ] 3.2 Add `data-testid` per `layout-assertions` and a visual/layout E2E
+      assertion that the first preferences row is visible (not clipped by the
+      header); refresh the `settings.auth.visual.spec.ts` screenshot baseline.
+      (Pending: requires running Playwright / a dev or mocked build.)
+
+## 4. Ship
+
+- [ ] 4.1 Open frontend PR; CI green; address review; merge to `main`.
+- [ ] 4.2 Cut frontend GitHub Release → prod AR retag.
+- [ ] 4.3 cloud-provisioning prod image pin-bump PR → ArgoCD auto-sync;
+      confirm the fix is live in prod.
+- [ ] 4.4 Archive this OpenSpec change once all tasks are complete.


### PR DESCRIPTION
## Description

Records the Settings page scroll/layout fix as an OpenSpec change (`fix-settings-layout`).

Adds a **Settings Page Layout and Scroll** requirement to the `settings` capability: the page renders a fixed header and a vertically scrollable content area; the section list scrolls within the content area without overlapping the fixed header, and the content-track grid item sets `min-block-size: 0` so the scroll container can engage `overflow-y: auto` rather than expanding the track.

`design.md` captures the root cause (the grid/flex `min-block-size: auto` gotcha), the sibling-route comparison, and the CUBE alignment (composition reuse + bracket-grouping correction).

Documentation only — no proto or generated-code changes.

## Related

- Implementation: liverty-music/frontend#391
- Tracking issue: liverty-music/frontend#390

> Note: the guest language-selector reactivity defect is intentionally out of scope here; it is tracked separately under the GuestService dissolution refactor.

close: liverty-music/frontend#390
