### PR TITLE
docs(store): add introduce-entity-store-layer OpenSpec change

### DIFF
--- a/openspec/changes/introduce-entity-store-layer/.openspec.yaml
+++ b/openspec/changes/introduce-entity-store-layer/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-31

--- a/openspec/changes/introduce-entity-store-layer/design.md
+++ b/openspec/changes/introduce-entity-store-layer/design.md
@@ -77,22 +77,62 @@ authenticated and guest data remains in localStorage, re-run the migration
 pattern of `user-hydration-task` (boot backfill + session flag) and the settings
 push self-heal.
 
-### Design risk to resolve: reconcile must not resurrect reverted state
+### Deterministic mechanism: a per-account guest-merge receipt
 
-Edge: migrate succeeds → clear fails → user changes the authed state (e.g.
-unfollows an artist) → reboot → naive reconcile re-migrates the stale guest item
-and **resurrects** it.
+Edge: migrate succeeds → clear fails → user reverts the authed state (e.g.
+unfollows an artist) → reboot → a naive "migrate whatever guest data is present"
+reconcile would **resurrect** the reverted item. Window-narrowing alone
+(early boot, session guard, prompt drain) is probabilistic and does not close
+this edge.
 
-Mitigations (to specify):
-- Run reconcile in the **earliest boot phase, before the UI is interactive**,
-  guarded by a per-session flag (as `user-hydration-task` does).
-- Treat guest localStorage as a **pending-migration queue** that is drained
-  (cleared) promptly and atomically with a successful migrate, so the
-  migrated-but-not-cleared window is minimal.
-- Reconcile only fires when a leftover queue is actually present.
+The deterministic fix: **a successful migration writes a persistent per-account
+receipt; the receipt, not the presence of guest data, decides whether to
+migrate.**
 
-This edge does not invalidate the approach; it is the one detail the
-reconciliation requirement must nail.
+- On first authenticated boot for an account, if there is **no receipt**, the
+  store migrates the guest queue (idempotent), then writes the receipt
+  (`liverty:guestMerged:<userId>`), then clears the guest queue.
+- On any later boot where the **receipt already exists**, residual guest data is
+  treated as stale and is **cleared without re-migrating** — so reverted state
+  is never resurrected, regardless of an earlier clear failure.
+
+The receipt makes migration exactly-once per account at the queue level; backend
+idempotency covers the create-then-write window. Guest follows additionally use
+per-item drain (remove each artist from the queue as its `Follow` succeeds), so
+even a single migration pass only ever retries genuinely failed items.
+
+### Sign-out also evicts user-specific caches
+
+`clearAll()` on the old `GuestService` path is replaced by per-store
+`SignedOut` handling. To avoid a privacy regression on a shared browser, **any
+store that caches user-specific data (e.g. `FollowStore`'s followed-artist
+projections) MUST evict it on `SignedOut`.** The cache-only `ConcertStore` /
+`ArtistStore` hold only non-user-specific public resources (e.g. ListTop) and so
+need not participate in migration, but still evict on `SignedOut` if they ever
+hold anything user-scoped.
+
+### Returning user with a pre-existing account (`ALREADY_EXISTS`)
+
+When `UserService.Create` returns `ALREADY_EXISTS`, the guest's onboarding
+home/language are **not** applied — a returning user's saved account preferences
+win (overwriting them with throwaway guest-session choices would be wrong). Only
+**follows** merge into the existing account (they are additive). This is a
+deliberate decision, not a silent drop.
+
+### NULL `preferred_language` on an existing account
+
+Independent of guest data: an authenticated user whose backend
+`preferred_language` is NULL (historical rows) has nothing in any guest queue,
+so reconcile does not fire for them. `UserStore` SHALL handle this by surfacing
+`I18N.getLocale()` and backfilling via `UpdatePreferredLanguage`, preserving the
+current `user-hydration-task` behavior.
+
+### Modal blocks on creation only, not on follow migration
+
+The SignUp modal awaits **user creation** (the awaited Create call) and then
+navigates. Follow migration runs in the background (best-effort, via
+`UserCreated`); the modal does not await it, and there is no completion barrier.
+Failed follows are healed by boot reconciliation.
 
 ## Reactivity cleanup
 
@@ -117,12 +157,15 @@ are included in this change only for layer-naming consistency
 ## Phasing (one change, multiple PRs)
 
 1. Store-layer scaffold + **UserStore** (absorb GuestService.home + guest
-   language + UserService) → **fixes the guest locale-selector bug**.
-2. **FollowStore** + `UserCreated` / `SignedOut` events + boot-reconcile
-   (absorb GuestService.follows + FollowServiceClient + GuestDataMergeService).
+   language + UserService) → **fixes the guest locale-selector bug**. Keep
+   `GuestDataMergeService.merge()` working by adapting it to `UserStore.create()`
+   so signups during phase 1 still migrate follows (its removal is deferred).
+2. **FollowStore** + `UserCreated` / `SignedOut` events + receipt-based
+   boot-reconcile (absorb GuestService.follows + FollowServiceClient; supersede
+   GuestDataMergeService).
 3. **ConcertStore / ArtistStore** cache renames.
 4. Consumer migration (11 sites) + removal of locale mirrors + delete
-   `GuestService`.
+   `GuestService` and `GuestDataMergeService`.
 
 ## Decisions captured
 
@@ -133,8 +176,12 @@ are included in this change only for layer-naming consistency
 | Scope | one change incl. cache-only Concert/Artist stores; phased PRs |
 | Boundary coordination | EA self-handling (`UserCreated`/`SignedOut`) + boot reconcile; **no orchestrator, no barrier** |
 | home/lang transition | Create-time inputs (no event) |
-| follows transition | post-`UserCreated`, idempotent, self-clear |
-| Failure handling | idempotent app-boot reconcile (not in-flight retry) |
+| follows transition | post-`UserCreated`, idempotent, per-item drain, self-clear |
+| Failure handling | app-boot reconcile keyed on a **per-account guest-merge receipt** (deterministic; no resurrection) |
+| `ALREADY_EXISTS` | existing account preferences win — guest home/lang NOT applied; only follows merge |
+| NULL server `preferred_language` | surface `I18N.getLocale()` + backfill via `UpdatePreferredLanguage` |
+| Sign-out | each store self-clears AND evicts user-specific caches |
+| SignUp modal | blocks on user creation only; follow migration is background |
 
 ## Out of scope
 

