### PR TITLE
docs(openspec): propose enhance-dashboard-filter change

### DIFF
--- a/openspec/changes/enhance-dashboard-filter/.openspec.yaml
+++ b/openspec/changes/enhance-dashboard-filter/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-04

--- a/openspec/changes/enhance-dashboard-filter/design.md
+++ b/openspec/changes/enhance-dashboard-filter/design.md
@@ -1,0 +1,56 @@
+## Context
+
+The dashboard filter (`dashboard-artist-filter`) is implemented entirely in the frontend: `DashboardRoute` holds an `@observable filteredArtistIds` array and a `filteredDateGroups` getter that filters the loaded `DateGroup[]` by artist, syncing an `artists` URL query parameter via `history.replaceState`. The filter UI is the `artist-filter-bar` component, which opens a shared `bottom-sheet` and renders followed artists as checkbox chips (`checked.bind="pendingIds" model.bind="artist.id"`), committing the pending selection on confirm.
+
+Ticket-journey status is already available on the frontend: `TicketJourneyService.ListByUser` is fetched on dashboard load and each `Concert` carries an optional `journeyStatus` (`tracking | applied | unpaid | paid | lost`). It is rendered today as a colour badge on the concert card and as a status control in the concert-detail sheet. The semantic hues already live as shared `--journey-hue-*` design tokens, but the per-status icon glyphs and labels are duplicated/inlined per component, with no single source of truth.
+
+This change is frontend-only. No Protobuf, backend, or infrastructure work is required.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Make the artist facet useful for high-volume followers: per-artist concert count, count-descending sort, hide zero-concert artists.
+- Add a ticket-journey-status filter facet to the same bottom sheet, with OR-within / AND-across-facet semantics and `journey` URL synchronisation.
+- Make the filter (artist facet) usable by guests; gate the journey facet to authenticated users.
+- Establish one canonical journey-status presentation map (label + emoji icon + hue token) consumed by every status-rendering component.
+
+**Non-Goals:**
+- No deadline display, urgency sorting, or reminders — those belong to the sales-phase / next-action features. The journey facet is *pure filtering on status*.
+- No "no status set" pseudo-status as a selectable option (explicitly out of scope).
+- No backend/proto change; journey data delivery is unchanged.
+- No concert-series filter dimension (analysed and deferred; series is a grouping concern, not a filter).
+
+## Decisions
+
+### D1 — Journey filter: extend the existing getter, not a value-converter
+Add `@observable filteredStatuses: JourneyStatus[]` and fold the journey predicate into `filteredDateGroups` as a single `keep` predicate: `(noArtist || ids.has(c.artistId)) && (noStatus || (c.journeyStatus && statuses.has(c.journeyStatus)))`. The getter already read-tracks its observable sources, so the view updates correctly. A value-converter was rejected: the logic depends on two VM-level observable arrays and runs in exactly one place, so a converter only relocates the logic and forces both arrays to be passed as parameters. The `!!c.artistId` ghost-card guard is preserved in both empty- and active-filter cases.
+
+### D2 — Single URL writer to avoid double `replaceState`
+Two facets each syncing the URL on change would fire `replaceState` twice in one commit (the first write missing the other facet). Resolve by building the URL from *both* arrays in one place and driving it from a **single watcher** keyed on both arrays (`@watch` on a composite of `filteredArtistIds` + `filteredStatuses`), which is async-batched and collapses the double commit into one write. URL shape: `/dashboard?artists=<ids>&journey=<statuses>`; each param omitted when its set is empty. Both params are parsed back in `loading()`.
+
+### D3 — Counts computed over the *unfiltered* set, cached with `@computed`
+`countedArtists` is a `@computed('dateGroups','followedArtists')` getter on `DashboardRoute` that builds a `Map<artistId, count>` from the full `dateGroups` (NOT `filteredDateGroups`, so counts stay stable as the user toggles chips), then returns `followedArtists` projected to `{id, name, count}`, filtered to `count > 0`, sorted by `count desc, name asc`. Explicit `@computed` deps act as the cache; dirty-checking never engages because every dependency is observable. The chip `repeat.for` uses `key.bind="artist.id"` so checkbox/`:has(input:checked)` state is reused when sort order changes.
+
+### D4 — Facet gating: keep outer onboarding guard, gate only the journey section
+The whole `artist-filter-bar` keeps `if.bind="!isOnboarding"` (onboarding still suppresses it; guests who are not onboarding pass it). The artist facet is always present. The journey `<section>` is wrapped in `if.bind="showJourneyFacet"` bound to `isAuthenticated`. `if.bind` (not `show.bind`) is used so the journey chips are absent from the DOM/accessibility tree for guests. Reactivity holds because `isAuthenticated` bottoms out on the auto-observed `user` property, so a mid-session sign-in adds the facet.
+
+### D5 — Canonical journey-status map as a plain exported const
+Define `JOURNEY_STATUS_CONFIG: readonly { status, labelKey, icon, hueToken }[]` in `src/entities/ticket-journey.ts`, alongside the existing plain exports (`JOURNEY_NAV_ORDER`, etc.) that already serve as the journey single-source-of-truth. Each consuming VM exposes it as a public field for `repeat.for`. Rejected: value-converter (wrong shape for iterating the 5 statuses; the scalar status→label lookup stays as the existing `t.bind` i18n call), static class member (couples to one component), DI service (overkill for static immutable data). Labels reuse the existing `eventDetail.journeyStatus.*` i18n keys. Icons: `tracking`👀, `applied`📝, `unpaid`💰, `paid`🎟️, `lost`💔.
+
+### D6 — Filter chip ordering with a process/outcome break
+Journey chips are ordered in journey-flow order with a line break between the process phase and the outcome phase, mirroring the concert-detail two-phase layout: process row = `TRACKING`, `APPLIED`; outcome row = `UNPAID`, `PAID`, `LOST`. Selected chip fills with its `--journey-hue-*`; unselected chip is a neutral outline carrying a small colour cue so the hue association survives in both states (icon + label provide the non-colour cue).
+
+## Risks / Trade-offs
+
+- [Emoji render inconsistently across OSes] → Centralising icons in one const means a future swap to SVG is a single edit; emoji are interpolated as plain text (HTML-escaped, no XSS surface).
+- [Journey facet shown but most concerts have no status → selecting a status yields a near-empty highway] → Acceptable: this is the intended high-signal behaviour (surface the few engaged concerts); the existing empty-state placeholder is reused.
+- [Guest "filter not visible" root cause is empirically onboarding/zero-follows, not an auth gate] → Implementation must verify the exact observed gate before claiming guest enablement; the spec states the intended availability and the code reconciles it.
+- [Refactoring event-card/detail-sheet to the shared map could regress current rendering] → Behaviour is unchanged except the `LOST` glyph; covered by existing component/visual tests, and the i18n label keys are reused verbatim.
+
+## Migration Plan
+
+Pure additive frontend change, no data migration. Ships via the standard frontend release flow. Rollback is a straight revert of the frontend PR; the `journey` URL param degrades gracefully (ignored by the prior build). Note the frontend visual-baseline refresh constraint: the intentional UI changes (counted artist chips, journey chips, `LOST` icon) will require regenerating visual baselines.
+
+## Open Questions
+
+- None blocking. Section ordering (journey above artists), clear-all scope (clears both facets), and the exclusion of a "no status set" option are all decided.

