### PR TITLE
docs(openspec): propose add-admin-console change

### DIFF
--- a/openspec/changes/add-admin-console/.openspec.yaml
+++ b/openspec/changes/add-admin-console/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-05

--- a/openspec/changes/add-admin-console/design.md
+++ b/openspec/changes/add-admin-console/design.md
@@ -1,0 +1,196 @@
+## Context
+
+The consumer SPA (`frontend` repo) is an Aurelia 2 app built with Vite, served by
+Caddy from a single container image, authenticated against Zitadel via
+`oidc-client-ts` (PKCE), and configured at runtime by fetching `/config.json`
+(mounted per-environment as a Kubernetes ConfigMap). Zitadel is split into two
+orgs:
+
+- **`admin` role org** — internal humans, **Google Workspace IDP** already wired
+  (`google-admin-idp`, per archived change `add-zitadel-console-admin-via-google-idp`).
+- **`liverty-music` product org** — end-user fans, passkey-only login policy.
+
+There is no internal developer/operator web UI. This design establishes the
+foundation for one at `admin.liverty-music.app`. Features are out of scope and
+ship in later changes; this change delivers auth + an empty authenticated shell.
+
+Key existing invariants this design must respect:
+
+- `loadAppConfig()` fetches `/config.json` from a **hardcoded path**; the whole
+  codebase assumes **one app → one `/config.json`** (also enforced by
+  `KNOWN_HOSTS` / `validateEnvironmentMatchesHost`).
+- The consumer image's `Caddyfile` SPA-fallback is `try_files {path} /index.html`.
+- Delivery is GitOps: image → Artifact Registry → ArgoCD image-updater (digest) →
+  ArgoCD sync. Prod is a heavier GH-Release-driven retag + pin-bump path.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- A deployed, access-controlled `admin.liverty-music.app` that only internal
+  Google Workspace accounts can sign into, showing a welcome placeholder.
+- **Zero impact** on the consumer SPA's bundle size, Core Web Vitals, hosting,
+  Zitadel app, or release cadence.
+- Maximum reuse of existing patterns (auth-service, runtime-config contract,
+  gateway, ArgoCD) with a clean seam for future extraction to its own repo.
+
+**Non-Goals:**
+
+- Any admin feature, RPC, or backend endpoint.
+- Authorization granularity beyond the Google-IDP authentication gate (no admin
+  roles/scopes yet).
+- Audit logging, session policy hardening, or admin-specific observability.
+- Migrating or changing the consumer SPA in any behavioral way.
+
+## Decisions
+
+### D1 — Auth via the `admin` org + Google Workspace IDP (authN as the boundary)
+
+The admin console authenticates against the **`admin` org**, reusing
+`oidc-client-ts` PKCE exactly like the consumer SPA, but passing the admin org id
+in the `urn:zitadel:iam:org:id:<id>` scope so Zitadel applies the admin org's
+Google-IDP login policy. Because only Google Workspace accounts can complete that
+flow, **authentication itself is the access boundary** — no separate
+authorization layer is needed for the foundation.
+
+- *Why over reusing the product org (passkey) + a role check (authZ boundary)?*
+  Every fan can already authenticate against the product org, so that path would
+  require building and maintaining a role/claim gate just to keep fans out. The
+  admin org gives the boundary for free and matches the "developer-only" intent.
+  Confirmed acceptable: all current admin users have Google Workspace accounts.
+- *Future:* if non-Workspace operators ever need access, add Zitadel project
+  roles + an ID-token role guard then (the consumer app already enables
+  `idTokenRoleAssertion`).
+
+A new `ApplicationOidc` is provisioned **in the admin org** (SPA / PKCE / no
+secret), with redirect URIs `https://admin.{dev,}liverty-music.app/auth/callback`
+and matching post-logout URIs. It is a sibling of the consumer `web-frontend`
+app, not a modification of it.
+
+### D2 — One repo, two Vite entry points (MPA), bundle-isolated
+
+The admin app lives in the **same `frontend` repo** as a **second Vite/Rollup
+HTML entry** (`admin.html` → admin bootstrap). Rollup builds an independent chunk
+graph per entry, so consumer pages load only consumer chunks; admin-only code is
+never shipped to fans. Shared modules (e.g. `AuthService`, the config loader)
+become shared chunks only when both entries import them — which the consumer
+already loads, so its bundle does not grow.
+
+- *Why over Aurelia runtime "multi-root"?* Multi-root (`new Aurelia()` ×N on one
+  page) is a runtime composition feature; both roots ship in **one bundle**, so
+  it does **not** isolate bundles. It solves a different problem (multiple mount
+  points on a single page) and would defeat the zero-impact goal.
+- *Why over a separate repo now?* A placeholder does not justify standing up a
+  whole new repo + CI + visual-baseline pipeline + ArgoCD app from scratch.
+  One-repo MPA reuses tooling; D4 keeps a clean extraction seam for later.
+
+### D3 — Dedicated top-level `frontend/admin/` directory (not `src/admin/`)
+
+Admin source lives in a top-level `admin/` directory, sibling to `src/`, with
+cross-app code in a shared location both can import:
+
+```
+frontend/
+  index.html              # consumer entry (unchanged)
+  admin.html              # admin entry (new)
+  src/                    # consumer app (unchanged)
+  admin/                  # admin app (new, self-contained)
+    main.ts               # admin bootstrap (reuses shared AuthService, admin org id)
+    admin-shell.ts/.html  # welcome placeholder shell + route guard
+  shared/                 # the ONLY cross-app import surface
+    services/auth-service.ts
+    config/app-config.ts
+```
+
+- *Why over `src/admin/`?* A top-level directory makes the boundary **physical**:
+  the seam between "consumer", "admin", and "shared" is visible in the tree and
+  trivial to enforce with an import-boundary lint rule (admin and src may only
+  cross via `shared/`). It also mirrors ③b's runtime isolation at the source
+  level and means a future extraction is "lift `admin/` + `shared/` into a new
+  repo" rather than untangling intertwined `src/` subtrees.
+- *Trade-off:* tsconfig / Vite / Biome / Vitest must be made aware of the extra
+  root. This is config-only and one-time.
+
+### D4 — Separate image + separate Deployment for serving (option ③b)
+
+The admin console is served by its **own container image** (admin `Dockerfile` +
+`Caddyfile`) and its **own Kubernetes Deployment/Service/HTTPRoute**, behind the
+same shared external gateway, rather than co-served from the consumer pod by
+Host-based Caddy routing (③a).
+
+- *Why over ③a (same image, host-routed Caddy)?* ③a has fewer k8s objects but
+  forces two **load-bearing** seams to become host-conditional, breaking
+  codebase invariants:
+  1. **config delivery** — a single pod serving one `/config.json` cannot hand
+     the admin entry its different org id/client id without either a host-aware
+     Caddy rewrite or parameterizing the hardcoded `loadAppConfig()` path.
+  2. **SPA fallback** — `try_files` must branch per host (`/admin.html` vs
+     `/index.html`).
+  Plus both ConfigMaps would mount on one Deployment, so a Reloader restart from
+  an admin config change would **also restart the consumer pod** (blast-radius
+  leak), and admin/consumer would deploy in **lockstep** (an admin copy tweak
+  would re-release the consumer prod image).
+- ③b keeps every invariant intact: the admin pod mounts its **own** `/config.json`
+  at the canonical path → `loadAppConfig()` is reused unchanged; the admin
+  `Caddyfile` is a trivial single-fallback copy; ConfigMap blast radius and
+  release cadence are isolated. Cost is **+1 small pod** (dev spot, negligible)
+  and a set of **clean copies** of existing k8s/Pulumi patterns.
+- *Build vs serve split:* `npm run build` stays **one build** producing both
+  entries into `dist/`; only the serving layer (Dockerfile/Caddyfile) is split
+  into a second image. The admin image copies/serves the admin entry's output.
+
+### D5 — Reuse the existing GitOps delivery path
+
+The admin image is published to Artifact Registry and tracked by the existing
+ArgoCD **image-updater** as its own alias, synced by ArgoCD like the consumer
+app. Admin and consumer are independent artifacts and release independently
+(direct consequence of D4).
+
+## Risks / Trade-offs
+
+- **Import boundary erosion** (a `src/` ↔ `admin/` import sneaks in, leaking
+  admin code into the consumer bundle) → Add a dependency/import-boundary lint
+  rule (e.g. Biome `noRestrictedImports` or a dependency-cruiser check) wired
+  into `make lint`/CI so a cross-import fails the build. Verify post-build that
+  the consumer entry's chunk graph contains no admin modules.
+- **PWA service worker over-precaching** — the consumer uses
+  `VitePWA injectManifest` (single SW). An MPA build could pull admin assets into
+  the precache manifest, or the admin host could register the consumer SW →
+  Scope the SW to the consumer entry only; the admin placeholder ships **no SW**.
+- **Zitadel admin-org app misconfig** (wrong redirect URI / org scope → login
+  loop) → Mirror the consumer app's proven `ApplicationOidc` settings; verify the
+  end-to-end Google sign-in on dev before prod.
+- **Cert/DNS propagation lag** for the new `admin.*` hostname → Add the hostname
+  to certmap + Cloud DNS first; gate the HTTPRoute cutover on cert readiness.
+- **Two release paths to remember** — admin now has its own image/release →
+  Document the admin release path alongside the consumer's; keep them structurally
+  identical to minimize cognitive load.
+
+## Migration Plan
+
+Greenfield surface (no existing admin users/data), so no data migration. Rollout
+order, parallelizing per the cross-repo release protocol:
+
+1. **specification**: this change merged → spec is canonical.
+2. **cloud-provisioning (Pulumi)**: provision the admin-org `ApplicationOidc`,
+   certmap + Cloud DNS entries for `admin.{dev,}liverty-music.app`.
+3. **frontend**: add `admin/` + `shared/`, the second Vite entry, admin
+   Dockerfile/Caddyfile, import-boundary lint. Build produces both entries.
+   Publish the admin image to AR.
+4. **cloud-provisioning (k8s)**: admin Deployment/Service/HTTPRoute + per-env
+   `admin-app-runtime-config` ConfigMap; image-updater alias; ArgoCD picks it up.
+5. Verify dev: Google sign-in works, welcome placeholder renders, consumer
+   bundle/Lighthouse unchanged. Then promote to prod via the standard
+   GH-Release/pin-bump path.
+
+**Rollback:** purely additive — remove/disable the admin HTTPRoute (or scale the
+admin Deployment to 0). The consumer surface is untouched at every step.
+
+## Open Questions
+
+- Admin image/serving: a fully separate `admin` Kubernetes namespace, or a second
+  workload inside the existing `frontend` namespace? (Leaning: reuse `frontend`
+  namespace to minimize new RBAC/NetworkPolicy surface; revisit if admin later
+  needs stricter isolation.)
+- Whether the admin console should share the consumer's i18n bundle or ship
+  English-only for the foundation (placeholder likely English-only).

