### PR TITLE
docs(openspec): reduce-gemini-search-cost change

### DIFF
--- a/openspec/changes/reduce-gemini-search-cost/.openspec.yaml
+++ b/openspec/changes/reduce-gemini-search-cost/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-01

--- a/openspec/changes/reduce-gemini-search-cost/design.md
+++ b/openspec/changes/reduce-gemini-search-cost/design.md
@@ -1,0 +1,149 @@
+## Context
+
+`SearchNewConcerts` (`backend/internal/usecase/concert_uc.go`) gates the Gemini search
+behind a single freshness check: `SearchLog.IsFresh(now, searchCacheTTL)` where
+`searchCacheTTL` is a compile-time constant `24 * time.Hour`, shared by all
+environments. The CronJob runs daily in prod (`0 9 * * *`), so each followed artist is
+re-searched roughly every 24h whether or not anything changed.
+
+Cost is dominated by Step 1 of the searcher (grounded GoogleSearch + URLContext +
+medium/high thinking). Skipping a search saves a whole Step 1 + Step 2 pass.
+
+The data layer can answer "when did we last *search*?" (`latest_search_logs.searched_at`)
+but **not** "when did we last *discover something new*?" — there is no discovery
+timestamp on `latest_search_logs`, and `events` has no `created_at` column (its `id` is
+UUIDv7 but reconstructing discovery time through the series→performer join is brittle and
+unsuitable as a primary signal).
+
+## Goals / Non-Goals
+
+**Goals:**
+- Reduce Gemini API spend by skipping searches that are very unlikely to yield new data.
+- Make the freshness TTL environment-configurable; set prod to 72h, keep dev at 24h.
+- Add a "skip if a new concert was discovered within the last 14 days" condition, backed
+  by a first-class discovery timestamp.
+- Ship to prod (config + migration + release), not just merge.
+
+**Non-Goals:**
+- Follower-weighted / engagement-weighted cadence (future change).
+- Official-site change-detection as a search trigger (future change).
+- Failed-search backoff — rejected: prod failures are currently ~zero and error alerting
+  already provides detection; backoff would solve a non-problem and add complexity.
+- Resetting to a *shorter* interval immediately after a discovery — rejected: for the
+  batch-then-quiet (Japanese tour) announcement pattern, a fresh discovery predicts
+  *quiet*, not more activity, so we lengthen rather than shorten after a hit.
+
+## Decisions
+
+### D1: Configurable TTL and discovery window via env (default 24h / 14d, prod 72h)
+
+Replace the `searchCacheTTL` constant with config-sourced values. Add two `time.Duration`
+env fields resolved with env-precedence-over-default, mirroring the existing
+`SearchModelExtract()` / `SearchModelParse()` helpers in `gemini-searcher-config`:
+
+- `GCP_GEMINI_SEARCH_CACHE_TTL` — freshness window, default `24h`.
+- `GCP_GEMINI_SEARCH_DISCOVERY_WINDOW` — recent-discovery skip window, default `336h` (14d).
+
+The prod `concert-discovery` configmap sets `CACHE_TTL=72h` (and may set the discovery
+window explicitly to `336h` for visibility, or omit it to inherit the default); dev omits
+both and inherits the defaults.
+
+- *Alternative considered*: change the constant to 72h globally. Rejected — prod-specific
+  tuning is wanted, and a config knob lets us tune per-env without a code release.
+- *Alternative considered*: keep the 14d window a code constant. Rejected per decision to
+  env-configure it from the start, so the window can be tuned without a backend release.
+- *Alternative considered*: make these `JobConfig` top-level fields rather than under
+  `GCPConfig`. Either works; placing them alongside the other Gemini-search settings keeps
+  the searcher-config capability cohesive.
+
+### D2: Track discovery time with a nullable `last_found_at` column
+
+Add `last_found_at TIMESTAMPTZ NULL` to `latest_search_logs`. It is set to "now" only
+when a search publishes ≥1 genuinely new concert (i.e. `FilterNew` returns a non-empty
+set in `executeSearch`). NULL means "never discovered anything yet" → the discovery-skip
+never fires for that artist.
+
+- *Alternative considered*: derive discovery time from `events.id` UUIDv7 via
+  series→performer join. Rejected — brittle, couples the skip logic to ID-encoding
+  details and the dedup/UPSERT id-stability behavior; a dedicated column is explicit and
+  cheap. (`auto-concert-discovery` already keeps a discovery-skip concern out of the
+  event table.)
+- *Alternative considered*: a separate `concert_discoveries` audit table. Rejected —
+  over-engineered for a single "last" timestamp; the search log is already the per-artist
+  cadence record.
+
+### D3: Two independent skip gates, OR-combined
+
+`SearchNewConcerts` skips the external call when **either**:
+1. `IsFresh(now, ttl)` — recently *searched* (existing behavior, now configurable), **or**
+2. `last_found_at` is set **and** `now - last_found_at < discoveryWindow` — recently *discovered*.
+
+The pending/in-progress guard (`IsPending`) is unchanged. Both the TTL **and** the
+discovery window are env-configurable from day one (see D5), each with a built-in default
+(24h and 14d=336h respectively). Both gates are advisory caches over the same source of
+truth, so OR is correct: any reason to believe "nothing new soon" suppresses the call.
+
+### D4: Skip vs. fresh-status interaction
+
+The discovery-skip only consults `last_found_at`; it does not require `status =
+completed`. But because `last_found_at` is only ever written on a successful discovery,
+its presence already implies a past completed run. A `failed` newer run does not clear
+`last_found_at` (we keep the last *successful* discovery time), which is the intended
+behavior — a transient failure should not force a re-search storm inside the 14-day
+window.
+
+### D5: Config delivery via Kustomize configmap.env (not Pulumi/ESC)
+
+Both knobs are non-secret tuning values, so they follow the established split: Pulumi
+(`cloud-provisioning/src/`) manages GCP infra + GSM secrets only (it creates **zero** k8s
+ConfigMaps today), while non-secret cronjob env lives in committed Kustomize
+`configmap.env` overlays. The new env vars are set in the prod `concert-discovery`
+configmap; dev inherits the code defaults.
+
+- *Alternative considered*: define the values in Pulumi ESC and have Pulumi render a new
+  k8s ConfigMap. Rejected — introduces a brand-new "Pulumi owns a backend ConfigMap"
+  pattern for a plain tuning value; the existing configmap.env path is simpler and
+  consistent with every other non-secret cronjob env.
+- *Alternative considered*: ESC → GSM → ExternalSecret (the API-key path). Rejected —
+  these are not secrets; treating them as such is a category error.
+
+## Risks / Trade-offs
+
+- **Delayed notification for incremental tour adds** → For artists who *do* add dates
+  within 14 days of a first announcement, the new date is detected up to ~14 days late.
+  Mitigation: acceptable given the current tiny user base and cost priority; the window
+  is a single constant we can shorten quickly, and TTL/config is env-tunable without a
+  migration.
+- **`last_found_at` semantics drift** → If `executeSearch`'s "new concert" definition
+  (post-`FilterNew`) changes, the discovery signal changes with it. Mitigation: write
+  `last_found_at` at exactly the same point we publish `concert.discovered`, so the
+  column tracks "we emitted a discovery event," which is the meaningful definition.
+- **Migration ordering** → The backend code reading `last_found_at` must not roll out
+  before the column exists. Mitigation: Atlas Operator sync-wave ordering already
+  sequences `backend-migrations` ahead of the backend workloads (per backend CLAUDE.md);
+  the new column is nullable and additive, so an old binary tolerates it too.
+- **Duration parsing** → A malformed `GCP_GEMINI_SEARCH_CACHE_TTL` or
+  `GCP_GEMINI_SEARCH_DISCOVERY_WINDOW` must fail fast. Mitigation: parse + validate in
+  `JobConfig.Validate()` like the existing thinking-level validation.
+
+## Migration Plan
+
+1. Backend PR: config field + entity field + usecase skip branch + repo read/write +
+   Atlas migration (`add_last_found_at_to_search_logs`) registered in the migrations
+   kustomization; unit tests. `make check` green.
+2. Merge backend PR → cut backend Release `vX.Y.Z` → prod AR pin bump → ArgoCD sync.
+3. cloud-provisioning PR: prod `concert-discovery` configmap adds the 72h TTL env (and the
+   discovery-window env); bump the prod image pin to `vX.Y.Z`. Atlas Operator applies the
+   migration ahead of the CronJob.
+4. Verify in prod: next CronJob run logs show the new skip branch firing; `latest_search_logs`
+   shows `last_found_at` populated after a discovery.
+
+**Rollback**: revert the configmap/pin PR (TTL + window fall back to defaults; old binary
+ignores the column). The additive nullable column needs no down-migration.
+
+## Open Questions
+
+- Confirm whether the TTL/window knobs belong on `GCPConfig` (cohesive with searcher
+  settings) vs. `JobConfig` top-level — minor, settle during implementation.
+- (Resolved) Discovery window is env-configurable from day one; config delivery is via
+  Kustomize configmap.env, not Pulumi/ESC.

