### PR TITLE
feat(admin): concert approval queue — ConcertModerationService proto + spec

### DIFF
--- a/openspec/changes/add-concert-approval-queue/.openspec.yaml
+++ b/openspec/changes/add-concert-approval-queue/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-07

--- a/openspec/changes/add-concert-approval-queue/design.md
+++ b/openspec/changes/add-concert-approval-queue/design.md
@@ -1,0 +1,137 @@
+# Design: Concert Approval Queue
+
+## Context
+
+Discovery pipeline today (all async via Watermill):
+
+```
+SearchNewConcerts ──publish CONCERT.discovered──▶ ConcertConsumer.Handle
+                                                        │
+                                                        ▼
+                                              CreateFromDiscovered
+                                                ├─ resolve venue (Google Places)
+                                                ├─ insert series / events / performers (UPSERT)
+                                                └─ publish CONCERT.created ──▶ push "new concert!"
+```
+
+`CONCERT.discovered` carries raw `ScrapedConcert` (pre-venue-resolution). Read RPCs (`List`,
+`ListByFollower`, `ListWithProximity`) read straight from `events`, so a concert is visible to
+fans the instant `CreateFromDiscovered` finishes. The deterministic series id
+(`SHA1(venue_id|date)`) plus the `(date, listed_venue_name)` dedup mean a deleted bad event is
+re-created identically on the next daily run.
+
+## Goals
+
+- A human checkpoint between discovery and fan-visible publication.
+- Re-discovery never silently re-publishes a known-bad event **without** re-review.
+- Reject is **not** a permanent blocklist — a later run with corrected data can re-surface the item.
+- Keep a durable record of rejections for searcher-quality analysis.
+- No re-architecture needed to later relax the gate (auto-approve).
+
+## Decision 1 — Gate by staging, not by post-hoc delete
+
+Insert an approval state between discovery and the `events` write. Discovered items become
+`staged_concert(pending)`; only **approve** runs the existing series/event/performer insert.
+
+```
+SearchNewConcerts ──CONCERT.discovered──▶ consumer
+                                             ├─ resolve venue (Places)
+                                             └─ upsert staged_concert(pending)   ← NO events write
+
+admin console ── ApproveConcert ──▶ insert series/events/performers + publish CONCERT.created
+             └─ RejectConcert  ──▶ delete staged row + append rejected_concerts_log
+```
+
+Why staging over "auto-insert + delete": delete is reactive (bad data is live until a human
+notices) and fights the re-discovery loop. Staging is opt-in publication — nothing bad is ever
+fan-visible, and the loop is handled by the dedup rule (Decision 4).
+
+## Decision 2 — Resolve the venue **before** staging (review fidelity)
+
+Venue mis-resolution (Places matching the wrong place, or a venue string that should not resolve
+at all) is itself a common error class. Resolving up front lets the reviewer see the canonical
+venue name + `admin_area` next to the raw `listed_venue_name` and catch those errors.
+
+Sub-decision **B2 (recommended): resolve but do not persist a `venues` row until approval.**
+At staging time, call Places and **denormalize** the resolved fields (place_id, canonical name,
+admin_area, lat/lng) onto the `staged_concert` row. Create/lookup the real `venues` row only at
+approval. This keeps the `venues` table free of orphans from rejected items — important because
+the upcoming `add-admin-venue-list` (duplicate detection) reads that table and orphan venues
+would pollute it.
+
+Alternative B1 (reuse `resolveVenue` as-is, which creates the `venues` row at staging) is less
+code but leaves orphan venues for every rejected/never-approved item. Rejected.
+
+Cost: Places is called for items that may be rejected. Volume is (followed artists × daily), so
+this is negligible.
+
+## Decision 3 — `CONCERT.created` fires at approval, not discovery
+
+Downstream consumers of `CONCERT.created` (notably push "new concert!") must only run for
+verified data. Move the publish from `CreateFromDiscovered` into the approve use case. This is
+strictly more correct: fans are never notified about unverified concerts.
+
+## Decision 4 — Dedup consults published + pending, never rejected
+
+`FilterNew` currently excludes concerts already in `events`. Extend it to also exclude items
+already `pending` in `staged_concerts`, so the same item is not queued twice. **Rejected items
+are deliberately not consulted** — per the product decision, a later run may bring corrected data
+and should re-surface the item for re-review.
+
+Natural key for staging dedup: `(artist_id, local_date, google_place_id)` using the resolved
+place id (more robust than the raw listed name). When the venue does not resolve, fall back to
+`(artist_id, local_date, listed_venue_name)`.
+
+Resulting staging model is effectively **pending-only**:
+
+```
+discover:
+  ├ natural key in events            → skip (already published)
+  ├ natural key in staged(pending)   → refresh payload, stay pending (latest data wins)
+  └ otherwise                        → insert pending
+
+approve → insert into events + delete staged row + publish CONCERT.created
+reject  → delete staged row + append rejected_concerts_log
+          (next run may re-insert it as pending → re-review)
+```
+
+Known, accepted cost: if Gemini returns the *exact same* wrong data the next day, a rejected item
+re-appears as pending and must be rejected again (review-level churn, never fan-visible).
+
+## Decision 5 — `rejected_concerts_log` is append-only, analysis-only
+
+A rejection writes one row: raw scraped payload, resolved-venue preview, reason, reviewer
+identity, timestamp. It is **never** read by the dedup path (it does not suppress). It exists to
+answer "which errors does the searcher repeat?" and feed searcher tuning. Keeping it separate
+from `staged_concerts` preserves the pending-only simplicity of the staging table.
+
+## Decision 6 — Admin-scoped moderation service
+
+New `ConcertModerationService` in `rpc/admin/v1`, authorized only for the admin org (per
+`rpc-auth-scoping`), consistent with the admin console's auth boundary. A dedicated `admin`
+package leaves room for the future venue-admin service without crowding the consumer-facing
+`ConcertService`.
+
+- `ListPendingConcerts` → `PendingConcert[]` (staged id, artist, title, local_date, start_time,
+  listed_venue_name, resolved venue {name, admin_area, place_id}, source_url, discovered_at).
+- `ApproveConcert(staged_id)` → publishes the concert; idempotent if already approved/gone.
+- `RejectConcert(staged_id, reason)` → drops + logs; idempotent if already gone.
+
+The published entity shape (`entity.v1.Concert`) is unchanged; `PendingConcert` is a distinct
+review DTO because a staged item has no `EventId` yet.
+
+## Onboarding tradeoff (accepted)
+
+Onboarding reads `listConcerts()` straight from `events` right after follow. Gated, a
+brand-new artist (never followed by anyone) shows zero concerts until approval. Popular artists
+are pre-approved by the daily cron, so the common path is mostly unaffected. Accepted as a
+temporary cost; the relaxation path (auto-approve allowlist) is out of scope here.
+
+## Open questions
+
+- **Approve edits?** MVP approves the staged item as-is. Inline correction at review time
+  (fix a wrong date/venue then approve) is deferred — for now a wrong-detail item is rejected and
+  expected to come back corrected, or handled by the future event-edit change.
+- **Reviewer identity source** — Zitadel subject from the admin session; confirm it is available
+  to the RPC for `rejected_concerts_log.reviewed_by`.
+- **Retention** of `rejected_concerts_log` — unbounded for now; revisit if volume grows.