--- a/openspec/changes/introduce-entity-store-layer/design.md
+++ b/openspec/changes/introduce-entity-store-layer/design.md
@@ -1,0 +1,142 @@
+# Design
+
+## Goal
+
+Organize client state by **entity/aggregate**, not by auth-state. Each
+entity/aggregate is owned by an observable **store** that internally resolves
+its source (guest localStorage / authed backend) and caches its resources, so
+callers never branch on `auth.isAuthenticated`.
+
+## Naming: "store", not "repository"
+
+The layer holds observable in-memory state, caches resources, AND selects a
+persistence source. That is a **store** (Pinia/Svelte sense), not a classic
+stateless DDD repository. The existing classes are `*Service`; renaming to
+`*Store` signals "observable state owner + cache + source selection" more
+honestly than either `Service` or `Repository`.
+
+## Store inventory
+
+| Store | guest/authed dual ownership | Responsibilities | Boundary participation |
+|---|---|---|---|
+| **UserStore** | yes (`home`, `preferredLanguage`) | User entity state; guest = synthesized "current user" view (Null Object) from localStorage; identity when authed | create (home/lang at Create-time), self-clear |
+| **FollowStore** | yes (`follows` + `hype`) | follow set state + followed-artist cache | migrate on `UserCreated`, self-clear |
+| **ConcertStore** | no | cache read-only resources (e.g. ListTop 50) | none (cache-only) |
+| **ArtistStore** | no | artist query cache | none (cache-only) |
+
+`GuestService` dissolves: `home` → UserStore, `follows`/`hype` → FollowStore.
+`UserService` → UserStore. `FollowServiceClient` → FollowStore.
+`ConcertService` → ConcertStore.
+
+## Auth-boundary transitions — event-driven, per-store, no orchestrator
+
+The earlier proposal posited a saga/orchestrator for atomicity + ordering.
+That requirement **dissolves** once state is per-store, because there is no
+cross-store dependency that needs a global barrier:
+
+- **home / language are Create-time inputs, not post-event migrations.**
+  `auth-callback` reads the guest view and calls
+  `userStore.create(email, locale, home)`. They are baked into the Create RPC
+  atomically; nothing migrates them afterward. `UserStore.create()` clears its
+  own guest localStorage on success.
+- **follows are the only post-create migration**, and only `FollowStore` cares.
+  The single ordering edge is "create before follow-migrate" (follows need a
+  `user_id`). Expressed as: `UserStore.create()` publishes `UserCreated` →
+  `FollowStore` subscribes, migrates (idempotent), clears its own localStorage.
+- **No completion barrier** is needed: each store clears its own data when its
+  own migration completes; stores are mutually independent.
+
+```
+sign-up
+  auth-callback
+    └─ userStore.create(email, locale, home)        # home/lang = Create inputs
+         ├─ persist + current = authed user
+         ├─ clear own guest localStorage (home/lang)
+         └─ publish UserCreated ─────────────► FollowStore (subscribe)
+                                                  ├─ migrate follows+hype (idempotent)
+                                                  └─ clear own guest localStorage
+
+sign-out
+  publish SignedOut ─────────► UserStore.clear / FollowStore.clear   # each self-clears
+
+app boot (safety net)
+  each store.init: if authed && leftover guest data → idempotent reconcile (re-migrate + clear)
+```
+
+EA fits here precisely because the barrier requirement is gone: the boundary
+signals (`UserCreated`, `SignedOut`) are decoupled, and each store self-handles
+its own slice. This matches the codebase's existing EA usage
+(`i18n:locale:changed`, `ConsentChanged`, `Snack`).
+
+## Failure handling: app-boot reconciliation (not in-flight retry)
+
+Partial-migration failures (crash mid-migrate, network loss) are healed by an
+idempotent boot-time reconcile rather than a saga retry: on init, if the user is
+authenticated and guest data remains in localStorage, re-run the migration
+(backend follow/setHype are idempotent) and clear. This reuses the established
+pattern of `user-hydration-task` (boot backfill + session flag) and the settings
+push self-heal.
+
+### Design risk to resolve: reconcile must not resurrect reverted state
+
+Edge: migrate succeeds → clear fails → user changes the authed state (e.g.
+unfollows an artist) → reboot → naive reconcile re-migrates the stale guest item
+and **resurrects** it.
+
+Mitigations (to specify):
+- Run reconcile in the **earliest boot phase, before the UI is interactive**,
+  guarded by a per-session flag (as `user-hydration-task` does).
+- Treat guest localStorage as a **pending-migration queue** that is drained
+  (cleared) promptly and atomically with a successful migrate, so the
+  migrated-but-not-cleared window is minimal.
+- Reconcile only fires when a leftover queue is actually present.
+
+This edge does not invalidate the approach; it is the one detail the
+reconciliation requirement must nail.
+
+## Reactivity cleanup
+
+Each store exposes a single resolved `@observable`. Remove:
+- `SettingsRoute.currentLocale` / `currentHome` getters' auth branching → read
+  `userStore` directly.
+- `welcome-route`'s `@observable currentLocale` mirror + `currentLocaleChanged`.
+- The render-time `I18N.getLocale()` read that froze the guest selector.
+
+The guest language-selector highlight becomes reactive because `UserStore`
+exposes the active language as observable state for both guest and authed paths.
+
+## Caching (ConcertStore / ArtistStore)
+
+Read-only resources (ListTop 50, followed-artist projections) are cached in
+their store. These stores have no guest/authed ownership duality (a guest may
+hit a different RPC variant, but the data is fetched, not owned), so they do not
+subscribe to `UserCreated` / `SignedOut` and are excluded from reconcile. They
+are included in this change only for layer-naming consistency
+(`*Service` → `*Store`).
+
+## Phasing (one change, multiple PRs)
+
+1. Store-layer scaffold + **UserStore** (absorb GuestService.home + guest
+   language + UserService) → **fixes the guest locale-selector bug**.
+2. **FollowStore** + `UserCreated` / `SignedOut` events + boot-reconcile
+   (absorb GuestService.follows + FollowServiceClient + GuestDataMergeService).
+3. **ConcertStore / ArtistStore** cache renames.
+4. Consumer migration (11 sites) + removal of locale mirrors + delete
+   `GuestService`.
+
+## Decisions captured
+
+| Decision | Resolution |
+|---|---|
+| Layer name | **store** (not repository) |
+| Granularity | per-entity/aggregate (UserStore owns home+lang+identity), not per-field |
+| Scope | one change incl. cache-only Concert/Artist stores; phased PRs |
+| Boundary coordination | EA self-handling (`UserCreated`/`SignedOut`) + boot reconcile; **no orchestrator, no barrier** |
+| home/lang transition | Create-time inputs (no event) |
+| follows transition | post-`UserCreated`, idempotent, self-clear |
+| Failure handling | idempotent app-boot reconcile (not in-flight retry) |
+
+## Out of scope
+
+- Backend / proto / DB changes (none).
+- The `fix-settings-layout` scroll fix (already shipped).