--- a/openspec/changes/enhance-dashboard-filter/proposal.md
+++ b/openspec/changes/enhance-dashboard-filter/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+The dashboard filter currently only narrows the concert highway by artist, and the artist chips are listed in an arbitrary, unsorted order — so a fan following many artists cannot quickly find the artists that actually have lots of upcoming concerts (the only ones where filtering pays off). Fans also have no way to narrow the highway by their own ticket-acquisition state (e.g. "show only the shows I've applied to" or "the ones I still need to pay for"), even though that state is already tracked per concert. This change makes the existing filter more useful for high-volume followers and adds ticket-journey status as a second, orthogonal filter dimension.
+
+## What Changes
+
+- **Artist chips show a concert count and are sorted by it.** Each artist chip in the filter bottom sheet is prefixed with the number of that artist's upcoming concerts in the loaded dashboard set, the list is sorted by that count descending (ties broken by name ascending), and artists with zero upcoming concerts are hidden (filtering only matters where concerts exist).
+- **A second filter facet: ticket journey status.** The same bottom sheet gains a multi-select journey-status chip group (`TRACKING`, `APPLIED`, `UNPAID`, `PAID`, `LOST`). Selection semantics are OR within the facet and AND across facets (artist set AND journey set). The active filter is reflected in a new `journey` URL query parameter. This is a **pure filtering** feature — it does not display deadlines, sort by urgency, or send reminders (those belong to separate features).
+- **Guest availability.** The filter trigger and the artist facet are available to unauthenticated (guest) users, who can already follow artists locally — only the onboarding flow suppresses the filter. The journey facet is shown to authenticated users only.
+- **A single canonical journey-status presentation map.** The label, emoji icon, and semantic hue for each journey status are defined once and consumed by the new filter chips, the existing concert-card journey badge, and the concert-detail status control, so the visual identity of each status is consistent app-wide. The failure (`LOST`) status adopts a 💔 icon.
+
+## Capabilities
+
+### New Capabilities
+- `dashboard-journey-filter`: A ticket-journey-status filter facet on the dashboard filter sheet — multi-select chips with OR-within / AND-across-facet semantics, a `journey` URL query parameter synchronised with the UI, and facet visibility gated to authenticated users.
+- `journey-status-presentation`: A single source-of-truth mapping from each ticket-journey status to its display label, emoji icon, and semantic hue token, consumed by every component that renders journey status (filter chips, concert-card badge, concert-detail status control).
+
+### Modified Capabilities
+- `dashboard-artist-filter`: The artist-selection bottom sheet now prefixes each chip with its upcoming-concert count, sorts chips by count descending, and hides zero-concert artists; the filter trigger and artist facet are explicitly available to guest (unauthenticated) users.
+
+## Impact
+
+- **frontend** (only — no proto/backend/infra change):
+  - `src/routes/dashboard/dashboard-route.ts` / `.html`: a `filteredStatuses` observable, an extended `filteredDateGroups` predicate (artist AND journey), a `countedArtists` computed list, a combined URL sync (single watcher writing both `artists` and `journey` params), and an `isAuthenticated` binding for facet gating.
+  - `src/components/artist-filter-bar/*`: a second journey-status chip group, counted/sorted artist chips, guest-aware journey-facet visibility.
+  - `src/entities/ticket-journey.ts`: a new `JOURNEY_STATUS_CONFIG` constant (label key + emoji + hue token) as the canonical map.
+  - `src/components/live-highway/event-card.*` and `event-detail-sheet.*`: refactored to source labels/icons from the canonical map (no behavioural change beyond the `LOST` icon becoming 💔).
+- **No changes** to Protobuf schema, BSR, backend, or cloud-provisioning. Journey status is already delivered to the frontend via the existing `TicketJourneyService.ListByUser` path and attached to each concert.

