### PR TITLE
feat(openspec): add merch-discovery change for Series.merch_url

### DIFF
--- a/openspec/changes/add-series-merch-url/.openspec.yaml
+++ b/openspec/changes/add-series-merch-url/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-02

--- a/openspec/changes/add-series-merch-url/design.md
+++ b/openspec/changes/add-series-merch-url/design.md
@@ -1,0 +1,58 @@
+## Context
+
+The `Series` entity (defined in `event-management`) already carries an optional `source_url` for official source/announcement pages, rendered by the event detail sheet (`concert-detail`) as an official-info link. Fans have no in-app path to a tour's official merchandise page. This change adds a single optional merch URL plus the mechanism that keeps it populated.
+
+The first design piggybacked merch-url extraction on the concert-discovery Gemini crawl (`gemini-grounded-extract-and-coerce`). That was rejected: concert discovery runs 6–12 months ahead of events (before merch pages exist), targets the official website (merch is often richest on official social media), and loops per-artist (merch URL is per-series). Instead, a dedicated time-windowed job resolves the URL when the information actually exists. This aligns with feature A (sales timeline), which already adopted a dedicated per-series Gemini searcher rather than extending concert search.
+
+This is the "C. グッズ・物販" feature of the never-miss-a-live roadmap, scoped down (after explicit product review) from a richer merch-timeline model to a single link.
+
+## Goals / Non-Goals
+
+**Goals:**
+- One-tap access from the event detail sheet to a tour's/single-live's official merch page (official site or official social media).
+- Resolve the URL at the right time (close to the event) and keep it healthy (revalidate dead links).
+- Minimal, additive, non-breaking schema change that mirrors `Series.source_url`.
+
+**Non-Goals:**
+- Storing sale timing (start/deadline), sales channels, limited-goods detail, prices, inventory, or item catalogs — these live on the linked page and are the user's to read.
+- Feeding the Next Action dashboard (F): because no timing is stored, merch contributes no deadlines. F's deadline sources remain ticket sales (A) and ticket-email-import.
+- Per-event or per-venue merch links — the link is series-level only.
+- Verifying merch availability or page content beyond a URL liveness (HTTP status) check.
+
+## Decisions
+
+**1. A field on `Series`, not a new `MerchSale` entity.**
+The requirement reduced to "one official merch link per tour." A dedicated entity (channel/timing/items) was rejected as over-modeling: nothing beyond the URL is stored, and one-URL-per-series is exactly the `source_url` precedent. Field number `5`, optional `Url`, additive — no breaking change.
+
+**2. Store only the URL.**
+Alternative considered: a merch-timeline model carrying sale start/deadline so reminders could fire and F could surface "受注締切まであと2日." Rejected per product direction — the linked page already holds those details. Accepted consequence: C is purely a navigational link and does not participate in deadline aggregation.
+
+**3. A dedicated scheduled job, not a concert-search piggyback.**
+Resolving `merch_url` inside the concert-discovery crawl fails on three axes:
+
+| Axis | Concert-search piggyback | Dedicated merch-url job |
+|------|--------------------------|--------------------------|
+| Timing | Runs 6–12 months ahead; merch page does not exist yet → field stays empty with no reliable re-visit | Runs against series whose earliest event is ≤ 60 days away — when merch info actually exists; retries each run until found |
+| Source | Tuned for the official-site schedule; merch is often richest on official social media | Prompt restricted to official site **or** official social media |
+| Granularity | Per-artist loop | Per-series scan (matches `Series.merch_url`) |
+| Prompt/cost | Bolts merch onto a complex multi-event extraction prompt; cost on every crawl | Single-purpose Flash-Lite prompt; cost bounded to the within-60-day empty/dead set |
+
+The job mirrors `cmd/job/concert-discovery` and adopts `auto-concert-discovery`'s resilience (consecutive-failure circuit breaker, per-series non-fatal failures, job always exits success). Feature A's per-series searcher shares this shape; a future "series enrichment scanner" could host both extractors, but the two features ship independently for now.
+
+**4. Candidate selection and dead-link revalidation.**
+A series is a candidate when its **earliest event's** `local_date` falls in `[today, today+60d]` **and** its `merch_url` is empty or dead. For a non-empty `merch_url` in that window, the job performs an HTTP liveness check: a definitive non-2xx/3xx response (or hard failure) means dead → clear the field → re-search. Transient/ambiguous results (timeouts, network blips, bot-blocked HEAD) are treated as alive to avoid churn. The earliest-event baseline means lookup starts ~60 days before the first show, when tour merch is typically announced, and the series naturally drops out once that date passes.
+
+**5. Gemini resolution: official-only, single best URL, or empty.**
+The job calls Gemini Flash-Lite with search grounding, passing the artist name and series title, and asks for the one URL with the richest merch sales information, sourced only from the official site or official social media accounts. When no confident official source exists (common in the 60-day window before merch drops), it returns empty rather than a plausible-but-wrong URL. The resolved value MAY be a social-media post (e.g. an X status), since those frequently carry the fullest merch lineup. Persistence is fill-once: set only when the field is empty (or just cleared as dead), never overwriting a live URL, and always `Url`-validated.
+
+## Risks / Trade-offs
+
+- **Social-media post is deleted but still returns HTTP 200** → Status-based liveness catches hard-dead links (404/410/5xx) but not all social deletions, which can render as a 200 "post unavailable" page. Accepted limitation; the link is optional and low-harm if stale.
+- **Officialness is soft** → Restricting to "official site or official social media" relies on the prompt + grounding, with no hard ownership proof. Same trust model as feature A's searcher. Mitigated by the empty-if-uncertain rule.
+- **Liveness false-positive (bot-blocked HEAD)** → Only a definitive non-2xx/3xx triggers deletion; transient/ambiguous keeps the URL, avoiding needless re-search churn and re-billing Gemini.
+- **Gemini cost / quota** → Bounded by the within-60-day empty/dead candidate set and Flash-Lite pricing; the circuit breaker stops the job on repeated failures.
+
+## Migration Plan
+
+- Add a nullable `merch_url` column to the series table via an additive migration. No backfill; existing rows are NULL until the job populates them.
+- Standard cross-repo order: specification proto change → BSR generation → backend (column + repository + job) → frontend (link + i18n) → cloud-provisioning (CronJob manifest). All steps are additive; rollback is removing the CronJob, dropping the unused column, and reverting the optional field.