--- a/openspec/changes/introduce-entity-store-layer/proposal.md
+++ b/openspec/changes/introduce-entity-store-layer/proposal.md
@@ -1,0 +1,126 @@
+## Why
+
+Client state today is partitioned by **auth-state** rather than by **domain
+concept**. Guest (unauthenticated) state lives in `GuestService`
+(localStorage), authenticated state in `UserService.current` (the backend
+`User` entity), and read-only resources in ad-hoc service caches
+(`ConcertService`, etc.). Because the split is by auth-state, every call site
+that needs a value branches on `auth.isAuthenticated`:
+
+```
+currentHome():   auth.isAuthenticated ? user.home : guest.home
+currentLocale(): user.preferredLanguage ?? <guest locale read from i18n>
+follows:         authed ? followService.list() : guest.follows
+```
+
+This produces two concrete problems:
+
+1. **Caller-side branching, repeated across 11 `IGuestService` consumers** —
+   each new derived value re-implements the guest/authed fork.
+2. **Low cohesion → latent inconsistency.** `GuestService` groups `home`,
+   `follows`, `hype` (and, by omission, language) under one roof solely because
+   they share "guest-ness". The asymmetry this produced is the guest
+   **language-selector reactivity bug**: guest `home` is a first-class
+   `@observable` (`GuestService.home`), but guest *language* has no observable
+   owner — it is only read back through the unobservable `I18N.getLocale()`, so
+   the language selector highlight freezes after a guest changes the language
+   while the home row stays reactive.
+
+The fix is to organize client state by **entity/aggregate**, each owned by an
+observable **store** that internally resolves its guest(localStorage) /
+authed(backend) source and caches its resources. Callers read the store and
+never branch on auth. `GuestService` and the entity `*Service` classes dissolve
+into this store layer.
+
+> Supersedes the earlier `dissolve-guest-service` proposal; that narrower framing
+> is generalized here into the store-layer introduction (GuestService dissolution
+> becomes one outcome). Properly fixes the guest language-selector reactivity
+> defect left out of `fix-settings-layout`.
+
+## What Changes
+
+- **Introduce a client-side store layer.** One observable store per
+  entity/aggregate. A store owns: observable state, source selection
+  (guest localStorage / authed backend), and resource caching. Callers stop
+  branching on `auth.isAuthenticated`.
+  - **`UserStore`** — owns the User entity: `home`, `preferredLanguage`,
+    identity. For a guest it exposes a synthesized "current user" view sourced
+    from localStorage (Null Object); for an authenticated user it owns the
+    backend entity. Absorbs `GuestService.home`, the guest language storage, and
+    `UserService`. Settings' `currentHome` / `currentLocale` branching collapses
+    into this store.
+  - **`FollowStore`** — owns the follow set + hype; caches followed artists.
+    Absorbs `GuestService.follows` and `FollowServiceClient`.
+  - **`ConcertStore` / `ArtistStore`** — cache-only stores for read-only
+    resources (e.g. ListTop 50). No guest/authed state ownership; they do not
+    participate in the auth-boundary operations. Rename of the existing
+    `ConcertService` / artist query services for layer consistency.
+- **Dissolve `GuestService`** — its state moves into `UserStore` (home/language)
+  and `FollowStore` (follows/hype). No single auth-state-partitioned service
+  remains.
+- **Auth-boundary transitions become event-driven, per-store self-handling — no
+  orchestrator, no completion barrier:**
+  - **home / language**: captured at signup as **Create-time inputs**.
+    `auth-callback` calls `userStore.create(email, locale, home)` (home/language
+    read from the guest view). `UserStore.create()` persists them, switches
+    `current` to the authed entity, and clears its own guest localStorage. No
+    event needed for these fields.
+  - **follows**: `UserStore.create()` publishes `UserCreated`; `FollowStore`
+    subscribes and migrates follows/hype (idempotent backend calls, now that a
+    `user_id` exists), then clears its own guest localStorage. Best-effort.
+  - **sign-out**: a `SignedOut` event is published; each store self-clears its
+    own guest/authed state (idempotent, order-independent).
+  - **failure / partial state**: an **app-boot reconciliation** — each store, on
+    init, if authenticated and leftover guest data remains in localStorage,
+    re-runs its idempotent migration and clears. Reuses the established
+    boot-reconcile pattern (`user-hydration-task` backfill, settings push
+    self-heal).
+- **Reactivity cleanup.** Each store exposes a single resolved `@observable`;
+  Settings' `currentLocale` / `currentHome` getters and `welcome-route`'s
+  `currentLocale` mirror are removed. The guest language-selector highlight
+  becomes reactive (the deferred Bug 2 fix).
+
+## Capabilities
+
+### New Capabilities
+
+- `entity-store-layer` — defines the store-layer pattern: one observable store
+  per entity/aggregate owning state + source selection (guest localStorage /
+  authed backend) + resource caching; the event-driven, per-store self-handling
+  auth-boundary transitions (`UserCreated` / `SignedOut`); and the app-boot
+  reconciliation safety net. (Name TBD in design.)
+
+### Modified Capabilities
+
+- `guest-mode-access` — guest state ownership moves from a single `GuestService`
+  to per-entity stores.
+- `guest-data-merge` — the signup transition is per-store self-handling
+  (home/language at Create-time, follows via `UserCreated`), with boot
+  reconciliation replacing in-flight retry coordination; clarifies merge scope
+  and the idempotency contract.
+- `user-home` — home preference resolution (guest storage vs `User.home`) moves
+  behind `UserStore`; callers stop branching.
+- `user-language-preference` — guest language gains a first-class observable
+  source in `UserStore`, unified with the authed `User.preferredLanguage`;
+  Settings' selector highlight becomes reactive.
+- `settings` — the Language row + selector derive from `UserStore` (no auth
+  branching, no render-time `I18N.getLocale()` read).
+
+## Impact
+
+- **Frontend only**, cross-cutting. `IGuestService` consumers to migrate (11):
+  `main.ts`, `user-home-selector`, `guest-data-merge-service`,
+  `follow-service-client`, `concert-service`, `dashboard-route`,
+  `my-artists-route`, `auth-callback-route`, `settings-route`,
+  `discovery-route`, `welcome-route`. Plus the `*Service` → `*Store` renames.
+- **Removes** guest/authed caller branching and the ad-hoc locale mirrors
+  (settings + welcome).
+- **Phased delivery.** One change, multiple PRs: (1) store-layer scaffold +
+  `UserStore` (fixes the locale bug), (2) `FollowStore` + boundary events +
+  boot-reconcile, (3) `ConcertStore` / `ArtistStore` cache renames, (4) consumer
+  migration + mirror removal.
+- **Design risk to resolve in design.md:** boot-reconcile must not resurrect
+  state the user reverted after signup (run early, session-guarded; treat guest
+  localStorage as a promptly-drained pending queue).
+- **No backend, proto, or DB changes.**
+- **Ships to prod** via the normal frontend release per phase.