--- a/openspec/changes/add-concert-approval-queue/design.md
+++ b/openspec/changes/add-concert-approval-queue/design.md
@@ -113,7 +113,7 @@ package leaves room for the future venue-admin service without crowding the cons
 `ConcertService`.
 
 - `ListPendingConcerts` → `PendingConcert[]` (staged id, artist, title, local_date, start_time,
-  listed_venue_name, resolved venue {name, admin_area, place_id}, source_url, discovered_at).
+  listed_venue_name, resolved venue {name, admin_area, place_id}, source_url, discovered_time).
 - `ApproveConcert(staged_id)` → publishes the concert; idempotent if already approved/gone.
 - `RejectConcert(staged_id, reason)` → drops + logs; idempotent if already gone.
 

--- a/openspec/changes/add-concert-approval-queue/proposal.md
+++ b/openspec/changes/add-concert-approval-queue/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+Concerts are discovered by a Gemini-grounded searcher and **persisted automatically** the moment `CONCERT.discovered` fires. While the searcher's precision is still stabilizing, this means hallucinated or mis-extracted events (wrong date, wrong venue, non-existent show) reach fans immediately — and the only remedy today is a manual DB delete, which the **daily discovery cron re-creates the next day** because the deterministic series id and the dedup rule both regenerate the exact same row. There is no human checkpoint and no way to stop a known-bad event from re-appearing.
+
+This change inserts a **developer approval gate** between discovery and publication. Discovered concerts land in a staging queue; a developer reviews each one in the admin console and **approves** (publish to fans) or **rejects** (drop). Reject is intentionally **non-permanent** — the next discovery run may bring corrected data and re-surface the item for re-review — but every rejection is recorded in an append-only log so we can study which errors the searcher repeats and feed that back into searcher tuning. This is a **temporary quality measure**: once searcher precision stabilizes, the gate can be relaxed (e.g. an auto-approve allowlist) without re-architecting.
+
+This is the admin console's first business feature, building on the access-controlled shell delivered by the `admin-console` capability.
+
+## What Changes
+
+- **Route discovery through a staging queue instead of direct insert.** The `CONCERT.discovered` consumer no longer writes to `events`. It resolves the venue (Google Places) up front so the reviewer sees the canonical venue, then writes a `staged_concert` row in `pending` state. `events`/`series`/`event_performers`/`venues` are written only on **approval**.
+- **Move `CONCERT.created` to approval time.** The downstream pipeline (push notifications "new concert!") fires when a developer approves, never on raw discovery — so fans are never notified about unverified data.
+- **Add an admin-only moderation service.** New admin-scoped RPCs: list pending concerts (with resolved-venue preview), approve, reject (with reason). Authorized only for the admin org, consistent with the admin console's auth boundary.
+- **Build the approval-queue UI in the admin console.** A reviewer screen listing pending concerts with all reviewable fields (artist, title, date, start time, raw listed venue name, resolved venue name + admin_area, source URL, discovered-at) and approve/reject actions.
+- **Extend dedup so re-discovery respects the queue.** A discovered concert is skipped only when its natural key already exists in `events` (published) **or** as a `pending` staged row. Rejected items are **not** suppressed — they may re-enter the queue on a later run.
+- **Record every rejection in an append-only `rejected_concerts_log`** (raw payload, resolved venue, reason, timestamp, reviewer). Used for searcher-quality analysis only; it never suppresses future discovery.
+
+## Capabilities
+
+### New Capabilities
+- `concert-approval-queue`: The staging lifecycle (`pending` → approved/published or rejected/dropped) for Gemini-discovered concerts, the up-front venue resolution at staging time, the re-discovery dedup rule that consults published + pending (but not rejected) state, the append-only rejection log, the admin-scoped moderation RPCs, and the admin-console reviewer UI.
+
+### Modified Capabilities
+- `concert-service`: The **Concert Persistence** requirement changes from "automatically persist any new concert discovered" to "stage any new concert discovered for approval; persist only on approval." The **Search Concerts by Artist** dedup scenario is extended so newly discovered concerts also exclude those already sitting in the approval queue as `pending`.
+
+## Impact
+
+- **specification**: New `rpc/admin/v1/concert_moderation_service.proto` (`ConcertModerationService` with `ListPendingConcerts`, `ApproveConcert`, `RejectConcert`, and a `PendingConcert` message carrying the staged data plus resolved-venue preview). No change to `entity/v1/concert.proto` or `entity/v1/event.proto` — the published entity shape is unchanged.
+- **backend**: Atlas migration for `staged_concerts` and `rejected_concerts_log`. New `StagedConcert` entity + `StagedConcertRepository`. The `CONCERT.discovered` consumer (`CreateFromDiscovered`) is split: venue-resolve + stage on discovery; the existing series/event/performer insert path moves behind a new "approve" use case that also publishes `CONCERT.created`. `FilterNew` dedup extended to consult `staged_concerts(pending)`. New admin RPC handler with admin-org authorization (per `rpc-auth-scoping`).
+- **frontend**: New approval-queue route + components in the `admin/` app (bundle-isolated from the consumer SPA), consuming `ConcertModerationService`.
+- **cloud-provisioning**: None expected — no new job or manifest; the existing discovery cron is unchanged (it still calls `SearchNewConcerts`; only the downstream consumer behavior changes).
+- **Product tradeoff (accepted)**: Onboarding loses concert immediacy for **brand-new artists nobody has followed before** — their concerts stay invisible until a developer approves. Already-followed (popular) artists are largely pre-approved via the daily cron, so the common onboarding path is mostly unaffected. Accepted as a temporary cost of the quality gate.
+- **Out of scope**: event-level delete of already-approved concerts (post-publication correction — a separate change); the admin venue-list / duplicate-detection screen (separate change `add-admin-venue-list`); auto-approve allowlist / confidence-based auto-approval (a later relaxation once precision stabilizes).

