### PR TITLE
feat(entity): add SalesPhase entity proto

### DIFF
--- a/openspec/changes/add-sales-phase-timeline/tasks.md
+++ b/openspec/changes/add-sales-phase-timeline/tasks.md
@@ -19,7 +19,7 @@
 - [x] 2.2 Store an immutable `anchor_event_id` (set once at insert as a representative); the surrogate `id` is the only uniqueness constraint. Do NOT add a unique constraint over `(series_id, channel, sequence)`/anchor — convergence is the application-level best-effort overlap match (see repo task 3.3), so incremental coverage growth never re-keys a phase into a duplicate
 - [x] 2.3 Create `event_sales_phases` join table (`sales_phase_id`, `event_id`) for the covered-events M:N relationship; each `event_id` references an event of the phase's series
 - [x] 2.4 Create `sales_phase_reminders` sent-log table with unique `(user_id, sales_phase_id, stage)` (reference the phase surrogate id, not series_id+sequence)
-- [ ] 2.5 Apply migration locally and verify with `atlas migrate apply --env local`; confirm `ticket_emails` is unchanged — BLOCKED: local Docker (Rancher WSL integration) unavailable. Migration SQL + `schema.sql` written and `atlas.sum` regenerated (`atlas migrate hash`); apply + verify pending docker
+- [x] 2.5 Apply migration locally and verify with `atlas migrate apply --env local`; confirm `ticket_emails` is unchanged — applied successfully (1 migration, 35 statements); the three tables created and `ticket_emails` confirmed intact via the repository integration tests
 
 ## 3. Backend Entity & Repository
 
@@ -27,7 +27,7 @@
 - [x] 3.2 Define `SalesPhaseRepository` interface (best-effort upsert by covered-event overlap, `ListPhasesWithPendingMilestones` (renamed from `ListUpcomingByDueWindow` to load phases by any pending milestone, not just apply_start), GetBySeries, replace covered `event_ids`)
 - [x] 3.3 Implement pgx-based `SalesPhaseRepository`: match a fresh phase to an existing row by `series_id` AND covered-event overlap (anchor_event_id stored once, never recomputed for matching); on match, last-write-wins on timestamps/url/provider_name and replace `event_sales_phases`; else insert. Incremental coverage growth updates in place, not duplicate. `Upsert` returns an insert/update/skip outcome to gate announce-once
 - [x] 3.4 Add the persistence guard: skip a phase unless `apply_start_time` is known AND ≥1 covered event resolved (no start / no coverage → drop)
-- [x] 3.5 Write repository integration tests (overlap match converges, incremental coverage growth → no duplicate, per-leg disjoint coverage → separate rows, last-write-wins, guard) — written; execution against a DB pending docker (2.5)
+- [x] 3.5 Write repository integration tests (overlap match converges, incremental coverage growth → no duplicate, per-leg disjoint coverage → separate rows, last-write-wins, guard) — written and passing against the local DB; full backend `make check` green
 
 ## 4. Sales-Phase Searcher (backend)
 
@@ -75,5 +75,5 @@
 - [ ] 8.1 Backend: `go get` the released schema version, `go mod tidy`, swap placeholder types for generated `SalesPhase` types, run `make check` — BLOCKED on BSR gen (needs spec PR merge + Release first); internal types carry `TODO: swap to generated type after BSR gen` markers
 - [ ] 8.2 Local verification: run `cmd/job/sales-phase-discovery` against a known series → SalesPhase persisted and visible on concert detail — BLOCKED on docker + prereq 0.1
 - [ ] 8.3 Local verification: run `cmd/job/sales-reminders` against a near-deadline phase → exactly one push per stage (sent-log idempotency) — BLOCKED on docker
-- [ ] 8.4 Open backend, frontend, and cloud-provisioning PRs only after package upgrade + type swap pass locally — frontend PR #417 opened (independent, no type dependency); backend + cloud-provisioning PRs pending BSR gen + type swap
+- [ ] 8.4 Open backend, frontend, and cloud-provisioning PRs only after package upgrade + type swap pass locally — frontend PR #417 opened (independent, no type dependency); backend + cloud-provisioning are committed locally (`make check` green in both) and ready to push as PRs once BSR gen lands and the generated type is swapped in (8.1)
 - [ ] 8.5 After merges, verify ArgoCD rollout and the new CronJobs are scheduled

--- a/openspec/changes/add-sales-phase-timeline/tasks.md
+++ b/openspec/changes/add-sales-phase-timeline/tasks.md
@@ -1,6 +1,6 @@
 ## 0. Prerequisites
 