--- a/openspec/changes/introduce-entity-store-layer/proposal.md
+++ b/openspec/changes/introduce-entity-store-layer/proposal.md
@@ -92,8 +92,6 @@ into this store layer.
 
 ### Modified Capabilities
 
-- `guest-mode-access` — guest state ownership moves from a single `GuestService`
-  to per-entity stores.
 - `guest-data-merge` — the signup transition is per-store self-handling
   (home/language at Create-time, follows via `UserCreated`), with boot
   reconciliation replacing in-flight retry coordination; clarifies merge scope

--- a/openspec/changes/introduce-entity-store-layer/specs/entity-store-layer/spec.md
+++ b/openspec/changes/introduce-entity-store-layer/specs/entity-store-layer/spec.md
@@ -60,25 +60,44 @@ completes.
 - **AND** each store SHALL clear its own state independently
 - **AND** clearing SHALL be idempotent and order-independent across stores
 
+#### Scenario: Sign-out evicts user-specific caches
+- **WHEN** the user signs out
+- **THEN** any store that caches user-specific data (e.g. the follow store's
+  followed-artist projections) SHALL evict that cache
+- **AND** a subsequent visitor on the same browser SHALL NOT see the previous
+  user's cached data
+- **AND** cache-only stores holding only non-user-specific public resources
+  (e.g. a top-artists list) MAY retain their cache
+
 ### Requirement: Boot Reconciliation of Unmerged Guest Data
 
 Each store SHALL reconcile leftover guest data at application start to heal
-partial-migration failures, without in-flight retry coordination. The
-reconciliation SHALL be idempotent and SHALL NOT resurrect state the user has
-already changed after signup.
+partial-migration failures, without in-flight retry coordination. A successful
+migration SHALL write a persistent per-account **guest-merge receipt**; the
+receipt — not the mere presence of guest data — SHALL decide whether a
+reconcile migrates, so reverted state is never resurrected.
 
-#### Scenario: Leftover guest data reconciled on authenticated boot
+#### Scenario: Leftover guest data migrated on first authenticated boot
 - **WHEN** the application starts
 - **AND** the user is authenticated
-- **AND** a store finds leftover guest data in localStorage that should have
-  migrated
-- **THEN** the store SHALL re-run its idempotent migration and then clear the
+- **AND** no guest-merge receipt exists for the account
+- **AND** a store finds leftover guest data in localStorage
+- **THEN** the store SHALL run its idempotent migration, then write the
+  per-account receipt (e.g. `liverty:guestMerged:<userId>`), then clear the
   leftover guest data
 
 #### Scenario: Reconciliation does not resurrect reverted state
-- **WHEN** boot reconciliation runs
-- **THEN** it SHALL run in the earliest boot phase, before the UI is interactive
-- **AND** it SHALL be guarded so it runs at most once per session
-- **AND** guest localStorage SHALL be treated as a pending-migration queue that
-  is drained promptly on a successful migrate, minimizing the
-  migrated-but-not-cleared window
+- **WHEN** the application starts
+- **AND** a guest-merge receipt already exists for the account
+- **AND** residual guest data is still present (a prior clear failed)
+- **THEN** the store SHALL clear the residual guest data WITHOUT re-running the
+  migration
+- **AND** state the user changed after signup SHALL NOT be resurrected
+
+#### Scenario: Per-item drain for the follow queue
+- **WHEN** the follow store migrates the guest follow queue
+- **THEN** it SHALL remove each artist from `guest.followedArtists` as that
+  artist's `Follow` call succeeds
+- **AND** the leftover queue SHALL therefore contain only items that failed
+- **AND** a subsequent reconcile SHALL retry only those failed items, never
+  re-following an already-migrated artist

