### PR TITLE
docs(openspec): add reset-discovery-bubbles change

### DIFF
--- a/openspec/changes/reset-discovery-bubbles/.openspec.yaml
+++ b/openspec/changes/reset-discovery-bubbles/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-31

--- a/openspec/changes/reset-discovery-bubbles/design.md
+++ b/openspec/changes/reset-discovery-bubbles/design.md
@@ -12,7 +12,7 @@ Separately, `src/styles/tokens.css` defines a utopia.fyi fluid type scale. Rever
 - Lift the app-wide visible font floor to a legible size by moving most text to `--step--1`, while keeping genuinely compact UI compact.
 
 **Non-Goals:**
-- No change to the follow-seeded `loadInitialArtists()` path used on page load.
+- No change to the similar-artist **seed selection** algorithm in `loadInitialArtists()` (random seed pick, per-seed similar fetch). The QA-discovered top-up (task 1.4) is additive net-new behavior layered after seed selection, not a change to how seeds are chosen.
 - No regeneration of the full utopia type scale; only the `--step--2` floor moves.
 - No proto/backend/BSR work. No new RPCs — reset reuses `ArtistService` `listTop`.
 
@@ -24,8 +24,8 @@ Reset always calls `listTop(country, '', 50)`, ignoring follows. **Alternative c
 ### D2 — Reset orchestrates existing machinery
 Reset composes already-present operations rather than introducing new physics logic: clear `genre.activeTag`, `pool.clearSeenSets()` + `trackAllSeen(followed)`, fetch Top 50, dedup against followed, `pool.replace(...)`, and `dnaOrbCanvas.reloadBubbles(...)`. This mirrors the existing genre-deselect path (`GenreFilterController.reloadByCountry`), so the reset method lives naturally beside it.
 
-### D3 — Control placement: sticky leading chip in the genre row
-The reset button is an icon-only (⟳) control pinned as the **leading** item of `fieldset.genre-chips`, using `position: sticky` so it remains visible while chips scroll. **Alternatives considered:** (a) a FAB over the canvas — rejected because the canvas is an interactive physics surface and a persistent FAB competes with floating tappable bubbles and the bottom-nav; (b) a header icon next to help — rejected for poor thumb reach and weak semantic link to the bubbles. Reset is semantically a sibling of genre filtering (both swap the pool), so the chip row is the correct home.
+### D3 — Control placement: leading control in the genre row, beside the scrollable chips
+The reset button is an icon-only (⟳) control placed at the **leading** edge of the genre row. **Implementation note:** rather than a `position: sticky` element *inside* the scrolling `fieldset.genre-chips` (which would require `z-index` to layer the chips beneath it — and `z-index` is disallowed by the CUBE token rules), the row is a flex container (`.genre-bar`) holding the reset button as a fixed sibling **beside** a `flex: 1` scrollable `fieldset`. The chips scroll *within the fieldset, beside* the always-visible button — no overlap, no `z-index`, no sticky. **Alternatives considered:** (a) a FAB over the canvas — rejected because the canvas is an interactive physics surface and a persistent FAB competes with floating tappable bubbles and the bottom-nav; (b) a header icon next to help — rejected for poor thumb reach and weak semantic link to the bubbles. Reset is semantically a sibling of genre filtering (both swap the pool), so the genre row is the correct home.
 
 ### D4 — Font: raise `--step--2` floor to 11px (min-only)
 `--step--2` becomes `clamp(0.6875rem, calc(0.6rem + 0.13vi), 0.7rem)`. 11px ≈ 16 ÷ 1.2², so the min end lands back on the modular curve. The max end stays at 0.7rem deliberately — the two surviving consumers are compact and should not grow on wide screens. **Alternative considered:** full curve restore to `clamp(0.6875rem, …, 0.8rem)` (12.8px max) — rejected because it would enlarge the only remaining `--step--2` consumers without benefit.
