### PR TITLE
docs(openspec): propose remove-gpl-zk-prover change

### DIFF
--- a/openspec/changes/remove-gpl-zk-prover/.openspec.yaml
+++ b/openspec/changes/remove-gpl-zk-prover/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-05

--- a/openspec/changes/remove-gpl-zk-prover/design.md
+++ b/openspec/changes/remove-gpl-zk-prover/design.md
@@ -1,0 +1,82 @@
+## Context
+
+Liverty's ticket-entry flow uses a Semaphore-style Groth16 zk-SNARK: the fan proves on-device that they know a `trapdoor` whose Poseidon commitment is a leaf in an event's Merkle tree, plus a nullifier to prevent double-entry. Proof generation runs in a Web Worker (`proof.worker.ts`) so the `trapdoor` (private input) never leaves the device — this client-side locality IS the privacy guarantee. The backend verifies with `gnark` (Apache-2.0) via the `vocdoni/circom2gnark` adapter.
+
+**Decision history — why the GPL library is here.** The original ticket-system MVP research (`implement-ticket-system-mvp/research/zkp-browser-client.md`, 2026-02-20) selected `circom + snarkjs` on three grounds: (1) it was the only production-ready browser Groth16 prover whose output the `gnark` backend can verify; (2) full offline WASM support for venue entry; (3) the `circomlib` template ecosystem (Poseidon/Merkle/nullifier). **License was never an evaluation criterion** — `snarkjs`, `ffjavascript`, and `circomlib` are all GPL-3.0, and this was not noticed. The same research explicitly flagged `arkworks` (`ark-circom`) as the intended successor "if [browser `wasm-bindgen`] lands in 2026 … 10–20x faster proving and compatible Groth16 output," tracked via mopro issue #290. As of 2026-06 that tooling has landed (mopro documents web builds via `wasm-bindgen-rayon` with the arkworks circom prover). This change therefore executes a pre-scoped upgrade, not a novel rewrite.
+
+**The two GPL vectors in the distributed bundle:**
+1. Proving runtime: `snarkjs` + `ffjavascript` (GPL-3.0), imported verbatim into the worker chunk.
+2. Circuit artifacts: `ticketcheck.wasm` (2.0 MB) + `ticketcheck.zkey` (3.1 MB), compiled from a circuit that `include`s `circomlib`'s GPL-3.0 `poseidon.circom`.
+
+Backend verification (`gnark` / `circom2gnark`) is already permissively licensed and is not a GPL source.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Remove all copyleft (GPL-3.0) licensed code from the distributed frontend bundle, across both vectors.
+- Preserve the proof's verifiability by the existing `gnark` backend (BN254 Groth16, snarkjs-compatible proof JSON), ideally with zero backend change.
+- Preserve on-device proof generation (privacy), offline capability (Service Worker caching), and SHA-256 circuit-integrity verification.
+- Resolve, before any irreversible swap, the two cost-determining unknowns (R1CS reuse; browser prover viability).
+
+**Non-Goals:**
+- The OSS-license page UI and the legal three-set (terms / privacy / OSS licenses) — separate change.
+- Moving proof generation server-side — rejected: it would expose the `trapdoor` and destroy the zero-knowledge privacy model.
+- Migrating to a non-Groth16 proof system (Noir/halo2/plonky2) — rejected: incompatible with the `gnark` Groth16 verifier (same constraint that drove the original snarkjs choice).
+- Changing the `EntryService` RPC contracts (`GetMerklePath` / `VerifyEntry`) — they are library-agnostic and unchanged.
+
+## Decisions
+
+### Decision 1: Path A (replace with permissive prover) over Path B (arm's-length isolation) — RECOMMENDED, final call gated
+
+**Choice (recommended):** Path A — eliminate the GPL code physically. Swap `snarkjs` → `ark-circom`/arkworks (MIT/Apache) WASM prover; swap `circomlib` poseidon → an MIT-relicensed Poseidon source and recompile.
+
+**Rationale:** For a proprietary, app-store-bound product, removing the GPL code is unambiguous and one-time. The only hard constraint that ever justified snarkjs — gnark-verifiable Groth16 output — is met by arkworks (same BN254 Groth16). Current proof time (~2 s in-browser for this 5286-constraint circuit) is already acceptable, so Path A is justified by licensing alone; the potential 10–20x speedup is a bonus that de-risks "will a rewrite hurt mobile UX."
+
+**Alternative — Path B (fallback):** Keep `snarkjs` but treat the Web Worker as a separate GPL-3.0 program communicating at arm's length via `postMessage` (serialized `{input}` → `{proof}`, no linking/shared memory ≈ mere aggregation). Ship the worker chunk as the GPL component with a written source offer + license text. Near-zero code change, but relies on the contested separate-program interpretation and on the bundler never inlining `snarkjs` into the main chunk. Reserve as an interim if a launch deadline precedes Path A completion, or if a verification gate makes Path A infeasible.
+
+**The final A/B decision is gated by the two verification tasks below — keep it open until both report.**
+
+### Decision 2: Reuse the existing `.zkey` / verification key if the recompiled R1CS is identical
+
+**Choice:** Use an MIT-licensed Poseidon `circom` source that is structurally identical to `circomlib`'s (e.g., the Semaphore-relicensed `poseidon.circom`, MIT since 2022-07; Poseidon's BN254 constants are spec-fixed, so a faithful reimplementation yields the same constraints). Recompile and compare the R1CS / circuit hash against the current artifacts.
+
+- **Identical** → reuse existing `ticketcheck.zkey` and backend `verification_key.json`; no new trusted setup; backend untouched.
+- **Divergent** → run a fresh Groth16 phase-2 setup and deploy a new `verification_key.json` to the backend (coordinated cross-repo change).
+
+**Rationale:** This is the single largest cost fork. Reuse keeps the change frontend-local; divergence pulls in a ceremony + backend release.
+
+### Decision 3: Preserve the proof-JSON / gnark contract with a thin adapter if needed
+
+**Choice:** The new prover must emit a proof + public signals that `vocdoni/circom2gnark` → `gnark.Verify` accepts unchanged. `ark-circom` outputs Groth16/BN254 but its native serialization may differ from snarkjs's `proof.json` shape; if so, add a thin frontend adapter that re-serializes to the snarkjs format the backend already parses.
+
+**Rationale:** Keeps backend verification a no-op change and isolates all churn to the frontend.
+
+### Decision 4: Threading model is an open decision tied to cross-origin isolation
+
+**Choice (deferred):** Prefer multithreaded WASM (`wasm-bindgen-rayon`) for the speedup, but only if cross-origin isolation (COOP/COEP) can be enabled without breaking the PWA (Service Worker, CSP, PostHog and other third-party embeds). Otherwise fall back to single-threaded WASM and accept slower proving. Resolved by verification gate 2.
+
+## Risks / Trade-offs
+
+- **R1CS divergence forces a trusted-setup + backend vkey deploy** → Mitigation: verification gate 1 compiles and diff-checks the R1CS hash before committing; if divergent, coordinate a backend `verification_key.json` release via the cross-repo workflow.
+- **`ark-circom` browser path is less battle-tested than its mobile-native path** (mopro's core is iOS/Android UniFFI bindings; Liverty is PWA-first and needs the pure-browser WASM path) → Mitigation: verification gate 2 spikes the actual browser build and benchmarks on real mobile browsers before adoption.
+- **Multithreaded WASM requires COOP/COEP**, which can break third-party embeds and complicate CSP → Mitigation: treat threading as optional; validate header impact in a spike; single-threaded fallback always available.
+- **New Rust→WASM build step** adds toolchain complexity (`wasm-bindgen`, possibly `wasm-pack`) to a TS frontend → Mitigation: vendor a prebuilt WASM artifact + bindings, or isolate the Rust build behind a single make target; keep it out of the hot dev loop.
+- **Bundle/WASM size regression** vs current snarkjs (~1–1.5 MB JS + 5.2 MB artifacts) → Mitigation: measure in gate 2; the artifacts are reused, only the prover JS/WASM changes.
+- **Interim Path B legal interpretation may be rejected by counsel** → Mitigation: Path B is fallback-only and time-boxed; Path A remains the target end state.
+
+## Migration Plan
+
+1. Run verification gate 1 (R1CS reuse) and gate 2 (browser prover viability) — both are reversible spikes, no production impact.
+2. Decide A vs B from gate results; record the decision here.
+3. (Path A) Recompile circuit from MIT Poseidon; regenerate artifacts + SHA-256 integrity manifest; reuse or regenerate `.zkey`/vkey per gate 1.
+4. (Path A) Integrate the arkworks WASM prover behind the existing `ProofService` interface; keep `proof.worker.ts`'s `postMessage` contract stable; add the proof-JSON adapter if needed.
+5. Verify end-to-end against the unchanged (or newly-keyed) backend with a known-good proof round-trip.
+6. Remove `snarkjs` / `ffjavascript` from `package.json`; confirm the distributed bundle is GPL-free.
+7. **Rollback:** the prover swap is behind the worker boundary; reverting the dependency + artifacts restores the prior behavior. If a new vkey was deployed, roll it back in lockstep with the frontend.
+
+## Open Questions
+
+- **A vs B final decision** — pending verification gates (Decision 1).
+- **R1CS identical?** — pending compile-and-diff (Decision 2 / gate 1).
+- **Multithreaded vs single-threaded WASM** — pending COOP/COEP feasibility on the PWA (Decision 4 / gate 2).
+- **`ark-circom` directly vs via mopro** — direct `circom-compat` + hand-rolled `wasm-bindgen` wrapper, versus mopro's adapter; decide in gate 2 by maintenance/bundle trade-off.

--- a/openspec/changes/remove-gpl-zk-prover/proposal.md
+++ b/openspec/changes/remove-gpl-zk-prover/proposal.md
@@ -4,7 +4,7 @@ The frontend bundle distributed to every fan's browser contains GPL-3.0 code thr
 
 ## What Changes
 
-- Replace the client-side proving runtime `snarkjs` (GPL-3.0) with an `arkworks` / `ark-circom`-based prover (MIT/Apache-2.0) compiled to WASM, reusing the existing circom `.wasm` witness calculator and `.zkey` proving key.
+- Replace the client-side proving runtime `snarkjs` (GPL-3.0) with an `arkworks` / `ark-circom`-based prover (MIT/Apache-2.0) compiled to WASM; the existing `.zkey` proving key is reused only if gate 1 confirms an identical R1CS hash. The witness-calculator `.wasm` is GPL vector ② and is unconditionally recompiled from permissive sources (see the next bullet), never reused as-is.
 - Replace the GPL-3.0 `circomlib` `poseidon.circom` include with a permissively-licensed (MIT) Poseidon source and recompile the circuit artifacts, so the distributed `.wasm` / `.zkey` derive from non-copyleft sources.
 - Preserve the hard invariant that generated proofs remain verifiable by the existing `gnark` + `vocdoni/circom2gnark` backend (BN254 Groth16, snarkjs-compatible proof JSON) — backend verification stays unchanged when the proof format and verification key are preserved.
 - Preserve offline proof generation (Service Worker caching of prover WASM + circuit artifacts) and SHA-256 circuit-integrity verification; regenerate integrity hashes after recompilation.

--- a/openspec/changes/remove-gpl-zk-prover/proposal.md
+++ b/openspec/changes/remove-gpl-zk-prover/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+The frontend bundle distributed to every fan's browser contains GPL-3.0 code through two paths: the proving runtime (`snarkjs` + `ffjavascript`, imported by `proof.worker.ts`) and the circuit artifacts (`ticketcheck.wasm` / `ticketcheck.zkey`, compiled from `circomlib`'s GPL-3.0 `poseidon.circom`). Serving a JavaScript/WASM bundle that embeds this code is distribution under the GPL, which is incompatible with shipping Liverty as a proprietary, app-store-bound product. The license was never evaluated when `snarkjs` was selected; the original choice was driven purely by it being the only production-ready browser Groth16 prover compatible with the `gnark` backend verifier. The original design research already named `arkworks` as the intended successor once browser WASM tooling matured — that tooling (mopro / `wasm-bindgen`) has now landed, so this is the planned upgrade, not a risky deviation.
+
+## What Changes
+
+- Replace the client-side proving runtime `snarkjs` (GPL-3.0) with an `arkworks` / `ark-circom`-based prover (MIT/Apache-2.0) compiled to WASM, reusing the existing circom `.wasm` witness calculator and `.zkey` proving key.
+- Replace the GPL-3.0 `circomlib` `poseidon.circom` include with a permissively-licensed (MIT) Poseidon source and recompile the circuit artifacts, so the distributed `.wasm` / `.zkey` derive from non-copyleft sources.
+- Preserve the hard invariant that generated proofs remain verifiable by the existing `gnark` + `vocdoni/circom2gnark` backend (BN254 Groth16, snarkjs-compatible proof JSON) — backend verification stays unchanged when the proof format and verification key are preserved.
+- Preserve offline proof generation (Service Worker caching of prover WASM + circuit artifacts) and SHA-256 circuit-integrity verification; regenerate integrity hashes after recompilation.
+- **BREAKING** (build/deploy, not API): adopting multithreaded WASM proving (`wasm-bindgen-rayon`) requires cross-origin isolation (COOP/COEP) headers — a hosting/CSP change. A single-threaded fallback avoids this at a performance cost; the threading decision is an open decision resolved by the verification gates.
+- Two verification gates precede the irreversible swap and decide final cost/approach: (1) whether the MIT-Poseidon recompile yields an identical R1CS so existing `.zkey`/verification key can be reused, and (2) whether the `ark-circom` browser WASM prover is production-viable for a PWA (threading model, bundle/WASM size, real mobile-browser proof time, proof-JSON compatibility).
+
+## Capabilities
+
+### New Capabilities
+- `client-zk-proving`: The browser-side zero-knowledge proving runtime — its license constraint (no copyleft code in the distributed bundle), its output contract (gnark-verifiable BN254 Groth16), offline capability, and circuit-integrity verification. Currently implicit in the ticket-system MVP; this change makes it explicit and removes the GPL dependency.
+
+### Modified Capabilities
+<!-- zkp-entry (backend EntryService RPC contracts) is library-agnostic and unchanged.
+     frontend-hosting may gain a conditional cross-origin-isolation requirement only if
+     multithreaded WASM is adopted; that decision is deferred to design.md, so no delta
+     spec is forced here. -->
+
+## Impact
+
+- **Frontend code**: `src/workers/proof.worker.ts` (prover swap), `src/services/proof-service.ts` (worker invocation / proof serialization adapter), `src/resource.d.ts` (drop `snarkjs` module decl).
+- **Dependencies**: remove `snarkjs` + transitive `ffjavascript` (GPL-3.0); add `ark-circom` / mopro-based WASM prover (MIT/Apache); new Rust→WASM build step (`wasm-bindgen`) in the frontend pipeline.
+- **Circuit artifacts**: `frontend/circuits/ticketcheck-v1/ticketcheck.circom` (poseidon include source), regenerated `public/circuits/ticketcheck-v1/ticketcheck.wasm` + `ticketcheck.zkey`, and their SHA-256 integrity manifest.
+- **Backend**: `internal/infrastructure/zkp/verifier.go` — unchanged if the verification key and proof JSON format are preserved; requires a new `verification_key.json` only if the R1CS changes (verification gate 1).
+- **Hosting / PWA**: Caddyfile / CSP and Service Worker caching, plus conditional COOP/COEP cross-origin-isolation headers if multithreaded WASM proving is adopted.
+- **Out of scope**: the OSS-license page UI and the legal three-set (terms / privacy / OSS licenses) are tracked as a separate change.