--- a/openspec/changes/introduce-entity-store-layer/specs/entity-store-layer/spec.md
+++ b/openspec/changes/introduce-entity-store-layer/specs/entity-store-layer/spec.md
@@ -1,0 +1,84 @@
+## ADDED Requirements
+
+### Requirement: Per-Entity Store Ownership
+
+Client-side state SHALL be owned by observable **stores** organized by
+entity/aggregate, not by authentication state. Each store SHALL own the
+observable state for its entity, SHALL internally resolve its source
+(guest localStorage vs authenticated backend), and MAY cache read-only
+resources. Callers SHALL read state from the store and SHALL NOT branch on
+`auth.isAuthenticated` to select a guest-vs-authed source.
+
+#### Scenario: Caller reads without auth branching
+- **WHEN** a view model or service needs an entity value owned by a store
+- **THEN** it SHALL read the store's exposed observable
+- **AND** it SHALL NOT inspect `auth.isAuthenticated` to choose between a guest
+  store and an authenticated entity
+
+#### Scenario: UserStore owns home and language for both auth states
+- **WHEN** the current user's home area or preferred language is read
+- **THEN** it SHALL be sourced from `UserStore`
+- **AND** for an authenticated user `UserStore` SHALL surface the backend `User`
+  entity values
+- **AND** for a guest `UserStore` SHALL surface a synthesized current-user view
+  sourced from guest localStorage
+- **AND** the exposed value SHALL be observable so dependent bindings
+  re-evaluate on change
+
+#### Scenario: Cache-only stores own no guest/authed duality
+- **WHEN** a store owns read-only resources (e.g. a top-artists list)
+- **THEN** it SHALL cache those resources
+- **AND** it SHALL NOT participate in guest→authed transition or sign-out clear
+
+### Requirement: Event-Driven Auth-Boundary Transitions
+
+Guest→authenticated transition and sign-out SHALL be handled per-store via
+domain events, with no central orchestrator and no cross-store completion
+barrier. Each store SHALL clear its own guest data when its own migration
+completes.
+
+#### Scenario: Home and language migrate as Create-time inputs
+- **WHEN** a guest signs up
+- **THEN** the sign-up flow SHALL read home and language from `UserStore`'s
+  guest view and pass them to the user-create call as inputs
+- **AND** `UserStore` SHALL persist them, switch its current user to the
+  authenticated entity, and clear its own guest localStorage for those fields
+- **AND** no post-creation event SHALL be required to migrate home or language
+
+#### Scenario: Follows migrate after the user exists
+- **WHEN** the authenticated user has been created
+- **THEN** a `UserCreated` event SHALL be published
+- **AND** the follow store SHALL migrate guest follows and hype to the backend
+  using idempotent calls now that a user id exists
+- **AND** the follow store SHALL clear its own guest localStorage on success
+- **AND** follow migration SHALL be best-effort (a failed item SHALL be logged
+  and SHALL NOT block the remaining items)
+
+#### Scenario: Sign-out clears each store independently
+- **WHEN** the user signs out
+- **THEN** a `SignedOut` event SHALL be published
+- **AND** each store SHALL clear its own state independently
+- **AND** clearing SHALL be idempotent and order-independent across stores
+
+### Requirement: Boot Reconciliation of Unmerged Guest Data
+
+Each store SHALL reconcile leftover guest data at application start to heal
+partial-migration failures, without in-flight retry coordination. The
+reconciliation SHALL be idempotent and SHALL NOT resurrect state the user has
+already changed after signup.
+
+#### Scenario: Leftover guest data reconciled on authenticated boot
+- **WHEN** the application starts
+- **AND** the user is authenticated
+- **AND** a store finds leftover guest data in localStorage that should have
+  migrated
+- **THEN** the store SHALL re-run its idempotent migration and then clear the
+  leftover guest data
+
+#### Scenario: Reconciliation does not resurrect reverted state
+- **WHEN** boot reconciliation runs
+- **THEN** it SHALL run in the earliest boot phase, before the UI is interactive
+- **AND** it SHALL be guarded so it runs at most once per session
+- **AND** guest localStorage SHALL be treated as a pending-migration queue that
+  is drained promptly on a successful migrate, minimizing the
+  migrated-but-not-cleared window

--- a/openspec/changes/introduce-entity-store-layer/specs/guest-data-merge/spec.md
+++ b/openspec/changes/introduce-entity-store-layer/specs/guest-data-merge/spec.md
@@ -1,0 +1,70 @@
+## MODIFIED Requirements
+
+### Requirement: Data Merge on Authentication
+
+The system SHALL sync locally stored guest data to the backend after successful
+authentication, using a per-store, event-driven transition with no central
+orchestrator. Home and language SHALL be migrated as Create-time inputs; follows
+and hype SHALL be migrated by the follow store after the user exists. Each store
+SHALL clear its own guest data when its own migration completes. Partial
+failures SHALL be healed by boot reconciliation (see the `entity-store-layer`
+capability), not by an in-flight retry barrier.
+
+#### Scenario: Successful data merge
+
+- **WHEN** authentication completes successfully for a guest who has onboarding data
+- **THEN** the system SHALL call `UserService.Create` with the user's email,
+  home, and preferred language (home/language read from `UserStore`'s guest view)
+- **AND** `UserStore` SHALL switch to the authenticated entity and clear its own
+  guest home/language localStorage
+- **AND** upon user creation the system SHALL publish a `UserCreated` event
+- **AND** the follow store SHALL call `ArtistService.Follow` (and `SetHype` for
+  non-default hype) for each artist in `guest.followedArtists`, then clear its
+  own guest follow localStorage on success
+
+#### Scenario: User already exists during merge
+
+- **WHEN** `UserService.Create` returns `ALREADY_EXISTS`
+- **THEN** the system SHALL treat this as success and continue with the follow
+  migration
+
+#### Scenario: Follow call fails during merge
+
+- **WHEN** any `ArtistService.Follow` or `SetHype` call fails during migration
+- **THEN** the system SHALL log the error
+- **AND** the system SHALL continue with remaining calls (best-effort)
+- **AND** the system SHALL still set `onboardingStep` to COMPLETED
+- **AND** the leftover guest follow data SHALL remain in localStorage for boot
+  reconciliation to retry idempotently on the next authenticated start
+
+#### Scenario: Merge progress indication
+
+- **WHEN** the data merge is in progress
+- **THEN** the system SHALL display a loading indicator on the SignUp modal
+- **AND** the system SHALL NOT navigate away until the merge completes or all retries are exhausted
+
+### Requirement: Guest Data Cleanup
+
+The system SHALL remove guest data from LocalStorage after a successful
+migration or when the user starts a fresh tutorial. Each store SHALL clear its
+own guest data; sign-out clearing SHALL be triggered by the `SignedOut` event
+and SHALL be idempotent and order-independent across stores.
+
+#### Scenario: Cleanup after successful migration
+
+- **WHEN** a store's migration completes successfully
+- **THEN** that store SHALL remove its own guest keys from LocalStorage
+  (`UserStore`: `guest.home` and the anonymous-period `language` key;
+  follow store: `guest.followedArtists`)
+
+#### Scenario: Cleanup on sign-out
+
+- **WHEN** the user signs out
+- **THEN** a `SignedOut` event SHALL be published
+- **AND** each store SHALL clear its own state idempotently, independent of order
+
+#### Scenario: Cleanup on fresh tutorial start
+
+- **WHEN** a user taps [Get Started] on the LP to begin the tutorial
+- **AND** stale guest keys exist in LocalStorage
+- **THEN** the system SHALL clear those keys before starting Step 1

--- a/openspec/changes/introduce-entity-store-layer/specs/guest-data-merge/spec.md
+++ b/openspec/changes/introduce-entity-store-layer/specs/guest-data-merge/spec.md
@@ -27,6 +27,9 @@ capability), not by an in-flight retry barrier.
 - **WHEN** `UserService.Create` returns `ALREADY_EXISTS`
 - **THEN** the system SHALL treat this as success and continue with the follow
   migration