--- a/openspec/changes/enhance-dashboard-filter/specs/dashboard-artist-filter/spec.md
+++ b/openspec/changes/enhance-dashboard-filter/specs/dashboard-artist-filter/spec.md
@@ -1,0 +1,74 @@
+## MODIFIED Requirements
+
+### Requirement: Artist-selection bottom sheet
+A bottom sheet SHALL allow the user to select one or more followed artists as a filter. Artists SHALL be presented as pill-shaped chip elements. Each artist chip SHALL be prefixed with the number of that artist's upcoming concerts in the loaded dashboard set. The artist chips SHALL be ordered by that concert count descending (ties broken by artist name ascending), and artists with zero upcoming concerts SHALL NOT be listed. A "全て解除" (Clear all) button SHALL appear beside the sheet title and allow the user to deselect all pending selections across every facet in the sheet before confirming.
+
+The sheet content SHALL be structured as a `<section>` element (not `<fieldset>`) with an `<h2>` heading as the title. The chip list SHALL carry `aria-labelledby` referencing the heading ID. `role="group"` SHALL NOT be applied to the `<ul>` element as it overrides the native `list` role and causes screen readers to lose item count information.
+
+#### Scenario: Opening the bottom sheet
+- **WHEN** the user taps the filter trigger button
+- **THEN** the bottom sheet SHALL open listing the followed artists (that have upcoming concerts) as selectable chips
+
+#### Scenario: Artist chip shows upcoming-concert count
+- **WHEN** an artist chip is rendered
+- **THEN** it SHALL display the count of that artist's upcoming concerts in the loaded dashboard set as a prefix to the artist name
+
+#### Scenario: Chips ordered by concert count descending
+- **WHEN** the artist chips are listed
+- **THEN** they SHALL be ordered by upcoming-concert count descending
+- **AND** ties SHALL be broken by artist name ascending
+
+#### Scenario: Zero-concert artists hidden
+- **WHEN** a followed artist has no upcoming concerts in the loaded dashboard set
+- **THEN** that artist SHALL NOT appear in the chip list
+
+#### Scenario: Counts stable while filtering
+- **WHEN** the user toggles an artist or journey selection
+- **THEN** the per-artist counts SHALL remain computed over the full unfiltered loaded set (they SHALL NOT drop as the active filter narrows the highway)
+
+#### Scenario: Pre-selecting current filter
+- **WHEN** the bottom sheet opens while a filter is already active
+- **THEN** the currently filtered artists SHALL be pre-selected (chips in selected state)
+
+#### Scenario: Chip selected state
+- **WHEN** the user taps an artist chip
+- **THEN** the chip SHALL display a checkmark and a brand-colour tinted background to indicate selection
+
+#### Scenario: Clear all pending selections
+- **WHEN** one or more chips are in the pending-selected state (in any facet)
+- **THEN** the "全て解除" button SHALL be enabled
+- **WHEN** the user taps "全て解除"
+- **THEN** all pending selections across every facet SHALL be cleared (chips return to unselected state)
+- **AND** the change SHALL NOT be applied until the user confirms
+
+#### Scenario: Clear all button disabled when nothing selected
+- **WHEN** no chips are in the pending-selected state in any facet
+- **THEN** the "全て解除" button SHALL be disabled
+
+#### Scenario: Confirming selection
+- **WHEN** the user selects artists and taps the confirm button
+- **THEN** `filteredArtistIds` SHALL be updated to the selected set
+- **THEN** the bottom sheet SHALL close
+
+#### Scenario: Confirming empty selection
+- **WHEN** the user deselects all artists (or taps "全て解除") and confirms
+- **THEN** the filter SHALL be cleared (equivalent to no filter)
+
+#### Scenario: Sheet snaps flush to viewport bottom
+- **WHEN** the filter bottom sheet opens
+- **THEN** the sheet body SHALL be snapped flush to the bottom of the viewport via `scroll-snap-align: end` on `.sheet-body`
+- **AND** the section content height SHALL be correctly reported to the scroll container (no `fieldset`/`legend` height anomalies)
+
+## ADDED Requirements
+
+### Requirement: Filter availability for guest users
+The filter trigger and the artist facet SHALL be available to unauthenticated (guest) users, who can follow artists locally. The filter SHALL NOT be gated by authentication; only the onboarding flow suppresses it.
+
+#### Scenario: Guest sees the filter trigger and artist facet
+- **WHEN** an unauthenticated (guest) user who has followed at least one artist views the dashboard outside of onboarding
+- **THEN** the filter trigger button SHALL be visible
+- **AND** opening the sheet SHALL present the artist facet with that guest's followed artists
+
+#### Scenario: Filter still suppressed during onboarding
+- **WHEN** the user (guest or authenticated) is in the onboarding flow
+- **THEN** the filter trigger SHALL remain hidden

