### PR TITLE
docs(openspec): add fix-zitadel-login-ja-i18n change

### DIFF
--- a/openspec/changes/fix-zitadel-login-ja-i18n/.openspec.yaml
+++ b/openspec/changes/fix-zitadel-login-ja-i18n/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-03

--- a/openspec/changes/fix-zitadel-login-ja-i18n/design.md
+++ b/openspec/changes/fix-zitadel-login-ja-i18n/design.md
@@ -1,0 +1,36 @@
+## Context
+
+Zitadel is self-hosted (v4.14.0) with the Login UI v2 (`zitadel-api-login` Next.js container, served at `/ui/v2/login/*`), provisioned via Pulumi under `cloud-provisioning/src/zitadel/`. The hosted login renders the Japanese screen in English. Root cause, confirmed end-to-end:
+
+- `apps/login/src/i18n/request.ts` resolves the locale from the `accept-language` header / `NEXT_LOCALE` cookie (OIDC `ui_locales` is NOT used), gated by `allowedLanguages` from `GetGeneralSettings`. It then renders `deepmerge([en.json, <locale>.json, GetHostedLoginTranslation(locale)])` — the API translation is merged **last and wins**.
+- The frontend bundle `apps/login/locales/ja.json` is complete Japanese, but the backend default `internal/query/v2-default.json` ships only `de,en,es,it,nl,pl,ru,zh` — **no `ja`**. So `GetHostedLoginTranslation(ja)` falls back to the instance default (`en`) and returns English, which overrides the Japanese bundle. `de` works because `v2-default.json` includes it.
+- Verified: `GetGeneralSettings` → `allowedLanguages` includes `ja`, `defaultLanguage = en` (our config is correct); `GetHostedLoginTranslation(ja)` → English, `(de)` → German; `v2-default.json` has `de` (`"Ein weiteres Konto hinzufügen"`, matching the API) and no `ja`; live `NEXT_LOCALE=de` → German, `=ja` → English. `main` (latest) still omits `ja`, so a version bump does not fix it.
+
+The existing Zitadel component graph already includes custom automation that calls Zitadel APIs with the `pulumi-admin` JWT via Pulumi dynamic providers under `src/zitadel/dynamic/` (e.g. user-IdP-link, permanent-password). The Settings v2 API exposes `SetHostedLoginTranslation` (instance or org level), which merges the supplied keys over the system defaults and accepts any supported BCP 47 locale (incl. `ja`).
+
+## Goals / Non-Goals
+
+**Goals:**
+- The hosted Login UI v2 presents Japanese interface text for `ja` users of the product login flow, instead of falling back to English.
+- Declarative, IaC-managed, shipped through the existing Pulumi/ArgoCD flow; survives instance rebuilds; dev/prod parity; verified on prod.
+- Track the permanent upstream fix so the override can be retired.
+
+**Non-Goals:**
+- Fixing the unrelated middleware CSP `fetch() returned undefined` error (separate instance-host-header issue).
+- Overriding languages other than Japanese (product is JA/EN; the rest are covered by the upstream issue).
+- Any frontend/backend/proto change, login logo, or login behavior change.
+
+## Decisions
+
+- **Override Japanese via a Hosted Login Translation, provisioned as a Pulumi dynamic resource.** `@pulumiverse/zitadel` has no native resource for hosted-login translations, so implement a dynamic provider (mirroring `src/zitadel/dynamic/`) that calls Settings v2 `SetHostedLoginTranslation` with the `pulumi-admin` JWT. Provisioning it in IaC (vs a one-off API call) makes it reviewable, repeatable, and durable across instance rebuilds.
+  - **Level: product org (`liverty-music`).** Set the translation at the product-org level so it scopes to product end-user logins and does not alter the admin/console org. (Instance level is the alternative; org level is the narrower, product-aligned blast radius. Either renders Japanese for `ja` viewers; org level is preferred.)
+- **Ship the COMPLETE `ja` key set.** The API English-fills any key the override omits, and that English then wins the `deepmerge` over the bundled `ja.json`. A partial override would leave the un-supplied keys in English. Source the payload from upstream `apps/login/locales/ja.json` **pinned to the deployed Zitadel version (`v4.14.0`)** so keys line up with what the running login app expects.
+- **Branding cache caveat.** The Login UI v2 caches translation/branding; after applying, the change may require a `kubectl rollout restart deploy/zitadel-api-login` to render (same operational pattern observed for the label-policy branding rollout). Capture this in tasks/verification.
+- **Permanent fix is upstream.** File a Zitadel issue (and ideally a PR) to add `ja` (and the other missing languages) to `internal/query/v2-default.json`. Once a Zitadel release ships Japanese defaults, this override becomes redundant and can be removed — note this exit condition in the change.
+
+## Risks / Trade-offs
+
+- [Translation drift vs upstream] The override duplicates upstream's `ja.json`. If Zitadel renames/adds keys in a later login version, the pinned payload can go stale (new keys would fall back to English). → Mitigation: pin the payload to the deployed Zitadel version and re-sync on Zitadel upgrades; the upstream fix removes the duplication entirely. → low/medium.
+- [Settings v2 API surface via dynamic provider] `SetHostedLoginTranslation` must work against self-hosted v4.14.0 with the `pulumi-admin` JWT at org level. → Mitigation: the same JWT already drives other Settings/Management calls in `src/zitadel/dynamic/`; verify on prod (dev Zitadel is currently stopped). → low.
+- [Cache masking the result] Post-apply the login may keep serving cached English until the login pod is restarted. → Mitigation: include a rollout-restart + re-verify step; do not conclude failure before restart. → low.
+- [Blast radius] Org-level override only affects product `ja` logins (currently English); it cannot regress en/de/other users or auth logic. → low.

