### PR TITLE
docs(openspec): propose add-legal-documents change

### DIFF
--- a/openspec/changes/add-legal-documents/.openspec.yaml
+++ b/openspec/changes/add-legal-documents/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-05

--- a/openspec/changes/add-legal-documents/design.md
+++ b/openspec/changes/add-legal-documents/design.md
@@ -1,0 +1,77 @@
+## Context
+
+Settings → 情報 (About) shows three rows — 利用規約 / プライバシーポリシー / OSSライセンス — all linking to empty `https://liverty.me/*` pages. The app is a guest-capable Aurelia 2 PWA with ja/en i18n already wired (`src/locales/{ja,en}/translation.json`, `settings.termsOfService` etc.). The route guard (`AuthHook`) already grants unauthenticated users early access to Settings, and public routes opt out via `data: { auth: false }`.
+
+The Privacy Policy is the load-bearing document: the app runs PostHog analytics with cross-border transfer to PostHog Cloud EU, which the consent layer already models against APPI Art. 28. The operating entity is at the individual-developer / trade-name stage, so concrete entity values (trade name, contact email) are fill-ins, not blockers — an individual is a valid 個人情報取扱事業者.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Give each legal document a stable in-app URL reachable by guests and store reviewers.
+- Produce review-ready full ja/en drafts of Terms and Privacy grounded in the real data inventory.
+- Keep the OSS Licenses list accurate automatically via build-time generation.
+- Scope the Privacy Policy to Japan/APPI; structure it so EU/GDPR clauses can be added later without a rewrite.
+
+**Non-Goals:**
+- GDPR compliance now — not required unless the service targets EU residents; PostHog Cloud EU is a processor location, not a GDPR trigger.
+- Standalone marketing site at `liverty.me` — in-app routes are the source of truth; a future external site can 301 to them.
+- Final legal sign-off — drafts are a starting point requiring professional review before launch.
+- Tokushōhō (特定商取引法) address disclosure — not required while there is no paid offering; a contact email suffices.
+
+## Decisions
+
+### Decision 1: In-app routes, not modal dialogs
+
+**Choice:** Render each document at a real route (`/legal/terms`, `/legal/privacy`, `/legal/licenses`).
+
+**Rationale:** App Store Connect and Google Play Console both require a reachable Privacy Policy **URL**; a modal/bottom-sheet has no URL and fails submission. Routes are also shareable and deep-linkable. The dialog idea (raised earlier) is fine for ephemeral content but cannot satisfy the store URL requirement, so it is rejected for these documents.
+
+**Alternatives considered:** External `liverty.me` pages (rejected: needs separate hosting + its own i18n, and duplicates content); modal dialog (rejected: no URL).
+
+### Decision 2: Guest-reachable public routes
+
+**Choice:** Register the `/legal/*` routes with `data: { auth: false }` so unauthenticated users and store reviewers can open them directly.
+
+**Rationale:** Store review happens without an account; legal docs must be reachable pre-auth. Consistent with the route guard's existing early-Settings access for guests.
+
+### Decision 3: Author Terms + Privacy as full drafts; auto-generate OSS Licenses
+
+**Choice:** Hand-author full ja/en drafts for Terms and Privacy from the verified data inventory. Generate the OSS Licenses page content at build time from the production dependency tree (`license-checker` or equivalent) into an artifact consumed by `/legal/licenses`.
+
+**Rationale:** Terms/Privacy require human judgment and entity specifics; OSS attribution is mechanical and rot-prone if hand-maintained. Auto-generation also doubles as a license audit (it surfaced the GPL issue in the first place).
+
+### Decision 4: Privacy Policy content contract (from the real inventory)
+
+The Privacy Policy SHALL enumerate, accurately:
+- **Collected data:** account email + user id (Zitadel, self-hosted), `safe_address`, home area, followed artists, language preference, push subscription / FCM token, PostHog events (cookies/localStorage).
+- **Purposes:** service provision; usage analysis (improvement); ad-effectiveness measurement; push delivery.
+- **Third-party processors / transfers:** PostHog Cloud EU (analytics; cross-border, APPI Art. 28), Resend (email, US), Google FCM/Web Push (push, US), Google Gemini/Vertex AI (concert search, US), Last.fm (artist metadata; browser-direct, IP exposure, UK). Zitadel is self-hosted → not a transfer.
+- **Consent withdrawal:** the Settings "使い心地の改善" / "広告効果の測定" toggles.
+- **Subject rights / contact:** disclosure / correction / deletion request channel = contact email.
+
+### Decision 5: Entity values as placeholders
+
+**Choice:** Drafts use clearly-marked placeholders (`<!-- 事業者名 -->`, `<!-- 連絡先メール -->`, governing law = Japanese law, jurisdiction = entity's district court). Implementation fills the real values.
+
+**Rationale:** Unblocks drafting and review structure without waiting on entity finalization.
+
+## Risks / Trade-offs
+
+- **Drafts mistaken for final legal text** → Mitigation: mark every draft "DRAFT — pending legal review" and gate launch on professional sign-off.
+- **Data inventory drifts as features change** (new SDK/processor added later) → Mitigation: the Privacy Policy's processor list must be revisited whenever a third-party integration is added; note this in the spec.
+- **OSS generator output churns the page on every dep bump** → Mitigation: generate at build time into a versioned artifact; the page reflects the shipped bundle, which is correct behavior.
+- **Auto-generated OSS list could still show GPL until `remove-gpl-zk-prover` lands** → Mitigation: the generator is the source of truth; if shipped before that change, the page truthfully lists GPL — acceptable transitional state, resolved when the prover swap merges.
+
+## Migration Plan
+
+1. Add `/legal/*` routes (public) + minimal page shells; repoint Settings About links.
+2. Land the OSS license generator + wire `/legal/licenses`.
+3. Author ja/en Terms + Privacy drafts; fill entity placeholders.
+4. Legal review pass; incorporate feedback.
+5. Ship to dev, then production release; update App Store Connect / Play Console Privacy Policy URL to `/legal/privacy`.
+6. **Rollback:** revert the Settings link targets to the prior external URLs; routes are additive and can be removed without side effects.
+
+## Open Questions
+
+- Final operating-entity values (trade name, contact email, jurisdiction) — supplied at implementation.
+- Whether to add a lightweight "last updated" date + version stamp per document (recommended for Privacy Policy change tracking).

--- a/openspec/changes/add-legal-documents/proposal.md
+++ b/openspec/changes/add-legal-documents/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+The Settings "About" section links to Terms of Service, Privacy Policy, and OSS Licenses, but all three point to `https://liverty.me/*` URLs that have no content. This is both a broken UX and a compliance gap: the app collects personal data (Zitadel account email/id, home area, follows, push subscriptions) and runs PostHog product analytics with cross-border transfer to PostHog Cloud EU — so a published Privacy Policy is mandatory under Japan's APPI (利用目的の公表 / 越境移転の情報提供) and is a hard requirement for App Store / Google Play submission (both require a reachable Privacy Policy URL). The OSS Licenses page is required by the attribution terms of the Apache-2.0 / MIT dependencies actually shipped in the bundle. Terms of Service, while not legally mandated, is practically required for an account-based service that surfaces third-party concert/ticket data (disclaimer of third-party-data accuracy).
+
+## What Changes
+
+- Add three in-app legal document pages reachable as real routes (not external links, not modal dialogs) so each has a stable URL — required for the App Store Connect / Play Console "Privacy Policy URL" field and for in-app reachability during review:
+  - `/legal/terms` — Terms of Service
+  - `/legal/privacy` — Privacy Policy
+  - `/legal/licenses` — OSS Licenses
+- Author full Japanese and English drafts of the Terms of Service and Privacy Policy, grounded in the actual data inventory (see Impact). Drafts are review-ready but SHALL be confirmed by a legal professional before public launch.
+- Generate the OSS Licenses content automatically at build time from the production dependency tree (e.g. `license-checker` / `generate-license-file`), so it stays accurate without manual upkeep.
+- Make the three legal routes reachable by guests / unauthenticated users (and by store reviewers), consistent with the route guard's existing early-guest Settings access.
+- **MODIFIED**: the Settings About Section links change from external `liverty.me` URLs to the in-app routes.
+- Carry the operating-entity details (trade name, contact email, governing law) as fill-in placeholders in the drafts; the individual-developer / trade-name stage values are supplied at implementation time.
+
+## Capabilities
+
+### New Capabilities
+- `legal-documents`: In-app Terms of Service, Privacy Policy, and OSS Licenses pages — their routes, guest reachability, i18n (ja/en), required content sections, and the build-time auto-generation of the OSS license list.
+
+### Modified Capabilities
+- `settings`: The About Section requirement changes so its three links target the in-app `/legal/*` routes instead of external/webview URLs.
+
+## Impact
+
+- **Data inventory feeding the Privacy Policy** (verified from code): personal data — account email + user_id (Zitadel, self-hosted), `safe_address` (ERC-4337, derived from user id), home area, followed artists, language preference, push subscription / FCM device token, PostHog analytics events (cookies/localStorage). Third-party processors / transfers — **PostHog Cloud EU** (analytics, cross-border / APPI Art. 28), **Resend** (transactional email, US), **Google FCM / Web Push** (push, US), **Google Gemini / Vertex AI** (concert search, US), **Last.fm** (artist metadata, called from browser → IP exposure, UK). Zitadel is self-hosted on the project's own GKE, so it is not a third-party transfer.
+- **Frontend code**: new `src/routes/legal/*` route components + templates, route registration in `app-shell.ts` with `data: { auth: false }`, i18n keys in `src/locales/{ja,en}/translation.json`, and the Settings About-section link targets in `settings-route.html`.
+- **Build pipeline**: a license-extraction step that emits the OSS license list as a build artifact consumed by `/legal/licenses`.
+- **Out of scope**: the GPL-in-zk-prover removal is tracked by the separate `remove-gpl-zk-prover` change; once it lands, the auto-generated OSS list will reflect the GPL-free dependency set. No GPL packages should remain by the time this page ships, but the generator is the source of truth regardless.

--- a/openspec/changes/add-legal-documents/specs/legal-documents/spec.md
+++ b/openspec/changes/add-legal-documents/specs/legal-documents/spec.md
@@ -1,0 +1,78 @@
+## ADDED Requirements
+
+### Requirement: Legal documents are served as in-app routes with stable URLs
+
+The system SHALL serve the Terms of Service, Privacy Policy, and OSS Licenses each as a dedicated in-app route with its own stable URL (`/legal/terms`, `/legal/privacy`, `/legal/licenses`). These documents SHALL NOT be served only as modal dialogs or external links, so that each has a URL usable as the App Store Connect / Google Play Privacy Policy URL and for deep linking.
+
+#### Scenario: Each document has its own route
+
+- **WHEN** a user navigates to `/legal/terms`, `/legal/privacy`, or `/legal/licenses`
+- **THEN** the system SHALL render the corresponding document as a full page at that URL
+
+#### Scenario: Privacy Policy URL is externally linkable
+
+- **WHEN** the Privacy Policy URL is opened directly (e.g. by a store reviewer or from a store listing)
+- **THEN** the page SHALL load and display the Privacy Policy without requiring prior in-app navigation
+
+### Requirement: Legal documents are reachable without authentication
+
+The `/legal/*` routes SHALL be reachable by unauthenticated and guest users, registered as public routes that opt out of the authentication guard.
+
+#### Scenario: Guest opens a legal document
+
+- **WHEN** an unauthenticated user navigates to a `/legal/*` route
+- **THEN** the system SHALL render the document
+- **AND** the authentication guard SHALL NOT redirect the user away
+
+### Requirement: Legal documents are localized
+
+Each legal document SHALL be available in Japanese and English, following the application's active locale and existing i18n mechanism. Japanese is the primary locale for the legal content.
+
+#### Scenario: Document follows the active locale
+
+- **WHEN** a legal document is displayed while the active locale is Japanese (or English)
+- **THEN** the document content SHALL render in that locale
+
+### Requirement: Privacy Policy discloses the actual data practices
+
+The Privacy Policy SHALL accurately disclose, at minimum: the categories of personal data collected; the purposes of use; third-party processors and any cross-border transfer; how to withdraw analytics consent; and the contact channel for disclosure / correction / deletion requests. The disclosure SHALL reflect the system's real integrations and SHALL be revised when a new third-party data integration is added.
+
+#### Scenario: Collected data and purposes are stated
+
+- **WHEN** the Privacy Policy is displayed
+- **THEN** it SHALL list the collected personal data categories (account identity, home area, follows, language preference, push subscription, analytics events) and the purpose of each use
+
+#### Scenario: Third-party transfer and cross-border processing are disclosed
+
+- **WHEN** the Privacy Policy is displayed
+- **THEN** it SHALL identify third-party processors (analytics, email, push, search, artist-metadata)
+- **AND** it SHALL disclose cross-border transfer of analytics data to PostHog Cloud EU consistent with APPI Article 28
+
+#### Scenario: Consent withdrawal and rights are explained
+
+- **WHEN** the Privacy Policy is displayed
+- **THEN** it SHALL explain that analytics consent can be withdrawn via the Settings privacy toggles
+- **AND** it SHALL provide a contact channel for disclosure / correction / deletion requests
+
+### Requirement: Terms of Service disclaims third-party data accuracy
+
+The Terms of Service SHALL include, at minimum: the service description, account and prohibited-conduct terms, a disclaimer that third-party-sourced concert / ticket / sales information is not guaranteed accurate or current, limitation of liability, and governing law / jurisdiction.
+
+#### Scenario: Third-party data disclaimer present
+
+- **WHEN** the Terms of Service is displayed
+- **THEN** it SHALL state that concert, ticket, and sales-timing information originates from third parties and is provided without a guarantee of accuracy or timeliness
+
+### Requirement: OSS Licenses content is generated from the shipped dependencies
+
+The OSS Licenses page content SHALL be generated at build time from the production dependency tree, listing each bundled third-party package with its license and required attribution, so that the displayed list reflects what is actually distributed and does not require manual maintenance.
+
+#### Scenario: License list reflects the production bundle
+
+- **WHEN** the OSS Licenses page is displayed
+- **THEN** it SHALL list the third-party packages included in the production build with their license names and attribution / copyright notices
+
+#### Scenario: List regenerates on dependency change
+
+- **WHEN** the production dependency set changes and the app is rebuilt
+- **THEN** the OSS Licenses content SHALL regenerate to match the new dependency set

--- a/openspec/changes/add-legal-documents/specs/settings/spec.md
+++ b/openspec/changes/add-legal-documents/specs/settings/spec.md
@@ -1,0 +1,10 @@
+## MODIFIED Requirements
+
+### Requirement: About Section
+The system SHALL provide access to legal and licensing information via in-app routes.
+
+#### Scenario: Legal links
+- **WHEN** the About section is displayed
+- **THEN** the system SHALL show links to Terms of Service, Privacy Policy, and OSS Licenses
+- **AND** each link SHALL target its in-app route (`/legal/terms`, `/legal/privacy`, `/legal/licenses`) rather than an external URL
+- **AND** tapping a link SHALL navigate to the corresponding in-app legal document page

--- a/openspec/changes/add-legal-documents/tasks.md
+++ b/openspec/changes/add-legal-documents/tasks.md
@@ -1,0 +1,35 @@
+## 1. Routes and navigation
+
+- [ ] 1.1 Create `src/routes/legal/` route components + templates for terms, privacy, and licenses
+- [ ] 1.2 Register `/legal/terms`, `/legal/privacy`, `/legal/licenses` in `app-shell.ts` with `data: { auth: false }` (public/guest-reachable)
+- [ ] 1.3 Repoint the Settings About-section links in `settings-route.html` from `https://liverty.me/*` to the in-app routes; drop `target="_blank"` external attributes
+- [ ] 1.4 Verify guest reachability: unauthenticated navigation to each `/legal/*` route renders without auth redirect
+
+## 2. OSS Licenses auto-generation
+
+- [ ] 2.1 Add a build-time license extraction step (`license-checker` / `generate-license-file` or equivalent) over the production dependency tree
+- [ ] 2.2 Emit the license list as a build artifact (package name, license, copyright/attribution) consumed by the `/legal/licenses` page
+- [ ] 2.3 Render the generated list on `/legal/licenses`; confirm it reflects the shipped bundle and regenerates on dependency change
+
+## 3. Privacy Policy draft (ja/en)
+
+- [ ] 3.1 Draft the collected-data and purposes sections from the verified inventory (account email/id, safe_address, home area, follows, language, push token, PostHog events)
+- [ ] 3.2 Draft third-party processors + cross-border transfer (PostHog Cloud EU / APPI Art. 28; Resend; Google FCM/Web Push; Gemini/Vertex AI; Last.fm) — exclude Zitadel as self-hosted
+- [ ] 3.3 Draft consent-withdrawal (Settings privacy toggles) and subject-rights / contact sections
+- [ ] 3.4 Add entity placeholders (trade name, contact email, governing law = Japanese law, jurisdiction) and a "last updated" stamp
+- [ ] 3.5 Produce the English translation; wire both into i18n
+
+## 4. Terms of Service draft (ja/en)
+
+- [ ] 4.1 Draft service description, account terms, and prohibited-conduct clauses
+- [ ] 4.2 Draft the third-party-data accuracy disclaimer (concert / ticket / sales-timing info not guaranteed)
+- [ ] 4.3 Draft limitation of liability, account suspension/termination, and governing law / jurisdiction
+- [ ] 4.4 Add entity placeholders + "last updated" stamp; produce the English translation; wire into i18n
+
+## 5. Review, verify, and ship
+
+- [ ] 5.1 Mark all drafts "DRAFT — pending legal review"; route them through a legal professional and incorporate feedback
+- [ ] 5.2 Fill the real operating-entity values once confirmed
+- [ ] 5.3 Run `make check`; add a smoke/component test that each `/legal/*` route renders in ja and en
+- [ ] 5.4 Open the frontend PR; merge after CI; ship to dev then cut the production release
+- [ ] 5.5 Set the App Store Connect / Google Play Console Privacy Policy URL to the production `/legal/privacy` URL


### PR DESCRIPTION
## Summary

Adds the OpenSpec change `add-legal-documents`, capturing the plan to give Liverty real in-app legal documents.

The Settings → About links for 利用規約 / プライバシーポリシー / OSSライセンス currently point to empty `https://liverty.me/*` URLs — broken UX and a compliance gap. The app collects personal data (Zitadel account, home area, follows, push subscriptions) and runs PostHog product analytics with cross-border transfer to **PostHog Cloud EU**, so a published **Privacy Policy is mandatory under APPI** and is a hard requirement for App Store / Google Play submission (both require a reachable Privacy Policy URL).

This PR contains **only the OpenSpec artifacts** (no code/implementation).

## Changes

- `proposal.md` — why the change is needed and the verified data inventory feeding the Privacy Policy (third-party processors: PostHog Cloud EU, Resend, Google FCM/Web Push, Gemini/Vertex AI, Last.fm; Zitadel is self-hosted → not a transfer).
- `design.md` — in-app routes over modal dialogs (stable URL required for store submission), guest-reachable public routes, the Privacy Policy content contract, GDPR deferred until EU targeting, and entity values as placeholders pending legal review.
- `specs/legal-documents/spec.md` — new capability: stable per-document URLs, unauthenticated reachability, ja/en localization, Privacy Policy real-disclosure requirements, Terms third-party-data disclaimer, and build-time auto-generation of the OSS license list.
- `specs/settings/spec.md` — **MODIFIED** the About Section so its three links target the in-app `/legal/*` routes instead of external URLs.
- `tasks.md` — routes + navigation, OSS auto-generation, full ja/en Terms + Privacy drafts, legal review, and production release ending with setting the store Privacy Policy URL.

## Testing

- `openspec validate add-legal-documents` → valid.
- Documentation-only change; no proto or code modifications.

## Out of scope

The GPL-in-zk-prover removal is tracked separately (`remove-gpl-zk-prover`, #595). Once it lands, the auto-generated OSS list reflects the GPL-free dependency set.

close: #596