--- a/openspec/changes/add-admin-console/proposal.md
+++ b/openspec/changes/add-admin-console/proposal.md
@@ -1,0 +1,80 @@
+## Why
+
+The team has no internal web surface for developer/operator tooling: every
+operational task today is done via raw `kubectl`, `gcloud`, SQL, or the Zitadel
+console. As the platform approaches launch we need a dedicated, authenticated
+home — `admin.liverty-music.app` — that internal developers can grow tooling on.
+This change builds only the *foundation* (auth + an empty authenticated shell);
+actual admin features land in separate changes. Establishing the foundation now
+lets feature work start against a real, deployed, access-controlled surface
+instead of blocking on plumbing.
+
+## What Changes
+
+- Introduce a **second Vite entry point** in the existing `frontend` repo so the
+  admin console is built alongside the consumer SPA but **bundle-isolated** —
+  Rollup splits per HTML entry, so the consumer app never downloads any admin
+  code and its bundle size / Core Web Vitals are unaffected.
+- Place admin source under a **dedicated top-level `frontend/admin/` directory**
+  (sibling to `src/`), with cross-app code consumed from a shared location. This
+  makes the import boundary physical and lint-enforceable, and keeps a clean
+  seam for future extraction into its own repository.
+- Authenticate the admin console with **Zitadel OIDC via the existing `admin`
+  role org + Google Workspace IDP** (the same mechanism the consumer SPA uses —
+  `oidc-client-ts` PKCE — but scoped to the admin org). Authentication itself is
+  the access boundary: only Google Workspace accounts can sign in. A new
+  **`ApplicationOidc`** is provisioned in the admin org with admin-host redirect
+  URIs.
+- Add an **authenticated route guard** and a **post-login welcome placeholder**
+  page. No business features.
+- Serve the admin console from a **separate container image and Kubernetes
+  Deployment/Service** (option ③b) — *not* host-routed off the consumer pod —
+  so the consumer SPA's `/config.json` invariant, Caddy SPA-fallback, blast
+  radius, and release cadence stay fully isolated. The admin pod mounts its own
+  `/config.json` at the canonical path (admin org id + admin client id).
+- Add a dedicated **HTTPRoute hostname** for `admin.{dev,}liverty-music.app` on
+  the shared external gateway, plus **certmap and Cloud DNS** entries.
+- Wire the admin image into the existing **ArgoCD + image-updater** delivery
+  path as its own tracked artifact.
+
+## Capabilities
+
+### New Capabilities
+
+- `admin-console`: the developer admin console frontend foundation — a dedicated
+  Vite MPA entry in the `frontend` repo built with bundle isolation from the
+  consumer SPA, Zitadel OIDC authentication via the admin org + Google Workspace
+  IDP, an authenticated route guard, and a post-login welcome placeholder.
+- `admin-console-hosting`: serving and delivery for `admin.liverty-music.app` —
+  a separate container image and Kubernetes Deployment/Service, a dedicated
+  HTTPRoute hostname on the shared external gateway, certmap + Cloud DNS entries,
+  per-host runtime config delivery, and the ArgoCD/image-updater wiring. Also
+  covers the new admin-org `ApplicationOidc` Zitadel resource.
+
+### Modified Capabilities
+
+None. The admin console reuses the existing `frontend-runtime-config` `/config.json`
+contract, the `authentication` OIDC mechanism, and the `gke-gateway-infrastructure`
+gateway unchanged — it adds a parallel surface rather than changing their
+requirements.
+
+## Impact
+
+- **frontend repo**: new `admin/` top-level directory, a shared code location,
+  a second Vite/Rollup entry (`admin.html`), an admin-specific `Dockerfile` +
+  `Caddyfile`, admin bootstrap reusing `AuthService` with the admin org id, an
+  import-boundary lint rule. Consumer SPA code is untouched; consumer bundle
+  output is unchanged.
+- **cloud-provisioning repo**:
+  - Pulumi: new `ApplicationOidc` in the admin org (`admin-host/auth/callback`
+    redirect URIs); admin hostnames added to certmap + Cloud DNS.
+  - k8s: a new `frontend` (or new `admin`) namespace Deployment/Service/HTTPRoute
+    + per-env ConfigMap (`admin-app-runtime-config`) for the admin pod; ArgoCD
+    image-updater alias for the new admin image.
+- **CI/CD**: a second image build/push in the frontend pipeline; admin and
+  consumer release independently.
+- **No changes to**: backend, Connect-RPC contracts, database, the consumer SPA
+  bundle, consumer hosting, or the existing Zitadel consumer app/login policy.
+- **Out of scope**: any admin feature/RPC, admin authorization roles beyond the
+  Google-IDP authentication gate, audit logging, and admin-specific backend
+  endpoints — all deferred to follow-up changes.

