### PR TITLE
docs(onboarding-celebration): capture unseal-celebration-overlay change

### DIFF
--- a/openspec/changes/unseal-celebration-overlay/.openspec.yaml
+++ b/openspec/changes/unseal-celebration-overlay/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-07

--- a/openspec/changes/unseal-celebration-overlay/design.md
+++ b/openspec/changes/unseal-celebration-overlay/design.md
@@ -1,0 +1,84 @@
+## Context
+
+The celebration overlay (`celebration-overlay.css`) currently darkens the whole viewport behind its text:
+
+```css
+.celebration-overlay {
+  background: oklch(0% 0 0deg / 80%);   /* full-screen 80% black veil */
+  backdrop-filter: blur(8px);            /* + heavy blur of everything behind */
+}
+```
+
+During exploration this was verified against a maximally vibrant timetable (oklch 75% chroma 0.3 cards): the veil collapses the festival palette to ~20%-luminance muddy blocks. The "封印" (seal) is this full-screen veil.
+
+Note on a separate, already-resolved issue: an earlier screenshot showed the heading and sub-text split to the top/bottom thirds with an empty center. Reproducing the **current** CSS (HEAD `6521462`, which added `align-content: center`) showed the two lines centered with only the 16px row-gap between them. That layout problem is already fixed and is **out of scope** here; this change is purely about the backdrop.
+
+Constraints:
+- CUBE CSS methodology, `@layer block` + `@scope (celebration-overlay)`, design tokens from `tokens.css`.
+- Behavior (two-tier gating, once-per-tier, confetti flag, tap-to-dismiss, reduced-motion) must not change.
+- Legibility must hold over the brightest stage cards (near-stage cyan `oklch(82% 0.16 195)`, accent green, amber) — the worst case for white text.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Reveal the completed timetable as the visual payoff: keep the screen edges fully colorful behind the overlay.
+- Guarantee heading + sub-text contrast on any background, including the brightest cards.
+- Keep the change CSS-only and minimal (low regression risk).
+
+**Non-Goals:**
+- No change to celebration tiers, gating, dismissal, confetti, or reduced-motion logic.
+- No change to the centering/spacing of the text (already fixed).
+- No new animation system, no JS changes (a possible spotlight-sweep is deferred).
+
+## Decisions
+
+### Decision: Adopt the "text-lens" backdrop (explored option C1)
+
+Replace the full-screen opaque veil with a light overall scrim plus a **feathered radial darkening sized to the text group**, layered with the existing brand-purple glow halo:
+
+```css
+.celebration-overlay {
+  background: oklch(0% 0 0deg / 18%);   /* light overall scrim — edges stay vivid */
+}
+.celebration-overlay::before {          /* dark "lens" hugging the text, + purple halo */
+  background:
+    radial-gradient(ellipse 78% 24% at 50% 47%,
+      oklch(0% 0 0deg / 72%) 0%, oklch(0% 0 0deg / 40%) 52%, transparent 80%),
+    radial-gradient(ellipse 64% 32% at 50% 47%,
+      oklch(72% 0.26 294deg / 26%) 0%, transparent 72%);
+}
+```
+
+Heading/sub-text shadows are strengthened; the sub-text additionally gets a thin dark outline (multi-stop `text-shadow`) as a hard legibility floor.
+
+**Why C1 over the alternatives** (all mocked over identical vibrant + worst-case bright backgrounds during exploration):
+
+| Option | Idea | Verdict |
+|---|---|---|
+| A | Thin veil + vignette | Great balance, but dims the whole screen more than needed |
+| B | Top-down spotlight cone | Best world-fit (matches event-card spotlight / highway lasers) but heavier; deferred as a follow-up |
+| C0 | Light scrim + purple halo only | Sub-text fails on bright near-stage cards (legibility hole) |
+| **C1** | **Light scrim + text-lens + halo** | **Edges fully vibrant AND text legible on the worst-case background — chosen** |
+| C2 | Near-zero scrim + text outline only | Most see-through, but small sub-text is marginal on bright cards |
+| D | Translucent text panel | Safe legibility, but re-introduces a "box" and kills immersion |
+
+C1 keeps the "most see-through / most vibrant" character the product wanted while closing C0's legibility hole by darkening **only** behind the text rather than the whole viewport.
+
+### Decision: Drop the full-screen `backdrop-filter: blur(8px)`
+
+The full-screen blur is the second half of the seal and adds GPU cost. The text-lens provides contrast locally, so the global blur is removed. (An optional very light blur could live inside the lens region only; default is none.)
+
+## Risks / Trade-offs
+
+- [Lower overall scrim could hurt heading contrast on a pathological all-white card cluster] → the text-lens + strengthened shadows + sub-text outline provide a contrast floor independent of the background; validated against the brightest stage palette during exploration.
+- [Intentional UI change invalidates frontend visual baselines] → regenerate baselines per the project's baseline-refresh process as part of the PR.
+- [Removing the global blur changes the "frosted" feel some may expect] → acceptable and intended; the goal is to reveal, not frost.
+
+## Migration Plan
+
+CSS-only, no data or API migration. Ship via the normal frontend PR → `make check` → visual-baseline regeneration → merge → release flow. Rollback is reverting the single CSS file.
+
+## Open Questions
+
+- Should the brand-purple halo hue track the matched-artist hue for extra "personalization", or stay fixed brand purple? Default: fixed brand purple (simplest, on-brand).
+- Defer or include the option-B spotlight sweep as a later enhancement? Default: defer.