--- a/openspec/changes/add-concert-approval-queue/specs/concert-approval-queue/spec.md
+++ b/openspec/changes/add-concert-approval-queue/specs/concert-approval-queue/spec.md
@@ -1,0 +1,177 @@
+## ADDED Requirements
+
+### Requirement: Discovered concerts are staged, not published
+
+A concert discovered by the search pipeline SHALL be written to a staging queue in a `pending`
+state and SHALL NOT be inserted into the published `events`/`series`/`event_performers` tables
+until a developer approves it. The `CONCERT.discovered` consumer SHALL perform venue resolution
+up front and persist a `staged_concert` row; it SHALL NOT publish `CONCERT.created`.
+
+#### Scenario: Discovery writes a pending staged concert
+
+- **WHEN** the `CONCERT.discovered` consumer processes a newly discovered concert
+- **THEN** it SHALL resolve the venue via Google Places
+- **AND** it SHALL persist a `staged_concert` row in `pending` state carrying the scraped fields
+  and the resolved-venue preview
+- **AND** it SHALL NOT insert any row into `events`, `series`, or `event_performers`
+- **AND** it SHALL NOT publish `CONCERT.created`
+
+#### Scenario: Pending concerts are not fan-visible
+
+- **WHEN** a concert is in `pending` state in the approval queue
+- **THEN** it SHALL NOT be returned by any consumer-facing read RPC (`List`, `ListByFollower`,
+  `ListWithProximity`)
+
+### Requirement: Venue resolved at staging time, persisted at approval
+
+The system SHALL resolve the venue (Google Places) when a concert is staged and SHALL denormalize
+the resolved venue fields (place id, canonical name, admin_area, coordinates) onto the
+`staged_concert` row for reviewer display. A `venues` row SHALL be created or looked up only when
+the staged concert is approved, so that rejected or never-approved concerts SHALL NOT create
+orphan `venues` rows.
+
+#### Scenario: Resolved venue stored on the staged row
+
+- **WHEN** a concert is staged and its venue resolves via Google Places
+- **THEN** the resolved canonical venue name, `admin_area`, place id, and coordinates SHALL be
+  stored on the `staged_concert` row
+- **AND** no `venues` row SHALL be created at this point
+
+#### Scenario: Venue row created on approval
+
+- **WHEN** a staged concert is approved
+- **THEN** the system SHALL create or reuse the `venues` row for the resolved venue
+- **AND** associate the published event with it
+
+#### Scenario: Rejected concert leaves no orphan venue
+
+- **WHEN** a staged concert is rejected
+- **THEN** no `venues` row SHALL have been created on its behalf
+
+### Requirement: Approval publishes the concert
+
+The system SHALL provide an approval operation that, given a `pending` staged concert, inserts the
+published `series`/`events`/`event_performers` rows (reusing the existing bulk-insert and
+natural-key UPSERT behavior), removes the staged row, and publishes `CONCERT.created`.
+
+#### Scenario: Approve publishes and notifies
+
+- **WHEN** a developer approves a `pending` staged concert
+- **THEN** the system SHALL insert the published event (and its series and performers)
+- **AND** SHALL delete the staged row
+- **AND** SHALL publish `CONCERT.created` so downstream notification consumers run
+
+#### Scenario: Approve is idempotent
+
+- **WHEN** an approve operation targets a staged concert that no longer exists (already approved
+  or rejected)
+- **THEN** the operation SHALL succeed without error and SHALL NOT create a duplicate event
+
+### Requirement: Rejection drops the concert and is non-permanent
+
+The system SHALL provide a reject operation that removes a `pending` staged concert and records
+the rejection in an append-only log. Rejection SHALL NOT permanently suppress the concert: a
+later discovery run that produces the same natural key SHALL re-stage it as `pending` for
+re-review.
+
+#### Scenario: Reject drops and logs
+
+- **WHEN** a developer rejects a `pending` staged concert with a reason
+- **THEN** the system SHALL delete the staged row
+- **AND** SHALL append a `rejected_concerts_log` entry capturing the raw scraped payload, the
+  resolved-venue preview, the reason, the reviewer identity, and the timestamp
+
+#### Scenario: Rejected concert can re-enter the queue
+
+- **WHEN** a concert was previously rejected
+- **AND** a later discovery run produces the same natural key
+- **AND** that natural key is not present in `events` or as a `pending` staged row
+- **THEN** the system SHALL re-stage it as `pending`
+
+#### Scenario: Reject is idempotent
+
+- **WHEN** a reject operation targets a staged concert that no longer exists
+- **THEN** the operation SHALL succeed without error
+
+### Requirement: Re-discovery dedup consults published and pending state
+
+When the search pipeline filters newly discovered concerts, it SHALL exclude any concert whose
+natural key already exists in the published `events` table OR as a `pending` row in the staging
+queue. It SHALL NOT consult the `rejected_concerts_log` for this filtering.
+
+#### Scenario: Already published is skipped
+
+- **WHEN** a discovered concert's natural key matches an existing published event
+- **THEN** it SHALL NOT be staged
+
+#### Scenario: Already pending is refreshed, not duplicated
+
+- **WHEN** a discovered concert's natural key matches an existing `pending` staged row
+- **THEN** the system SHALL update that staged row's payload with the latest discovered data
+- **AND** SHALL NOT create a second `pending` row for the same natural key
+
+#### Scenario: Previously rejected is not suppressed
+
+- **WHEN** a discovered concert's natural key matches only a `rejected_concerts_log` entry (and is
+  absent from `events` and `pending` staging)
+- **THEN** the concert SHALL be staged as `pending`
+
+### Requirement: Rejection log is append-only and analysis-only
+
+The system SHALL maintain a `rejected_concerts_log` that is append-only and used solely for
+searcher-quality analysis. It SHALL NOT participate in discovery dedup or otherwise suppress
+future staging.
+
+#### Scenario: Log does not affect staging
+
+- **WHEN** the discovery pipeline evaluates whether to stage a concert
+- **THEN** the presence of a matching `rejected_concerts_log` entry SHALL have no effect on the
+  staging decision
+
+### Requirement: Admin-scoped moderation RPCs
+
+The system SHALL expose a `ConcertModerationService` whose RPCs are authorized only for the admin
+org, consistent with the admin console authentication boundary. The service SHALL provide
+operations to list pending concerts, approve a pending concert, and reject a pending concert with
+a reason.
+
+#### Scenario: Admin lists pending concerts
+
+- **WHEN** an authenticated admin-org caller invokes `ListPendingConcerts`
+- **THEN** the response SHALL contain each pending concert's staged id, performing artist, title,
+  local date, start time, raw `listed_venue_name`, resolved venue (name, admin_area, place id),
+  source URL, and discovered-at timestamp
+
+#### Scenario: Non-admin caller is denied
+
+- **WHEN** a caller outside the admin org invokes any `ConcertModerationService` RPC
+- **THEN** the call SHALL be rejected with a permission error and SHALL NOT mutate state
+
+#### Scenario: Approve and reject act on the identified staged concert
+
+- **WHEN** an admin invokes `ApproveConcert` or `RejectConcert` with a staged concert id
+- **THEN** the system SHALL apply the corresponding approval or rejection behavior to that staged
+  concert
+
+### Requirement: Admin console approval-queue UI
+
+The admin console SHALL provide a reviewer screen that lists pending concerts with all reviewable
+fields and offers approve and reject (with reason) actions. The screen SHALL live in the
+bundle-isolated `admin/` app and SHALL consume `ConcertModerationService`.
+
+#### Scenario: Reviewer sees pending concerts with resolved venue
+
+- **WHEN** an authenticated developer opens the approval-queue screen
+- **THEN** it SHALL list each pending concert showing the artist, title, date, start time, the raw
+  listed venue name, and the resolved venue name with its admin_area
+
+#### Scenario: Reviewer approves an item
+
+- **WHEN** the developer approves a pending concert
+- **THEN** the UI SHALL call `ApproveConcert` and remove the item from the pending list on success
+
+#### Scenario: Reviewer rejects an item with a reason
+
+- **WHEN** the developer rejects a pending concert and provides a reason
+- **THEN** the UI SHALL call `RejectConcert` with that reason and remove the item from the pending
+  list on success

--- a/openspec/changes/add-concert-approval-queue/specs/concert-approval-queue/spec.md
+++ b/openspec/changes/add-concert-approval-queue/specs/concert-approval-queue/spec.md
@@ -140,7 +140,7 @@ a reason.
 - **WHEN** an authenticated admin-org caller invokes `ListPendingConcerts`
 - **THEN** the response SHALL contain each pending concert's staged id, performing artist, title,
   local date, start time, raw `listed_venue_name`, resolved venue (name, admin_area, place id),
-  source URL, and discovered-at timestamp
+  source URL, and discovered-time timestamp
 
 #### Scenario: Non-admin caller is denied
 

