### PR TITLE
feat(entity): add optional merch_url field to Series

### DIFF
--- a/openspec/changes/add-series-merch-url/tasks.md
+++ b/openspec/changes/add-series-merch-url/tasks.md
@@ -1,40 +1,40 @@
 ## 1. Specification (proto)
 
-- [ ] 1.1 Add `Url merch_url = 5;` to the `Series` message in `proto/liverty_music/entity/v1/series.proto`, marked `OPTIONAL`, with a doc comment mirroring `source_url` and noting it is the official merch info page (no timing/channel/item data)
-- [ ] 1.2 Run `buf lint` and `buf breaking` locally to confirm the change is additive and non-breaking
+- [x] 1.1 Add `Url merch_url = 5;` to the `Series` message in `proto/liverty_music/entity/v1/series.proto`, marked `OPTIONAL`, with a doc comment mirroring `source_url` and noting it is the official merch info page (no timing/channel/item data)
+- [x] 1.2 Run `buf lint` and `buf breaking` locally to confirm the change is additive and non-breaking
 - [ ] 1.3 Open the specification PR; after review + CI pass, merge and publish a GitHub Release (`vX.Y.Z`) to trigger BSR generation (CI-only — do not run `buf push`/`buf generate` locally)
 - [ ] 1.4 Monitor `buf-release.yml` until BSR generation completes successfully
 
 ## 2. Backend — persistence & hydration
 
-- [ ] 2.1 Add an additive migration introducing a nullable `merch_url` column on the series table (Atlas)
-- [ ] 2.2 Upgrade the generated proto package to the released version (`go get ...@vX.Y.Z`, `go mod tidy`)
-- [ ] 2.3 Update the series repository read/write to map the `merch_url` column ↔ `Series.merch_url`, treating empty/NULL as absent; add a method to clear `merch_url` (set NULL) for dead-link handling
-- [ ] 2.4 Ensure `Concert` hydration carries `merch_url` through the embedded `Series` exactly as `source_url` is carried
+- [x] 2.1 Add an additive migration introducing a nullable `merch_url` column on the series table (Atlas)
+- [ ] 2.2 Upgrade the generated proto package to the released version (`go get ...@vX.Y.Z`, `go mod tidy`) — GATED on BSR gen
+- [x] 2.3 Update the series repository read/write to map the `merch_url` column ↔ `Series.merch_url`, treating empty/NULL as absent; add a method to clear `merch_url` (set NULL) for dead-link handling
+- [~] 2.4 Ensure `Concert` hydration carries `merch_url` through the embedded `Series` exactly as `source_url` is carried — repository/entity hydration done; proto-mapper `MerchUrl` emit is the post-BSR one-line swap (TODO marker in `internal/adapter/rpc/mapper/concert.go`)
 
 ## 3. Backend — merch-url discovery job
 
-- [ ] 3.1 Add a repository query that lists candidate series: earliest event `local_date` within `[today, today+60d]` and `merch_url` empty (and a way to fetch in-window series with a non-empty `merch_url` for revalidation)
-- [ ] 3.2 Implement an HTTP liveness checker: definitive non-2xx/3xx (or hard failure) → dead; transient/ambiguous → alive (no clear)
-- [ ] 3.3 Implement the Gemini Flash-Lite searcher: prompt with artist name + series title; restrict to official site / official social media; return the single richest merch URL or empty (no hallucinated/non-official URL)
-- [ ] 3.4 Implement fill-once persistence: clear dead links, then set `merch_url` only when empty; never overwrite a live URL; validate `Url` and discard invalid values
-- [ ] 3.5 Add resilience: per-series non-fatal failure, consecutive-failure circuit breaker with reset on success, job always exits successfully (mirror `auto-concert-discovery`)
-- [ ] 3.6 Create the job entrypoint `cmd/job/merch-discovery/main.go` with job-specific DI and graceful resource cleanup (mirror `cmd/job/concert-discovery/main.go`)
-- [ ] 3.7 Add unit tests: candidate selection (in/out of window, empty/dead), liveness check (dead vs transient), resolution (found/empty/social-media), fill-once + invalid-URL discard, circuit breaker
-- [ ] 3.8 Run `make check` and confirm green
+- [x] 3.1 Add a repository query that lists candidate series: earliest event `local_date` within `[today, today+60d]` and `merch_url` empty (and a way to fetch in-window series with a non-empty `merch_url` for revalidation)
+- [x] 3.2 Implement an HTTP liveness checker: definitive non-2xx/3xx (or hard failure) → dead; transient/ambiguous → alive (no clear)
+- [x] 3.3 Implement the Gemini Flash-Lite searcher: prompt with artist name + series title; restrict to official site / official social media; return the single richest merch URL or empty (no hallucinated/non-official URL)
+- [x] 3.4 Implement fill-once persistence: clear dead links, then set `merch_url` only when empty; never overwrite a live URL; validate `Url` and discard invalid values
+- [x] 3.5 Add resilience: per-series non-fatal failure, consecutive-failure circuit breaker with reset on success, job always exits successfully (mirror `auto-concert-discovery`)
+- [x] 3.6 Create the job entrypoint `cmd/job/merch-discovery/main.go` with job-specific DI and graceful resource cleanup (mirror `cmd/job/concert-discovery/main.go`)
+- [x] 3.7 Add unit tests: candidate selection (in/out of window, empty/dead), liveness check (dead vs transient), resolution (found/empty/social-media), fill-once + invalid-URL discard, circuit breaker
+- [x] 3.8 Run `make check` and confirm green
 
 ## 4. Frontend — detail sheet link
 
