### PR TITLE
docs(openspec): add replace-pwa-app-icons change

### DIFF
--- a/openspec/changes/replace-pwa-app-icons/.openspec.yaml
+++ b/openspec/changes/replace-pwa-app-icons/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-04

--- a/openspec/changes/replace-pwa-app-icons/design.md
+++ b/openspec/changes/replace-pwa-app-icons/design.md
@@ -1,0 +1,79 @@
+## Context
+
+The finalized brand icon set arrives as `frontend/favicon.zip` (a RealFaviconGenerator export):
+
+| File | Size | Notes |
+|------|------|-------|
+| `favicon.svg` | 6.7 MB | **Not vector** — a single 1528×1528 PNG embedded as base64, zero `<path>` elements |
+| `favicon-96x96.png` | 21 KB | browser-tab favicon |
+| `favicon.ico` | 15 KB | legacy / implicit `/favicon.ico` |
+| `apple-touch-icon.png` | 66 KB | iOS home screen, 180×180 |
+| `web-app-manifest-192x192.png` | 74 KB | PWA install |
+| `web-app-manifest-512x512.png` | 457 KB | PWA install + maskable |
+| `site.webmanifest` | 448 B | generic boilerplate (`"MyWebSite"`, white theme, 2 icons) |
+
+Current state in `frontend/public/`: a real 440 B hand-authored `favicon.svg`, a 447 B `apple-touch-icon.svg`, and 593 B / 2.2 KB placeholder PWA PNGs at `icons/icon-192x192.png` and `icons/icon-512x512.png`. The head links live in `frontend/index.html`; the PWA manifest is the carefully customized `frontend/public/manifest.webmanifest`.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Present the finalized brand mark in browser tab, iOS home screen, and Android/PWA install.
+- Keep transfer size small and Core Web Vitals unaffected.
+- Preserve all existing manifest customization (`share_target` ticket-email import, `lang: ja`, themed colors, maskable variant).
+- Make the smallest set of edits that achieves the above.
+
+**Non-Goals:**
+- Producing a true vector SVG of the new logo (would require a designer re-export; out of scope here).
+- Migrating asset paths to a `/icons/` subtree per the export's default snippet.
+- Adopting the export's `site.webmanifest` (generic boilerplate; rejected).
+- Any backend, proto, or runtime JS change.
+
+## Decisions
+
+**1. PNG/ICO favicon — drop the SVG favicon.**
+The exported `favicon.svg` is a raster wearing an `.svg` extension (1528×1528 PNG, base64-embedded, 6.7 MB). It carries none of the scalability benefit of a true vector but inflates transfer size ~15,000×. Browsers render favicons at ≤180 px, so a 96 px PNG plus a multi-resolution ICO is sufficient. We therefore delete `favicon.svg` rather than attempt to optimize the embedded raster.
+- *Alternative considered:* downscale + re-embed the raster into a ~tens-of-KB SVG. Rejected — strictly worse than PNG (still raster, extra base64 overhead, no benefit).
+- *Alternative considered:* keep an SVG favicon. Rejected — the new asset is not vector, so there is nothing to keep.
+
+**2. Preserve the existing manifest; edit only the `icons` array.**
+The export's `site.webmanifest` is generic boilerplate and would destroy the existing `share_target`, `lang: ja`, and themed configuration. We keep `frontend/public/manifest.webmanifest` and only update its `icons`: remove the two SVG entries (`/favicon.svg`, `/apple-touch-icon.svg`), point apple-touch at the new `/apple-touch-icon.png`, and keep the 192/512 entries (including the maskable 512) by saving the new PWA PNGs under the existing filenames.
+
+**3. Save new PWA PNGs under the existing filenames.**
+`web-app-manifest-192x192.png` → `public/icons/icon-192x192.png`, `web-app-manifest-512x512.png` → `public/icons/icon-512x512.png`. This keeps the manifest's `/icons/icon-*` `src` paths valid with only a byte swap and avoids touching the three 512 entries' paths.
+
+**4. Keep the public-root file layout.**
+The export snippet assumes everything under `/icons/` (including the manifest). We keep root-level placement (`/favicon-96x96.png`, `/favicon.ico`, `/apple-touch-icon.png`, `/manifest.webmanifest`) to minimize edits to `index.html` and avoid a path migration.
+
+**5. Unify `theme-color` to `#1a1333`.**
+`index.html` declares `#1a1a3a`; the manifest declares `#1a1333`. The manifest drives PWA/start-url theming and is treated as the source of truth, so `index.html` is aligned to `#1a1333`.
+
+Resulting `index.html` head:
+```html
+<meta name="theme-color" content="#1a1333">
+...
+<link rel="icon" type="image/png" href="/favicon-96x96.png" sizes="96x96">
+<link rel="shortcut icon" href="/favicon.ico">
+<link rel="apple-touch-icon" href="/apple-touch-icon.png">
+<link rel="manifest" href="/manifest.webmanifest">
+```
+
+## Risks / Trade-offs
+
+- **No vector favicon → no automatic crisp scaling beyond the supplied raster sizes** → 96 px PNG + multi-res ICO cover all real rendering sizes (≤180 px); negligible in practice.
+- **No `prefers-color-scheme` adaptation in the favicon** (an SVG could embed media queries) → the brand mark is designed against a fixed dark background; not required.
+- **Frontend visual baselines may flag the new icons** → if any visual test captures the tab/app icon, regenerate baselines per the project's main-branch baseline-refresh process.
+- **Stale caches** → favicons are aggressively cached by browsers; the change is non-breaking and resolves on natural cache expiry / hard reload. No mitigation needed for correctness.
+
+## Migration Plan
+
+1. Extract `frontend/favicon.zip` to a temp location.
+2. Place/replace assets in `frontend/public/` per Decisions 3–4; remove `favicon.svg` and `apple-touch-icon.svg`.
+3. Edit `index.html` head and `manifest.webmanifest` `icons`.
+4. Remove `frontend/favicon.zip` from the repo.
+5. `make check` in `frontend`.
+
+Rollback: revert the commit; the previous placeholder assets and head links are restored wholesale.
+
+## Open Questions
+
+None.