--- a/openspec/changes/add-concert-approval-queue/specs/concert-service/spec.md
+++ b/openspec/changes/add-concert-approval-queue/specs/concert-service/spec.md
@@ -1,0 +1,79 @@
+## MODIFIED Requirements
+
+### Requirement: Search Concerts by Artist
+
+System must provide a way to search for future concerts of a specific artist using generative AI grounding. Error returns SHALL include contextual wrapping indicating which operation failed.
+
+#### Scenario: Successful Search with known official site
+
+- **WHEN** `SearchNewConcerts` is called for an existing artist
+- **AND** the artist has a persisted official site record
+- **THEN** the system returns a list of upcoming concerts found on the web
+- **AND** each concert includes title, venue, date, and start time
+- **AND** results exclude concerts that are already stored in the database
+- **AND** results exclude concerts that are already present in the approval queue in `pending` state
+
+#### Scenario: Successful Search without official site
+
+- **WHEN** `SearchNewConcerts` is called for an existing artist
+- **AND** the artist has no persisted official site record
+- **THEN** the system SHALL still perform the external search using the artist name
+- **AND** return a list of upcoming concerts if found
+- **AND** NOT return an error solely because the official site is missing
+
+#### Scenario: Filter Past Events
+
+- **WHEN** the search results include events with dates in the past
+- **THEN** the system must filter them out and only return future events
+
+#### Scenario: No Results
+
+- **WHEN** no upcoming concerts are found for the artist
+- **THEN** the system returns an empty list without error
+
+#### Scenario: Error context in failures
+
+- **WHEN** any internal operation fails (get artist, list existing concerts, search external API)
+- **THEN** the error SHALL be wrapped with `fmt.Errorf` indicating which step failed
+- **AND** the original error SHALL be preserved via `%w` verb
+
+### Requirement: Concert Persistence
+
+The system SHALL route any new concert discovered via the search mechanism into the approval queue
+rather than persisting it directly. A discovered concert SHALL be staged in `pending` state and
+SHALL be inserted into the published `events`/`concerts`/`series`/`event_performers` tables only
+when a developer approves it. The `ConcertRepository.Create` method SHALL remain the persistence
+path used at approval time: it SHALL accept a variadic number of concerts for bulk insert support
+and SHALL use the PostgreSQL `unnest` pattern instead of manual placeholder construction.
+
+#### Scenario: Discovered concerts are staged, not persisted
+
+- **WHEN** `SearchNewConcerts` finds concerts not currently in the database
+- **THEN** those concerts SHALL be staged in the approval queue in `pending` state
+- **AND** they SHALL NOT be inserted into the `events`/`concerts` tables until approved
+
+#### Scenario: Persist on approval
+
+- **WHEN** a developer approves a pending staged concert
+- **THEN** the concert SHALL be saved to the persisted storage via a single bulk insert call
+- **AND** persisted with a valid ID
+
+#### Scenario: Persist Venues on approval
+
+- **WHEN** a staged concert is approved and its resolved venue does not exist in the database
+- **THEN** a new venue is created based on the resolved venue from staging
+- **AND** if an `admin_area` was extracted for the concert, it SHALL be stored on the venue record
+- **AND** the new venue SHALL have `enrichment_status` set to `'pending'`
+- **AND** the approved concert is associated with this new venue
+
+#### Scenario: Bulk insert uses unnest
+
+- **WHEN** `Create` is called with multiple concerts
+- **THEN** the repository SHALL use `unnest` arrays for both `events` and `concerts` table inserts
+- **AND** the implementation SHALL NOT use manual `fmt.Sprintf` placeholder construction
+- **AND** no `maxConcertsPerBatch` batching loop SHALL be required
+
+#### Scenario: Single concert creation
+
+- **WHEN** `Create` is called with a single concert argument
+- **THEN** it SHALL behave identically to the previous single-insert implementation

--- a/openspec/changes/add-concert-approval-queue/tasks.md
+++ b/openspec/changes/add-concert-approval-queue/tasks.md
@@ -1,7 +1,7 @@
 ## 1. Proto Definitions (specification)
 
 - [x] 1.1 Create `rpc/admin/v1/concert_moderation_service.proto` with `service ConcertModerationService`
-- [x] 1.2 Define `PendingConcert` message: `staged_id`, performing `Artist`, `title`, `LocalDate local_date`, optional `StartTime start_time`, `listed_venue_name`, resolved `Venue` (name, admin_area, place id, coordinates), `source_url` (reuse `Url` VO), `discovered_at`
+- [x] 1.2 Define `PendingConcert` message: `staged_id`, performing `Artist`, `title`, `LocalDate local_date`, optional `StartTime start_time`, `listed_venue_name`, resolved `Venue` (name, admin_area, place id, coordinates), `source_url` (reuse `Url` VO), `discovered_time` (proto `_time` suffix; maps to the DB `discovered_at` column)
 - [x] 1.3 Define `ListPendingConcerts` (request/response with `repeated PendingConcert`), `ApproveConcert` (`staged_id`), `RejectConcert` (`staged_id`, required `reason`) RPCs with protovalidate constraints
 - [x] 1.4 Document each RPC's `Possible errors` (PERMISSION_DENIED for non-admin, INVALID_ARGUMENT, NOT_FOUND tolerated as idempotent no-op per design)
 - [x] 1.5 Run `buf lint` and `buf format -w`; confirm additive-only (no breaking change; consumer protos untouched)

--- a/openspec/changes/add-concert-approval-queue/tasks.md
+++ b/openspec/changes/add-concert-approval-queue/tasks.md
@@ -10,11 +10,11 @@
 
 ## 2. Database Migration (backend)
 
-- [ ] 2.1 Atlas migration for `staged_concerts`: `id` UUID PK, `artist_id` FK→artists, `title`, `local_date` DATE, `start_at`/`open_at` TIMESTAMPTZ nullable, `listed_venue_name` TEXT, `admin_area` TEXT nullable, `source_url` TEXT, resolved-venue columns (`resolved_place_id`, `resolved_venue_name`, `resolved_admin_area`, `resolved_lat`, `resolved_lng`) nullable, `discovered_at` TIMESTAMPTZ NOT NULL
-- [ ] 2.2 Add a uniqueness constraint over the staging natural key `(artist_id, local_date, resolved_place_id)` with a NULL-safe fallback path on `listed_venue_name` so re-discovery refreshes the pending row rather than duplicating it
-- [ ] 2.3 Atlas migration for `rejected_concerts_log` (append-only): `id` UUID PK, raw scraped payload columns, resolved-venue preview columns, `reason` TEXT, `reviewed_by` TEXT, `rejected_at` TIMESTAMPTZ NOT NULL; no FK that would cascade-delete history
-- [ ] 2.4 Apply locally with `atlas migrate apply --env local`; confirm `events`/`venues` schemas unchanged
-- [ ] 2.5 Upgrade backend to the BSR-published proto version (`go get ...@vX.Y.Z`, `go mod tidy`); confirm `make check`
+- [x] 2.1 Atlas migration for `staged_concerts`: `id` UUID PK, `artist_id` FK→artists, `title`, `local_date` DATE, `start_at`/`open_at` TIMESTAMPTZ nullable, `listed_venue_name` TEXT, `admin_area` TEXT nullable, `source_url` TEXT, resolved-venue columns (`resolved_place_id`, `resolved_venue_name`, `resolved_admin_area`, `resolved_lat`, `resolved_lng`) nullable, `discovered_at` TIMESTAMPTZ NOT NULL
+- [x] 2.2 Add a uniqueness constraint over the staging natural key `(artist_id, local_date, resolved_place_id)` with a NULL-safe fallback path on `listed_venue_name` so re-discovery refreshes the pending row rather than duplicating it
+- [x] 2.3 Atlas migration for `rejected_concerts_log` (append-only): `id` UUID PK, raw scraped payload columns, resolved-venue preview columns, `reason` TEXT, `reviewed_by` TEXT, `rejected_at` TIMESTAMPTZ NOT NULL; no FK that would cascade-delete history
+- [x] 2.4 Apply locally with `atlas migrate apply --env local`; confirm `events`/`venues` schemas unchanged
+- [ ] 2.5 (BLOCKED on BSR gen) Upgrade backend to the BSR-published proto version (`go get ...@vX.Y.Z`, `go mod tidy`); confirm `make check`
 
 ## 3. Backend Entity & Repository
 