+- **AND** the guest-chosen home and preferred language SHALL NOT be applied to
+  the pre-existing account — the returning user's saved account preferences win
+  (only follows merge, as they are additive)
 
 #### Scenario: Follow call fails during merge
 
@@ -34,16 +37,19 @@ capability), not by an in-flight retry barrier.
 - **THEN** the system SHALL log the error
 - **AND** the system SHALL continue with remaining calls (best-effort)
 - **AND** the system SHALL still set `onboardingStep` to COMPLETED
-- **AND** the leftover guest follow data SHALL remain in localStorage for boot
+- **AND** each artist SHALL be removed from `guest.followedArtists` as its
+  `Follow` succeeds, so only the failed items remain in localStorage for boot
   reconciliation to retry idempotently on the next authenticated start
 
 #### Scenario: Merge progress indication
 
-- **WHEN** the data merge is in progress
+- **WHEN** sign-up is in progress
 - **THEN** the system SHALL display a loading indicator on the SignUp modal
-- **AND** the system SHALL NOT navigate away until the merge attempt completes
-- **AND** any items that failed the best-effort attempt SHALL be left for boot
-  reconciliation rather than retried in-flight
+- **AND** the system SHALL NOT navigate away until **user creation** completes
+  (the awaited Create call)
+- **AND** the system SHALL NOT block navigation on follow migration, which runs
+  in the background via `UserCreated` (best-effort); failed items are healed by
+  boot reconciliation rather than retried in-flight
 
 ### Requirement: Guest Data Cleanup
 

--- a/openspec/changes/introduce-entity-store-layer/specs/guest-data-merge/spec.md
+++ b/openspec/changes/introduce-entity-store-layer/specs/guest-data-merge/spec.md
@@ -41,7 +41,9 @@ capability), not by an in-flight retry barrier.
 
 - **WHEN** the data merge is in progress
 - **THEN** the system SHALL display a loading indicator on the SignUp modal
-- **AND** the system SHALL NOT navigate away until the merge completes or all retries are exhausted
+- **AND** the system SHALL NOT navigate away until the merge attempt completes
+- **AND** any items that failed the best-effort attempt SHALL be left for boot
+  reconciliation rather than retried in-flight
 
 ### Requirement: Guest Data Cleanup
 

--- a/openspec/changes/introduce-entity-store-layer/specs/settings/spec.md
+++ b/openspec/changes/introduce-entity-store-layer/specs/settings/spec.md
@@ -1,0 +1,33 @@
+## MODIFIED Requirements
+
+### Requirement: Guest Language Preference
+
+The system SHALL allow a guest user to change the display language from
+Settings. For guests, the change SHALL apply via `I18N.setLocale()` only and
+SHALL NOT call `UserService.UpdatePreferredLanguage` (no backend persistence is
+possible without an account). The language selector's selected-state indicator
+and the Language row SHALL derive from `UserStore`'s observable current-language
+value — NOT from a render-time read of `I18N.getLocale()` that the binding
+engine cannot observe — so they reflect the active locale reactively for guests.
+
+#### Scenario: Guest changes language
+
+- **WHEN** an unauthenticated user selects a language different from the current one
+- **THEN** the system SHALL call `I18N.setLocale()` to change the active locale
+- **AND** all UI text SHALL immediately update to the selected language
+- **AND** the system SHALL NOT call `UserService.UpdatePreferredLanguage`
+
+#### Scenario: Selector highlight follows the active locale for guests
+
+- **WHEN** an unauthenticated user changes the language (e.g. English → 日本語)
+- **AND** subsequently reopens the language selector
+- **THEN** the selector SHALL highlight the newly active language (日本語)
+- **AND** SHALL NOT continue highlighting the previously active language
+- **AND** the Settings "Language" row SHALL display the newly active language name
+
+#### Scenario: Guest home area sourced from the user store
+
+- **WHEN** an unauthenticated user views or changes "My Home Area"
+- **THEN** the system SHALL read and write the home-area code via `UserStore`
+  (backed by guest localStorage for a guest) rather than branching on auth state
+  at the call site

--- a/openspec/changes/introduce-entity-store-layer/specs/user-home/spec.md
+++ b/openspec/changes/introduce-entity-store-layer/specs/user-home/spec.md
@@ -1,0 +1,50 @@
+## MODIFIED Requirements
+
+### Requirement: Frontend home area persistence via RPC
+
+The frontend SHALL store the user's home area server-side via RPC, replacing
+localStorage-based persistence for authenticated users. Home area SHALL be owned
+by `UserStore`, which resolves its source (guest localStorage vs the
+authenticated `User` entity) internally; callers SHALL read home from
+`UserStore` and SHALL NOT branch on `auth.isAuthenticated`.
+
+#### Scenario: Onboarding home area selection persisted at account creation
+
+- **WHEN** a guest user has selected their home area during onboarding
+- **AND** the user subsequently creates an account
+- **THEN** the frontend SHALL include the selected home (read from `UserStore`'s
+  guest view) in the `UserService.Create` request
+- **AND** SHALL NOT make a separate `UpdateHome` call for the initial home
+- **AND** `UserStore` SHALL clear its own guest home localStorage on success
+
+#### Scenario: Settings home area change triggers UpdateHome RPC
+
+- **WHEN** an authenticated user changes their home area via the `user-home-selector`
+- **THEN** the frontend SHALL call `UserService.UpdateHome` with the new structured home
+- **AND** SHALL NOT write to localStorage for the home area
+
+#### Scenario: Dashboard reads home from the user store
+
+- **WHEN** the dashboard loads
+- **THEN** the lane assignment logic SHALL read the home area from `UserStore`
+- **AND** SHALL NOT call `UserService.Get` independently
+- **AND** SHALL NOT branch on `auth.isAuthenticated` to choose the source
+
+#### Scenario: Settings reads home from the user store
+
+- **WHEN** the settings page loads
+- **THEN** the My Home Area display SHALL read from `UserStore`
+- **AND** SHALL NOT read `I18N.getLocale()` or branch on auth state at the call site
+
+#### Scenario: Guest home sourced from store-backed localStorage
+
+- **WHEN** a guest (unauthenticated) user selects their home area
+- **THEN** `UserStore` SHALL store the selection in localStorage under `guest.home`
+- **AND** the dashboard and settings SHALL read the home area from `UserStore`'s
+  observable value (which stays reactive when the guest changes it)
+
+#### Scenario: Dashboard reloads data after authenticated home change
+
+- **WHEN** an authenticated user changes their home area via the `user-home-selector` on the dashboard
+- **THEN** the dashboard SHALL reload concert data via `loadDashboardEvents()` after the home update completes
+- **AND** the reloaded data SHALL reflect the new lane classification based on the updated home