--- a/openspec/changes/enhance-dashboard-filter/specs/dashboard-journey-filter/spec.md
+++ b/openspec/changes/enhance-dashboard-filter/specs/dashboard-journey-filter/spec.md
@@ -17,6 +17,7 @@ The dashboard SHALL accept a `journey` query parameter containing one or more ti
 
 #### Scenario: Concerts without a journey status are excluded when filtering
 - **WHEN** a `journey` filter is active
+- **AND** the user is authenticated
 - **AND** a concert has no `journeyStatus` set
 - **THEN** that concert SHALL NOT be shown
 

--- a/openspec/changes/enhance-dashboard-filter/specs/dashboard-journey-filter/spec.md
+++ b/openspec/changes/enhance-dashboard-filter/specs/dashboard-journey-filter/spec.md
@@ -1,0 +1,105 @@
+## ADDED Requirements
+
+### Requirement: URL-driven journey filter
+The dashboard SHALL accept a `journey` query parameter containing one or more ticket-journey status values (comma-separated, from `tracking`, `applied`, `unpaid`, `paid`, `lost`). When present, only concerts whose `journeyStatus` is in the listed set SHALL be displayed. When absent or empty, concerts SHALL NOT be constrained by journey status.
+
+#### Scenario: Single status filter from URL
+- **WHEN** the user navigates to `/dashboard?journey=unpaid`
+- **THEN** only concerts whose `journeyStatus` is `unpaid` SHALL be shown in the concert highway
+
+#### Scenario: Multiple status filter from URL
+- **WHEN** the user navigates to `/dashboard?journey=applied,unpaid`
+- **THEN** only concerts whose `journeyStatus` is in `{applied, unpaid}` SHALL be shown
+
+#### Scenario: No journey filter — unconstrained by status
+- **WHEN** the user navigates to `/dashboard` with no `journey` param
+- **THEN** concerts SHALL NOT be filtered by journey status (concerts with no status set SHALL still be shown)
+
+#### Scenario: Concerts without a journey status are excluded when filtering
+- **WHEN** a `journey` filter is active
+- **AND** a concert has no `journeyStatus` set
+- **THEN** that concert SHALL NOT be shown
+
+#### Scenario: Unknown status value in filter
+- **WHEN** a `journey` value contains a token that is not a valid status
+- **THEN** that token SHALL be silently ignored; concerts for remaining valid statuses SHALL still be shown
+
+#### Scenario: Filter yields empty result
+- **WHEN** the journey filter (combined with any artist filter) has no matching upcoming concerts
+- **THEN** the empty-state placeholder SHALL be displayed (same as the no-concerts state)
+
+### Requirement: Journey filter combines with artist filter
+When both the artist filter and the journey filter are active, a concert SHALL be shown only if it satisfies BOTH facets. Selections within a single facet SHALL combine as OR; the two facets SHALL combine as AND.
+
+#### Scenario: Both facets active
+- **WHEN** the artist filter is `{A, B}` and the journey filter is `{applied, unpaid}`
+- **THEN** a concert SHALL be shown only if its `artistId` is in `{A, B}` AND its `journeyStatus` is in `{applied, unpaid}`
+
+#### Scenario: Only journey facet active
+- **WHEN** the artist filter is empty and the journey filter is `{paid}`
+- **THEN** all followed-artist concerts whose `journeyStatus` is `paid` SHALL be shown regardless of artist
+
+#### Scenario: Only artist facet active
+- **WHEN** the journey filter is empty and the artist filter is `{A}`
+- **THEN** all of artist A's concerts SHALL be shown regardless of journey status
+
+### Requirement: Journey filter state synchronised with URL
+When the user changes the journey filter via the UI, the dashboard URL SHALL be updated to reflect the new state without a full page reload, and the artist and journey parameters SHALL be written together in a single URL update.
+
+#### Scenario: User changes the journey filter
+- **WHEN** the user selects journey statuses in the filter sheet and confirms
+- **THEN** the browser URL SHALL update to include `journey=<selectedStatuses>` via `history.replaceState`
+- **AND** the concert highway SHALL immediately display only matching concerts
+
+#### Scenario: A single URL update writes both facets
+- **WHEN** a confirm commits changes to both the artist and journey selections
+- **THEN** the URL SHALL be updated exactly once with both `artists` and `journey` parameters reflecting the final state
+
+#### Scenario: Page reload preserves the journey filter
+- **WHEN** the user reloads the page while a journey filter is active
+- **THEN** the `journey` query param SHALL be re-parsed from the URL and the same filtered view SHALL be restored
+
+### Requirement: Journey-status facet in the filter sheet
+The filter bottom sheet SHALL present a ticket-journey-status facet as a multi-select chip group, in addition to the artist facet. Statuses SHALL be ordered in journey-flow order with a visual break separating the process phase (`tracking`, `applied`) from the outcome phase (`unpaid`, `paid`, `lost`). Each chip SHALL derive its label, icon, and hue from the canonical journey-status presentation map.
+
+#### Scenario: Facet rendered as its own section
+- **WHEN** the filter sheet opens for an authenticated user
+- **THEN** the journey-status facet SHALL be rendered as a `<section>` with its own `<h*>` heading, and the chip list SHALL carry `aria-labelledby` referencing that heading
+
+#### Scenario: Status ordering with process/outcome break
+- **WHEN** the journey facet is rendered
+- **THEN** `tracking` and `applied` SHALL appear first as the process phase
+- **AND** a visual break SHALL separate them from the outcome phase `unpaid`, `paid`, `lost` in that order
+
+#### Scenario: Chip selected state
+- **WHEN** the user taps a status chip
+- **THEN** the chip SHALL fill with that status's semantic hue and indicate selection
+- **AND** the unselected chips SHALL remain as neutral outlines that still carry the status icon and label
+
+#### Scenario: Pre-selecting the current journey filter
+- **WHEN** the sheet opens while a journey filter is active
+- **THEN** the currently filtered statuses SHALL be pre-selected
+
+#### Scenario: Confirming clears or sets the journey filter
+- **WHEN** the user changes the status selection and confirms
+- **THEN** the active journey filter SHALL be updated to the selected set (empty selection clears the journey filter)
+
+#### Scenario: Clear all covers the journey facet
+- **WHEN** the user taps the sheet "全て解除" (Clear all) button
+- **THEN** pending journey-status selections SHALL be cleared together with the pending artist selections
+
+### Requirement: Journey facet visible to authenticated users only
+The journey-status facet SHALL be rendered only when the user is authenticated. Unauthenticated (guest) users SHALL NOT see the journey facet, and the `journey` query parameter SHALL have no effect for them.
+
+#### Scenario: Authenticated user sees the journey facet
+- **WHEN** an authenticated user opens the filter sheet
+- **THEN** the journey-status facet SHALL be present in the sheet
+
+#### Scenario: Guest does not see the journey facet
+- **WHEN** an unauthenticated (guest) user opens the filter sheet
+- **THEN** the journey-status facet SHALL NOT be rendered (absent from the DOM and accessibility tree)
+- **AND** the artist facet SHALL still be available
+
+#### Scenario: Sign-in mid-session reveals the facet
+- **WHEN** a guest signs in while on the dashboard
+- **THEN** the journey-status facet SHALL become available without a full page reload