--- a/openspec/changes/add-series-merch-url/proposal.md
+++ b/openspec/changes/add-series-merch-url/proposal.md
@@ -1,0 +1,34 @@
+## Why
+
+Fans who never want to miss a live also do not want to miss official merchandise — but today the platform offers no path from a concert to its goods page, forcing fans to search externally. The lowest-cost, highest-value step is a single tap from the event detail sheet to the tour's official merch page. We intentionally store only the link (not sale timing, channels, or item catalogs): the linked page already carries those details, and keeping the model to one URL mirrors the proven `Series.source_url` pattern.
+
+Merch information, however, surfaces on a different cadence and from different sources than concert schedules: it is published close to the event (weeks before, not the 6–12 months ahead that concert discovery runs), and it is frequently richest on an artist's official **social media** post rather than the official website. A merch URL is therefore resolved by a dedicated, time-windowed discovery job rather than piggybacking on the concert-discovery crawl.
+
+## What Changes
+
+- Add an optional `merch_url` field (type `Url`) to the `Series` entity, mirroring the existing optional `source_url` (next field number, `5`). Non-breaking, additive.
+- Persist `merch_url` on the series row (new nullable column) and resolve it onto the embedded `Series` in every `Concert` response, exactly as `source_url` is handled.
+- Add a dedicated, scheduled **merch-url discovery job** (mirroring the existing concert-discovery job) that:
+  - selects series whose **earliest event** is within the next 60 days and whose `merch_url` is empty **or** a dead link (HTTP non-2xx/3xx) — clearing dead links before re-searching;
+  - asks Gemini Flash-Lite (with search grounding) for the single URL carrying the richest merch sales information, restricted to the **official site or official social media**, returning empty when no confident official source exists (no hallucinated URL);
+  - persists the resolved URL fill-once (never overwriting a live URL), with `Url` validation.
+- Render a "グッズ情報" (merch info) link in the event detail sheet when `concert.series.merch_url` is present, as a sibling to the existing official-info link, with parallel JA/EN i18n copy.
+
+## Capabilities
+
+### New Capabilities
+
+- `merch-discovery`: A scheduled job that discovers and maintains official merch information for series with an upcoming event — currently the merch page URL (`Series.merch_url`) — using a time-windowed candidate scan, dead-link revalidation, and a Gemini Flash-Lite search restricted to official site / official social media.
+
+### Modified Capabilities
+
+- `event-management`: The `Series` entity gains an optional `merch_url` (`Url`) field; series persistence and the embedded `Series` in the `Concert` DTO carry it through to clients.
+- `concert-detail`: The event detail sheet renders a merch info link when the embedded series carries a `merch_url`, with a dedicated `eventDetail.*` i18n key.
+
+## Impact
+
+- **specification**: `series.proto` gains `Url merch_url = 5`; regenerated Go/TS types via BSR. Additive — no breaking change.
+- **backend**: New nullable `merch_url` column on the series table (migration); repository read/write and Concert hydration. New job under `cmd/job/merch-discovery` (mirroring `cmd/job/concert-discovery`): series-listing query (earliest-event within 60 days, `merch_url` empty/dead), HTTP liveness checker, Gemini Flash-Lite searcher, fill-once persistence, and `auto-concert-discovery`-style resilience.
+- **frontend**: `event-detail-sheet` template + view model render the link; new `eventDetail.viewMerch` i18n key in JA/EN `translation.json`.
+- **cloud-provisioning**: New CronJob manifest scheduling the merch-url discovery job (daily in prod, weekly in dev), reusing the Vertex AI workload-identity service account already used by concert discovery.
+- **dependencies**: None new. Reuses the existing `Url` value object, the Gemini client, and the established job/scheduling and `source_url` rendering flows.

