### PR TITLE
docs(openspec): add compact-ticket-status-layout change

### DIFF
--- a/openspec/changes/compact-ticket-status-layout/.openspec.yaml
+++ b/openspec/changes/compact-ticket-status-layout/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-04

--- a/openspec/changes/compact-ticket-status-layout/design.md
+++ b/openspec/changes/compact-ticket-status-layout/design.md
@@ -1,0 +1,62 @@
+## Context
+
+The ticket-status control in `event-detail-sheet` renders the ticket journey as a radiogroup of status nodes across two phases: a process phase (`追跡中 › 申込済み`, already horizontal) and an outcome phase. The outcome phase is the height bottleneck: it stacks the win route (`当選・未入金 → ↓ → 入金済み`) vertically inside one bordered card and the lose route (`落選`) inside a second bordered card below. Measured on a mobile sheet, the outcome phase alone is ~214px of a ~330px control — roughly two-thirds.
+
+Each node carries `min-block-size: 2.75rem` (44px) as a tap target, so the win route alone is two 44px nodes + a down-arrow + a route label + card padding ≈ 146px. The structure is pure CSS/template geometry; the journey state machine, status values, i18n keys, and the canonical per-status label/icon/hue map (`journey-status-presentation`) are untouched.
+
+The flow arrow (`.journey-arrow`) has no dedicated margin — its only breathing room is the container's `gap: var(--space-3xs)` (~4–5px) — and uses a hairline `›` at `--step--1`, so it reads as cramped between the chips.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Cut the ticket-status control's vertical footprint to ~half (~330px → ~165px) on mobile.
+- Keep every status node, the radiogroup semantics, keyboard navigation, `data-testid` hooks, and the canonical label/icon/hue.
+- Give the flow arrow visible breathing room and a non-hairline glyph in both phases.
+
+**Non-Goals:**
+- No change to the journey state machine, status enum, i18n keys, or the canonical presentation map.
+- No reduction of the 44px tap-target minimum.
+- No backend/proto/BSR impact.
+
+## Decisions
+
+### D1: Lay the outcome phase out horizontally (single row), not vertically stacked cards
+
+The win route and lose route move into one horizontal row: `[当選・未入金] › [入金済み]  ·  [落選]`. This collapses the dominant ~146px vertical win-route into a single 44px row.
+
+- **Why over alternatives:**
+  - *Per-card horizontal (keep both bordered cards, only flatten the win route internally)* — keeps the card framing but only reaches ~25% reduction; misses the "half" target.
+  - *Shrink node height / tighten gaps only* — 44px is the accessibility tap-target floor; shrinking trades misclicks for height and still falls short of half.
+  - *Single unified 5-node horizontal timeline* — elegant but will not fit 5 nodes on a 360px viewport.
+- The horizontal single-row approach is the only option that hits the ~half target with a local CSS change.
+
+### D2: Remove per-route bordered card chrome; distinguish routes with a divider + existing dimming
+
+The `border` + `padding` on `.journey-route` is dropped. Win vs lose separation is carried by a lightweight inline divider (e.g. a centered middot/separator) plus the existing `data-dimmed` route dimming and per-status hue. This removes double framing and reclaims vertical padding.
+
+### D3: Unify connectors on the horizontal `›`; retire `journey-arrow-down`
+
+With the outcome row horizontal, the `↓` connector (`.journey-arrow-down`) is no longer meaningful. Both phases use the same `›` connector. The `journey-arrow-down` modifier class is removed from the template and CSS.
+
+### D4: Give the flow arrow dedicated inline margin and a larger glyph
+
+`.journey-arrow` gets explicit `margin-inline` (≈`--space-2xs`) so its spacing no longer depends on the container `gap`, and the glyph size rises to ~`--step-0` so it is not hairline. Applies uniformly to both the process row and the new outcome row.
+
+### D5: Mobile narrow-width fallback — allow wrap
+
+At 360px the outcome row holds three nodes plus connector/divider. The row is allowed to `flex-wrap`; if it wraps, `落選` drops to a second line. Even the wrapped worst case (~2×44px ≈ 110px) stays well under the current ~214px, so the half-height target holds either way.
+
+## Risks / Trade-offs
+
+- **Weaker win/lose visual separation** (cards removed) → Mitigation: keep the divider, route dimming, and distinct per-status hues; the lose route stays visually distinct via its red hue and the separator.
+- **Radiogroup arrow-key expectations shift** (outcome was vertical, now horizontal) → Mitigation: the existing `onJourneyKeydown` handler already drives selection across the node set; verify Left/Right and Up/Down both still traverse the nodes and adjust the handler only if a direction regresses.
+- **Visual regression baselines** → Mitigation: this is an intentional UI change; expect to regenerate the frontend visual baselines (delete the visual-baselines CI artifact to force regen) and re-confirm component/E2E `journey-btn` tests pass.
+- **Cramped row on very narrow / large-font devices** → Mitigation: D5 wrap fallback prevents overflow; nodes keep `flex: 1 1 auto`.
+
+## Migration Plan
+
+Pure frontend, no data or API migration. Ship as a normal frontend PR. Rollback is reverting the CSS/template diff. No feature flag needed.
+
+## Open Questions
+
+- Exact divider treatment between the win and lose routes (middot `·`, a thin vertical rule, or just spacing) — to be finalized during implementation against the live sheet.

