### PR TITLE
docs(openspec): revise pin-bump bypass to ci-bot App (D9), relax D1 boundary

### DIFF
--- a/openspec/changes/automate-prod-pin-bump/design.md
+++ b/openspec/changes/automate-prod-pin-bump/design.md
@@ -85,6 +85,17 @@ environment: ${{ github.event_name == 'workflow_dispatch' && 'prod-pin' || '' }}
 
 `repository_dispatch` runs resolve the environment to the empty string and never enter `prod-pin`, so the required-reviewer rule is skipped and the release path stays unattended; `workflow_dispatch` runs enter `prod-pin` and pause for admin approval. (Alternatives considered: splitting into two single-trigger workflows — cleaner isolation but two files to keep in sync; or a job-level `if:` actor-allowlist guard — less auditable than an Environment gate. The conditional-environment expression is the minimal change that satisfies both requirements.) The fallback is documented as a privileged admin-only recovery operation, not a routine path.
 
+### D9: The `main` bypass actor is the org-owned ci-bot App, not `github-actions[bot]` (revises D1)
+
+**Discovered during prod rollout.** D1/D8 assumed the bump push would be done by the built-in `GITHUB_TOKEN` (`github-actions[bot]`), with the `main` bypass scoped to that actor — keeping the cross-repo dispatch credential unable to push `main`. Applying that hit two hard GitHub limits:
+
+1. **Repository ruleset + `github-actions` bypass → `422`:** *"Actor GitHub Actions integration must be part of the ruleset source or owner organization."* The global `github-actions` app is GitHub-owned, so it cannot be a bypass actor on a *repository* ruleset (only org-owned or repo-installed Apps qualify).
+2. **Organization ruleset (which *does* accept the `github-actions` integration) → `403`:** *"Upgrade to GitHub Team to enable this feature."* Org rulesets require a paid plan; the org is on Free. (Classic `BranchProtection` was also ruled out: it has no per-actor bypass for the strict up-to-date status check.)
+
+**Chosen:** a **repository ruleset** whose sole bypass actor is the **org-owned `liverty-music-ci-bot` App** (org-owned Apps pass the repo-ruleset validation). `bump-prod-pin.yml` mints a ci-bot installation token and pushes `main` as the App.
+
+**Consequence — relaxes the D1 boundary:** ci-bot is also the dispatch credential held on the backend/frontend `prod` environments, so a compromised prod release workflow *can* now push `cloud-provisioning:main` (move prod) directly — exactly what D1's "Auth blast radius" argument sought to prevent. Accepted for a solo-dev org because: (a) the ci-bot secrets are scoped to the `prod` GitHub Environment (release events only, not arbitrary workflows), (b) the provenance gate (D7) still blocks bogus-tag pins, and (c) cutting the GitHub Release remains the human gate. **Open question / future hardening:** restore the strict boundary by introducing a dedicated push-only App (installed and keyed only on `cloud-provisioning`) as the bypass actor, distinct from the dispatch credential — at the cost of a second App to manage.
+
 ## Risks / Trade-offs
 
 - **A bad/bogus tag corrupts `cloud-provisioning:main`** → Mitigated by D7 (prod-AR manifest existence check, fail-closed, *before* the edit) + D2 (`kustomize build`) + D4 idempotency. A non-existent tag is rejected before any commit; a structurally-valid-but-wrong real tag is still caught by ArgoCD at sync, and the bogus-tag *silent* path is eliminated.

--- a/openspec/changes/automate-prod-pin-bump/proposal.md
+++ b/openspec/changes/automate-prod-pin-bump/proposal.md
@@ -7,10 +7,10 @@ Promoting a release to prod today is a two-gate process: cutting the GitHub Rele
 - The backend (`deploy.yml`) and frontend (`push-image.yaml`) release paths SHALL, **after** the prod-AR retag succeeds, emit a GitHub `repository_dispatch` event to `liverty-music/cloud-provisioning` carrying `{ component, tag, sha }` (component ∈ `backend | frontend`).
 - A **new** `cloud-provisioning` workflow (`bump-prod-pin.yml`) SHALL receive that dispatch and, for the named component, rewrite the prod overlay's `images[].newTag` (all 4 entries for backend, the single `web-app` entry for frontend) and the `app.kubernetes.io/version` label to the new release version, in lock-step.
 - The bump workflow SHALL **validate** `kustomize build` of the affected prod overlay before committing; a build failure aborts the push (replacing the CI gate the manual PR used to provide).