--- a/openspec/changes/add-series-merch-url/specs/concert-detail/spec.md
+++ b/openspec/changes/add-series-merch-url/specs/concert-detail/spec.md
@@ -1,0 +1,56 @@
+## ADDED Requirements
+
+### Requirement: Merch Info Link in Concert Detail
+
+The concert detail sheet SHALL render a merchandise information link when the concert's embedded series carries a `merch_url`, as a sibling to the existing official-info link. The link SHALL be omitted entirely when `merch_url` is absent, with no placeholder or disabled state.
+
+#### Scenario: Merch link rendered when merch_url is present
+
+- **WHEN** the concert detail view is open and `concert.series.merch_url` is present
+- **THEN** it SHALL render a button linking to `merch_url` in a new tab
+- **AND** the button's visible label SHALL be sourced from the `eventDetail.viewMerch` i18n key
+
+#### Scenario: Merch link omitted when merch_url is absent
+
+- **WHEN** the concert detail view is open and `concert.series.merch_url` is absent
+- **THEN** no merch information button SHALL be rendered
+- **AND** the absence SHALL NOT affect rendering of the official-info link or any other control
+
+## MODIFIED Requirements
+
+### Requirement: Localized Concert Detail Sheet Copy
+
+The frontend SHALL render all user-facing text in the concert detail sheet via i18n keys under a dedicated `eventDetail.*` namespace, with parallel JA and EN translations in `frontend/src/locales/<locale>/translation.json`. No literal English (or any other language) text SHALL be embedded directly in the `event-detail-sheet.html` template.
+
+#### Scenario: Static labels are i18n-keyed
+
+- **WHEN** the concert detail sheet renders any static label (date/time row prefix, action button text, ticket-status section heading, removal button)
+- **THEN** the label SHALL be sourced from an `eventDetail.*` i18n key
+- **AND** the JA and EN translation files SHALL both contain a value for that key
+- **AND** the displayed string SHALL match the locale resolved by `@aurelia/i18n`
+
+#### Scenario: Required i18n keys
+
+- **WHEN** the concert detail sheet is implemented
+- **THEN** the following `eventDetail.*` keys SHALL be defined in both JA and EN translation files:
+  - `eventDetail.ariaLabel` — the sheet's `aria-label`
+  - `eventDetail.openStart` — the open/start time line with `{{open}}` and `{{start}}` interpolation placeholders. When the open time is unknown, the `{{open}}` slot SHALL be filled with the em-dash character `—` (U+2014) supplied directly by the component (locale-invariant; not routed through an i18n key).
+  - `eventDetail.openInGoogleMaps` — the Google Maps link label
+  - `eventDetail.ticketStatus` — the ticket-status section heading
+  - `eventDetail.stopTracking` — the "remove ticket journey" button label
+  - `eventDetail.viewOfficialInfo` — the official info link label
+  - `eventDetail.viewMerch` — the merchandise info link label
+  - `eventDetail.addToCalendar` — the add-to-calendar link label
+
+#### Scenario: Journey status enum values are i18n-keyed
+
+- **WHEN** the concert detail sheet renders a `TicketJourneyStatus` value as a button label or as the currently-displayed status
+- **THEN** the surface form SHALL be sourced from a sub-namespace `eventDetail.journeyStatus.<value>` rather than the raw enum string
+- **AND** the JA and EN translation files SHALL both contain values for every supported `TicketJourneyStatus` value (currently `tracking`, `applied`, `lost`, `unpaid`, `paid`)
+- **AND** the raw enum string SHALL NOT appear in the rendered UI
+
+#### Scenario: Adding a new TicketJourneyStatus value
+
+- **WHEN** a new value is added to the `TicketJourneyStatus` type
+- **THEN** the change SHALL add a corresponding `eventDetail.journeyStatus.<newValue>` entry to both the JA and EN translation files
+- **AND** the absence of either locale value SHALL be a defect

