### PR TITLE
docs(openspec): archive redesign-settings-ui + sync settings spec

### DIFF
--- a/openspec/changes/archive/2026-06-01-redesign-settings-ui/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-01-redesign-settings-ui/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-01

--- a/openspec/changes/archive/2026-06-01-redesign-settings-ui/design.md
+++ b/openspec/changes/archive/2026-06-01-redesign-settings-ui/design.md
@@ -1,0 +1,107 @@
+## Context
+
+The Settings page lives in the `frontend` repo (Aurelia 2 PWA) at `src/routes/settings/settings-route.{html,ts,css}`, with copy in `src/locales/{ja,en}/translation.json`. It follows CUBE CSS (`@layer` + `@scope`) and uses design tokens from `src/styles/tokens.css`.
+
+Current toggle anatomy: each toggle row is a single `<button role="switch">` containing a `.settings-toggle-col` (label + `.settings-row-hint`) on the left and a `.settings-toggle-track` (with an absolutely-positioned `.settings-toggle-thumb`) on the right, laid out with `display:flex; align-items:center; justify-content:space-between`.
+
+Verified defect (Playwright, viewport 412px, real tokens + real CSS): `.settings-toggle-track` has computed `flex-shrink: 1` (no `flex-shrink: 0`), so under the long Japanese consent description it collapses from its declared `2.75rem` (44px) to **20.63px**. The thumb uses a fixed `transform: translateX(1.25rem)` for the ON state, so it ends **21.38px past the (collapsed) track's right edge** and **4.05px past the card's right edge** — matching the "white dot pinned to the card edge, no visible track" symptom in the reported screenshot.
+
+The second analytics toggle (`marketingConsent`) binds to `consent.marketingMeasurement` and is consumed by both the signup consent screen (`src/routes/consent/consent-route.ts`) and the Settings opt-out (`src/routes/settings/settings-route.ts`). The in-flight `introduce-analytics-tool` change (`analytics-consent`) mandates per-purpose toggles and a persistent Settings opt-out. The current Settings label frames this purpose as geography ("海外での分析処理を許可する"), which is a labeling defect, not a redundant control.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Toggle track keeps its size and the thumb stays contained, for any description length, on a 412px-class viewport.
+- Long consent descriptions are collapsible/expandable with correct switch + disclosure accessibility semantics.
+- Consent toggle copy is purpose-based and opt-in friendly; the marketing toggle is relabeled (not removed).
+- The guest sign-in/sign-up CTA is a prominent top-of-page hero; authenticated account controls stay at the bottom.
+- The iOS sound hint only appears on iOS.
+- No regressions to existing Settings behaviors (home area, language, push, sign out) or to the consent state model shared with `consent-route`.
+
+**Non-Goals:**
+
+- No backend, proto, or RPC changes.
+- No change to *what* consent data is collected or to the signup consent flow's behavior — only the Settings-page rendering/labeling of existing purposes.
+- The cross-border (PostHog/Netherlands) legal disclosure is out of scope here; it remains owned by the signup consent screen and privacy policy.
+- Not introducing a full design-system button library (see decision on CTA styling).
+
+## Decisions
+
+### D0. Settings list layout engine: card-grid + row-subgrid (supersedes per-row flex)
+
+The rows were originally independent flex containers that pushed their trailing control to the right edge per-row, so cross-row column alignment was *emergent* — it held only while every row's box model matched exactly. It didn't: the consent rows wrapped the toggle in a `.settings-switch` button whose UA/explicit padding inset the track ~6–8px, and the disclosure split shifted vertical alignment. The toggle misalignment was a symptom of this fragility.
+
+Decision: make `.settings-card` a grid (`grid-template-columns: auto 1fr auto` → lead icon | content | trailing control) and every `.settings-row` a `subgrid` spanning those tracks. Alignment becomes *structural* — icons, labels, and trailing controls snap to shared column lines regardless of each row's content or inner markup. Rows that don't fit the 3-column model (sign-out, volume slider, dividers) opt out via `grid-column: 1 / -1`.
+
+- Per `modern-web-guidance` (css-layout) and `web-design-specialist` (layout-engines): subgrid is Baseline (since 2023-09-15, incl. iOS Safari 16+); the canonical "form labels aligned across fields / ragged-edge card" subgrid pattern is exactly this case. Each `subgrid` line carries an explicit track list above it as a same-cascade fallback.
+- a11y: whole-row interactive rows (`<button>`/`<a>`) become the subgrid container themselves (`display: grid; grid-template-columns: subgrid`) — the element keeps its box and role; `display: contents` is avoided (drops the box, historically breaks AT). Split consent rows keep the icon as a direct row child (col1) so no nested subgrid is needed: disclosure → col2, switch → col3.
+- A `<button>.settings-row` inherits UA `text-align: center`; since the label is a stretched col2 grid item, the row resets `text-align: start` so labels left-align instead of drifting to the column centre.
+- This replaces D1/D2's flex-specific fixes (still valid as defence-in-depth: `flex-shrink: 0` now guards only the in-`.settings-switch` track).
+
+### D1. Fix track sizing with `flex-shrink: 0` + text-column `min-inline-size: 0`
+
+Add `flex-shrink: 0` to `.settings-toggle-track` so it never collapses, and `min-inline-size: 0` to the text column so it absorbs the remaining width and wraps instead of starving the track. Switch the row to `align-items: flex-start` for toggle rows so the control aligns to the first line.
+
+- *Alternative considered*: give the track an explicit `flex-basis`/`min-inline-size` only. Rejected — `flex-shrink: 0` is the direct, intent-revealing fix and is the actual missing declaration; the text column still needs `min-inline-size: 0` to wrap correctly.
+
+### D2. Stop double-purposing `.settings-row-hint`'s indent
+
+`.settings-row-hint` carries `margin-inline-start: var(--space-l)` to align icon-less hints under a label. Inside the toggle column this indent compounds the width starvation. Decouple the toggle description's styling from the icon-alignment hint (separate class / no inherited inline-start margin) so the description can use the full column width.
+
+### D3. Split the switch row into disclosure + switch siblings
+
+To make the description expandable without nesting interactive elements inside a `role="switch"` button, restructure the row into two sibling controls:
+
+- a disclosure `<button aria-expanded>` wrapping the label + collapsible description + chevron, and
+- the `<button role="switch" aria-checked>` for the track/thumb.
+
+The chevron only renders when a collapsible description exists. The switch's activation target gets vertical padding so the tap target reaches ≥44px in the block dimension even though the visible track is 24px tall.
+
+- *Trade-off*: the generous "tap anywhere on the row toggles the switch" behavior is lost; tapping the text area now expands rather than toggles. This is the unavoidable cost of accessible disclosure semantics and is acceptable for a low-frequency settings control.
+- *Alternative considered*: a tooltip/popover `(i)` button instead of inline expand. Rejected — inline disclosure keeps the explanation in context and avoids an extra overlay primitive.
+
+### D4. Relabel marketing toggle to its purpose; keep it visible
+
+Change `settings.analytics.crossBorderLabel`/`crossBorderDescription` (and the `en` mirror) to describe ad-effectiveness measurement. Keep the toggle bound to `marketingMeasurement`. Do not add a domestic/overseas region switch.
+
+Proposed JA copy (subject to `brand-vocabulary` lint):
+- Section: keep `プライバシーと分析`.
+- Analytics: label `使い心地の改善に協力する`; desc `「どこで迷いやすいか」を匿名データから見つけ、次のアップデートに活かします。個人を特定する情報は集めません。`
+- Marketing: label `広告効果の測定に協力する`; desc `広告から来てくれた人の動きを匿名で測り、届け方の改善に役立てます。オフにしても他の機能には影響しません。`
+
+- *Rationale*: aligns the Settings rendering with the `analytics-consent` per-purpose model and removes a misleading geographic framing that could be read as "turning this off stops domestic processing too" (domestic processing is not optional and not what this toggle controls).
+
+### D5. Guest hero placement and styling
+
+Render a guest-only hero (`if.bind="!auth.isAuthenticated"`) at the top of `.settings-scroll`, before the preferences section. Visual emphasis via a brand-tinted surface (`oklch(from var(--color-brand-primary) l c h / ~12%)` background, `~30%` brand border) with a filled primary `ログイン` button and a ghost/text `新規登録` action. The bottom ACCOUNT section keeps authenticated-only controls; the guest branch of that section is removed (its CTA moves to the hero). Remove the orphan `.settings-guest-prompt` class.
+
+CTA button styling decision: **scope the CTA styles to the settings route for now** rather than introducing a shared button primitive, because no reusable primary-button class exists and a design-system button is a larger, separate effort. Leave a note so a future shared primitive can absorb it. *(Open question O1 if the team prefers the primitive now.)*
+
+New/updated copy: heading `ログインして、もっと便利に`; body `お気に入りと通知を、どの端末でもそのまま使えます` (also resolves the awkward double-を in the current `guestPrompt`).
+
+### D6. iOS-only sound hint
+
+Gate `settings.soundEffectsHint` behind an iOS platform check computed in the ViewModel (e.g. a small `isIOS` derived from the user agent / platform), exposed as a bindable used with `if.bind`. Keep the hint string iOS-specific.
+
+- *Alternative considered*: generalize the wording to drop the iOS reference. Rejected as the weaker option — the hint exists specifically to explain iOS silent-mode behavior; showing it elsewhere is noise, and a generic version loses the informational value.
+
+## Risks / Trade-offs
+
+- [Visual regression baselines] The toggle, hero, and copy changes will alter `e2e/visual/settings.auth.visual.spec.ts` snapshots → intentional; regenerate baselines per the project's main-branch visual-baseline refresh process (delete stale baseline artifacts to force regen).
+- [Shared consent state] `marketingConsent`/`analyticsConsent` are shared with `consent-route` via the consent service → only labels/markup change here; the binding fields and persistence stay identical to avoid touching the signup flow.
+- [iOS detection fragility] UA/platform sniffing is imperfect → keep the check narrow and defaulting to "hide the iOS hint" when uncertain, so non-iOS never sees iOS-only noise.
+- [Tap-target vs. visual size] The 24px-tall track needs invisible vertical padding to reach 44px → ensure the padding lands on the switch button, not the disclosure, so the two targets don't overlap confusingly.
+- [Disclosure discoverability] Users may not notice the chevron → only show it when content is actually truncated, and rotate it on expand for a clear affordance.
+
+## Migration Plan
+
+Pure frontend change, no data migration. Deploy via the normal frontend PR → merge → release path. Rollback is a revert of the frontend PR. Regenerate visual baselines as part of merge. Verify locally at 412px (the reproduced defect width) that the track stays 44px and the thumb is contained, and that the guest hero renders for unauthenticated users.
+
+## Open Questions
+
+### Resolved
+
+- **O1 (resolved)**: Keep the guest-hero CTA styles **settings-scoped for this change** (already shipped in v1.5.0), and extract a **shared brand primary-button primitive as a separate follow-up**. Rationale: there are now two near-identical filled primaries — `consent-btn-primary` (consent-route) and `settings-guest-hero-primary` (settings-route), both white-on-brand, brand-secondary hover, `--radius-button`, `--shadow-button`. That duplication justifies consolidation, but extracting now would pull consent-route into this change's diff and broaden blast radius for no user-facing gain. Recommended target: a CUBE **utility-layer** class (e.g. `.button-primary` / `.button-ghost`) that both routes adopt, or a small `<brand-button>` custom element if behaviour (loading/disabled states) is later needed. Tracked as a follow-up; not blocking.
+- **O2 (resolved)**: The shipped copy passed `brand-vocabulary` lint (`make check` green), so no vocabulary adjustment was required.
+- **O3 (resolved)**: The onboarding consent screen (`onboarding.consent.marketing`, owned by the in-flight `introduce-analytics-tool` change) still labels the marketing toggle by **geography** ("海外での分析処理を許可する"), which has drifted from the `analytics-consent` spec (two **purpose** toggles: product analytics + marketing measurement). Decision: align the onboarding marketing **toggle label/description** to the same purpose-based wording as Settings, leaving the screen's cross-border legal disclosure in the `intro`/`commitment` paragraphs untouched. This is spec-alignment, not a reinterpretation. Coordinated into `introduce-analytics-tool` so its owner keeps the aligned wording rather than reverting.