-- The bump workflow SHALL commit and push **directly to `cloud-provisioning:main`** using its own `GITHUB_TOKEN` (the `github-actions[bot]` actor), bypassing the manual-PR step. ArgoCD's existing auto-sync then rolls the change out.
+- The bump workflow SHALL commit and push **directly to `cloud-provisioning:main`** as the org-owned `liverty-music-ci-bot` App (minting an installation token), bypassing the manual-PR step. ArgoCD's existing auto-sync then rolls the change out. (The built-in `GITHUB_TOKEN` / `github-actions[bot]` cannot be a repo-ruleset bypass actor — see design D9.)
 - The bump SHALL be **idempotent** (no-op if `newTag` already equals the target) and SHALL **rebase-retry** on push rejection to tolerate a backend+frontend release landing close together.
 - The manual pin-bump PR ceases to be the rollout gate. The Release act becomes the single human gate; the dispatch → validate → push chain is fully automated.
-- Cross-repo auth uses `repository_dispatch` specifically so the release workflows hold **no** write credential to `cloud-provisioning` — the bump workflow pushes to *its own* repo with the built-in token. No long-lived PAT is introduced.
+- Cross-repo auth uses a short-lived `liverty-music-ci-bot` GitHub App installation token (no long-lived PAT). The same App is the `main` ruleset bypass actor, so — unlike the original intent (design D1) — the release-held credential CAN push `cloud-provisioning:main`; this relaxed boundary is mitigated by prod-environment secret scoping, the provenance gate, and Release-as-gate (design D9).
 
 ## Capabilities
 
@@ -25,6 +25,6 @@ Promoting a release to prod today is a two-gate process: cutting the GitHub Rele
 - **`liverty-music/backend`** — `deploy.yml`: append a `repository_dispatch`-emitting step to the release path, gated on all 4 retag matrix entries succeeding.
 - **`liverty-music/frontend`** — `push-image.yaml`: append the same dispatch step to the release path; optionally chain the existing prod smoke (`workflow_dispatch` → automatic) after rollout.
 - **`liverty-music/cloud-provisioning`** — new `.github/workflows/bump-prod-pin.yml`; the prod overlays under `k8s/namespaces/{backend,frontend}/overlays/prod/kustomization.yaml` become CI-written for the `newTag` + version-label fields.
-- **GitHub settings** — `cloud-provisioning` branch protection / ruleset MUST add `github-actions[bot]` as a bypass actor for direct `main` push (and thereby the up-to-date requirement). No new secrets.
+- **GitHub settings** — `cloud-provisioning:main` is governed by a repository ruleset whose sole bypass actor is the `liverty-music-ci-bot` App (covering the PR + up-to-date requirements). The ci-bot App credential is provisioned as backend/frontend `prod` environment secrets (dispatch) and cloud-provisioning repository secrets (push).
 - **Operational** — prod rollout latency drops from "manual PR + rebase + merge" to "dispatch + kustomize validate + push" (seconds). Rollback remains `git revert` of the bump commit. ArgoCD auto-sync behavior is unchanged.
 - **Risk surface** — a buggy edit could push a broken manifest to prod; mitigated by the mandatory `kustomize build` validation gate and idempotency. ArgoCD still self-heals/prunes as before.

--- a/openspec/changes/automate-prod-pin-bump/specs/prod-image-pipeline/spec.md
+++ b/openspec/changes/automate-prod-pin-bump/specs/prod-image-pipeline/spec.md
@@ -2,7 +2,9 @@
 
 ### Requirement: Prod kustomize pin-bumps SHALL be automated via repository_dispatch
 