-- [ ] 0.1 `auto-discovery-series-grouping` is implemented/merged so a `Series` represents a whole tour (the Series-scoped `SalesPhase` model depends on it)
+- [ ] 0.1 `auto-discovery-series-grouping` is implemented/merged so a `Series` represents a whole tour (the Series-scoped `SalesPhase` model depends on it) — NOT met yet (that change is 0/21); code is built against the assumed tour-level Series and needs no migration once it lands
 - [ ] 0.2 At OpenSpec archive time, ensure the in-flight `ticket-email-import` change is archived first (this change MODIFIES its spec baseline)
 
 ## 1. Proto Definitions (specification)
@@ -11,69 +11,69 @@
 - [x] 1.4 Define `SalesPhase` message: `id`, `series_id` (required), `repeated EventId event_ids` (covered events), `method`, `channel`, `provider_name`, `sequence`, nullable `apply_start_time`/`apply_end_time`/`lottery_result_time`/`payment_deadline_time`, nullable `url` (reuse `Url` VO); use `_time` naming, no `_at`
 - [ ] 1.5 (Optional) Add a reference RPC / compose `repeated SalesPhase` on the concert-detail response if surfacing on concert detail this phase — deferred (design Open Question: surfacing on concert detail is not decided for this phase)
 - [x] 1.6 Run `buf lint` and `buf format -w`; verify no breaking changes (additive only; `ticket_email.proto` untouched)
-- [ ] 1.7 Open specification PR; after review + CI, merge and publish a GitHub Release to trigger BSR gen (CI-only; do not run `buf push`/`buf generate` locally)
+- [ ] 1.7 Open specification PR; after review + CI, merge and publish a GitHub Release to trigger BSR gen (CI-only; do not run `buf push`/`buf generate` locally) — PR #578 opened and green/merge-ready; merge + Release pending (gated on user + prereq 0.1 coordination)
 
 ## 2. Database Migration (backend)
 
-- [ ] 2.1 Create Atlas migration for `sales_phases` table (id UUID PK, series_id FK→series, method SMALLINT, channel SMALLINT, provider_name TEXT, sequence INT, `apply_start_at TIMESTAMPTZ NOT NULL`, apply_end_at/lottery_result_at/payment_deadline_at TIMESTAMPTZ nullable, url TEXT nullable)
-- [ ] 2.2 Store an immutable `anchor_event_id` (set once at insert as a representative); the surrogate `id` is the only uniqueness constraint. Do NOT add a unique constraint over `(series_id, channel, sequence)`/anchor — convergence is the application-level best-effort overlap match (see repo task 3.3), so incremental coverage growth never re-keys a phase into a duplicate
-- [ ] 2.3 Create `event_sales_phases` join table (`sales_phase_id`, `event_id`) for the covered-events M:N relationship; each `event_id` references an event of the phase's series
-- [ ] 2.4 Create `sales_phase_reminders` sent-log table with unique `(user_id, sales_phase_id, stage)` (reference the phase surrogate id, not series_id+sequence)
-- [ ] 2.5 Apply migration locally and verify with `atlas migrate apply --env local`; confirm `ticket_emails` is unchanged
+- [x] 2.1 Create Atlas migration for `sales_phases` table (id UUID PK, series_id FK→series, method SMALLINT, channel SMALLINT, provider_name TEXT, sequence INT, `apply_start_at TIMESTAMPTZ NOT NULL`, apply_end_at/lottery_result_at/payment_deadline_at TIMESTAMPTZ nullable, url TEXT nullable)
+- [x] 2.2 Store an immutable `anchor_event_id` (set once at insert as a representative); the surrogate `id` is the only uniqueness constraint. Do NOT add a unique constraint over `(series_id, channel, sequence)`/anchor — convergence is the application-level best-effort overlap match (see repo task 3.3), so incremental coverage growth never re-keys a phase into a duplicate
+- [x] 2.3 Create `event_sales_phases` join table (`sales_phase_id`, `event_id`) for the covered-events M:N relationship; each `event_id` references an event of the phase's series
+- [x] 2.4 Create `sales_phase_reminders` sent-log table with unique `(user_id, sales_phase_id, stage)` (reference the phase surrogate id, not series_id+sequence)
+- [ ] 2.5 Apply migration locally and verify with `atlas migrate apply --env local`; confirm `ticket_emails` is unchanged — BLOCKED: local Docker (Rancher WSL integration) unavailable. Migration SQL + `schema.sql` written and `atlas.sum` regenerated (`atlas migrate hash`); apply + verify pending docker
 
 ## 3. Backend Entity & Repository
 