--- a/openspec/changes/fix-zitadel-login-ja-i18n/proposal.md
+++ b/openspec/changes/fix-zitadel-login-ja-i18n/proposal.md
@@ -1,0 +1,41 @@
+## Why
+
+The self-hosted Zitadel hosted Login UI v2 (`/ui/v2/login/*` at `auth.liverty-music.app`) renders the **Japanese** login screen in **English**, even though the instance allows Japanese and the user's language is Japanese. For a Japanese-first consumer product this is a visible, trust-eroding defect on the very first authenticated screen. The cause was confirmed end-to-end (live behavior + API responses + Zitadel source): Zitadel's backend default translations are missing Japanese, and that English fallback overrides the (complete) Japanese bundle. This is not fixable by configuration we already control, nor by upgrading Zitadel (latest `main` is still missing Japanese), so it needs a deliberate provisioning-side override.
+
+## What Changes
+
+- Provision a **Hosted Login Translation override for Japanese (`ja`)** on the `liverty-music` Zitadel deployment via the Settings v2 API (`SetHostedLoginTranslation`), so the hosted Login UI v2 renders Japanese text for `ja` users instead of falling back to English.
+- The override carries the **complete** Japanese key set (sourced from Zitadel's own `apps/login/locales/ja.json`), because the API English-fills any key the override omits — a partial override would leave untranslated keys in English.
+- Provision it declaratively through `cloud-provisioning` alongside the existing Zitadel resources, so it ships through the normal Pulumi/ArgoCD flow and survives instance rebuilds.
+- File an **upstream Zitadel issue** to add the missing languages (`ja` plus `ar, cs, fr, hu, id, ko, mk, pt, ro, sv, tr, uk`) to `internal/query/v2-default.json`, tracking the permanent fix that would let the override be retired.
+
+### Root cause (confirmed)
+
+- Login v2 (`apps/login/src/i18n/request.ts`) computes messages as `deepmerge([en.json, <locale>.json, customMessages])`, where `customMessages = GetHostedLoginTranslation(locale)` is merged **last (wins)**.
+- The frontend bundle `apps/login/locales/ja.json` is fully translated, but the backend default `internal/query/v2-default.json` contains only 8 languages (`de,en,es,it,nl,pl,ru,zh`) — **no `ja`**. So `GetHostedLoginTranslation(ja)` falls back to the instance default (`en`) and returns English, overriding the Japanese bundle.
+- Evidence: `GetGeneralSettings` shows `allowedLanguages` includes `ja` and `defaultLanguage = en` (our config is correct); `GetHostedLoginTranslation` returns English for `ja` but German for `de`; the source `v2-default.json` has `de` but no `ja`; live `NEXT_LOCALE=de` → German, `NEXT_LOCALE=ja` → English. OIDC `ui_locales` is not consulted by login v2; the `accept-language` header and `NEXT_LOCALE` cookie ARE honored (proven via `de`).
+
+### Out of scope
+
+- The login middleware `fetch() returned undefined` / "Failed to load security settings for CSP" error (the middleware's API fetch omits the instance host header, so CSP falls back to default). Unrelated to localization — tracked separately.
+- Login **logo** branding (no asset yet) — deferred, separate change.
+- Other missing languages' overrides — this change ships Japanese only (the product's languages are JA/EN); the upstream issue covers the rest.
+
+## Capabilities
+
+### New Capabilities
+
+<!-- none -->
+
+### Modified Capabilities
+
+- `identity-management`: add a requirement that the hosted Login UI v2 presents its interface text in Japanese for the product, provisioned via a Zitadel Hosted Login Translation override, since Zitadel's built-in defaults omit Japanese.
+
+## Impact
+
+- **`cloud-provisioning` only** — no proto, backend, or frontend changes.
+  - Add a Zitadel Hosted Login Translation resource for `ja` (Settings v2 `SetHostedLoginTranslation`), provisioned in the Zitadel component graph. `@pulumiverse/zitadel` has no native resource for this, so it is implemented as a Pulumi **dynamic provider** (or equivalent seed) that calls the Settings v2 API with the `pulumi-admin` JWT — consistent with existing custom Zitadel automation under `src/zitadel/dynamic/`.
+  - Carry the full `ja` translation payload (derived from upstream `apps/login/locales/ja.json`, pinned to the deployed Zitadel version `v4.14.0`).
+- **Specification**: modify the `identity-management` capability spec (this change).
+- **Upstream**: a Zitadel GitHub issue/PR to add the missing languages to `internal/query/v2-default.json` (permanent fix; lets this override be removed later).
+- Ships through the normal Pulumi/ArgoCD flow; prod parity; visually verified on prod (JA login renders Japanese in light + dark).

--- a/openspec/changes/fix-zitadel-login-ja-i18n/specs/identity-management/spec.md
+++ b/openspec/changes/fix-zitadel-login-ja-i18n/specs/identity-management/spec.md
@@ -1,0 +1,29 @@
+## ADDED Requirements
+
+### Requirement: Localize Login UI Text for the Product
+
+The system SHALL ensure the hosted Login UI v2 for the `liverty-music` product application presents its interface text in Japanese for end users whose login language is Japanese, instead of falling back to English. Because Zitadel's built-in hosted-login default translations omit Japanese (so the Settings API returns English for the `ja` locale and that English overrides the login app's bundled Japanese), the system SHALL provision a Zitadel **Hosted Login Translation** override for the `ja` locale, declaratively via the Settings v2 API, carrying the complete Japanese key set.
+
+#### Scenario: Japanese hosted login translation is provisioned
+
+- **WHEN** the Zitadel resources for the `liverty-music` product org are provisioned
+- **THEN** a Hosted Login Translation for the `ja` locale SHALL be applied (Settings v2 `SetHostedLoginTranslation`) scoped to the product org
+- **AND** it SHALL contain the complete Japanese key set (no key left to English fallback), sourced from the deployed Zitadel login version's Japanese translations
+
+#### Scenario: Japanese login screen renders Japanese
+
+- **WHEN** an end user reaches the hosted login screen (`/ui/v2/login/*`) through the product OIDC flow with a Japanese language preference (browser `accept-language` or the in-login language selector set to 日本語)
+- **THEN** the login interface text (titles, labels, buttons) SHALL be displayed in Japanese
+- **AND** it SHALL NOT fall back to English
+
+#### Scenario: Other languages and the default are unaffected
+
+- **WHEN** the Japanese override is applied
+- **THEN** users with non-Japanese language preferences (e.g. English, German) SHALL continue to see their existing language unchanged
+- **AND** the admin/console org login SHALL remain unaffected (the override is scoped to the product org)
+
+#### Scenario: Override is retired once upstream ships Japanese defaults
+
+- **WHEN** a future Zitadel version includes Japanese in its hosted-login default translations
+- **THEN** the product MAY remove the Japanese override
+- **AND** the Japanese login SHALL still render Japanese from the upstream defaults

