### PR TITLE
docs(add-admin-console): re-scope verification to prod (no dev env)

### DIFF
--- a/openspec/changes/add-admin-console/design.md
+++ b/openspec/changes/add-admin-console/design.md
@@ -179,9 +179,13 @@ order, parallelizing per the cross-repo release protocol:
    Publish the admin image to AR.
 4. **cloud-provisioning (k8s)**: admin Deployment/Service/HTTPRoute + per-env
    `admin-app-runtime-config` ConfigMap; image-updater alias; ArgoCD picks it up.
-5. Verify dev: Google sign-in works, welcome placeholder renders, consumer
-   bundle/Lighthouse unchanged. Then promote to prod via the standard
-   GH-Release/pin-bump path.
+5. Promote to prod via the standard GH-Release/pin-bump path, then verify in
+   prod: Google sign-in works, welcome placeholder renders, a non-Workspace
+   account is rejected, consumer surface unchanged. There is **no dev
+   environment** to verify against first (it is intentionally shut down for cost
+   and not part of this rollout), so prod is the verification surface —
+   confidence before prod comes from the local build/bundle-isolation checks,
+   unit tests, and the `pulumi preview` diffs rather than a live dev sign-in.
 
 **Rollback:** purely additive — remove/disable the admin HTTPRoute (or scale the
 admin Deployment to 0). The consumer surface is untouched at every step.

--- a/openspec/changes/add-admin-console/tasks.md
+++ b/openspec/changes/add-admin-console/tasks.md
@@ -40,19 +40,18 @@
 - [x] 6.4 Add the admin image alias to the ArgoCD image-updater config.
 - [x] 6.5 `kubectl kustomize` dry-run for the dev overlay (spot nodeSelector + non-empty resources present, patches apply).
 
-## 7. Dev verification
+## 7. Production rollout
 
-- [ ] 7.1 After dev deploys, verify Google Workspace sign-in completes and the welcome placeholder renders at `https://admin.dev.liverty-music.app`.
-- [ ] 7.2 Confirm the consumer SPA is unaffected: bundle output and Lighthouse/Core Web Vitals unchanged, consumer hostname routes and config delivery unchanged.
-- [ ] 7.3 Confirm a non-Workspace account cannot complete sign-in.
+There is no dev environment to verify against (it is intentionally shut down for
+cost and not part of this rollout), so verification happens directly in prod —
+the prod OIDC app, certmap, and Cloud DNS provide the real surface to test the
+Google-Workspace sign-in, welcome render, and access boundary on.
 
-## 8. Production rollout
+- [x] 7.1 Provision the prod admin OIDC app, prod certmap, and prod Cloud DNS; run `pulumi preview` for prod and apply from the Pulumi Cloud console after approval.
+- [ ] 7.2 Release the admin image to prod via the standard frontend release path (GH Release → retag → prod AR → pin-bump → ArgoCD), independently of the consumer SPA. Wire the deferred admin-prod pieces: prod-overlay opt-in (`../../base/admin` + `admin-app-runtime-config` + `admin-app` pin), `bump-prod-pin.yml` per-component image selection, and re-enable the `frontend-admin` dispatch.
+- [ ] 7.3 Verify prod at `https://admin.liverty-music.app`: Google Workspace sign-in completes and the welcome placeholder renders; a non-Workspace account cannot complete sign-in; the consumer prod surface (bundle output, hostname routing, config delivery) is unchanged.
 
-- [ ] 8.1 Provision the prod admin OIDC app, prod certmap, and prod Cloud DNS; run `pulumi preview` for prod and apply from the Pulumi Cloud console after approval.
-- [ ] 8.2 Release the admin image to prod via the standard frontend release path (GH Release → retag → prod AR → pin-bump → ArgoCD), independently of the consumer SPA.
-- [ ] 8.3 Verify prod: admin sign-in works at `https://admin.liverty-music.app`, welcome placeholder renders, consumer prod surface unchanged.
+## 8. Post-merge deployment verification
 
-## 9. Post-merge deployment verification
-
-- [ ] 9.1 Monitor ArgoCD sync for the admin workload in dev and prod; confirm pods are running with the expected config.
-- [x] 9.2 Document the admin release path alongside the consumer's, noting the two are independent artifacts.
+- [ ] 8.1 Monitor ArgoCD sync for the admin workload in prod; confirm pods are running with the expected config.
+- [x] 8.2 Document the admin release path alongside the consumer's, noting the two are independent artifacts.


### PR DESCRIPTION
Removes the dev-verification phase from the `add-admin-console` tasks — there is no dev environment to verify against, so verification is prod-direct.

- §7 reworked to **Production rollout** (was 'Dev verification'); §8 is post-merge verification (prod).
- `design.md` Migration Plan step 5 → prod verification.
- Ticks 7.1 (prod Pulumi apply done — admin OIDC/cert/DNS created).

Refs: #604