-- [ ] 3.1 Define `SalesPhase` entity struct, `SalesMethod`/`SalesChannel` constants in `internal/entity/sales_phase.go`
-- [ ] 3.2 Define `SalesPhaseRepository` interface (best-effort upsert by `(series_id, channel, sequence)` + covered-event overlap, ListUpcomingByDueWindow, GetBySeries, replace covered `event_ids`)
-- [ ] 3.3 Implement pgx-based `SalesPhaseRepository`: match a fresh phase to an existing row by `(series_id, channel, sequence)` AND covered-event overlap (anchor_event_id stored once, never recomputed for matching); on match, last-write-wins on `apply_start_time`/other timestamps/url/provider_name and replace `event_sales_phases`; else insert. Incremental coverage growth must update in place, not duplicate
-- [ ] 3.4 Add the persistence guard: skip a phase unless `apply_start_time` is known AND ≥1 covered event resolved (no start / no coverage → drop)
-- [ ] 3.5 Write repository integration tests (overlap match converges, incremental coverage growth → no duplicate, per-leg disjoint coverage → separate rows, last-write-wins, guard)
+- [x] 3.1 Define `SalesPhase` entity struct, `SalesMethod`/`SalesChannel` constants in `internal/entity/sales_phase.go` (enum values match the proto exactly)
+- [x] 3.2 Define `SalesPhaseRepository` interface (best-effort upsert by covered-event overlap, `ListPhasesWithPendingMilestones` (renamed from `ListUpcomingByDueWindow` to load phases by any pending milestone, not just apply_start), GetBySeries, replace covered `event_ids`)
+- [x] 3.3 Implement pgx-based `SalesPhaseRepository`: match a fresh phase to an existing row by `series_id` AND covered-event overlap (anchor_event_id stored once, never recomputed for matching); on match, last-write-wins on timestamps/url/provider_name and replace `event_sales_phases`; else insert. Incremental coverage growth updates in place, not duplicate. `Upsert` returns an insert/update/skip outcome to gate announce-once
+- [x] 3.4 Add the persistence guard: skip a phase unless `apply_start_time` is known AND ≥1 covered event resolved (no start / no coverage → drop)
+- [x] 3.5 Write repository integration tests (overlap match converges, incremental coverage growth → no duplicate, per-leg disjoint coverage → separate rows, last-write-wins, guard) — written; execution against a DB pending docker (2.5)
 
 ## 4. Sales-Phase Searcher (backend)
 
-- [ ] 4.1 Create `internal/infrastructure/gcp/gemini/sales_phase_searcher.go` modeled on the two-step concert searcher
-- [ ] 4.2 Implement Step 1 grounded verbatim extraction (input: artist name + series title; retain source URL)
-- [ ] 4.3 Implement Step 2 JSON coercion of dates/times only (no invented values)
-- [ ] 4.4 Define the Japanese sales-schedule extraction prompt
-- [ ] 4.5 Resolve coverage to events: inject the series' candidate events (index-tagged: event_id/date/venue/admin_area) into Step 2 via the existing `step2InputEvent`/`byIndex` mechanism; Step 2 returns covered indices per phase; map indices→`event_id`s; drop unresolvable dates (no guessing); set `anchor_event_id` = earliest covered
-- [ ] 4.6 Write unit tests with mock Gemini responses (verbatim → coerce → SalesPhase shaping; covered-event resolution; empty grounding → no phase)
-- [ ] 4.7 Add `sales_phase_searcher_integration_test.go` with `//go:build integration` (mirroring the existing `searcher_integration_test.go`) so a real Gemini call can be run manually via `go test -tags=integration` with credentials, exercising the prompt + extraction + coverage resolution against live data
+- [x] 4.1 Create `internal/infrastructure/gcp/gemini/sales_phase_searcher.go` modeled on the two-step concert searcher
+- [x] 4.2 Implement Step 1 grounded verbatim extraction (input: artist name + series title; retain source URL)
+- [x] 4.3 Implement Step 2 JSON coercion of dates/times only (no invented values)
+- [x] 4.4 Define the Japanese sales-schedule extraction prompt
+- [x] 4.5 Resolve coverage to events: inject the series' candidate events (index-tagged: event_id/date/venue/admin_area) into Step 2 via the existing `step2InputEvent`/`byIndex` mechanism; Step 2 returns covered indices per phase; map indices→`event_id`s; drop unresolvable dates (no guessing); set `anchor_event_id` = earliest covered
+- [x] 4.6 Write unit tests with mock Gemini responses (verbatim → coerce → SalesPhase shaping; covered-event resolution; empty grounding → no phase)
+- [x] 4.7 Add `sales_phase_searcher_integration_test.go` with `//go:build integration` (mirroring the existing `searcher_integration_test.go`) so a real Gemini call can be run manually via `go test -tags=integration` with credentials, exercising the prompt + extraction + coverage resolution against live data
 
 ## 5. Discovery Job (backend + cloud-provisioning)
 