-After a release path successfully promotes images to prod AR, the originating workflow SHALL trigger an automated update of the prod kustomize pin in `cloud-provisioning` rather than relying on a manually-authored pull request. The backend `deploy.yml` and frontend `push-image.yaml` release paths SHALL emit a GitHub `repository_dispatch` event to `liverty-music/cloud-provisioning` with `event_type: bump-prod-pin` and a `client_payload` of `{ component, tag, sha }`, where `component` is `backend` or `frontend`, `tag` is the release tag (`vX.Y.Z`), and `sha` is `${GITHUB_SHA}`. The dispatch trigger SHALL be the only cross-repo action the release workflows perform. The dispatch credential requires `Contents: write` on `cloud-provisioning` (the documented minimum for `repository_dispatch`); the release workflows therefore SHALL NOT be able to push to `cloud-provisioning:main` — that protection rests on branch protection (bypass scoped to `github-actions[bot]` only, see "cloud-provisioning branch protection SHALL allow the bot to bypass"), not on the token's content scope. Because ArgoCD tracks `main` only, a dispatch credential limited to non-`main` refs cannot move prod.
+After a release path successfully promotes images to prod AR, the originating workflow SHALL trigger an automated update of the prod kustomize pin in `cloud-provisioning` rather than relying on a manually-authored pull request. The backend `deploy.yml` and frontend `push-image.yaml` release paths SHALL emit a GitHub `repository_dispatch` event to `liverty-music/cloud-provisioning` with `event_type: bump-prod-pin` and a `client_payload` of `{ component, tag, sha }`, where `component` is `backend` or `frontend`, `tag` is the release tag (`vX.Y.Z`), and `sha` is `${GITHUB_SHA}`. The dispatch trigger SHALL be the only cross-repo action the release workflows perform. The dispatch credential is the org-owned `liverty-music-ci-bot` GitHub App, which requires `Contents: write` on `cloud-provisioning` (the documented minimum for `repository_dispatch`).
+
+> **Boundary note (revised during implementation — see design D9).** The original design (D1) intended the release workflows to be unable to push to `cloud-provisioning:main`, with the `main` bypass scoped to `github-actions[bot]` only. That proved infeasible: a repository ruleset rejects the global `github-actions` integration as a bypass actor (`422 — must be part of the ruleset source or owner organization`, GitHub-owned), and an organization ruleset (which would accept it) requires a GitHub Team plan (`403` on Free). The `main` bypass actor is therefore the org-owned `ci-bot` App — the same credential the release workflows hold — so a compromised prod release workflow CAN push `cloud-provisioning:main`. This relaxed boundary is accepted and mitigated by: the ci-bot secrets being scoped to the `prod` environment (release events only), the provenance gate (a bump cannot pin a non-existent prod image), and the GitHub Release remaining the human gate. The strict boundary MAY be restored later by introducing a dedicated push-only App (keyed/installed only on `cloud-provisioning`) as the bypass actor.
 
 The dispatch step SHALL run only after the prod-AR retag for that component has succeeded. For the backend's 4-image `fail-fast: false` matrix, the dispatch SHALL be a job gated on the retag job completing successfully (`needs` + `if: <retag>.result == 'success'`), so a partially-failed retag never bumps the pin to a release tag whose prod images are incomplete.
 
@@ -22,11 +24,12 @@ The dispatch step SHALL run only after the prod-AR retag for that component has 
 - **THEN** the dispatch step SHALL NOT run
 - **AND** no `bump-prod-pin` event SHALL be emitted to `cloud-provisioning`
 
-#### Scenario: Release workflows cannot push to cloud-provisioning main
+#### Scenario: Dispatch credential is the org-owned ci-bot App, prod-env scoped
 
 - **WHEN** inspecting the secrets/permissions used by the dispatch step in `deploy.yml` and `push-image.yaml`
-- **THEN** the credential SHALL be limited to the `repository_dispatch` trigger (a fine-grained PAT or GitHub App token; `Contents: write` is the documented minimum for the dispatches API)
-- **AND** branch protection on `cloud-provisioning:main` SHALL deny that credential a push to `main` (bypass scoped to `github-actions[bot]` only), so the release job cannot directly push a manifest change that ArgoCD would sync
+- **THEN** the credential SHALL be the `liverty-music-ci-bot` GitHub App (App id + private key), with `Contents: write` (the documented minimum for the dispatches API)
+- **AND** those secrets SHALL be scoped to the backend/frontend `prod` GitHub Environments (release events), NOT org-wide
+- **AND** because that same App is the `cloud-provisioning:main` ruleset bypass actor (design D9), a release workflow CAN push `main`; this relaxed boundary SHALL be mitigated by the prod-environment scoping, the provenance gate, and the Release-as-human-gate (it SHALL NOT rely on the token being unable to push `main`)
 
 ### Requirement: A cloud-provisioning workflow SHALL apply the prod pin-bump on dispatch
 