--- a/openspec/changes/compact-ticket-status-layout/proposal.md
+++ b/openspec/changes/compact-ticket-status-layout/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+On the concert detail sheet, the "チケット状況" (ticket status) control occupies far more vertical space than its information density warrants — roughly two-thirds of it is the "結果" (outcome) phase, which stacks the win route (`当選・未入金 → ↓ → 入金済み`) vertically inside one bordered card and the lose route (`落選`) inside a second bordered card below it. On a mobile sheet this pushes the primary action buttons (公式情報を見る, etc.) far down the scroll. The control should fit in roughly half its current height. Separately, the flow arrow (`›`) between nodes is visually cramped — it has no dedicated inline margin and a hairline glyph, so it reads as squeezed between the chips.
+
+## What Changes
+
+- Lay the outcome phase out **horizontally** in a single row — the win route (`当選・未入金 › 入金済み`) and the lose route (`落選`) sit side by side, separated by a lightweight divider, instead of two vertically stacked bordered cards.
+- Remove the per-route bordered card chrome (border + padding); rely on the divider and existing route dimming to keep the win/lose routes distinguishable.
+- Replace the vertical down-arrow (`↓`) connector with the horizontal `›` connector, unifying both phases on one connector style.
+- Give the flow arrow dedicated inline breathing room (explicit `margin-inline`) and a slightly larger glyph so it no longer reads as cramped — applies to both the process row and the new outcome row.
+- Net effect: the ticket-status control's vertical footprint drops to ~half of its current height while preserving every node, the radiogroup semantics, and the canonical per-status label/icon/hue.
+
+Non-goals: no change to journey state machine, status values, i18n keys, the canonical status presentation map, or any RPC behavior. Tap targets stay at the 44px accessibility minimum.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `concert-detail`: The journey-status control's outcome phase changes from a vertically stacked two-card layout to a compact single-row horizontal layout, halving the control's vertical footprint while keeping all status nodes and radiogroup behavior.
+
+## Impact
+
+- **frontend** only: `src/components/live-highway/event-detail-sheet.css` (outcome/route/arrow rules), and a small template touch in `event-detail-sheet.html` to retire the `journey-arrow-down` modifier.
+- DOM structure, radiogroup roles, `data-testid` hooks, and keyboard navigation handler are preserved; existing component/E2E tests for the journey control should continue to pass (with possible visual-baseline regeneration).
+- No specification/proto, backend, or BSR impact.

--- a/openspec/changes/compact-ticket-status-layout/specs/concert-detail/spec.md
+++ b/openspec/changes/compact-ticket-status-layout/specs/concert-detail/spec.md
@@ -1,0 +1,32 @@
+## ADDED Requirements
+
+### Requirement: Compact journey-status control layout
+
+The concert detail sheet's ticket-journey status control SHALL render in a compact layout whose outcome phase is arranged horizontally in a single row, so the control's vertical footprint is roughly half of a vertically stacked outcome layout. The control SHALL preserve every journey status node, the radiogroup semantics, keyboard navigation, and the canonical per-status label, icon, and hue.
+
+#### Scenario: Outcome routes arranged horizontally
+
+- **WHEN** the ticket-journey status control is displayed
+- **THEN** the win route nodes (`unpaid`, `paid`) and the lose route node (`lost`) SHALL be arranged horizontally in a single row rather than as vertically stacked bordered cards
+- **AND** the win-route nodes SHALL be connected by the horizontal `›` flow connector (not a vertical `↓` connector)
+- **AND** the win route and lose route SHALL remain visually distinguishable via a separator and their per-status hues
+
+#### Scenario: All status nodes and behavior preserved
+
+- **WHEN** the compact layout is rendered
+- **THEN** all five status nodes (`tracking`, `applied`, `unpaid`, `paid`, `lost`) SHALL still be present and selectable
+- **AND** each node SHALL retain a tap target of at least 44px
+- **AND** the radiogroup role, keyboard navigation, and `data-testid` hooks SHALL be unchanged
+- **AND** each node's label, icon, and hue SHALL still be sourced from the canonical journey-status presentation map
+
+#### Scenario: Flow connector is not cramped
+
+- **WHEN** a flow connector (`›`) is rendered between two status nodes in either the process phase or the outcome phase
+- **THEN** the connector SHALL have dedicated inline spacing on both sides independent of the container gap
+- **AND** the connector glyph SHALL be rendered at a size that is legible rather than hairline
+
+#### Scenario: Narrow viewport does not overflow
+
+- **WHEN** the control is displayed on a narrow mobile viewport where the outcome row cannot fit on one line
+- **THEN** the outcome row SHALL wrap rather than overflow horizontally
+- **AND** the control's vertical footprint SHALL remain smaller than the prior vertically stacked outcome layout