--- a/openspec/changes/fix-zitadel-login-ja-i18n/tasks.md
+++ b/openspec/changes/fix-zitadel-login-ja-i18n/tasks.md
@@ -1,0 +1,22 @@
+## 1. Prepare the Japanese translation payload
+
+- [ ] 1.1 Pull the complete Japanese hosted-login key set from upstream Zitadel `apps/login/locales/ja.json` at the **deployed version tag `v4.14.0`**, and confirm it covers the keys the running login app renders (loginname/title/buttons/accounts/etc.).
+- [ ] 1.2 Convert/shape it into the `SetHostedLoginTranslation` `translations` payload (Settings v2 schema). Pin a copy in `cloud-provisioning` (e.g. `src/zitadel/translations/ja.json`) with a comment noting it mirrors upstream `v4.14.0` and is retired once upstream `v2-default.json` ships `ja`.
+
+## 2. Provision the override (cloud-provisioning)
+
+- [ ] 2.1 Add a Pulumi **dynamic resource** (mirroring `src/zitadel/dynamic/`) that calls Settings v2 `SetHostedLoginTranslation` for the `liverty-music` **product org**, `locale = ja`, with the pinned payload, authenticating via the `pulumi-admin` JWT. Make updates idempotent (re-apply on payload change; etag-aware if practical).
+- [ ] 2.2 Wire it into the `Zitadel` orchestrator / Frontend component graph (depends on `productOrg`).
+- [ ] 2.3 Run `pulumi preview` and confirm only the expected hosted-login-translation add appears (no unintended resource churn). `make check` passes.
+
+## 3. Ship and verify on prod
+
+- [ ] 3.1 Apply through the normal release/ArgoCD/Pulumi flow.
+- [ ] 3.2 If the login still serves English after apply, `kubectl rollout restart deploy/zitadel-api-login -n zitadel` to clear the Login UI v2 translation cache (do not conclude failure before the restart).
+- [ ] 3.3 Verify via the product OIDC flow with a Japanese preference (`accept-language: ja` and/or the in-login 日本語 selector) that the login renders **Japanese** (titles, labels, buttons) in both light and dark mode, with no English fallback.
+- [ ] 3.4 Confirm non-Japanese logins (en, de) are unchanged and the admin/console org login is unaffected.
+
+## 4. Track the permanent upstream fix
+
+- [ ] 4.1 File a Zitadel GitHub issue (and ideally a PR) to add `ja` — plus the other missing languages (`ar, cs, fr, hu, id, ko, mk, pt, ro, sv, tr, uk`) present in `apps/login/locales/` but absent from `internal/query/v2-default.json` — to the backend hosted-login defaults. Link the issue in the override code/comment.
+- [ ] 4.2 Record the exit condition: once a deployed Zitadel version includes Japanese defaults, remove the override and re-verify the Japanese login still renders from upstream defaults.