--- a/openspec/changes/add-concert-approval-queue/tasks.md
+++ b/openspec/changes/add-concert-approval-queue/tasks.md
@@ -1,0 +1,57 @@
+## 1. Proto Definitions (specification)
+
+- [x] 1.1 Create `rpc/admin/v1/concert_moderation_service.proto` with `service ConcertModerationService`
+- [x] 1.2 Define `PendingConcert` message: `staged_id`, performing `Artist`, `title`, `LocalDate local_date`, optional `StartTime start_time`, `listed_venue_name`, resolved `Venue` (name, admin_area, place id, coordinates), `source_url` (reuse `Url` VO), `discovered_at`
+- [x] 1.3 Define `ListPendingConcerts` (request/response with `repeated PendingConcert`), `ApproveConcert` (`staged_id`), `RejectConcert` (`staged_id`, required `reason`) RPCs with protovalidate constraints
+- [x] 1.4 Document each RPC's `Possible errors` (PERMISSION_DENIED for non-admin, INVALID_ARGUMENT, NOT_FOUND tolerated as idempotent no-op per design)
+- [x] 1.5 Run `buf lint` and `buf format -w`; confirm additive-only (no breaking change; consumer protos untouched)
+- [ ] 1.6 Open specification PR; after review + CI, merge and publish a GitHub Release (`vX.Y.Z`) to trigger BSR gen (CI-only; do NOT run `buf push`/`buf generate` locally)
+- [ ] 1.7 Monitor `buf-release.yml` until BSR gen completes; record the published version
+
+## 2. Database Migration (backend)
+
+- [ ] 2.1 Atlas migration for `staged_concerts`: `id` UUID PK, `artist_id` FK→artists, `title`, `local_date` DATE, `start_at`/`open_at` TIMESTAMPTZ nullable, `listed_venue_name` TEXT, `admin_area` TEXT nullable, `source_url` TEXT, resolved-venue columns (`resolved_place_id`, `resolved_venue_name`, `resolved_admin_area`, `resolved_lat`, `resolved_lng`) nullable, `discovered_at` TIMESTAMPTZ NOT NULL
+- [ ] 2.2 Add a uniqueness constraint over the staging natural key `(artist_id, local_date, resolved_place_id)` with a NULL-safe fallback path on `listed_venue_name` so re-discovery refreshes the pending row rather than duplicating it
+- [ ] 2.3 Atlas migration for `rejected_concerts_log` (append-only): `id` UUID PK, raw scraped payload columns, resolved-venue preview columns, `reason` TEXT, `reviewed_by` TEXT, `rejected_at` TIMESTAMPTZ NOT NULL; no FK that would cascade-delete history
+- [ ] 2.4 Apply locally with `atlas migrate apply --env local`; confirm `events`/`venues` schemas unchanged
+- [ ] 2.5 Upgrade backend to the BSR-published proto version (`go get ...@vX.Y.Z`, `go mod tidy`); confirm `make check`
+
+## 3. Backend Entity & Repository
+
+- [ ] 3.1 Define `StagedConcert` entity (`internal/entity/staged_concert.go`) with the scraped + resolved-venue fields and a `pending`-only model
+- [ ] 3.2 Define `StagedConcertRepository` interface: `Upsert(pending)` (refresh-on-conflict by natural key), `ListPending`, `GetByID`, `Delete`, plus a `ListPendingNaturalKeys` (or equivalent) for dedup
+- [ ] 3.3 Implement pgx `StagedConcertRepository` (unnest where bulk; UPSERT refresh on natural key)
+- [ ] 3.4 Define `RejectedConcertLogRepository` interface + pgx impl: `Append(entry)` only
+- [ ] 3.5 Repository integration tests: refresh-on-conflict (no duplicate pending), delete, append-only log, NULL-safe natural key fallback
+
+## 4. Backend Discovery → Staging Rewrite
+
+- [ ] 4.1 Split `CreateFromDiscovered`: keep venue **resolution** (Google Places) on the discovery path; replace the `events`/`series`/`performers` insert + `CONCERT.created` publish with `StagedConcertRepository.Upsert(pending)`
+- [ ] 4.2 Implement B2 venue handling: resolve via Places, denormalize onto the staged row; do NOT create a `venues` row on the discovery path
+- [ ] 4.3 Extend `FilterNew` dedup to also exclude concerts already `pending` in `staged_concerts`; confirm it does NOT consult `rejected_concerts_log`
+- [ ] 4.4 Unit tests: discovery stages pending and writes no `events`/`venues`; pending refresh; rejected key re-stages
+
+## 5. Backend Approve / Reject Use Cases + RPC
+
+- [ ] 5.1 Implement `ApproveConcert` use case: create/reuse `venues` row, run the existing series/event/performer bulk insert (UPSERT), delete the staged row, publish `CONCERT.created`; idempotent when the staged row is gone
+- [ ] 5.2 Implement `RejectConcert` use case: append `rejected_concerts_log` (with reviewer identity + reason), delete the staged row; idempotent when gone
+- [ ] 5.3 Confirm `CONCERT.created` is published ONLY from the approve path (removed from discovery)
+- [ ] 5.4 Implement `ConcertModerationService` handler (`ListPendingConcerts`/`ApproveConcert`/`RejectConcert`) with mappers to `PendingConcert`
+- [ ] 5.5 Apply admin-org authorization per `rpc-auth-scoping`; non-admin callers get PERMISSION_DENIED. Wire reviewer identity (Zitadel subject) into reject logging
+- [ ] 5.6 Register the service in DI / RPC server wiring
+- [ ] 5.7 Use-case + handler tests (approve publishes + notifies; reject logs + drops; idempotency; auth denial); `make check` green
+
+## 6. Frontend Admin Console UI
+
+- [ ] 6.1 Upgrade the frontend to the BSR-published proto version; generate the `ConcertModerationService` client
+- [ ] 6.2 Add an approval-queue route + component in the bundle-isolated `admin/` app (no consumer-SPA import; respect the import-boundary lint)
+- [ ] 6.3 Render the pending list with all reviewable fields (artist, title, date, start time, raw listed venue name, resolved venue name + admin_area, source URL, discovered-at)
+- [ ] 6.4 Wire approve action (`ApproveConcert`) and reject action with a reason prompt (`RejectConcert`); remove the row on success; surface errors
+- [ ] 6.5 Component/unit tests; `make check` green
+
+## 7. Ship to Production
+
+- [ ] 7.1 Open backend PR after the proto package upgrade + swap succeeds locally (CI green from first push); merge
+- [ ] 7.2 Open frontend PR; merge
+- [ ] 7.3 Release backend (`vX.Y.Z`) and frontend per each repo's release process so the gate runs in production; verify the discovery cron now stages (no direct publish) and the admin console approval queue works against prod
+- [ ] 7.4 Confirm `CONCERT.created` (push notifications) fires only on approval in production