--- a/openspec/changes/add-admin-console/specs/admin-console-hosting/spec.md
+++ b/openspec/changes/add-admin-console/specs/admin-console-hosting/spec.md
@@ -1,0 +1,102 @@
+## ADDED Requirements
+
+### Requirement: Dedicated container image and Kubernetes workload
+
+The admin console SHALL be served from its own container image and its own
+Kubernetes Deployment and Service, independent of the consumer SPA workload. The
+consumer SPA's image, Deployment, Caddy configuration, and config delivery MUST
+remain unchanged. A change to the admin workload MUST NOT trigger a restart or
+redeploy of the consumer SPA workload.
+
+#### Scenario: Independent workloads
+
+- **WHEN** the admin console is deployed
+- **THEN** it runs as a separate Deployment/Service and the consumer SPA
+  Deployment is not modified or restarted by the admin deployment
+
+#### Scenario: Isolated config reload
+
+- **WHEN** the admin runtime config changes and triggers a rollout of the admin
+  workload
+- **THEN** only the admin pod restarts; the consumer SPA pod is unaffected
+
+### Requirement: Dedicated hostname on the shared external gateway
+
+The admin console SHALL be reachable at `admin.{env-base-domain}` (e.g.
+`admin.dev.liverty-music.app`, `admin.liverty-music.app`) via a dedicated
+HTTPRoute attached to the shared external gateway, routing that hostname to the
+admin Service. The consumer hostname's routing MUST remain unchanged.
+
+#### Scenario: Admin hostname routes to admin workload
+
+- **WHEN** a request arrives for the admin hostname
+- **THEN** the shared gateway routes it to the admin Service
+
+#### Scenario: Consumer hostname unaffected
+
+- **WHEN** a request arrives for the consumer hostname
+- **THEN** it continues to route to the consumer SPA Service unchanged
+
+### Requirement: Per-host runtime config delivery
+
+The admin pod SHALL serve its own `/config.json` at the canonical path,
+containing the admin org id and the admin OIDC client id, mounted per environment
+as a Kubernetes ConfigMap. The admin console MUST resolve its runtime
+configuration from the canonical `/config.json` path without altering the shared
+config-loading contract used by the consumer SPA.
+
+#### Scenario: Admin receives admin configuration
+
+- **WHEN** the admin console fetches `/config.json` at boot
+- **THEN** it receives the admin org id and admin client id for the current
+  environment
+
+#### Scenario: Shared config contract preserved
+
+- **WHEN** the admin console boots
+- **THEN** it uses the same `/config.json` canonical path and loader contract as
+  the consumer SPA, with no host-conditional rewrite of the config path
+
+### Requirement: Admin-org OIDC application provisioning
+
+A Zitadel `ApplicationOidc` SHALL be provisioned in the `admin` org as a public
+SPA client (PKCE, no secret) with redirect URIs at
+`https://admin.{env-base-domain}/auth/callback` and matching post-logout redirect
+URIs per environment. It SHALL be a distinct resource from the consumer
+`web-frontend` application, leaving the consumer application and product-org
+login policy unchanged.
+
+#### Scenario: Admin OIDC app exists per environment
+
+- **WHEN** infrastructure is provisioned for an environment
+- **THEN** an admin-org `ApplicationOidc` exists with that environment's admin
+  redirect and post-logout URIs
+
+#### Scenario: Consumer application untouched
+
+- **WHEN** the admin OIDC application is provisioned
+- **THEN** the consumer `web-frontend` application and the product-org login
+  policy are not modified
+
+### Requirement: TLS certificate and DNS for the admin hostname
+
+The admin hostname SHALL be covered by a managed TLS certificate via the gateway
+certmap and SHALL resolve via Cloud DNS for each environment, before the admin
+HTTPRoute begins serving production traffic.
+
+#### Scenario: Admin hostname is reachable over TLS
+
+- **WHEN** the admin hostname is requested over HTTPS
+- **THEN** it presents a valid managed certificate and resolves to the gateway
+
+### Requirement: GitOps delivery for the admin image
+
+The admin image SHALL be published to Artifact Registry and reconciled through
+the existing ArgoCD image-updater automation as its own tracked artifact, so the
+admin console releases independently of the consumer SPA.
+
+#### Scenario: Admin image is auto-reconciled
+
+- **WHEN** a new admin image digest is published to Artifact Registry
+- **THEN** ArgoCD image-updater updates the admin workload to that digest without
+  affecting the consumer SPA's tracked image