--- a/openspec/changes/reduce-gemini-search-cost/proposal.md
+++ b/openspec/changes/reduce-gemini-search-cost/proposal.md
@@ -1,0 +1,64 @@
+## Why
+
+The `concert-discovery` CronJob calls the Gemini search API (a grounded two-step
+pipeline whose Step 1 is the dominant cost) once per followed artist on every run.
+Empirically most of these calls are wasteful: in a representative prod run only a
+small fraction yielded any new concert, and for Japanese artists tour line-ups are
+typically announced as a single batch and then stay quiet for weeks. Re-searching an
+artist a day after a discovery just re-finds the same concerts and dedups to nothing.
+With a small user base today, notification latency is cheap and Gemini cost is the
+priority — so we can safely skip more aggressively.
+
+## What Changes
+
+- Make the search-freshness TTL **configurable** instead of a hard-coded 24h constant,
+  and set **prod = 72h** (dev stays at the 24h default). An artist searched within the
+  TTL is skipped, as today — just with a longer window in prod.
+- Add a new skip condition: **skip the external search if a new concert was discovered
+  for the artist within the last 14 days.** The 14-day window is **env-configurable**
+  (default 14d). This requires tracking *when* an artist last yielded a new concert, which
+  is not recorded anywhere today.
+- Record a `last_found_at` timestamp on the artist's search log whenever a search
+  publishes at least one genuinely new (post-dedup) concert.
+
+Out of scope (future, separate changes): follower-weighted search cadence, and
+official-site change-detection as a search trigger.
+
+## Capabilities
+
+### New Capabilities
+
+(none — all behavior modifies existing capabilities)
+
+### Modified Capabilities
+
+- `concert-search`: the "Search Concerts by Artist" skip rule changes — the freshness
+  window becomes configurable (default 24h) rather than a fixed 24h, and a second skip
+  condition is added (skip when a new concert was discovered within the last 14 days).
+- `concert-search-log`: the `latest_search_logs` schema gains a nullable `last_found_at`
+  column, and a new tracking rule records it when a search discovers new concerts.
+- `gemini-searcher-config`: two new env-configurable settings are added — the
+  search-cache TTL and the recent-discovery skip window — each resolved with env-var
+  precedence over a built-in default, following the existing per-step model-resolution
+  pattern.
+
+## Impact
+
+- **backend**
+  - `pkg/config`: new TTL env field on `JobConfig`/`GCPConfig` with default + validation.
+  - `internal/usecase/concert_uc.go`: TTL **and** discovery window sourced from config
+    (not the `searchCacheTTL` constant); new "discovered within window" skip branch in
+    `SearchNewConcerts`; `executeSearch` updates `last_found_at` when post-dedup new
+    concerts are published.
+  - `internal/entity/search_log.go`: `SearchLog` gains `LastFoundTime`; new helper for
+    the discovery-recency check.
+  - `internal/infrastructure/database/rdb`: search-log repository reads/writes
+    `last_found_at`; new Atlas migration adding the nullable column.
+  - tests: usecase + repository + entity unit tests updated for the new branch/column.
+- **cloud-provisioning**
+  - prod `concert-discovery` Kustomize `configmap.env` sets the TTL env to 72h (and
+    optionally the discovery-window env); dev unchanged. Non-secret tuning stays on the
+    existing configmap.env path — Pulumi/ESC is not involved (it manages secrets only).
+- **Deployment**: ships through backend Release → prod AR pin bump → ArgoCD sync, plus
+  the Atlas Operator applying the new migration before the CronJob picks it up.
+- **No proto/BSR change** — purely backend behavior + infra config.

