### PR TITLE
docs(openspec): propose single-source guest locale (unify-guest-locale-single-source)

### DIFF
--- a/openspec/changes/unify-guest-locale-single-source/.openspec.yaml
+++ b/openspec/changes/unify-guest-locale-single-source/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-04

--- a/openspec/changes/unify-guest-locale-single-source/design.md
+++ b/openspec/changes/unify-guest-locale-single-source/design.md
@@ -1,0 +1,56 @@
+## Context
+
+The anonymous (guest) UI locale is currently persisted in **two** decoupled `localStorage` keys:
+
+- `language` — the `i18next-browser-languagedetector` cache (`lookupLocalStorage: 'language'`, `caches: ['localStorage']`). This drives the **actually rendered** locale via the i18next detection chain at boot.
+- `guest.language` — owned exclusively by `UserStore`. `UserStore.currentLanguage` (guest branch) returns `guestLanguage ?? i18nLocale`, and the Settings/Welcome selector binds its highlight to that value.
+
+There is no boot-time reconciliation for guests: `UserHydrationTask.runUserHydration()` returns early on `!auth.isAuthenticated`, and no other code path applies `guest.language` to i18n. When the two keys drift (e.g. the authed hydration cleanup removes `language`, a later guest reload re-detects `navigator='en-US'` → `language='en'`, while an earlier explicit choice left `guest.language='ja'`), the selector highlights 日本語 while the UI renders English.
+
+`guest.language` was introduced by the `introduce-entity-store-layer` change to fix a selector-reactivity bug (the highlight was previously driven by an unobservable render-time `i18n.getLocale()` read). But that same change also added `UserStore.i18nLocale`, an `@observable` mirror of the active locale kept in sync via the `Signals.I18N_EA_CHANNEL` event. The reactive mirror alone is sufficient for a reactive selector, which makes `guest.language` redundant — and the redundancy is the drift's root cause.
+
+Verified during exploration: `guest.language` has exactly one reader (`UserStore`); no E2E or other module seeds/reads it; and the `clearGuest` "don't reset the visible language on login" decoupling exists solely to undo a side-effect that `clearGuest` itself introduces by clearing `guestLanguage`. Language participates in no signup/login heuristic (only `guestHome` does).
+
+## Goals / Non-Goals
+
+**Goals:**
+- The guest selector highlight can never disagree with the rendered UI (eliminate the bug as a class, not an instance).
+- Reduce code: one source of truth for the anonymous locale.
+- Bring the implementation back into alignment with the existing `frontend-i18n` spec (single `language` key model).
+- Migrate existing installs off `guest.language` without losing a guest's explicit choice.
+
+**Non-Goals:**
+- No change to the authenticated locale path (DB-sourced `preferred_language` via `user-profile-hydration` / `user-account-sync`).
+- No change to the i18next detection-chain configuration in `main.ts`.
+- No proto / backend / BSR work — frontend only.
+
+## Decisions
+
+### Decision 1: Remove `guest.language` entirely; derive the guest locale from `i18nLocale`
+
+`UserStore.currentLanguage` (guest branch) returns `this.i18nLocale` instead of `guestLanguage ?? i18nLocale`. `i18nLocale` is already an `@observable` seeded from `i18n.getLocale()` and updated on every `setLocale` via the i18n EA channel, so it is both reactive AND always equal to the active locale. The selector highlight therefore tracks the rendered locale by construction.
+
+Removed surface: `KEY_LANGUAGE` / `saveLanguage` / `loadLanguage` (`guest-storage.ts`); `guestLanguage` `@observable`, `setGuestLanguage`, `guestLanguageChanged` (`UserStore`).
+
+**Alternative considered — keep two keys, reconcile on guest boot** (extend `runUserHydration`'s `!auth.isAuthenticated` branch to apply `guest.language` to i18n). Rejected: it entrenches a redundant key, requires a new MODIFIED spec requirement documenting the two-key model, and leaves a structure that can still drift between the apply and the next navigator re-detection. Single-source removes the failure mode rather than patching it.
+
+### Decision 2: `changeLocale` anonymous path writes `language` explicitly
+
+The anonymous path becomes `i18n.setLocale(lang)` followed by an explicit `localStorage.setItem('language', lang)`, matching the `frontend-i18n` "Shared Language Switching Utility → Anonymous caller path" requirement verbatim. We no longer rely on the detector's implicit `languageChanged` cache side-effect to persist the choice — the persistence is explicit and ordering-independent.
+
+### Decision 3: `clearGuest` no longer touches the locale
+
+`clearGuest` clears guest home + help-seen only. With `guest.language` gone there is nothing locale-related to clear, and the single `language` key persists across the Login reset — the cancelled-login behavior is preserved trivially, with no decoupling to reason about.
+
+### Decision 4: One-time migration in `migrateStorageKeys()`, explicit choice wins
+
+`migrateStorageKeys()` (already the home for idempotent legacy key migrations) gains a step: if `guest.language` exists, copy it into `language` when the two differ (the explicit guest choice outranks the detector cache), then remove `guest.language`. Idempotent and safe on every startup. This converges all existing installs and, for the user who reported the bug, honors their Japanese choice on the next boot before the redundant key is dropped.
+
+**Alternative considered — let `language` win / just delete `guest.language`.** Rejected: `guest.language` was only ever written on an explicit user selection, whereas `language` may be an auto-detected navigator value, so deleting `guest.language` outright could silently discard a real preference (exactly the reporter's case).
+
+## Risks / Trade-offs
+
+- **[A guest who relied on the drift loses the stale `ja` highlight]** → By design: after migration the explicit `ja` is promoted into `language`, so the UI renders Japanese AND the selector highlights Japanese — the consistent, intended end-state. No preference is lost.
+- **[Existing tests assert the old two-key behavior]** (`change-locale.spec.ts` asserts `setGuestLanguage`; UserStore tests reference `guestLanguage`) → Update them to the single-source assertions (anonymous path asserts `i18n.setLocale` + `localStorage.setItem('language', ...)`; `currentLanguage` guest branch asserts it tracks `i18nLocale`). The spec scenarios in this change are the test contract.
+- **[Migration runs on every startup]** → It is a cheap, idempotent `getItem`/conditional-`setItem`/`removeItem` triple; after the first run `guest.language` is absent and it short-circuits.
+- **[Rollback]** → Pure frontend change with no persisted-schema or backend coupling; reverting the commit restores the prior behavior. The migration is one-directional (it deletes `guest.language`), but since that key is being abandoned, a rollback simply returns to reading a now-absent key — equivalent to a fresh guest, which the code already handles.

--- a/openspec/changes/unify-guest-locale-single-source/design.md
+++ b/openspec/changes/unify-guest-locale-single-source/design.md
@@ -44,7 +44,9 @@ The anonymous path becomes `i18n.setLocale(lang)` followed by an explicit `local
 
 ### Decision 4: One-time migration in `migrateStorageKeys()`, explicit choice wins
 
-`migrateStorageKeys()` (already the home for idempotent legacy key migrations) gains a step: if `guest.language` exists, copy it into `language` when the two differ (the explicit guest choice outranks the detector cache), then remove `guest.language`. Idempotent and safe on every startup. This converges all existing installs and, for the user who reported the bug, honors their Japanese choice on the next boot before the redundant key is dropped.
+`migrateStorageKeys()` (already the home for idempotent legacy key migrations) gains a step: if `guest.language` exists, copy it into `language` when the two differ (the explicit guest choice outranks the detector cache), then remove `guest.language`. Idempotent and safe on every startup. `migrateStorageKeys()` is already invoked at `main.ts` startup (currently line ~129) BEFORE `new Aurelia()` and the i18next plugin registration, so i18next detection reads the promoted `language` value in the SAME session — the affected guest renders Japanese immediately, not only on the next reload. This converges all existing installs and honors the reporter's explicit Japanese choice on their next app load, after which the redundant key is gone.
+
+This same-session guarantee depends on the migration running before i18next detection. That ordering is a prerequisite the migration relies on, not a change to the detection-chain configuration (the latter is a Non-Goal); the implementation tasks lock it in explicitly.
 
 **Alternative considered — let `language` win / just delete `guest.language`.** Rejected: `guest.language` was only ever written on an explicit user selection, whereas `language` may be an auto-detected navigator value, so deleting `guest.language` outright could silently discard a real preference (exactly the reporter's case).
 

--- a/openspec/changes/unify-guest-locale-single-source/proposal.md
+++ b/openspec/changes/unify-guest-locale-single-source/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+A guest (unauthenticated) user sees the Settings/Welcome language selector highlight **日本語** while the entire UI renders in **English**. The anonymous locale is stored in two decoupled `localStorage` keys — `language` (the i18next detector cache that drives the rendered locale) and `guest.language` (UserStore-owned, drives only the selector highlight) — and nothing reconciles them on a guest boot. When the two keys drift, the selector and the rendered UI disagree. The second key is redundant: UserStore already exposes a reactive mirror of the active locale (`i18nLocale`), so a single source of truth both fixes the bug and removes code.
+
+## What Changes
+
+- **BREAKING (storage)**: Remove the `guest.language` localStorage key and all of its plumbing — `KEY_LANGUAGE`, `saveLanguage`, `loadLanguage` in `guest-storage.ts`; the `guestLanguage` `@observable`, `setGuestLanguage`, and `guestLanguageChanged` in `UserStore`.
+- `UserStore.currentLanguage` (guest branch) returns the existing reactive `i18nLocale` mirror, which always equals the active i18n locale — so the selector highlight can never drift from the rendered UI.
+- `changeLocale` anonymous path persists the new locale by calling `i18n.setLocale(lang)` **and** an explicit `localStorage.setItem('language', lang)`, matching the existing `frontend-i18n` "Anonymous caller path" requirement verbatim instead of relying on the detector's implicit cache side-effect.
+- `UserStore.clearGuest` clears only the guest home + help-seen flags; it never touches the locale. The single `language` key persists naturally, preserving the cancelled-login behavior with no decoupling needed.
+- One-time migration in `migrateStorageKeys()`: if a legacy `guest.language` value exists, treat it as the user's explicit choice (higher intent than the detector cache), copy it into `language` when they differ, then delete `guest.language`. This removes the redundant key for all existing installs and honors the affected guest's Japanese choice on their next boot.
+- Update `change-locale.spec.ts` and the `UserStore` tests to the single-source assertions.
+
+## Capabilities
+
+### New Capabilities
+<!-- none -->
+
+### Modified Capabilities
+- `frontend-i18n`: The anonymous locale is a single source of truth (`localStorage['language']`); add a requirement that the language selector highlight reflects the active i18n locale (so it can never disagree with the rendered UI), and a requirement for the one-time `guest.language` → `language` migration precedence (explicit guest choice wins, then the legacy key is removed).
+
+## Impact
+
+- **Frontend only** — no proto, no backend, no BSR generation, no release coordination.
+- Affected code: `src/adapter/storage/guest-storage.ts`, `src/constants/storage-keys.ts` (`migrateStorageKeys`), `src/services/user-store.ts`, `src/util/change-locale.ts`, and the tests `src/util/change-locale.spec.ts`, `src/services/user-store.spec.ts` (and any UserStore guest-language tests).
+- No change to the authenticated locale path (DB-sourced `preferred_language` via `user-profile-hydration` / `user-account-sync`) or to the i18next detection chain config in `main.ts`.
+- Unwinds the two-key design introduced by the `introduce-entity-store-layer` change; the reactivity goal of that change is retained via the `i18nLocale` observable.

--- a/openspec/changes/unify-guest-locale-single-source/specs/frontend-i18n/spec.md
+++ b/openspec/changes/unify-guest-locale-single-source/specs/frontend-i18n/spec.md
@@ -11,7 +11,6 @@ This requirement makes the selector's data source explicit: prior to this change
 - **WHEN** an anonymous user opens the Settings or Welcome language selector
 - **AND** the active i18n locale is `en`
 - **THEN** the selector SHALL highlight the `en` option
-- **AND** there SHALL be no persisted state under which the selector highlights a locale different from the one the UI is rendering
 
 #### Scenario: No secondary localStorage key backs the anonymous locale
 
@@ -28,13 +27,22 @@ This requirement makes the selector's data source explicit: prior to this change
 
 ### Requirement: One-Time Migration of the Legacy `guest.language` Key
 
-The startup storage-migration routine SHALL reconcile and remove the legacy `guest.language` key so existing installs converge to the single-source model. Because `guest.language` was only ever written on an explicit user language choice, its value represents higher intent than the detector cache and SHALL take precedence when the two differ. The migration SHALL be idempotent and safe to run on every startup. The migration SHALL run before i18next detection reads `localStorage['language']`, so a promoted value takes effect in the same session (not only on the next reload).
+The startup storage-migration routine SHALL reconcile and remove the legacy `guest.language` key so existing installs converge to the single-source model. Because `guest.language` was only ever written on an explicit user language choice, its value represents higher intent than the detector cache and SHALL take precedence when the two differ. An absent `localStorage['language']` SHALL be treated as differing from a present `guest.language`, so the explicit choice is promoted even when the detector cache was previously cleared (e.g. by the authenticated-session cleanup). The migration SHALL be idempotent and safe to run on every startup. The migration SHALL run before i18next detection reads `localStorage['language']`, so a promoted value takes effect in the same session (not only on the next reload).
 
 #### Scenario: Legacy explicit choice differs from the detector cache
 
 - **WHEN** the application starts
 - **AND** `localStorage['guest.language']` is `ja`
 - **AND** `localStorage['language']` is `en`
+- **THEN** the system SHALL write `ja` to `localStorage['language']`
+- **AND** the system SHALL remove `localStorage['guest.language']`
+- **AND** the active locale on this session SHALL render in `ja`
+
+#### Scenario: Legacy explicit choice present but detector cache absent
+
+- **WHEN** the application starts
+- **AND** `localStorage['guest.language']` is `ja`
+- **AND** `localStorage['language']` is absent (e.g. cleared by a prior authenticated session)
 - **THEN** the system SHALL write `ja` to `localStorage['language']`
 - **AND** the system SHALL remove `localStorage['guest.language']`
 - **AND** the active locale on this session SHALL render in `ja`

--- a/openspec/changes/unify-guest-locale-single-source/specs/frontend-i18n/spec.md
+++ b/openspec/changes/unify-guest-locale-single-source/specs/frontend-i18n/spec.md
@@ -1,0 +1,55 @@
+## ADDED Requirements
+
+### Requirement: Anonymous Locale is a Single Source of Truth
+
+For an anonymous (unauthenticated) session, the active i18n locale SHALL be derived from exactly one persisted source — `localStorage['language']` (the i18next detector cache). No secondary `localStorage` key SHALL shadow, mirror, or override the anonymous locale. Any reactive projection of the anonymous locale (e.g. the value a language selector binds to for its highlight) SHALL be derived from the active i18n locale, NOT from a separate persisted key, so the selector highlight can never disagree with the rendered UI.
+
+This requirement makes the selector's data source explicit: prior to this change the selector highlight was driven by a separate `guest.language` key that could drift from the detector's `language` key, producing a UI that rendered in one locale while the selector highlighted another.
+
+#### Scenario: Selector highlight matches the rendered locale for an anonymous user
+
+- **WHEN** an anonymous user opens the Settings or Welcome language selector
+- **AND** the active i18n locale is `en`
+- **THEN** the selector SHALL highlight the `en` option
+- **AND** there SHALL be no persisted state under which the selector highlights a locale different from the one the UI is rendering
+
+#### Scenario: No secondary localStorage key backs the anonymous locale
+
+- **WHEN** an anonymous user changes or has previously chosen a language
+- **THEN** the only `localStorage` key that persists the anonymous locale SHALL be `language`
+- **AND** the system SHALL NOT write a separate `guest.language` (or equivalent shadow) key
+
+#### Scenario: Resetting guest state does not change the rendered locale
+
+- **WHEN** anonymous guest state is reset (e.g. on tapping Login, before sign-in begins)
+- **THEN** the guest home and per-page help-seen flags SHALL be cleared
+- **AND** `localStorage['language']` SHALL be left intact
+- **AND** the rendered locale SHALL NOT change as a result of the reset
+
+### Requirement: One-Time Migration of the Legacy `guest.language` Key
+
+The startup storage-migration routine SHALL reconcile and remove the legacy `guest.language` key so existing installs converge to the single-source model. Because `guest.language` was only ever written on an explicit user language choice, its value represents higher intent than the detector cache and SHALL take precedence when the two differ. The migration SHALL be idempotent and safe to run on every startup.
+
+#### Scenario: Legacy explicit choice differs from the detector cache
+
+- **WHEN** the application starts
+- **AND** `localStorage['guest.language']` is `ja`
+- **AND** `localStorage['language']` is `en`
+- **THEN** the system SHALL write `ja` to `localStorage['language']`
+- **AND** the system SHALL remove `localStorage['guest.language']`
+- **AND** the active locale on this session SHALL render in `ja`
+
+#### Scenario: Legacy value matches the detector cache
+
+- **WHEN** the application starts
+- **AND** `localStorage['guest.language']` is `ja`
+- **AND** `localStorage['language']` is `ja`
+- **THEN** the system SHALL remove `localStorage['guest.language']`
+- **AND** `localStorage['language']` SHALL remain `ja`
+
+#### Scenario: No legacy key present
+
+- **WHEN** the application starts
+- **AND** `localStorage['guest.language']` is absent
+- **THEN** the migration SHALL be a no-op
+- **AND** `localStorage['language']` SHALL be left unchanged

--- a/openspec/changes/unify-guest-locale-single-source/specs/frontend-i18n/spec.md
+++ b/openspec/changes/unify-guest-locale-single-source/specs/frontend-i18n/spec.md
@@ -28,7 +28,7 @@ This requirement makes the selector's data source explicit: prior to this change
 
 ### Requirement: One-Time Migration of the Legacy `guest.language` Key
 
-The startup storage-migration routine SHALL reconcile and remove the legacy `guest.language` key so existing installs converge to the single-source model. Because `guest.language` was only ever written on an explicit user language choice, its value represents higher intent than the detector cache and SHALL take precedence when the two differ. The migration SHALL be idempotent and safe to run on every startup.
+The startup storage-migration routine SHALL reconcile and remove the legacy `guest.language` key so existing installs converge to the single-source model. Because `guest.language` was only ever written on an explicit user language choice, its value represents higher intent than the detector cache and SHALL take precedence when the two differ. The migration SHALL be idempotent and safe to run on every startup. The migration SHALL run before i18next detection reads `localStorage['language']`, so a promoted value takes effect in the same session (not only on the next reload).
 
 #### Scenario: Legacy explicit choice differs from the detector cache
 

--- a/openspec/changes/unify-guest-locale-single-source/tasks.md
+++ b/openspec/changes/unify-guest-locale-single-source/tasks.md
@@ -15,7 +15,7 @@
 ## 4. One-time legacy-key migration
 
 - [ ] 4.1 In `migrateStorageKeys()` (`src/constants/storage-keys.ts`), add an idempotent step: if `localStorage['guest.language']` exists, copy it into `localStorage['language']` when the two differ (explicit guest choice wins), then remove `guest.language`. Document the precedence in a comment.
-- [ ] 4.2 Confirm `migrateStorageKeys()` is invoked at startup before i18next detection runs (check `main.ts` ordering) so the promoted `language` value is what the detector reads.
+- [ ] 4.2 Lock in that `migrateStorageKeys()` runs before i18next detection: confirm the existing `main.ts` ordering (migration call precedes `new Aurelia()` / `I18nConfiguration` registration / `au.start()`), and if it has regressed, move the call earlier so the promoted `language` value is what the detector reads in the same session. The same-session spec guarantee depends on this ordering.
 
 ## 5. Tests
 

--- a/openspec/changes/unify-guest-locale-single-source/tasks.md
+++ b/openspec/changes/unify-guest-locale-single-source/tasks.md
@@ -1,0 +1,37 @@
+## 1. Remove the `guest.language` storage surface
+
+- [ ] 1.1 Delete `KEY_LANGUAGE`, `saveLanguage`, and `loadLanguage` from `src/adapter/storage/guest-storage.ts` (including the decoupling-rationale comment block).
+- [ ] 1.2 Remove the `guestLanguage` `@observable`, `setGuestLanguage`, and `guestLanguageChanged` from `src/services/user-store.ts`, and drop the now-unused `loadLanguage`/`saveLanguage` imports.
+
+## 2. Single-source the guest locale in UserStore
+
+- [ ] 2.1 Change `UserStore.currentLanguage` (guest branch) to return `this.i18nLocale` instead of `guestLanguage ?? i18nLocale`; verify the authenticated branch is untouched.
+- [ ] 2.2 Update `clearGuest` to clear only guest home + help-seen flags; confirm it no longer references any locale state, and refresh its doc comment to drop the decoupling explanation.
+
+## 3. Explicit persistence in the shared locale utility
+
+- [ ] 3.1 Change the anonymous path of `changeLocale` in `src/util/change-locale.ts` to call `i18n.setLocale(lang)` then `localStorage.setItem('language', lang)` (remove the `userStore.setGuestLanguage` write); update the function doc comment to describe the single-key persistence.
+
+## 4. One-time legacy-key migration
+
+- [ ] 4.1 In `migrateStorageKeys()` (`src/constants/storage-keys.ts`), add an idempotent step: if `localStorage['guest.language']` exists, copy it into `localStorage['language']` when the two differ (explicit guest choice wins), then remove `guest.language`. Document the precedence in a comment.
+- [ ] 4.2 Confirm `migrateStorageKeys()` is invoked at startup before i18next detection runs (check `main.ts` ordering) so the promoted `language` value is what the detector reads.
+
+## 5. Tests
+
+- [ ] 5.1 Update `src/util/change-locale.spec.ts`: anonymous path asserts `i18n.setLocale` + `localStorage.setItem('language', lang)` and issues no RPC; remove `setGuestLanguage` assertions.
+- [ ] 5.2 Update `src/services/user-store.spec.ts` (and any UserStore guest-language tests): `currentLanguage` guest branch tracks `i18nLocale`; remove `guestLanguage`/`setGuestLanguage` cases.
+- [ ] 5.3 Add `migrateStorageKeys()` tests covering the three spec scenarios: guest.language differs from language (promote + remove), equals (remove only), absent (no-op).
+- [ ] 5.4 Run `make check` (lint + typecheck + unit tests) until green.
+
+## 6. Manual verification
+
+- [ ] 6.1 Reproduce the original bug locally: seed `localStorage` with `language=en` + `guest.language=ja`, load the app, confirm post-migration the UI renders Japanese AND the selector highlights 日本語, and `guest.language` is gone.
+- [ ] 6.2 Verify the anonymous happy path: switch language in Settings/Welcome, reload, confirm the choice persists with only the `language` key present and the selector matches the UI.
+- [ ] 6.3 Verify cancelled-login: as a guest, tap Login then cancel/return; confirm the rendered locale is unchanged.
+
+## 7. Ship
+
+- [ ] 7.1 Open the frontend PR (commit per Liverty-Music convention with `Refs: #<issue>`); drive CI green and merge once all checks pass.
+- [ ] 7.2 Confirm the merge deploys to the dev environment (ArgoCD sync / new pod) and smoke-check the guest locale behavior in dev.
+- [ ] 7.3 Cut the frontend GitHub Release (prod gate) and confirm the automated prod pin-bump → ArgoCD prod sync completes, then smoke-check in prod.

--- a/openspec/changes/unify-guest-locale-single-source/tasks.md
+++ b/openspec/changes/unify-guest-locale-single-source/tasks.md
@@ -21,7 +21,7 @@
 
 - [ ] 5.1 Update `src/util/change-locale.spec.ts`: anonymous path asserts `i18n.setLocale` + `localStorage.setItem('language', lang)` and issues no RPC; remove `setGuestLanguage` assertions.
 - [ ] 5.2 Update `src/services/user-store.spec.ts` (and any UserStore guest-language tests): `currentLanguage` guest branch tracks `i18nLocale`; remove `guestLanguage`/`setGuestLanguage` cases.
-- [ ] 5.3 Add `migrateStorageKeys()` tests covering the three spec scenarios: guest.language differs from language (promote + remove), equals (remove only), absent (no-op).
+- [ ] 5.3 Add `migrateStorageKeys()` tests covering the four spec scenarios: guest.language differs from language (promote + remove), guest.language present while language is absent (promote + remove), equals (remove only), and no guest.language (no-op).
 - [ ] 5.4 Run `make check` (lint + typecheck + unit tests) until green.
 
 ## 6. Manual verification


### PR DESCRIPTION
## 🔗 Related Issue

close: #581

## 📝 Summary of Changes

Adds the OpenSpec change `unify-guest-locale-single-source`, which proposes collapsing the anonymous (guest) UI locale to a **single source of truth** in the `frontend-i18n` capability. Documentation only — no proto or generated-code changes; the eventual implementation is **frontend only** (no proto / backend / BSR).

### The bug

A guest sees the Settings/Welcome language selector highlight **日本語** while the UI renders **English**. The anonymous locale is split across two decoupled `localStorage` keys — `language` (i18next detector cache; drives the rendered locale) and `guest.language` (UserStore-owned; drives only the selector highlight) — with **no boot-time reconciliation for guests** (`UserHydrationTask` returns early on `!auth.isAuthenticated`). When the keys drift, the selector and the UI disagree.

### Root cause & fix

`guest.language` is redundant: `UserStore` already owns `i18nLocale`, an `@observable` mirror of the active locale that is sufficient for a reactive selector. The proposal removes `guest.language` so the selector derives from the active locale and can never drift:

- Remove the `guest.language` key and its plumbing.
- `UserStore.currentLanguage` (guest branch) returns `i18nLocale`.
- `changeLocale` anonymous path persists explicitly via `i18n.setLocale(lang)` + `localStorage.setItem('language', lang)`.
- `clearGuest` no longer touches the locale (preserves cancelled-login behavior trivially).
- One-time `migrateStorageKeys()` step promotes a legacy `guest.language` value into `language` when they differ (explicit choice wins), then deletes it.

### Artifacts

- **`proposal.md`** — why the two-key design drifts; what collapses to a single source.
- **`design.md`** — four decisions with rejected alternatives + rollback notes.
- **`specs/frontend-i18n/spec.md`** — **ADDED** two requirements (single-source anonymous locale + selector reflects active locale; one-time migration precedence/removal), six scenarios.
- **`tasks.md`** — implementation breakdown through dev verification and prod release.

## ✅ Self-Checklist

- [x] I have linked the related issue.
- [x] I have updated the relevant documentation (`openspec validate` passes; 4/4 artifacts complete).
- [x] I have run `buf lint` and `buf format` locally and all checks have passed. (No proto changed — doc-only.)
- [x] My proto definitions follow the project's style guidelines and validation rules. (No proto changes.)
- [x] Breaking changes have been justified and documented if applicable. (None — doc-only proposal.)