--- a/openspec/changes/unseal-celebration-overlay/proposal.md
+++ b/openspec/changes/unseal-celebration-overlay/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+The onboarding celebration overlay is meant to be the emotional payoff for "your personal timetable is ready" — yet its backdrop (`background: oklch(0% 0 0deg / 80%)` + `backdrop-filter: blur(8px)`) covers the entire viewport, collapsing the vibrant festival-palette timetable into dark, muddy blocks at the exact moment we most want to show it off. The celebration says "あなただけのタイムテーブルが完成しました！" while hiding the very thing it is celebrating. The first impression therefore reads as flat and dull ("地味").
+
+## What Changes
+
+- Replace the celebration overlay's full-screen opaque veil with a **localized "text-lens"**: a feathered radial darkening sized to the heading + sub-text group, so the completed timetable stays fully colorful at the screen edges while the text retains guaranteed contrast.
+- Lower the overall scrim (full-viewport dim) to a light value and drop the heavy full-screen `backdrop-filter: blur(8px)`, so the timetable behind reads as the vibrant payoff rather than a dark smudge.
+- Keep the existing brand-purple glow halo behind the heading and strengthen text shadows so legibility holds even over the brightest stage cards (e.g. near-stage cyan).
+- Preserve all current behavior: two-tier gating (`maybeCelebrate()`), at-most-once-per-tier, confetti flag, tap-to-dismiss, and `prefers-reduced-motion` handling are unchanged.
+
+## Capabilities
+
+### New Capabilities
+<!-- none -->
+
+### Modified Capabilities
+- `onboarding-celebration`: add a requirement governing the overlay backdrop — the celebration MUST keep the completed timetable visible/legible behind the text instead of fully obscuring it, while preserving heading/sub-text contrast.
+
+## Impact
+
+- **Frontend only.** Affected file: `frontend/src/components/celebration-overlay/celebration-overlay.css` (backdrop / scrim / text-shadow rules).
+- Potentially `frontend/src/components/celebration-overlay/celebration-overlay.spec.ts` if a contrast/backdrop assertion is added; frontend visual baselines may need regeneration (intentional UI change).
+- No backend, no proto/BSR, no API, no dependency changes. Behavior (tiers, gating, dismissal, reduced-motion) is unchanged.

--- a/openspec/changes/unseal-celebration-overlay/specs/onboarding-celebration/spec.md
+++ b/openspec/changes/unseal-celebration-overlay/specs/onboarding-celebration/spec.md
@@ -1,0 +1,21 @@
+## ADDED Requirements
+
+### Requirement: Celebration Reveals the Timetable Behind the Text
+
+The celebration overlay SHALL keep the completed dashboard timetable visible behind the celebration text rather than fully obscuring it, so the overlay reveals the payoff it is announcing. The overlay backdrop SHALL NOT apply a full-viewport opaque veil or a full-viewport blur of the content behind it. Darkening SHALL be localized to the region behind the heading and sub-text (a feathered "text-lens"), leaving the screen edges showing the timetable's colors. Regardless of the colors behind it — including the brightest stage cards — the heading and sub-text SHALL remain legible. This requirement governs only the overlay's backdrop and text-contrast treatment; it does not change the celebration tiers, gating, once-per-tier behavior, confetti flag, tap-to-dismiss, or reduced-motion handling defined by `Requirement: Two-Tier Celebration Overlay`.
+
+#### Scenario: Timetable colors remain visible at the screen edges
+
+- **WHEN** the celebration overlay is displayed over the loaded timetable
+- **THEN** the timetable's card colors SHALL remain visible at the screen edges (outside the text region)
+- **AND** the overlay SHALL NOT cover the viewport with an opaque veil or a full-viewport blur
+
+#### Scenario: Heading and sub-text stay legible over bright cards
+
+- **WHEN** the celebration overlay is displayed over bright/light-colored timetable cards (e.g. near-stage cyan)
+- **THEN** both the heading and the sub-text SHALL remain legible against that background
+
+#### Scenario: Existing celebration behavior is preserved
+
+- **WHEN** the celebration overlay is shown in either tier (guest light or post-signup full)
+- **THEN** the tier gating, at-most-once-per-tier persistence, confetti flag, tap-to-dismiss, and `prefers-reduced-motion` handling SHALL behave exactly as before this change