--- a/openspec/changes/introduce-entity-store-layer/specs/user-home/spec.md
+++ b/openspec/changes/introduce-entity-store-layer/specs/user-home/spec.md
@@ -34,7 +34,7 @@ authenticated `User` entity) internally; callers SHALL read home from
 
 - **WHEN** the settings page loads
 - **THEN** the My Home Area display SHALL read from `UserStore`
-- **AND** SHALL NOT read `I18N.getLocale()` or branch on auth state at the call site
+- **AND** SHALL NOT branch on `auth.isAuthenticated` at the call site
 
 #### Scenario: Guest home sourced from store-backed localStorage
 

--- a/openspec/changes/introduce-entity-store-layer/specs/user-language-preference/spec.md
+++ b/openspec/changes/introduce-entity-store-layer/specs/user-language-preference/spec.md
@@ -21,3 +21,18 @@ store's observable value.
 - **THEN** `UserStore` SHALL surface `User.preferredLanguage` for an
   authenticated user and the anonymous-period language for a guest
 - **AND** callers SHALL NOT branch on `auth.isAuthenticated` to choose the source
+
+### Requirement: UserStore Handles NULL Server Preferred Language
+
+`UserStore` SHALL handle an authenticated user whose backend
+`preferred_language` is NULL (historical rows not yet backfilled). This path is
+independent of the guest-data reconciliation, which only fires when guest data
+is present in localStorage.
+
+#### Scenario: NULL preferred_language surfaced and backfilled
+- **WHEN** the authenticated user's `User.preferredLanguage` is NULL
+- **THEN** `UserStore` SHALL surface `I18N.getLocale()` as the effective language
+- **AND** `UserStore` SHALL backfill the server value via
+  `UpdatePreferredLanguage`, preserving the current `user-hydration-task`
+  behavior
+- **AND** this SHALL occur whether or not any guest data exists in localStorage

--- a/openspec/changes/introduce-entity-store-layer/specs/user-language-preference/spec.md
+++ b/openspec/changes/introduce-entity-store-layer/specs/user-language-preference/spec.md
@@ -1,0 +1,23 @@
+## ADDED Requirements
+
+### Requirement: Guest Language as Observable Store State
+
+The guest (anonymous-period) language preference SHALL be owned by `UserStore`
+as observable state, unified with the authenticated `User.preferredLanguage`
+source. The frontend SHALL NOT read the active guest language through an
+unobservable `I18N.getLocale()` call at render time for the purpose of driving
+UI state; bindings that depend on the current language SHALL depend on the
+store's observable value.
+
+#### Scenario: Guest language exposed as observable
+- **WHEN** a guest's preferred language is read for display or selection state
+- **THEN** it SHALL be sourced from `UserStore`'s observable current-language
+  value (backed by the anonymous-period `language` localStorage key)
+- **AND** a change to the guest language SHALL notify dependent bindings so they
+  re-evaluate without a manual mirror or a render-time `I18N.getLocale()` read
+
+#### Scenario: Unified resolution across auth states
+- **WHEN** the current preferred language is read
+- **THEN** `UserStore` SHALL surface `User.preferredLanguage` for an
+  authenticated user and the anonymous-period language for a guest
+- **AND** callers SHALL NOT branch on `auth.isAuthenticated` to choose the source

--- a/openspec/changes/introduce-entity-store-layer/tasks.md
+++ b/openspec/changes/introduce-entity-store-layer/tasks.md
@@ -13,7 +13,14 @@ One change, delivered in phased PRs. Each phase ships independently to prod.
       (guest = localStorage-backed synthesized view; authed = `User` entity).
 - [ ] 1.3 `UserStore.create(email, locale, home)`: persist Create-time inputs,
       switch `current` to the authed entity, clear own guest localStorage,
-      publish `UserCreated`.
+      publish `UserCreated`. On `ALREADY_EXISTS`, do NOT apply guest home/language
+      (existing account wins). Handle a NULL server `preferred_language` by
+      surfacing `I18N.getLocale()` and backfilling via `UpdatePreferredLanguage`.
+- [ ] 1.3a Keep `GuestDataMergeService.merge()` functional by adapting it to call
+      the new `UserStore.create()` for the user-creation step, so guest follows
+      continue to migrate at signup throughout phase 1. Defer its REMOVAL to
+      phase 4 (after `FollowStore` + boot-reconcile land) — no signup between
+      deploys may strand guest follows.
 - [ ] 1.4 Migrate `SettingsRoute` to read home/language from `UserStore`; remove
       the `currentLocale` / `currentHome` auth-branching getters and the
       render-time `I18N.getLocale()` read. Remove `welcome-route`'s
@@ -26,15 +33,18 @@ One change, delivered in phased PRs. Each phase ships independently to prod.
 
 - [ ] 2.1 Introduce `FollowStore`: absorb `GuestService.follows`/hype and
       `FollowServiceClient`; cache followed artists; expose observable follow set.
-- [ ] 2.2 Subscribe `UserCreated` → migrate follows + hype (idempotent), then
-      self-clear guest follow localStorage (best-effort). Replaces
-      `GuestDataMergeService.merge()`.
+- [ ] 2.2 Subscribe `UserCreated` → migrate follows + hype (idempotent),
+      removing each artist from `guest.followedArtists` as its `Follow` succeeds
+      (per-item drain; only failures remain). Write the per-account guest-merge
+      receipt on success.
 - [ ] 2.3 Publish/subscribe `SignedOut` → each store self-clears (idempotent,
-      order-independent). Replace `GuestService.clearAll()` call sites.
-- [ ] 2.4 Implement boot reconciliation: on init, if authenticated and leftover
-      guest data remains, re-run idempotent migration + clear; run in the
-      earliest boot phase, session-guarded, treating guest localStorage as a
-      promptly-drained pending queue (no resurrection of reverted state).
+      order-independent) AND evicts user-specific caches (e.g. followed-artist
+      projections), preserving the privacy guarantee of the old
+      `GuestService.clearAll()` sign-out path.
+- [ ] 2.4 Implement boot reconciliation keyed on the **guest-merge receipt**:
+      no receipt + leftover queue → migrate, write receipt, clear; receipt
+      already present + residual queue → clear WITHOUT re-migrating (no
+      resurrection). Run early, session-guarded.
 - [ ] 2.5 Tests: migration on `UserCreated`, self-clear, sign-out clear,
       boot-reconcile (incl. the no-resurrect guard). `make check` green.
 - [ ] 2.6 Open PR 2, CI green, merge, release, ship to prod.