--- a/openspec/changes/archive/2026-06-01-redesign-settings-ui/proposal.md
+++ b/openspec/changes/archive/2026-06-01-redesign-settings-ui/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+The Settings page (`frontend`, Aurelia 2 PWA) has a confirmed layout defect and several UX/spec-conformance gaps. The toggle switch collapses and its thumb visibly overflows the card edge when paired with long descriptions (reproduced empirically at 412px: the declared 44px track renders at 20.63px and the thumb pokes 4px past the card border). Separately, the guest sign-in entry is buried at the bottom as a plain list row indistinguishable from legal links, and the second analytics consent toggle is mislabeled as a geographic ("overseas processing") control when it actually binds to the `marketingMeasurement` consent purpose, creating a labeling mismatch with the `analytics-consent` requirements.
+
+## What Changes
+
+- Fix the toggle control so its track keeps its intended size and the thumb never overflows the track or card, regardless of adjacent description length.
+- Restructure each toggle row so a long description can be expanded/collapsed without compromising the switch's accessibility semantics (split the single `role="switch"` button into a disclosure control plus the switch).
+- Rewrite the Privacy & Analytics consent copy to be opt-in friendly (benefit-led, with explicit "no PII / can be turned off" reassurance).
+- **Relabel the marketing-measurement consent toggle to describe its purpose ("ad-effectiveness measurement") instead of geography ("overseas processing").** The toggle is NOT removed — it remains the user-controlled, persistent opt-out the `analytics-consent` requirements mandate.
+- Relocate the guest sign-in / sign-up call to action from the bottom ACCOUNT section to a visually emphasized hero at the TOP of the Settings page (guest-only); authenticated account controls (email, verification, sign out) remain in the bottom ACCOUNT section.
+- Show the iOS-specific sound-effects hint only on iOS (or generalize the wording) instead of on every platform.
+- Remove the orphan `.settings-guest-prompt` class (applied in markup, undefined in CSS) as part of the guest-CTA rework.
+
+## Capabilities
+
+### New Capabilities
+<!-- None — all changes are to the existing settings capability. -->
+
+### Modified Capabilities
+- `settings`: Toggle controls gain a layout-integrity requirement (track sizing and thumb containment). Toggle rows gain an expandable-description requirement with preserved switch semantics. The Privacy & Analytics consent toggles gain a labeling requirement (labels describe the consent purpose, not data geography). The existing "Guest-Adaptive Account Section" requirement is modified to relocate the guest call to action to a prominent top-of-page hero, separated from authenticated account controls. A platform-conditional requirement is added for the sound-effects hint.
+
+## Impact
+
+- **Frontend (Aurelia 2)**: `src/routes/settings/settings-route.{html,ts,css}` — toggle CSS (`flex-shrink`, text-column `min-inline-size`, alignment), row anatomy (disclosure + switch split), guest hero markup/styles, platform check for the sound hint, orphan-class cleanup.
+- **i18n copy**: `src/locales/{ja,en}/translation.json` — `settings.analytics.*` (section/toggle copy, purpose-based marketing label), `settings.guestPrompt` / new hero strings (fixes awkward double-を phrasing), `settings.soundEffectsHint`.
+- **Cross-change coordination**: The marketing-toggle relabel concerns the consent purpose introduced by the in-flight `introduce-analytics-tool` change (`analytics-consent`). This change owns only the Settings-page rendering/labeling of that purpose; the cross-border (PostHog/Netherlands) disclosure remains the responsibility of the signup consent screen and the privacy policy, not a per-region Settings toggle.
+- **Tests**: `test/routes/settings-route.spec.ts`, `e2e/visual/settings.auth.visual.spec.ts` (visual baselines will need regeneration), `e2e/pwa/pwa-settings.spec.ts`.
+- **No backend / proto / API changes.**