--- a/openspec/changes/add-series-merch-url/specs/event-management/spec.md
+++ b/openspec/changes/add-series-merch-url/specs/event-management/spec.md
@@ -1,0 +1,50 @@
+## MODIFIED Requirements
+
+### Requirement: Series as Parent Aggregation
+
+The system SHALL support a `Series` entity that aggregates one or more `Event` rows representing a tour, a multi-day single-venue run, or a festival. Each `Event` SHALL belong to exactly one `Series`. A `Series` SHALL own the metadata that is common across all its events.
+
+The `Series` entity SHALL include: `SeriesId`, `Title`, `SeriesType`, an optional `source_url`, and an optional `merch_url`. Both `source_url` and `merch_url` are of type `Url` and follow identical optionality semantics: a nil wrapper is valid and skips inner-`Url` validation, while a present wrapper SHALL satisfy the `Url` value-object constraints. `merch_url` SHALL point to the official merchandise information page shared across the series; it carries no sale timing, channel, or item data — those remain on the linked page. The `SeriesType` enum SHALL declare:
+
+- `SERIES_TYPE_UNSPECIFIED = 0` — the proto3-mandated zero-value sentinel; rejected at the proto boundary by `(buf.validate.field).enum.not_in = [0]` so it can never be persisted.
+- `SERIES_TYPE_TOUR = 1` — a series of events at multiple venues by the same set of performers, typically branded with a tour name.
+- `SERIES_TYPE_SINGLE = 2` — a standalone engagement at a single venue, spanning one or more consecutive days.
+- `SERIES_TYPE_FESTIVAL = 3` — a multi-performer event such as a music festival.
+
+The proto-prefixed identifiers above are enforced by `buf lint ENUM_VALUE_PREFIX` and match the generated Go / TS constants; the bare `TOUR` / `SINGLE` / `FESTIVAL` aliases used elsewhere in this spec refer to the same values in prose. The `SeriesType` enum SHALL be designed as additive — new non-zero values MAY be appended without breaking existing consumers.
+
+#### Scenario: Series owns shared metadata
+
+- **WHEN** a tour spans multiple stops on different dates and venues
+- **THEN** the tour title and source URL SHALL be stored on the parent `Series` row exactly once
+- **AND** each stop SHALL be persisted as a separate `Event` row referencing the same `series_id`
+
+#### Scenario: Series owns the merch URL
+
+- **WHEN** a series has an official merchandise information page
+- **THEN** the `merch_url` SHALL be stored on the parent `Series` row exactly once
+- **AND** it SHALL be carried through to clients via the embedded `Series` on every `Concert` response
+
+#### Scenario: Merch URL is optional
+
+- **WHEN** a series has no known official merchandise page
+- **THEN** the `merch_url` SHALL be absent (nil wrapper)
+- **AND** persistence and serialization SHALL succeed without error
+
+#### Scenario: Every Event belongs to a Series
+
+- **WHEN** an `Event` is created
+- **THEN** the `series_id` foreign key SHALL be non-null and reference an existing `Series` row
+- **AND** even a one-off single-day concert SHALL have a `Series` row created for it (typically with `type = SINGLE`)
+
+#### Scenario: SeriesType enumerates supported series shapes
+
+- **WHEN** a `Series` is created
+- **THEN** its `type` SHALL be one of `SERIES_TYPE_TOUR`, `SERIES_TYPE_SINGLE`, or `SERIES_TYPE_FESTIVAL`
+- **AND** the `SERIES_TYPE_UNSPECIFIED` value SHALL never be persisted
+
+#### Scenario: Series natural identity is not enforced at the database layer
+
+- **WHEN** two distinct `Series` rows with similar or identical titles are inserted
+- **THEN** the database SHALL accept both writes
+- **AND** deduplication SHALL be performed at the application layer using fuzzy matching on title and related fields