### PR DESCRIPTION
## 🔗 Related Issue

Refs: liverty-music/cloud-provisioning#349

<!-- Tracked in cloud-provisioning (the implementation repo); closed by the implementation PR, not this spec-doc PR. -->

## 📝 Summary of Changes

Adds the OpenSpec change **`fix-zitadel-login-ja-i18n`** (proposal + design + specs + tasks) capturing a fully-confirmed bug and its fix plan. No proto changes — OpenSpec documents only.

**Problem:** the self-hosted Zitadel hosted Login UI v2 renders the **Japanese** login screen in **English**.

**Confirmed root cause (evidence-backed):** login v2 renders `deepmerge([en.json, <locale>.json, GetHostedLoginTranslation(locale)])` — the API translation is merged **last and wins**. The frontend bundle `apps/login/locales/ja.json` is complete Japanese, but Zitadel's backend default `internal/query/v2-default.json` ships only 8 languages (`de,en,es,it,nl,pl,ru,zh`) — **no `ja`** — so `GetHostedLoginTranslation(ja)` returns the English fallback and overrides the Japanese bundle. Verified via live behavior (`NEXT_LOCALE=de`→German, `=ja`→English), direct API calls (`GetGeneralSettings` shows `ja` allowed + `defaultLanguage=en`; `GetHostedLoginTranslation(ja)`→English, `(de)`→German), and Zitadel source. Our instance config is correct; `main` (latest) still omits `ja`, so a version bump does **not** fix it.

**Proposed fix (modifies `identity-management`):** provision a declarative **product-org Hosted Login Translation override for `ja`** (Settings v2 `SetHostedLoginTranslation`, Pulumi dynamic resource in cloud-provisioning) carrying the **complete** Japanese key set (the API English-fills omissions), shipped through the normal Pulumi/ArgoCD flow and verified on prod (may need a `zitadel-api-login` rollout restart to clear the translation cache). Also file an upstream Zitadel issue to add the missing languages to `v2-default.json` as the permanent fix, with an exit condition to retire the override.

**Out of scope:** the unrelated middleware CSP `fetch() returned undefined` (instance-host-header) error; login logo branding.

## ✅ Self-Checklist

- [x] I have linked the related issue. <!-- cross-repo: cloud-provisioning#349 -->
- [x] I have updated the relevant documentation (OpenSpec change artifacts).
- [x] I have run `buf lint` and `buf format` locally and all checks have passed. <!-- N/A — no proto changes; pre-commit hooks ran clean -->
- [x] My proto definitions follow the project's style guidelines. <!-- N/A — no proto changes -->
- [x] Breaking changes have been justified and documented if applicable. <!-- N/A — OpenSpec docs only -->