--- a/openspec/changes/enhance-dashboard-filter/specs/journey-status-presentation/spec.md
+++ b/openspec/changes/enhance-dashboard-filter/specs/journey-status-presentation/spec.md
@@ -1,0 +1,36 @@
+## ADDED Requirements
+
+### Requirement: Canonical journey-status presentation map
+The frontend SHALL define a single canonical mapping from each ticket-journey status to its display label, icon, and semantic hue token. Every component that renders a journey status SHALL derive its label, icon, and hue from this map rather than defining them inline.
+
+#### Scenario: Single source of truth
+- **WHEN** a journey status needs a label, icon, or hue in any component
+- **THEN** the value SHALL be read from the canonical map
+- **AND** no component SHALL inline its own per-status label, icon, or hue
+
+#### Scenario: Map covers every status
+- **WHEN** the canonical map is defined
+- **THEN** it SHALL include an entry for each of `tracking`, `applied`, `unpaid`, `paid`, and `lost`
+- **AND** each entry SHALL provide a label (via the existing `eventDetail.journeyStatus.*` i18n key), an icon, and a hue token
+
+### Requirement: Status icon and hue assignments
+Each journey status SHALL have a defined icon and a meaning-based hue so the status is understandable through a non-colour cue (icon plus label) as well as colour.
+
+#### Scenario: Icon per status
+- **WHEN** a journey status is rendered
+- **THEN** its icon SHALL be: `tracking` 👀, `applied` 📝, `unpaid` 💰, `paid` 🎟️, `lost` 💔
+
+#### Scenario: Hue per status
+- **WHEN** a journey status is rendered with colour
+- **THEN** its hue SHALL be the shared journey-hue token for that status: process (`tracking`, `applied`) neutral, `unpaid` amber, `paid` green, `lost` red
+
+#### Scenario: Meaning survives without colour
+- **WHEN** any journey status is rendered
+- **THEN** it SHALL present its icon and text label in addition to colour
+
+### Requirement: Consistent rendering across components
+A given journey status SHALL render with the same label, icon, and hue wherever it appears — the dashboard filter chips, the concert-card journey badge, and the concert-detail status control.
+
+#### Scenario: Same status looks the same everywhere
+- **WHEN** the same journey status appears as a filter chip, a card badge, and a detail-control node
+- **THEN** all three SHALL show the same icon, label, and hue sourced from the canonical map