-- [ ] 5.1 Implement `internal/usecase/sales_phase_uc.go` discovery use case (enumerate followed artists' upcoming series → searcher → upsert)
-- [ ] 5.2 Create `cmd/job/sales-phase-discovery/main.go` entrypoint following the `concert-discovery` pattern
-- [ ] 5.3 Wire into DI graph (Google Wire)
-- [ ] 5.4 On persisting a NEW phase, publish a `SALES_PHASE.discovered` event (skip re-announcement for already-known phases); add the subject constant
-- [ ] 5.5 Add an announcement consumer in `internal/adapter/event/` that resolves the phase's covered events → performers → followers (hype filter) and pushes via `webpush.Sender`; wire into DI + router
-- [ ] 5.6 Write use-case tests (idempotent re-run produces no duplicates; new phase announces once, re-discovery does not)
-- [ ] 5.7 Add `cronjob/sales-phase-discovery/cronjob.yaml` (daily) in cloud-provisioning
+- [x] 5.1 Implement `internal/usecase/sales_phase_uc.go` discovery use case (enumerate followed artists' upcoming series → searcher → upsert)
+- [x] 5.2 Create `cmd/job/sales-phase-discovery/main.go` entrypoint following the `concert-discovery` pattern
+- [x] 5.3 Wire into DI graph
+- [x] 5.4 On persisting a NEW phase, publish a `SALES_PHASE.discovered` event (skip re-announcement for already-known phases; gated on the upsert insert/update outcome); add the subject constant
+- [x] 5.5 Add an announcement consumer in `internal/adapter/event/` that resolves the phase's covered events → performers → followers (hype filter) and pushes via `webpush.Sender`; wire into DI + router
+- [x] 5.6 Write use-case tests (idempotent re-run produces no duplicates; new phase announces once, re-discovery does not)
+- [x] 5.7 Add `cronjob/sales-phase-discovery/cronjob.yaml` (daily) in cloud-provisioning
 
 ## 6. Multi-Stage Reminders (backend + cloud-provisioning)
 
-- [ ] 6.1 Implement `internal/usecase/sales_reminder_uc.go`: scan due phases, compute stages (open / 24h-before / 1h-before / result-day at 09:00 local; NOT payment-deadline), skip milestones already past at first sight, resolve each phase's covered `event_ids`→performers→followers reusing the hype filter from `NotifyNewConcerts`
-- [ ] 6.1a Apply quiet hours (22:00–08:00 in `users.time_zone`, fallback `Asia/Tokyo`): non-deadline stages defer to 08:00; deadline stages defer to 08:00 only if before `apply_end_time`, else bring forward to prior 22:00 (never wake, never past deadline)
-- [ ] 6.1b Build notification content per recipient (reuse `NotificationPayload`): times in the recipient's timezone, copy by `preferred_language` (default en), generic ticket label when channel=UNSPECIFIED, `url`→phase.url else concert detail, `tag`=`(sales_phase_id, stage)`
-- [ ] 6.2 Publish a `SALES_PHASE.reminder.due` event; add the subject constant and a new consumer in `internal/adapter/event/`
-- [ ] 6.3 Reminder consumer sends via existing `webpush.Sender` + `PushSubscriptionRepository.ListByUserIDs`; reuse gone-subscription cleanup
-- [ ] 6.4 Enforce once-only delivery via the `sales_phase_reminders` sent-log
-- [ ] 6.5 Create `cmd/job/sales-reminders/main.go` entrypoint (scan + publish)
-- [ ] 6.6 Wire into DI graph; register the consumer handler
-- [ ] 6.7 Write tests: correct stage selection, null/past milestone → no reminder, quiet-hours shift (defer vs. bring-forward, never past deadline), per-recipient TZ/language content, idempotent sent-log (no double send)
-- [ ] 6.8 Add `cronjob/sales-reminders/cronjob.yaml` (~15-minute schedule) in cloud-provisioning
-- [ ] 6.9 Confirm Vertex AI / DB access IAM for the two new jobs
+- [x] 6.1 Implement `internal/usecase/sales_reminder_uc.go`: scan due phases, compute stages (open / 24h-before / 1h-before / result-day at 09:00 local; NOT payment-deadline), skip milestones already past at first sight, resolve each phase's covered `event_ids`→performers→followers reusing the hype filter (`ShouldNotify`) from `NotifyNewConcerts`
+- [x] 6.1a Apply quiet hours (22:00–08:00 in `users.time_zone`, fallback `Asia/Tokyo`): non-deadline stages defer to 08:00; deadline stages defer to 08:00 only if before `apply_end_time`, else bring forward to prior 22:00 (never wake, never past deadline)
+- [x] 6.1b Build notification content per recipient (reuse `NotificationPayload`): times in the recipient's timezone, copy by `preferred_language` (default en), generic ticket label when channel=UNSPECIFIED, `url`→phase.url else concert detail, `tag`=`(sales_phase_id, stage)`
+- [x] 6.2 Publish a `SALES_PHASE.reminder.due` event; add the subject constant and a new consumer in `internal/adapter/event/`
+- [x] 6.3 Reminder consumer sends via existing `webpush.Sender` + `PushSubscriptionRepository.ListByUserIDs`; reuse gone-subscription cleanup
+- [x] 6.4 Enforce once-only delivery via the `sales_phase_reminders` sent-log
+- [x] 6.5 Create `cmd/job/sales-reminders/main.go` entrypoint (scan + publish)
+- [x] 6.6 Wire into DI graph; register the consumer handler
+- [x] 6.7 Write tests: correct stage selection, null/past milestone → no reminder, quiet-hours shift (defer vs. bring-forward, never past deadline), per-recipient TZ/language content, idempotent sent-log (no double send)
+- [x] 6.8 Add `cronjob/sales-reminders/cronjob.yaml` (~15-minute schedule) in cloud-provisioning
+- [x] 6.9 Confirm Vertex AI / DB access IAM for the two new jobs — no new IAM required; both reuse KSA `backend-app`→GSA which already holds `roles/aiplatform.user` + `roles/cloudsql.instanceUser`
 
 ## 7. Disable Email Import Entry (frontend)
 
-- [ ] 7.1 Remove the `share_target` entry from `manifest.webmanifest`
-- [ ] 7.2 Disable the Service Worker share-target POST interception handler
-- [ ] 7.3 Make the `/import/ticket-email` route unavailable: remove its navigation entry and present an unavailable state on direct access (retain components + RPC client code)
-- [ ] 7.4 Run `make check` (frontend)
+- [x] 7.1 Remove the `share_target` entry from `manifest.webmanifest`
+- [x] 7.2 Disable the Service Worker share-target POST interception handler
+- [x] 7.3 Make the `/import/ticket-email` route unavailable: remove its navigation entry and present an unavailable state on direct access (retain components + RPC client code)
+- [x] 7.4 Run `make check` (frontend) — passes; committed and pushed (PR #417)
 
 ## 8. Integration & Release
 
-- [ ] 8.1 Backend: `go get` the released schema version, `go mod tidy`, swap placeholder types for generated `SalesPhase` types, run `make check`
-- [ ] 8.2 Local verification: run `cmd/job/sales-phase-discovery` against a known series → SalesPhase persisted and visible on concert detail
-- [ ] 8.3 Local verification: run `cmd/job/sales-reminders` against a near-deadline phase → exactly one push per stage (sent-log idempotency)
-- [ ] 8.4 Open backend, frontend, and cloud-provisioning PRs only after package upgrade + type swap pass locally
+- [ ] 8.1 Backend: `go get` the released schema version, `go mod tidy`, swap placeholder types for generated `SalesPhase` types, run `make check` — BLOCKED on BSR gen (needs spec PR merge + Release first); internal types carry `TODO: swap to generated type after BSR gen` markers
+- [ ] 8.2 Local verification: run `cmd/job/sales-phase-discovery` against a known series → SalesPhase persisted and visible on concert detail — BLOCKED on docker + prereq 0.1
+- [ ] 8.3 Local verification: run `cmd/job/sales-reminders` against a near-deadline phase → exactly one push per stage (sent-log idempotency) — BLOCKED on docker
+- [ ] 8.4 Open backend, frontend, and cloud-provisioning PRs only after package upgrade + type swap pass locally — frontend PR #417 opened (independent, no type dependency); backend + cloud-provisioning PRs pending BSR gen + type swap
 - [ ] 8.5 After merges, verify ArgoCD rollout and the new CronJobs are scheduled

--- a/openspec/changes/add-sales-phase-timeline/tasks.md
+++ b/openspec/changes/add-sales-phase-timeline/tasks.md
@@ -5,12 +5,12 @@
 
 ## 1. Proto Definitions (specification)
 
-- [ ] 1.1 Define `SalesPhaseId` wrapper message (UUID) in `entity/v1/sales_phase.proto`
-- [ ] 1.2 Define `SalesMethod` enum (`UNSPECIFIED`, `LOTTERY`, `FIRST_COME`) in `entity/v1/sales_phase.proto`
-- [ ] 1.3 Define `SalesChannel` enum (`UNSPECIFIED`, `FAN_CLUB`, `OFFICIAL`, `PLAYGUIDE`, `CREDIT_CARD`, `MOBILE_CARRIER`, `GENERAL`)
-- [ ] 1.4 Define `SalesPhase` message: `id`, `series_id` (required), `repeated EventId event_ids` (covered events), `method`, `channel`, `provider_name`, `sequence`, nullable `apply_start_time`/`apply_end_time`/`lottery_result_time`/`payment_deadline_time`, nullable `url` (reuse `Url` VO); use `_time` naming, no `_at`
-- [ ] 1.5 (Optional) Add a reference RPC / compose `repeated SalesPhase` on the concert-detail response if surfacing on concert detail this phase
-- [ ] 1.6 Run `buf lint` and `buf format -w`; verify no breaking changes (additive only; `ticket_email.proto` untouched)
+- [x] 1.1 Define `SalesPhaseId` wrapper message (UUID) in `entity/v1/sales_phase.proto`
+- [x] 1.2 Define `SalesMethod` enum (`UNSPECIFIED`, `LOTTERY`, `FIRST_COME`) in `entity/v1/sales_phase.proto`
+- [x] 1.3 Define `SalesChannel` enum (`UNSPECIFIED`, `FAN_CLUB`, `OFFICIAL`, `PLAYGUIDE`, `CREDIT_CARD`, `MOBILE_CARRIER`, `GENERAL`)
+- [x] 1.4 Define `SalesPhase` message: `id`, `series_id` (required), `repeated EventId event_ids` (covered events), `method`, `channel`, `provider_name`, `sequence`, nullable `apply_start_time`/`apply_end_time`/`lottery_result_time`/`payment_deadline_time`, nullable `url` (reuse `Url` VO); use `_time` naming, no `_at`
+- [ ] 1.5 (Optional) Add a reference RPC / compose `repeated SalesPhase` on the concert-detail response if surfacing on concert detail this phase — deferred (design Open Question: surfacing on concert detail is not decided for this phase)
+- [x] 1.6 Run `buf lint` and `buf format -w`; verify no breaking changes (additive only; `ticket_email.proto` untouched)
 - [ ] 1.7 Open specification PR; after review + CI, merge and publish a GitHub Release to trigger BSR gen (CI-only; do not run `buf push`/`buf generate` locally)
 
 ## 2. Database Migration (backend)

--- a/proto/liverty_music/entity/v1/sales_phase.proto
+++ b/proto/liverty_music/entity/v1/sales_phase.proto
@@ -1,0 +1,156 @@
+syntax = "proto3";
+
+// Package liverty_music.entity.v1 defines core business entities for the Liverty Music platform.
+package liverty_music.entity.v1;
+
+import "buf/validate/validate.proto";
+import "google/api/field_behavior.proto";
+import "google/protobuf/timestamp.proto";
+import "liverty_music/entity/v1/entity.proto";
+import "liverty_music/entity/v1/event.proto";
+import "liverty_music/entity/v1/series.proto";
+
+option go_package = "github.com/liverty-music/specification/gen/go/liverty_music/entity/v1;entityv1";
+
+// SalesPhaseId is a globally unique identifier for a single ticket-sales phase.
+// Each phase is a distinct selling opportunity (e.g. a fan-club presale or a
+// general lottery round) within a series, and this surrogate id is the phase's
+// only hard identity — the handle that the reminder sent-log references.
+message SalesPhaseId {
+  // A UUID string mapping to the sales phase's unique identity.
+  string value = 1 [(buf.validate.field).string.uuid = true];
+}
+
+// SalesMethod classifies how tickets are allocated within a sales phase. It is
+// orthogonal to SalesChannel (who/where sells them) and to the round ordinal
+// (SalesPhase.sequence), so reclassifying the method never collapses two phases
+// into one. New values may be appended; existing values must not be renumbered.
+enum SalesMethod {
+  // Default value; permitted to mean "not yet determined" because the method is
+  // often unknown when a phase is first discovered. Unlike most enums in this
+  // package, the zero value is a valid persisted state, not a rejected boundary.
+  SALES_METHOD_UNSPECIFIED = 0;
+  // Tickets are allocated by lottery (抽選販売): applicants enter a draw and only
+  // winners proceed to payment. The dominant method in the Japanese live market.
+  SALES_METHOD_LOTTERY = 1;
+  // Tickets are sold first-come, first-served (先着販売) until they sell out.
+  SALES_METHOD_FIRST_COME = 2;
+}
+
+// SalesChannel classifies who sells the tickets and through which gate a fan
+// must pass to apply. It is orthogonal to SalesMethod and SalesPhase.sequence:
+// the channel captures the slowly-changing "who/where" eligibility, while the
+// round ordering lives in `sequence`. New values may be appended; existing
+// values must not be renumbered.
+enum SalesChannel {
+  // Default value; permitted to mean "not yet determined" because the channel is
+  // often unknown when a phase is first discovered.
+  SALES_CHANNEL_UNSPECIFIED = 0;
+  // Sold through the artist's fan club (ファンクラブ先行), usually requiring a paid
+  // membership to apply. Typically the earliest presale.
+  SALES_CHANNEL_FAN_CLUB = 1;
+  // Sold through an official-but-non-fan-club gate such as the artist or label's
+  // own site or an official app (オフィシャル先行).
+  SALES_CHANNEL_OFFICIAL = 2;
+  // Sold through a third-party play guide platform (プレイガイド) such as e+,
+  // ぴあ, or ローチケ; the concrete provider is named in `provider_name`.
+  SALES_CHANNEL_PLAYGUIDE = 3;
+  // Sold through a credit-card company presale (クレジットカード会員先行).
+  SALES_CHANNEL_CREDIT_CARD = 4;
+  // Sold through a mobile carrier presale (キャリア先行) such as a docomo/au/
+  // SoftBank membership gate.
+  SALES_CHANNEL_MOBILE_CARRIER = 5;
+  // Sold through the general on-sale (一般販売) open to everyone without a
+  // membership gate. Typically the latest phase.
+  SALES_CHANNEL_GENERAL = 6;
+}
+
+// SalesPhase models one ticket-sales opportunity for a series (tour). A single
+// tour can announce several phases — distinct rounds (fan-club presale, general
+// on-sale) and distinct legs (first-half dates vs. second-half dates) — so each
+// phase belongs to one Series but covers only the subset of that series' events
+// it actually sells, expressed by `event_ids`.
+//
+// The row's existence signals "this phase is happening"; a null timeline field
+// unambiguously means "that date is not yet announced", so no separate
+// to-be-determined flag is needed. `apply_start_time` and at least one covered
+// event are mandatory because a phase with no known start cannot anchor a
+// reminder and a phase with no resolved event has no audience.
+message SalesPhase {
+  // The unique identifier for this sales phase. Server-generated surrogate id;
+  // it is the phase's only hard identity (re-discovery converges to it via
+  // best-effort covered-event overlap, not via any business-field equality).
+  SalesPhaseId id = 1 [
+    (google.api.field_behavior) = OUTPUT_ONLY,
+    (buf.validate.field).required = true
+  ];
+
+  // The series (tour) this phase belongs to. The only required entity reference;
+  // it scopes the phase and bounds the candidate events its coverage resolves to.
+  SeriesId series_id = 2 [
+    (google.api.field_behavior) = REQUIRED,
+    (buf.validate.field).required = true
+  ];
+
+  // The events this phase sells, all belonging to `series_id`. At least one is
+  // required: coverage is how a per-leg phase notifies only the followers of its
+  // own dates. Immutable event ids are also the primary signal that converges
+  // re-discovery of the same real phase onto one row.
+  repeated EventId event_ids = 3 [
+    (google.api.field_behavior) = REQUIRED,
+    (buf.validate.field).repeated.min_items = 1
+  ];
+
+  // How tickets are allocated. Optional: UNSPECIFIED means "not yet determined"
+  // and is never used as a hard match key, so a later reclassification updates
+  // the existing row in place rather than forking a duplicate.
+  SalesMethod method = 4 [
+    (google.api.field_behavior) = OPTIONAL,
+    (buf.validate.field).enum.defined_only = true
+  ];
+
+  // Who sells the tickets / which gate applies. Optional with the same
+  // "not yet determined" semantics and non-key status as `method`.
+  SalesChannel channel = 5 [
+    (google.api.field_behavior) = OPTIONAL,
+    (buf.validate.field).enum.defined_only = true
+  ];
+
+  // The concrete provider name when relevant, primarily for PLAYGUIDE channels
+  // (e.g. "イープラス", "チケットぴあ", "ローソンチケット"). Free text shown in copy;
+  // optional because many phases (e.g. fan-club) have no separate provider.
+  optional string provider_name = 6 [(buf.validate.field).string.max_len = 255];
+
+  // The round ordinal within the series: 0 = earliest, 1 = first round, 2 =
+  // second, and so on. Ordinals (not enum values) carry round/leg ordering so
+  // additional rounds or a first/second-half split need no schema change.
+  // Like channel, it disambiguates clearly-different sales but is not a hard
+  // match key.
+  int32 sequence = 7;
+
+  // When applications open (受付開始). Required — a phase is never persisted
+  // without it, because an unknown start cannot anchor the "application open"
+  // reminder and signals the phase is not yet actionable for a fan.
+  google.protobuf.Timestamp apply_start_time = 8 [
+    (google.api.field_behavior) = REQUIRED,
+    (buf.validate.field).required = true
+  ];
+
+  // When applications close (受付終了). Nullable: null means "not yet announced".
+  // Anchors the 24-hour-before and 1-hour-before reminder stages when present.
+  google.protobuf.Timestamp apply_end_time = 9 [(google.api.field_behavior) = OPTIONAL];
+
+  // When lottery results are announced (当落発表). Nullable: null means "not yet
+  // announced" or "not a lottery phase". Anchors the result-day reminder stage.
+  google.protobuf.Timestamp lottery_result_time = 10 [(google.api.field_behavior) = OPTIONAL];
+
+  // The payment deadline for winners (入金期限). Nullable; captured for
+  // completeness but does NOT drive a reminder stage yet, because only lottery
+  // winners owe payment and win/loss gating is out of scope for now.
+  google.protobuf.Timestamp payment_deadline_time = 11 [(google.api.field_behavior) = OPTIONAL];
+
+  // The application URL fans follow to apply for this phase. Optional: a nil
+  // wrapper skips inner-Url validation (matching Series.source_url semantics),
+  // and notifications deep-link here when present, else to the concert detail.
+  Url url = 12 [(google.api.field_behavior) = OPTIONAL];
+}


### PR DESCRIPTION
## What

Adds `entity/v1/sales_phase.proto` defining the `SalesPhase` entity and its supporting types:

- **`SalesPhaseId`** — UUID wrapper (the phase's only hard identity; the handle the reminder sent-log references).
- **`SalesMethod`** — `UNSPECIFIED` / `LOTTERY` / `FIRST_COME`.
- **`SalesChannel`** — `UNSPECIFIED` / `FAN_CLUB` / `OFFICIAL` / `PLAYGUIDE` / `CREDIT_CARD` / `MOBILE_CARRIER` / `GENERAL`.
- **`SalesPhase`** — belongs to a `Series` (tour) and covers a subset of its events via `repeated EventId event_ids`; orthogonal `method` / `channel` / `sequence` / `provider_name`; nullable timeline timestamps (`apply_start_time` required, `apply_end_time` / `lottery_result_time` / `payment_deadline_time` nullable); optional `url` (reuses the `Url` VO).

## Why

The platform has no objective record of the **ticket sales timeline**, which is how fans "miss" a show even after knowing it exists. This proto is the first-class data model that the discovery searcher writes and the reminder scan reads (see the OpenSpec change `add-sales-phase-timeline`).

Design notes encoded in the schema:
- Timestamps are nullable message fields → a null unambiguously means "not yet announced"; no separate TBD flag needed.
- `apply_start_time` is required → a phase without a known start cannot anchor a reminder.
- `method` / `channel` are optional enums where `UNSPECIFIED` = "not yet determined" and are **never** hard identity keys → a later reclassification converges onto the same row rather than forking a duplicate.

## Notes

- **Additive only.** `buf lint`, `buf format -w`, and `buf breaking` all pass; `ticket_email.proto` is untouched.
- The optional concert-detail surfacing (reference RPC) is deferred — see the design's Open Question.
- This is the **specification half** of a cross-repo change. On merge + Release, BSR gen publishes the generated types for the backend/frontend PRs.

Refs: #571