--- a/openspec/changes/add-admin-console/specs/admin-console/spec.md
+++ b/openspec/changes/add-admin-console/specs/admin-console/spec.md
@@ -1,0 +1,98 @@
+## ADDED Requirements
+
+### Requirement: Bundle isolation from the consumer SPA
+
+The admin console SHALL be built as a separate Vite/Rollup entry point in the
+`frontend` repository such that no admin-only code is included in any chunk
+loaded by the consumer SPA. Adding the admin console MUST NOT increase the
+consumer SPA's downloaded bundle size or regress its Core Web Vitals.
+
+#### Scenario: Consumer page loads no admin code
+
+- **WHEN** a fan loads the consumer SPA at the consumer hostname
+- **THEN** the network requests for the consumer entry's chunk graph contain no
+  module originating from the admin source directory
+
+#### Scenario: Consumer bundle size unchanged
+
+- **WHEN** the production build runs with the admin entry present
+- **THEN** the consumer entry's emitted chunk set is byte-for-byte equivalent to a
+  build without the admin entry (excluding shared chunks the consumer already
+  loads)
+
+### Requirement: Authentication via the admin org with Google Workspace IDP
+
+The admin console SHALL authenticate users through Zitadel OIDC (PKCE, no client
+secret) scoped to the `admin` role org, so that the admin org's Google Workspace
+IDP login policy applies. Only accounts that can complete the Google Workspace
+sign-in SHALL gain access; authentication itself is the access boundary.
+
+#### Scenario: Internal developer signs in
+
+- **WHEN** an internal user with a Google Workspace account initiates sign-in on
+  the admin console
+- **THEN** they are redirected through the admin org's Google IDP and, on success,
+  returned authenticated to the admin console
+
+#### Scenario: Non-Workspace account cannot enter
+
+- **WHEN** a user without an eligible Google Workspace account attempts to sign in
+- **THEN** they cannot complete authentication and are not granted access to the
+  admin console
+
+#### Scenario: Org scope drives the login policy
+
+- **WHEN** the admin console starts its OIDC sign-in flow
+- **THEN** the request carries the admin org id in the
+  `urn:zitadel:iam:org:id:<id>` scope so Zitadel applies the admin org login
+  policy rather than the consumer product-org policy
+
+### Requirement: Authenticated route guard
+
+Every admin console route SHALL require authentication by default. An
+unauthenticated visitor MUST be redirected into the sign-in flow before any
+admin content renders. The OIDC callback route is the only exception.
+
+#### Scenario: Unauthenticated access is redirected
+
+- **WHEN** an unauthenticated visitor navigates to any admin console route other
+  than the auth callback
+- **THEN** they are redirected into the Zitadel sign-in flow and no admin content
+  is shown
+
+#### Scenario: Callback completes the session
+
+- **WHEN** Zitadel redirects back to the admin console's `/auth/callback`
+- **THEN** the console completes the OIDC code exchange and establishes the
+  authenticated session
+
+### Requirement: Post-login welcome placeholder
+
+After successful authentication the admin console SHALL display a welcome
+placeholder page and SHALL NOT expose any business feature. The placeholder
+exists only to confirm the authenticated foundation is in place.
+
+#### Scenario: Welcome page after login
+
+- **WHEN** an authenticated developer lands on the admin console root
+- **THEN** a welcome placeholder is shown with no admin business functionality
+
+### Requirement: Dedicated source directory with an enforced import boundary
+
+Admin console source SHALL live in a dedicated top-level `admin/` directory in
+the `frontend` repository, separate from the consumer `src/` directory.
+Cross-app code SHALL be consumed only from a shared location. An automated lint
+check SHALL fail the build if consumer (`src/`) code imports admin (`admin/`)
+code or vice versa, except through the shared location.
+
+#### Scenario: Cross-import fails lint
+
+- **WHEN** a module under `src/` imports a module under `admin/` (or the reverse)
+  directly rather than through the shared location
+- **THEN** the lint/CI check fails
+
+#### Scenario: Shared code is importable by both
+
+- **WHEN** both the consumer and admin entries import a module from the shared
+  location
+- **THEN** the import is permitted and the module is emitted as a shared chunk