--- a/openspec/changes/enhance-dashboard-filter/tasks.md
+++ b/openspec/changes/enhance-dashboard-filter/tasks.md
@@ -7,7 +7,7 @@
 
 ## 2. Dashboard ViewModel — journey filter and counts
 
-- [ ] 2.1 Add `@observable filteredStatuses: JourneyStatus[]` to `DashboardRoute` and parse the `journey` query param in `loading()`
+- [ ] 2.1 Add `@observable filteredStatuses: JourneyStatus[]` to `DashboardRoute` and parse the `journey` query param in `loading()`; ignore the param entirely for unauthenticated users (guests get the unfiltered view — the param has no effect, never an empty highway)
 - [ ] 2.2 Extend `filteredDateGroups` to a single `keep` predicate combining artist (OR) AND journey (OR), preserving the `!!c.artistId` ghost-card guard
 - [ ] 2.3 Replace the per-array URL sync with a single watcher that writes both `artists` and `journey` params in one `history.replaceState` (avoid double write)
 - [ ] 2.4 Add `@computed('dateGroups','followedArtists') get countedArtists` building counts over the unfiltered `dateGroups`, projecting to `{id,name,count}`, hiding `count === 0`, sorting by count desc then name asc

--- a/openspec/changes/enhance-dashboard-filter/tasks.md
+++ b/openspec/changes/enhance-dashboard-filter/tasks.md
@@ -1,0 +1,36 @@
+## 1. Canonical journey-status presentation map
+
+- [ ] 1.1 Add `JOURNEY_STATUS_CONFIG` (status → labelKey, icon, hueToken) as a plain exported const in `src/entities/ticket-journey.ts`, with icons `tracking`👀 `applied`📝 `unpaid`💰 `paid`🎟️ `lost`💔
+- [ ] 1.2 Add a unit test asserting the map covers all five statuses and reuses the existing `eventDetail.journeyStatus.*` i18n keys
+- [ ] 1.3 Refactor `event-card` journey badge to source its label/icon/hue from `JOURNEY_STATUS_CONFIG` (no inline per-status values)
+- [ ] 1.4 Refactor `event-detail-sheet` journey status control to source label/icon/hue from the map, updating the `lost` glyph to 💔
+
+## 2. Dashboard ViewModel — journey filter and counts
+
+- [ ] 2.1 Add `@observable filteredStatuses: JourneyStatus[]` to `DashboardRoute` and parse the `journey` query param in `loading()`
+- [ ] 2.2 Extend `filteredDateGroups` to a single `keep` predicate combining artist (OR) AND journey (OR), preserving the `!!c.artistId` ghost-card guard
+- [ ] 2.3 Replace the per-array URL sync with a single watcher that writes both `artists` and `journey` params in one `history.replaceState` (avoid double write)
+- [ ] 2.4 Add `@computed('dateGroups','followedArtists') get countedArtists` building counts over the unfiltered `dateGroups`, projecting to `{id,name,count}`, hiding `count === 0`, sorting by count desc then name asc
+- [ ] 2.5 Expose `isAuthenticated` to the template for journey-facet gating
+- [ ] 2.6 Unit-test the filter predicate (artist-only, journey-only, both, no-status excluded) and the count/sort/hide-zero derivation
+
+## 3. Filter bar UI — journey facet, counted artist chips, guest gating
+
+- [ ] 3.1 Bind `counted-artists` into `artist-filter-bar`; render the count prefix on each artist chip with `key.bind="artist.id"` on the repeat
+- [ ] 3.2 Add a journey-status `<section>` (own `<h*>` + `aria-labelledby`) with multi-select chips driven by a `pendingStatuses` array and `JOURNEY_STATUS_CONFIG`, ordered with the process/outcome line break
+- [ ] 3.3 Add `selected-statuses` two-way bindable and commit it in `confirmSelection()`; make `clearAll()` also clear pending statuses and `hasPendingSelection` consider both facets
+- [ ] 3.4 Gate the journey `<section>` with `if.bind="showJourneyFacet"` (bound to `isAuthenticated`); keep the outer `!isOnboarding` guard and confirm the artist facet renders for guests
+- [ ] 3.5 Style selected journey chips with `--journey-hue-*` fill and unselected as neutral outlines retaining icon + label (cube-css layers; confirm hue token naming with the cube-css skill)
+
+## 4. Tests and verification
+
+- [ ] 4.1 Add/extend component smoke tests for the two-facet sheet, guest (no journey facet) vs authenticated, and counted/sorted artist chips
+- [ ] 4.2 Add an e2e/integration check for URL round-trip: `?artists=…&journey=…` parses on load and a single `replaceState` writes both on confirm
+- [ ] 4.3 Run `make check`; the FE Smoke path must mock backend responses (dev env is intentionally stopped — do not proxy)
+- [ ] 4.4 Refresh frontend visual baselines for the intentional UI changes (counted chips, journey chips, `lost` 💔) per the baseline-refresh constraint
+
+## 5. Ship
+
+- [ ] 5.1 Open the frontend PR (assignee/reviewer `pannpers`), drive CI green, resolve any bot review findings, and merge
+- [ ] 5.2 Archive this OpenSpec change in the specification repo once tasks are complete
+- [ ] 5.3 Cut the frontend GH Release (retag → prod AR), confirm the automated prod pin-bump lands in cloud-provisioning and ArgoCD syncs, and verify the filter works in prod