--- a/openspec/changes/reduce-gemini-search-cost/specs/concert-search-log/spec.md
+++ b/openspec/changes/reduce-gemini-search-cost/specs/concert-search-log/spec.md
@@ -1,0 +1,38 @@
+## ADDED Requirements
+
+### Requirement: Track Last Concert Discovery Time
+
+The system SHALL record, per artist, the timestamp at which a search most recently discovered at least one genuinely new concert. This timestamp drives the discovery-recency skip in concert search and is distinct from `searched_at` (which records every search attempt, productive or not).
+
+#### Scenario: Record discovery when new concerts are published
+
+- **WHEN** a search for an artist produces one or more new concerts after deduplication (i.e. a `concert.discovered` event is published)
+- **THEN** the system MUST set the artist's `last_found_at` to the current timestamp in `latest_search_logs`
+
+#### Scenario: Do not record discovery when nothing new is found
+
+- **WHEN** a search for an artist completes but yields no new concerts after deduplication
+- **THEN** the system MUST NOT modify the artist's `last_found_at`
+- **AND** the existing `last_found_at` value (if any) MUST be preserved
+
+#### Scenario: Never discovered
+
+- **WHEN** an artist has never had a search produce a new concert
+- **THEN** the artist's `last_found_at` MUST be null
+
+## MODIFIED Requirements
+
+### Requirement: Search Log Persistence
+
+The system SHALL store search logs in a `latest_search_logs` table with `artist_id` as the primary key, `searched_at` as a non-null timestamp with timezone, and `last_found_at` as a nullable timestamp with timezone recording the most recent successful discovery.
+
+#### Scenario: Schema definition
+
+- **WHEN** the `latest_search_logs` table is queried
+- **THEN** it MUST contain columns `artist_id` (PK, FK to `artists.id`), `searched_at` (timestamptz, NOT NULL), and `last_found_at` (timestamptz, NULL)
+
+#### Scenario: Additive nullable column migration
+
+- **WHEN** the migration adding `last_found_at` is applied
+- **THEN** existing rows MUST retain their `artist_id` and `searched_at`
+- **AND** their `last_found_at` MUST default to null without requiring a backfill