--- a/openspec/changes/compact-ticket-status-layout/tasks.md
+++ b/openspec/changes/compact-ticket-status-layout/tasks.md
@@ -1,0 +1,31 @@
+## 1. Layout implementation (CSS)
+
+- [ ] 1.1 In `event-detail-sheet.css`, change `.journey-outcome` from `flex-direction: column` to a horizontal row holding the win route and lose route side by side
+- [ ] 1.2 Flatten `.journey-route-success` to lay `unpaid › paid` horizontally instead of stacked
+- [ ] 1.3 Remove the bordered-card chrome (`border` + `padding`) from `.journey-route`; introduce a lightweight separator between the win and lose routes and keep `data-dimmed` route dimming
+- [ ] 1.4 Allow the outcome row to `flex-wrap` so a narrow (~360px) viewport wraps instead of overflowing; keep node `flex: 1 1 auto` and the 44px (`min-block-size: 2.75rem`) tap target intact
+- [ ] 1.5 Give `.journey-arrow` dedicated `margin-inline` (≈`--space-2xs`) independent of the container gap, and raise the glyph size to ~`--step-0` so it is not hairline
+- [ ] 1.6 Remove the `.journey-arrow-down` rule (vertical `↓`); both phases now use the horizontal `›`
+
+## 2. Template cleanup
+
+- [ ] 2.1 In `event-detail-sheet.html`, remove the `journey-arrow-down` modifier from the win-route connector so it renders the horizontal `›`
+- [ ] 2.2 Confirm the DOM structure, radiogroup roles, `data-testid` hooks, and `keydown.trigger="onJourneyKeydown"` binding are unchanged
+
+## 3. Behavior & accessibility verification
+
+- [ ] 3.1 Verify radiogroup keyboard navigation still traverses all five nodes in the new horizontal arrangement (Left/Right and Up/Down); adjust `onJourneyKeydown` only if a direction regresses
+- [ ] 3.2 Measure the control's vertical footprint and confirm it is ~half the prior height on a mobile viewport
+- [ ] 3.3 Confirm each node still shows the canonical label/icon/hue and that win/lose routes stay visually distinguishable
+
+## 4. Tests & checks
+
+- [ ] 4.1 Run `make check` (lint + unit) in `frontend` and fix any failures
+- [ ] 4.2 Update/confirm component and Playwright E2E tests for the journey control (`journey-btn`, `journey-remove-btn`) still pass; E2E mocks the RPC (dev env is intentionally stopped — mock, do not proxy)
+- [ ] 4.3 Regenerate frontend visual baselines for the changed sheet (intentional UI change blocks merge until the visual-baselines CI artifact is deleted to force regen)
+
+## 5. Ship
+
+- [ ] 5.1 Open the frontend PR (commit with `Refs: #<issue>`; body explains the why) and drive CI to green
+- [ ] 5.2 Merge to `main` after all CI checks pass and review comments are resolved
+- [ ] 5.3 Cut the frontend prod release (GH Release retag → prod AR; automated repository_dispatch bumps the cloud-provisioning prod pin → ArgoCD auto-sync) and confirm the change is live in prod


### PR DESCRIPTION
## 🔗 Related Issue

close: #588

## 📝 Summary of Changes

Adds the OpenSpec change `compact-ticket-status-layout` (proposal + design + specs + tasks). No proto or generated-code changes — documentation only.

**Motivation:** On the concert detail sheet, the "チケット状況" ticket-journey control spends roughly two-thirds of its height on the "結果" (outcome) phase, which stacks the win route (`当選・未入金 → ↓ → 入金済み`) vertically in one bordered card and the lose route (`落選`) in a second card below. On a mobile sheet this pushes the primary action buttons far down the scroll. The flow arrow (`›`) is also cramped — no dedicated inline margin and a hairline glyph.

**Proposed approach (recorded in this change):**
- Lay the outcome phase out horizontally in a single row (`当選・未入金 › 入金済み · 落選`) instead of two vertically stacked cards.
- Drop the per-route bordered card chrome; distinguish win/lose via a separator + existing route dimming and per-status hue.
- Unify both phases on the horizontal `›` connector (retire the vertical `↓`).
- Give the arrow dedicated `margin-inline` and a non-hairline glyph.
- Net effect: the control's vertical footprint drops to ~half while preserving every node, the 44px tap target, radiogroup semantics, keyboard navigation, and the canonical label/icon/hue.

**Capability:** modifies `concert-detail` (ADDED requirement: *Compact journey-status control layout*). Implementation scope is frontend-only (`event-detail-sheet.{css,html}`).

## ✅ Self-Checklist

- [x] I have linked the related issue.
- [x] I have updated the relevant documentation (OpenSpec change artifacts).
- [x] I have run `buf lint` and `buf format` locally (no proto changes; pre-commit hooks passed).
- [x] My proto definitions follow the project's style guidelines and validation rules. (N/A — no proto changes)
- [x] Breaking changes have been justified and documented if applicable. (N/A — none)
