### PR TITLE
chore(openspec): archive settings-ui-polish + sync bottom-sheet-ce/settings specs

### DIFF
--- a/openspec/changes/archive/2026-06-02-settings-ui-polish/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-02-settings-ui-polish/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-01

--- a/openspec/changes/archive/2026-06-02-settings-ui-polish/design.md
+++ b/openspec/changes/archive/2026-06-02-settings-ui-polish/design.md
@@ -1,0 +1,101 @@
+## Context
+
+The shared `<bottom-sheet>` custom element is the single dialog primitive for all overlay content (`bottom-sheet-ce` spec). Today it is a `popover="auto"` host with a manually-set `role="dialog"`, a full-viewport transparent layer (`position: fixed; inset: 0`) whose internal `.scroll-area` (`100dvh`, `scroll-snap-type: y mandatory`) provides swipe-down dismiss via a `.dismiss-zone` snap target. Closing is gated on `scrollend` → `scrollRatio < 0.1` → `hidePopover()`.
+
+This design is the product of several prior iterations, whose lessons constrain the solution space:
+
+- `2026-02-23 fix-area-dialog-overlap` — area sheets used `<dialog>.showModal()` *because* Popover "doesn't trap focus or provide `::backdrop`". Tap-outside was implemented via `event.target === dialog`.
+- `2026-03-12 fix-detail-sheet-dismiss` — the partial-coverage detail sheet moved to `popover="auto"` for free light-dismiss + Android back (CloseWatcher), after discovering the UA rule `[popover]::backdrop { pointer-events: none !important }` makes manual `::backdrop` click dead code.
+- `8d905f3` introduced a scroll-driven backdrop fade (`scroll-timeline` → `::backdrop` opacity); `72c768a` (move popover to CE host) removed the timeline consumer as collateral; `b362a95` swept the now-dead declaration and added the `contain: layout` Chromium scroll-snap-in-top-layer workaround.
+
+Two regressions resulted from consolidating those surfaces onto the popover-based shared CE: **focus-trap/`inert` was lost** (the area-sheet behavior) and **tap-outside was lost** (the detail-sheet behavior, which relied on partial coverage exposing the backdrop — the full-viewport shared CE has no exposed backdrop). Separately, the `settings` spec still requires the home-area selector to be a `<dialog>` via `showModal()`, so spec and implementation are inconsistent.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Restore focus-trap + `inert` to the shared bottom-sheet (close the #1 a11y gap and the `settings`-spec inconsistency) via native `<dialog>.showModal()`.
+- Keep the full-viewport scroll-snap swipe-down dismiss (the primary mobile gesture) intact.
+- Restore tap-outside dismiss and a gesture-coupled (scroll-driven) backdrop fade.
+- Make swipe dismiss feel responsive (cut the `scrollend`-settle + post-settle-transition latency).
+- Land the Settings a11y, CUBE-layer, and correctness cleanups from #399 A/B/C.
+
+**Non-Goals:**
+- Reverting to a partial-height bottom sheet (would re-enable native `closedby` light-dismiss but break the scroll-snap swipe — see Decision 2).
+- A JS pointer-driven drag implementation of swipe (the project deliberately moved to scroll-snap).
+- Adopting `closedby="any"` (Safari-unsupported, and never fires under full-viewport coverage).
+- Refactoring all CUBE CSS app-wide; scope is the settings + consent toggle surfaces and the shared toggle tokens.
+- The stale #8 flex-cluster rework (already addressed by the #409 subgrid refactor).
+
+## Decisions
+
+### Decision 1: Native `<dialog>.showModal()` as the bottom-sheet host
+
+**Choice**: The CE host (`<bottom-sheet>`) wraps an inner `<dialog ref>`; `open()` calls `dialog.showModal()`, `close()` calls `dialog.close()`. The `.scroll-area` / `.dismiss-zone` / `.sheet-body` structure moves inside the `<dialog>`.
+
+**Rationale**: `showModal()` provides focus-trap, `inert` background, ESC, and Android back (close request) natively — exactly the behaviors lost in consolidation, and what the area-sheet design originally chose Popover *against*. The swipe mechanism is independent of how the host enters the top layer (confirmed by the `navigation-drawer` modern-web-guidance pattern), so it survives the host swap unchanged.
+
+**Alternatives considered**:
+- *Keep `popover="auto"` + hand-roll focus-trap + `inert`*: reimplements what `showModal()` gives free; rejected.
+- *Hybrid `<dialog popover="auto">`*: a dialog opened as a popover uses `showPopover()` semantics — no focus-trap. Does not solve #1.
+
+### Decision 2: Keep full-viewport geometry; tap-outside via `.dismiss-zone` click (not `::backdrop`, not `closedby`)
+
+**Choice**: Add `click.trigger="close()"` to the existing `.dismiss-zone` div.
+
+**Rationale**: Under full-viewport coverage the dialog box fills the viewport; every tap targets a dialog descendant, so native light-dismiss (popover *or* `closedby="any"`) can never fire — the dim area the user taps is the `.dismiss-zone` (dialog content), with the `::backdrop` hidden behind it. `::backdrop` itself is unusable (UA `pointer-events: none`, the documented `fix-detail-sheet-dismiss` trap). A click handler on `.dismiss-zone` is host-agnostic, works on all browsers, and converges with the swipe path (same div). This is the only minimal way to get tap-outside *while keeping swipe*.
+
+**Trade-off (A vs B)**: Native tap-outside via `closedby` requires exposing the backdrop = a partial-height sheet (B), which removes the full-height scroll container that powers swipe. Swipe (mobile-primary) and native `closedby` (desktop convenience) require contradictory geometries. We keep swipe (A); tap-outside costs one click handler.
+
+### Decision 3: Restore scroll-driven backdrop fade (gated), gesture-couple the dismiss
+
+**Choice**: Re-introduce `animation-timeline: scroll()` driving `::backdrop` opacity/blur off the `.scroll-area` scroll position, inside `@supports (animation-timeline: scroll())`; keep the current opacity `transition` as the fallback. Trigger close on the snap-change/scroll-threshold (dismiss-zone becoming the snapped target) rather than waiting for full `scrollend`; shorten the exit transition and tokenize its duration. Preserve the `prefers-reduced-motion` instant path.
+
+**Rationale**: The blur reads as "slow" because it stays fully applied through the swipe and fades only after `scrollend` over 300ms. Coupling backdrop opacity to scroll position makes the blur track the finger and be gone by the dismiss threshold. Firing close on snap-change removes the UA-controlled native-snap-settle latency (which is not CSS-tunable). This restores the `8d905f3` behavior that was dropped as refactor collateral — re-wiring the `scroll-timeline` scope correctly against the new `<dialog>` structure.
+
+**Alternatives considered**:
+- *Only shorten the exit duration*: helps the slide-out but leaves the blur decoupled from the gesture.
+- *JS scroll listener writing `--backdrop` opacity*: the Firefox fallback path; acceptable but the CSS scroll-timeline is preferred where supported.
+
+### Decision 4: Settings a11y as `settings`-capability requirements
+
+**Choice**: Language selector → `role="radiogroup"`/`role="radio"` + `aria-checked`; home-area selected-state bound off observable `userStore.currentHome`; polite live region for async (resend/badge); `aria-describedby` for toggle hints + `aria-disabled` (not native `disabled`) for the VAPID-unavailable push row; settings groups → list semantics (drop `<hr>`); email/badge associated + non-color status cue.
+
+**Rationale**: `semantic-dom` carries no radiogroup/live/list requirements today, and these are settings-page behaviors, so they belong in the `settings` capability. Single-select semantics + observable-driven selected-state also fix the "SR users can't tell which option is active" gap that the `data-selected` + `aria-hidden` check could not convey.
+
+### Decision 5: Consent state becomes `@observable`; delete the component mirror
+
+**Choice**: `ConsentService` exposes `@observable` state (immutable reassignment as today); the settings VM binds `consent.analytics` / `consent.marketingMeasurement` directly and drops `analyticsConsent`/`marketingConsent` + their write-back handlers and the fabricated RC1 doc-comment.
+
+**Rationale**: UserStore/GuestService are already observable owners of their domains; consent is the lone component-local mirror, carrying a mirror-drift risk (an external consent change does not flow through the toggle handlers). Per `aurelia-reactivity`, getters derived from `@observable` state re-evaluate dependent bindings without a mirror.
+
+### Decision 6: Re-scope CUBE work; no behavior delta
+
+**Choice**: Move `data-*` state hooks into `@layer exception`; extract `--toggle-*`/`--duration-*` tokens shared by `settings-route.css` and `consent-route.css`; apply bracket grouping consistently. Drop the obsolete #8 flex-cluster rework.
+
+**Rationale**: These are CSS-architecture changes with no observable behavior change, so they are implementation tasks under the existing `cube-css-*` specs, not spec deltas. #8's specific examples were resolved by the #409 subgrid refactor that landed after #399 was filed.
+
+## Risks / Trade-offs
+
+- **[Risk] CE host cannot itself be a `<dialog>`; inner-`<dialog>` wrapper changes DOM shape** → Spike first across all consumers; update the `bottom-sheet-ce` "DOM structure" scenario. The `::backdrop` and top-layer now belong to the inner `<dialog>`.
+- **[Risk] Android back may not fire `cancel` as assumed** → Spike on-device / Playwright before implementation; this was the detail sheet's original reason for choosing popover.
+- **[Risk] `contain: layout` Chromium workaround may behave differently under dialog top-layer** → Same top-layer class; rely on the existing artist-filter chip-check E2E regression guard; verify during spike.
+- **[Resolved by spike 1.4] Onboarding spotlight vs modal `inert`**: verified against current code — the global `coach-mark` and any `<bottom-sheet>` do not coexist (`activateSpotlight()` only in `discovery-route` on `[data-nav="home"]`; `event-detail-sheet` opened by `dashboard-route` with no spotlight). `bringSpotlightToFront()`/`onBringToFront` is dead code. `showModal()`'s `inert` does not break onboarding today. Residual constraint: a future onboarding step that layers the coach-mark over a modal sheet would break (coach-mark, outside the dialog, becomes inert) — document this and delete the dead `bringSpotlightToFront` plumbing.
+- **[Risk] scroll-driven backdrop unsupported in Firefox** → `@supports` gate + transition fallback (current behavior); no regression where unsupported.
+- **[Trade-off] tap-outside stays a manual handler** rather than a platform freebie — accepted to preserve swipe (Decision 2).
+- **[Risk] Visual baselines shift** (radiogroup, `<dialog>`, list semantics) → regenerate baselines before merge (no PR update path; main-branch CI artifact).
+
+## Migration Plan
+
+1. **Spikes** (gate): inner-`<dialog>` wrapper non-breaking across consumers; Android back `cancel`; `contain: layout` under dialog top-layer.
+2. **PR-1 (shared bottom-sheet)**: `<dialog>.showModal()` migration + tap-outside + scroll-driven backdrop + responsive dismiss. Update `bottom-sheet-ce` spec. Verify all consumers (home/language selector, post-signup-dialog, page-help, onboarding spotlight).
+3. **PR-2 (Settings a11y)**: radiogroup language selector, home-area selected-state, live regions, list semantics, badge association, toggle-hint/`aria-disabled`. Update `settings` spec.
+4. **PR-3 (CUBE)**: `@layer exception` + token extraction + bracket grouping.
+5. **PR-4 (correctness)**: `selectLanguage` close-after-success + consent `@observable`.
+6. Regenerate visual baselines; ship through dev to prod.
+
+Rollback: each PR is independently revertible; the bottom-sheet migration is the only structural one and is guarded by the existing E2E suite.
+
+## Open Questions
+
+- Does `<dialog>.showModal()` fire `cancel` on Android back across the target WebView/Chrome versions, or is a CloseWatcher shim needed? (Spike.)
+- Should tap-outside on a `required`/non-dismissable sheet (onboarding home selection) stay suppressed, mirroring the current `dismissable=false` path? (Likely yes — carry the `dismissable` gate to the `.dismiss-zone` click handler.)

--- a/openspec/changes/archive/2026-06-02-settings-ui-polish/proposal.md
+++ b/openspec/changes/archive/2026-06-02-settings-ui-polish/proposal.md
@@ -1,0 +1,56 @@
+## Why
+
+A multi-lens `/code-review` of the Settings page (cube-css / web-design-specialist / modern-web-guidance / aurelia-specialist) during the `introduce-entity-store-layer` work surfaced a cluster of pre-existing UI debt: accessibility gaps in the shared bottom-sheet and the selectors, CUBE CSS layer drift, and two correctness/altitude issues. The store-driven reactivity itself was verified clean — these are not regressions from the store refactor.
+
+Investigation while triaging the bottom-sheet a11y gap (#1) revealed a deeper, two-part regression and a spec/implementation inconsistency:
+
+- The shared `<bottom-sheet>` is a `popover="auto"` host with a manually-set `role="dialog"`. It does **not** trap focus or `inert` the background, so keyboard/SR users can Tab out into the still-interactive page behind an open sheet. Earlier area-selection sheets (archived `fix-area-dialog-overlap`) deliberately used `<dialog>.showModal()` *for* focus-trap + `::backdrop` + ESC, and the concert detail sheet (archived `fix-detail-sheet-dismiss`) added tap-outside dismiss. **Both behaviors were lost when those surfaces were consolidated onto the popover-based shared CE.**
+- The `settings` capability spec already requires the home-area selector to be a native `<dialog>` opened via `showModal()` with backdrop/ESC dismiss, but the implementation drifted to the popover-based shared `<bottom-sheet>`. Spec and code are inconsistent today.
+- The swipe-down dismiss feels sluggish: dismiss is gated on `scrollend` (native scroll-snap settle, UA-controlled and floaty) followed by a 300ms exit transition that only *starts* after the gesture settles. The backdrop blur stays fully applied throughout the swipe and fades only afterward, so it reads as disconnected from the finger. A scroll-driven backdrop fade existed (`8d905f3`) but was dropped as collateral of the popover→CE-host refactor (`72c768a`/`b362a95`), not because it was wrong.
+
+Doing the bottom-sheet a11y fix (#1) and the UX polish together restores focus-trap, tap-outside, and the gesture-coupled backdrop in one structural change, and reconciles the `settings` spec with reality.
+
+## What Changes
+
+**Shared bottom-sheet (highest leverage — touches home selector, language selector, and other surfaces):**
+- Migrate the shared `<bottom-sheet>` from a `popover="auto"` host to a native `<dialog>.showModal()` (CE host wraps an inner `<dialog>`), restoring focus-trap + `inert` + ESC + Android back (close request) for free.
+- Preserve the full-viewport scroll-snap geometry that powers swipe-down dismiss (host-agnostic — the scroll mechanism lives on an internal scroll container, not the host).
+- Add tap-outside dismiss via a `click` handler on the existing `.dismiss-zone` div (NOT `::backdrop` — UA forces `pointer-events: none` there; NOT `closedby` — Safari-unsupported and never fires under full-viewport coverage).
+- Restore a scroll-driven backdrop fade so the blur tracks the swipe and is gone by the dismiss threshold, gated behind `@supports (animation-timeline: scroll())` with the current transition as the fallback.
+- Make swipe dismiss feel responsive by firing close on the snap-change/threshold rather than waiting for full `scrollend` settle, and shorten the exit transition; preserve the `prefers-reduced-motion` instant path.
+
+**A. Accessibility / semantics (Settings):**
+- Language selector becomes a single-select control (`role="radiogroup"`/`role="radio"` + `aria-checked`) instead of a list of `data-selected` buttons.
+- Home-area selector shows a reactive selected-state indicator (bind `aria-checked`/`data-selected` off the now-observable `userStore.currentHome`).
+- Async state changes announced via a polite live region (resend-verification button text, verified/not-verified badge).
+- Toggle hint text associated via `aria-describedby`; the VAPID-unavailable push row uses `aria-disabled` + explanation instead of native `disabled` (which removes it from AT discovery).
+- Settings groups gain list semantics (`role="list"`/`<ul><li>`), dropping the `<hr>` separator noise.
+- Email + verification badge programmatically associated; badge gains a non-color status cue.
+
+**B. CUBE CSS:**
+- Move `data-*` state hooks (`data-on`/`data-selected`/`data-disabled`/`data-verified`) into the declared-but-unused `@layer exception`.
+- Extract duplicated toggle geometry/duration into `--toggle-*` / `--duration-*` tokens (currently hard-coded byte-for-byte in both `settings-route.css` and `consent-route.css`).
+- Apply bracket grouping (`[ block ] [ composition ] [ utilities ]`) consistently.
+- NOTE: the original #8 finding (`.settings-row` re-implementing flex clusters, `.settings-volume-row` double-applied) is **largely obsolete** — the `align rows via card-grid + row-subgrid` refactor (#409, merged after the issue was filed) already moved rows to subgrid. This change re-scopes B to the still-valid `@layer exception` + token-extraction work and drops the stale parts.
+
+**C. Correctness / altitude:**
+- `selectLanguage` closes the sheet *after* success (and surfaces the non-`ConnectError` failure class) instead of closing before the guard + `await`.
+- Consent toggles bind the consent state directly: make `ConsentService` expose `@observable` state and delete the component-local `analyticsConsent`/`marketingConsent` mirrors + write-back handlers (and the fabricated "RC1 won't re-evaluate a getter" doc-comment). Removes a mirror-drift risk and makes consent consistent with the observable UserStore/GuestService owners.
+
+## Capabilities
+
+### New Capabilities
+<!-- None — all changes modify existing capabilities. -->
+
+### Modified Capabilities
+- `bottom-sheet-ce`: dialog primitive changes from Popover API host to native `<dialog>.showModal()`; adds focus-trap/`inert`, tap-outside (via `.dismiss-zone`), gesture-coupled scroll-driven backdrop fade, and responsive (snap-change/threshold) dismiss; ESC/Android back via close request. Reconciles with the `settings` spec's existing `<dialog>`/`showModal()` requirement.
+- `settings`: language selector single-select (radiogroup) semantics; home-area selected-state indicator; async live-region announcements; toggle-hint association + `aria-disabled` push row; settings-group list semantics; email/badge association + non-color cue; `selectLanguage` close-after-success + error surfacing; consent toggles bound to observable consent state (no component-local mirror).
+
+## Impact
+
+- **Frontend code**: `src/components/bottom-sheet/` (host → `<dialog>`, scroll-driven backdrop, dismiss timing), `src/routes/settings/` (template a11y, CSS layer/token cleanup, `selectLanguage`, consent binding), `src/components/user-home-selector/` (selected-state), `src/lib/consent/consent-service.ts` (`@observable` state), `src/routes/consent/consent-route.css` (shared toggle tokens).
+- **Other bottom-sheet consumers** (verify non-breaking under `showModal()`): language selector, `user-home-selector`, `post-signup-dialog`, onboarding `page-help`, onboarding spotlight top-layer coordination (LIFO ordering with the coach-mark popover — see archived `fix-detail-sheet-dismiss`).
+- **Spikes required before implementation**: (1) CE host wrapping an inner `<dialog>` is non-breaking across all consumers; (2) `<dialog>.showModal()` fires `cancel` on Android back (close request); (3) the `contain: layout` Chromium scroll-snap workaround still holds under dialog top-layer (regression guard: artist-filter chip-check E2E).
+- **Browser support**: `<dialog>`/`showModal()`/`::backdrop` are Baseline widely available; scroll-driven backdrop is Chrome 115+/Safari 26+/not-Firefox → `@supports` gate + transition fallback.
+- **Testing/CI**: DOM-shape changes (radiogroup, `<dialog>`, list semantics) will shift visual baselines — baseline regeneration is required before merge (frontend visual baselines are a main-branch CI artifact with no PR update path).
+- Tracked by frontend#399. Goal includes shipping through dev to prod, not stopping at merge.

--- a/openspec/changes/archive/2026-06-02-settings-ui-polish/specs/bottom-sheet-ce/spec.md
+++ b/openspec/changes/archive/2026-06-02-settings-ui-polish/specs/bottom-sheet-ce/spec.md
@@ -1,9 +1,5 @@
-# Bottom Sheet Custom Element
+## MODIFIED Requirements
 
-## Purpose
-
-Provides a `<bottom-sheet>` custom element as the single dialog primitive for all overlay content, using the Popover API on the CE host element with CSS scroll-snap dismiss via an internal scroll container.
-## Requirements
 ### Requirement: Bottom Sheet Custom Element
 The system SHALL provide a `<bottom-sheet>` custom element as the single dialog primitive for all overlay content, using a native `<dialog>` element opened via `showModal()` (promoted to the Top Layer with native focus-trap, `inert` background, and close-request handling) with CSS scroll-snap dismiss via an internal scroll container. The CE host (`<bottom-sheet>`) SHALL wrap an inner `<dialog>` element; the scroll container, dismiss zone, and sheet body SHALL live inside that `<dialog>`.
 
@@ -136,4 +132,3 @@ The system SHALL provide a `<bottom-sheet>` custom element as the single dialog 
 - **THEN** all event listeners (`cancel`/`close`, `.dismiss-zone` click, scroll detection) SHALL be removed
 - **AND** `close()` SHALL be called on the inner `<dialog>`
 - **AND** no memory leaks SHALL occur
-

--- a/openspec/changes/archive/2026-06-02-settings-ui-polish/specs/settings/spec.md
+++ b/openspec/changes/archive/2026-06-02-settings-ui-polish/specs/settings/spec.md
@@ -1,0 +1,101 @@
+## ADDED Requirements
+
+### Requirement: Language Selector Single-Select Semantics
+The language selection UI SHALL be exposed to assistive technology as a single-select control so screen-reader users can perceive which language is active and that exactly one may be chosen. A visual-only `data-selected` highlight with an `aria-hidden` check icon SHALL NOT be the sole indicator of selection.
+
+#### Scenario: Language options form a radiogroup
+- **WHEN** the language selection UI is displayed
+- **THEN** the option container SHALL expose `role="radiogroup"` (or use native `<input type="radio">`) with an accessible group name
+- **AND** each language option SHALL expose `role="radio"` (or be a native radio) with `aria-checked` reflecting whether it is the active language
+- **AND** the currently active language option SHALL have `aria-checked="true"` and all others `aria-checked="false"`
+
+#### Scenario: Selected language is announced
+- **WHEN** a screen-reader user navigates the language options
+- **THEN** the active option SHALL be announced as the checked/selected radio
+- **AND** selection state SHALL NOT depend on a CSS `data-selected` attribute or an `aria-hidden` check icon alone
+
+---
+
+### Requirement: Home Area Selected-State Indicator
+The home-area selector SHALL indicate the currently selected prefecture/city reactively, consistent with the language selector's selected-state treatment.
+
+#### Scenario: Current home area is highlighted
+- **WHEN** the home-area selector is open and the user has a current home area
+- **THEN** the option matching `userStore.currentHome` SHALL carry a selected-state indicator (`aria-checked`/`data-selected`) bound off the observable `userStore.currentHome`
+- **AND** the indicator SHALL update reactively if the current home area changes
+
+---
+
+### Requirement: Settings Async Status Live Region
+Asynchronous status changes on the Settings page SHALL be announced to assistive technology via a polite live region rather than updating silently.
+
+#### Scenario: Resend-verification status is announced
+- **WHEN** the resend-verification button transitions between its states (idle → "Sending…" → "Sent")
+- **THEN** the status change SHALL be conveyed through an `aria-live="polite"` region
+- **AND** the email verification badge transition (Verified ↔ Not-verified) SHALL likewise be announced politely
+
+---
+
+### Requirement: Toggle Hint Association And Disabled Push Row
+Descriptive hint text for a toggle row SHALL be programmatically associated with its control, and a control that is unavailable due to missing configuration SHALL remain discoverable by assistive technology.
+
+#### Scenario: Toggle hint associated via aria-describedby
+- **WHEN** a toggle row (`role="switch"`) has accompanying hint/description text
+- **THEN** the switch SHALL reference that text via `aria-describedby`
+
+#### Scenario: VAPID-unavailable push row stays discoverable
+- **WHEN** push notifications are unavailable because the VAPID public key is missing
+- **THEN** the push row SHALL use `aria-disabled="true"` plus an explanation rather than the native `disabled` attribute (which removes the control from assistive-technology discovery)
+
+---
+
+### Requirement: Settings Group List Semantics
+Each Settings card SHALL expose list semantics so assistive technology announces a bounded list of items rather than a flat run of buttons interspersed with separator noise.
+
+#### Scenario: Cards expose list semantics
+- **WHEN** a Settings card containing multiple rows is rendered
+- **THEN** the card SHALL use `role="list"` (or `<ul>`) with each row as a `role="listitem"` (or `<li>`)
+- **AND** decorative `<hr>` separators between rows SHALL be removed (visual separation handled by CSS)
+
+---
+
+### Requirement: Email And Verification Badge Association
+The account email and its verification badge SHALL be programmatically associated, and verification status SHALL be conveyed by more than color alone.
+
+#### Scenario: Badge associated with email and not color-only
+- **WHEN** the account section renders the email address and the Verified / Not-verified badge
+- **THEN** the badge SHALL be programmatically associated with the email (e.g., via `aria-describedby` or an accessible-name relationship)
+- **AND** the badge SHALL convey status with a non-color cue (text and/or icon) in addition to color
+
+---
+
+### Requirement: Consent Toggle Observable Binding
+The Settings consent toggles SHALL bind directly to the observable consent state owned by `ConsentService`, with no component-local mirror of that state.
+
+#### Scenario: Consent toggles reflect service state without a mirror
+- **WHEN** the Settings page renders the analytics / marketing-measurement consent toggles
+- **THEN** the `aria-checked` and `data-on` bindings SHALL derive from `ConsentService`'s `@observable` state directly
+- **AND** the component SHALL NOT maintain `analyticsConsent` / `marketingConsent` mirror fields or write-back handlers
+
+#### Scenario: External consent change updates the toggles
+- **WHEN** consent state changes outside the Settings toggle handlers (e.g., via the onboarding consent screen earlier in the session)
+- **THEN** the Settings toggles SHALL reflect the new state on next render without manual re-sync
+
+---
+
+### Requirement: Language Selection Sheet Dismiss And Error Surfacing
+The language selection sheet SHALL close after a selection is applied (or is a no-op), and a non-`ConnectError` failure SHALL be surfaced rather than leaving the row silently stale.
+
+#### Scenario: Sheet closes after successful change
+- **WHEN** a user selects a language different from the current one and the change is applied successfully
+- **THEN** the selection sheet SHALL close after the change is applied
+- **AND** the Language row SHALL reflect the new language
+
+#### Scenario: Re-selecting the current language closes without an RPC
+- **WHEN** a user selects the language already in effect
+- **THEN** the sheet SHALL close and no RPC SHALL be issued
+
+#### Scenario: Non-ConnectError failure is surfaced
+- **WHEN** applying a language change raises a non-`ConnectError` (a programmer error reaching the handler)
+- **THEN** the error SHALL propagate to the global error boundary
+- **AND** the UI SHALL NOT present a silently dismissed sheet with the row still showing the old language as if the change succeeded

--- a/openspec/changes/archive/2026-06-02-settings-ui-polish/tasks.md
+++ b/openspec/changes/archive/2026-06-02-settings-ui-polish/tasks.md
@@ -1,0 +1,54 @@
+## 1. Spikes (gate — resolve before implementation)
+
+- [x] 1.1 Spike: prove the CE host (`<bottom-sheet>`) can wrap an inner `<dialog ref>` opened via `showModal()` without breaking any consumer (language selector, `user-home-selector`, `post-signup-dialog`, onboarding `page-help`). FINDING: 11 consumer surfaces; the bindable contract (`open`/`dismissable`/`sheet-closed`/`aria-label`) must be preserved verbatim. Non-dismissable consumers (`error-banner`, tickets-generating) depend on suppress-dismiss; `event-detail-sheet` adds its own `popstate`/`pushState` history handling on top of the sheet.
+- [x] 1.2 Spike: `<dialog>.showModal()` fires `cancel` on Android back — CONFIRMED on-device; no CloseWatcher shim needed.
+- [x] 1.3 Spike: `contain: layout` workaround holds under `<dialog>` top-layer — CONFIRMED (artist-filter chip-check E2E green in PR #410 and #415 CI).
+- [x] 1.4 Spike: audit onboarding spotlight top-layer coordination against a modal `<dialog>` sheet. FINDING (verified against current code, NOT the stale archived `fix-detail-sheet-dismiss` doc): the global `coach-mark` (app-shell) and any `<bottom-sheet>` do NOT coexist in current flows — `activateSpotlight()` is called only in `discovery-route` targeting `[data-nav="home"]` (no sheet open), and `event-detail-sheet` is opened by `dashboard-route` (no spotlight). `bringSpotlightToFront()`/`onBringToFront` is dead code (no caller). So `showModal()`'s `inert` does NOT break onboarding today. RESIDUAL NOTE: if a future onboarding step layers the coach-mark over a now-modal sheet, the inert conflict would bite — document the constraint and delete the dead `bringSpotlightToFront` plumbing.
+
+## 2. PR-1 — Shared bottom-sheet migration to `<dialog>.showModal()`
+
+- [x] 2.1 Restructure `bottom-sheet.html` so the CE host wraps an inner `<dialog ref>`; move `.scroll-area > .dismiss-zone + section.sheet-body` inside it
+- [x] 2.2 Swap `showPopover()`/`hidePopover()` → `showModal()`/`close()` in `bottom-sheet.ts`; replace the `toggle` listener with `cancel`/`close` handlers; keep the pre-attach retry + detach cleanup
+- [x] 2.3 Move `popover`/`:popover-open` CSS to `<dialog>` equivalents (`[open]`, `dialog::backdrop`); keep `@starting-style` + `transition: overlay allow-discrete` on the `<dialog>`
+- [x] 2.4 Add tap-outside: `click.trigger` on `.dismiss-zone` (`onDismissZoneClick`), gated by `dismissable`
+- [x] 2.5 Make swipe dismiss responsive: fire close on `scrollsnapchange` (snap target = dismiss zone) instead of waiting for full `scrollend` settle; `onScrollEnd` kept as fallback. CODE COMPLETE — live snap timing needs runtime verify.
+- [x] 2.6 Restore scroll-driven backdrop fade via `animation-timeline: scroll()` inside `@supports (animation-timeline: scroll())`; keep the opacity `transition` as the Firefox fallback; tokenize (`--_duration`) + shorten (300ms→240ms). CODE COMPLETE — visual fade needs runtime verify.
+- [x] 2.7 Non-dismissable mode: `preventDefault()` the `cancel` event so ESC / Android back do not close; preserve dismiss-zone `pointer-events: none`
+- [x] 2.8 `prefers-reduced-motion` retargeted to `.sheet-dialog`; scroll-driven fade is scroll-position-based (inherently no time-motion). CSS COMPLETE — visual needs runtime verify.
+- [x] 2.9 Rewrote both unit specs to the dialog API (25 tests); full suite green (106 files / 1187 tests) → no consumer regression. Focus-trap/ESC/Android live behavior = runtime (jsdom lacks `showModal`).
+- [x] 2.10 `bottom-sheet-ce` spec scenarios satisfied; the `settings` spec's `<dialog>`/`showModal()` home-selector requirement is now structurally met by the shared CE. `make lint` + `tsc` green.
+- [x] 2.11 RUNTIME MERGE-GATE: verified focus-trap + inert + radiogroup (browser a11y tree: `dialog … modal: true`), ESC + Android back close (on-device), tap-outside, `contain: layout` stability (chip-check E2E green). Scroll-driven backdrop shipped. Dead `bringSpotlightToFront`/`onBringToFront` plumbing removed in PR #415 (merged `e27ab4e`).
+
+## 3. PR-2 — Settings accessibility / semantics
+
+- [x] 3.1 Language selector → `role="radiogroup"` + `role="radio"` + `aria-checked` (visual check icon + `data-selected` retained for styling only)
+- [x] 3.2 Home-area selector → `data-selected`/`aria-current` bound off observable `userStore.currentHome` (`currentHomeCode` getter); `codeToHome(code).level1 === code` confirms format match for authed + guest
+- [x] 3.3 Verification badge is an `<output aria-live="polite">`; resend button is `aria-live="polite"` so its label transitions announce
+- [x] 3.4 Toggle hints associated via `aria-describedby` (`push-na-hint` / `sound-ios-hint`); push row switched to `aria-disabled` + `toggleNotifications` guard (not native `disabled`)
+- [x] 3.5 Cards are `<ul role="list">` + `<li class="settings-list-item">` (display:contents, subgrid preserved); `<hr>`s dropped, dividers now CSS row borders
+- [x] 3.6 Email associated with badge via `aria-describedby`; badge carries a non-color status icon (check / alert-triangle)
+- [x] 3.7 VM unit tests unaffected (full suite 1189 green); DOM/visual snapshot regen is the runtime baseline gate
+
+## 4. PR-3 — CUBE CSS cleanup
+
+- [x] 4.1 DESCOPED (not implemented): moving state hooks to `@layer exception` is blocked by `cube/data-attr-naming` (exception layer permits only `data-state`/`data-variant`/`data-theme`) + the `no-ternary`/`no-data-interpolation` template rules → needs a separate `data-state` vocabulary migration. NOT a spec requirement (no spec delta depends on it); state hooks stay valid flat `data-*` rules in `@layer block`. Removed from this change's scope; capture as a standalone follow-up if pursued.
+- [x] 4.2 Extracted `--toggle-*` geometry tokens (tokens.css) + reused existing `--transition-*` durations; de-duplicated the toggle track/thumb values in `settings-route.css` and `consent-route.css`
+- [x] 4.3 DESCOPED (not implemented): single-class `<li>`s + the bracketed volume row already group correctly; a full bracket sweep of the remaining two-block-class rows is a low-value cosmetic follow-up with no lint rule enforcing it. Removed from this change's scope.
+- [x] 4.4 `make lint` green (biome + stylelint + tsc + cube-css rules + brand-vocab); production build green; no intended behavior change (visual baseline regen at runtime gate)
+
+## 5. PR-4 — Correctness / altitude
+
+- [x] 5.1 `selectLanguage`: close the sheet after success (and on the no-op path); on a non-`ConnectError` rethrow keep the sheet OPEN so the failure is not masked as a successful dismissal; close + Snack on ConnectError. Test updated.
+- [x] 5.2 `ConsentService`: `@observable private state` (immutable reassignment unchanged); `grant`/`revoke` still publish `ConsentChanged`
+- [x] 5.3 Settings VM: `consent` made public; template binds `consent.analytics` / `consent.marketingMeasurement` directly; deleted `analyticsConsent`/`marketingConsent` mirrors + write-back + the fabricated RC1 doc-comment; handlers write through to the service
+- [x] 5.4 Added tests: external consent change reflected with no mirror; `handleAnalyticsToggle` writes through. 63 affected tests green.
+
+## 6. Validation, baselines, and release
+
+- [x] 6.1 `make lint` + full unit suite green (PR #410 and #415 CI).
+- [x] 6.2 E2E (Playwright) green in CI (bottom-sheet + settings flows; chip-check guard).
+- [x] 6.3 Visual baselines regenerated (deleted stale artifacts → main CI regenerated on merge of #410).
+- [x] 6.4 Merged: #410 (impl, `edb3c88`) + #415 (dead-code cleanup, `e27ab4e`).
+- [x] 6.5 dev verify N/A — dev env intentionally stopped; verified locally (browser a11y tree) instead.
+- [x] 6.6 Shipped to prod: release **v1.5.2** → prod AR retag → pin-bump (`bd17ba8`) → ArgoCD synced; prod `web-app` on v1.5.2, 1/1 Healthy.
+- [x] 6.7 Archive this OpenSpec change (this step).

--- a/openspec/specs/bottom-sheet-ce/spec.md
+++ b/openspec/specs/bottom-sheet-ce/spec.md
@@ -70,7 +70,7 @@ The system SHALL provide a `<bottom-sheet>` custom element as the single dialog 
 - **WHEN** the sheet is open and `dismissable` is `true`
 - **AND** the user taps/clicks the dimmed area above the sheet body (the `.dismiss-zone`)
 - **THEN** the CE SHALL set `open` to `false`, call `close()`, and dispatch `sheet-closed`
-- **NOTE** Tap-outside is implemented as a `click` handler on the `.dismiss-zone` element, NOT via `::backdrop` (the UA stylesheet forces `pointer-events: none` on `::backdrop`) and NOT via `closedby` (under full-viewport coverage every tap targets a `<dialog>` descendant, so native light-dismiss never fires)
+- **NOTE** Tap-outside is implemented as a `click` handler on the `.dismiss-zone` element, NOT via `::backdrop` and NOT via `closedby`: under full-viewport coverage the dialog box occludes the backdrop, so every tap targets a `<dialog>` descendant and neither the `::backdrop` (the `event.target === dialog` light-dismiss pattern) nor `closedby` native light-dismiss ever fires. (The `[popover]::backdrop { pointer-events: none }` UA rule applies to popovers, not `<dialog>::backdrop`, so it is not the reason here.)
 - **WHEN** `dismissable` is `false`
 - **THEN** the `.dismiss-zone` tap SHALL NOT close the sheet
 

--- a/openspec/specs/bottom-sheet-ce/spec.md
+++ b/openspec/specs/bottom-sheet-ce/spec.md
@@ -2,7 +2,8 @@
 
 ## Purpose
 
-Provides a `<bottom-sheet>` custom element as the single dialog primitive for all overlay content, using the Popover API on the CE host element with CSS scroll-snap dismiss via an internal scroll container.
+Provides a `<bottom-sheet>` custom element as the single dialog primitive for all overlay content, using a native `<dialog>` element opened via `showModal()` with CSS scroll-snap dismiss via an internal scroll container.
+
 ## Requirements
 ### Requirement: Bottom Sheet Custom Element
 The system SHALL provide a `<bottom-sheet>` custom element as the single dialog primitive for all overlay content, using a native `<dialog>` element opened via `showModal()` (promoted to the Top Layer with native focus-trap, `inert` background, and close-request handling) with CSS scroll-snap dismiss via an internal scroll container. The CE host (`<bottom-sheet>`) SHALL wrap an inner `<dialog>` element; the scroll container, dismiss zone, and sheet body SHALL live inside that `<dialog>`.

--- a/openspec/specs/settings/spec.md
+++ b/openspec/specs/settings/spec.md
@@ -3,9 +3,7 @@
 ## Purpose
 
 Provides user access to account management, system preferences, and legal information. The Settings page is a grouped list UI accessible via the Bottom Navigation Bar's Settings tab.
-
 ## Requirements
-
 ### Requirement: My Home Area Preference
 The system SHALL allow users to change their home area preference (prefecture) which determines the Live Highway Dashboard's geographical context.
 
@@ -264,3 +262,104 @@ The Settings page SHALL only show the iOS-specific sound-effects behavior hint o
 
 - **WHEN** the Settings page is rendered on a non-iOS platform (Android, desktop)
 - **THEN** the sound-effects row SHALL NOT display the iOS-specific hint
+
+### Requirement: Language Selector Single-Select Semantics
+The language selection UI SHALL be exposed to assistive technology as a single-select control so screen-reader users can perceive which language is active and that exactly one may be chosen. A visual-only `data-selected` highlight with an `aria-hidden` check icon SHALL NOT be the sole indicator of selection.
+
+#### Scenario: Language options form a radiogroup
+- **WHEN** the language selection UI is displayed
+- **THEN** the option container SHALL expose `role="radiogroup"` (or use native `<input type="radio">`) with an accessible group name
+- **AND** each language option SHALL expose `role="radio"` (or be a native radio) with `aria-checked` reflecting whether it is the active language
+- **AND** the currently active language option SHALL have `aria-checked="true"` and all others `aria-checked="false"`
+
+#### Scenario: Selected language is announced
+- **WHEN** a screen-reader user navigates the language options
+- **THEN** the active option SHALL be announced as the checked/selected radio
+- **AND** selection state SHALL NOT depend on a CSS `data-selected` attribute or an `aria-hidden` check icon alone
+
+---
+
+### Requirement: Home Area Selected-State Indicator
+The home-area selector SHALL indicate the currently selected prefecture/city reactively, consistent with the language selector's selected-state treatment.
+
+#### Scenario: Current home area is highlighted
+- **WHEN** the home-area selector is open and the user has a current home area
+- **THEN** the option matching `userStore.currentHome` SHALL carry a selected-state indicator (`aria-checked`/`data-selected`) bound off the observable `userStore.currentHome`
+- **AND** the indicator SHALL update reactively if the current home area changes
+
+---
+
+### Requirement: Settings Async Status Live Region
+Asynchronous status changes on the Settings page SHALL be announced to assistive technology via a polite live region rather than updating silently.
+
+#### Scenario: Resend-verification status is announced
+- **WHEN** the resend-verification button transitions between its states (idle → "Sending…" → "Sent")
+- **THEN** the status change SHALL be conveyed through an `aria-live="polite"` region
+- **AND** the email verification badge transition (Verified ↔ Not-verified) SHALL likewise be announced politely
+
+---
+
+### Requirement: Toggle Hint Association And Disabled Push Row
+Descriptive hint text for a toggle row SHALL be programmatically associated with its control, and a control that is unavailable due to missing configuration SHALL remain discoverable by assistive technology.
+
+#### Scenario: Toggle hint associated via aria-describedby
+- **WHEN** a toggle row (`role="switch"`) has accompanying hint/description text
+- **THEN** the switch SHALL reference that text via `aria-describedby`
+
+#### Scenario: VAPID-unavailable push row stays discoverable
+- **WHEN** push notifications are unavailable because the VAPID public key is missing
+- **THEN** the push row SHALL use `aria-disabled="true"` plus an explanation rather than the native `disabled` attribute (which removes the control from assistive-technology discovery)
+
+---
+
+### Requirement: Settings Group List Semantics
+Each Settings card SHALL expose list semantics so assistive technology announces a bounded list of items rather than a flat run of buttons interspersed with separator noise.
+
+#### Scenario: Cards expose list semantics
+- **WHEN** a Settings card containing multiple rows is rendered
+- **THEN** the card SHALL use `role="list"` (or `<ul>`) with each row as a `role="listitem"` (or `<li>`)
+- **AND** decorative `<hr>` separators between rows SHALL be removed (visual separation handled by CSS)
+
+---
+
+### Requirement: Email And Verification Badge Association
+The account email and its verification badge SHALL be programmatically associated, and verification status SHALL be conveyed by more than color alone.
+
+#### Scenario: Badge associated with email and not color-only
+- **WHEN** the account section renders the email address and the Verified / Not-verified badge
+- **THEN** the badge SHALL be programmatically associated with the email (e.g., via `aria-describedby` or an accessible-name relationship)
+- **AND** the badge SHALL convey status with a non-color cue (text and/or icon) in addition to color
+
+---
+
+### Requirement: Consent Toggle Observable Binding
+The Settings consent toggles SHALL bind directly to the observable consent state owned by `ConsentService`, with no component-local mirror of that state.
+
+#### Scenario: Consent toggles reflect service state without a mirror
+- **WHEN** the Settings page renders the analytics / marketing-measurement consent toggles
+- **THEN** the `aria-checked` and `data-on` bindings SHALL derive from `ConsentService`'s `@observable` state directly
+- **AND** the component SHALL NOT maintain `analyticsConsent` / `marketingConsent` mirror fields or write-back handlers
+
+#### Scenario: External consent change updates the toggles
+- **WHEN** consent state changes outside the Settings toggle handlers (e.g., via the onboarding consent screen earlier in the session)
+- **THEN** the Settings toggles SHALL reflect the new state on next render without manual re-sync
+
+---
+
+### Requirement: Language Selection Sheet Dismiss And Error Surfacing
+The language selection sheet SHALL close after a selection is applied (or is a no-op), and a non-`ConnectError` failure SHALL be surfaced rather than leaving the row silently stale.
+
+#### Scenario: Sheet closes after successful change
+- **WHEN** a user selects a language different from the current one and the change is applied successfully
+- **THEN** the selection sheet SHALL close after the change is applied
+- **AND** the Language row SHALL reflect the new language
+
+#### Scenario: Re-selecting the current language closes without an RPC
+- **WHEN** a user selects the language already in effect
+- **THEN** the sheet SHALL close and no RPC SHALL be issued
+
+#### Scenario: Non-ConnectError failure is surfaced
+- **WHEN** applying a language change raises a non-`ConnectError` (a programmer error reaching the handler)
+- **THEN** the error SHALL propagate to the global error boundary
+- **AND** the UI SHALL NOT present a silently dismissed sheet with the row still showing the old language as if the change succeeded
+


### PR DESCRIPTION
## Description

Archives the completed **settings-ui-polish** change (issue #399) and syncs its delta specs into the canonical specs. The change shipped to prod as frontend **v1.5.2**.

- `bottom-sheet-ce`: updated to the native modal `<dialog>.showModal()` primitive — focus-trap, `inert` background, ESC + Android-back close requests, tap-outside via the dismiss zone, and the scroll-driven backdrop fade, while preserving the full-viewport scroll-snap swipe dismiss.
- `settings`: 8 added a11y requirements — radiogroup language selector, home-area selected-state, live-region verification badge, list semantics, `aria-describedby` hints + `aria-disabled` push row, consent observable binding, and language-sheet dismiss ordering.

Doc/tracking change only (no proto). The change folder moves to `openspec/changes/archive/2026-06-02-settings-ui-polish/`.

Refs: #399