--- a/openspec/changes/add-concert-approval-queue/tasks.md
+++ b/openspec/changes/add-concert-approval-queue/tasks.md
@@ -18,36 +18,36 @@
 
 ## 3. Backend Entity & Repository
 
-- [ ] 3.1 Define `StagedConcert` entity (`internal/entity/staged_concert.go`) with the scraped + resolved-venue fields and a `pending`-only model
-- [ ] 3.2 Define `StagedConcertRepository` interface: `Upsert(pending)` (refresh-on-conflict by natural key), `ListPending`, `GetByID`, `Delete`, plus a `ListPendingNaturalKeys` (or equivalent) for dedup
-- [ ] 3.3 Implement pgx `StagedConcertRepository` (unnest where bulk; UPSERT refresh on natural key)
-- [ ] 3.4 Define `RejectedConcertLogRepository` interface + pgx impl: `Append(entry)` only
-- [ ] 3.5 Repository integration tests: refresh-on-conflict (no duplicate pending), delete, append-only log, NULL-safe natural key fallback
+- [x] 3.1 Define `StagedConcert` entity (`internal/entity/staged_concert.go`) with the scraped + resolved-venue fields and a `pending`-only model
+- [x] 3.2 Define `StagedConcertRepository` interface: `Upsert(pending)` (refresh-on-conflict by natural key), `ListPending`, `GetByID`, `Delete`, plus a `ListPendingNaturalKeys` (or equivalent) for dedup
+- [x] 3.3 Implement pgx `StagedConcertRepository` (unnest where bulk; UPSERT refresh on natural key)
+- [x] 3.4 Define `RejectedConcertLogRepository` interface + pgx impl: `Append(entry)` only
+- [x] 3.5 Repository integration tests: refresh-on-conflict (no duplicate pending), delete, append-only log, NULL-safe natural key fallback
 
 ## 4. Backend Discovery → Staging Rewrite
 
-- [ ] 4.1 Split `CreateFromDiscovered`: keep venue **resolution** (Google Places) on the discovery path; replace the `events`/`series`/`performers` insert + `CONCERT.created` publish with `StagedConcertRepository.Upsert(pending)`
-- [ ] 4.2 Implement B2 venue handling: resolve via Places, denormalize onto the staged row; do NOT create a `venues` row on the discovery path
-- [ ] 4.3 Extend `FilterNew` dedup to also exclude concerts already `pending` in `staged_concerts`; confirm it does NOT consult `rejected_concerts_log`
-- [ ] 4.4 Unit tests: discovery stages pending and writes no `events`/`venues`; pending refresh; rejected key re-stages
+- [x] 4.1 Split `CreateFromDiscovered`: keep venue **resolution** (Google Places) on the discovery path; replace the `events`/`series`/`performers` insert + `CONCERT.created` publish with `StagedConcertRepository.Upsert(pending)`
+- [x] 4.2 Implement B2 venue handling: resolve via Places, denormalize onto the staged row; do NOT create a `venues` row on the discovery path
+- [x] 4.3 Extend `FilterNew` dedup to also exclude concerts already `pending` in `staged_concerts`; confirm it does NOT consult `rejected_concerts_log`
+- [x] 4.4 Unit tests: discovery stages pending and writes no `events`/`venues`; pending refresh; rejected key re-stages
 
 ## 5. Backend Approve / Reject Use Cases + RPC
 
-- [ ] 5.1 Implement `ApproveConcert` use case: create/reuse `venues` row, run the existing series/event/performer bulk insert (UPSERT), delete the staged row, publish `CONCERT.created`; idempotent when the staged row is gone
-- [ ] 5.2 Implement `RejectConcert` use case: append `rejected_concerts_log` (with reviewer identity + reason), delete the staged row; idempotent when gone
-- [ ] 5.3 Confirm `CONCERT.created` is published ONLY from the approve path (removed from discovery)
-- [ ] 5.4 Implement `ConcertModerationService` handler (`ListPendingConcerts`/`ApproveConcert`/`RejectConcert`) with mappers to `PendingConcert`
-- [ ] 5.5 Apply admin-org authorization per `rpc-auth-scoping`; non-admin callers get PERMISSION_DENIED. Wire reviewer identity (Zitadel subject) into reject logging
-- [ ] 5.6 Register the service in DI / RPC server wiring
-- [ ] 5.7 Use-case + handler tests (approve publishes + notifies; reject logs + drops; idempotency; auth denial); `make check` green
+- [x] 5.1 Implement `ApproveConcert` use case: create/reuse `venues` row, run the existing series/event/performer bulk insert (UPSERT), delete the staged row, publish `CONCERT.created`; idempotent when the staged row is gone
+- [x] 5.2 Implement `RejectConcert` use case: append `rejected_concerts_log` (with reviewer identity + reason), delete the staged row; idempotent when gone
+- [x] 5.3 Confirm `CONCERT.created` is published ONLY from the approve path (removed from discovery)
+- [ ] (BSR-blocked) 5.4 Implement `ConcertModerationService` handler (`ListPendingConcerts`/`ApproveConcert`/`RejectConcert`) with mappers to `PendingConcert`
+- [ ] (BSR-blocked) 5.5 Apply admin-org authorization per `rpc-auth-scoping`; non-admin callers get PERMISSION_DENIED. Wire reviewer identity (Zitadel subject) into reject logging
+- [ ] (BSR-blocked) 5.6 Register the service in DI / RPC server wiring
+- [ ] (BSR-blocked) 5.7 Use-case + handler tests (approve publishes + notifies; reject logs + drops; idempotency; auth denial); `make check` green
 
 ## 6. Frontend Admin Console UI
 
-- [ ] 6.1 Upgrade the frontend to the BSR-published proto version; generate the `ConcertModerationService` client
-- [ ] 6.2 Add an approval-queue route + component in the bundle-isolated `admin/` app (no consumer-SPA import; respect the import-boundary lint)
-- [ ] 6.3 Render the pending list with all reviewable fields (artist, title, date, start time, raw listed venue name, resolved venue name + admin_area, source URL, discovered-at)
-- [ ] 6.4 Wire approve action (`ApproveConcert`) and reject action with a reason prompt (`RejectConcert`); remove the row on success; surface errors
-- [ ] 6.5 Component/unit tests; `make check` green
+- [ ] (BSR-blocked) 6.1 Upgrade the frontend to the BSR-published proto version; generate the `ConcertModerationService` client
+- [ ] (BSR-blocked) 6.2 Add an approval-queue route + component in the bundle-isolated `admin/` app (no consumer-SPA import; respect the import-boundary lint)
+- [ ] (BSR-blocked) 6.3 Render the pending list with all reviewable fields (artist, title, date, start time, raw listed venue name, resolved venue name + admin_area, source URL, discovered-at)
+- [ ] (BSR-blocked) 6.4 Wire approve action (`ApproveConcert`) and reject action with a reason prompt (`RejectConcert`); remove the row on success; surface errors
+- [ ] (BSR-blocked) 6.5 Component/unit tests; `make check` green
 
 ## 7. Ship to Production
 

--- a/proto/liverty_music/entity/v1/staged_concert.proto
+++ b/proto/liverty_music/entity/v1/staged_concert.proto
@@ -1,0 +1,16 @@
+syntax = "proto3";
+
+package liverty_music.entity.v1;
+
+import "buf/validate/validate.proto";
+
+option go_package = "github.com/liverty-music/specification/gen/go/liverty_music/entity/v1;entityv1";
+
+// StagedConcertId uniquely identifies a concert held in the approval queue while
+// it awaits developer review. It is distinct from EventId because a staged
+// concert has not yet been published as an event; the id is assigned when the
+// concert is first staged by the discovery pipeline.
+message StagedConcertId {
+  // A UUID string representing the unique identity of the staged concert.
+  string value = 1 [(buf.validate.field).string.uuid = true];
+}

