### PR TITLE
chore(openspec): archive redesign-journey-status-ui and sync ticket-journey spec

### DIFF
--- a/openspec/changes/archive/2026-06-02-redesign-journey-status-ui/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-02-redesign-journey-status-ui/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-02

--- a/openspec/changes/archive/2026-06-02-redesign-journey-status-ui/design.md
+++ b/openspec/changes/archive/2026-06-02-redesign-journey-status-ui/design.md
@@ -1,0 +1,106 @@
+## Context
+
+The Ticket Status control lives in `EventDetailSheet` (`src/components/live-highway/`). It lets an authenticated user self-report their ticket-acquisition status for a concert. The five statuses are stored as a single `TicketJourneyStatus` value per `(user, event)`; the backend enforces **no** state machine (any status is settable at any time — see `ticket-journey` spec). The UI is therefore a self-report selector, not a guided wizard.
+
+Current implementation renders the five statuses via `repeat.for` as a flat horizontal wrap of pills. The active state is shown with a 25%-opacity tinted background plus a per-status outline color defined as scoped `--_journey-*` custom properties. This produces two problems documented in the proposal: (1) the selected pill is barely visible against the dark sheet, and (2) the flat row hides the real branching journey.
+
+The real journey is a branching DAG, not a linear list:
+
+```
+TRACKING ─▸ APPLIED ─┬─▸ LOST                 (failure, terminal)
+                     └─▸ UNPAID ─▸ PAID        (success route)
+```
+
+`UNPAID` and `PAID` both imply "won the lottery"; "当選" is a derived grouping label, not a stored status.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Make the currently-selected status unmistakable regardless of which status it is.
+- Express the journey's sequence and win/lose fork visually so users can locate and tap their real status quickly.
+- Keep the change frontend-only: no proto/backend/BSR/enum changes.
+- Preserve existing behavior: any status freely settable, auth-gated visibility, immediate dashboard-badge reflection, "stop tracking" removal.
+- Improve accessibility (single-select semantics, non-color cues).
+
+**Non-Goals:**
+- Enforcing transition rules / a state machine (backend explicitly allows any transition; UI must not block transitions).
+- Changing the `TicketJourneyStatus` enum, RPCs, or storage.
+- Fixing the `JP-13` venue-label bug (separate `fix-event-detail-venue-label` change).
+- Restyling the dashboard card badge (noted as optional consistency follow-up only).
+
+## Decisions
+
+### D1: Two-phase layout (process / outcome)
+
+Split the five statuses into **① 申込フロー** (`TRACKING ▸ APPLIED`, horizontal segment) and **② 結果** (outcome). This mirrors the two semantic phases of the DAG: a neutral pre-result process, then a mutually-exclusive result.
+
+- **Alternative considered — keep one flat row:** rejected; it is the source of the current UX problem and cannot express the fork.
+- **Alternative considered — horizontal flowchart with branch arrows:** rejected for a ~340px bottom sheet; five nodes + arrows cramp tap targets and shrink labels.
+
+### D2: Outcome as a vertical stack, success on top (Good is Up)
+
+In ② 結果, stack the routes vertically: the **当選 success route on top** (`UNPAID → PAID` vertical mini-flow), the **`LOST` failure route below and de-emphasized**.
+
+- **Rationale:** The "Good is Up" conceptual metaphor (Lakoff & Johnson; Meier & Robinson 2004) is robust and cross-cultural — far stronger than horizontal valence. Horizontal left/right valence is weak and handedness-dependent (Casasanto's body-specificity hypothesis), so an earlier "lost-left / won-right" idea was rejected as ungrounded. Vertical stacking also de-emphasizes failure (UX convention: do not give error/failure states equal visual weight) and, practically, gives each route the full sheet width — larger tap targets, no side-by-side cramping at 340px.
+- **Alternative considered — side-by-side `LOST` | 当選:** rejected; gives failure equal billing and cramps the win route's two sub-states.
+
+### D3: Cumulative progress derived from the single stored status
+
+The stored data is one status, but the DAG is fixed, so the path-to-here is derivable. Render passed states as completed (`✓`, low-emphasis), the current state as the sole solid-filled node, and future states as outlined.
+
+Derivation (pure view-model logic in the `.ts`):
+
+| Current status | Completed (✓) | Current (solid) | Dimmed (exclusive) |
+|----------------|---------------|-----------------|--------------------|
+| `TRACKING` | — | TRACKING | 結果 section (結果待ち) |
+| `APPLIED` | TRACKING | APPLIED | 結果 section (結果待ち) |
+| `LOST` | TRACKING, APPLIED | LOST | 当選 route |
+| `UNPAID` | TRACKING, APPLIED | UNPAID | LOST route |
+| `PAID` | TRACKING, APPLIED, UNPAID | PAID | LOST route |
+
+- **Alternative considered — highlight current only (no ✓):** rejected; loses the "where am I in the journey" affordance that motivated the redesign.
+
+### D4: Contrast via fill-vs-outline, not color intensity
+
+Exactly one node is solid-filled (the current state) at any time; everything else is outlined or low-emphasis. This is the structural fix for the visibility problem — the selection reads as "the one filled chip," so it no longer depends on hue saturation or tint opacity surviving against a dark background.
+
+- **Alternative considered — bump the 25% tint to a higher opacity:** rejected as a band-aid; still relies on color intensity and still flattens `LOST`'s muted palette.
+
+### D5: Semantic hue assignment
+
+Hue encodes meaning, not selection:
+
+| Status | Hue (current/solid) | Meaning |
+|--------|---------------------|---------|
+| `TRACKING`, `APPLIED` | neutral / blue | in-progress, emotionally neutral |
+| `LOST` | red (solid → legible even if dark) | failure, terminal |
+| `UNPAID` | **amber / orange (highest attention)** | action required — pay now |
+| `PAID` | green | success, terminal |
+
+`UNPAID` is deliberately the most attention-grabbing because it is the only state with a pending real-world action. Colors are defined as scoped `oklch()` custom properties consistent with the existing CUBE CSS token approach (`cube/require-token-variables`).
+
+### D6: Outcome gating = visible-but-dimmed, always tappable
+
+Before `APPLIED` is reached, ② 結果 is shown dimmed with a "結果待ち" affordance, but remains tappable. This honors the backend's "any transition allowed" contract (a user may correct/jump) while signaling the natural order.
+
+- **Alternative considered — disable 結果 until APPLIED:** rejected; would contradict the no-state-machine contract and block legitimate self-correction.
+
+### D7: Accessibility — radiogroup
+
+Replace the `button[data-active]` pills with a `role="radiogroup"` containing `role="radio"` options (`aria-checked`), since the control is single-select. Each option carries a non-color cue (icon ✓ / ! / ✕ / ● plus its text label) so meaning survives without color. Maintain ≥44px tap targets (the vertical stack and full-width cards make this natural). The existing `data-testid` hooks for E2E are preserved.
+
+## Risks / Trade-offs
+
+- **[Increased template/CSS complexity vs the simple `repeat.for`]** → Keep the status→view-state mapping (✓ / current / future / dimmed) as small pure getters in the `.ts`, unit-tested per status; the template binds to those rather than computing inline.
+- **[Vertical layout adds height to the sheet]** → The sheet already scrolls; the two-phase grouping with full-width rows is acceptable on mobile. Verify against the shortest supported viewport.
+- **[Color-only meaning would fail a11y]** → Mandated icon + text cue per state (D7); covered by a spec scenario.
+- **[Risk of implying an enforced state machine]** → Copy and gating must read as guidance, not restriction; 結果 stays tappable (D6). Covered by a spec scenario asserting any status remains settable.
+- **[Dashboard badge palette could drift from the new sheet palette]** → Out of scope here, but flagged so a later change can align them; tokens are defined centrally to make that cheap.
+
+## Migration Plan
+
+Pure frontend presentation change; no data migration. Ship as a single frontend PR. Rollback = revert the PR (no schema/RPC coupling). Validate via `make check` (Biome + stylelint + typecheck + vitest), updated component unit tests for the view-state derivation, and a manual/visual pass over all five statuses in the bottom sheet. Refresh visual baselines if the frontend visual-regression suite flags the intended UI change.
+
+## Open Questions
+
+- None blocking. The dashboard-badge palette alignment is intentionally deferred to a future change.

--- a/openspec/changes/archive/2026-06-02-redesign-journey-status-ui/proposal.md
+++ b/openspec/changes/archive/2026-06-02-redesign-journey-status-ui/proposal.md
@@ -1,0 +1,39 @@
+## Why
+
+The Ticket Status control in `EventDetailSheet` renders the five journey statuses (`TRACKING`, `APPLIED`, `LOST`, `UNPAID`, `PAID`) as a flat horizontal row of pills with no indication of order, branching, or the user's current progress. Two concrete problems result:
+
+- **Poor visibility of the selected state.** The active state is conveyed only by a 25%-opacity background tint over a dark sheet, so the current selection is barely distinguishable from unselected pills — worst for `LOST`, which is intentionally the most muted color.
+- **The layout does not match the real acquisition journey.** The statuses form a branching flow (apply → win/lose; win → pay), but the flat row hides the sequence and the win/lose fork, making it hard for users to locate and tap their actual status.
+
+## What Changes
+
+- Replace the flat horizontal pill row with a **two-phase layout** in the Ticket Status section:
+  - **① 申込フロー (process):** `TRACKING ▸ APPLIED` as a horizontal segmented progression.
+  - **② 結果 (outcome):** a vertical stack with the **success route on top** (`UNPAID → PAID` as a vertical mini-flow under a "当選" heading) and the **failure route (`LOST`) below and de-emphasized**.
+- **Cumulative progress display:** states the user has passed through (derived from the single stored status via the known journey DAG) are shown as completed (`✓`), the current state is the sole solid-filled node, and future states are outlined.
+- **Outcome gating:** the 結果 section remains always tappable (self-reported), but is visually dimmed ("結果待ち") until `APPLIED` is reached.
+- **Mutual exclusivity made visible:** selecting `LOST` dims the win route and vice-versa.
+- **Contrast via fill-vs-outline, not color intensity:** exactly one node is solid-filled at a time, so the current selection is unmistakable regardless of hue.
+- **Semantic hue assignment:** `UNPAID` = amber/highest-attention (action required), `PAID` = green (success), `LOST` = red (failure), `TRACKING`/`APPLIED` = neutral/blue (in-progress).
+- **Accessibility:** the status control becomes a single-select `role="radiogroup"` of `role="radio"` options with `aria-checked`, and every state carries a non-color cue (icon + text label).
+- Frontend-only. No proto, backend, or BSR changes — the `TicketJourneyStatus` enum, RPCs, and storage are unchanged.
+
+Out of scope: the `JP-13` raw `adminArea` venue-label bug (handled by the separate `fix-event-detail-venue-label` change).
+
+## Capabilities
+
+### New Capabilities
+<!-- None — this change modifies presentation of an existing capability. -->
+
+### Modified Capabilities
+- `ticket-journey`: add requirements governing the Ticket Status UI layout, cumulative progress display, outcome gating, visual contrast model, semantic color mapping, and radiogroup accessibility. The existing data model, RPC, and auth-visibility requirements are unchanged.
+
+## Impact
+
+- **Affected code (frontend only):**
+  - `src/components/live-highway/event-detail-sheet.html` — replace the `repeat.for` pill row with the two-phase structure and radiogroup semantics.
+  - `src/components/live-highway/event-detail-sheet.css` — new fill-vs-outline contrast model, semantic color tokens, two-phase/vertical-stack layout.
+  - `src/components/live-highway/event-detail-sheet.ts` — derive cumulative/dim/exclusivity view-state from the current `journeyStatus`; selection still calls the existing `journeyService.setStatus`.
+  - `src/locales/{ja,en}/translation.json` — copy for the "当選" group heading and the 申込フロー / 結果 section labels.
+- **Unchanged:** `TicketJourneyService` proto/RPC, backend handlers, `ticket_journeys` schema, `TicketJourneyStatus` enum values.
+- **Consistency follow-up (optional):** the dashboard card status badge (`event-card.html`) may later adopt the same semantic palette for coherence — noted in design, not required by this change.

--- a/openspec/changes/archive/2026-06-02-redesign-journey-status-ui/specs/ticket-journey/spec.md
+++ b/openspec/changes/archive/2026-06-02-redesign-journey-status-ui/specs/ticket-journey/spec.md
@@ -1,0 +1,97 @@
+## ADDED Requirements
+
+### Requirement: Ticket Status UI two-phase layout
+
+The Ticket Status control in `EventDetailSheet` SHALL present the journey statuses in two phases instead of a flat row: a **process phase** (`TRACKING ▸ APPLIED`) and an **outcome phase**. The outcome phase SHALL stack its routes vertically with the success route (`UNPAID → PAID`, grouped under a "当選" heading) above the failure route (`LOST`).
+
+#### Scenario: Process phase shows the pre-result sequence
+
+- **WHEN** an authenticated user opens the concert detail sheet
+- **THEN** the process phase SHALL render `TRACKING` and `APPLIED` as a horizontal segmented sequence in that order
+
+#### Scenario: Outcome phase stacks success above failure
+
+- **WHEN** the outcome phase is rendered
+- **THEN** the success route (`UNPAID` then `PAID`) SHALL appear above the failure route (`LOST`)
+- **AND** `UNPAID` and `PAID` SHALL be grouped under a single "当選" heading
+
+### Requirement: Ticket Status cumulative progress display
+
+The Ticket Status control SHALL derive and display the user's progress through the journey from the single stored status, using the fixed journey DAG (`TRACKING → APPLIED → {LOST | UNPAID → PAID}`). States already passed SHALL be shown as completed, the current state SHALL be the only solid-filled node, and not-yet-reached states SHALL be shown as outlined.
+
+#### Scenario: Passed states are marked completed
+
+- **WHEN** the current status is `PAID`
+- **THEN** `TRACKING`, `APPLIED`, and `UNPAID` SHALL be displayed as completed (e.g. a check cue)
+- **AND** `PAID` SHALL be displayed as the current solid-filled node
+
+#### Scenario: Future states are outlined
+
+- **WHEN** the current status is `APPLIED`
+- **THEN** `APPLIED` SHALL be the solid-filled node
+- **AND** `TRACKING` SHALL be displayed as completed
+- **AND** the outcome states SHALL be displayed as not-yet-reached (outlined)
+
+#### Scenario: Exactly one solid-filled node
+
+- **WHEN** any status is selected
+- **THEN** exactly one node SHALL be solid-filled at a time
+
+### Requirement: Ticket Status selection contrast
+
+The currently selected status SHALL be conveyed primarily through a solid fill versus outlined unselected states, rather than through background color intensity or opacity. The selected node SHALL remain clearly distinguishable from unselected nodes for every status value, including `LOST`.
+
+#### Scenario: Selected LOST is clearly distinguishable
+
+- **WHEN** the current status is `LOST`
+- **THEN** the `LOST` node SHALL be solid-filled
+- **AND** it SHALL be visually distinct from the unselected/outlined nodes
+
+### Requirement: Ticket Status semantic color and non-color cues
+
+Each status SHALL carry a meaning-based color and a non-color cue (icon plus text label) so the control is understandable without relying on color alone. `UNPAID` SHALL be the highest-attention color (amber/orange) to signal a required payment action, `PAID` SHALL use a success color (green), `LOST` SHALL use a failure color (red), and `TRACKING`/`APPLIED` SHALL use neutral/in-progress colors.
+
+#### Scenario: UNPAID is emphasized as action-required
+
+- **WHEN** the current status is `UNPAID`
+- **THEN** the `UNPAID` node SHALL use the highest-attention (amber/orange) color
+- **AND** it SHALL include a non-color action cue
+
+#### Scenario: Meaning survives without color
+
+- **WHEN** any status node is rendered
+- **THEN** it SHALL include a text label and a non-color cue (icon) in addition to color
+
+### Requirement: Ticket Status outcome gating
+
+The outcome phase SHALL be visually de-emphasized (dimmed, with a "結果待ち" affordance) until the `APPLIED` state has been reached, while remaining selectable at all times. Selecting the failure route SHALL de-emphasize the success route and vice-versa.
+
+#### Scenario: Outcome dimmed before applied
+
+- **WHEN** the current status is `TRACKING` or `APPLIED`
+- **THEN** the outcome phase SHALL be displayed dimmed with a "結果待ち" affordance
+- **AND** the outcome states SHALL still be selectable
+
+#### Scenario: Mutually exclusive routes
+
+- **WHEN** the current status is `LOST`
+- **THEN** the success route (`UNPAID`/`PAID`) SHALL be dimmed
+- **AND WHEN** the current status is `UNPAID` or `PAID`
+- **THEN** the failure route (`LOST`) SHALL be dimmed
+
+#### Scenario: Any status remains settable
+
+- **WHEN** the user taps any status node, including a dimmed one
+- **THEN** the control SHALL set that status via `TicketJourneyService/SetStatus`
+- **AND** the UI SHALL NOT block the selection (no enforced state machine)
+
+### Requirement: Ticket Status radiogroup accessibility
+
+The Ticket Status control SHALL expose single-select semantics as a `role="radiogroup"` containing `role="radio"` options with `aria-checked` reflecting the current status. Each option SHALL be an accessible, ≥44px tap target.
+
+#### Scenario: Radiogroup semantics
+
+- **WHEN** the Ticket Status control is rendered for an authenticated user
+- **THEN** it SHALL be a `radiogroup` of `radio` options
+- **AND** the option matching the current status SHALL have `aria-checked="true"`
+- **AND** all other options SHALL have `aria-checked="false"`

--- a/openspec/changes/archive/2026-06-02-redesign-journey-status-ui/tasks.md
+++ b/openspec/changes/archive/2026-06-02-redesign-journey-status-ui/tasks.md
@@ -1,0 +1,37 @@
+## 1. View-model: derive UI state from status
+
+- [x] 1.1 In `event-detail-sheet.ts`, add a pure helper that maps the current `journeyStatus` to per-node UI state (`completed` / `current` / `future` / `dimmed`) using the journey DAG (`TRACKING → APPLIED → {LOST | UNPAID → PAID}`)
+- [x] 1.2 Add getters for the two phases: process nodes (`TRACKING`, `APPLIED`) and outcome routes (failure: `LOST`; success: `UNPAID`, `PAID`)
+- [x] 1.3 Add an `outcomePending` getter that is true until `APPLIED` is reached (drives the "結果待ち" dim)
+- [x] 1.4 Keep selection wired to the existing `journeyService.setStatus`; ensure any node (including dimmed) remains selectable (no state-machine guard)
+- [x] 1.5 Unit-test the derivation for all five statuses (completed/current/future/dimmed sets + `outcomePending`) in `test/components/live-highway/`
+
+## 2. Template: two-phase layout + radiogroup
+
+- [x] 2.1 Replace the flat `repeat.for` pill row in `event-detail-sheet.html` with the process phase (`TRACKING ▸ APPLIED` horizontal segment)
+- [x] 2.2 Add the outcome phase as a vertical stack: success route (`当選` heading → `UNPAID → PAID` mini-flow) on top, failure route (`LOST`) below
+- [x] 2.3 Convert the control to `role="radiogroup"` with `role="radio"` options and bind `aria-checked` to the current status
+- [x] 2.4 Add per-node non-color cues (icon for completed `✓` / action `!` / fail `✕` / current `●`) alongside text labels
+- [x] 2.5 Preserve existing `data-testid` hooks and the "stop tracking" (remove journey) control
+
+## 3. Styling: fill-vs-outline contrast + semantic color
+
+- [x] 3.1 In `event-detail-sheet.css`, define scoped `oklch()` semantic color tokens (neutral/blue process, red `LOST`, amber `UNPAID`, green `PAID`) compliant with `cube/require-token-variables`
+- [x] 3.2 Implement the contrast model: solid fill for `current`, low-emphasis `✓` for `completed`, outline for `future`, reduced-opacity for `dimmed` — exactly one solid node at a time
+- [x] 3.3 Style the two-phase / vertical-outcome layout for the ~340px bottom sheet with ≥44px tap targets
+- [x] 3.4 Remove the obsolete 25%-tint `[data-active]` / per-status `--_journey-*` active styles
+
+## 4. Copy
+
+- [x] 4.1 Add i18n keys for the "申込フロー" and "結果" section headings, the "当選" group heading, and the "結果待ち" affordance in `src/locales/ja/translation.json` and `src/locales/en/translation.json`
+
+## 5. Verify
+
+- [x] 5.1 Run `make check` (Biome + stylelint + typecheck + vitest) until green
+- [x] 5.2 Manually verify all five statuses render correctly (current solid, passed `✓`, future outlined, exclusive route dimmed, `UNPAID` most prominent) in the bottom sheet
+- [x] 5.3 If the visual-regression suite flags the intended UI change, refresh frontend visual baselines per the established baseline-refresh process
+
+## 6. Ship
+
+- [x] 6.1 Open the frontend PR (Conventional Commits, mandatory body + `Refs: #<issue>`); drive CI green and merge after all checks pass
+- [x] 6.2 Cut the frontend prod release (GH Release retag → prod AR) and confirm the automated pin-bump → ArgoCD auto-sync reflects the change in prod

--- a/openspec/specs/ticket-journey/spec.md
+++ b/openspec/specs/ticket-journey/spec.md
@@ -3,9 +3,7 @@
 ## Purpose
 
 The `ticket-journey` capability allows users to track their personal ticket acquisition status for concerts and events. Users can set, update, and remove journey statuses representing stages of the ticket acquisition process (tracking, applied, lost, unpaid, paid).
-
 ## Requirements
-
 ### Requirement: Ticket Journey Entity
 
 The system SHALL define a `TicketJourney` entity representing a user's personal ticket acquisition status for a specific event. Each journey is uniquely identified by the combination of user and event.
@@ -119,3 +117,100 @@ The Ticket Status UI in `EventDetailSheet` SHALL only be rendered when the user 
 - **WHEN** an unauthenticated (guest) user opens the concert detail sheet
 - **THEN** the Ticket Status section SHALL NOT be rendered
 - **AND** no RPC call to `TicketJourneyService/SetStatus` SHALL be made
+
+### Requirement: Ticket Status UI two-phase layout
+
+The Ticket Status control in `EventDetailSheet` SHALL present the journey statuses in two phases instead of a flat row: a **process phase** (`TRACKING ▸ APPLIED`) and an **outcome phase**. The outcome phase SHALL stack its routes vertically with the success route (`UNPAID → PAID`, grouped under a "当選" heading) above the failure route (`LOST`).
+
+#### Scenario: Process phase shows the pre-result sequence
+
+- **WHEN** an authenticated user opens the concert detail sheet
+- **THEN** the process phase SHALL render `TRACKING` and `APPLIED` as a horizontal segmented sequence in that order
+
+#### Scenario: Outcome phase stacks success above failure
+
+- **WHEN** the outcome phase is rendered
+- **THEN** the success route (`UNPAID` then `PAID`) SHALL appear above the failure route (`LOST`)
+- **AND** `UNPAID` and `PAID` SHALL be grouped under a single "当選" heading
+
+### Requirement: Ticket Status cumulative progress display
+
+The Ticket Status control SHALL derive and display the user's progress through the journey from the single stored status, using the fixed journey DAG (`TRACKING → APPLIED → {LOST | UNPAID → PAID}`). States already passed SHALL be shown as completed, the current state SHALL be the only solid-filled node, and not-yet-reached states SHALL be shown as outlined.
+
+#### Scenario: Passed states are marked completed
+
+- **WHEN** the current status is `PAID`
+- **THEN** `TRACKING`, `APPLIED`, and `UNPAID` SHALL be displayed as completed (e.g. a check cue)
+- **AND** `PAID` SHALL be displayed as the current solid-filled node
+
+#### Scenario: Future states are outlined
+
+- **WHEN** the current status is `APPLIED`
+- **THEN** `APPLIED` SHALL be the solid-filled node
+- **AND** `TRACKING` SHALL be displayed as completed
+- **AND** the outcome states SHALL be displayed as not-yet-reached (outlined)
+
+#### Scenario: Exactly one solid-filled node
+
+- **WHEN** any status is selected
+- **THEN** exactly one node SHALL be solid-filled at a time
+
+### Requirement: Ticket Status selection contrast
+
+The currently selected status SHALL be conveyed primarily through a solid fill versus outlined unselected states, rather than through background color intensity or opacity. The selected node SHALL remain clearly distinguishable from unselected nodes for every status value, including `LOST`.
+
+#### Scenario: Selected LOST is clearly distinguishable
+
+- **WHEN** the current status is `LOST`
+- **THEN** the `LOST` node SHALL be solid-filled
+- **AND** it SHALL be visually distinct from the unselected/outlined nodes
+
+### Requirement: Ticket Status semantic color and non-color cues
+
+Each status SHALL carry a meaning-based color and a non-color cue (icon plus text label) so the control is understandable without relying on color alone. `UNPAID` SHALL be the highest-attention color (amber/orange) to signal a required payment action, `PAID` SHALL use a success color (green), `LOST` SHALL use a failure color (red), and `TRACKING`/`APPLIED` SHALL use neutral/in-progress colors.
+
+#### Scenario: UNPAID is emphasized as action-required
+
+- **WHEN** the current status is `UNPAID`
+- **THEN** the `UNPAID` node SHALL use the highest-attention (amber/orange) color
+- **AND** it SHALL include a non-color action cue
+
+#### Scenario: Meaning survives without color
+
+- **WHEN** any status node is rendered
+- **THEN** it SHALL include a text label and a non-color cue (icon) in addition to color
+
+### Requirement: Ticket Status outcome gating
+
+The outcome phase SHALL be visually de-emphasized (dimmed, with a "結果待ち" affordance) until the `APPLIED` state has been reached, while remaining selectable at all times. Selecting the failure route SHALL de-emphasize the success route and vice-versa.
+
+#### Scenario: Outcome dimmed before applied
+
+- **WHEN** the current status is `TRACKING` or `APPLIED`
+- **THEN** the outcome phase SHALL be displayed dimmed with a "結果待ち" affordance
+- **AND** the outcome states SHALL still be selectable
+
+#### Scenario: Mutually exclusive routes
+
+- **WHEN** the current status is `LOST`
+- **THEN** the success route (`UNPAID`/`PAID`) SHALL be dimmed
+- **AND WHEN** the current status is `UNPAID` or `PAID`
+- **THEN** the failure route (`LOST`) SHALL be dimmed
+
+#### Scenario: Any status remains settable
+
+- **WHEN** the user taps any status node, including a dimmed one
+- **THEN** the control SHALL set that status via `TicketJourneyService/SetStatus`
+- **AND** the UI SHALL NOT block the selection (no enforced state machine)
+
+### Requirement: Ticket Status radiogroup accessibility
+
+The Ticket Status control SHALL expose single-select semantics as a `role="radiogroup"` containing `role="radio"` options with `aria-checked` reflecting the current status. Each option SHALL be an accessible, ≥44px tap target.
+
+#### Scenario: Radiogroup semantics
+
+- **WHEN** the Ticket Status control is rendered for an authenticated user
+- **THEN** it SHALL be a `radiogroup` of `radio` options
+- **AND** the option matching the current status SHALL have `aria-checked="true"`
+- **AND** all other options SHALL have `aria-checked="false"`
+


### PR DESCRIPTION
## Summary

Archives the completed `redesign-journey-status-ui` OpenSpec change and syncs its delta into the canonical capability spec.

The Ticket Status journey UI redesign shipped to production (frontend `v1.6.0`, PR liverty-music/frontend#414), so:

- Move `openspec/changes/redesign-journey-status-ui/` → `openspec/changes/archive/2026-06-02-redesign-journey-status-ui/`.
- Apply its **6 ADDED requirements** to `openspec/specs/ticket-journey/spec.md` (two-phase layout, cumulative progress display, selection contrast, semantic color + non-color cues, outcome gating, radiogroup accessibility) — additive, no modifications/removals to existing requirements.

## Related

- Implements / closes: liverty-music/frontend#412, liverty-music/frontend#413
- Frontend PR: liverty-music/frontend#414 (merged, released as v1.6.0)