--- a/openspec/changes/introduce-entity-store-layer/tasks.md
+++ b/openspec/changes/introduce-entity-store-layer/tasks.md
@@ -1,0 +1,65 @@
+# Tasks
+
+One change, delivered in phased PRs. Each phase ships independently to prod.
+
+## 1. Store-layer scaffold + UserStore (PR 1 — also fixes the guest locale bug)
+
+- [ ] 1.1 Define the store-layer convention (observable state owner + source
+      selection + cache) and a minimal guest storage adapter pattern, following
+      the `OnboardingService` precedent.
+- [ ] 1.2 Introduce `UserStore`: absorb `UserService` (authed `current`) and the
+      guest home + anonymous-period language storage from `GuestService`. Expose
+      a single resolved observable for home and for preferred language
+      (guest = localStorage-backed synthesized view; authed = `User` entity).
+- [ ] 1.3 `UserStore.create(email, locale, home)`: persist Create-time inputs,
+      switch `current` to the authed entity, clear own guest localStorage,
+      publish `UserCreated`.
+- [ ] 1.4 Migrate `SettingsRoute` to read home/language from `UserStore`; remove
+      the `currentLocale` / `currentHome` auth-branching getters and the
+      render-time `I18N.getLocale()` read. Remove `welcome-route`'s
+      `currentLocale` mirror.
+- [ ] 1.5 Verify the guest language-selector highlight is reactive (change en→ja
+      as a guest, reopen selector → reflects ja). Unit + component tests.
+- [ ] 1.6 `make check` green. Open PR 1, CI green, merge, release, ship to prod.
+
+## 2. FollowStore + boundary events + boot reconcile (PR 2)
+
+- [ ] 2.1 Introduce `FollowStore`: absorb `GuestService.follows`/hype and
+      `FollowServiceClient`; cache followed artists; expose observable follow set.
+- [ ] 2.2 Subscribe `UserCreated` → migrate follows + hype (idempotent), then
+      self-clear guest follow localStorage (best-effort). Replaces
+      `GuestDataMergeService.merge()`.
+- [ ] 2.3 Publish/subscribe `SignedOut` → each store self-clears (idempotent,
+      order-independent). Replace `GuestService.clearAll()` call sites.
+- [ ] 2.4 Implement boot reconciliation: on init, if authenticated and leftover
+      guest data remains, re-run idempotent migration + clear; run in the
+      earliest boot phase, session-guarded, treating guest localStorage as a
+      promptly-drained pending queue (no resurrection of reverted state).
+- [ ] 2.5 Tests: migration on `UserCreated`, self-clear, sign-out clear,
+      boot-reconcile (incl. the no-resurrect guard). `make check` green.
+- [ ] 2.6 Open PR 2, CI green, merge, release, ship to prod.
+
+## 3. Cache-only stores (PR 3)
+
+- [ ] 3.1 Rename `ConcertService` → `ConcertStore` and the artist query service →
+      `ArtistStore`; keep their resource caches (e.g. ListTop 50). No guest/authed
+      ownership; no boundary-event participation.
+- [ ] 3.2 Update consumers of the renamed stores. `make check` green.
+- [ ] 3.3 Open PR 3, CI green, merge, release, ship to prod.
+
+## 4. Consumer migration + GuestService removal (PR 4)
+
+- [ ] 4.1 Migrate the remaining `IGuestService` consumers (dashboard,
+      my-artists, discovery, concert-service, user-home-selector,
+      auth-callback, main.ts) to the stores; remove all
+      `auth.isAuthenticated` source-selection branching at call sites.
+- [ ] 4.2 Delete `GuestService` and `GuestDataMergeService` once no references
+      remain.
+- [ ] 4.3 Tests + `make check` green. Open PR 4, CI green, merge, release, ship
+      to prod.
+
+## 5. Close-out
+
+- [ ] 5.1 Confirm all phases live in prod; verify the guest language selector and
+      home flows in the running app.
+- [ ] 5.2 Archive this OpenSpec change.


### PR DESCRIPTION
## Description

Adds the OpenSpec change **`introduce-entity-store-layer`** — the client-side store-layer refactor for the frontend.

Organizes client state by **entity/aggregate** rather than by auth-state. Each entity is owned by an observable **store** that internally resolves its source (guest localStorage vs authenticated backend) and caches its resources, so callers stop branching on `auth.isAuthenticated`. `GuestService` and the entity `*Service` classes dissolve into this layer.

This is the broader, proper solution to the single-source-state / reactivity problem tracked in liverty-music/frontend#368, and it fixes the guest language-selector reactivity defect deliberately left out of `fix-settings-layout`.

Documentation only (OpenSpec artifacts); no proto or generated-code changes.

## Key design decisions

- **`store`** naming (observable state owner + cache + source selection), per-**entity/aggregate** granularity (`UserStore` owns home + language + identity; `FollowStore` owns follows + hype; `ConcertStore`/`ArtistStore` are cache-only).
- **No orchestrator, no completion barrier.** home/language migrate as Create-time inputs; follows migrate post-`UserCreated` in `FollowStore` (idempotent, self-clear); sign-out clears each store via `SignedOut`; partial failures are healed by an idempotent **app-boot reconciliation** (with a no-resurrect guard).

## Changes

- **New capability** `entity-store-layer`: per-entity store ownership, event-driven auth-boundary transitions, boot reconciliation.
- **Modified** `settings` (reactive guest language selector), `user-home`, `user-language-preference`, `guest-data-merge` (per-store event-driven migration + boot reconcile).
- 4 phased PRs in tasks.md (UserStore → FollowStore → cache stores → consumer migration + GuestService removal), each shipping to prod.

## Verification

- `openspec validate introduce-entity-store-layer --strict` passes.

## Related

- Supersedes the earlier `dissolve-guest-service` framing.
- Refs: liverty-music/frontend#368 (implementation lands in frontend phase PRs; not closed here).