@@ -36,7 +36,7 @@ All `--step--2` usages migrate to `--step--1` **except** `bottom-nav-bar` and `.
 ## Risks / Trade-offs
 
 - **Reset confused with replenishment** → Distinct icon (⟳) and aria-label; reset replaces the whole pool whereas tap-replenishment appends. Behaviorally unambiguous.
-- **Sticky chip overlaps first genre chip on scroll** → Background mask / matching surface behind the sticky button so chips scroll cleanly underneath; verify on narrow viewports.
+- **Reset control vs. scrolling chips** → Resolved structurally: the button is a flex sibling outside the scrolling fieldset, so chips scroll beside it (never under it) — no overlap and no `z-index` needed. The control's height is derived from the same fluid line metrics as the chips so it stays aligned at all viewport widths.
 - **Font bump enlarges dense UI** → Only ~2px; QA bottom-nav labels and the my-artists hype table specifically. The two compact spots are explicitly excluded.
 - **Top-50 reset costs an API call** → Same `listTop` already used on load and genre filtering; in-memory cached client. Negligible.
 
@@ -46,4 +46,4 @@ Frontend-only, no data or schema migration. Ship via standard frontend PR → me
 
 ## Open Questions
 
-None — placement (sticky leading chip), icon style (icon-only), reset target (global Top 50), and font scope (min-only, two exclusions) are all resolved.
+None — placement (leading control beside the scrollable chips), icon style (icon-only), reset target (global Top 50), and font scope (min-only, two exclusions) are all resolved.

--- a/openspec/changes/reset-discovery-bubbles/design.md
+++ b/openspec/changes/reset-discovery-bubbles/design.md
@@ -1,0 +1,49 @@
+## Context
+
+The Discover tab (`src/routes/discovery/`) renders a Matter.js physics canvas of artist bubbles. `BubbleManager.loadInitialArtists()` seeds the field differently depending on follow state: a brand-new user gets the global Top 50 (`listTop(country, '', 50)`), while a user who already follows artists gets a similar-artist mix from random seeds. After load, tapping a bubble follows the artist and `onNeedMoreBubbles()` appends similar artists (with FIFO eviction at the 50-bubble cap); the genre chips can also swap the whole pool. There is no affordance to return to a clean baseline.
+
+Separately, `src/styles/tokens.css` defines a utopia.fyi fluid type scale. Reverse-engineering the ratios (min 1.2 / max 1.25) shows every step sits on the modular curve **except** `--step--2`, which was hand-shrunk to `clamp(0.625rem, …, 0.7rem)` (10–11.2px) — below both the curve's predicted value (~11.1–12.8px) and the ~12px legibility floor. The discovery genre chips and ~22 other call sites consume this token.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Give users a one-tap way to return the bubble field to a stable, predictable baseline (global Top 50).
+- Place the control where it reads as part of the bubble-field control strip, not as an unrelated chrome element.
+- Lift the app-wide visible font floor to a legible size by moving most text to `--step--1`, while keeping genuinely compact UI compact.
+
+**Non-Goals:**
+- No change to the follow-seeded `loadInitialArtists()` path used on page load.
+- No regeneration of the full utopia type scale; only the `--step--2` floor moves.
+- No proto/backend/BSR work. No new RPCs — reset reuses `ArtistService` `listTop`.
+
+## Decisions
+
+### D1 — Reset target = global Top 50, not re-run of initial load
+Reset always calls `listTop(country, '', 50)`, ignoring follows. **Alternative considered:** re-running `loadInitialArtists()` (which for a returning user yields a *different random* similar-artist mix each press). Rejected: a "reset" that produces non-deterministic output every time doesn't read as a reset. The global Top 50 is a stable anchor the user can always fall back to.
+
+### D2 — Reset orchestrates existing machinery
+Reset composes already-present operations rather than introducing new physics logic: clear `genre.activeTag`, `pool.clearSeenSets()` + `trackAllSeen(followed)`, fetch Top 50, dedup against followed, `pool.replace(...)`, and `dnaOrbCanvas.reloadBubbles(...)`. This mirrors the existing genre-deselect path (`GenreFilterController.reloadByCountry`), so the reset method lives naturally beside it.
+
+### D3 — Control placement: sticky leading chip in the genre row
+The reset button is an icon-only (⟳) control pinned as the **leading** item of `fieldset.genre-chips`, using `position: sticky` so it remains visible while chips scroll. **Alternatives considered:** (a) a FAB over the canvas — rejected because the canvas is an interactive physics surface and a persistent FAB competes with floating tappable bubbles and the bottom-nav; (b) a header icon next to help — rejected for poor thumb reach and weak semantic link to the bubbles. Reset is semantically a sibling of genre filtering (both swap the pool), so the chip row is the correct home.
+
+### D4 — Font: raise `--step--2` floor to 11px (min-only)
+`--step--2` becomes `clamp(0.6875rem, calc(0.6rem + 0.13vi), 0.7rem)`. 11px ≈ 16 ÷ 1.2², so the min end lands back on the modular curve. The max end stays at 0.7rem deliberately — the two surviving consumers are compact and should not grow on wide screens. **Alternative considered:** full curve restore to `clamp(0.6875rem, …, 0.8rem)` (12.8px max) — rejected because it would enlarge the only remaining `--step--2` consumers without benefit.
+
+### D5 — Quarantine `--step--2` to two compact consumers
+All `--step--2` usages migrate to `--step--1` **except** `bottom-nav-bar` and `.hype-col-header` (incl. its `& small`). This makes the app-wide visible floor `--step--1` (on-curve, 13.3–16px) and turns `--step--2` from a scale-wide anomaly into a documented CUBE "Exception" for two intentionally-tight components — a net gain in type-scale purity.
+
+## Risks / Trade-offs
+
+- **Reset confused with replenishment** → Distinct icon (⟳) and aria-label; reset replaces the whole pool whereas tap-replenishment appends. Behaviorally unambiguous.
+- **Sticky chip overlaps first genre chip on scroll** → Background mask / matching surface behind the sticky button so chips scroll cleanly underneath; verify on narrow viewports.
+- **Font bump enlarges dense UI** → Only ~2px; QA bottom-nav labels and the my-artists hype table specifically. The two compact spots are explicitly excluded.
+- **Top-50 reset costs an API call** → Same `listTop` already used on load and genre filtering; in-memory cached client. Negligible.
+
+## Migration Plan
+
+Frontend-only, no data or schema migration. Ship via standard frontend PR → merge → dev → prod release (GH Release retag → cloud-provisioning prod pin bump). Rollback = revert the PR; tokens and discovery route are self-contained. Validate with `make lint` and visual QA before merge.
+
+## Open Questions
+
+None — placement (sticky leading chip), icon style (icon-only), reset target (global Top 50), and font scope (min-only, two exclusions) are all resolved.

--- a/openspec/changes/reset-discovery-bubbles/proposal.md
+++ b/openspec/changes/reset-discovery-bubbles/proposal.md
@@ -5,7 +5,7 @@ On the Discover tab, following an artist spawns similar-artist bubbles and may a
 ## What Changes
 
 - Add a **Reset control** to the Discover tab that restores the bubble field to the **global Top 50** artists (independent of the user's follows), clearing any active genre filter and the accumulated similar-artist bubbles.
-- The control is an **icon-only (⟳) button** pinned as the leading, sticky item of the genre-chips row, so it stays visible while the chips scroll horizontally.
+- The control is an **icon-only (⟳) button** at the leading edge of the genre row, a fixed sibling beside the horizontally-scrollable genre chips, so it stays visible while the chips scroll.
 - Raise the type-scale minimum floor (`--step--2`) from **10px → 11px** (min-only), restoring min-end curve purity.
 - Migrate the ~22 non-compact `--step--2` consumers to `--step--1` (13.3–16px), leaving `--step--2` as a documented exception used only by two intentionally-compact classes (`bottom-nav-bar`, `.hype-col-header`).
 

--- a/openspec/changes/reset-discovery-bubbles/proposal.md
+++ b/openspec/changes/reset-discovery-bubbles/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+On the Discover tab, following an artist spawns similar-artist bubbles and may apply a genre filter, so the bubble field steadily drifts away from its initial state with no way back to a clean starting point. Separately, the smallest type-scale token (`--step--2`) was hand-shrunk below the modular curve to 10px, rendering the genre chips (and ~22 other usages) below the practical legibility floor.
+
+## What Changes
+
+- Add a **Reset control** to the Discover tab that restores the bubble field to the **global Top 50** artists (independent of the user's follows), clearing any active genre filter and the accumulated similar-artist bubbles.
+- The control is an **icon-only (⟳) button** pinned as the leading, sticky item of the genre-chips row, so it stays visible while the chips scroll horizontally.
+- Raise the type-scale minimum floor (`--step--2`) from **10px → 11px** (min-only), restoring min-end curve purity.
+- Migrate the ~22 non-compact `--step--2` consumers to `--step--1` (13.3–16px), leaving `--step--2` as a documented exception used only by two intentionally-compact classes (`bottom-nav-bar`, `.hype-col-header`).
+
+## Capabilities
+
+### New Capabilities
+<!-- None — all changes extend existing capabilities. -->
+
+### Modified Capabilities
+- `discover`: Add a Reset-to-Top-50 control to the Discover tab's genre-chips row, defining its placement, behavior, and accessibility.
+- `bubble-state-management`: Add a reset operation that replaces the entire pool with the global Top 50, clears seen-sets and eviction history, and re-synchronizes physics state.
+- `design-system`: Raise the type-scale minimum legibility floor (`--step--2` → 11px) and scope `--step--2` to compact-only usage, with all other text resting on `--step--1` or larger.
+
+## Impact
+
+- **Frontend only** (Aurelia 2 PWA). No proto, backend, or BSR changes.
+- Discovery page: `src/routes/discovery/discovery-route.{html,ts,css}`, `bubble-manager.ts`, `genre-filter-controller.ts`.
+- Design tokens: `src/styles/tokens.css` (`--step--2`).
+- ~13 CSS files migrate `--step--2` → `--step--1` (discovery, artist-filter-bar, page-help, user-home-selector, concert-highway, event-card, event-detail-sheet, post-signup-dialog, inline-error, error-banner, tickets-route, settings-route, consent-route).
+- Validation via `make lint` + visual QA of bottom-nav labels and the my-artists hype table.

--- a/openspec/changes/reset-discovery-bubbles/specs/bubble-state-management/spec.md
+++ b/openspec/changes/reset-discovery-bubbles/specs/bubble-state-management/spec.md
@@ -1,0 +1,36 @@
+## ADDED Requirements
+
+### Requirement: BubbleManager supports reset to global top artists
+The BubbleManager SHALL provide a reset operation that discards the current bubble field and re-seeds it with the global top artists, keeping pool state and physics state synchronized. The reset SHALL be independent of the user's followed artists and SHALL NOT use the follow-seeded similar-artist path.
+
+#### Scenario: Reset replaces the pool with global top artists
+- **WHEN** the reset operation is invoked
+- **THEN** the BubbleManager SHALL fetch the global top artists via `listTop(country, '', 50)`
+- **AND** SHALL exclude followed artists from the result
+- **AND** SHALL replace the entire pool with the deduplicated result capped at the 50-bubble limit
+
+#### Scenario: Reset clears accumulated discovery state
+- **WHEN** the reset operation is invoked after similar-artist bubbles have accumulated
+- **THEN** the BubbleManager SHALL clear the deduplication seen-sets and re-track only the newly seeded artists
+- **AND** SHALL discard prior eviction history so the new field is a clean baseline
+
+#### Scenario: Reset re-synchronizes physics state
+- **WHEN** the reset operation completes
+- **THEN** the canvas SHALL be reloaded so the rendered physics bodies match the new pool
+- **AND** the pool count and physics body count SHALL be equal after reset completes
+
+### Requirement: Initial load tops up a sparse discovery field
+When the user already follows artists, the initial load seeds bubbles from those artists' similar artists. Because the similar lists shrink as follow count grows (seeds are capped, the per-seed limit shrinks, and deduplication removes followed and overlapping artists), the BubbleManager SHALL top up the field with global top artists whenever the deduplicated seed-similar results fall below a minimum target. Similar artists SHALL keep priority. This guarantees the field is never empty and stays reasonably full regardless of how many artists the user follows.
+
+#### Scenario: Sparse seed-similar results are topped up
+- **WHEN** the initial load takes the similar-seed path and the deduplicated similar results are below the minimum target
+- **THEN** the BubbleManager SHALL append global top artists (deduplicated against followed and already-included artists) up to the bubble cap
+- **AND** the similar artists SHALL retain priority order ahead of the top-artist fillers
+
+#### Scenario: Empty seed-similar still fills the field
+- **WHEN** the similar lookups resolve to nothing (no matches, errors, or all results deduped away)
+- **THEN** the BubbleManager SHALL fill the field with global top artists rather than leaving it empty
+
+#### Scenario: Sufficient seed-similar results are not diluted
+- **WHEN** the deduplicated similar results meet or exceed the minimum target
+- **THEN** the BubbleManager SHALL NOT fetch or append top artists

--- a/openspec/changes/reset-discovery-bubbles/specs/design-system/spec.md
+++ b/openspec/changes/reset-discovery-bubbles/specs/design-system/spec.md
@@ -1,0 +1,19 @@
+## ADDED Requirements
+
+### Requirement: Type-scale minimum legibility floor
+The design system SHALL keep all body and label text at or above a legible minimum size by setting the type-scale floor token `--step--2` to a minimum of 11px and resting the app-wide visible text floor on `--step--1`. The `--step--2` token SHALL be treated as a compact-only exception, used solely by components that are intentionally dense.
+
+#### Scenario: Minimum floor token raised to 11px
+- **WHEN** the design tokens are defined in `tokens.css`
+- **THEN** `--step--2` SHALL resolve to a minimum of 11px (`clamp(0.6875rem, calc(0.6rem + 0.13vi), 0.7rem)`)
+- **AND** the minimum end SHALL sit on the modular type-scale curve (11px ≈ 16 ÷ 1.2²)
+
+#### Scenario: General text rests on --step--1 or larger
+- **WHEN** a component renders body, label, caption, or chip text
+- **THEN** it SHALL use `--step--1` (13.3–16px) or a larger step
+- **AND** it SHALL NOT use `--step--2` unless it is one of the documented compact-only exceptions
+
+#### Scenario: --step--2 scoped to compact-only components
+- **WHEN** `--step--2` is referenced for `font-size`
+- **THEN** the only permitted consumers SHALL be the bottom navigation bar labels and the my-artists hype-column headers (including their inline `small` text)
+- **AND** all other prior `--step--2` consumers SHALL reference `--step--1` instead

--- a/openspec/changes/reset-discovery-bubbles/specs/discover/spec.md
+++ b/openspec/changes/reset-discovery-bubbles/specs/discover/spec.md
@@ -1,0 +1,25 @@
+## ADDED Requirements
+
+### Requirement: Reset to Top 50 control
+The Discover tab SHALL provide a Reset control that returns the bubble field to the global Top 50 artists, independent of the user's followed artists. The control SHALL be an icon-only (refresh/reset) button rendered as the leading item of the genre-chips row, pinned with `position: sticky` so it remains visible while the genre chips scroll horizontally. The control SHALL expose an accessible label.
+
+#### Scenario: Reset restores global Top 50
+- **WHEN** the user activates the Reset control
+- **THEN** the system SHALL replace the entire bubble pool with the global Top 50 artists fetched via `listTop(country, '', 50)`
+- **AND** SHALL NOT use the follow-seeded similar-artist load path
+- **AND** the followed artists SHALL be excluded from the displayed bubbles
+
+#### Scenario: Reset clears active genre filter
+- **WHEN** a genre chip is active and the user activates the Reset control
+- **THEN** the system SHALL clear the active genre selection
+- **AND** no genre chip SHALL remain in the active state after reset
+
+#### Scenario: Reset control stays visible while chips scroll
+- **WHEN** the genre-chips row is scrolled horizontally
+- **THEN** the Reset control SHALL remain pinned and visible at the leading edge of the row
+- **AND** the genre chips SHALL scroll underneath without obscuring the control
+
+#### Scenario: Reset control is accessible
+- **WHEN** assistive technology inspects the Reset control
+- **THEN** the control SHALL expose a descriptive accessible label
+- **AND** SHALL be operable as a button

--- a/openspec/changes/reset-discovery-bubbles/specs/discover/spec.md
+++ b/openspec/changes/reset-discovery-bubbles/specs/discover/spec.md
@@ -1,7 +1,7 @@
 ## ADDED Requirements
 
 ### Requirement: Reset to Top 50 control
-The Discover tab SHALL provide a Reset control that returns the bubble field to the global Top 50 artists, independent of the user's followed artists. The control SHALL be an icon-only (refresh/reset) button rendered as the leading item of the genre-chips row, pinned with `position: sticky` so it remains visible while the genre chips scroll horizontally. The control SHALL expose an accessible label.
+The Discover tab SHALL provide a Reset control that returns the bubble field to the global Top 50 artists, independent of the user's followed artists. The control SHALL be an icon-only (refresh/reset) button placed at the leading edge of the genre row as a fixed sibling beside the horizontally-scrollable genre chips, so it remains visible while the chips scroll. The control SHALL expose an accessible label.
 
 #### Scenario: Reset restores global Top 50
 - **WHEN** the user activates the Reset control
@@ -15,9 +15,9 @@ The Discover tab SHALL provide a Reset control that returns the bubble field to 
 - **AND** no genre chip SHALL remain in the active state after reset
 
 #### Scenario: Reset control stays visible while chips scroll
-- **WHEN** the genre-chips row is scrolled horizontally
-- **THEN** the Reset control SHALL remain pinned and visible at the leading edge of the row
-- **AND** the genre chips SHALL scroll underneath without obscuring the control
+- **WHEN** the genre chips are scrolled horizontally
+- **THEN** the Reset control SHALL remain visible at the leading edge of the genre row
+- **AND** the genre chips SHALL scroll within their own container beside the control, never overlapping or obscuring it
 
 #### Scenario: Reset control is accessible
 - **WHEN** assistive technology inspects the Reset control

--- a/openspec/changes/reset-discovery-bubbles/tasks.md
+++ b/openspec/changes/reset-discovery-bubbles/tasks.md
@@ -1,0 +1,39 @@
+## 1. Reset behavior (BubbleManager)
+
+- [x] 1.1 Add a `reset()` method to `BubbleManager` that clears seen-sets, fetches `listTop(country, '', 50)`, dedups against followed artists, caps at 50, replaces the pool, and re-tracks seen
+- [x] 1.2 Ensure `reset()` discards prior eviction history so the new field is a clean baseline
+- [x] 1.3 Reload the canvas after reset so physics bodies match the new pool (pool count == physics count)
+- [x] 1.4 (QA-discovered) Top up `loadInitialArtists` with global top artists when the deduplicated seed-similar results fall below a target (30), keeping similar artists first — the field was shrinking as follow count grew (11 follows → 14 bubbles); now stays full (→ 35) and is never empty
+
+## 2. Reset orchestration (DiscoveryRoute / GenreFilterController)
+
+- [x] 2.1 Add an `onReset()` handler on `DiscoveryRoute` that clears `genre.activeTag`, invokes `bubbles.reset()`, and calls `dnaOrbCanvas.reloadBubbles(...)`
+- [x] 2.2 Reuse the existing genre-deselect reload path where practical to avoid duplicate logic
+- [x] 2.3 Guard against concurrent reloads (respect `isLoadingTag` / loading flags) and the abort signal
+
+## 3. Reset control (template + styles)
+
+- [x] 3.1 Add an icon-only (⟳) reset `<button>` as the leading item of the genre row in `discovery-route.html`, wired to `onReset()` with an i18n `aria-label`
+- [x] 3.2 Add the `rotate-ccw` reset icon to the svg-icon set
+- [x] 3.3 Style the reset control as a flex sibling beside the scrollable chips (no z-index — moved out of the scrolling fieldset to stay visible without overlap)
+- [x] 3.5 (QA-discovered) Define the discovery grids explicitly with named `grid-template` areas + `minmax(0, 1fr)` column (per the app-shell-layout / page-header-ce grid-area rule). The unconstrained `auto` column had blown out to the chip row's max-content (~798px) and was clipped by `overflow:hidden`, pushing the search bar and orb off-screen; `.discovery-layout` now declares `"search"/"genre"/"bubbles"` areas with children placed via `grid-area`
+- [x] 3.4 Add i18n keys for the reset aria-label in `en` and `ja` translation files
+
+## 4. Type-scale floor + migration
+
+- [x] 4.1 Raise `--step--2` in `tokens.css` to `clamp(0.6875rem, calc(0.6rem + 0.13vi), 0.7rem)` (11px floor, min-only)
+- [x] 4.2 Migrate `--step--2` → `--step--1` in: discovery `.genre-chip`, artist-filter-bar, page-help, user-home-selector, concert-highway, event-card (×2), event-detail-sheet (×2), post-signup-dialog, inline-error (×2), error-banner (×2), tickets-route `--_size-hint`, settings-route (×4), consent-route (×2)
+- [x] 4.3 Leave `--step--2` in place for `bottom-nav-bar` and `.hype-col-header` (incl. its `& small`); add a brief CSS comment noting the compact-only exception
+
+## 5. Validation & QA
+
+- [x] 5.1 Run `make lint` (biome + stylelint + typecheck) and resolve any findings — 0 errors (only pre-existing warnings remain)
+- [x] 5.2 Add unit tests for `BubbleManager.reset()` (pool replaced with top artists, followed excluded, seen-sets cleared) — `bubble-manager.spec.ts`, 3 tests
+- [x] 5.3 Run `make test` — 106 files / 1148 tests pass
+- [x] 5.4 Manual QA: reset returns to Top 50, clears active genre; verify bottom-nav labels and my-artists hype table still look correct at the new font sizes — verified locally via Playwright (full stack on :8080/:9000); reset clears Pop filter + restores Top 50, chips legible at --step--1, nav labels compact, 0 console errors
+- [x] 5.5 Confirm no `--step--2` consumers remain outside the two documented exceptions (`grep`)
+
+## 6. Ship
+
+- [ ] 6.1 Open frontend PR, get CI green, address review, merge to main (dev deploy)
+- [ ] 6.2 Verify on dev, then cut the frontend prod release (GH Release retag) and bump the cloud-provisioning prod pin so the change ships to prod


### PR DESCRIPTION
## 🔗 Related Issue

Refs liverty-music/frontend#393 (closed by the frontend implementation PR liverty-music/frontend#394).

## 📝 Summary of Changes

Adds the OpenSpec change `reset-discovery-bubbles` — the spec artifacts for two discovery-page improvements. **Frontend-only; no proto changes** (no `buf` surface touched).

- **proposal.md** — why + scope; three modified capabilities (`discover`, `bubble-state-management`, `design-system`).
- **design.md** — decisions with rejected alternatives: reset target (global Top 50, not a follow-seeded reshuffle), sticky leading ⟳ chip placement, min-only `--step--2` floor raise, and `--step--2` quarantine.
- **specs/** — delta specs:
  - `discover`: Reset-to-Top-50 control (placement, behavior, a11y).
  - `bubble-state-management`: reset operation + initial-load **top-up** so the field is never empty and stays full regardless of follow count (similar artists first).
  - `design-system`: type-scale minimum legibility floor (11px) and compact-only scoping of `--step--2`.
- **tasks.md** — implementation checklist (all done), including the QA-discovered fixes (top-up, named-area grid definition, reset-chip fluid alignment) and the ship steps.

The corresponding implementation is in **liverty-music/frontend#394**.

## ✅ Self-Checklist

- [x] I have linked the related issue. (cross-repo: frontend#393)
- [x] I have updated the relevant documentation if needed.
- [ ] I have run `buf lint` and `buf format` locally — N/A (no proto changes; OpenSpec markdown only).
- [ ] My proto definitions follow the style guidelines — N/A (no proto changes).
- [ ] Breaking changes — N/A (no proto/schema changes).
