### PR TITLE
docs(openspec): resolve add-admin-console open questions

### DIFF
--- a/openspec/changes/add-admin-console/design.md
+++ b/openspec/changes/add-admin-console/design.md
@@ -186,11 +186,23 @@ order, parallelizing per the cross-repo release protocol:
 **Rollback:** purely additive — remove/disable the admin HTTPRoute (or scale the
 admin Deployment to 0). The consumer surface is untouched at every step.
 
-## Open Questions
+## Resolved Questions
 
-- Admin image/serving: a fully separate `admin` Kubernetes namespace, or a second
-  workload inside the existing `frontend` namespace? (Leaning: reuse `frontend`
-  namespace to minimize new RBAC/NetworkPolicy surface; revisit if admin later
-  needs stricter isolation.)
-- Whether the admin console should share the consumer's i18n bundle or ship
-  English-only for the foundation (placeholder likely English-only).
+- **Kubernetes namespace / ArgoCD app → reuse the existing `frontend` namespace
+  (N1).** The admin workload is added as an `admin/` sibling to `web/` in the
+  `frontend` kustomize tree, served by the existing `frontend` ArgoCD
+  Application. *Rationale:* the `frontend` namespace carries no NetworkPolicy /
+  RBAC / ResourceQuota today, so a separate namespace would duplicate boilerplate
+  (a new ArgoCD Application + overlay tree) without an isolation benefit at the
+  policy layer. ③b's isolation that actually matters — separate image, pod,
+  `/config.json`, and release artifact — is preserved regardless of namespace.
+  *Accepted trade-off:* admin and consumer share one ArgoCD Application sync, so a
+  malformed admin manifest can mark the `frontend` app `OutOfSync`/`Degraded`.
+  Mitigation: keep admin manifests as a clean copy of the consumer pattern and
+  rely on the k8s dry-run gate; promote to a dedicated `admin` namespace + ArgoCD
+  app if/when admin needs its own NetworkPolicy, quota, or service account.
+- **i18n → English-only for the foundation.** The admin console ships no
+  `@aurelia/i18n` machinery; the welcome placeholder is English-only. *Rationale:*
+  it is an internal developer tool and i18n would add infrastructure to the admin
+  bundle for no benefit. If admin later needs localization, it can pull i18n
+  through the `shared/` location (D2/D3) at that point.

--- a/openspec/changes/add-admin-console/proposal.md
+++ b/openspec/changes/add-admin-console/proposal.md
@@ -68,9 +68,10 @@ requirements.
 - **cloud-provisioning repo**:
   - Pulumi: new `ApplicationOidc` in the admin org (`admin-host/auth/callback`
     redirect URIs); admin hostnames added to certmap + Cloud DNS.
-  - k8s: a new `frontend` (or new `admin`) namespace Deployment/Service/HTTPRoute
-    + per-env ConfigMap (`admin-app-runtime-config`) for the admin pod; ArgoCD
-    image-updater alias for the new admin image.
+  - k8s: an admin Deployment/Service/HTTPRoute added to the existing `frontend`
+    namespace (an `admin/` sibling to `web/`, served by the existing `frontend`
+    ArgoCD app) + per-env ConfigMap (`admin-app-runtime-config`) for the admin
+    pod; ArgoCD image-updater alias for the new admin image.
 - **CI/CD**: a second image build/push in the frontend pipeline; admin and
   consumer release independently.
 - **No changes to**: backend, Connect-RPC contracts, database, the consumer SPA

--- a/openspec/changes/add-admin-console/tasks.md
+++ b/openspec/changes/add-admin-console/tasks.md
@@ -23,7 +23,7 @@
 - [ ] 4.1 Implement the admin bootstrap to start OIDC sign-in scoped to the admin org id (`urn:zitadel:iam:org:id:<id>`), reusing the shared `AuthService`.
 - [ ] 4.2 Implement the admin auth callback route (`/auth/callback`) completing the code exchange.
 - [ ] 4.3 Implement an authenticated route guard so all admin routes except the callback require sign-in.
-- [ ] 4.4 Implement the post-login welcome placeholder shell (no business features).
+- [ ] 4.4 Implement the post-login welcome placeholder shell (no business features), English-only (no `@aurelia/i18n` machinery in the admin entry).
 - [ ] 4.5 Add unit tests for the route guard and the org-scoped sign-in; `make check` passes.
 
 ## 5. Frontend — serving image (frontend repo)
@@ -34,7 +34,7 @@
 
 ## 6. Infrastructure — admin workload (cloud-provisioning, k8s)
 
-- [ ] 6.1 Add the admin Deployment + Service (own image, spot nodeSelector, explicit requests/limits, readiness/liveness probes) — decide namespace (reuse `frontend` vs new `admin`) per the design open question.
+- [ ] 6.1 Add the admin Deployment + Service in the existing `frontend` namespace as an `admin/` sibling to `web/` (own image, spot nodeSelector, explicit requests/limits, readiness/liveness probes); the existing `frontend` ArgoCD Application picks it up.
 - [ ] 6.2 Add the admin HTTPRoute binding `admin.{base-domain}` (per-overlay hostname) to the admin Service on the shared external gateway.
 - [ ] 6.3 Add per-env `admin-app-runtime-config` ConfigMap (admin org id + admin client id + apiBaseUrl + issuer) mounted at `/config.json`; annotate the admin Deployment for Reloader.
 - [ ] 6.4 Add the admin image alias to the ArgoCD image-updater config.


### PR DESCRIPTION
## 🔗 Related Issue

Refs #599

## 📝 Summary of Changes

Follow-up to #600: resolves the two Open Questions in the `add-admin-console`
design so the spec is unambiguous before implementation. Docs-only (OpenSpec
artifacts), no proto or code changes.

- **Kubernetes namespace → reuse the existing `frontend` namespace.** The admin
  workload is added as an `admin/` sibling to `web/` and served by the existing
  `frontend` ArgoCD Application, rather than a dedicated `admin` namespace + app.
  The `frontend` namespace carries no NetworkPolicy/RBAC/quota today, so a
  separate namespace would duplicate boilerplate without an isolation benefit;
  option ③b's meaningful isolation (separate image, pod, `/config.json`, release
  artifact) is preserved regardless. Accepted trade-off (shared ArgoCD app sync)
  and the future promotion path to a dedicated namespace are documented.
- **i18n → English-only for the foundation.** No `@aurelia/i18n` machinery in the
  admin entry; the welcome placeholder is English-only since it is an internal
  developer tool. Localization can be pulled through `shared/` later if needed.

Updates: proposal Impact, design (Open Questions → Resolved Questions), tasks 4.4
and 6.1.

## Validation

- `openspec validate add-admin-console` → valid.

## ✅ Self-Checklist

- [x] I have linked the related issue.
- [x] I have updated the relevant documentation (OpenSpec artifacts) if needed.
- [ ] I have run `buf lint` and `buf format` locally and all checks have passed. — N/A (docs-only, no proto changes)
- [ ] My proto definitions follow the project's style guidelines and validation rules. — N/A (no proto changes)
- [ ] Breaking changes have been justified and documented if applicable. — N/A
