### PR TITLE
docs(openspec): archive simplify-onboarding-to-single-flag + sync specs

### DIFF
--- a/openspec/changes/archive/2026-06-09-simplify-onboarding-to-single-flag/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-09-simplify-onboarding-to-single-flag/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-08

--- a/openspec/changes/archive/2026-06-09-simplify-onboarding-to-single-flag/design.md
+++ b/openspec/changes/archive/2026-06-09-simplify-onboarding-to-single-flag/design.md
@@ -1,0 +1,85 @@
+## Context
+
+`OnboardingService` currently owns a 6-state linear machine (`LP → DISCOVERY → DASHBOARD → MY_ARTISTS → CONSENT → COMPLETED`) persisted to `localStorage['onboardingStep']`, plus ordinal navigation gating in `AuthHook`, a `readyForDashboard` predicate, and a discovery-count mirror (`setDiscoveryCounts`). A code audit (issue #444) showed the machine now causes more harm than value:
+
+- The `MY_ARTISTS → CONSENT` transition is fired by a hype change in `onHypeInput`, which calls `setStep(CONSENT)` but never navigates. The second hype tap then hits the `isOnboarding` revert guard and is silently rolled back — the user-visible #444 bug.
+- A pure guest never reaches `COMPLETED` (nothing navigates to the consent route, which is the only place `complete()` runs for guests), so `isOnboarding` stays `true` forever.
+- The current code has regressed against the `my-artists` capability spec, which already mandates "hype change reverted during MY_ARTISTS step (REMOVED)".
+
+A survey of all consumers shows the machine is really being used for only two things: (A) a first-run guidance phase, and (B) a "first run complete" flag. Everything else (`STEP_ORDER`, `STEP_ROUTE_MAP`, `stepIndex`, `normalizeStep`, the count mirror, the ordinal guard) is scaffolding for forced step ordering that the product no longer needs.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Collapse onboarding state to a single persisted boolean while keeping the public `isOnboarding` / `isCompleted` API stable so consumer call sites do not change.
+- Fix #444 at the root by decoupling hype editing from onboarding progression.
+- Keep the first-run coach mark as a delight beat, but as an independent UI service driven by live data rather than step transitions.
+- Make the dashboard reachable at any time (soft gate), guiding empty guests with an empty-state CTA.
+- Provide a one-time, lossless migration off the legacy `onboardingStep` key.
+
+**Non-Goals:**
+
+- Showing or redesigning the analytics consent screen. The `CONSENT` step is removed from the onboarding flow; consent *application* (fail-closed PostHog default, settings opt-out, `ConsentService`/`AnalyticsService`) is untouched and out of scope.
+- Changing the discovery bubble UI, celebration visuals, page-help, or signup-banner behavior beyond their dependency on the retained `isOnboarding`/`isCompleted` getters.
+- Reworking authentication gating in `AuthHook` (only the onboarding-ordering branches are removed).
+
+## Decisions
+
+### D1: Single boolean with retained getters, persisted as `onboardingComplete`
+
+`OnboardingService` exposes `get isOnboarding()` and `get isCompleted()`; internally it holds one latched boolean and a single `finish()` mutator. The backing boolean MUST be `@observable` (Aurelia), because the getters are derived from it and consumers rely on change notification — `pwa-install-service` `@watch((vm) => vm.onboarding.isCompleted)`, the `app-shell.html` `if.bind` on `onboarding.isCompleted`, and the dashboard/my-artists `isOnboarding` template bindings. A plain field would leave these stale when `finish()` runs (PWA prompt never fires, banners/coach mark don't update). The **persisted** value uses completed-polarity (`onboardingComplete`, absent key = `false` = still onboarding), because localStorage absence naturally maps to falsy, and "not yet completed" is the correct default for a brand-new user. The **exposed** primary getter stays `isOnboarding = !onboardingComplete`.
+
+- **Why over keeping the enum**: the enum's only load-bearing states were "in first run" and "done"; the ordered intermediate states existed solely to drive forced navigation, which we are removing.
+- **Why retain `isCompleted`**: `notification-prompt`, `pwa-install-service`, and the dashboard signup banner read it; keeping it as `!isOnboarding` means zero churn at those call sites.
+
+### D2: Completion latch = first dashboard arrival ∧ sign-up (B1 ∧ B2)
+
+`finish()` is one-way. It is called from two idempotent sites:
+
+- **B1 — first meaningful dashboard arrival**. The latch fires when the dashboard's timetable is real (region set and data loaded) **and** the guest has actually engaged (`followedCount >= 1`). It runs **after** the light-celebration decision (so `maybeCelebrate()` still observes `isOnboarding === true`) but is **independent of whether the celebration overlay is actually shown** — it must NOT be gated on the celebration firing. Two failure modes this avoids:
+  - *Tying the latch to the celebration lifecycle* would strand any guest for whom the celebration is suppressed (`onboarding.celebrationShown === '1'` from a prior session, or any path that early-returns from `maybeCelebrate()`): `finish()` would never run and `isOnboarding` would stay `true` forever — re-creating the very "guest never completes" bug this change fixes. So the latch is driven by the *data-ready + engaged* condition, with the celebration merely sequenced ahead of it when it does show.
+  - *Latching on a 0-follow dashboard arrival* (a brand-new guest deep-linking to `/dashboard`, allowed by the soft gate's empty state) would mark onboarding complete with no first-run done, suppressing the discovery coach mark and page-help auto-open thereafter. The `followedCount >= 1` gate prevents this; such a guest stays in onboarding until they follow an artist (then revisit dashboard) or sign up.
+  - It must NOT be placed naively in `dashboard.attached()`, which fires before region selection / data load.
+- **B2 — sign-up**, in `auth-callback`, as an idempotent backstop (covers users who sign up before a guest dashboard visit).
+
+- **Alternative considered (B2 only)**: latch only on sign-up. Rejected — a pure guest would stay `isOnboarding === true` forever, so the dashboard signup banner (gated on `isCompleted && !auth`) would never appear, defeating conversion.
+
+### D3: Soft gate via dashboard empty-state, not guard redirect (Option A)
+
+`AuthHook` keeps auth gating, early-unlocked routes, and free roam, but drops the onboarding ordinal tree (`tutorialStep` comparison, `readyForDashboard`, step-route redirects, blocked-nav snackbars). A guest with no follows who lands on the dashboard sees an empty-state CTA pointing to discovery instead of being redirected.
+
+- **Why over the ordered guard**: the guard's redirects only existed to enforce step order; removing the order removes the need. Empty-state guidance is the standard pattern and needs no state machine.
+
+### D4: Coach mark extracted to `CoachMarkService`, triggered by live counts (decision 2b)
+
+Spotlight state (`target`, `message`, `radius`, `active`, `onTap`) and `activate`/`deactivate` move from `OnboardingService` to a new `CoachMarkService`. `DiscoveryRoute` computes the trigger from its own live values: `isOnboarding && (followedCount >= DASHBOARD_FOLLOW_TARGET || artistsWithConcertsCount >= DASHBOARD_CONCERT_TARGET) && !shown`. `onTap` performs navigation only — it no longer advances any step. The targets move to a `constants` module.
+
+- **Why extract rather than delete (2a)**: keeping the coach mark preserves the first-run delight, and moving it out is what lets `OnboardingService` become genuinely just a flag.
+- **Why live counts over the mirror**: `DiscoveryRoute` already holds `followedCount` (live) and `artistsWithConcertsCount`; the `OnboardingService.setDiscoveryCounts` mirror was pure duplication of the follow-store source of truth.
+
+### D5: Lossless one-time migration
+
+On `OnboardingService` construction: if `localStorage['onboardingStep']` exists, set `onboardingComplete` to whether the legacy value denoted completion, persist under the new key, and delete the legacy key. "Denotes completion" MUST cover every legacy completed marker, not just the literal string `'completed'` — the deleted `STEP_MIGRATION` mapped the legacy numeric index `'7'` to `COMPLETED`, so a client still holding `onboardingStep === '7'` must migrate to `onboardingComplete = true`. Compare against the completed set `{'completed', '7'}` (inline, since `STEP_MIGRATION`/`normalizeStep` are deleted along with the enum). Any other value (including `'my-artists'`, `'discovery'`, `'detail'`, absent) maps to `false`.
+
+## Risks / Trade-offs
+
+- **Latch never fires when the celebration is suppressed** → drive `finish()` from the *data-ready + `followedCount >= 1`* condition, NOT from the celebration firing; the celebration is only sequenced ahead of it (D2). Covered by a test where `onboarding.celebrationShown === '1'` yet the latch still fires on a meaningful dashboard arrival.
+- **Latch sequencing bug if placed in `attached()`** → evaluate after region selection / data load, honoring the `needsRegion` deferral, as in D2.
+- **Stale reactivity** → the backing flag is `@observable` (D1); covered by a test asserting `pwa-install-service`'s `isCompleted` watcher and the `isOnboarding` bindings update when `finish()` runs.
+- **Spec drift across six capabilities** → the `state-transition-diagram`, `frontend-route-guard`, and `onboarding-tutorial` specs encode the old machine. Each gets an explicit delta (MODIFIED/REMOVED) so the spec set stays the source of truth.
+- **Losing the forced funnel reduces follow pressure** → accepted per Option A; the empty-state CTA plus the retained coach mark provide pull-based guidance. Revisit only if first-run follow conversion measurably drops.
+- **Hidden `isOnboarding` consumers** → `onboarding-popover-guide`, `onboarding-page-help`, and `onboarding-celebration` all read `isOnboarding`/`isCompleted`; because both getters are retained with identical semantics for the two surviving states, these specs remain valid without a delta.
+
+## Migration Plan
+
+1. Land the single-flag `OnboardingService` with the construction-time legacy-key migration (D5).
+2. Remove the enum/order/route-map and the `AuthHook` onboarding branches in the same change so no caller references deleted symbols.
+3. Introduce `CoachMarkService` and repoint `DiscoveryRoute` / `app-shell` wiring.
+4. Apply the #444 fix in `my-artists-route.ts`.
+5. Wire `finish()` at the two latch sites (dashboard celebration lifecycle, auth-callback).
+6. Rollback: revert the change set; the legacy key is already gone for migrated users, but `onboardingComplete` round-trips to the same two-state meaning, so a revert simply reinstates the old default-`LP` behavior for those users (worst case: they see the first-run guidance again).
+
+## Open Questions
+
+_None blocking._ Empty-state CTA copy/visual is a presentation detail to settle during implementation against the existing design system.

--- a/openspec/changes/archive/2026-06-09-simplify-onboarding-to-single-flag/proposal.md
+++ b/openspec/changes/archive/2026-06-09-simplify-onboarding-to-single-flag/proposal.md
@@ -1,0 +1,36 @@
+## Why
+
+The guest onboarding flow is modeled as a 6-state linear machine (`LP → DISCOVERY → DASHBOARD → MY_ARTISTS → CONSENT → COMPLETED`) backed by `STEP_ORDER`, `STEP_ROUTE_MAP`, ordinal route-guard gating, a `readyForDashboard` predicate, and a mirrored discovery-count cache. Now that earlier features have been stripped, only two of these states carry product weight: a first-run guidance phase and a "first run done" flag. The machinery causes real bugs — issue #444 (hype taps after the first become unresponsive on My Artists) is a direct consequence of repurposing a hype change as the `MY_ARTISTS → CONSENT` step trigger, and a pure guest never reaches `COMPLETED` (stuck at `CONSENT` forever, `isOnboarding` latched `true`). The current code has also regressed against the `my-artists` spec, which already mandates that hype changes never revert.
+
+## What Changes
+
+- **BREAKING (internal state model)**: Replace the 6-state onboarding machine with a single persisted boolean. Public API stays `isOnboarding` (getter); `isCompleted` is retained as `!isOnboarding` for call-site compatibility. The persisted value uses `onboardingComplete` polarity (absent key = `false` = still onboarding). A single one-way latch `finish()` is the only mutator.
+- **Adopt a soft first-run gate (Option A)**: Remove forced step ordering. The dashboard is always reachable; when a guest has no follows, the dashboard surfaces an empty-state CTA ("find artists") instead of a guard redirect.
+- **Completion latch = B1 ∧ B2**: `finish()` fires on the guest's first dashboard arrival (sequenced after the light celebration, respecting the `needsRegion` deferral) and on sign-up (`auth-callback`, idempotent backstop).
+- **Fix #444 at the root**: Remove the onboarding-specific branch (`setStep(CONSENT)`) and the `isOnboarding` revert guard from `onHypeInput`. Hype editing is fully decoupled from onboarding progression and always applies. This re-aligns the code with the existing `my-artists` spec.
+- **Extract the coach mark into a dedicated `CoachMarkService`** (decision 2b): move spotlight state and `activate`/`deactivate`/`onTap` out of `OnboardingService`. Trigger is computed in `DiscoveryRoute` from live data: `isOnboarding && (followedCount >= 5 || artistsWithConcertsCount >= 3) && !shown`. `onTap` no longer advances any step (navigation only). Move `DASHBOARD_FOLLOW_TARGET` / `DASHBOARD_CONCERT_TARGET` to a constants module.
+- **Remove**: `OnboardingStep` enum, `STEP_ORDER`, `stepIndex`, `STEP_ROUTE_MAP`, `getRouteForCurrentStep`, `normalizeStep`/`STEP_MIGRATION`, `readyForDashboard`, `setDiscoveryCounts`, the `followedCount`/`artistsWithConcertsCount` mirror, the onboarding ordinal branches of `AuthHook`, and every path that wires the `CONSENT` step into the onboarding flow.
+- **Migration**: On boot, convert legacy `localStorage['onboardingStep']` once via `onboardingComplete = (step === 'completed')`, then delete the legacy key.
+
+## Capabilities
+
+### New Capabilities
+
+_None._ The single-flag state fits within the existing `frontend-onboarding-flow` capability; the coach-mark extraction is an ownership change within `onboarding-spotlight`.
+
+### Modified Capabilities
+
+- `frontend-onboarding-flow`: Replace the linear step sequence with a single `isOnboarding` boolean; define the `finish()` completion latch (first dashboard arrival ∧ sign-up); the discovery→dashboard transition becomes a soft, non-gating navigation.
+- `frontend-route-guard`: Remove onboarding ordinal gating (`tutorialStep` comparison, `readyForDashboard`, step-based redirects and their snackbars). Keep auth gating, early-unlocked routes, and free roam. The dashboard is reachable at any onboarding state.
+- `onboarding-tutorial`: Remove the "Linear Step Progression" requirement; there is no forced step machine to progress through.
+- `onboarding-spotlight`: The coach mark becomes a single, transient, **non-blocking** hint owned by a dedicated `CoachMarkService` (not `OnboardingService`); `onTap` performs navigation only and never advances an onboarding step; the trigger is driven by live follow/concert counts gated on `isOnboarding`. The viewport click-blocker layer, scroll lock, and multi-step continuous-spotlight persistence (all tied to the deleted step machine) are removed.
+- `my-artists`: Hype changes are fully decoupled from onboarding — remove the residual "advance `onboardingStep`" effect from the guest hype-change scenario; reaffirm that hype is persisted and never reverted regardless of onboarding state.
+
+> Note: the `state-transition-diagram` capability is a descriptive Mermaid document, not a `### Requirement:`-formatted spec, so it cannot carry a delta. Its onboarding state-machine section is refreshed to the two-state (`onboarding` → `completed`) model as a documentation task during implementation (see tasks.md), not as a spec delta file.
+
+## Impact
+
+- **Code (frontend)**: `services/onboarding-service.ts` (collapses to one flag), `entities/onboarding.ts` (most of it deleted), `adapter/storage/onboarding-storage.ts` (key + migration), `hooks/auth-hook.ts` (drop onboarding branches), `routes/my-artists/my-artists-route.ts` (#444 fix), `routes/discovery/discovery-route.ts` (live-count coach-mark trigger, drop count mirror), `routes/dashboard/dashboard-route.ts` (latch + empty-state CTA), `routes/welcome/welcome-route.ts` (drop `reset`/`setStep`), `routes/auth-callback/auth-callback-route.ts` (`finish()`), new `services/coach-mark-service.ts`, plus `constants/` for the targets.
+- **Consumers of `isCompleted`** (`notification-prompt`, `pwa-install-service`, dashboard signup banner): unchanged — they read the retained `isCompleted` getter.
+- **Out of scope**: The analytics consent screen is NOT shown. This change only removes the `CONSENT` step from the onboarding flow; the consent application logic (PostHog fail-closed default, settings opt-out toggle, `ConsentService`/`AnalyticsService`) is untouched. No coordination with the in-flight `introduce-analytics-tool` change is required.
+- **Tests**: `my-artists` hype-repeat behavior (#444 regression), route-guard soft-gate behavior, coach-mark trigger from live counts, latch timing vs. celebration, legacy-key migration.

--- a/openspec/changes/archive/2026-06-09-simplify-onboarding-to-single-flag/specs/frontend-onboarding-flow/spec.md
+++ b/openspec/changes/archive/2026-06-09-simplify-onboarding-to-single-flag/specs/frontend-onboarding-flow/spec.md
@@ -1,0 +1,107 @@
+## ADDED Requirements
+
+### Requirement: Single-Flag Onboarding State
+
+The system SHALL model onboarding state as a single persisted boolean rather than an ordered step machine. `OnboardingService` SHALL expose `isOnboarding` as the primary getter and SHALL retain `isCompleted` as its negation (`isCompleted === !isOnboarding`) for call-site compatibility. The persisted value SHALL use completed-polarity (`onboardingComplete`; an absent key means `false`, i.e. still onboarding) so a brand-new user defaults to `isOnboarding === true`. Completion SHALL be a one-way latch exposed as a single `finish()` mutator; once `isOnboarding` becomes `false` it SHALL NOT return to `true` except via an explicit fresh-onboarding reset. The service SHALL NOT expose step values, step ordering, route maps, or a `readyForDashboard` predicate.
+
+#### Scenario: Brand-new user defaults to onboarding
+
+- **WHEN** a user opens the app for the first time and no onboarding key exists in localStorage
+- **THEN** `OnboardingService.isOnboarding` SHALL be `true`
+- **AND** `OnboardingService.isCompleted` SHALL be `false`
+
+#### Scenario: Completion latches on first meaningful dashboard arrival
+
+- **WHEN** an unauthenticated guest reaches the dashboard for the first time
+- **AND** the timetable is real (region is set and concert data has loaded)
+- **AND** the guest has at least one followed artist (`followedCount >= 1`)
+- **THEN** the system SHALL call `finish()` so `isOnboarding` becomes `false`
+- **AND** the latch SHALL be evaluated after the light-celebration decision (so `maybeCelebrate()` observed `isOnboarding === true`), honoring the `needsRegion` deferral
+
+#### Scenario: Latch is independent of whether the celebration is shown
+
+- **WHEN** a guest reaches a meaningful first dashboard (region set, data loaded, `followedCount >= 1`)
+- **AND** the light celebration is suppressed (e.g. `localStorage['onboarding.celebrationShown'] === '1'` from a prior session, or `maybeCelebrate()` otherwise early-returns)
+- **THEN** the system SHALL still call `finish()`
+- **AND** the latch SHALL NOT be gated on the celebration overlay actually rendering
+
+#### Scenario: No latch for a zero-follow dashboard arrival
+
+- **WHEN** an unauthenticated guest with zero followed artists lands on the dashboard (e.g. via deep link, served the empty-state CTA)
+- **THEN** the system SHALL NOT call `finish()`
+- **AND** `isOnboarding` SHALL remain `true` so the discovery coach mark and page-help auto-open still apply until the guest follows an artist or signs up
+
+#### Scenario: Completion latches on sign-up
+
+- **WHEN** a user completes sign-up via the auth callback
+- **THEN** the system SHALL call `finish()` so `isOnboarding` becomes `false`
+- **AND** the call SHALL be idempotent if onboarding was already completed
+
+#### Scenario: Completion is one-way
+
+- **WHEN** `isOnboarding` is already `false`
+- **AND** the user revisits the dashboard or any onboarding-relevant surface
+- **THEN** the system SHALL keep `isOnboarding === false`
+
+#### Scenario: Legacy step value migration
+
+- **WHEN** `OnboardingService` is constructed
+- **AND** the legacy `localStorage['onboardingStep']` key exists
+- **THEN** the system SHALL set `onboardingComplete = true` when the legacy value denotes completion — i.e. it is in the completed set `{'completed', '7'}` (the legacy numeric index `'7'` mapped to `COMPLETED`)
+- **AND** the system SHALL set `onboardingComplete = false` for any other legacy value (e.g. `'discovery'`, `'my-artists'`, `'detail'`)
+- **AND** the system SHALL persist the new value and delete the legacy `onboardingStep` key
+- **AND** the migration SHALL run at most once per client
+
+## MODIFIED Requirements
+
+### Requirement: Interactive Artist Discovery (Bubble Network UI)
+
+The system SHALL provide an engaging, gamified interface for users to discover and follow artists using Last.fm API data. During onboarding, followed artists are stored locally (not via backend RPC). The system SHALL trigger a background concert search for each followed artist and track which artists have concerts. The Coach Mark SHALL appear when the progression condition is reached and SHALL hint that the personal timetable is ready; it is owned by `CoachMarkService` (see `onboarding-spotlight`). Navigation to the Dashboard is never forced — the dashboard is always reachable and the user taps the Home nav tab at their own pace. Tapping the coach mark target SHALL navigate only; it SHALL NOT advance any onboarding step (there is no step machine).
+
+#### Scenario: Guest user follows artist via bubble tap
+
+- **WHEN** a guest user (in onboarding) taps an artist bubble
+- **THEN** the system SHALL trigger the absorption animation
+- **AND** the system SHALL store the artist via `FollowStore` (which routes to the guest queue for unauthenticated users)
+- **AND** the system SHALL initiate a background concert search/track for the artist via `ConcertService`
+- **AND** the system SHALL NOT call any backend RPC for the follow operation itself
+
+#### Scenario: Guest follow default hype level
+
+- **WHEN** a guest user (in onboarding) requests the list of followed artists via `FollowStore.listFollowed()`
+- **THEN** the system SHALL return each followed artist with hype level `'watch'` (observation tier)
+
+#### Scenario: Discover to Dashboard coach-mark trigger
+
+- **WHEN** a user is in onboarding (`isOnboarding === true`)
+- **AND** either the user has followed 5 or more artists, OR the live `artistsWithConcertsCount` >= 3
+- **AND** the coach mark has not yet been shown this session
+- **THEN** the system SHALL activate a coach mark spotlight on the Dashboard nav icon via `CoachMarkService`
+- **AND** the trigger SHALL be evaluated from live follow/concert counts in `DiscoveryRoute`, not from a mirrored count cache
+- **AND** the user MAY tap the Dashboard icon at any time (with or without the spotlight) to navigate to `/dashboard`
+- **AND** tapping the Dashboard icon SHALL navigate only and SHALL NOT advance any onboarding step
+
+#### Scenario: Coach Mark does not reappear
+
+- **WHEN** the coach mark has already been shown for the current onboarding session
+- **THEN** the system SHALL NOT display it again even if the user follows more artists
+
+#### Scenario: Pre-seeded follows on page reload
+
+- **WHEN** the discovery page loads during onboarding
+- **THEN** the system SHALL hydrate follows from `FollowStore.guestFollows` into the active follow list
+- **AND** the system SHALL initiate a concert search via `ConcertService` for any artists not yet tracked
+
+#### Scenario: Snack notification on concert found
+
+- **WHEN** a followed artist's search completes with status `completed`
+- **AND** `listConcerts(artistId)` returns at least one concert
+- **THEN** the system SHALL display a snack notification indicating the artist has upcoming events
+
+## REMOVED Requirements
+
+### Requirement: Step Sequence
+
+**Reason**: The ordered step machine (`LP → DISCOVERY → DASHBOARD → MY_ARTISTS → … → COMPLETED`) only existed to enforce forced navigation ordering, which is removed in favor of a soft first-run gate. Onboarding state collapses to the single `isOnboarding` boolean defined in "Single-Flag Onboarding State".
+
+**Migration**: Delete `OnboardingStep`, `STEP_ORDER`, `stepIndex`, `STEP_ROUTE_MAP`, `getRouteForCurrentStep`, `normalizeStep`, and `STEP_MIGRATION`. The DASHBOARD-arrival effect (formerly "advance to MY_ARTISTS") is replaced by the `finish()` completion latch. The legacy `onboardingStep` localStorage value is converted once to `onboardingComplete` (see "Single-Flag Onboarding State" → "Legacy step value migration").

--- a/openspec/changes/archive/2026-06-09-simplify-onboarding-to-single-flag/specs/frontend-route-guard/spec.md
+++ b/openspec/changes/archive/2026-06-09-simplify-onboarding-to-single-flag/specs/frontend-route-guard/spec.md
@@ -1,9 +1,5 @@
-# Frontend Route Guard
+## MODIFIED Requirements
 
-## Purpose
-
-Defines the global authentication / onboarding navigation guard (`AuthHook`) that gates SPA route loads based on auth state and onboarding step — including the contextual feedback shown when navigation is blocked, the routes reachable early by guests (Settings, Welcome), and free roam after the dashboard.
-## Requirements
 ### Requirement: Global Auth Hook
 
 The system SHALL provide a global authentication lifecycle hook (`AuthHook`) that gates SPA route loads based on authentication state only. The hook SHALL NOT enforce onboarding step ordering — there is no step machine and no ordinal `tutorialStep` comparison. For guests (unauthenticated users) the hook SHALL permit free roam across application routes (soft gate); account-only features SHALL be hidden at point of use per `guest-mode-access` rather than blocked by navigation. The dashboard SHALL be reachable at any onboarding state; a guest with no follows SHALL be guided by an in-page empty-state call-to-action toward discovery, not by a guard redirect.
@@ -60,3 +56,10 @@ The system SHALL allow an unauthenticated user in onboarding to navigate back to
 - **AND** merely viewing Welcome SHALL NOT change onboarding state
 - **AND** onboarding state SHALL change only via the completion latch (`finish()`), never by viewing Welcome
 
+## REMOVED Requirements
+
+### Requirement: Onboarding Dashboard Readiness
+
+**Reason**: The `readyForDashboard` predicate existed only to gate the forced discovery→dashboard transition. With the soft gate, the dashboard is always reachable and no readiness predicate is needed; the follow/concert thresholds now drive the coach-mark hint only (computed from live counts in `DiscoveryRoute`).
+
+**Migration**: Delete `OnboardingService.readyForDashboard`, `setDiscoveryCounts`, and the mirrored `followedCount` / `artistsWithConcertsCount` fields. Move `DASHBOARD_FOLLOW_TARGET` / `DASHBOARD_CONCERT_TARGET` to a constants module consumed directly by `DiscoveryRoute` for the coach-mark trigger.

--- a/openspec/changes/archive/2026-06-09-simplify-onboarding-to-single-flag/specs/my-artists/spec.md
+++ b/openspec/changes/archive/2026-06-09-simplify-onboarding-to-single-flag/specs/my-artists/spec.md
@@ -1,0 +1,28 @@
+## MODIFIED Requirements
+
+### Requirement: Hype Change Persisted for Guest Users
+
+The system SHALL persist hype changes made by guest users to localStorage without reverting them, and SHALL keep hype editing fully decoupled from onboarding state. Changing a hype level SHALL NOT advance, complete, or otherwise mutate onboarding state, and a repeated hype change (second tap onward) SHALL always apply.
+
+#### Scenario: Guest user changes hype during onboarding
+
+- **WHEN** a guest user changes a hype level while `OnboardingService.isOnboarding` is `true`
+- **AND** the user is not authenticated
+- **THEN** the system SHALL persist the hype value in `GuestService` under `liverty:guest:hypes`
+- **AND** the system SHALL NOT revert the hype change in the UI
+- **AND** the system SHALL NOT mutate onboarding state (no step advance, no completion)
+- **AND** the signup-prompt-banner SHALL already have been visible (per the `Signup Banner on My Artists` requirement in the `signup-prompt-banner` capability); no additional banner-visibility mutation is required by this change handler
+
+#### Scenario: Repeated hype change applies every time
+
+- **WHEN** a guest user changes a hype level
+- **AND** then changes a hype level a second (or subsequent) time on the same or another artist
+- **THEN** every change SHALL apply and persist
+- **AND** no change SHALL be reverted due to onboarding state
+
+#### Scenario: Guest user changes hype after onboarding completion
+
+- **WHEN** a guest user (onboarding completed) changes a hype level on the My Artists page
+- **THEN** the system SHALL persist the hype value in `GuestService`
+- **AND** the system SHALL NOT show a modal dialog
+- **AND** the signup-prompt-banner SHALL remain visible (non-modal, persistent per its own capability spec)

--- a/openspec/changes/archive/2026-06-09-simplify-onboarding-to-single-flag/specs/onboarding-spotlight/spec.md
+++ b/openspec/changes/archive/2026-06-09-simplify-onboarding-to-single-flag/specs/onboarding-spotlight/spec.md
@@ -1,0 +1,90 @@
+## ADDED Requirements
+
+### Requirement: Single Transient Non-Blocking Coach Mark
+
+With the step machine removed, the coach mark SHALL be a single, transient, non-blocking hint rather than a multi-step blocking overlay. At most one coach mark SHALL be active at a time. It SHALL NOT lock page scroll and SHALL NOT block interaction with the rest of the page; it visually highlights its target and lets the user keep using the app. State and lifecycle are owned by `CoachMarkService` (`activate` / `deactivate`), and the `<coach-mark>` component SHALL be placed once at the app-shell level, driven by `CoachMarkService` (target selector, message, radius, active flag, `onTap`). The coach mark SHALL be dismissed when the user taps its target or when the host route detaches.
+
+#### Scenario: Coach mark does not block the rest of the page
+
+- **WHEN** a coach mark is active
+- **THEN** the page outside the highlighted target SHALL remain interactive (no full-viewport click-blockers)
+- **AND** page scroll SHALL NOT be locked (`<au-viewport>` `overflow` SHALL NOT be forced to `hidden`)
+- **AND** the dashboard is reachable at any time, consistent with the soft gate
+
+#### Scenario: Single coach mark driven from the app shell
+
+- **WHEN** the coach mark is active
+- **THEN** the `<coach-mark>` component SHALL be rendered once in the app shell, not in individual route templates
+- **AND** `CoachMarkService` SHALL drive its target selector, message, spotlight radius, and active state
+- **AND** no more than one coach mark SHALL be active simultaneously
+
+#### Scenario: Coach mark dismissed on tap or route detach
+
+- **WHEN** the user taps the coach mark target, OR the host route's `detaching()` lifecycle hook fires
+- **THEN** `CoachMarkService.deactivate()` SHALL be called
+- **AND** the spotlight, tooltip, and any anchor-name SHALL be fully cleaned up
+
+## MODIFIED Requirements
+
+### Requirement: Coach Mark Overlay System
+
+The system SHALL provide a reusable coach mark overlay component that highlights a target element as a non-blocking hint. Coach mark state (target selector, message, radius, active flag, and `onTap` callback) SHALL be owned by a dedicated `CoachMarkService`, not by `OnboardingService`. The `aria-label` on the tooltip SHALL be `"Onboarding tip"`. Navigation SHALL be delegated to the target element's native click behavior; the coach mark SHALL NOT call `router.load()`. The `onTap` callback SHALL NOT advance any onboarding step (there is no step machine); it MAY perform incidental non-navigation side effects only. Target selectors SHALL be scoped to a specific component context (e.g., `concert-highway [data-stage="home"]`) to prevent matching elements in unrelated components.
+
+#### Scenario: Spotlight renders for active coach mark
+
+- **WHEN** a coach mark is activated via `CoachMarkService`
+- **THEN** the system SHALL display the spotlight overlay with instructional text
+- **AND** the tooltip `aria-label` SHALL be `"Onboarding tip"`
+
+#### Scenario: Nav tab tap through spotlight delegates to href
+
+- **WHEN** a coach mark spotlight is active on a nav tab element
+- **AND** the user taps the spotlighted element
+- **THEN** the system SHALL call `currentTarget.click()` to fire the element's native click event
+- **AND** the system SHALL call the `onTap?.()` callback (for incidental side effects only, never step advancement)
+- **AND** the system SHALL NOT call `router.load()` from within the coach mark component or its `onTap` callback
+
+#### Scenario: Off-target interaction is allowed (non-blocking)
+
+- **WHEN** a coach mark spotlight is active
+- **AND** the user taps or scrolls an area outside the highlighted target
+- **THEN** the interaction SHALL reach the underlying page (no click-blocker interception)
+- **AND** page scroll SHALL remain enabled
+
+#### Scenario: Target selector is scoped to component context
+
+- **WHEN** `CoachMarkService.activate()` is called with a target selector
+- **THEN** the selector SHALL include a component-scoped prefix (e.g., `concert-highway [data-stage="home"]` instead of bare `[data-stage="home"]`)
+- **AND** `document.querySelector()` SHALL NOT match elements in unrelated components (e.g., `page-help` decorative labels)
+
+### Requirement: Coach Mark Target Click Delegates Navigation to Aurelia Router
+
+The coach mark's `target-interceptor` div overlays the actual target element. When the user taps the interceptor, it programmatically calls `currentTarget.click()` on the real target element. For navigation targets (e.g., `<a>` with `href`), this `.click()` triggers Aurelia Router's `href` intercept, which handles the route transition declaratively. The `onTap` callback SHALL only perform incidental application side effects (never onboarding step advancement, which no longer exists) and SHALL never call imperative `router.load()`.
+
+#### Scenario: Nav link target navigates via Aurelia Router href intercept
+- **WHEN** the coach mark target is a navigation link (e.g., `<a data-nav="home" href="dashboard">`)
+- **AND** the user taps the `target-interceptor` overlay
+- **THEN** `currentTarget.click()` SHALL fire on the `<a>` element
+- **AND** Aurelia Router's `useHref` intercept SHALL handle the resulting click event as a declarative route transition
+- **AND** the `onTap` callback SHALL NOT advance any onboarding step
+- **AND** `router.load()` SHALL NOT be called imperatively from the `onTap` callback
+
+#### Scenario: Non-nav target triggers onTap callback for application logic
+- **WHEN** the coach mark target is a non-navigation element (e.g., concert card)
+- **AND** the user taps the `target-interceptor` overlay
+- **THEN** `currentTarget.click()` SHALL fire on the target element, triggering its bound event handlers
+- **AND** the `onTap` callback SHALL be invoked for incidental application logic only (e.g., opening a detail sheet), never onboarding step advancement
+
+## REMOVED Requirements
+
+### Requirement: Click-Blocker Layer via Transparent Anchor-Positioned Divs
+
+**Reason**: The coach mark is now a non-blocking hint (see "Single Transient Non-Blocking Coach Mark"). Blocking all off-target interaction and locking scroll contradicts the soft gate, under which the dashboard and every route remain reachable at any time.
+
+**Migration**: Remove the four `.mask-top` / `.mask-right` / `.mask-bottom` / `.mask-left` click-blocker divs and the `<au-viewport>` scroll lock from the coach mark component. The spotlight remains a visual-only cutout (`pointer-events: none`); tapping the target still delegates to its native click. Off-target taps reach the page.
+
+### Requirement: Continuous Spotlight Persistence
+
+**Reason**: This requirement is built entirely on the deleted linear step machine — a single overlay that persists from "Step 1" through "Step 6", reassigning anchor-names as `onboardingStep` advances, with a scroll lock released "at Step 6". With onboarding reduced to a single `isOnboarding` boolean and a single transient coach mark on the discovery page, there is no multi-step persistence to maintain.
+
+**Migration**: Remove the persist-across-steps behavior, the `onboardingStep`-driven anchor-name reassignment, the Step-6 `hidePopover()`/scroll-lock-release path, and the app-shell placement scenario's dependency on `OnboardingService`. Single-coach-mark placement, app-shell rendering, and detach cleanup are now defined by "Single Transient Non-Blocking Coach Mark"; the empty-selector guard and retry-timer cancellation in `findAndHighlight()` move with the coach-mark component into `CoachMarkService`.

--- a/openspec/changes/archive/2026-06-09-simplify-onboarding-to-single-flag/specs/onboarding-tutorial/spec.md
+++ b/openspec/changes/archive/2026-06-09-simplify-onboarding-to-single-flag/specs/onboarding-tutorial/spec.md
@@ -1,0 +1,13 @@
+## REMOVED Requirements
+
+### Requirement: Linear Step Progression
+
+**Reason**: There is no longer a linear onboarding step machine to progress through. Onboarding state collapses to a single `isOnboarding` boolean (see `frontend-onboarding-flow` → "Single-Flag Onboarding State"), and forced navigation ordering is replaced by a soft gate. The discrete steps (`'lp'`, `'discovery'`, `'dashboard'`, `'my-artists'`, `'completed'`) and their per-step advance effects no longer exist.
+
+**Migration**: Remove all `setStep()` calls and `onboardingStep`-keyed branching. The Welcome "Get Started" action simply navigates to discovery (no step set, since `isOnboarding` already defaults to `true`). Dashboard arrival no longer advances a step; it triggers the `finish()` completion latch instead (see `frontend-onboarding-flow`). First-visit help auto-open continues to gate on `isOnboarding` (per `onboarding-page-help`).
+
+### Requirement: Route guard onboarding enforcement
+
+**Reason**: The auth hook no longer compares step ordering via `stepIndex()`; onboarding step metadata on routes (`data.onboardingStep`) and ordinal gating are removed in favor of guest free roam (see `frontend-route-guard` → "Global Auth Hook").
+
+**Migration**: Remove `data.onboardingStep` from route definitions and delete the `stepIndex()`-based allow/redirect branches in `AuthHook`. Guests are permitted to load application routes; account-only features are hidden at point of use per `guest-mode-access`.

--- a/openspec/changes/archive/2026-06-09-simplify-onboarding-to-single-flag/tasks.md
+++ b/openspec/changes/archive/2026-06-09-simplify-onboarding-to-single-flag/tasks.md
@@ -1,0 +1,55 @@
+## 1. Collapse OnboardingService to a single flag
+
+- [x] 1.1 Rewrite `services/onboarding-service.ts` to hold one `@observable` latched boolean (`onboardingComplete`) with `get isOnboarding()` (= `!onboardingComplete`), `get isCompleted()` (= `!isOnboarding`), and a single one-way `finish()` mutator. The backing field MUST be `@observable` so the getters notify dependent bindings/watchers (`pwa-install-service` `@watch(isCompleted)`, `app-shell.html` `if.bind`). Remove `step`, `setStep`, `reset`, `complete`, `currentStep`, `getRouteForCurrentStep`, `readyForDashboard`, `setDiscoveryCounts`, `followedCount`, `artistsWithConcertsCount`, and the spotlight properties/methods.
+- [x] 1.2 Reduce `entities/onboarding.ts` to the minimum: delete `OnboardingStep`, `STEP_ORDER`, `stepIndex`, `STEP_MIGRATION`, `normalizeStep`, `isOnboarding`/`isCompleted` step predicates. Remove `STEP_ROUTE_MAP` from `onboarding-service.ts`.
+- [x] 1.3 Update `adapter/storage/onboarding-storage.ts`: persist `onboardingComplete` (boolean) under a single key; add a one-time construction-time migration that sets `onboardingComplete = completedSet.has(legacy onboardingStep)` where `completedSet = {'completed', '7'}` (legacy numeric `'7'` mapped to `COMPLETED`), then deletes the legacy `onboardingStep` key. Any other legacy value (`'discovery'`, `'my-artists'`, `'detail'`, absent) maps to `false`.
+- [x] 1.4 Move `DASHBOARD_FOLLOW_TARGET` / `DASHBOARD_CONCERT_TARGET` out of `onboarding-service.ts` into a `constants` module.
+- [x] 1.5 Update `entities/index.ts` and any barrel exports to drop the removed onboarding symbols.
+
+## 2. Extract the coach mark into CoachMarkService
+
+- [x] 2.1 Create `services/coach-mark-service.ts` owning spotlight state (`target`, `message`, `radius`, `active`, `onTap`) and `activate()` / `deactivate()`; register it in `main.ts`.
+- [x] 2.2 Repoint `app-shell.html` coach-mark bindings from `onboarding.*` to the new `CoachMarkService`.
+- [x] 2.3 Update `DiscoveryRoute` to compute the coach-mark trigger from live counts: `isOnboarding && (followedCount >= DASHBOARD_FOLLOW_TARGET || artistsWithConcertsCount >= DASHBOARD_CONCERT_TARGET) && !shown`; call `coachMark.activate(...)`. Remove the `setDiscoveryCounts` mirror writes and the `@watch` handlers that fed it.
+- [x] 2.4 Ensure the coach-mark `onTap` performs navigation only (no step advance); deactivate on route `detaching()`.
+- [x] 2.5 Make the coach mark non-blocking: remove the four `.mask-*` click-blocker divs and the `<au-viewport>` scroll lock from the coach-mark component (the spotlight stays a `pointer-events: none` visual cutout). Remove the multi-step "continuous spotlight persistence" logic (anchor-name reassignment across steps, Step-6 teardown) and the empty-selector guard / retry-timer cancellation move into `CoachMarkService`.
+
+## 3. Fix #444 — decouple hype editing from onboarding
+
+- [x] 3.1 In `routes/my-artists/my-artists-route.ts` `onHypeInput`, remove the `isOnboardingStepMyArtists` branch (`setStep(CONSENT)`) and the `if (this.isOnboarding) { artist.hype = prev; return }` revert guard so every hype change applies and persists.
+- [x] 3.2 Remove now-unused `isOnboardingStepMyArtists` / `OnboardingStep` references from the My Artists route; confirm the guest path persists via `followStore.setHype` only.
+
+## 4. Soft-gate the route guard
+
+- [x] 4.1 In `hooks/auth-hook.ts`, remove the onboarding ordinal branches (`tutorialStep`/`onboardingStep` comparison, `readyForDashboard`, step-route redirects, blocked-nav snackbars, the LP-limbo Priority 5 path). Keep: authenticated bypass, `data.auth === false` public allow, guest free roam.
+- [x] 4.2 Remove `data.onboardingStep` and `data.earlyUnlock` route metadata from `app-shell.ts` route definitions that only existed for ordinal gating.
+- [x] 4.3 Add a dashboard empty-state CTA (to discovery) shown when an unauthenticated user has zero follows, per `frontend-route-guard` "Guest with no follows lands on the dashboard".
+
+## 5. Wire the completion latch (B1 ∧ B2)
+
+- [x] 5.1 In `routes/dashboard/dashboard-route.ts`, replace the `DASHBOARD → MY_ARTISTS` `setStep` with a `finish()` call gated on a *meaningful* first arrival: timetable real (region set + data loaded) AND `followedCount >= 1`. Evaluate it after the `maybeCelebrate()` decision (so it observed `isOnboarding === true`) honoring the `needsRegion` deferral, but drive it from the data-ready+engaged condition — NOT from the celebration actually rendering (a guest with `celebrationShown === '1'` must still latch). Do NOT latch on a zero-follow arrival.
+- [x] 5.2 In `routes/auth-callback/auth-callback-route.ts`, replace `onboarding.complete()` with `finish()` (idempotent backstop).
+- [x] 5.3 In `routes/welcome/welcome-route.ts`, drop `onboarding.reset()` / `setStep(DISCOVERY)`; "Get Started" simply navigates to discovery.
+
+## 6. Update dependent consumers and docs
+
+- [x] 6.1 Confirm `notification-prompt`, `pwa-install-service`, and the dashboard signup banner still read `isCompleted` (now `!isOnboarding`) and behave correctly; adjust any `@watch` targets if needed.
+- [x] 6.2 Confirm `onboarding-popover-guide` and `onboarding-page-help` still gate on `isOnboarding`; no behavior change expected.
+- [ ] 6.3 Refresh the `state-transition-diagram` capability doc: replace the onboarding state-machine section/Mermaid with the two-state (`onboarding` → `completed`) model and the single `finish()` latch trigger (documentation sync, applied during archive per the OpenSpec sync workflow).
+
+## 7. Tests
+
+- [x] 7.1 My Artists: regression test for #444 — second and subsequent hype taps apply and persist (guest, during onboarding) and never revert.
+- [x] 7.2 OnboardingService: legacy-key migration (`'completed'` → `false`, any other value / absent → `true`) and `finish()` one-way latch.
+- [x] 7.3 AuthHook: guest free roam (dashboard reachable with zero follows → empty-state, no redirect); authenticated bypass; public-route allow.
+- [x] 7.4 Coach mark: trigger fires from live follow/concert counts gated on `isOnboarding`, shows once per session, `onTap` navigates without step mutation.
+- [x] 7.5 Latch timing: a region-less guest still sees the light celebration before `finish()` latches; and `finish()` still fires when the celebration is suppressed (`celebrationShown === '1'`) on a meaningful arrival.
+- [x] 7.6 Latch engagement gate: a zero-follow guest landing on the dashboard does NOT latch (`isOnboarding` stays `true`); latches only after `followedCount >= 1`.
+- [x] 7.7 Reactivity: `finish()` flips `isCompleted`/`isOnboarding` and fires the `pwa-install-service` watcher and `app-shell` bindings (asserts the `@observable` backing field).
+
+## 8. Verify, ship to prod
+
+- [x] 8.1 Run `make check` (lint + test + typecheck) until green.
+- [x] 8.2 This change adds new rendered UI (dashboard empty-state CTA in 4.3, non-blocking coach-mark changes in 2.5), so visual baselines WILL change: delete all visual-baselines artifacts on main to force baseline regeneration (mandatory — an intentional UI change otherwise blocks merge).
+- [x] 8.3 Open the frontend PR (Refs #444); drive CI green and merge.
+- [x] 8.4 Cut the frontend GitHub Release (SemVer tag) to retag the prod AR image and trigger the automated prod-pin bump (frontend prod is AR-only; ArgoCD auto-syncs). Confirm the rollout.

--- a/openspec/specs/frontend-onboarding-flow/spec.md
+++ b/openspec/specs/frontend-onboarding-flow/spec.md
@@ -3,41 +3,33 @@
 ## Purpose
 
 Defines the guest onboarding flow: interactive artist discovery, the linear onboarding step sequence (LP → DISCOVERY → DASHBOARD → MY_ARTISTS → … → COMPLETED), and the local-storage-backed progression that precedes account creation.
-
 ## Requirements
-
 ### Requirement: Interactive Artist Discovery (Bubble Network UI)
 
-The system SHALL provide an engaging, gamified interface for users to discover and follow artists using Last.fm API data. During onboarding, followed artists are stored locally (not via backend RPC). The system SHALL trigger a background concert search for each followed artist and track which artists have concerts. The Coach Mark SHALL appear when the progression condition is reached, remain visible for 2 seconds, then fade out. Navigation to the Dashboard is not triggered automatically — the user taps the Home nav tab at their own pace.
+The system SHALL provide an engaging, gamified interface for users to discover and follow artists using Last.fm API data. During onboarding, followed artists are stored locally (not via backend RPC). The system SHALL trigger a background concert search for each followed artist and track which artists have concerts. The Coach Mark SHALL appear when the progression condition is reached and SHALL hint that the personal timetable is ready; it is owned by `CoachMarkService` (see `onboarding-spotlight`). Navigation to the Dashboard is never forced — the dashboard is always reachable and the user taps the Home nav tab at their own pace. Tapping the coach mark target SHALL navigate only; it SHALL NOT advance any onboarding step (there is no step machine).
 
 #### Scenario: Guest user follows artist via bubble tap
 
 - **WHEN** a guest user (in onboarding) taps an artist bubble
 - **THEN** the system SHALL trigger the absorption animation
-- **AND** the system SHALL store the artist in `FollowServiceClient.followedArtists` (which delegates to `GuestService` for guest users)
-- **AND** the system SHALL call `ConcertServiceClient.searchAndTrack(artistId)` to initiate background search and polling
+- **AND** the system SHALL store the artist via `FollowStore` (which routes to the guest queue for unauthenticated users)
+- **AND** the system SHALL initiate a background concert search/track for the artist via `ConcertService`
 - **AND** the system SHALL NOT call any backend RPC for the follow operation itself
 
 #### Scenario: Guest follow default hype level
 
-- **WHEN** a guest user (in onboarding) requests the list of followed artists via `listFollowed()`
+- **WHEN** a guest user (in onboarding) requests the list of followed artists via `FollowStore.listFollowed()`
 - **THEN** the system SHALL return each followed artist with hype level `'watch'` (observation tier)
 
-#### Scenario: Discover to Dashboard transition condition
+#### Scenario: Discover to Dashboard coach-mark trigger
 
-- **WHEN** a user is at Step `'discovery'`
-- **AND** either the user has followed 5 or more artists, OR `ConcertServiceClient.artistsWithConcertsCount` >= 3
-- **THEN** the system SHALL activate a coach mark spotlight on the Dashboard icon for 2 seconds
-- **AND** after 2 seconds the spotlight SHALL fade out automatically
-- **AND** the user MAY tap the Dashboard icon at any time (including after the spotlight fades) to navigate to `/dashboard`
-- **AND** when the user taps the Dashboard icon, the system SHALL advance `onboardingStep` to `'dashboard'`
-
-#### Scenario: Coach Mark fades after 2 seconds
-
-- **WHEN** the progression condition is first met
-- **THEN** the system SHALL display the coach mark spotlight
-- **AND** after 2000ms the system SHALL deactivate the spotlight
-- **AND** the Dashboard nav icon SHALL remain tappable without the spotlight
+- **WHEN** a user is in onboarding (`isOnboarding === true`)
+- **AND** either the user has followed 5 or more artists, OR the live `artistsWithConcertsCount` >= 3
+- **AND** the coach mark has not yet been shown this session
+- **THEN** the system SHALL activate a coach mark spotlight on the Dashboard nav icon via `CoachMarkService`
+- **AND** the trigger SHALL be evaluated from live follow/concert counts in `DiscoveryRoute`, not from a mirrored count cache
+- **AND** the user MAY tap the Dashboard icon at any time (with or without the spotlight) to navigate to `/dashboard`
+- **AND** tapping the Dashboard icon SHALL navigate only and SHALL NOT advance any onboarding step
 
 #### Scenario: Coach Mark does not reappear
 
@@ -47,8 +39,8 @@ The system SHALL provide an engaging, gamified interface for users to discover a
 #### Scenario: Pre-seeded follows on page reload
 
 - **WHEN** the discovery page loads during onboarding
-- **THEN** the system SHALL hydrate follows from `GuestService.follows` into `FollowServiceClient`
-- **AND** the system SHALL call `ConcertServiceClient.searchAndTrack()` for any artists not yet tracked
+- **THEN** the system SHALL hydrate follows from `FollowStore.guestFollows` into the active follow list
+- **AND** the system SHALL initiate a concert search via `ConcertService` for any artists not yet tracked
 
 #### Scenario: Snack notification on concert found
 
@@ -56,19 +48,55 @@ The system SHALL provide an engaging, gamified interface for users to discover a
 - **AND** `listConcerts(artistId)` returns at least one concert
 - **THEN** the system SHALL display a snack notification indicating the artist has upcoming events
 
-### Requirement: Step Sequence
+### Requirement: Single-Flag Onboarding State
 
-The onboarding step sequence SHALL be LP → DISCOVERY → DASHBOARD → MY_ARTISTS → … → COMPLETED. The DETAIL step is removed. The DASHBOARD step SHALL complete on dashboard arrival (no Lane Intro sequence). The MY_ARTISTS → COMPLETED transition is out of scope for this change (owned by the consent-step flow).
+The system SHALL model onboarding state as a single persisted boolean rather than an ordered step machine. `OnboardingService` SHALL expose `isOnboarding` as the primary getter and SHALL retain `isCompleted` as its negation (`isCompleted === !isOnboarding`) for call-site compatibility. The persisted value SHALL use completed-polarity (`onboardingComplete`; an absent key means `false`, i.e. still onboarding) so a brand-new user defaults to `isOnboarding === true`. Completion SHALL be a one-way latch exposed as a single `finish()` mutator; once `isOnboarding` becomes `false` it SHALL NOT return to `true` except via an explicit fresh-onboarding reset. The service SHALL NOT expose step values, step ordering, route maps, or a `readyForDashboard` predicate.
 
-#### Scenario: Step sequence excludes DETAIL
+#### Scenario: Brand-new user defaults to onboarding
 
-- **WHEN** `onboardingStep` is `'dashboard'`
-- **AND** the Dashboard page is attached
-- **THEN** the system SHALL advance `onboardingStep` to `'my-artists'`
-- **AND** the system SHALL NOT pass through any intermediate `'detail'` step
+- **WHEN** a user opens the app for the first time and no onboarding key exists in localStorage
+- **THEN** `OnboardingService.isOnboarding` SHALL be `true`
+- **AND** `OnboardingService.isCompleted` SHALL be `false`
 
-#### Scenario: Legacy localStorage value migration
+#### Scenario: Completion latches on first meaningful dashboard arrival
 
-- **WHEN** the system reads `liverty:onboardingStep` from localStorage
-- **AND** the stored value is `'detail'`
-- **THEN** the system SHALL treat it as `'dashboard'` for routing and step logic
+- **WHEN** an unauthenticated guest reaches the dashboard for the first time
+- **AND** the timetable is real (region is set and concert data has loaded)
+- **AND** the guest has at least one followed artist (`followedCount >= 1`)
+- **THEN** the system SHALL call `finish()` so `isOnboarding` becomes `false`
+- **AND** the latch SHALL be evaluated after the light-celebration decision (so `maybeCelebrate()` observed `isOnboarding === true`), honoring the `needsRegion` deferral
+
+#### Scenario: Latch is independent of whether the celebration is shown
+
+- **WHEN** a guest reaches a meaningful first dashboard (region set, data loaded, `followedCount >= 1`)
+- **AND** the light celebration is suppressed (e.g. `localStorage['onboarding.celebrationShown'] === '1'` from a prior session, or `maybeCelebrate()` otherwise early-returns)
+- **THEN** the system SHALL still call `finish()`
+- **AND** the latch SHALL NOT be gated on the celebration overlay actually rendering
+
+#### Scenario: No latch for a zero-follow dashboard arrival
+
+- **WHEN** an unauthenticated guest with zero followed artists lands on the dashboard (e.g. via deep link, served the empty-state CTA)
+- **THEN** the system SHALL NOT call `finish()`
+- **AND** `isOnboarding` SHALL remain `true` so the discovery coach mark and page-help auto-open still apply until the guest follows an artist or signs up
+
+#### Scenario: Completion latches on sign-up
+
+- **WHEN** a user completes sign-up via the auth callback
+- **THEN** the system SHALL call `finish()` so `isOnboarding` becomes `false`
+- **AND** the call SHALL be idempotent if onboarding was already completed
+
+#### Scenario: Completion is one-way
+
+- **WHEN** `isOnboarding` is already `false`
+- **AND** the user revisits the dashboard or any onboarding-relevant surface
+- **THEN** the system SHALL keep `isOnboarding === false`
+
+#### Scenario: Legacy step value migration
+
+- **WHEN** `OnboardingService` is constructed
+- **AND** the legacy `localStorage['onboardingStep']` key exists
+- **THEN** the system SHALL set `onboardingComplete = true` when the legacy value denotes completion — i.e. it is in the completed set `{'completed', '7'}` (the legacy numeric index `'7'` mapped to `COMPLETED`)
+- **AND** the system SHALL set `onboardingComplete = false` for any other legacy value (e.g. `'discovery'`, `'my-artists'`, `'detail'`)
+- **AND** the system SHALL persist the new value and delete the legacy `onboardingStep` key
+- **AND** the migration SHALL run at most once per client
+

--- a/openspec/specs/my-artists/spec.md
+++ b/openspec/specs/my-artists/spec.md
@@ -3,9 +3,7 @@
 ## Purpose
 
 Display and manage the user's followed artists, providing list and grid views with passion level controls.
-
 ## Requirements
-
 ### Requirement: Artist List Row (REMOVED)
 
 **Reason**: The swipe-to-dismiss unfollow mechanism was abandoned due to `display: table-row` layout constraints that prevented the scroll-snap container from functioning correctly inside the artist list. Replaced by the long-press-to-unfollow flow.
@@ -29,16 +27,23 @@ Display and manage the user's followed artists, providing list and grid views wi
 
 ### Requirement: Hype Change Persisted for Guest Users
 
-The system SHALL persist hype changes made by guest users to localStorage without reverting them, regardless of onboarding step.
+The system SHALL persist hype changes made by guest users to localStorage without reverting them, and SHALL keep hype editing fully decoupled from onboarding state. Changing a hype level SHALL NOT advance, complete, or otherwise mutate onboarding state, and a repeated hype change (second tap onward) SHALL always apply.
 
-#### Scenario: Guest user changes hype during MY_ARTISTS onboarding step
+#### Scenario: Guest user changes hype during onboarding
 
-- **WHEN** a user at Step `'my-artists'` changes a hype level
+- **WHEN** a guest user changes a hype level while `OnboardingService.isOnboarding` is `true`
 - **AND** the user is not authenticated
 - **THEN** the system SHALL persist the hype value in `GuestService` under `liverty:guest:hypes`
 - **AND** the system SHALL NOT revert the hype change in the UI
-- **AND** the system SHALL advance `onboardingStep` to `'completed'`
+- **AND** the system SHALL NOT mutate onboarding state (no step advance, no completion)
 - **AND** the signup-prompt-banner SHALL already have been visible (per the `Signup Banner on My Artists` requirement in the `signup-prompt-banner` capability); no additional banner-visibility mutation is required by this change handler
+
+#### Scenario: Repeated hype change applies every time
+
+- **WHEN** a guest user changes a hype level
+- **AND** then changes a hype level a second (or subsequent) time on the same or another artist
+- **THEN** every change SHALL apply and persist
+- **AND** no change SHALL be reverted due to onboarding state
 
 #### Scenario: Guest user changes hype after onboarding completion
 
@@ -165,3 +170,4 @@ The artists-table column-header cells (`.hype-col-header` in `my-artists-route.h
   - `🔥🔥 Nearby`
   - `🔥🔥🔥 Away`
 - **AND** these surface forms SHALL remain identical across all supported locales
+

--- a/openspec/specs/onboarding-spotlight/spec.md
+++ b/openspec/specs/onboarding-spotlight/spec.md
@@ -1,3 +1,9 @@
+# Onboarding Spotlight
+
+## Purpose
+
+Defines the coach mark spotlight overlay — the visual cutout, tooltip, target-click delegation, and lifecycle. The coach mark is a single, transient, non-blocking hint owned by `CoachMarkService`.
+## Requirements
 ### Requirement: Spotlight Visual Layer via Box-Shadow
 
 The coach mark spotlight SHALL use a CSS Anchor Positioning hybrid approach. A `.visual-spotlight` element SHALL be positioned over the target using `anchor()` functions in `inset` properties, with `box-shadow: 0 0 0 100vmax` to create the dark overlay and a transparent cutout. The element SHALL use `border-radius: var(--spotlight-radius)` for shape control and `pointer-events: none` to allow click-through.
@@ -24,11 +30,11 @@ The coach mark spotlight SHALL use a CSS Anchor Positioning hybrid approach. A `
 
 ### Requirement: Coach Mark Overlay System
 
-The system SHALL provide a reusable coach mark overlay component that highlights a target element. The `aria-label` on the tooltip SHALL be `"Onboarding tip"`. Navigation SHALL be delegated to the target element's native click behavior; the coach mark SHALL NOT call `router.load()`. Target selectors SHALL be scoped to a specific component context (e.g., `concert-highway [data-stage="home"]`) to prevent matching elements in unrelated components.
+The system SHALL provide a reusable coach mark overlay component that highlights a target element as a non-blocking hint. Coach mark state (target selector, message, radius, active flag, and `onTap` callback) SHALL be owned by a dedicated `CoachMarkService`, not by `OnboardingService`. The `aria-label` on the tooltip SHALL be `"Onboarding tip"`. Navigation SHALL be delegated to the target element's native click behavior; the coach mark SHALL NOT call `router.load()`. The `onTap` callback SHALL NOT advance any onboarding step (there is no step machine); it MAY perform incidental non-navigation side effects only. Target selectors SHALL be scoped to a specific component context (e.g., `concert-highway [data-stage="home"]`) to prevent matching elements in unrelated components.
 
-#### Scenario: Spotlight renders for active step
+#### Scenario: Spotlight renders for active coach mark
 
-- **WHEN** an onboarding step requires a coach mark
+- **WHEN** a coach mark is activated via `CoachMarkService`
 - **THEN** the system SHALL display the spotlight overlay with instructional text
 - **AND** the tooltip `aria-label` SHALL be `"Onboarding tip"`
 
@@ -37,62 +43,21 @@ The system SHALL provide a reusable coach mark overlay component that highlights
 - **WHEN** a coach mark spotlight is active on a nav tab element
 - **AND** the user taps the spotlighted element
 - **THEN** the system SHALL call `currentTarget.click()` to fire the element's native click event
-- **AND** the system SHALL call `onTap?.()` callback (for step-advance logic only)
+- **AND** the system SHALL call the `onTap?.()` callback (for incidental side effects only, never step advancement)
 - **AND** the system SHALL NOT call `router.load()` from within the coach mark component or its `onTap` callback
 
-#### Scenario: Blocker divs prevent off-target interaction
+#### Scenario: Off-target interaction is allowed (non-blocking)
 
 - **WHEN** a coach mark spotlight is active
-- **THEN** blocker divs SHALL cover the viewport area outside the spotlight target
-- **AND** taps on blocker divs SHALL be silently ignored (no navigation, no error)
-- **AND** the scroll lock (`overflow: hidden` on `au-viewport`) SHALL remain active while the coach mark is active
+- **AND** the user taps or scrolls an area outside the highlighted target
+- **THEN** the interaction SHALL reach the underlying page (no click-blocker interception)
+- **AND** page scroll SHALL remain enabled
 
 #### Scenario: Target selector is scoped to component context
 
-- **WHEN** `activateSpotlight()` is called with a target selector
+- **WHEN** `CoachMarkService.activate()` is called with a target selector
 - **THEN** the selector SHALL include a component-scoped prefix (e.g., `concert-highway [data-stage="home"]` instead of bare `[data-stage="home"]`)
 - **AND** `document.querySelector()` SHALL NOT match elements in unrelated components (e.g., `page-help` decorative labels)
-
-### Requirement: Click-Blocker Layer via Transparent Anchor-Positioned Divs
-
-The coach mark SHALL use four transparent click-blocker divs (top, right, bottom, left) positioned with CSS `anchor()` functions to block interactions outside the target element.
-
-#### Scenario: Clicks outside spotlight are blocked
-
-- **WHEN** the coach mark overlay is active
-- **AND** the user taps an area covered by a click-blocker div
-- **THEN** the tap SHALL be intercepted by the blocker (`pointer-events: auto`)
-- **AND** the tap SHALL NOT reach the underlying page content
-
-#### Scenario: Clicks inside spotlight reach the target
-
-- **WHEN** the coach mark overlay is active
-- **AND** the user taps inside the spotlight cutout area
-- **THEN** the tap SHALL pass through to the actual target element
-- **AND** the target element SHALL receive the click event natively
-
-#### Scenario: Target interceptor invokes onTap callback
-
-- **WHEN** the coach mark overlay is active with an `onTap` callback registered
-- **AND** the user taps the target interceptor overlay
-- **THEN** the `onTap` callback SHALL be invoked
-- **AND** the caller MAY use the callback to deactivate the spotlight (e.g., `deactivateSpotlight()`)
-
-#### Scenario: Click-blockers cover the entire viewport except target bounds
-
-- **WHEN** the coach mark overlay is active
-- **THEN** `.mask-top` SHALL cover from viewport top to `anchor(target top)`
-- **AND** `.mask-bottom` SHALL cover from `anchor(target bottom)` to viewport bottom
-- **AND** `.mask-left` SHALL cover from viewport left to `anchor(target left)`, between target top and bottom
-- **AND** `.mask-right` SHALL cover from `anchor(target right)` to viewport right, between target top and bottom
-
-#### Scenario: My Artists step provides onTap dismissal callback
-
-- **WHEN** the onboarding step is `my-artists`
-- **AND** `activateSpotlight` is called for the `[data-hype-header]` target
-- **THEN** an `onTap` callback SHALL be provided that calls `deactivateSpotlight()`
-- **AND** after the spotlight is dismissed, the hype sliders SHALL be interactive
-- **AND** the user SHALL be able to change a hype level to complete onboarding
 
 ### Requirement: Spotlight Uses Popover Top Layer
 
@@ -102,7 +67,7 @@ The coach mark overlay container SHALL use `popover="manual"` to render on the b
 
 - **WHEN** the coach mark is activated
 - **THEN** the overlay container SHALL call `showPopover()` to enter the top layer
-- **AND** the spotlight and click-blockers SHALL render above all other content regardless of z-index
+- **AND** the spotlight SHALL render above all other content regardless of z-index
 
 #### Scenario: Popover UA styles are neutralized
 
@@ -110,66 +75,14 @@ The coach mark overlay container SHALL use `popover="manual"` to render on the b
 - **THEN** the container SHALL have `background: transparent`, `border: none`, `padding: 0`, `margin: 0`
 - **AND** `::backdrop` SHALL be set to `display: none`
 
-### Requirement: Continuous Spotlight Persistence
-
-The spotlight SHALL remain continuously active from the moment it first appears (Step 1, Dashboard icon) until the sign-up modal is displayed (Step 6). The popover SHALL NOT be closed and reopened between steps; instead, the target SHALL be updated via anchor-name reassignment while the overlay remains open. This provides uninterrupted visual guidance throughout the entire onboarding tutorial. **Exception**: the Step 1→3 transition (Discovery → Dashboard) SHALL deactivate and reactivate the spotlight — the popover must be cleared before navigation so that Dashboard overlays (celebration, region selector) render above the top layer without being blocked by click-blockers (see `onboarding-tutorial`, "Step 1 - Spotlight deactivation before navigation"). **Additionally**, route components with active spotlights SHALL call `deactivateSpotlight()` in their `detaching()` lifecycle hook to ensure cleanup regardless of navigation trigger.
-
-The `findAndHighlight()` method SHALL validate `targetSelector` before calling `querySelector`. When `targetSelector` is empty or falsy, the method SHALL return immediately without calling `querySelector` or initiating retry logic. This prevents `InvalidSelectorError` caused by non-deterministic Aurelia binding update order when multiple Store properties change simultaneously.
-
-The `findAndHighlight()` method SHALL cancel any pending retry timer before starting a new retry chain. This prevents timer leaks when `targetSelectorChanged` fires while a previous retry is still running (e.g., during the lane introduction sequence where phases advance every 2 seconds but retry chains run up to 5 seconds).
-
-#### Scenario: Spotlight activates at Step 1 and persists through Step 5
-
-- **WHEN** the coach mark first activates at Step 1 (Dashboard icon in discover page)
-- **THEN** the overlay popover SHALL call `showPopover()` once
-- **AND** the popover SHALL remain open through all subsequent steps (Step 3 lane intro, Step 3 card, Step 4 My Artists tab, Step 5 Passion Level)
-- **AND** the target SHALL change by reassigning `anchor-name` to the new target element
-- **AND** the tooltip message SHALL update to match the current step
-
-#### Scenario: Spotlight deactivates at Step 6
-
-- **WHEN** `onboardingStep` advances to 6 (SignUp)
-- **THEN** the overlay popover SHALL call `hidePopover()`
-- **AND** the current target's `anchor-name` SHALL be cleared
-- **AND** the scroll lock on `<au-viewport>` SHALL be released (`overflow` reset)
-- **AND** no orphaned click-blockers or anchor-names SHALL remain in the DOM
-
-#### Scenario: Route detach triggers deactivation
-
-- **WHEN** a route containing an active spotlight detaches
-- **THEN** `deactivateSpotlight()` SHALL be called in the `detaching()` lifecycle hook
-- **AND** the spotlight state SHALL be fully cleaned up before the new route attaches
-
-#### Scenario: App-shell level placement
-
-- **WHEN** the onboarding spotlight is active
-- **THEN** the `<coach-mark>` component SHALL be rendered in the app shell (`my-app.html`), not in individual route page templates
-- **AND** the onboarding service SHALL drive the target selector, message, spotlight radius, and active state
-- **AND** individual route pages SHALL NOT contain their own `<coach-mark>` instances for onboarding steps
-
-#### Scenario: Empty target selector is safely ignored
-
-- **WHEN** the `targetSelector` bindable property is set to an empty string (e.g., via Store `clearSpotlight` dispatch)
-- **AND** `targetSelectorChanged()` fires before `activeChanged()` due to non-deterministic binding update order
-- **THEN** `findAndHighlight()` SHALL return immediately without calling `document.querySelector`
-- **AND** no `InvalidSelectorError` SHALL be thrown
-- **AND** no retry timer SHALL be started
-
-#### Scenario: Retry timer cancelled on new target
-
-- **WHEN** `findAndHighlight()` is called while a previous retry chain is still pending
-- **THEN** the pending retry timer SHALL be cancelled via `cleanup()` before starting the new retry chain
-- **AND** only one retry chain SHALL be active at any time
-
 ### Requirement: Route Detach Spotlight Cleanup
 
-When the dashboard route detaches (user navigates away), the spotlight SHALL be deactivated via the `detaching()` lifecycle hook to prevent orphaned View Transitions and popover state. Note: `unloading()` (router lifecycle) is also a valid placement since it runs earlier in the navigation sequence (`canUnload → canLoad → unloading → loading → detaching`), but `detaching()` is chosen for consistency with existing cleanup code (AbortController, timers, scroll listeners) already in this hook.
+When a route hosting an active coach mark detaches (user navigates away), the spotlight SHALL be deactivated via the `detaching()` lifecycle hook to prevent orphaned View Transitions and popover state. Note: `unloading()` (router lifecycle) is also a valid placement since it runs earlier in the navigation sequence (`canUnload → canLoad → unloading → loading → detaching`), but `detaching()` is chosen for consistency with existing cleanup code (AbortController, timers, scroll listeners) already in this hook.
 
-#### Scenario: Dashboard detaching cleans up spotlight
-- **WHEN** the dashboard route's `detaching()` lifecycle hook fires
-- **THEN** `onboardingService.deactivateSpotlight()` SHALL be called
+#### Scenario: Route detaching cleans up spotlight
+- **WHEN** the host route's `detaching()` lifecycle hook fires
+- **THEN** `CoachMarkService.deactivate()` SHALL be called
 - **AND** any in-progress View Transition SHALL be safely terminated
-- **AND** the scroll lock on `<au-viewport>` SHALL be released
 
 #### Scenario: Navigation during active spotlight does not throw
 - **WHEN** the spotlight is active with a View Transition in progress
@@ -179,21 +92,21 @@ When the dashboard route detaches (user navigates away), the spotlight SHALL be 
 
 ### Requirement: Coach Mark Target Click Delegates Navigation to Aurelia Router
 
-The coach mark's `target-interceptor` div overlays the actual target element. When the user taps the interceptor, it programmatically calls `currentTarget.click()` on the real target element. For navigation targets (e.g., `<a>` with `href`), this `.click()` triggers Aurelia Router's `href` intercept, which handles the route transition declaratively. The `onTap` callback SHALL only perform state updates (e.g., `setStep`), never imperative `router.load()`.
+The coach mark's `target-interceptor` div overlays the actual target element. When the user taps the interceptor, it programmatically calls `currentTarget.click()` on the real target element. For navigation targets (e.g., `<a>` with `href`), this `.click()` triggers Aurelia Router's `href` intercept, which handles the route transition declaratively. The `onTap` callback SHALL only perform incidental application side effects (never onboarding step advancement, which no longer exists) and SHALL never call imperative `router.load()`.
 
 #### Scenario: Nav link target navigates via Aurelia Router href intercept
-- **WHEN** the coach mark target is a navigation link (e.g., `<a data-nav="my-artists" href="my-artists">`)
+- **WHEN** the coach mark target is a navigation link (e.g., `<a data-nav="home" href="dashboard">`)
 - **AND** the user taps the `target-interceptor` overlay
 - **THEN** `currentTarget.click()` SHALL fire on the `<a>` element
 - **AND** Aurelia Router's `useHref` intercept SHALL handle the resulting click event as a declarative route transition
-- **AND** the `onTap` callback SHALL only update onboarding state (e.g., `onboardingService.setStep()`)
+- **AND** the `onTap` callback SHALL NOT advance any onboarding step
 - **AND** `router.load()` SHALL NOT be called imperatively from the `onTap` callback
 
 #### Scenario: Non-nav target triggers onTap callback for application logic
 - **WHEN** the coach mark target is a non-navigation element (e.g., concert card)
 - **AND** the user taps the `target-interceptor` overlay
 - **THEN** `currentTarget.click()` SHALL fire on the target element, triggering its bound event handlers
-- **AND** the `onTap` callback SHALL be invoked for additional application logic (e.g., advancing onboarding step, opening detail sheet)
+- **AND** the `onTap` callback SHALL be invoked for incidental application logic only (e.g., opening a detail sheet), never onboarding step advancement
 
 ### Requirement: Smooth Spotlight Movement via View Transitions API
 
@@ -313,6 +226,30 @@ The `findAndHighlight()` method SHALL reject target elements that are invisible 
 - **AND** the element's bounding rect has zero dimensions
 - **THEN** the system SHALL skip this element
 - **AND** the system SHALL retry until a visible matching element appears or timeout is reached
+
+### Requirement: Single Transient Non-Blocking Coach Mark
+
+With the step machine removed, the coach mark SHALL be a single, transient, non-blocking hint rather than a multi-step blocking overlay. At most one coach mark SHALL be active at a time. It SHALL NOT lock page scroll and SHALL NOT block interaction with the rest of the page; it visually highlights its target and lets the user keep using the app. State and lifecycle are owned by `CoachMarkService` (`activate` / `deactivate`), and the `<coach-mark>` component SHALL be placed once at the app-shell level, driven by `CoachMarkService` (target selector, message, radius, active flag, `onTap`). The coach mark SHALL be dismissed when the user taps its target or when the host route detaches.
+
+#### Scenario: Coach mark does not block the rest of the page
+
+- **WHEN** a coach mark is active
+- **THEN** the page outside the highlighted target SHALL remain interactive (no full-viewport click-blockers)
+- **AND** page scroll SHALL NOT be locked (`<au-viewport>` `overflow` SHALL NOT be forced to `hidden`)
+- **AND** the dashboard is reachable at any time, consistent with the soft gate
+
+#### Scenario: Single coach mark driven from the app shell
+
+- **WHEN** the coach mark is active
+- **THEN** the `<coach-mark>` component SHALL be rendered once in the app shell, not in individual route templates
+- **AND** `CoachMarkService` SHALL drive its target selector, message, spotlight radius, and active state
+- **AND** no more than one coach mark SHALL be active simultaneously
+
+#### Scenario: Coach mark dismissed on tap or route detach
+
+- **WHEN** the user taps the coach mark target, OR the host route's `detaching()` lifecycle hook fires
+- **THEN** `CoachMarkService.deactivate()` SHALL be called
+- **AND** the spotlight, tooltip, and any anchor-name SHALL be fully cleaned up
 
 ## Test Cases
 

--- a/openspec/specs/onboarding-tutorial/spec.md
+++ b/openspec/specs/onboarding-tutorial/spec.md
@@ -1,58 +1,7 @@
 ## Purpose
 
 Define the guided first-run onboarding tutorial: the linear step progression through landing, artist discovery, dashboard arrival, and My Artists, including how spotlights and coach marks steer the user. The dashboard Lane Intro sequence (blocker divs, scroll lock, nav dimming) has been removed; arriving at the dashboard completes that step.
-
 ## Requirements
-
-### Requirement: Linear Step Progression
-
-The system SHALL guide the user forward through onboarding steps. The DASHBOARD step has no Lane Intro sequence, blocker divs, or scroll lock — arriving at the dashboard completes the step. After dashboard arrival the user explores freely. (The MY_ARTISTS → COMPLETED transition is owned by the consent-step flow and is out of scope for this change.)
-
-> **Note on Step numbering**: The "Step N" labels mirror the `onboardingStep` state-machine values (`'lp'` = Step 0, `'discovery'` = Step 1, `'dashboard'` = Step 3, `'my-artists'` = Step 5, `'completed'` = Step 7, per `frontend-route-guard`).
-
-#### Scenario: Step 0 - Landing Page entry
-
-- **WHEN** a user is at Step `'lp'`
-- **AND** the user taps the [Get Started] CTA
-- **THEN** the system SHALL advance `onboardingStep` to `'discovery'`
-- **AND** navigate to the Artist Discovery screen
-
-#### Scenario: Step 1 - Artist Discovery completion
-
-- **WHEN** a user is at Step `'discovery'`
-- **AND** the progression condition is met (5 follows OR 3 artists with concerts)
-- **THEN** the system SHALL activate the coach mark spotlight on the Dashboard icon and SHALL keep it active until the user taps the highlighted target
-- **AND** the spotlight SHALL NOT auto-dismiss based on elapsed time
-- **AND** when the user taps the Home/Dashboard icon, the system SHALL advance `onboardingStep` to `'dashboard'`
-- **AND** the system SHALL navigate to `/dashboard`
-
-#### Scenario: Step 3 - Dashboard arrival completes the step
-
-- **WHEN** a user is at Step `'dashboard'`
-- **AND** the Dashboard page is attached
-- **THEN** the system SHALL advance `onboardingStep` to `'my-artists'`
-- **AND** the system SHALL NOT run any Lane Intro sequence, blocker divs, or scroll lock
-- **AND** all nav tabs SHALL be fully interactive
-
-#### Scenario: Step 3 - Concert card tap opens Detail Sheet
-
-- **WHEN** a user taps a concert card on the dashboard during onboarding
-- **THEN** the system SHALL open the EventDetailSheet for that concert
-- **AND** the system SHALL NOT advance any onboarding step
-
-#### Scenario: Step 5 - My Artists first visit auto-opens help
-
-- **WHEN** a user at Step `'my-artists'` navigates to the My Artists page
-- **THEN** the PageHelp bottom-sheet SHALL auto-open (first visit, per `onboarding-page-help` spec)
-- **AND** the sheet SHALL explain hype levels
-
-#### Scenario: Step 1 spotlight cleanup on non-target navigation
-
-- **WHEN** the Step 1 coach mark spotlight is active on the Dashboard icon
-- **AND** the user navigates away from Discovery by means other than tapping the spotlighted target
-- **THEN** the spotlight SHALL be deactivated via the route's `detaching()` lifecycle hook (per `onboarding-spotlight` "Route Detach Spotlight Cleanup")
-- **AND** no time-based fade timer SHALL be involved in the cleanup path
-
 ### Requirement: Coach Mark Navigation Delegation
 
 The system SHALL delegate navigation from coach mark taps to the target element's native href, not to a separate `router.load()` call.
@@ -64,19 +13,3 @@ The system SHALL delegate navigation from coach mark taps to the target element'
 - **THEN** the nav tab's native click event SHALL handle navigation
 - **AND** the system SHALL NOT call `router.load()` from the `onTap` callback
 
-### Requirement: Route guard onboarding enforcement
-
-The system SHALL use route data `onboardingStep` (string step value) to control access during onboarding. The auth hook SHALL compare step ordering using `stepIndex()` rather than numeric comparison.
-
-#### Scenario: Route guard allows current or past steps
-
-- **WHEN** a route has `data.onboardingStep` set to a step value
-- **AND** the user is in the onboarding flow
-- **THEN** the auth hook SHALL allow navigation if `stepIndex(currentStep) >= stepIndex(route.onboardingStep)`
-
-#### Scenario: Route guard redirects future steps
-
-- **WHEN** a route has `data.onboardingStep` set to a step value
-- **AND** the user is in the onboarding flow
-- **AND** `stepIndex(currentStep) < stepIndex(route.onboardingStep)`
-- **THEN** the auth hook SHALL redirect to the route for the current step

--- a/openspec/specs/state-transition-diagram/spec.md
+++ b/openspec/specs/state-transition-diagram/spec.md
@@ -1,62 +1,63 @@
 # State Transition Diagram Specification
 
-## 1. Onboarding State Machine
+## 1. Onboarding State
 
 ### 1.1 Overview
 
-The onboarding state machine guides new users through a linear multi-step introduction flow.
-Each step advances strictly forward. The flow completes when the user sets a hype level on the
-My Artists screen.
+Onboarding is a single latched boolean, not an ordered step machine. A brand-new user
+starts in the `onboarding` state and transitions once, irreversibly, to `completed`. There
+is no forced navigation ordering: the dashboard and every route are reachable at any time
+(soft gate), and a guest with no follows is guided by an in-page empty-state CTA rather than
+a guard redirect. The flag is exposed as `OnboardingService.isOnboarding`
+(`isCompleted === !isOnboarding`) and persisted as `onboardingComplete` (absent key =
+still onboarding).
 
 ### 1.2 States
 
-| State       | Description                              |
-|-------------|------------------------------------------|
-| `lp`        | Landing page (initial state)             |
-| `discovery` | Artist discovery screen                  |
-| `dashboard` | Personal timetable dashboard             |
-| `my-artists`| User's followed-artists list             |
-| `completed` | Onboarding finished (terminal state)     |
+| State        | Description                                                |
+|--------------|------------------------------------------------------------|
+| `onboarding` | First-run experience (default for a new user)              |
+| `completed`  | Onboarding finished (terminal; one-way)                    |
 
 ### 1.3 Transitions
 
-| Trigger                  | From          | To            | Where                          |
-|--------------------------|---------------|---------------|--------------------------------|
-| Get Started button       | `lp`          | `discovery`   | welcome-route                  |
-| Dashboard nav tap ¹      | `discovery`   | `dashboard`   | auth-hook (coach-mark / readyForDashboard) |
-| Dashboard arrival        | `dashboard`   | `my-artists`  | dashboard-route (`attached`)   |
-| Hype level set           | `my-artists`  | `completed`   | my-artists-route               |
+| Trigger                              | From         | To          | Where                          |
+|--------------------------------------|--------------|-------------|--------------------------------|
+| Meaningful first dashboard arrival ¹ | `onboarding` | `completed` | dashboard-route (`finish()`)   |
+| Sign-up (idempotent backstop)        | `onboarding` | `completed` | auth-callback-route (`finish()`)|
 
-¹ User taps the Dashboard nav tab once the progression condition is met (coach-mark spotlight or `readyForDashboard`). There is no longer a separate "Generate Dashboard" CTA, and no `detail` step.
+¹ "Meaningful" = the timetable is real (region set + concert data loaded) **and** the guest
+has at least one followed artist (`followedCount >= 1`). The latch is evaluated after the
+light-celebration decision but is driven by the data-ready + engaged condition, not by whether
+the celebration overlay rendered. A zero-follow dashboard arrival does NOT latch. Completion is
+one-way; it never returns to `onboarding` except via an explicit fresh-onboarding reset. The
+legacy `onboardingStep` value is migrated once on load (`'completed'`/`'7'` → completed).
 
-### 1.4 Spotlight Sub-States
+### 1.4 Coach Mark (independent)
 
-Within each onboarding step, a spotlight overlay can be activated to highlight a UI target.
-The spotlight is set and cleared independently of step transitions.
+The coach mark is a single, transient, non-blocking hint owned by `CoachMarkService` — not part
+of the onboarding state. It is activated from `DiscoveryRoute` when `isOnboarding` and the live
+follow/concert counts cross the threshold (`followedCount >= 5` OR `artistsWithConcertsCount >= 3`),
+and dismissed on target tap or route detach. It does not lock scroll or block off-target
+interaction, and tapping it navigates only (no state mutation).
 
-| Action                    | From       | To         |
-|---------------------------|------------|------------|
-| `onboarding/setSpotlight` | `inactive` | `active`   |
-| `onboarding/clearSpotlight`| `active`  | `inactive` |
+| Action                       | From       | To         |
+|------------------------------|------------|------------|
+| `CoachMarkService.activate`  | `inactive` | `active`   |
+| `CoachMarkService.deactivate`| `active`   | `inactive` |
 
 ### 1.5 State Diagram
 
 ```mermaid
 stateDiagram-v2
-    [*] --> lp
-
-    lp --> discovery : Get Started
-    discovery --> dashboard : Dashboard nav tap (coach-mark / readyForDashboard)
-    state "my-artists" as my_artists
-    dashboard --> my_artists : dashboard .attached() (Lane Intro removed)
-    my_artists --> completed : Hype level set
-
+    [*] --> onboarding
+    onboarding --> completed : finish() — meaningful dashboard arrival OR sign-up
     completed --> [*]
 
-    state "Spotlight (per step)" as spotlight {
+    state "Coach mark (independent)" as coachmark {
         [*] --> inactive
-        inactive --> active : setSpotlight
-        active --> inactive : clearSpotlight
+        inactive --> active : activate (isOnboarding & counts threshold)
+        active --> inactive : deactivate (tap / route detach)
     }
 ```
 


### PR DESCRIPTION
Spec side of the onboarding simplification (frontend **v1.13.0**, already shipped to prod). Syncs the single-flag onboarding deltas into the canonical specs and archives the change.

## Canonical spec updates
- **frontend-onboarding-flow**: single-flag `isOnboarding` state + `finish()` latch; remove `Step Sequence`.
- **frontend-route-guard**: auth-only soft gate (guest free roam, empty-state CTA); remove `Onboarding Dashboard Readiness`.
- **my-artists**: hype editing fully decoupled from onboarding (no step advance, no revert) — the #444 spec fix.
- **onboarding-tutorial**: remove `Linear Step Progression` + `Route guard onboarding enforcement`.
- **onboarding-spotlight**: non-blocking coach mark owned by `CoachMarkService`; remove click-blocker layer + continuous spotlight persistence. Also adds a missing `## Requirements` section so the spec parses (pre-existing structural defect).
- **state-transition-diagram**: replace the linear step machine with the two-state (`onboarding → completed`) model.

## Notes
- Implementation already merged + released (frontend PR #448, v1.13.0). This PR is documentation/spec-sync only.
- Archived under `openspec/changes/archive/2026-06-09-simplify-onboarding-to-single-flag/`.

Refs: #444