--- a/openspec/changes/add-series-merch-url/specs/merch-discovery/spec.md
+++ b/openspec/changes/add-series-merch-url/specs/merch-discovery/spec.md
@@ -1,0 +1,104 @@
+## ADDED Requirements
+
+### Requirement: Scheduled Merch URL Discovery Job
+
+The system SHALL provide a scheduled job that resolves and maintains `Series.merch_url`. The job SHALL run on a recurring schedule — daily in production and weekly in development — mirroring the concert-discovery job's cadence. The job SHALL NOT extend or depend on the concert-discovery Gemini crawl.
+
+#### Scenario: Scheduled execution
+
+- **WHEN** the merch-url discovery job is triggered on its schedule
+- **THEN** it SHALL load the set of candidate series, resolve each candidate's merch URL, and persist any resolved URLs
+- **AND** it SHALL run independently of the concert-discovery job
+
+### Requirement: Candidate Selection by Earliest Event and Missing Link
+
+The job SHALL consider a series a candidate when its **earliest** event's `local_date` falls within the window `[today, today + 60 days]` and its `merch_url` is empty or has been determined to be a dead link. Series whose earliest event is more than 60 days away, or already in the past, SHALL NOT be candidates.
+
+#### Scenario: Series with an upcoming earliest event and no merch URL
+
+- **WHEN** a series has `merch_url` empty and its earliest event's `local_date` is within the next 60 days
+- **THEN** the series SHALL be selected as a candidate
+
+#### Scenario: Earliest event beyond the window
+
+- **WHEN** a series has `merch_url` empty and its earliest event's `local_date` is more than 60 days away
+- **THEN** the series SHALL NOT be selected
+- **AND** it SHALL become a candidate on a later run once its earliest event enters the 60-day window
+
+#### Scenario: Series already populated with a live URL
+
+- **WHEN** a series has a non-empty `merch_url` that passes the liveness check
+- **THEN** the series SHALL NOT be re-searched
+- **AND** its existing `merch_url` SHALL be left unchanged
+
+### Requirement: Dead-Link Revalidation
+
+For an in-window series whose `merch_url` is non-empty, the job SHALL perform an HTTP liveness check before deciding whether to re-search. A response that is a definitive non-2xx and non-3xx status (or a hard request failure) SHALL be treated as a dead link: the job SHALL clear `merch_url` to empty and treat the series as a candidate for re-search. A transient or ambiguous result (timeout, network error, or a bot-blocking response that is not a definitive failure) SHALL be treated as alive, leaving `merch_url` unchanged.
+
+#### Scenario: Dead link is cleared and re-searched
+
+- **WHEN** an in-window series' `merch_url` returns a definitive non-2xx/3xx status
+- **THEN** the job SHALL clear `merch_url`
+- **AND** the series SHALL be re-searched in the same run
+
+#### Scenario: Transient failure does not clear the link
+
+- **WHEN** an in-window series' `merch_url` liveness check times out or returns an ambiguous result
+- **THEN** the job SHALL leave `merch_url` unchanged
+- **AND** the series SHALL NOT be re-searched on that basis
+
+### Requirement: Gemini Merch URL Resolution Restricted to Official Sources
+
+For each candidate, the job SHALL call Gemini Flash-Lite with search grounding, supplying the performing artist name and the series title, and SHALL request the single URL that carries the richest merch sales information. The result SHALL be sourced only from the artist's official website or official social media accounts. When no confident official source exists, the job SHALL return an empty result rather than a non-official or low-confidence URL. The resolved value MAY be a social-media post URL.
+
+#### Scenario: Confident official merch URL found
+
+- **WHEN** Gemini identifies a single best merch URL on the official site or official social media
+- **THEN** the job SHALL treat that URL as the resolution result
+
+#### Scenario: No confident official source
+
+- **WHEN** Gemini finds no merch information from an official site or official social media account
+- **THEN** the job SHALL return an empty result
+- **AND** the job SHALL NOT persist any URL for that series on this run
+
+#### Scenario: Richest source is a social-media post
+
+- **WHEN** the official social media post carries fuller merch information than the official site
+- **THEN** the job MAY resolve `merch_url` to that social-media post URL
+
+### Requirement: Fill-Once Persistence of Resolved URL
+
+The job SHALL persist a resolved URL only when the series' `merch_url` is empty (including a value just cleared as a dead link). It SHALL NOT overwrite a `merch_url` that passed the liveness check. Every persisted value SHALL satisfy the `Url` value-object constraints; a value failing validation SHALL be discarded and the field left empty.
+
+#### Scenario: Resolved URL persisted for an empty field
+
+- **WHEN** the job resolves a valid official URL for a series whose `merch_url` is empty
+- **THEN** the job SHALL persist that URL to `Series.merch_url`
+
+#### Scenario: Invalid URL discarded
+
+- **WHEN** a resolved value fails `Url` validation
+- **THEN** the job SHALL NOT persist it
+- **AND** `merch_url` SHALL remain empty
+
+### Requirement: Job Resilience
+
+The job SHALL isolate per-series failures and SHALL always exit successfully so that the schedule is not disrupted. A per-series resolution or persistence failure SHALL NOT abort the run. The job SHALL stop early via a circuit breaker after a configured number of consecutive failures, and a successful resolution SHALL reset the consecutive-failure counter.
+
+#### Scenario: Individual series failure is non-fatal
+
+- **WHEN** resolving or persisting one series fails
+- **THEN** the job SHALL continue processing the remaining candidates
+- **AND** the job SHALL still exit successfully
+
+#### Scenario: Circuit breaker on consecutive failures
+
+- **WHEN** the configured number of consecutive failures is reached
+- **THEN** the job SHALL stop processing further candidates
+- **AND** the job SHALL exit without surfacing a non-zero failure that would disrupt the schedule
+
+#### Scenario: Successful resolution resets the counter
+
+- **WHEN** a series is resolved successfully after prior failures
+- **THEN** the consecutive-failure counter SHALL reset to zero

