### PR TITLE
docs(analytics): clarify PostHog billing caps are org-level

### DIFF
--- a/docs/analytics/posthog-project-setup.md
+++ b/docs/analytics/posthog-project-setup.md
@@ -42,7 +42,7 @@ settings → Billing → Spending controls):
 
 | Product | Hard cap | Rationale |
 | --- | --- | --- |
-| Product Analytics | **$20/month** (prod) | Only actively-used product. $20 covers ~80M events above the 1M free tier — generous headroom while bounding runaway-bug cost. Dev / staging billing caps can be lazier; dev typically has negligible traffic. |
+| Product Analytics | **$20/month** | Only actively-used product. $20 covers ~80M events above the 1M free tier — generous headroom while bounding runaway-bug cost. This is an org-level cap sized for prod traffic; dev and staging have negligible traffic and will naturally stay within it. |
 | Session Replay | **$0** | Disabled at SDK level and project level (see §4). Cap-at-zero locks accidental enablement out. |
 | Feature Flags | **$0** | `IAnalyticsService.getFeatureFlag` is wired but no flags are evaluated yet. Bump only when an actual flag goes into rollout. |
 | Experiments | **$0** | Not used. |


### PR DESCRIPTION
## Description

Follow-up to the merged PostHog runbook (#546). Clarifies that PostHog billing caps are configured **org-wide**, not per-project, fixing a self-contradiction between §2 and §7 of `docs/analytics/posthog-project-setup.md`.

PostHog spending controls are a single set of caps for the whole organisation — there is no per-project configuration. §7 already states this, but the §2 phrasing (`$20/month (prod)` + "Dev / staging billing caps can be lazier") implied per-project caps, so an operator following §2 would look for controls that do not exist. This was raised as an automated review comment on #546 but the PR merged before it was addressed; this PR resolves it as a follow-up.

## Changes

- `docs/analytics/posthog-project-setup.md`: reword the Product Analytics row of the §2 billing table.
  - Drop the misleading `(prod)` qualifier on the `$20/month` cap.
  - State that the `$20` is an **org-level** cap sized for prod traffic, and dev/staging have negligible traffic and naturally stay within it.

## Type of Change

- [x] docs: Documentation only

## Verification

Documentation-only change; no proto or code impact (no BSR gen / Release needed).

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

Refs: #532
