### PR TITLE
docs(openspec): add brand-zitadel-login-ui change

### DIFF
--- a/openspec/changes/brand-zitadel-login-ui/.openspec.yaml
+++ b/openspec/changes/brand-zitadel-login-ui/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-02

--- a/openspec/changes/brand-zitadel-login-ui/design.md
+++ b/openspec/changes/brand-zitadel-login-ui/design.md
@@ -1,0 +1,54 @@
+## Context
+
+Zitadel is self-hosted (v4.14.0, Helm chart `zitadel/zitadel-charts@9.34.1`) with the new Login UI v2 (a separate Next.js container `zitadel-api-login`, served at `/ui/v2/login/*`). The instance is provisioned via Pulumi using `@pulumiverse/zitadel@^0.2.0` under `cloud-provisioning/src/zitadel/`, which manages an OIDC application, login policy, SMTP, actions, and a machine user for the `liverty-music` product org. No branding is configured today: `src/zitadel/index.ts` sets `privateLabelingSetting: PRIVATE_LABELING_SETTING_UNSPECIFIED` and there is no label policy. A live check of the prod login confirmed an unbranded screen (no logo, default colors).
+
+Login UI v2 automatically honors the org/instance label policy, so branding is purely a provisioning concern — no changes to the login app, Helm chart, frontend, backend, or proto.
+
+## Goals / Non-Goals
+
+**Goals:**
+- The hosted Login UI v2 shows Liverty Music brand colors for the product org, enforced for the product application's login flow.
+- Declarative, IaC-managed, shipped through the existing Pulumi/ArgoCD flow; dev and prod parity.
+
+**Non-Goals:**
+- **Logo** — no Liverty Music logo asset exists yet; colors/theme only this change. Logo is a fast follow.
+- Login text/string customization (Login UI v2 texts need the Settings V2 API; not provider-supported and immature — separate future change).
+- Building/self-hosting a custom login app, or changing the Helm chart.
+- Any frontend/backend/proto change.
+
+## Decisions
+
+- **Branding values live on an org-level `zitadel.LabelPolicy`; enforcement is per-application via the project.** Zitadel has **no application-level label policy** — branding is defined only at instance (`DefaultLabelPolicy`) or org (`LabelPolicy`) level. The per-application control is the **`Project.privateLabelingSetting`**, which selects *which* org's label policy the app's login flow renders. So:
+  - Define a `LabelPolicy` on the `liverty-music` product org (the project's resource-owner org).
+  - Set the product `Project.privateLabelingSetting` to `PRIVATE_LABELING_SETTING_ENFORCE_PROJECT_RESOURCE_OWNER_POLICY` (currently `UNSPECIFIED`) so the product app **always** renders the product org's branding, independent of the logging-in user's org.
+  - This supersedes the existing defensive `UNSPECIFIED` (the old comment cited SMTP-conflict caution, which is unrelated to label policy); flip it deliberately and verify on dev.
+  - Alternative considered: `DefaultLabelPolicy` (instance-level) — rejected; it would also brand the admin org's console login, which is intentionally separate.
+  - Alternative considered: leaving `privateLabelingSetting: UNSPECIFIED` and relying on the org policy alone — rejected; enforcement is what guarantees the product app's login shows product branding regardless of the user's resource-owner org.
+- **Reuse the frontend brand palette (colors only).** Frontend brand tokens (oklch) converted to the hex values Zitadel expects:
+
+  | LabelPolicy field | Light | Dark | Source token |
+  |---|---|---|---|
+  | `primaryColor` / `primaryColorDark` | `#fd00a6` | `#fd00a6` | `--color-brand-primary` (pink) |
+  | `backgroundColor` / `backgroundColorDark` | `#ffffff` | `#0d1023` | white / `--color-surface-base` |
+  | `fontColor` / `fontColorDark` | `#161929` | `#fafafa` | dark navy / `--color-text-primary` |
+  | `warnColor` / `warnColorDark` | `#f14d4c` | `#f14d4c` | `--color-error` |
+
+  Also set `themeMode: THEME_MODE_AUTO` (follow the system; the v2 login exposes a toggle and both palettes are defined), `disableWatermark: true`, and `hideLoginNameSuffix: true` (cleaner consumer login name). Leave `logoUrl`/`logoPath` unset until an asset exists. Hex values are derived from the tokens and SHALL be visually confirmed on dev after apply.
+- **Activate the policy.** Label policies are staged then activated in Zitadel; the resource must set it active (`setActive`) so the change is live.
+- **Place the resource in the Zitadel component graph.** Add the `LabelPolicy` inside `FrontendComponent` (or a small dedicated branding component) and adjust `privateLabelingSetting` on the project in `src/zitadel/index.ts`.
+
+## Risks / Trade-offs
+
+- [Color-only branding without a logo] → A colors-only policy still meaningfully on-brands the login (brand-tinted buttons/links/background) without a logo. The logo slot simply stays empty, matching today's behavior. Acceptable; logo is a follow-up. → low.
+- [Provider feature parity at v0.2.0] → Confirm `LabelPolicy` (colors + setActive) and `Project.privateLabelingSetting=ENFORCE_PROJECT_RESOURCE_OWNER_POLICY` work against self-hosted v4.14.0 via the pinned provider. Mitigation: verify on dev first.
+- [Color accuracy] → Zitadel expects hex; the frontend tokens are oklch. Convert to the nearest hex and visually verify on dev.
+- [Flipping privateLabelingSetting] → Changing it from `UNSPECIFIED` is a behavioral change to the login flow; verify on dev that console/admin login is unaffected (separate org) before prod.
+
+## Open Questions
+
+All blocking questions are resolved; the change is ready to implement.
+
+- **Brand color hex** — resolved (table above; converted from frontend oklch tokens, to be visually confirmed on dev).
+- **Admin/console org branding** — resolved: leave it as the Zitadel default. The admin/console org is intentionally separate; `ENFORCE_PROJECT_RESOURCE_OWNER_POLICY` is set only on the product project, so console login is untouched. No admin branding in this change.
+- **`themeMode` / `hideLoginNameSuffix`** — resolved: `THEME_MODE_AUTO` + `hideLoginNameSuffix: true` (both palettes defined; adjustable after dev review).
+- (Deferred, not blocking) **Logo asset** — file/URL and upload-vs-hosted-URL, for the follow-up logo change.

--- a/openspec/changes/brand-zitadel-login-ui/proposal.md
+++ b/openspec/changes/brand-zitadel-login-ui/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+The self-hosted Zitadel Login UI v2 (`/ui/v2/login/*` at `auth.liverty-music.app`) currently renders with no product branding: a live check of the prod login screen shows no logo, default neutral colors (blue focus ring, gray buttons), and generic copy — it does not look like Liverty Music. The Zitadel instance has no label policy configured (`privateLabelingSetting: PRIVATE_LABELING_SETTING_UNSPECIFIED`, no `LabelPolicy`), so users authenticating into the product land on an unbranded, off-product screen. Applying Liverty Music's logo and brand colors is a low-risk, high-visibility trust/polish win that is fully declarative via the existing Pulumi Zitadel provider.
+
+## What Changes
+
+- Add a Zitadel **label policy** (branding) for the `liverty-music` product org so the hosted Login UI v2 displays Liverty Music **brand colors** instead of the default Zitadel appearance.
+- **Enforce the branding per-application**: set the product `Project`'s `privateLabelingSetting` to `PRIVATE_LABELING_SETTING_ENFORCE_PROJECT_RESOURCE_OWNER_POLICY` (currently `UNSPECIFIED`) so the product app's login flow always renders the product org's branding regardless of the logging-in user's org. (Zitadel has no application-level label policy; the project's private-labeling setting is the per-application control that selects which org's branding applies.)
+- Configure colors: primary/background/font/warn (and dark variants) derived from the existing frontend brand tokens, plus theme mode and `disableWatermark` (so any future Zitadel watermark is suppressed). Activate the policy so it takes effect.
+- This is implemented in `cloud-provisioning` via the `@pulumiverse/zitadel` provider's native `LabelPolicy` resource + the `Project.privateLabelingSetting` field, wired into the existing Zitadel component graph; it ships through the normal Pulumi/ArgoCD flow.
+- **Logo is explicitly deferred**: no Liverty Music logo asset exists yet, so this change applies colors/theme only. Adding the logo is a fast follow once an asset is available.
+
+## Capabilities
+
+### New Capabilities
+
+<!-- none -->
+
+### Modified Capabilities
+
+- `identity-management`: add a requirement to configure Login UI branding (a Zitadel label policy with the Liverty Music logo and brand colors) for the product org, alongside the existing login-policy / OIDC-application provisioning.
+
+## Impact
+
+- **`cloud-provisioning` only** — no proto, backend, or frontend changes.
+  - `src/zitadel/components/frontend.ts` (or a new sibling branding component): add a `zitadel.LabelPolicy` resource for the product org (colors/theme/watermark).
+  - `src/zitadel/index.ts`: change the product `Project`'s `privateLabelingSetting` from `UNSPECIFIED` to `ENFORCE_PROJECT_RESOURCE_OWNER_POLICY`, and wire the label policy into the `Zitadel` orchestrator.
+  - No logo asset required (logo deferred).
+- Out of scope (deferred to separate future changes):
+  - **Logo** — no asset yet.
+  - **Login text/string customization** — Login UI v2 texts require the immature Settings V2 API.
+- Supersedes the discarded Zitadel-Cloud-era WIP that attempted login-text overrides via the legacy Management API — obsolete after the self-hosted v4.x + Login UI v2 migration.

--- a/openspec/changes/brand-zitadel-login-ui/specs/identity-management/spec.md
+++ b/openspec/changes/brand-zitadel-login-ui/specs/identity-management/spec.md
@@ -1,0 +1,37 @@
+## ADDED Requirements
+
+### Requirement: Configure Login UI Branding
+
+The system SHALL configure Liverty Music brand colors for the hosted Login UI v2 of the `liverty-music` product application, so its login flow presents product branding instead of the default Zitadel appearance. Because Zitadel defines branding only at instance or organization level (there is no application-level label policy), the system SHALL define an org-level label policy on the product org AND enforce it for the product application via the project's private-labeling setting. Branding SHALL be provisioned declaratively via the Zitadel Pulumi provider and activated.
+
+#### Scenario: Brand colors on the product org label policy
+
+- **WHEN** the Zitadel resources for the `liverty-music` product org are provisioned
+- **THEN** a label policy SHALL be applied to that org with the Liverty Music brand colors (primary, background, font, warn — including dark variants) sourced from the product's brand palette
+- **AND** the policy SHALL set `disableWatermark` so no Zitadel watermark is shown
+- **AND** the policy SHALL be activated (set active) so the hosted Login UI v2 renders it
+
+#### Scenario: Enforce product branding per application
+
+- **WHEN** the product `Project` is provisioned
+- **THEN** its private-labeling setting SHALL be `ENFORCE_PROJECT_RESOURCE_OWNER_POLICY`
+- **AND** the product application's login flow SHALL render the product org's label policy regardless of the logging-in user's organization
+- **AND** the separate admin/console org login SHALL remain unaffected (it is a different org)
+
+#### Scenario: Hosted Login UI v2 reflects the brand colors
+
+- **WHEN** an end user reaches the hosted login screen (`/ui/v2/login/*`) through the product OIDC flow
+- **THEN** the screen SHALL display the Liverty Music brand colors (buttons, links, background, text)
+- **AND** it SHALL NOT display the default unbranded Zitadel colors or watermark
+
+#### Scenario: Light and dark themes are branded
+
+- **WHEN** the login screen is rendered in either light or dark mode
+- **THEN** the corresponding brand colors SHALL be applied for that theme
+
+#### Scenario: Logo and login text remain out of scope
+
+- **WHEN** the login branding is applied
+- **THEN** only brand colors and theme SHALL be customized
+- **AND** no login logo SHALL be set (deferred until a brand logo asset exists)
+- **AND** login interface text strings SHALL remain the Zitadel Login UI v2 defaults (text customization is out of scope for this capability change)

--- a/openspec/changes/brand-zitadel-login-ui/tasks.md
+++ b/openspec/changes/brand-zitadel-login-ui/tasks.md
@@ -1,0 +1,15 @@
+## 1. Branding inputs (resolved — see design.md palette table)
+
+- [x] 1.1 Brand color hex values derived from frontend tokens: primary `#fd00a6`; background light `#ffffff` / dark `#0d1023`; font light `#161929` / dark `#fafafa`; warn `#f14d4c`. `themeMode: THEME_MODE_AUTO`, `disableWatermark: true`, `hideLoginNameSuffix: true`. No logo (deferred).
+
+## 2. Provision the label policy + per-app enforcement
+
+- [ ] 2.1 Add a `zitadel.LabelPolicy` resource (in `src/zitadel/components/frontend.ts` or a new branding component) for the `liverty-music` product org with the brand colors, `themeMode`, `disableWatermark: true`, and `setActive: true`. Leave `logoUrl`/`logoPath` unset.
+- [ ] 2.2 In `src/zitadel/index.ts`, change the product `Project`'s `privateLabelingSetting` from `PRIVATE_LABELING_SETTING_UNSPECIFIED` to `PRIVATE_LABELING_SETTING_ENFORCE_PROJECT_RESOURCE_OWNER_POLICY`, and wire the label policy into the `Zitadel` orchestrator.
+- [ ] 2.3 Run `pulumi preview` and confirm only the expected `LabelPolicy` add + `privateLabelingSetting` update appear (no unintended resource churn).
+
+## 3. Ship and verify on prod
+
+- [ ] 3.1 Apply through the normal release/ArgoCD flow.
+- [ ] 3.2 Open `https://auth.liverty-music.app/ui/v2/login/*` through the product OIDC flow and confirm the login shows the Liverty Music brand colors in both light and dark mode, with no Zitadel default colors/watermark.
+- [ ] 3.3 Confirm the admin/console login is unaffected by the `privateLabelingSetting` change (separate org).


### PR DESCRIPTION
## Summary
Adds the OpenSpec change `brand-zitadel-login-ui`: brand the self-hosted Zitadel **Login UI v2** with Liverty Music colors.

- **Mechanism**: org-level `zitadel.LabelPolicy` (brand colors / themeMode AUTO / disableWatermark / hideLoginNameSuffix) + product `Project.privateLabelingSetting = ENFORCE_PROJECT_RESOURCE_OWNER_POLICY` — B2C single-brand best practice (org defines values, the project setting enforces them per application; Zitadel has no app-level label policy).
- **Capability**: modifies `identity-management` (adds a Login UI Branding requirement).
- **Scope**: cloud-provisioning only. Logo (no asset yet) and login-text customization (Login UI v2 Settings V2 API is immature) are deferred.
- Supersedes the discarded Zitadel-Cloud-era WIP that used the legacy Management API `/management/v1/text/login`.

Specs/docs-only; no proto touched.

Refs: liverty-music/cloud-provisioning#346