--- a/openspec/changes/reduce-gemini-search-cost/specs/concert-search/spec.md
+++ b/openspec/changes/reduce-gemini-search-cost/specs/concert-search/spec.md
@@ -1,0 +1,66 @@
+## MODIFIED Requirements
+
+### Requirement: Search Concerts by Artist
+
+System must provide a way to search for future concerts of a specific artist using generative AI grounding. The system SHALL check the search log before calling the external API and skip the call when **either** a recent search exists **or** a new concert was recently discovered. The freshness window SHALL be configurable (default 24 hours) rather than fixed. The extracted concert data SHALL include the venue's administrative area (`admin_area`) when it can be determined with confidence. The `SearchNewConcerts` RPC SHALL be accessible without authentication to support guest onboarding flows.
+
+#### Scenario: Successful Search
+
+- **WHEN** `SearchNewConcerts` is called for an existing artist
+- **AND** no search log exists, or the last search was longer ago than the configured freshness TTL
+- **AND** no new concert was discovered for the artist within the configured discovery-skip window (default 14 days)
+- **THEN** the system MUST call the external search API
+- **AND** return a list of upcoming concerts found on the web
+- **AND** each concert includes title, listed venue name, date, and optionally start time and `admin_area`
+- **AND** results exclude concerts that are already stored in the database
+
+#### Scenario: Skip search when recently searched
+
+- **WHEN** `SearchNewConcerts` is called for an artist
+- **AND** a search log exists with `searched_at` within the configured freshness TTL
+- **THEN** the system MUST NOT call the external search API
+- **AND** return an empty list
+
+#### Scenario: Configurable freshness TTL per environment
+
+- **WHEN** the freshness TTL is configured to 72 hours (e.g. in production) via the search-cache-TTL setting
+- **AND** a search log exists with `searched_at` 50 hours ago
+- **THEN** the system MUST treat the search as fresh and MUST NOT call the external API
+- **AND** when the TTL is left unset, the system MUST default to 24 hours
+
+#### Scenario: Skip search when recently discovered a new concert
+
+- **WHEN** `SearchNewConcerts` is called for an artist
+- **AND** the artist's search log records a `last_found_at` within the configured discovery-skip window (default 14 days)
+- **THEN** the system MUST NOT call the external search API
+- **AND** return an empty list
+- **AND** this skip applies even if the last search itself is older than the freshness TTL
+
+#### Scenario: Do not skip on discovery when never discovered
+
+- **WHEN** `SearchNewConcerts` is called for an artist
+- **AND** the artist's search log has no `last_found_at` recorded (null)
+- **AND** no recent-search freshness skip applies
+- **THEN** the discovery-recency check MUST NOT cause a skip
+- **AND** the system MUST proceed to call the external search API
+
+#### Scenario: Filter Past Events
+
+- **WHEN** the search results include events with dates in the past
+- **THEN** the system MUST filter them out and only return future events
+
+#### Scenario: No Results
+
+- **WHEN** no upcoming concerts are found for the artist
+- **THEN** the system MUST return an empty list without error
+
+#### Scenario: Missing Artist ID
+
+- **WHEN** an `artist_id` is not provided
+- **THEN** the system MUST return an `INVALID_ARGUMENT` error
+
+#### Scenario: Unauthenticated access
+
+- **WHEN** `SearchNewConcerts` is called without a bearer token
+- **THEN** the system SHALL process the request normally (public procedure)
+- **AND** the search log cache SHALL prevent abuse by skipping external API calls for recently searched or recently discovered artists