--- a/openspec/changes/archive/2026-06-01-redesign-settings-ui/specs/settings/spec.md
+++ b/openspec/changes/archive/2026-06-01-redesign-settings-ui/specs/settings/spec.md
@@ -1,0 +1,110 @@
+## ADDED Requirements
+
+### Requirement: Toggle Control Layout Integrity
+
+The system SHALL render each Settings toggle switch at a fixed control size whose visual thumb remains fully contained within the toggle track and within the enclosing card, independent of the length of any adjacent label or description in the same row. The toggle track SHALL NOT shrink below its declared size when competing for horizontal space with sibling content.
+
+#### Scenario: Toggle paired with a long multi-line description
+
+- **WHEN** a toggle row is rendered with a description long enough to wrap onto multiple lines
+- **THEN** the toggle track SHALL retain its declared control width (it SHALL NOT collapse)
+- **AND** the toggle thumb SHALL remain fully inside the track in both the ON and OFF positions
+- **AND** no part of the thumb or track SHALL overflow the right edge of the enclosing card
+
+#### Scenario: Toggle vertical alignment against multi-line content
+
+- **WHEN** a toggle row's text column spans multiple lines
+- **THEN** the toggle control SHALL align to the first line of the label it controls rather than floating to the vertical centre of the whole text block
+
+---
+
+### Requirement: Expandable Toggle Description
+
+The system SHALL allow a toggle row's descriptive text to be collapsed by default and expanded on demand, without compromising the accessibility semantics of the switch. The expand/collapse control and the switch SHALL be distinct, sibling interactive elements — the switch SHALL NOT contain another interactive control.
+
+#### Scenario: Collapsed description with expand affordance
+
+- **WHEN** a toggle row has a collapsible description and is in the collapsed state
+- **THEN** the description SHALL NOT be rendered (the label and the expand affordance serve as the summary)
+- **AND** an expand affordance (e.g. a rotating chevron) SHALL be shown next to the label to indicate more content is available
+
+#### Scenario: Expanding and collapsing the description
+
+- **WHEN** the user activates the description's disclosure control
+- **THEN** the full description SHALL be revealed and the disclosure control's `aria-expanded` state SHALL reflect "true"
+- **AND** activating it again SHALL collapse the description and set `aria-expanded` to "false"
+- **AND** toggling the disclosure SHALL NOT change the switch's on/off value
+
+#### Scenario: Switch remains operable and accessibly separate
+
+- **WHEN** a toggle row presents both a disclosure control and a switch
+- **THEN** the switch SHALL expose `role="switch"` with `aria-checked` reflecting its value
+- **AND** the switch SHALL be an interactive element that is a sibling of (not a descendant of) the disclosure control
+- **AND** the switch's activation target SHALL be at least 24px on both axes (WCAG 2.5.8 AA), with the adjacent disclosure control providing a larger neighbouring target — the row no longer adds block-axis padding to the switch, so the track sits pixel-aligned with the other rows' trailing controls (see design decision D0: card-grid + row-subgrid)
+
+#### Scenario: No expand affordance when nothing to expand
+
+- **WHEN** a toggle row has no description, or a description that fits within the collapsed length
+- **THEN** no expand affordance SHALL be shown
+
+---
+
+### Requirement: Privacy & Analytics Consent Toggle Labeling
+
+The Settings page SHALL present the analytics consent toggles using labels and descriptions that name the consent *purpose* (what the data is used for), not the data's processing *geography*. Each consent toggle on the Settings page SHALL remain a persistent, user-controlled opt-out for the corresponding consent purpose. The Settings page SHALL NOT present a per-region ("domestic" vs "overseas") processing toggle, and SHALL NOT remove a consent purpose's Settings opt-out while that purpose can be granted at signup.
+
+#### Scenario: Product-analytics toggle is purpose-labeled
+
+- **WHEN** the Privacy & Analytics section is rendered
+- **THEN** the product-analytics toggle SHALL be bound to the product-analytics consent purpose
+- **AND** its label and description SHALL describe improving the product experience from anonymous usage data
+- **AND** its description SHALL state that no personally identifying information is collected
+
+#### Scenario: Marketing-measurement toggle is purpose-labeled (not geography)
+
+- **WHEN** the Privacy & Analytics section is rendered
+- **THEN** the second toggle SHALL be bound to the `marketingMeasurement` consent purpose
+- **AND** its label and description SHALL describe ad-effectiveness measurement, not "overseas" or "cross-border" data processing
+- **AND** turning it off SHALL be stated to have no effect on other features
+
+#### Scenario: Settings opt-out persists for a purpose granted at signup
+
+- **WHEN** a user granted a consent purpose at the signup consent screen
+- **THEN** the Settings page SHALL render a corresponding toggle that lets the user withdraw that consent
+- **AND** the toggle SHALL reflect the persisted consent state on load
+
+---
+
+### Requirement: Platform-Conditional Sound Effects Hint
+
+The Settings page SHALL only show the iOS-specific sound-effects behavior hint on iOS devices. On non-iOS platforms the system SHALL NOT display a hint that references iOS-only behavior.
+
+#### Scenario: iOS device shows the iOS hint
+
+- **WHEN** the Settings page is rendered on an iOS device
+- **THEN** the sound-effects row SHALL display the iOS-specific hint about the device's silent/manner mode
+
+#### Scenario: Non-iOS device does not show the iOS hint
+
+- **WHEN** the Settings page is rendered on a non-iOS platform (Android, desktop)
+- **THEN** the sound-effects row SHALL NOT display the iOS-specific hint
+
+## MODIFIED Requirements
+
+### Requirement: Guest-Adaptive Account Section
+
+The system SHALL adapt the Settings page to authentication state. For guests, the system SHALL present the sign-in / sign-up call to action as a visually emphasized hero placed at the TOP of the Settings page (before the preferences content), and SHALL hide account-bound controls (email address, email verification status, resend-verification, sign-out). For authenticated users, the system SHALL NOT render the guest hero, and the bottom ACCOUNT section SHALL present the existing account controls.
+
+#### Scenario: Guest sees a prominent sign-in hero at the top
+
+- **WHEN** an unauthenticated user views the Settings page
+- **THEN** the system SHALL render a guest call-to-action hero at the top of the page, above the preferences content
+- **AND** the hero SHALL be visually distinct from the standard list cards (e.g. brand-tinted background and a filled primary action)
+- **AND** the hero SHALL offer a primary "ログイン" action and a secondary "新規登録" action that initiate the OIDC sign-in / sign-up flow
+- **AND** the email address row, email-verification badge, and resend-verification button SHALL NOT be rendered
+
+#### Scenario: Authenticated user sees account controls and no guest hero
+
+- **WHEN** an authenticated user views the Settings page
+- **THEN** the system SHALL NOT render the guest hero
+- **AND** the bottom ACCOUNT section SHALL render the email address, the verification badge, the resend-verification button (when unverified), and the Sign Out control