--- a/openspec/changes/add-admin-console/tasks.md
+++ b/openspec/changes/add-admin-console/tasks.md
@@ -1,0 +1,58 @@
+## 1. Specification
+
+- [ ] 1.1 Merge this `add-admin-console` change so the spec is canonical (no proto changes required — no BSR generation/release needed).
+
+## 2. Infrastructure — Zitadel & networking (cloud-provisioning, Pulumi)
+
+- [ ] 2.1 Add an admin-org `ApplicationOidc` (public SPA, PKCE, no secret) with redirect URIs `https://admin.{base-domain}/auth/callback` and post-logout URIs `https://admin.{base-domain}/`, dev-mode + localhost URIs only for dev; mirror the consumer `web-frontend` app settings.
+- [ ] 2.2 Export the admin app's client id (and confirm the admin org id from `constants.ts adminOrgIdMap`) for use in the admin runtime ConfigMap.
+- [ ] 2.3 Add `admin.dev.liverty-music.app` and `admin.liverty-music.app` to the gateway certmap.
+- [ ] 2.4 Add Cloud DNS records for the admin hostnames per environment.
+- [ ] 2.5 `pulumi preview` for dev; present diff for approval (no auto `pulumi up` locally).
+
+## 3. Frontend — build separation & shared layer (frontend repo)
+
+- [ ] 3.1 Create the top-level `admin/` directory and a `shared/` location; move `AuthService` and the app-config loader into `shared/` (or re-export from it) without changing consumer behavior.
+- [ ] 3.2 Add `admin.html` and `admin/main.ts` bootstrap; register the second entry in `vite.config.ts` (`build.rollupOptions.input`).
+- [ ] 3.3 Update tsconfig / Biome / Vitest configs to include the `admin/` and `shared/` roots.
+- [ ] 3.4 Add an import-boundary lint rule (consumer `src/` ↔ admin `admin/` only via `shared/`) and wire it into `make lint` / CI.
+- [ ] 3.5 Scope the PWA service worker to the consumer entry only; ensure the admin entry ships no SW and is excluded from precache.
+
+## 4. Frontend — admin app behavior (frontend repo)
+
+- [ ] 4.1 Implement the admin bootstrap to start OIDC sign-in scoped to the admin org id (`urn:zitadel:iam:org:id:<id>`), reusing the shared `AuthService`.
+- [ ] 4.2 Implement the admin auth callback route (`/auth/callback`) completing the code exchange.
+- [ ] 4.3 Implement an authenticated route guard so all admin routes except the callback require sign-in.
+- [ ] 4.4 Implement the post-login welcome placeholder shell (no business features).
+- [ ] 4.5 Add unit tests for the route guard and the org-scoped sign-in; `make check` passes.
+
+## 5. Frontend — serving image (frontend repo)
+
+- [ ] 5.1 Add an admin `Dockerfile` + `Caddyfile` (single SPA fallback `try_files {path} /admin.html`, `/config.json` no-store) serving the admin entry's build output. Keep `npm run build` as a single build producing both entries.
+- [ ] 5.2 Verify locally: consumer build output is unchanged and the consumer chunk graph contains no `admin/` module (build-time assertion).
+- [ ] 5.3 Wire the admin image build/push into the frontend CI pipeline as a second artifact to Artifact Registry.
+
+## 6. Infrastructure — admin workload (cloud-provisioning, k8s)
+
+- [ ] 6.1 Add the admin Deployment + Service (own image, spot nodeSelector, explicit requests/limits, readiness/liveness probes) — decide namespace (reuse `frontend` vs new `admin`) per the design open question.
+- [ ] 6.2 Add the admin HTTPRoute binding `admin.{base-domain}` (per-overlay hostname) to the admin Service on the shared external gateway.
+- [ ] 6.3 Add per-env `admin-app-runtime-config` ConfigMap (admin org id + admin client id + apiBaseUrl + issuer) mounted at `/config.json`; annotate the admin Deployment for Reloader.
+- [ ] 6.4 Add the admin image alias to the ArgoCD image-updater config.
+- [ ] 6.5 `kubectl kustomize` dry-run for the dev overlay (spot nodeSelector + non-empty resources present, patches apply).
+
+## 7. Dev verification
+
+- [ ] 7.1 After dev deploys, verify Google Workspace sign-in completes and the welcome placeholder renders at `https://admin.dev.liverty-music.app`.
+- [ ] 7.2 Confirm the consumer SPA is unaffected: bundle output and Lighthouse/Core Web Vitals unchanged, consumer hostname routes and config delivery unchanged.
+- [ ] 7.3 Confirm a non-Workspace account cannot complete sign-in.
+
+## 8. Production rollout
+
+- [ ] 8.1 Provision the prod admin OIDC app, prod certmap, and prod Cloud DNS; run `pulumi preview` for prod and apply from the Pulumi Cloud console after approval.
+- [ ] 8.2 Release the admin image to prod via the standard frontend release path (GH Release → retag → prod AR → pin-bump → ArgoCD), independently of the consumer SPA.
+- [ ] 8.3 Verify prod: admin sign-in works at `https://admin.liverty-music.app`, welcome placeholder renders, consumer prod surface unchanged.
+
+## 9. Post-merge deployment verification
+
+- [ ] 9.1 Monitor ArgoCD sync for the admin workload in dev and prod; confirm pods are running with the expected config.
+- [ ] 9.2 Document the admin release path alongside the consumer's, noting the two are independent artifacts.