--- a/openspec/changes/replace-pwa-app-icons/design.md
+++ b/openspec/changes/replace-pwa-app-icons/design.md
@@ -39,7 +39,7 @@ The exported `favicon.svg` is a raster wearing an `.svg` extension (1528×1528 P
 The export's `site.webmanifest` is generic boilerplate and would destroy the existing `share_target`, `lang: ja`, and themed configuration. We keep `frontend/public/manifest.webmanifest` and only update its `icons`: remove the two SVG entries (`/favicon.svg`, `/apple-touch-icon.svg`), point apple-touch at the new `/apple-touch-icon.png`, and keep the 192/512 entries (including the maskable 512) by saving the new PWA PNGs under the existing filenames.
 
 **3. Save new PWA PNGs under the existing filenames.**
-`web-app-manifest-192x192.png` → `public/icons/icon-192x192.png`, `web-app-manifest-512x512.png` → `public/icons/icon-512x512.png`. This keeps the manifest's `/icons/icon-*` `src` paths valid with only a byte swap and avoids touching the three 512 entries' paths.
+`web-app-manifest-192x192.png` → `public/icons/icon-192x192.png`, `web-app-manifest-512x512.png` → `public/icons/icon-512x512.png`. This keeps the manifest's `/icons/icon-*` `src` paths valid with only a byte swap and avoids touching the 192 and both 512 entries' paths.
 
 **4. Keep the public-root file layout.**
 The export snippet assumes everything under `/icons/` (including the manifest). We keep root-level placement (`/favicon-96x96.png`, `/favicon.ico`, `/apple-touch-icon.png`, `/manifest.webmanifest`) to minimize edits to `index.html` and avoid a path migration.

--- a/openspec/changes/replace-pwa-app-icons/proposal.md
+++ b/openspec/changes/replace-pwa-app-icons/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+The current frontend ships placeholder brand icons: a hand-authored 440-byte `favicon.svg`, a tiny `apple-touch-icon.svg`, and 192/512 PNGs that were generated as low-fidelity placeholders. A new, finalized brand icon set is now available (RealFaviconGenerator export) and should replace the placeholders so the browser tab, iOS home screen, and Android PWA install all present the real Liverty Music brand mark.
+
+## What Changes
+
+- Replace the placeholder favicon / apple-touch / PWA icon assets in `frontend/public/` with the finalized brand icon set.
+- **Drop the SVG favicon entirely** and serve a PNG + ICO favicon instead. The new "SVG" from the export is a 1528×1528 raster embedded as base64 (6.7 MB, zero vector paths), so it carries none of the scalability benefits of a real vector while badly hurting transfer size. PNG/ICO at the sizes browsers actually render (≤180 px) is sufficient and far lighter.
+- Add `favicon.ico` at the public root (legacy browsers, Windows tiles, and the implicit `/favicon.ico` request) — the project currently has none.
+- Replace `apple-touch-icon.svg` with `apple-touch-icon.png` (the export's 180×180 PNG).
+- Update the PWA web app manifest `icons` array to drop the two SVG entries and point apple-touch + 192/512 PNGs at the new assets, while preserving all existing manifest customization (`share_target`, `lang: ja`, themed colors, maskable variant).
+- Unify the brand `theme-color`: `index.html` currently declares `#1a1a3a` while the manifest declares `#1a1333`. Align both to the manifest value `#1a1333`.
+- Keep the existing public-root file layout (no migration to a `/icons/` subtree) to minimize churn.
+
+## Capabilities
+
+### New Capabilities
+<!-- None — this change refines existing brand-identity behavior. -->
+
+### Modified Capabilities
+- `app-shell-layout`: The "Favicon and PWA icons" scenario under the **Brand Identity Elements** requirement is refined to (a) deliver the browser-tab favicon as PNG + ICO rather than requiring an SVG, and (b) require the HTML `theme-color` meta to match the web app manifest `theme_color`.
+
+## Impact
+
+- `frontend/public/` — icon asset files (favicon, apple-touch, 192/512 PWA icons) added/replaced/removed.
+- `frontend/public/manifest.webmanifest` — `icons` array updated; other fields unchanged.
+- `frontend/index.html` — `<head>` icon `<link>` tags and `theme-color` meta updated.
+- `frontend/favicon.zip` — source archive removed after extraction.
+- No backend, proto, or API changes. No runtime/JS behavior change beyond static asset delivery.

--- a/openspec/changes/replace-pwa-app-icons/specs/app-shell-layout/spec.md
+++ b/openspec/changes/replace-pwa-app-icons/specs/app-shell-layout/spec.md
@@ -1,0 +1,20 @@
+## MODIFIED Requirements
+
+### Requirement: Brand Identity Elements
+The system SHALL display proper brand identity elements across the application.
+
+#### Scenario: Page title displays service name
+- **WHEN** any page is loaded
+- **THEN** the HTML `<title>` SHALL include "Liverty Music" (e.g., "Liverty Music" or "Liverty Music - [Page Name]")
+- **AND** the system SHALL NOT display default scaffold or template names (e.g., "Aurelia", "Vite", "React App")
+
+#### Scenario: Favicon and PWA icons
+- **WHEN** the application is loaded
+- **THEN** the system SHALL display a brand favicon in the browser tab, served as PNG and ICO assets (no SVG favicon is required)
+- **AND** the system SHALL provide an `apple-touch-icon` PNG for the iOS home screen
+- **AND** the system SHALL provide a web app manifest with themed PNG icons (including a maskable variant) for Android and other PWA-compliant platforms
+- **AND** the web app manifest SHALL NOT reference SVG icon assets
+
+#### Scenario: Theme color is consistent across HTML and manifest
+- **WHEN** the application is loaded
+- **THEN** the `theme-color` declared in the HTML `<head>` meta tag SHALL equal the `theme_color` declared in the web app manifest

--- a/openspec/changes/replace-pwa-app-icons/tasks.md
+++ b/openspec/changes/replace-pwa-app-icons/tasks.md
@@ -1,0 +1,36 @@
+## 1. Extract and place assets
+
+- [x] 1.1 Extract `frontend/favicon.zip` to a temp location
+- [x] 1.2 Copy `favicon-96x96.png` → `frontend/public/favicon-96x96.png`
+- [x] 1.3 Copy `favicon.ico` → `frontend/public/favicon.ico`
+- [x] 1.4 Copy `apple-touch-icon.png` → `frontend/public/apple-touch-icon.png`
+- [x] 1.5 Copy `web-app-manifest-192x192.png` → `frontend/public/icons/icon-192x192.png` (overwrite placeholder, keep filename)
+- [x] 1.6 Copy `web-app-manifest-512x512.png` → `frontend/public/icons/icon-512x512.png` (overwrite placeholder, keep filename)
+- [x] 1.7 Delete `frontend/public/favicon.svg` and `frontend/public/apple-touch-icon.svg`
+- [x] 1.8 Do NOT copy the export's `site.webmanifest` (generic boilerplate, rejected)
+
+## 2. Update HTML head
+
+- [x] 2.1 In `frontend/index.html`, change `theme-color` meta from `#1a1a3a` to `#1a1333`
+- [x] 2.2 Replace the `<link rel="icon" ... favicon.svg>` and `<link rel="apple-touch-icon" ... apple-touch-icon.svg>` tags with: PNG `rel="icon"` (96x96), `rel="shortcut icon"` (favicon.ico), and `rel="apple-touch-icon"` (apple-touch-icon.png); keep the manifest link
+- [x] 2.3 Update `src/sw.ts` push-notification `icon`/`badge` (were `/favicon.svg`) to PNG assets — `/icons/icon-192x192.png` and `/favicon-96x96.png` — so they don't 404 after SVG removal
+
+## 3. Update web app manifest
+
+- [x] 3.1 In `frontend/public/manifest.webmanifest`, remove the `/favicon.svg` icon entry
+- [x] 3.2 Replace the `/apple-touch-icon.svg` entry with `/apple-touch-icon.png` (180x180, type image/png)
+- [x] 3.3 Verify the `/icons/icon-192x192.png` and both `/icons/icon-512x512.png` (incl. maskable) entries remain unchanged
+- [x] 3.4 Verify `share_target`, `lang`, `name`, `short_name`, `theme_color`, `background_color` are untouched
+
+## 4. Cleanup and verify
+
+- [x] 4.1 Remove `frontend/favicon.zip` from the repo
+- [x] 4.2 Run `make check` in `frontend` (lint, types, tests)
+- [x] 4.3 If frontend visual baselines capture the icon, regenerate baselines per the main-branch baseline-refresh process
+- [x] 4.4 Manually verify favicon in browser tab, and PWA install icon (DevTools → Application → Manifest shows new icons, no 404s)
+
+## 5. Ship
+
+- [ ] 5.1 Open frontend PR (Conventional Commits, body + `Refs: #<issue>`), drive CI green, merge to main
+- [ ] 5.2 Cut a frontend GitHub Release (retag → prod AR) to trigger the automated prod pin bump → ArgoCD sync
+- [ ] 5.3 Verify the new icons are live on `dev.liverty-music.app` (and prod once rolled out)


### PR DESCRIPTION
## 🔗 Related Issue

Refs liverty-music/frontend#422 (closure owned by the frontend implementation PR liverty-music/frontend#423)

## 📝 Summary of Changes

Adds the OpenSpec change `replace-pwa-app-icons`, capturing the proposal, design, spec delta, and tasks for replacing the placeholder PWA/app icons with the finalized Liverty Music brand icon set.

- **Motivation**: the shipped favicon/apple-touch/PWA icons were low-fidelity placeholders; a finalized brand icon set is now available.
- **Key decision**: drop the SVG favicon and serve PNG + ICO instead. The export's `favicon.svg` is a 1528×1528 raster embedded as base64 (6.7 MB, zero vector paths), so it offers none of the scalability benefit of a true vector while inflating transfer size; PNG/ICO covers every size browsers render (≤180 px).
- **Spec delta** (`app-shell-layout`): the *Brand Identity Elements* → *Favicon and PWA icons* scenario is modified to deliver the favicon as PNG + ICO (no SVG required) and to require that the web app manifest reference no SVG icons; a new scenario requires the HTML `theme-color` to match the manifest `theme_color`.

No proto changes — this PR only adds OpenSpec artifacts under `openspec/changes/`. The change will be archived into `openspec/specs/` once the implementation ships.

## ✅ Self-Checklist

- [x] I have linked the related issue.
- [x] I have updated the relevant documentation (e.g., `README.md`) if needed.
- [x] I have run `buf lint` and `buf format` locally and all checks have passed.
- [x] My proto definitions follow the project's style guidelines and validation rules.
- [x] Breaking changes have been justified and documented if applicable.