-- [ ] 4.1 Upgrade the generated proto package to the released version (`npm install @buf/...@latest`)
-- [ ] 4.2 Render a "グッズ情報" link in `event-detail-sheet.html`, gated on `concert.series.merch_url`, opening in a new tab; omit entirely when absent
-- [ ] 4.3 Add the `eventDetail.viewMerch` i18n key with parallel JA/EN values in `frontend/src/locales/<locale>/translation.json`
-- [ ] 4.4 Add/extend component tests covering the present and absent cases
-- [ ] 4.5 Run `make check` and confirm green
+- [ ] 4.1 Upgrade the generated proto package to the released version (`npm install @buf/...@latest`) — GATED on BSR gen; then swap the `merchUrl` mapper TODO in `concert-mapper.ts`
+- [x] 4.2 Render a "グッズ情報" link in `event-detail-sheet.html`, gated on `concert.series.merch_url`, opening in a new tab; omit entirely when absent (gated on `hasMerchUrl` getter; `event.merchUrl` in entity)
+- [x] 4.3 Add the `eventDetail.viewMerch` i18n key with parallel JA/EN values in `frontend/src/locales/<locale>/translation.json`
+- [x] 4.4 Add/extend component tests covering the present and absent cases (`hasMerchUrl` true/false/no-event; factories + mapper spec updated)
+- [ ] 4.5 Run `make check` and confirm green — GATED on 4.1 (worktree has no node_modules; runs with the package upgrade)
 
 ## 5. Cloud-provisioning — scheduling
 
-- [ ] 5.1 Add a CronJob manifest for the merch-url discovery job, scheduled daily in prod and weekly in dev (mirror the concert-discovery job's scheduling)
-- [ ] 5.2 Reuse the Vertex AI / Gemini workload-identity service account already granted to concert discovery; confirm no new IAM is required
+- [x] 5.1 Add a CronJob manifest for the merch-url discovery job, scheduled daily in prod and weekly in dev (mirror the concert-discovery job's scheduling) — also added the `merch-discovery` Dockerfile target + `deploy.yml` build-matrix entry + `bump-prod-pin.yml` provenance gate so the image is built and pinned
+- [x] 5.2 Reuse the Vertex AI / Gemini workload-identity service account already granted to concert discovery; confirm no new IAM is required (job runs as `serviceAccountName: backend-app`; Gemini uses the API key from `backend-secrets`; image lives in the existing `backend` AR repo — no new IAM, SA, or AR repo)
 
 ## 6. Wrap-up
 

--- a/proto/liverty_music/entity/v1/series.proto
+++ b/proto/liverty_music/entity/v1/series.proto
@@ -76,4 +76,14 @@ message Series {
   // semantics (Ignore.IGNORE_UNSPECIFIED), so callers omitting the
   // field never hit the Url.value min_len / uri rules.
   Url source_url = 4 [(google.api.field_behavior) = OPTIONAL];
+
+  // The official merchandise information page shared across the series
+  // (an official site page or official social media post). Optional and
+  // populated asynchronously by the merch-url discovery job, so most
+  // series carry a nil wrapper until their earliest event nears. Stores
+  // only the link: no sale timing, channel, price, or item data — those
+  // remain on the linked page. Same optionality semantics as source_url:
+  // a nil wrapper skips inner-Url validation, while a present wrapper
+  // SHALL satisfy the Url.value min_len / uri rules.
+  Url merch_url = 5 [(google.api.field_behavior) = OPTIONAL];
 }


### PR DESCRIPTION
## Summary

Adds an optional `Series.merch_url` (`Url`, field 5) so a series can carry a single official merchandise-info page, mirroring the existing optional `Series.source_url`. This is the schema half of the "C. グッズ・物販" feature of the never-miss-a-live roadmap: fans get a one-tap path from a concert to its official goods page.

Only the link is stored — no sale timing, channel, price, or item catalog (those remain on the linked page).

## Changes

- `proto/liverty_music/entity/v1/series.proto`: add `Url merch_url = 5 [(google.api.field_behavior) = OPTIONAL]` with a doc comment mirroring `source_url` (same nil-wrapper optionality semantics; populated asynchronously by the merch-discovery job).
- `openspec/changes/add-series-merch-url/tasks.md`: record implementation progress across all four repos. Remaining unchecked tasks are BSR-gated (downstream package upgrade, proto-mapper emit swap, downstream PRs, deploy verification) and depend on this change reaching BSR first.

## Testing

- `buf format -w`, `buf lint`, and `buf breaking --against '.git#branch=main'` all pass — the change is additive and **non-breaking** (no `buf skip breaking` label needed).

## Release flow

Per the cross-repo dependency order, merging this PR and publishing a GitHub Release (`vX.Y.Z`) triggers `buf-release.yml` → BSR generation. Backend and frontend then upgrade the generated package and swap the `merch_url` mapper TODO markers; those PRs follow once BSR gen completes.

Refs: #569