@@ -34,7 +37,7 @@ The dispatch step SHALL run only after the prod-AR retag for that component has 
 
 Before editing, the workflow SHALL validate the payload: `component` SHALL be one of `backend | frontend` and `tag` SHALL match `^v[0-9]+\.[0-9]+\.[0-9]+$`. Shape validation alone is insufficient — the workflow SHALL ALSO verify **image provenance** before any edit: for every image of the component (the 4 backend images, or the single `web-app` image) it SHALL confirm the prod-AR image at the target tag exists via `crane manifest asia-northeast2-docker.pkg.dev/liverty-music-prod/<component>/<img>:<tag>`. A missing manifest for any image SHALL abort the run before any file is edited (fail-closed). Because a prod-AR image at `:<tag>` exists only if the release retag wrote it, this provenance gate confirms the tag names a genuine release whose retag completed, and prevents a well-formed-but-bogus or stale tag from corrupting `main` (including the silent-downgrade-to-bogus-tag case).
 
-The workflow SHALL then validate the edited overlay with `kustomize build k8s/namespaces/<component>/overlays/prod` BEFORE committing; a non-zero build SHALL abort the run without pushing. On success it SHALL commit and push directly to `cloud-provisioning:main` using the workflow's own `GITHUB_TOKEN` (the `github-actions[bot]` actor). ArgoCD's existing auto-sync rolls the change out — the workflow SHALL NOT open a pull request.
+The workflow SHALL then validate the edited overlay with `kustomize build k8s/namespaces/<component>/overlays/prod` BEFORE committing; a non-zero build SHALL abort the run without pushing. On success it SHALL commit and push directly to `cloud-provisioning:main` using a `liverty-music-ci-bot` GitHub App installation token (the App is the `main` ruleset bypass actor — see design D9; the built-in `GITHUB_TOKEN` / `github-actions[bot]` cannot be a repo-ruleset bypass actor). ArgoCD's existing auto-sync rolls the change out — the workflow SHALL NOT open a pull request.
 
 #### Scenario: Dispatch updates newTag and version label in lock-step
 
@@ -59,7 +62,7 @@ The workflow SHALL then validate the edited overlay with `kustomize build k8s/na
 #### Scenario: Successful bump pushes directly to main, no PR
 
 - **WHEN** the edit validates and differs from the current pin
-- **THEN** the workflow SHALL commit and push to `cloud-provisioning:main` as `github-actions[bot]`
+- **THEN** the workflow SHALL commit and push to `cloud-provisioning:main` as the `liverty-music-ci-bot` App
 - **AND** SHALL NOT open a pull request
 - **AND** ArgoCD SHALL subsequently auto-sync the prod overlay to the new tag
 
@@ -74,23 +77,23 @@ The workflow SHALL then validate the edited overlay with `kustomize build k8s/na
 - **THEN** the workflow SHALL serialize the runs (`concurrency` group) and/or rebase-retry the push so that both the backend overlay and the frontend overlay end up bumped on `main`
 - **AND** neither bump SHALL be lost to a push rejection
 
-### Requirement: cloud-provisioning branch protection SHALL allow the bot to bypass for the pin-bump push
+### Requirement: cloud-provisioning main ruleset SHALL allow the ci-bot App to bypass for the pin-bump push
 
-To permit `bump-prod-pin.yml` to push directly to `cloud-provisioning:main`, the repository's branch protection / ruleset SHALL list `github-actions[bot]` as a bypass actor for the `main` branch (covering both the pull-request requirement and the "require branches up to date" requirement). No human identity and no long-lived personal access token SHALL be added as a bypass actor for this purpose.
+To permit `bump-prod-pin.yml` to push directly to `cloud-provisioning:main`, the repository's `main` ruleset SHALL list the org-owned `liverty-music-ci-bot` GitHub App as a bypass actor (`actorType: Integration`, covering both the pull-request requirement and the "require branches up to date" requirement). The bypass actor SHALL NOT be the built-in `github-actions[bot]` — a repository ruleset rejects the global `github-actions` integration ("must be part of the ruleset source or owner organization"), and an org ruleset (which would accept it) requires a GitHub Team plan; an org-owned App is the available mechanism. No human identity and no long-lived personal access token SHALL be added as a bypass actor.
 
-#### Scenario: Bot push to main is accepted
+#### Scenario: ci-bot push to main is accepted
 
-- **WHEN** `bump-prod-pin.yml` pushes a validated pin-bump commit to `cloud-provisioning:main` as `github-actions[bot]`
-- **THEN** branch protection SHALL accept the push without requiring a pull request or an up-to-date branch
+- **WHEN** `bump-prod-pin.yml` pushes a validated pin-bump commit to `cloud-provisioning:main` authenticated as a `liverty-music-ci-bot` installation token
+- **THEN** the ruleset SHALL accept the push without requiring a pull request or an up-to-date branch
 
-#### Scenario: Human pushes still obey branch protection
+#### Scenario: Human pushes still obey the ruleset
 