--- a/openspec/changes/unseal-celebration-overlay/tasks.md
+++ b/openspec/changes/unseal-celebration-overlay/tasks.md
@@ -1,0 +1,23 @@
+## 1. Implement the text-lens backdrop
+
+- [x] 1.1 In `frontend/src/components/celebration-overlay/celebration-overlay.css`, lower the `.celebration-overlay` scrim from `oklch(0% 0 0deg / 80%)` to a light value (~`/18%`) and remove the full-screen `backdrop-filter: blur(8px)`
+- [x] 1.2 Add a `.celebration-overlay::before` feathered radial "text-lens" (dark gradient sized to the text group) layered with the existing brand-purple glow halo, using design tokens / relative color syntax per CUBE CSS
+- [x] 1.3 Strengthen `.celebration-text` shadow and add a thin dark outline (multi-stop `text-shadow`) to `.celebration-sub-text` as a legibility floor
+- [x] 1.4 Confirm tiers, gating, confetti, tap-to-dismiss, and the `prefers-reduced-motion` block are untouched (backdrop-only diff)
+
+## 2. Verify appearance and legibility
+
+- [x] 2.1 Render the overlay over a vibrant timetable and over the worst-case bright cards (near-stage cyan / accent green / amber); confirm edges stay colorful and both text lines are legible
+- [x] 2.2 Confirm `prefers-reduced-motion: reduce` still disables confetti and transitions (block untouched by this change)
+- [x] 2.3 Update/extend `frontend/src/components/celebration-overlay/celebration-overlay.spec.ts` if a backdrop/contrast assertion is warranted — N/A: spec is a ViewModel-only unit test; backdrop is covered by visual baselines (3.2)
+
+## 3. Quality gate
+
+- [x] 3.1 Run `make check` in `frontend/` (Biome + stylelint + typecheck + unit tests) and fix any findings — green (113 files / 1252 tests passed)
+- [ ] 3.2 Regenerate frontend visual baselines for the celebration overlay (intentional UI change) per the project baseline-refresh process — release-time CI action (delete visual-baselines artifacts to force regen)
+
+## 4. Ship to production
+
+- [ ] 4.1 Open the frontend PR (commit per Liverty convention with `Refs: #<issue>`), get CI green, address review, merge to `main`
+- [ ] 4.2 Cut the frontend GitHub Release (retag → prod AR); the automated repository_dispatch pin-bump updates cloud-provisioning and ArgoCD auto-syncs
+- [ ] 4.3 Verify in production directly (no dev env): on the live app, trigger the celebration and confirm the timetable shows through with legible text


### PR DESCRIPTION
Records the OpenSpec change behind **frontend v1.11.1**.

## Summary

The onboarding celebration overlay must **reveal** the completed timetable behind its text instead of obscuring it with a full-viewport black veil + blur. Adds a localized "text-lens" requirement to the `onboarding-celebration` capability.

Artifacts:
- `proposal.md` — why (the veil collapsed the vibrant timetable into muddy blocks at the payoff moment)
- `design.md` — the C1 "text-lens" decision with A–D alternatives compared
- `specs/onboarding-celebration/spec.md` — ADDED requirement "Celebration Reveals the Timetable Behind the Text" (+ scenarios)
- `tasks.md` — implementation/ship checklist (all code tasks done)

## Status

Implementation already shipped: liverty-music/frontend#446 (merged) → released as v1.11.1 (prod retag + pin-bump dispatched). This PR captures the spec record; archive (delta → canonical spec) follows once prod is verified.

Refs: liverty-music/frontend#445