--- a/openspec/changes/archive/2026-06-01-redesign-settings-ui/tasks.md
+++ b/openspec/changes/archive/2026-06-01-redesign-settings-ui/tasks.md
@@ -1,0 +1,50 @@
+## 1. Toggle layout integrity (CSS)
+
+- [x] 1.1 Add `flex-shrink: 0` to `.settings-toggle-track` in `settings-route.css` so the track never collapses below its declared `2.75rem`
+- [x] 1.2 Add `min-inline-size: 0` to the toggle text column so it absorbs remaining width and wraps instead of starving the track
+- [x] 1.3 Switch toggle rows to `align-items: flex-start` so the control aligns to the first line of multi-line content
+- [x] 1.4 Decouple the toggle description styling from `.settings-row-hint`'s `margin-inline-start: var(--space-l)` (use a dedicated class with no inherited inline-start indent)
+- [x] 1.5 Verify at 412px that the rendered track width stays 44px and the thumb is contained in both ON and OFF states with no card-edge overflow (re-run the Playwright measurement from the design doc)
+
+## 2. Expandable toggle description (markup + a11y)
+
+- [x] 2.1 Restructure each long-description toggle row into two sibling controls: a disclosure `<button aria-expanded>` (label + collapsible description + chevron) and the `<button role="switch" aria-checked>` (track/thumb)
+- [x] 2.2 Collapse the description by default (truncate to collapsed length) and reveal full text on disclosure activation; toggle `aria-expanded` accordingly
+- [x] 2.3 Render the chevron affordance only when the description exceeds the collapsed length; rotate it on expand
+- [x] 2.4 Ensure the switch activation target is ≥44px in the block dimension via padding on the switch button (without overlapping the disclosure target)
+- [x] 2.5 Confirm activating the disclosure never changes the switch value, and vice versa
+
+## 3. Consent toggle copy & labeling (i18n)
+
+- [x] 3.1 Keep section title `プライバシーと分析`; update `settings.analytics.toggleLabel`/`toggleDescription` to the analytics opt-in-friendly copy (benefit + "no PII")
+- [x] 3.2 Relabel `settings.analytics.crossBorderLabel`/`crossBorderDescription` to describe ad-effectiveness measurement (purpose), not geography; keep the toggle bound to `consent.marketingMeasurement`
+- [x] 3.3 Update the `en` locale mirror for all changed `settings.analytics.*` keys
+- [x] 3.4 Run `make lint` brand-vocabulary check on the new copy and adjust to approved vocabulary if flagged (resolves O2)
+
+## 4. Guest CTA hero (markup + CSS)
+
+- [x] 4.1 Add a guest-only (`if.bind="!auth.isAuthenticated"`) hero card at the top of `.settings-scroll`, before the preferences section
+- [x] 4.2 Style the hero distinctly: brand-tinted background + brand border, a filled primary `ログイン` button and a ghost/text `新規登録` action (scoped to the settings route per D5)
+- [x] 4.3 Add hero copy: heading `ログインして、もっと便利に`, body `お気に入りと通知を、どの端末でもそのまま使えます`; remove/repurpose the old `settings.guestPrompt` string
+- [x] 4.4 Remove the guest branch from the bottom ACCOUNT section; keep authenticated-only controls there
+- [x] 4.5 Delete the orphan `.settings-guest-prompt` class (markup usage + ensure no CSS references remain)
+
+## 5. iOS-only sound hint
+
+- [x] 5.1 Compute an `isIOS` flag in `settings-route.ts` (platform/UA check, defaulting to false when uncertain)
+- [x] 5.2 Gate the `settings.soundEffectsHint` row with `if.bind` on the iOS flag
+
+## 6. Tests & verification
+
+- [x] 6.1 Update/extend `test/routes/settings-route.spec.ts` for the disclosure + switch split, iOS-hint gating, and guest-hero rendering by auth state
+- [x] 6.2 Regenerate `e2e/visual/settings.auth.visual.spec.ts` baselines (delete stale visual-baseline artifacts to force regen per project process)
+- [x] 6.3 Update `e2e/pwa/pwa-settings.spec.ts` if selectors changed
+- [x] 6.4 Run `make check` (lint + test) green locally
+- [x] 6.5 Manually verify on a 412px viewport: contained toggle, expandable descriptions, guest hero for unauthenticated users, no iOS hint on non-iOS
+
+## 7. Ship
+
+- [x] 7.1 Open the frontend PR (Conventional Commit, body explaining why, `Refs: #<issue>`); pass CI
+- [x] 7.2 Address review, merge to `main`
+- [x] 7.3 Cut the frontend GitHub Release so the change reaches production; confirm the prod rollout reflects the new Settings UI
+- [x] 7.4 Resolve open questions O1 (CTA primitive scope) and O3 (coordinate the marketing-toggle wording with `introduce-analytics-tool`)