### PR DESCRIPTION
## 🔗 Related Issue

Closes #599

## 📝 Summary of Changes

Proposes the OpenSpec change `add-admin-console`: the **foundation** for a
developer/operator admin console at `admin.liverty-music.app`. This is docs-only
(OpenSpec proposal, design, specs, tasks) — no proto or code changes. Actual
admin features land in separate changes; this defines auth + an empty
authenticated shell so feature work can start against a real, access-controlled
surface.

**Motivation**: the platform has no internal authenticated web surface for
operator tooling (everything is raw `kubectl`/`gcloud`/SQL/Zitadel console today).

**Approach / key decisions** (in `design.md`):

- **Auth (authN as the boundary)**: Zitadel OIDC (PKCE) scoped to the existing
  `admin` org + Google Workspace IDP. Only Workspace accounts can sign in, so no
  separate authorization layer is needed for the foundation. New admin-org
  `ApplicationOidc`; the consumer app and product-org login policy are untouched.
- **Build isolation**: one `frontend` repo, a second Vite/Rollup entry (MPA) so
  the admin app is bundle-isolated — the consumer SPA never downloads admin code
  and its bundle size / Core Web Vitals are unaffected. (Aurelia runtime
  "multi-root" was rejected — it ships both roots in one bundle and does not
  isolate.)
- **Source layout**: dedicated top-level `frontend/admin/` directory with
  cross-app code only via a `shared/` location and an enforced import-boundary
  lint, keeping a clean seam for future extraction to its own repo.
- **Serving (option ③b)**: separate container image + Kubernetes
  Deployment/Service/HTTPRoute rather than host-routing off the consumer pod —
  preserves the consumer `/config.json` invariant and Caddy SPA-fallback,
  isolates blast radius, and lets admin release independently. (Option ③a was
  rejected: it forces config delivery and SPA fallback to become host-conditional
  and couples admin/consumer releases.)

**New capabilities**: `admin-console` (frontend behavior), `admin-console-hosting`
(serving/infra + admin-org OIDC app). No existing capability requirements change.

## Validation

- `openspec validate add-admin-console` → valid.

## ✅ Self-Checklist

- [x] I have linked the related issue.
- [x] I have updated the relevant documentation (OpenSpec artifacts) if needed.
- [ ] I have run `buf lint` and `buf format` locally and all checks have passed. — N/A (docs-only, no proto changes)
- [ ] My proto definitions follow the project's style guidelines and validation rules. — N/A (no proto changes)
- [ ] Breaking changes have been justified and documented if applicable. — N/A