--- a/openspec/changes/reduce-gemini-search-cost/specs/gemini-searcher-config/spec.md
+++ b/openspec/changes/reduce-gemini-search-cost/specs/gemini-searcher-config/spec.md
@@ -1,0 +1,50 @@
+## ADDED Requirements
+
+### Requirement: Configurable search-cache TTL with env-var precedence over default
+
+The job configuration SHALL expose an environment-configurable search-cache TTL that controls how long a completed search is considered fresh. The value SHALL be resolvable from an environment variable (e.g. `GCP_GEMINI_SEARCH_CACHE_TTL`) and SHALL fall back to a built-in default of 24 hours when unset, following the same env-precedence-over-default pattern as the per-step model resolvers. The resolved TTL SHALL be passed into the concert-search use case instead of a hard-coded constant.
+
+#### Scenario: Env override honoured
+
+- **WHEN** the search-cache TTL env var is set to `72h`
+- **THEN** the resolved TTL SHALL be 72 hours
+
+#### Scenario: Default applied when env unset
+
+- **WHEN** the search-cache TTL env var is empty or unset
+- **THEN** the resolved TTL SHALL be 24 hours
+
+#### Scenario: Invalid value rejected at startup
+
+- **WHEN** the search-cache TTL env var is set to a non-parseable duration
+- **THEN** configuration validation SHALL fail fast at job startup with a descriptive error
+
+#### Scenario: No hard-coded freshness constant remains in the use case
+
+- **WHEN** the concert-search use case evaluates search freshness
+- **THEN** it SHALL use the configured TTL value
+- **AND** the codebase SHALL NOT contain a `searchCacheTTL` constant used as the freshness window
+
+### Requirement: Configurable discovery-skip window with env-var precedence over default
+
+The job configuration SHALL expose an environment-configurable discovery-skip window that controls how long after a successful discovery the external search is skipped. The value SHALL be resolvable from an environment variable (e.g. `GCP_GEMINI_SEARCH_DISCOVERY_WINDOW`) and SHALL fall back to a built-in default of 14 days (336 hours) when unset, following the same env-precedence-over-default pattern as the TTL and the per-step model resolvers. The resolved window SHALL be passed into the concert-search use case.
+
+#### Scenario: Env override honoured
+
+- **WHEN** the discovery-window env var is set to `168h`
+- **THEN** the resolved window SHALL be 168 hours (7 days)
+
+#### Scenario: Default applied when env unset
+
+- **WHEN** the discovery-window env var is empty or unset
+- **THEN** the resolved window SHALL be 14 days (336 hours)
+
+#### Scenario: Invalid value rejected at startup
+
+- **WHEN** the discovery-window env var is set to a non-parseable duration
+- **THEN** configuration validation SHALL fail fast at job startup with a descriptive error
+
+#### Scenario: No hard-coded discovery-window constant remains in the use case
+
+- **WHEN** the concert-search use case evaluates discovery recency
+- **THEN** it SHALL use the configured discovery-window value rather than a hard-coded constant