--- a/openspec/changes/remove-gpl-zk-prover/specs/client-zk-proving/spec.md
+++ b/openspec/changes/remove-gpl-zk-prover/specs/client-zk-proving/spec.md
@@ -1,0 +1,94 @@
+## ADDED Requirements
+
+### Requirement: Distributed bundle contains no copyleft-licensed code
+
+The frontend artifacts served to a fan's browser — the zero-knowledge proving runtime and the circuit artifacts (witness-calculator WASM and proving key) — SHALL NOT contain or be derived from copyleft-licensed (GPL-family) sources. The proving runtime SHALL be licensed under a permissive license (MIT, BSD, or Apache-2.0). The circuit artifacts SHALL be compiled from permissively-licensed circuit sources.
+
+#### Scenario: Proving runtime is permissively licensed
+
+- **WHEN** the production frontend bundle is built and inspected
+- **THEN** it SHALL NOT include `snarkjs`, `ffjavascript`, or any other GPL-family package
+- **AND** the zero-knowledge proving runtime present SHALL be licensed under MIT, BSD, or Apache-2.0
+
+#### Scenario: Circuit artifacts derive from permissive sources
+
+- **WHEN** the `ticketcheck` circuit is recompiled
+- **THEN** every `include`d circuit source (including the Poseidon implementation) SHALL be permissively licensed
+- **AND** the published `.wasm` and `.zkey` artifacts SHALL be the output of that permissively-licensed compilation
+
+#### Scenario: License check can be enforced mechanically
+
+- **WHEN** a dependency license audit runs over the distributed frontend dependencies
+- **THEN** it SHALL report zero GPL-family licenses in the shipped runtime
+
+### Requirement: Client-generated proofs remain verifiable by the gnark backend
+
+The client-side proving runtime SHALL produce BN254 Groth16 proofs and public signals that the existing backend verifier (`gnark` via `vocdoni/circom2gnark`) accepts. Changing the proving runtime SHALL NOT, by itself, require a backend code change; a backend change SHALL be required only if the circuit's verification key changes.
+
+#### Scenario: Proof round-trips through the unchanged backend
+
+- **WHEN** the new runtime generates a proof for a valid Merkle membership and nullifier, using a circuit whose verification key is unchanged
+- **THEN** the backend `VerifyEntry` handler SHALL verify it successfully without modification
+
+#### Scenario: Proof JSON conforms to the backend-parsed format
+
+- **WHEN** a proof is serialized for transport to `VerifyEntry`
+- **THEN** its JSON shape SHALL match the snarkjs-compatible format that `vocdoni/circom2gnark` parses
+- **AND** any difference in the runtime's native serialization SHALL be normalized to that format before transport
+
+#### Scenario: Verification key change is the only trigger for a backend update
+
+- **WHEN** circuit recompilation yields an R1CS identical to the current artifacts
+- **THEN** the existing `.zkey` and backend `verification_key.json` SHALL be reused unchanged
+- **WHEN** circuit recompilation yields a different R1CS
+- **THEN** a new trusted-setup output SHALL be produced and the backend `verification_key.json` SHALL be updated in lockstep
+
+### Requirement: Proof generation stays on-device
+
+The proving runtime SHALL generate proofs entirely within the browser so that the private input (`trapdoor`) never leaves the fan's device. The runtime SHALL NOT transmit the private input to any server.
+
+#### Scenario: Private input never sent to the server
+
+- **WHEN** a fan generates an entry proof
+- **THEN** all witness and proof computation SHALL occur in the browser
+- **AND** no request carrying the `trapdoor` or raw witness SHALL be sent to the backend
+
+### Requirement: Offline proof generation is preserved
+
+The proving runtime and circuit artifacts SHALL be cacheable by the Service Worker so that a fan can generate an entry proof without network connectivity at the venue.
+
+#### Scenario: Proof generation works offline
+
+- **WHEN** the prover WASM and circuit artifacts have been cached and the device is offline
+- **THEN** the fan SHALL still be able to generate a valid entry proof
+
+### Requirement: Circuit artifact integrity is verified before use
+
+Before using fetched circuit artifacts (`.wasm`, `.zkey`) for proof generation, the runtime SHALL verify each artifact against its expected SHA-256 hash and SHALL refuse to generate a proof if verification fails. Recompiled artifacts SHALL ship with a regenerated integrity manifest.
+
+#### Scenario: Tampered artifact is rejected
+
+- **WHEN** a fetched circuit artifact's SHA-256 hash does not match the expected manifest value
+- **THEN** the runtime SHALL NOT generate a proof
+- **AND** SHALL surface an integrity error
+
+#### Scenario: Integrity manifest matches recompiled artifacts
+
+- **WHEN** the circuit is recompiled with permissive sources
+- **THEN** the SHA-256 integrity manifest SHALL be regenerated to match the new artifacts
+
+### Requirement: Cross-origin isolation when multithreaded proving is used
+
+IF the proving runtime uses multithreaded WASM (shared-memory threading), THEN the application SHALL serve the cross-origin isolation headers (COOP and COEP) required to enable `SharedArrayBuffer`, without breaking Service Worker registration or required third-party embeds. IF cross-origin isolation cannot be enabled compatibly, THEN the runtime SHALL fall back to single-threaded proving.
+
+#### Scenario: Multithreaded proving requires isolation headers
+
+- **WHEN** the runtime is built to use shared-memory WASM threads
+- **THEN** the document SHALL be cross-origin isolated (COOP `same-origin` + COEP enforced)
+- **AND** Service Worker registration and required embeds SHALL continue to function
+
+#### Scenario: Fallback when isolation is not feasible
+
+- **WHEN** cross-origin isolation would break a required integration
+- **THEN** the runtime SHALL use the single-threaded proving path instead
+- **AND** SHALL still produce a gnark-verifiable proof