--- a/openspec/specs/settings/spec.md
+++ b/openspec/specs/settings/spec.md
@@ -150,18 +150,21 @@ The system SHALL allow authenticated users to sign out of their account. The Sig
 
 ### Requirement: Guest-Adaptive Account Section
 
-The system SHALL render the Settings ACCOUNT section conditionally on authentication state. For guests, the section SHALL present a sign-in / sign-up call to action and SHALL hide account-bound controls (email address, email verification status, resend-verification, sign-out). For authenticated users, the section SHALL present the existing account controls.
+The system SHALL adapt the Settings page to authentication state. For guests, the system SHALL present the sign-in / sign-up call to action as a visually emphasized hero placed at the TOP of the Settings page (before the preferences content), and SHALL hide account-bound controls (email address, email verification status, resend-verification, sign-out). For authenticated users, the system SHALL NOT render the guest hero, and the bottom ACCOUNT section SHALL present the existing account controls.
 
-#### Scenario: Guest sees auth entry in ACCOUNT section
+#### Scenario: Guest sees a prominent sign-in hero at the top
 
 - **WHEN** an unauthenticated user views the Settings page
-- **THEN** the ACCOUNT section SHALL present a "ログイン / 新規登録" call to action that initiates the OIDC sign-in / sign-up flow
+- **THEN** the system SHALL render a guest call-to-action hero at the top of the page, above the preferences content
+- **AND** the hero SHALL be visually distinct from the standard list cards (e.g. brand-tinted background and a filled primary action)
+- **AND** the hero SHALL offer a primary "ログイン" action and a secondary "新規登録" action that initiate the OIDC sign-in / sign-up flow
 - **AND** the email address row, email-verification badge, and resend-verification button SHALL NOT be rendered
 