--- a/openspec/changes/add-series-merch-url/tasks.md
+++ b/openspec/changes/add-series-merch-url/tasks.md
@@ -1,0 +1,43 @@
+## 1. Specification (proto)
+
+- [ ] 1.1 Add `Url merch_url = 5;` to the `Series` message in `proto/liverty_music/entity/v1/series.proto`, marked `OPTIONAL`, with a doc comment mirroring `source_url` and noting it is the official merch info page (no timing/channel/item data)
+- [ ] 1.2 Run `buf lint` and `buf breaking` locally to confirm the change is additive and non-breaking
+- [ ] 1.3 Open the specification PR; after review + CI pass, merge and publish a GitHub Release (`vX.Y.Z`) to trigger BSR generation (CI-only — do not run `buf push`/`buf generate` locally)
+- [ ] 1.4 Monitor `buf-release.yml` until BSR generation completes successfully
+
+## 2. Backend — persistence & hydration
+
+- [ ] 2.1 Add an additive migration introducing a nullable `merch_url` column on the series table (Atlas)
+- [ ] 2.2 Upgrade the generated proto package to the released version (`go get ...@vX.Y.Z`, `go mod tidy`)
+- [ ] 2.3 Update the series repository read/write to map the `merch_url` column ↔ `Series.merch_url`, treating empty/NULL as absent; add a method to clear `merch_url` (set NULL) for dead-link handling
+- [ ] 2.4 Ensure `Concert` hydration carries `merch_url` through the embedded `Series` exactly as `source_url` is carried
+
+## 3. Backend — merch-url discovery job
+
+- [ ] 3.1 Add a repository query that lists candidate series: earliest event `local_date` within `[today, today+60d]` and `merch_url` empty (and a way to fetch in-window series with a non-empty `merch_url` for revalidation)
+- [ ] 3.2 Implement an HTTP liveness checker: definitive non-2xx/3xx (or hard failure) → dead; transient/ambiguous → alive (no clear)
+- [ ] 3.3 Implement the Gemini Flash-Lite searcher: prompt with artist name + series title; restrict to official site / official social media; return the single richest merch URL or empty (no hallucinated/non-official URL)
+- [ ] 3.4 Implement fill-once persistence: clear dead links, then set `merch_url` only when empty; never overwrite a live URL; validate `Url` and discard invalid values
+- [ ] 3.5 Add resilience: per-series non-fatal failure, consecutive-failure circuit breaker with reset on success, job always exits successfully (mirror `auto-concert-discovery`)
+- [ ] 3.6 Create the job entrypoint `cmd/job/merch-discovery/main.go` with job-specific DI and graceful resource cleanup (mirror `cmd/job/concert-discovery/main.go`)
+- [ ] 3.7 Add unit tests: candidate selection (in/out of window, empty/dead), liveness check (dead vs transient), resolution (found/empty/social-media), fill-once + invalid-URL discard, circuit breaker
+- [ ] 3.8 Run `make check` and confirm green
+
+## 4. Frontend — detail sheet link
+
+- [ ] 4.1 Upgrade the generated proto package to the released version (`npm install @buf/...@latest`)
+- [ ] 4.2 Render a "グッズ情報" link in `event-detail-sheet.html`, gated on `concert.series.merch_url`, opening in a new tab; omit entirely when absent
+- [ ] 4.3 Add the `eventDetail.viewMerch` i18n key with parallel JA/EN values in `frontend/src/locales/<locale>/translation.json`
+- [ ] 4.4 Add/extend component tests covering the present and absent cases
+- [ ] 4.5 Run `make check` and confirm green
+
+## 5. Cloud-provisioning — scheduling
+
+- [ ] 5.1 Add a CronJob manifest for the merch-url discovery job, scheduled daily in prod and weekly in dev (mirror the concert-discovery job's scheduling)
+- [ ] 5.2 Reuse the Vertex AI / Gemini workload-identity service account already granted to concert discovery; confirm no new IAM is required
+
+## 6. Wrap-up
+
+- [ ] 6.1 Open backend and frontend PRs only after the package upgrade + build pass locally
+- [ ] 6.2 Verify end-to-end: a series with an upcoming earliest event gets a merch URL populated by the job; a dead link is cleared and re-resolved; the detail sheet shows the link when present and nothing when absent
+- [ ] 6.3 After merges, confirm the change ships to the dev/prod environment per the deployment flow


### PR DESCRIPTION
## Summary

Proposes feature **C. グッズ・物販** of the never-miss-a-live roadmap as the OpenSpec change `add-series-merch-url`: let fans reach a tour's / single-live's official merch page in one tap from the event detail sheet. Scope is intentionally minimal — store only the URL; sale timing, channels, prices, and item catalogs stay on the linked page.

This PR adds **OpenSpec artifacts only** (proposal / design / specs / tasks). No proto or code changes yet — implementation follows via `/opsx:apply` and the standard specification → BSR → backend/frontend flow.

## Changes

- **New capability `merch-discovery`** — a dedicated, scheduled job (not the concert-discovery crawl) that maintains official merch info for series with an upcoming event:
  - candidate = series whose **earliest event** is within `[today, today+60d]` and whose `merch_url` is empty **or** a dead link;
  - dead links are revalidated by HTTP status and cleared before re-search;
  - Gemini Flash-Lite + grounding resolves the single richest merch URL, restricted to **official site / official social media**, returning empty when no confident official source exists (the value may be a social-media post URL);
  - fill-once persistence with `Url` validation; `auto-concert-discovery`-style resilience.
- **`event-management` (MODIFIED)** — `Series` gains an optional `merch_url` (`Url`, field 5), carried to clients via the embedded `Series` in the `Concert` DTO.
- **`concert-detail` (ADDED + MODIFIED)** — render a "グッズ情報" link in the event detail sheet when `concert.series.merch_url` is present; add the `eventDetail.viewMerch` i18n key (JA/EN).

### Why a dedicated job (not concert-search piggyback)

Merch info appears close to the event (not 6–12 months ahead when discovery runs), is often richest on official social media (not the official site discovery targets), and is per-series. A time-windowed job resolves it when it actually exists — aligning with feature A's dedicated per-series searcher.

## Out of scope

- Sale timing / deadlines → this does **not** feed the Next Action dashboard (feature F).
- Per-event / per-venue merch links; prices; inventory; item catalog.

## Testing

- `openspec validate add-series-merch-url` → valid (4/4 artifacts complete).
- Cross-artifact consistency checked: proposal Capabilities match the delta folders (`event-management`, `concert-detail`, `merch-discovery`).

close: #569