--- a/proto/liverty_music/entity/v1/venue.proto
+++ b/proto/liverty_music/entity/v1/venue.proto
@@ -33,6 +33,16 @@ message VenueName {
   string value = 1 [(buf.validate.field).string.min_len = 1];
 }
 
+// PlaceId is the external Google Places identifier for a venue location.
+// It is an opaque, third-party string (not a Liverty UUID) used as the stable
+// venue identity for staging-level deduplication and venue resolution, mirroring
+// how Mbid wraps the external MusicBrainz identifier.
+message PlaceId {
+  // The Google Places place id. Opaque and externally assigned; validated only
+  // for non-emptiness since its format is controlled by Google.
+  string value = 1 [(buf.validate.field).string.min_len = 1];
+}
+
 // AdminArea represents the administrative division where a venue is located
 // as an ISO 3166-2 subdivision code (e.g., "JP-13" for Tokyo, "US-CA" for California).
 //

--- a/proto/liverty_music/rpc/admin/v1/concert_moderation_service.proto
+++ b/proto/liverty_music/rpc/admin/v1/concert_moderation_service.proto
@@ -1,0 +1,147 @@
+syntax = "proto3";
+
+// Package liverty_music.rpc.admin.v1 provides admin-only gRPC service definitions
+// for internal moderation tooling exposed through the developer admin console.
+//
+// These services are authorized solely for the admin organization and are never
+// reachable by the consumer product. The first capability is concert moderation:
+// reviewing AI-discovered concerts before they are published to fans.
+package liverty_music.rpc.admin.v1;
+
+import "buf/validate/validate.proto";
+import "google/protobuf/timestamp.proto";
+import "liverty_music/entity/v1/artist.proto";
+import "liverty_music/entity/v1/coordinates.proto";
+import "liverty_music/entity/v1/entity.proto";
+import "liverty_music/entity/v1/venue.proto";
+
+// ConcertModerationService lets internal developers review concerts discovered by
+// the generative-AI search pipeline before they become visible to fans.
+//
+// Discovered concerts are held in a staging queue in a pending state. A developer
+// approves a concert to publish it (and trigger the new-concert notification) or
+// rejects it to drop it. Rejection is not permanent: a later discovery run may
+// re-surface the same concert for re-review, and every rejection is recorded for
+// search-quality analysis.
+//
+// All RPCs are authorized only for the admin organization; callers outside it are
+// rejected with PERMISSION_DENIED.
+service ConcertModerationService {
+  // ListPendingConcerts returns every concert currently awaiting review, including
+  // the resolved-venue preview so the reviewer can judge venue accuracy.
+  //
+  // Possible errors:
+  // - PERMISSION_DENIED: The caller is not a member of the admin organization.
+  rpc ListPendingConcerts(ListPendingConcertsRequest) returns (ListPendingConcertsResponse);
+
+  // ApproveConcert publishes a pending concert to fans and emits the new-concert
+  // notification. The operation is idempotent: approving a staged concert that no
+  // longer exists succeeds without creating a duplicate.
+  //
+  // Possible errors:
+  // - PERMISSION_DENIED: The caller is not a member of the admin organization.
+  // - INVALID_ARGUMENT: The staged concert id is missing or malformed.
+  rpc ApproveConcert(ApproveConcertRequest) returns (ApproveConcertResponse);
+
+  // RejectConcert drops a pending concert and records the rejection (with reason)
+  // for search-quality analysis. The operation is idempotent: rejecting a staged
+  // concert that no longer exists succeeds.
+  //
+  // Possible errors:
+  // - PERMISSION_DENIED: The caller is not a member of the admin organization.
+  // - INVALID_ARGUMENT: The staged concert id is missing, or the reason is empty.
+  rpc RejectConcert(RejectConcertRequest) returns (RejectConcertResponse);
+}
+
+// StagedConcertId uniquely identifies a concert sitting in the approval queue.
+// It is distinct from EventId because a staged concert has not yet been published
+// as an event; the id is assigned when the concert is first staged.
+message StagedConcertId {
+  // A UUID string representing the unique identity of the staged concert.
+  string value = 1 [(buf.validate.field).string.uuid = true];
+}
+
+// ResolvedVenue is the venue preview produced by resolving the raw scraped venue
+// name against Google Places at staging time. It is shown alongside the raw
+// listed venue name so the reviewer can spot venue mis-resolution. No persisted
+// Venue (and therefore no VenueId) exists yet — the venue row is created only on
+// approval — so this is a dedicated review DTO rather than entity.v1.Venue.
+message ResolvedVenue {
+  // The canonical venue name as resolved by Google Places.
+  entity.v1.VenueName name = 1;
+
+  // The administrative area (ISO 3166-2) of the resolved venue, when determinable.
+  entity.v1.AdminArea admin_area = 2;
+
+  // The Google Places place id of the resolved venue, used as the stable venue
+  // identity for staging-level deduplication.
+  string place_id = 3;
+
+  // The geographic coordinates of the resolved venue, when available.
+  entity.v1.Coordinates coordinates = 4;
+}
+
+// PendingConcert is one concert awaiting developer review in the approval queue.
+// It carries the raw scraped fields together with the resolved-venue preview so a
+// reviewer has everything needed to judge accuracy without a follow-up fetch.
+message PendingConcert {
+  // The unique identifier of this staged concert, used to approve or reject it.
+  StagedConcertId staged_id = 1 [(buf.validate.field).required = true];
+
+  // The performing artist this concert was discovered for.
+  entity.v1.Artist performer = 2 [(buf.validate.field).required = true];
+
+  // The descriptive title extracted for the concert (e.g., the tour or show name).
+  entity.v1.Title title = 3 [(buf.validate.field).required = true];
+
+  // The scheduled calendar date of the concert in the venue's local timezone.
+  entity.v1.LocalDate local_date = 4 [(buf.validate.field).required = true];
+
+  // The scheduled start time. Optional; omitted when the source did not state one.
+  entity.v1.StartTime start_time = 5;
+
+  // The raw venue name exactly as scraped from the source, preserved for review.
+  entity.v1.ListedVenueName listed_venue_name = 6 [(buf.validate.field).required = true];
+
+  // The resolved-venue preview. Absent when the raw venue name could not be
+  // resolved against Google Places.
+  ResolvedVenue resolved_venue = 7;
+
+  // The source URL where the concert was found.
+  entity.v1.Url source_url = 8;
+
+  // The time at which the discovery pipeline staged this concert.
+  google.protobuf.Timestamp discovered_time = 9 [(buf.validate.field).required = true];
+}
+
+// ListPendingConcertsRequest is the request for retrieving all concerts awaiting
+// review. It takes no parameters; the full pending queue is returned.
+message ListPendingConcertsRequest {}
+
+// ListPendingConcertsResponse contains the concerts currently awaiting review.
+message ListPendingConcertsResponse {
+  // The concerts currently in the approval queue, in discovery order.
+  repeated PendingConcert pending_concerts = 1;
+}
+
+// ApproveConcertRequest identifies the staged concert to publish.
+message ApproveConcertRequest {
+  // Required. The unique identifier of the staged concert to approve.
+  StagedConcertId staged_id = 1 [(buf.validate.field).required = true];
+}
+
+// ApproveConcertResponse is returned upon successful approval.
+message ApproveConcertResponse {}
+
+// RejectConcertRequest identifies the staged concert to drop and the reason why.
+message RejectConcertRequest {
+  // Required. The unique identifier of the staged concert to reject.
+  StagedConcertId staged_id = 1 [(buf.validate.field).required = true];
+
+  // Required. The reviewer's reason for rejecting the concert, recorded in the
+  // rejection log for search-quality analysis.
+  string reason = 2 [(buf.validate.field).string.min_len = 1];
+}
+
+// RejectConcertResponse is returned upon successful rejection.
+message RejectConcertResponse {}