-#### Scenario: Authenticated user sees account controls
+#### Scenario: Authenticated user sees account controls and no guest hero
 
 - **WHEN** an authenticated user views the Settings page
-- **THEN** the ACCOUNT section SHALL render the email address, the verification badge, the resend-verification button (when unverified), and the Sign Out control
+- **THEN** the system SHALL NOT render the guest hero
+- **AND** the bottom ACCOUNT section SHALL render the email address, the verification badge, the resend-verification button (when unverified), and the Sign Out control
 
 ### Requirement: Guest Language Preference
 
@@ -178,3 +181,86 @@ The system SHALL allow a guest user to change the display language from Settings
 
 - **WHEN** an unauthenticated user views or changes "My Home Area"
 - **THEN** the system SHALL read and write the home-area code via guest storage rather than the backend User entity
+
+### Requirement: Toggle Control Layout Integrity
+
+The system SHALL render each Settings toggle switch at a fixed control size whose visual thumb remains fully contained within the toggle track and within the enclosing card, independent of the length of any adjacent label or description in the same row. The toggle track SHALL NOT shrink below its declared size when competing for horizontal space with sibling content.
+
+#### Scenario: Toggle paired with a long multi-line description
+
+- **WHEN** a toggle row is rendered with a description long enough to wrap onto multiple lines
+- **THEN** the toggle track SHALL retain its declared control width (it SHALL NOT collapse)
+- **AND** the toggle thumb SHALL remain fully inside the track in both the ON and OFF positions
+- **AND** no part of the thumb or track SHALL overflow the right edge of the enclosing card
+
+#### Scenario: Toggle vertical alignment against multi-line content
+
+- **WHEN** a toggle row's text column spans multiple lines
+- **THEN** the toggle control SHALL align to the first line of the label it controls rather than floating to the vertical centre of the whole text block
+
+### Requirement: Expandable Toggle Description
+
+The system SHALL allow a toggle row's descriptive text to be collapsed by default and expanded on demand, without compromising the accessibility semantics of the switch. The expand/collapse control and the switch SHALL be distinct, sibling interactive elements — the switch SHALL NOT contain another interactive control.
+
+#### Scenario: Collapsed description with expand affordance
+
+- **WHEN** a toggle row has a collapsible description and is in the collapsed state
+- **THEN** the description SHALL NOT be rendered (the label and the expand affordance serve as the summary)
+- **AND** an expand affordance (e.g. a rotating chevron) SHALL be shown next to the label to indicate more content is available
+
+#### Scenario: Expanding and collapsing the description
+
+- **WHEN** the user activates the description's disclosure control
+- **THEN** the full description SHALL be revealed and the disclosure control's `aria-expanded` state SHALL reflect "true"
+- **AND** activating it again SHALL collapse the description and set `aria-expanded` to "false"
+- **AND** toggling the disclosure SHALL NOT change the switch's on/off value
+
+#### Scenario: Switch remains operable and accessibly separate
+
+- **WHEN** a toggle row presents both a disclosure control and a switch
+- **THEN** the switch SHALL expose `role="switch"` with `aria-checked` reflecting its value
+- **AND** the switch SHALL be an interactive element that is a sibling of (not a descendant of) the disclosure control
+- **AND** the switch's activation target SHALL be at least 24px on both axes (WCAG 2.5.8 AA), with the adjacent disclosure control providing a larger neighbouring target — the row no longer adds block-axis padding to the switch, so the track sits pixel-aligned with the other rows' trailing controls (see design decision D0: card-grid + row-subgrid)
+
+#### Scenario: No expand affordance when nothing to expand
+
+- **WHEN** a toggle row has no description, or a description that fits within the collapsed length
+- **THEN** no expand affordance SHALL be shown
+
+### Requirement: Privacy & Analytics Consent Toggle Labeling
+
+The Settings page SHALL present the analytics consent toggles using labels and descriptions that name the consent *purpose* (what the data is used for), not the data's processing *geography*. Each consent toggle on the Settings page SHALL remain a persistent, user-controlled opt-out for the corresponding consent purpose. The Settings page SHALL NOT present a per-region ("domestic" vs "overseas") processing toggle, and SHALL NOT remove a consent purpose's Settings opt-out while that purpose can be granted at signup.
+
+#### Scenario: Product-analytics toggle is purpose-labeled
+
+- **WHEN** the Privacy & Analytics section is rendered
+- **THEN** the product-analytics toggle SHALL be bound to the product-analytics consent purpose
+- **AND** its label and description SHALL describe improving the product experience from anonymous usage data
+- **AND** its description SHALL state that no personally identifying information is collected
+
+#### Scenario: Marketing-measurement toggle is purpose-labeled (not geography)
+
+- **WHEN** the Privacy & Analytics section is rendered
+- **THEN** the second toggle SHALL be bound to the `marketingMeasurement` consent purpose
+- **AND** its label and description SHALL describe ad-effectiveness measurement, not "overseas" or "cross-border" data processing
+- **AND** turning it off SHALL be stated to have no effect on other features
+
+#### Scenario: Settings opt-out persists for a purpose granted at signup
+
+- **WHEN** a user granted a consent purpose at the signup consent screen
+- **THEN** the Settings page SHALL render a corresponding toggle that lets the user withdraw that consent
+- **AND** the toggle SHALL reflect the persisted consent state on load
+
+### Requirement: Platform-Conditional Sound Effects Hint
+
+The Settings page SHALL only show the iOS-specific sound-effects behavior hint on iOS devices. On non-iOS platforms the system SHALL NOT display a hint that references iOS-only behavior.
+
+#### Scenario: iOS device shows the iOS hint
+
+- **WHEN** the Settings page is rendered on an iOS device
+- **THEN** the sound-effects row SHALL display the iOS-specific hint about the device's silent/manner mode
+
+#### Scenario: Non-iOS device does not show the iOS hint
+
+- **WHEN** the Settings page is rendered on a non-iOS platform (Android, desktop)
+- **THEN** the sound-effects row SHALL NOT display the iOS-specific hint