### PR DESCRIPTION
## 🔗 Related Issue

close: #583

## 📝 Summary of Changes

Adds the OpenSpec change `enhance-dashboard-filter` (proposal, design, specs, tasks). This is a **specification-only PR** capturing the design; implementation lands in the frontend repo afterwards.

**Motivation:** the dashboard filter narrows the concert highway by artist only, with unsorted chips, and fans cannot narrow by their own ticket-acquisition state — even though each concert already carries a `journeyStatus`.

**What the change specifies (frontend-only; no proto/backend/infra):**

- **Artist facet** (`dashboard-artist-filter`, MODIFIED): each chip is prefixed with the artist's upcoming-concert count, chips are sorted by count descending (ties by name ascending), and zero-concert artists are hidden. The filter trigger + artist facet are explicitly available to guest users.
- **Journey facet** (`dashboard-journey-filter`, NEW): a multi-select ticket-journey-status chip group in the same bottom sheet — OR within the facet, AND across facets — synchronised to a `journey` URL query parameter, with the facet gated to authenticated users. Pure filtering (no deadlines, urgency sorting, or reminders — those belong to separate features).
- **Canonical presentation** (`journey-status-presentation`, NEW): a single source-of-truth map from each status to its label, emoji icon, and hue token, consumed by the filter chips, the concert-card badge, and the concert-detail control (`lost` adopts 💔).

**Technical approach** (see `design.md`): extend the existing `filteredDateGroups` getter with a combined artist-AND-journey predicate; a single watcher writes both URL params to avoid a double `replaceState`; a `@computed` `countedArtists` derives counts over the unfiltered set; the journey section is gated with `if.bind` on `isAuthenticated`; the presentation map is a plain exported const alongside the existing journey single-source-of-truth.

## ✅ Self-Checklist

- [x] I have linked the related issue.
- [x] I have updated the relevant documentation (OpenSpec change artifacts).
- [ ] I have run `buf lint` and `buf format` locally and all checks have passed. — N/A, no `.proto` changes (OpenSpec markdown only); `openspec validate` passes.
- [x] My proto definitions follow the project's style guidelines and validation rules. — N/A, no proto changes.
- [ ] Breaking changes have been justified and documented if applicable. — N/A, no breaking changes.