--- a/proto/liverty_music/rpc/admin/v1/concert_moderation_service.proto
+++ b/proto/liverty_music/rpc/admin/v1/concert_moderation_service.proto
@@ -13,6 +13,7 @@ import "google/protobuf/timestamp.proto";
 import "liverty_music/entity/v1/artist.proto";
 import "liverty_music/entity/v1/coordinates.proto";
 import "liverty_music/entity/v1/entity.proto";
+import "liverty_music/entity/v1/staged_concert.proto";
 import "liverty_music/entity/v1/venue.proto";
 
 // ConcertModerationService lets internal developers review concerts discovered by
@@ -53,14 +54,6 @@ service ConcertModerationService {
   rpc RejectConcert(RejectConcertRequest) returns (RejectConcertResponse);
 }
 
-// StagedConcertId uniquely identifies a concert sitting in the approval queue.
-// It is distinct from EventId because a staged concert has not yet been published
-// as an event; the id is assigned when the concert is first staged.
-message StagedConcertId {
-  // A UUID string representing the unique identity of the staged concert.
-  string value = 1 [(buf.validate.field).string.uuid = true];
-}
-
 // ResolvedVenue is the venue preview produced by resolving the raw scraped venue
 // name against Google Places at staging time. It is shown alongside the raw
 // listed venue name so the reviewer can spot venue mis-resolution. No persisted
@@ -87,7 +80,7 @@ message ResolvedVenue {
 // reviewer has everything needed to judge accuracy without a follow-up fetch.
 message PendingConcert {
   // The unique identifier of this staged concert, used to approve or reject it.
-  StagedConcertId staged_id = 1 [(buf.validate.field).required = true];
+  entity.v1.StagedConcertId staged_id = 1 [(buf.validate.field).required = true];
 
   // The performing artist this concert was discovered for.
   entity.v1.Artist performer = 2 [(buf.validate.field).required = true];
@@ -128,7 +121,7 @@ message ListPendingConcertsResponse {
 // ApproveConcertRequest identifies the staged concert to publish.
 message ApproveConcertRequest {
   // Required. The unique identifier of the staged concert to approve.
-  StagedConcertId staged_id = 1 [(buf.validate.field).required = true];
+  entity.v1.StagedConcertId staged_id = 1 [(buf.validate.field).required = true];
 }
 
 // ApproveConcertResponse is returned upon successful approval.
@@ -137,11 +130,14 @@ message ApproveConcertResponse {}
 // RejectConcertRequest identifies the staged concert to drop and the reason why.
 message RejectConcertRequest {
   // Required. The unique identifier of the staged concert to reject.
-  StagedConcertId staged_id = 1 [(buf.validate.field).required = true];
+  entity.v1.StagedConcertId staged_id = 1 [(buf.validate.field).required = true];
 
   // Required. The reviewer's reason for rejecting the concert, recorded in the
   // rejection log for search-quality analysis.
-  string reason = 2 [(buf.validate.field).required = true];
+  string reason = 2 [
+    (buf.validate.field).required = true,
+    (buf.validate.field).string.min_len = 1
+  ];
 }
 
 // RejectConcertResponse is returned upon successful rejection.

--- a/proto/liverty_music/rpc/admin/v1/concert_moderation_service.proto
+++ b/proto/liverty_music/rpc/admin/v1/concert_moderation_service.proto
@@ -74,8 +74,9 @@ message ResolvedVenue {
   entity.v1.AdminArea admin_area = 2;
 
   // The Google Places place id of the resolved venue, used as the stable venue
-  // identity for staging-level deduplication.
-  string place_id = 3;
+  // identity for staging-level deduplication. Absent when the venue did not
+  // resolve.
+  entity.v1.PlaceId place_id = 3;
 
   // The geographic coordinates of the resolved venue, when available.
   entity.v1.Coordinates coordinates = 4;
@@ -140,7 +141,7 @@ message RejectConcertRequest {
 
   // Required. The reviewer's reason for rejecting the concert, recorded in the
   // rejection log for search-quality analysis.
-  string reason = 2 [(buf.validate.field).string.min_len = 1];
+  string reason = 2 [(buf.validate.field).required = true];
 }
 
 // RejectConcertResponse is returned upon successful rejection.


### PR DESCRIPTION
## Summary

Specification half of a cross-repo change introducing a **developer approval gate** for AI-discovered concerts. Today the Gemini searcher persists discovered concerts immediately, so mis-extracted/hallucinated events reach fans at once — and a manual DB delete is recreated by the next daily cron (the deterministic series id + dedup regenerate the identical row). There is no human checkpoint and no way to stop a known-bad event re-appearing.

This PR adds the OpenSpec change and the admin-only RPC surface. Backend and frontend follow once this is released and BSR regenerates the client.

## Changes

- **`rpc/admin/v1/concert_moderation_service.proto`** (new) — `ConcertModerationService`, admin-org only:
  - `ListPendingConcerts` -> `PendingConcert[]` carrying the raw scraped fields **plus a resolved-venue preview** (Google Places name / admin_area / place_id / coordinates) so a reviewer can catch venue mis-resolution before publish.
  - `ApproveConcert(staged_id)` — publish + emit `CONCERT.created` (idempotent).
  - `RejectConcert(staged_id, reason)` — drop + log (idempotent); reason is mandatory.
- **`openspec/changes/add-concert-approval-queue/`** — proposal, design, tasks, and spec deltas:
  - New capability `concert-approval-queue` (staging lifecycle, up-front venue resolution, dedup, rejection log, admin RPCs, reviewer UI).
  - Modified `concert-service` (discovered concerts are **staged**, not auto-persisted; dedup excludes `pending` queue entries too).

## Design highlights

- **Reject is non-permanent.** Dedup consults published events + `pending` staged rows, but **not** the rejection log — a later run can re-surface corrected data. Every rejection is recorded append-only for searcher-quality analysis.
- **Venue resolved before staging (B2).** Resolution runs on discovery and is denormalized onto the staged row; the `venues` row is created only on approval, so rejected items leave no orphan venues.
- **`CONCERT.created` moves to approval time** — fans are never notified about unverified concerts.
- The published entity shape (`entity.v1.Concert`) is unchanged; `PendingConcert` is a distinct review DTO because a staged concert has no `EventId` yet.

## Testing

- `buf lint` OK
- `buf format -w` OK (no diff)
- `buf breaking --against '.git#branch=main'` OK (additive only; consumer protos untouched)

## Cross-repo

This is step 1 of the release workflow. After merge -> GitHub Release -> `buf-release.yml` BSR gen, the backend (staging tables, discovery->staging rewrite, approve/reject use cases + handler) and frontend (admin approval-queue screen) PRs follow.

Refs: #611