### PR DESCRIPTION
## Summary

Archives the completed `redesign-settings-ui` change and syncs its delta into the canonical `settings` capability spec. The change was implemented and shipped to production as frontend **v1.5.1**.

## Spec sync (`openspec/specs/settings/spec.md`)

**ADDED requirements:**
- Toggle Control Layout Integrity — track keeps its size, thumb stays contained
- Expandable Toggle Description — disclosure + switch as distinct sibling controls
- Privacy & Analytics Consent Toggle Labeling — labels name the consent *purpose*, not geography; persistent settings opt-out
- Platform-Conditional Sound Effects Hint — iOS-only hint shown only on iOS

**MODIFIED requirement:**
- Guest-Adaptive Account Section — guest sign-in CTA relocated from the bottom ACCOUNT list to a visually emphasized **top-of-page hero**; authenticated controls stay in the bottom section

## Archive

`openspec/changes/redesign-settings-ui/` → `openspec/changes/archive/2026-06-01-redesign-settings-ui/` (proposal, design incl. decision D0 = card-grid + row-subgrid, specs delta, tasks 30/30).

## Shipped

frontend PRs #401 (settings redesign), #404 (consent copy), #409 (grid/subgrid alignment) — all merged and released in v1.5.0 → v1.5.1, live in prod.

Refs: liverty-music/frontend#400