-- **WHEN** a human (non-bot) attempts to push directly to `cloud-provisioning:main`
-- **THEN** branch protection SHALL continue to require a pull request and the up-to-date check (the bypass SHALL be scoped to `github-actions[bot]` only)
+- **WHEN** a human (or any non-ci-bot actor, including `github-actions[bot]`) attempts to push directly to `cloud-provisioning:main`
+- **THEN** the ruleset SHALL continue to require a pull request and the up-to-date check (the bypass SHALL be scoped to the `liverty-music-ci-bot` App only)
 
 ### Requirement: The manual pin-bump fallback SHALL be admin-gated
 
-`bump-prod-pin.yml` SHALL provide a `workflow_dispatch` fallback (manual `component` + `tag` + `sha` inputs) for dropped-dispatch recovery. Because `workflow_dispatch` runs as `github-actions[bot]` — the branch-protection bypass actor — and is reachable by any contributor with `actions: write`, the bump job SHALL require admin approval via a GitHub Environment (e.g. `prod-pin`) with a required-reviewer rule **on the manual trigger only**. Since Environment protection rules have no trigger-type filter (they apply to every job referencing the environment), the workflow SHALL bind the environment conditionally — `environment: ${{ github.event_name == 'workflow_dispatch' && 'prod-pin' || '' }}` (or an equivalent two-workflow split) — so that `repository_dispatch` runs do NOT enter `prod-pin` and proceed unattended, while `workflow_dispatch` runs enter `prod-pin` and pause for approval. This fallback SHALL be documented as a privileged admin-only recovery operation, not a routine path. The provenance gate (see "A cloud-provisioning workflow SHALL apply the prod pin-bump on dispatch") applies to the fallback identically, so even an approved manual run cannot pin a tag whose prod image does not exist.
+`bump-prod-pin.yml` SHALL provide a `workflow_dispatch` fallback (manual `component` + `tag` + `sha` inputs) for dropped-dispatch recovery. Because a `workflow_dispatch` run mints a ci-bot token and pushes to `main` as the `liverty-music-ci-bot` App — the ruleset bypass actor — and is reachable by any contributor with `actions: write`, the bump job SHALL require admin approval via a GitHub Environment (e.g. `prod-pin`) with a required-reviewer rule **on the manual trigger only**. Since Environment protection rules have no trigger-type filter (they apply to every job referencing the environment), the workflow SHALL bind the environment conditionally — `environment: ${{ github.event_name == 'workflow_dispatch' && 'prod-pin' || '' }}` (or an equivalent two-workflow split) — so that `repository_dispatch` runs do NOT enter `prod-pin` and proceed unattended, while `workflow_dispatch` runs enter `prod-pin` and pause for approval. This fallback SHALL be documented as a privileged admin-only recovery operation, not a routine path. The provenance gate (see "A cloud-provisioning workflow SHALL apply the prod pin-bump on dispatch") applies to the fallback identically, so even an approved manual run cannot pin a tag whose prod image does not exist.
 
 #### Scenario: Manual fallback requires admin approval
 


### PR DESCRIPTION
## 🔗 Related Issue
Refs #553

## 📝 Summary of Changes
Documentation-only update to the `automate-prod-pin-bump` change artifacts, recording the implementation pivot forced by two GitHub limits hit during the prod rollout:
1. A **repository ruleset** rejects the global `github-actions` integration as a bypass actor — `422 "Actor GitHub Actions integration must be part of the ruleset source or owner organization"` (GitHub-owned, not org-owned).
2. An **organization ruleset** (which would accept it) requires a **GitHub Team plan** — `403` on Free.

So the `main` ruleset bypass actor is the org-owned **`liverty-music-ci-bot` App**, and `bump-prod-pin.yml` pushes as that App.

- **design.md**: adds **D9** (the 422/403 findings + the ci-bot-pusher decision) and records that it **relaxes D1** (the dispatch credential can now push `cloud-provisioning:main`), with mitigations and the future-hardening option (a dedicated push-only App).
- **spec.md**: updates the requirement text + scenarios — pusher/bypass actor is the ci-bot App (not `github-actions[bot]`); the "cannot push main" scenario becomes the "ci-bot is the dispatch credential AND the bypass actor; relaxed boundary mitigated by prod-env scoping + provenance + Release gate".
- **proposal.md**: same correction in the What Changes / Impact bullets.

No proto changes. Matches the implemented code in liverty-music/cloud-provisioning#341.