--- a/openspec/changes/remove-gpl-zk-prover/tasks.md
+++ b/openspec/changes/remove-gpl-zk-prover/tasks.md
@@ -1,0 +1,54 @@
+## 1. Verification Gate 1 — R1CS reuse (decides backend impact)
+
+- [ ] 1.1 Identify a permissively-licensed (MIT) Poseidon `circom` source structurally equivalent to `circomlib`'s (e.g. the Semaphore-relicensed `poseidon.circom`); record its license provenance
+- [ ] 1.2 Recompile `ticketcheck.circom` with the MIT Poseidon include; capture the resulting R1CS and circuit hash
+- [ ] 1.3 Diff the recompiled R1CS / circuit hash against the current `ticketcheck-v1` artifacts
+- [ ] 1.4 Record the outcome: identical → reuse existing `.zkey` + backend `verification_key.json`; divergent → schedule a fresh phase-2 trusted setup + backend vkey deploy
+
+## 2. Verification Gate 2 — browser prover viability (decides Path A feasibility & threading)
+
+- [ ] 2.1 (a) Spike `ark-circom`/arkworks circom Groth16 proving in a pure-browser WASM build (no native bindings), reusing the existing `ticketcheck.wasm` witness calculator and `.zkey`; confirm it produces a proof in a Web Worker for a known input
+- [ ] 2.2 (b) Evaluate the threading model: attempt multithreaded `wasm-bindgen-rayon` and verify whether COOP/COEP cross-origin isolation can be enabled without breaking Service Worker registration, CSP, or third-party embeds (PostHog etc.); also benchmark the single-threaded fallback
+- [ ] 2.3 (c) Measure prover JS + WASM bundle size and real proof-generation time on representative mobile browsers (mid- and low-end); A/B against the current snarkjs baseline (~2 s in-browser)
+- [ ] 2.4 (d) Confirm the prover's proof + public-signals output is accepted by `vocdoni/circom2gnark` → `gnark.Verify`; if the native serialization differs, prototype the thin snarkjs-format JSON adapter
+- [ ] 2.5 Decide `ark-circom` directly (hand-rolled `wasm-bindgen` wrapper) vs via mopro adapter, based on maintenance/bundle trade-off
+- [ ] 2.6 Record gate 2 outcome (viable / not viable; threaded / single-threaded)
+
+## 3. Decision Checkpoint — Path A vs Path B
+
+- [ ] 3.1 From gates 1 & 2, decide Path A (replace) or Path B (arm's-length interim); update `design.md` Open Questions with the resolution and rationale
+- [ ] 3.2 If Path B is chosen as interim, branch to section 8; otherwise proceed with Path A (sections 4–7)
+
+## 4. Path A — Circuit artifacts (vector ②: remove GPL Poseidon)
+
+- [ ] 4.1 Commit the MIT Poseidon include change to `frontend/circuits/ticketcheck-v1/ticketcheck.circom`; remove the `circomlib` GPL dependency from the circuit's `package.json`
+- [ ] 4.2 Regenerate `public/circuits/ticketcheck-v1/ticketcheck.wasm` and `ticketcheck.zkey` (reuse existing `.zkey` if gate 1 was identical; otherwise run the new trusted setup)
+- [ ] 4.3 Regenerate the SHA-256 circuit-integrity manifest to match the new artifacts
+- [ ] 4.4 If the R1CS diverged, deploy the new `verification_key.json` to the backend in lockstep (cross-repo coordination)
+
+## 5. Path A — Proving runtime (vector ①: remove snarkjs)
+
+- [ ] 5.1 Add the arkworks-based WASM prover (MIT/Apache) and its build step to the frontend pipeline; keep the Rust→WASM build behind a single make target
+- [ ] 5.2 Replace `groth16.fullProve` in `src/workers/proof.worker.ts` with the new prover, keeping the worker's `postMessage` request/result contract stable
+- [ ] 5.3 Add the snarkjs-format proof-JSON adapter in the worker / `proof-service.ts` if gate 2(d) showed a serialization mismatch
+- [ ] 5.4 Remove the `snarkjs` module declaration from `src/resource.d.ts`
+- [ ] 5.5 Apply the chosen threading decision (multithreaded + COOP/COEP, or single-threaded fallback) per gate 2(b)
+
+## 6. Path A — Cross-origin isolation (only if multithreaded)
+
+- [ ] 6.1 Add COOP/COEP headers in the Caddyfile / hosting config; reconcile with the existing CSP
+- [ ] 6.2 Verify Service Worker registration, circuit caching, and required third-party embeds still function under isolation
+
+## 7. Path A — Remove GPL, verify, and ship
+
+- [ ] 7.1 Remove `snarkjs` (and transitive `ffjavascript`) from `package.json`; run `make check`
+- [ ] 7.2 Run a dependency license audit over the production frontend deps and confirm zero GPL-family licenses in the shipped runtime
+- [ ] 7.3 End-to-end test: generate a proof with the new runtime and verify it round-trips through `VerifyEntry` (unchanged backend, or newly-keyed backend if vkey changed)
+- [ ] 7.4 Update the OSS-license inventory to reflect the removed GPL deps (hand-off note to the separate OSS-license-page change)
+- [ ] 7.5 Open the frontend PR (and backend PR if vkey changed); merge after CI; ship to dev, then cut the production release so the GPL-free bundle reaches prod
+
+## 8. Path B — Arm's-length interim (only if chosen at 3.2)
+
+- [ ] 8.1 Configure the bundler so the `snarkjs` proving worker builds as a separate chunk and is never inlined into the main app chunk
+- [ ] 8.2 Add the GPL-3.0 written source offer + full license text to the distributed app and the OSS-license surface
+- [ ] 8.3 Document the arm's-length boundary as a build invariant (guard against future bundler changes that would inline snarkjs) and schedule Path A as the follow-up end state


### PR DESCRIPTION
## Summary

Adds the OpenSpec change `remove-gpl-zk-prover`, capturing the analysis and remediation plan for the **GPL-3.0 code currently distributed in the frontend zk-proving stack**.

The frontend bundle served to every fan's browser embeds GPL-3.0 via two paths — the `snarkjs`/`ffjavascript` proving runtime, and the `ticketcheck.wasm`/`.zkey` circuit artifacts compiled from `circomlib`'s GPL `poseidon.circom` — which is incompatible with shipping Liverty as a proprietary, app-store-bound product. The backend verifier (`gnark` + `vocdoni/circom2gnark`) is already permissively licensed and unaffected. Server-side proving is rejected because the `trapdoor` private input must stay on-device to preserve the zero-knowledge privacy model.

This PR contains **only the OpenSpec artifacts** (no code/implementation).

## Changes

- `proposal.md` — why the change is needed, the two GPL vectors, and scope boundaries.
- `design.md` — decision history (snarkjs was chosen for gnark-compatibility, never evaluated for license; arkworks was already the pre-scoped successor), Path A (replace with `ark-circom`/MIT-Poseidon) recommended over Path B (arm's-length worker isolation, interim), with the final A/B call left as a gated open decision.
- `specs/client-zk-proving/spec.md` — new capability: no-copyleft-in-bundle, gnark-verifiable BN254 Groth16 output, on-device generation, offline capability, circuit-integrity verification, and conditional cross-origin isolation for multithreaded WASM.
- `tasks.md` — implementation breakdown that front-loads the two verification gates and ends at a production release.

## Testing

- `openspec validate remove-gpl-zk-prover` → valid.
- Documentation-only change; no proto or code modifications.

## Out of scope

The OSS-license page UI and the legal three-set (terms / privacy / OSS licenses) are tracked as a separate change.

close: #594
