### PR TITLE
docs(openspec): mark sales-phase-timeline 0.2 done (ticket-email-import archived)

### DIFF
--- a/openspec/changes/add-sales-phase-timeline/tasks.md
+++ b/openspec/changes/add-sales-phase-timeline/tasks.md
@@ -1,7 +1,7 @@
 ## 0. Prerequisites
 
 - [ ] 0.1 `auto-discovery-series-grouping` is implemented/merged so a `Series` represents a whole tour (the Series-scoped `SalesPhase` model depends on it) — NOT met yet (that change is 0/21); code is built against the assumed tour-level Series and needs no migration once it lands
-- [ ] 0.2 At OpenSpec archive time, ensure the in-flight `ticket-email-import` change is archived first (this change MODIFIES its spec baseline)
+- [x] 0.2 At OpenSpec archive time, ensure the in-flight `ticket-email-import` change is archived first (this change MODIFIES its spec baseline) — satisfied: `ticket-email-import` archived as `openspec/changes/archive/2026-06-04-ticket-email-import`, so the MODIFIED baseline now exists in `openspec/specs/`
 
 ## 1. Proto Definitions (specification)
 


### PR DESCRIPTION
Marks task 0.2 of `add-sales-phase-timeline` complete: the archive-ordering prerequisite is satisfied now that `ticket-email-import` is archived (`openspec/changes/archive/2026-06-04-ticket-email-import`), so the MODIFIED spec baseline exists in `openspec/specs/`. Docs only.

Progress: **48/53**. Remaining: 0.1 (external prereq), 1.5 (optional), 8.2/8.3/8.5 (held prod verification).

Refs: #571