--- a/openspec/changes/reduce-gemini-search-cost/tasks.md
+++ b/openspec/changes/reduce-gemini-search-cost/tasks.md
@@ -1,0 +1,43 @@
+## 1. Backend — config (TTL + discovery window)
+
+- [x] 1.1 Add a search-cache TTL env field (`GCP_GEMINI_SEARCH_CACHE_TTL`, `time.Duration`) to the job config in `pkg/config/config.go`, with a 24h default
+- [x] 1.2 Add a discovery-window env field (`GCP_GEMINI_SEARCH_DISCOVERY_WINDOW`, `time.Duration`), with a 336h (14d) default
+- [x] 1.3 Add resolver helpers for both (env-precedence over default) following the `SearchModelExtract()` / `SearchModelParse()` pattern
+- [x] 1.4 Validate both durations in `JobConfig.Validate()` so a non-parseable value fails fast at startup
+- [x] 1.5 Add/extend config unit tests (`pkg/config/config_test.go`) for override, default, and invalid value (both fields)
+
+## 2. Backend — search log entity & schema
+
+- [x] 2.1 Add `LastFoundTime time.Time` (nullable) to `SearchLog` in `internal/entity/search_log.go`
+- [x] 2.2 Add a helper (e.g. `WasRecentlyDiscovered(now, window) bool`) returning false when `LastFoundTime` is zero/null
+- [x] 2.3 Add the desired-state column `last_found_at TIMESTAMPTZ NULL` to `internal/infrastructure/database/rdb/schema/schema.sql` (+ COMMENT)
+- [x] 2.4 Add the Atlas migration `20260601120000_add_last_found_at_to_search_logs.sql` (hand-authored to match schema.sql + `atlas migrate hash`; `atlas migrate diff` blocked locally by the ephemeral dev-DB `app` search_path snapshot)
+- [x] 2.5 Register the new migration file in `k8s/atlas/base/kustomization.yaml` under `configMapGenerator.files`
+- [x] 2.6 Add entity unit tests for the discovery-recency helper (null, within window, outside window)
+
+## 3. Backend — repository
+
+- [x] 3.1 Update the search-log repository to read `last_found_at` in `GetByArtistID`
+- [x] 3.2 Add a method to set `last_found_at = now` for an artist (or extend Upsert/UpdateStatus) without disturbing `searched_at` semantics
+- [x] 3.3 Update repository integration tests for read + discovery-time write
+
+## 4. Backend — use case wiring
+
+- [x] 4.1 Thread the configured TTL and discovery window from `JobConfig` into the concert use case (via DI in `internal/di/job.go` and the server provider if shared); remove the hard-coded `searchCacheTTL` constant
+- [x] 4.2 Add the discovery-recency skip branch in `SearchNewConcerts`: OR-combine `IsFresh(now, ttl)` with `WasRecentlyDiscovered(now, discoveryWindow)` using the configured window
+- [x] 4.3 In `executeSearch`, set `last_found_at = now` exactly when post-`FilterNew` new concerts are published (same point as the `concert.discovered` publish)
+- [x] 4.4 Update use case unit tests: skip-on-recent-discovery, no-skip-when-null, TTL honoured, discovery recorded only on non-empty new set
+- [x] 4.5 `make check` passes (lint + unit/integration tests)
+
+## 5. cloud-provisioning — prod config
+
+- [x] 5.1 Add `GCP_GEMINI_SEARCH_CACHE_TTL=72h` (and optionally `GCP_GEMINI_SEARCH_DISCOVERY_WINDOW=336h` for visibility) to the prod `concert-discovery` Kustomize configmap (`k8s/namespaces/backend/overlays/prod/cronjob/concert-discovery/configmap.env`); leave dev unset (inherits defaults). Pulumi/ESC not involved — non-secret tuning stays on the configmap.env path
+- [x] 5.2 `kubectl kustomize k8s/namespaces/backend/overlays/prod` renders cleanly; `make check` passes
+
+## 6. Ship to prod
+
+- [ ] 6.1 Open + merge the backend PR (CI green) per cross-repo workflow
+- [ ] 6.2 Cut a backend GitHub Release `vX.Y.Z`; confirm prod AR images pushed
+- [ ] 6.3 Open + merge the cloud-provisioning PR (prod image pin bump to `vX.Y.Z` + TTL configmap)
+- [ ] 6.4 Confirm Atlas Operator applies the `last_found_at` migration ahead of the backend/CronJob rollout
+- [ ] 6.5 Verify in prod: a CronJob run logs the new skip branch firing, and `latest_search_logs.last_found_at` is populated after a discovery


### PR DESCRIPTION
OpenSpec change capturing the design for reducing Gemini concert-search API cost.

- **proposal / design / tasks** + delta specs for `concert-search`, `concert-search-log`, `gemini-searcher-config`.
- Decisions: configurable freshness TTL (prod 72h), configurable recent-discovery skip window (default 14d) backed by `latest_search_logs.last_found_at`. Rejected: failed-search backoff (alerts suffice; ~0 failures) and reset-to-short-on-discovery (announcements are batch-then-quiet). Config delivery via Kustomize configmap.env, not Pulumi/ESC.

Implementation PR: liverty-music/backend#324

Refs: liverty-music/backend#323