### PR TITLE
docs(openspec): split-admin-rpc-server — dedicated admin Connect server

### DIFF
--- a/openspec/changes/split-admin-rpc-server/.openspec.yaml
+++ b/openspec/changes/split-admin-rpc-server/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-09

--- a/openspec/changes/split-admin-rpc-server/design.md
+++ b/openspec/changes/split-admin-rpc-server/design.md
@@ -66,9 +66,14 @@ The admin console already loads a per-host `/config.json` (`admin-console-hostin
 
 ## Migration / sequencing
 
-This moves a live, prod-shipped service. To avoid a window where the admin console can't reach moderation:
-1. Ship backend serving `ConcertModerationService` on **both** the consumer and admin servers temporarily — OR sequence host+frontend so the admin client flips only after `api.admin` is live.
-2. Preferred: stand up `api.admin` (cloud-provisioning) → release backend (admin server live, still also on consumer server) → flip the admin frontend config to `api.admin` → remove the service from the consumer server in a follow-up. Decide at apply time whether the brief dual-serve is worth avoiding a flip-day gap.
+This moves a live, prod-shipped service, so the cutover must never (a) leave an admin RPC **ungated** or (b) **CORS-break** the admin console. The safe order is a coordinated flip with **no ungated dual-serve** and the consumer-CORS removal **last**:
+
+1. **cloud-provisioning**: stand up `api.admin` (Service + route + cert + DNS + health) and the admin CORS config. Keep the admin origin in the consumer CORS for now. The `api.admin` route is unhealthy until step 2 — fine, nothing uses it yet.
+2. **backend release**: the admin server serves `ConcertModerationService` (boundary-gated); the consumer server stops serving it in the **same** release. Until step 3 the admin console (still on the consumer API) gets `unimplemented` for moderation — a brief functional gap on an internal tool, with **no security exposure**.
+3. **frontend release**: flip the admin client to `api.admin` — gap closed.
+4. **cloud-provisioning follow-up**: drop the admin origin from the consumer CORS (the admin console no longer calls the consumer API).
+
+**Why not dual-serve to avoid the step-2→3 gap?** Because task 1.3 deletes the per-method check and the admin-authorization interceptor is admin-server-only, registering the service on the consumer server during the window would leave it **ungated** — any authenticated fan could call it. The only *safe* dual-serve is to additionally attach the admin-authorization interceptor to that handler on the consumer server too, then drop it in the follow-up. Given the admin surface is internal and low-traffic, the simple coordinated flip (accepting a brief moderation gap) is preferred over that added complexity.
 
 ## Open questions
 

--- a/openspec/changes/split-admin-rpc-server/design.md
+++ b/openspec/changes/split-admin-rpc-server/design.md
@@ -1,0 +1,77 @@
+# Design: dedicated admin RPC server
+
+## Context
+
+Today everything is one Connect server on one port:
+
+```
+:Port ── CORS(consumer+admin origins merged) ── authn.Middleware (shared issuer)
+   └─ one interceptor chain ─ one protectedMux
+        ├─ User / Artist / Concert / Ticket … (consumer)
+        └─ ConcertModerationService  ← only guarded by per-method RequireRole("admin")
+```
+
+A consumer fan's JWT is a valid token at this port (same Zitadel issuer), so it passes `authn`; only the in-handler `RequireRole` stops it. Precedent for splitting exists: `webhook` and `health` already run as separate `http.Server` listeners (`internal/infrastructure/server/{webhook,health}.go`).
+
+## Goals
+
+- An admin RPC cannot be served without admin authorization — make it structural, not per-method discipline.
+- Govern the admin surface (origins, limits, host, future IAP) independently of the public API.
+- Keep it one binary (no new deployment) — the isolation is network/governance, not process.
+- Zero proto change; `ConcertModerationService` only moves.
+
+## Decision 1 — Second in-process listener, not a new binary
+
+Add a second `ConnectServer` (the *admin server*) bound to its own port in the **same** backend binary, built by the same factory as the consumer server. One Deployment exposes two container ports.
+
+```
+backend Pod (one binary)
+ ├─ :PORT        consumer ConnectServer ── Service: server      ── HTTPRoute api.{env}
+ └─ :ADMIN_PORT  admin ConnectServer    ── Service: admin-server ── HTTPRoute api.admin.{env}
+```
+
+Why not a separate binary (Opt 3)? The admin surface is low-traffic and shares the same domain logic/deps; a separate deployment buys independent scaling/blast-radius we don't need yet, at real CI/release cost. Two listeners in one binary give the governance split (host, CORS, authz boundary) cheaply. Opt 3 stays open as a later step if admin ever needs independent scaling.
+
+## Decision 2 — Authorization at the server boundary
+
+The admin server applies a **fixed admin-authorization interceptor** to every handler, as an inner layer of the shared chain (after the claims bridge, so it sees the bridged claims):
+
+```
+admin server chain: tracing → ratelimit → accesslog → error → recover → claimsBridge → REQUIRE-ADMIN → validation
+```
+
+Because the admin server hosts **only** admin services and the interceptor is server-wide, it is impossible to register an un-gated admin RPC. The per-method `auth.RequireRole(ctx, "admin")` calls are deleted from `ConcertModerationHandler` — the handler becomes pure mapping again.
+
+Defense in depth (kept, not required): the admin server still runs the same `authn.Middleware` (valid-JWT, default-deny). A consumer token passes authn but fails REQUIRE-ADMIN. Optionally the admin `authFunc` could additionally pin the admin org id, but the role interceptor is the authoritative gate; pinning the org is a redundant nicety we can add without changing this contract.
+
+### Why not just keep per-method checks (Opt 1)?
+
+Opt 1 (an interceptor on the consumer server scoped to admin handlers) centralizes authz but still shares the port/CORS/host/limits — it does not give the governance split (independent origins, host, future IAP) that motivated this change. Opt 2 gets both the authz boundary **and** the governance split.
+
+## Decision 3 — Separate CORS, shared everything-else via a factory
+
+The admin server gets its own allowlist (`ADMIN_CORS_ALLOWED_ORIGINS` = `https://admin.{env}` + localhost in dev). The consumer `CORS_ALLOWED_ORIGINS` drops the admin origin that was merged in earlier.
+
+To prevent the two interceptor chains from drifting, both servers are built from **one factory** that takes (port, CORS origins, extra interceptors, handler set). The consumer call passes no extra authz interceptor; the admin call passes the REQUIRE-ADMIN interceptor. The `interceptor-chain-ordering` invariants hold for both.
+
+## Decision 4 — Ingress host `api.admin.{env}`
+
+Naming mirrors the existing trio: consumer app `app`/root, consumer API `api.{env}`, admin app `admin.{env}` → admin API **`api.admin.{env}`**. It gets its own `Service` (ClusterIP, h2c, gRPC health), `HTTPRoute` on the shared external gateway, certmap + Cloud DNS, and `HealthCheckPolicy` — symmetric with the consumer backend exposure and with `admin-console-hosting`'s frontend host. Consumer routing is untouched.
+
+The admin SPA runs in the developer's browser, so `api.admin.{env}` is a **public** host (not ClusterIP-only). The win is a *separately governed* public surface — its own CORS, its own route to hang IAP/Cloud Armor on later — not internal-only reachability.
+
+## Decision 5 — Frontend resolves the admin API host from runtime config
+
+The admin console already loads a per-host `/config.json` (`admin-console-hosting`). It gains the admin API base URL (`api.admin.{env}`); the admin `ConcertModerationService` client uses it. The consumer SPA keeps calling `api.{env}`. No code path conditionally rewrites hosts — each app reads its own config.
+
+## Migration / sequencing
+
+This moves a live, prod-shipped service. To avoid a window where the admin console can't reach moderation:
+1. Ship backend serving `ConcertModerationService` on **both** the consumer and admin servers temporarily — OR sequence host+frontend so the admin client flips only after `api.admin` is live.
+2. Preferred: stand up `api.admin` (cloud-provisioning) → release backend (admin server live, still also on consumer server) → flip the admin frontend config to `api.admin` → remove the service from the consumer server in a follow-up. Decide at apply time whether the brief dual-serve is worth avoiding a flip-day gap.
+
+## Open questions
+
+- **Host name**: `api.admin.{env}` vs `admin-api.{env}`? (proposal assumes `api.admin.{env}`.)
+- **Dual-serve during cutover** vs a coordinated single-flip — pick per risk tolerance (admin is internal/low-traffic, so a short coordinated flip is likely fine).
+- **Org pinning in the admin authFunc** — add now or leave the role interceptor as the sole gate?

--- a/openspec/changes/split-admin-rpc-server/proposal.md
+++ b/openspec/changes/split-admin-rpc-server/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+The admin moderation RPCs (`ConcertModerationService`) are served by the **same** Connect server, port, CORS allowlist, authn middleware, and interceptor chain as the consumer-facing RPCs. The only thing separating the admin surface from the public one is a per-method `auth.RequireRole(ctx, "admin")` call inside each handler method. This has two problems:
+
+- **Authorization is easy to get wrong.** Every new admin method must remember `RequireRole`; a single omission silently exposes an admin operation to any authenticated consumer (a fan's valid JWT already passes the shared authn — only the in-handler check stops them). There is no structural guarantee.
+- **The admin surface shares the consumer's blast radius and governance.** Admin and consumer traffic share one public host, one CORS list (the admin origin was merged into the consumer backend's `CORS_ALLOWED_ORIGINS`), one rate limiter, and one route — so the admin API cannot be governed (origins, limits, and a future IAP/Cloud Armor layer) independently of the public API.
+
+The codebase already runs multiple `http.Server` listeners on separate ports (the webhook and health servers), so a dedicated admin RPC server is consistent with the established topology — and symmetric with `admin-console-hosting`, which already isolates the admin **frontend** onto its own image, host, and config.
+
+## What Changes
+
+- **Add a dedicated admin Connect server** (a second listener in the same backend binary, on its own port) that serves **only** admin-scoped services. The consumer Connect server **stops serving** `ConcertModerationService`.
+- **Enforce admin authorization at the server boundary, not per method.** Every RPC on the admin server passes through a fixed admin-authorization interceptor that requires the `admin` role; non-admin (and unauthenticated) callers are rejected with `PERMISSION_DENIED` before any handler runs. The per-method `RequireRole` calls are removed — the admin server cannot host a non-admin-gated RPC by construction.
+- **Give the admin server its own CORS allowlist** (admin origins only). The consumer server's `CORS_ALLOWED_ORIGINS` no longer needs the admin origin.
+- **Expose the admin server on its own ingress host** — `api.admin.{env-base-domain}` (mirroring `admin.{env-base-domain}` + the consumer `api.{env-base-domain}`) — via its own Service + HTTPRoute + cert + DNS + health-check, leaving the consumer routing untouched.
+- **Point the admin console's RPC client at the admin host** via its per-host runtime config; the consumer SPA continues to call the consumer API.
+
+This is purely a relocation + hardening of an **existing** service. `ConcertModerationService` and its proto are unchanged — there is **no specification/proto/BSR change**.
+
+## Capabilities
+
+### New Capabilities
+- `admin-rpc-server`: A dedicated backend Connect server for admin-scoped RPCs — a separate in-process listener on its own port, serving only admin services, with boundary-level admin-role authorization (replacing per-method checks), an admin-only CORS allowlist, its own ingress host/Service/cert/DNS/health, and the consumer server's exclusion of admin services. The admin console's RPC client resolves the admin API host from its runtime config.
+
+## Impact
+
+- **backend**: Build a second `ConnectServer` (admin) in DI alongside the consumer one, sharing a server/interceptor factory to avoid drift; register both with the shutdown Drain phase. Add the admin-authorization interceptor as a fixed layer on the admin server and remove the per-method `RequireRole` from `ConcertModerationHandler`. Move `ConcertModerationService` registration from the consumer mux to the admin mux. New config: admin server port + admin CORS origins; drop the admin origin from the consumer CORS list.
+- **cloud-provisioning**: Expose a second container port on the backend Deployment; add an admin backend `Service` (h2c, gRPC health), an `HTTPRoute` for `api.admin.{env}` on the shared external gateway, certmap + Cloud DNS entries, and a `HealthCheckPolicy`. Add the admin CORS origins + admin port to the backend config/env; remove the admin origin from the consumer `CORS_ALLOWED_ORIGINS`.
+- **frontend**: The admin app's `ConcertModerationService` client base URL comes from the admin runtime config (`api.admin.{env}`) rather than the shared consumer API base. Consumer client unchanged.
+- **specification**: None — no proto change.
+- **Out of scope (later)**: putting Google IAP / Cloud Armor in front of the `api.admin` route (the split *enables* this defense-in-depth, but the IAP-vs-Zitadel interplay is a separate change); migrating other future admin services (this change establishes the server; later admin services simply register on the admin mux).

--- a/openspec/changes/split-admin-rpc-server/specs/admin-rpc-server/spec.md
+++ b/openspec/changes/split-admin-rpc-server/specs/admin-rpc-server/spec.md
@@ -1,0 +1,127 @@
+## ADDED Requirements
+
+### Requirement: Dedicated admin Connect server
+
+The backend SHALL serve admin-scoped RPCs from a dedicated Connect server bound to
+its own port, separate from the consumer-facing Connect server. Both servers MAY
+run in the same backend binary. The admin server SHALL serve ONLY admin-scoped
+services, and the consumer server SHALL NOT serve any admin-scoped service.
+
+#### Scenario: Admin service served only on the admin port
+
+- **WHEN** the backend starts
+- **THEN** `ConcertModerationService` is registered on the admin server's mux
+- **AND** it is NOT registered on the consumer server's mux
+
+#### Scenario: Consumer service served only on the consumer port
+
+- **WHEN** the backend starts
+- **THEN** consumer services (e.g. `UserService`, `ArtistService`, `ConcertService`)
+  are registered on the consumer server
+- **AND** they are NOT registered on the admin server
+
+#### Scenario: Both servers drain on shutdown
+
+- **WHEN** the backend receives a shutdown signal
+- **THEN** both the consumer and admin servers SHALL drain in-flight requests
+  during the shutdown Drain phase
+
+### Requirement: Boundary-level admin authorization
+
+Every RPC served by the admin server SHALL pass through a fixed admin-authorization
+layer that requires the caller to hold the `admin` role. Authorization SHALL be
+enforced at the server boundary for all admin RPCs uniformly, NOT by per-handler-method
+checks. A request that fails this check SHALL be rejected before any handler business
+logic executes.
+
+#### Scenario: Admin caller is allowed
+
+- **WHEN** a caller whose validated token carries the `admin` role invokes any admin RPC
+- **THEN** the admin-authorization layer SHALL allow the request to reach the handler
+
+#### Scenario: Authenticated non-admin caller is denied
+
+- **WHEN** a caller presents a valid JWT that does NOT carry the `admin` role
+- **THEN** the request SHALL be rejected with `PERMISSION_DENIED`
+- **AND** no handler business logic SHALL execute
+
+#### Scenario: Unauthenticated caller is denied
+
+- **WHEN** a caller presents no valid token to the admin server
+- **THEN** the request SHALL be rejected by the admin server's authn layer (default-deny)
+
+#### Scenario: Admin RPCs carry no per-method role check
+
+- **WHEN** an admin handler method is implemented
+- **THEN** it SHALL NOT contain its own per-method role assertion
+- **AND** the admin server's boundary layer SHALL be the sole admin-role gate
+
+### Requirement: Admin-only CORS allowlist
+
+The admin server SHALL use a CORS allowlist configured independently of the consumer
+server, containing only admin origins. The consumer server's CORS allowlist SHALL NOT
+be required to contain the admin origin.
+
+#### Scenario: Admin origin allowed on the admin server
+
+- **WHEN** the admin console origin sends a request to the admin server
+- **THEN** the admin server's CORS layer SHALL permit it
+
+#### Scenario: Admin origin not required on the consumer server
+
+- **WHEN** the consumer server's CORS allowlist is configured
+- **THEN** it SHALL NOT need to include the admin origin for the admin console to function
+
+### Requirement: Shared server construction to prevent interceptor drift
+
+The consumer and admin Connect servers SHALL be constructed through a shared factory
+so that the interceptor chain ordering invariants are identical for both, differing
+only by the admin-authorization layer and the CORS allowlist.
+
+#### Scenario: Both servers share the base interceptor chain
+
+- **WHEN** either server is constructed
+- **THEN** it SHALL apply the same base interceptor ordering (tracing, access log,
+  error handling, panic recovery, claims bridge, validation)
+- **AND** the admin server SHALL additionally apply the admin-authorization layer
+
+### Requirement: Dedicated admin API ingress host
+
+The admin server SHALL be reachable at a dedicated hostname `api.admin.{env-base-domain}`
+(e.g. `api.admin.dev.liverty-music.app`, `api.admin.liverty-music.app`) via its own
+Kubernetes Service and a dedicated HTTPRoute on the shared external gateway, with its
+own certificate, DNS entry, and gRPC health check. The consumer API host and routing
+SHALL remain unchanged.
+
+#### Scenario: Admin API host routes to the admin server
+
+- **WHEN** a request arrives for `api.admin.{env-base-domain}`
+- **THEN** the shared gateway routes it to the admin backend Service
+
+#### Scenario: Consumer API host unchanged
+
+- **WHEN** a request arrives for the consumer API host
+- **THEN** it continues to route to the consumer backend Service unchanged
+
+#### Scenario: Admin Service is internal and h2c with a health check
+
+- **WHEN** the admin backend Service is provisioned
+- **THEN** it SHALL be ClusterIP (reachable only via the gateway), advertise h2c via
+  `appProtocol`, and be covered by a gRPC `HealthCheckPolicy`
+
+### Requirement: Admin console resolves the admin API host from runtime config
+
+The admin console SHALL obtain the admin API base URL from its per-host runtime
+configuration and direct its admin RPC client (e.g. `ConcertModerationService`) to
+`api.admin.{env-base-domain}`. The consumer SPA SHALL continue to call the consumer
+API host. Neither app SHALL conditionally rewrite the other's host.
+
+#### Scenario: Admin client targets the admin API host
+
+- **WHEN** the admin console boots and reads its runtime config
+- **THEN** its admin RPC client base URL SHALL be the admin API host for that environment
+
+#### Scenario: Consumer client unchanged
+
+- **WHEN** the consumer SPA boots
+- **THEN** its RPC client SHALL continue to target the consumer API host

--- a/openspec/changes/split-admin-rpc-server/specs/admin-rpc-server/spec.md
+++ b/openspec/changes/split-admin-rpc-server/specs/admin-rpc-server/spec.md
@@ -81,9 +81,10 @@ only by the admin-authorization layer and the CORS allowlist.
 #### Scenario: Both servers share the base interceptor chain
 
 - **WHEN** either server is constructed
-- **THEN** it SHALL apply the same base interceptor ordering (tracing, access log,
-  error handling, panic recovery, claims bridge, validation)
+- **THEN** it SHALL apply the same base interceptor ordering (tracing, rate limiting,
+  access log, error handling, panic recovery, claims bridge, validation)
 - **AND** the admin server SHALL additionally apply the admin-authorization layer
+  (after the claims bridge, before validation)
 
 ### Requirement: Dedicated admin API ingress host
 

--- a/openspec/changes/split-admin-rpc-server/tasks.md
+++ b/openspec/changes/split-admin-rpc-server/tasks.md
@@ -10,7 +10,7 @@
 
 - [ ] 2.1 In DI, build the consumer server (existing services, minus admin) and the admin server (admin services only) via the factory; give the admin server its own health handler
 - [ ] 2.2 Register BOTH servers with the shutdown Drain phase so both drain on signal
-- [ ] 2.3 Move `ConcertModerationService` registration to the admin server; (cutover option) optionally keep it ALSO on the consumer server behind the per-method check during the migration window — decide per design "Migration / sequencing"
+- [ ] 2.3 Move `ConcertModerationService` registration to the admin server ONLY (boundary-gated); the consumer server stops serving it in the SAME release. Do NOT register it on the consumer server as a dual-serve — task 1.3 removed the per-method check and the admin-authorization interceptor is admin-server-only, so a consumer-side registration would be UNGATED. (If a zero-gap cutover is ever required, the only safe dual-serve is to additionally attach the admin-authorization interceptor to that handler on the consumer server too, then drop it in the follow-up — see design "Migration / sequencing".)
 - [ ] 2.4 `make check` green
 
 ## 3. cloud-provisioning — admin API ingress
@@ -19,7 +19,7 @@
 - [ ] 3.2 Add an admin backend `Service` (ClusterIP, `appProtocol: kubernetes.io/h2c`) targeting the admin port
 - [ ] 3.3 Add an `HTTPRoute` for `api.admin.{env}` on the shared external gateway → admin Service; leave the consumer API route unchanged
 - [ ] 3.4 Add certmap + Cloud DNS entries for `api.admin.{env}` and a gRPC `HealthCheckPolicy` for the admin Service
-- [ ] 3.5 Backend config/env: add `ADMIN_SERVER_PORT` + `ADMIN_CORS_ALLOWED_ORIGINS` (admin origins); REMOVE the admin origin from the consumer `CORS_ALLOWED_ORIGINS`
+- [ ] 3.5 Backend config/env: add `ADMIN_SERVER_PORT` + `ADMIN_CORS_ALLOWED_ORIGINS` (admin origins). KEEP the admin origin in the consumer `CORS_ALLOWED_ORIGINS` for now — it is removed only in the follow-up (5.4), AFTER the frontend flips to `api.admin`, so the admin console is never CORS-broken mid-cutover
 - [ ] 3.6 `make lint` / kustomize render green; `pulumi preview` clean for dev and prod
 
 ## 4. Frontend — admin client base URL
@@ -30,8 +30,8 @@
 
 ## 5. Ship to production (coordinated cutover)
 
-- [ ] 5.1 Merge + apply cloud-provisioning so `api.admin.{env}` is live (Service + route + cert + DNS + health) BEFORE the frontend flips
-- [ ] 5.2 Release backend so the admin server is live (per design, optionally still dual-serving on the consumer server during the window)
-- [ ] 5.3 Release frontend so the admin console targets `api.admin`; verify approve/reject works end-to-end against the admin host in prod
-- [ ] 5.4 Follow-up: remove `ConcertModerationService` from the consumer server (if dual-served) and drop the admin origin from the consumer CORS; confirm the consumer API no longer serves admin RPCs
-- [ ] 5.5 Verify a non-admin token is rejected at the admin host, and that the consumer host returns not-found/unimplemented for the moderation procedures
+- [ ] 5.1 Apply cloud-provisioning so `api.admin.{env}` is live (Service + route + cert + DNS + health) and the admin CORS config is in place. The consumer CORS still includes the admin origin. The `api.admin` route is unhealthy until the backend serves the admin port (5.2) — fine, nothing uses it yet
+- [ ] 5.2 Release backend: the admin server serves `ConcertModerationService` (boundary-gated) on the admin port; the consumer server no longer serves it. NOTE: until 5.3, the admin console (still pointed at the consumer API) gets `unimplemented` for moderation — a brief functional gap on an internal tool, with NO security exposure (the consumer API simply no longer hosts those procedures)
+- [ ] 5.3 Release frontend so the admin console targets `api.admin`; the gap closes. Verify approve/reject end-to-end against the admin host in prod
+- [ ] 5.4 Follow-up cloud-provisioning: now that the admin console no longer calls the consumer API, drop the admin origin from the consumer `CORS_ALLOWED_ORIGINS`
+- [ ] 5.5 Verify a non-admin token is rejected at the admin host, and that the consumer host returns `unimplemented` for the moderation procedures

--- a/openspec/changes/split-admin-rpc-server/tasks.md
+++ b/openspec/changes/split-admin-rpc-server/tasks.md
@@ -1,0 +1,37 @@
+## 1. Backend — server factory + admin authorization
+
+- [ ] 1.1 Extract a shared server/interceptor factory from `NewConnectServer` so the consumer and admin servers are built identically except for (port, CORS origins, extra interceptors, handler set); preserve the `interceptor-chain-ordering` invariants
+- [ ] 1.2 Implement an admin-authorization interceptor that reads the bridged claims and requires the `admin` role, rejecting others with `PERMISSION_DENIED`; place it after the claims bridge, before validation
+- [ ] 1.3 Remove the per-method `auth.RequireRole(ctx, "admin")` calls from `ConcertModerationHandler` (the handler returns to pure mapping)
+- [ ] 1.4 Add config for the admin server: `ADMIN_SERVER_PORT` and `ADMIN_CORS_ALLOWED_ORIGINS` (and wire defaults for local dev)
+- [ ] 1.5 Unit tests: admin server denies a valid non-admin JWT with `PERMISSION_DENIED`; allows an admin JWT; consumer server has no admin service registered; both chains preserve ordering
+
+## 2. Backend — DI wiring of two servers
+
+- [ ] 2.1 In DI, build the consumer server (existing services, minus admin) and the admin server (admin services only) via the factory; give the admin server its own health handler
+- [ ] 2.2 Register BOTH servers with the shutdown Drain phase so both drain on signal
+- [ ] 2.3 Move `ConcertModerationService` registration to the admin server; (cutover option) optionally keep it ALSO on the consumer server behind the per-method check during the migration window — decide per design "Migration / sequencing"
+- [ ] 2.4 `make check` green
+
+## 3. cloud-provisioning — admin API ingress
+
+- [ ] 3.1 Expose a second container port on the backend Deployment for the admin server
+- [ ] 3.2 Add an admin backend `Service` (ClusterIP, `appProtocol: kubernetes.io/h2c`) targeting the admin port
+- [ ] 3.3 Add an `HTTPRoute` for `api.admin.{env}` on the shared external gateway → admin Service; leave the consumer API route unchanged
+- [ ] 3.4 Add certmap + Cloud DNS entries for `api.admin.{env}` and a gRPC `HealthCheckPolicy` for the admin Service
+- [ ] 3.5 Backend config/env: add `ADMIN_SERVER_PORT` + `ADMIN_CORS_ALLOWED_ORIGINS` (admin origins); REMOVE the admin origin from the consumer `CORS_ALLOWED_ORIGINS`
+- [ ] 3.6 `make lint` / kustomize render green; `pulumi preview` clean for dev and prod
+
+## 4. Frontend — admin client base URL
+
+- [ ] 4.1 Add the admin API base URL (`api.admin.{env}`) to the admin per-host runtime config (`/config.json`) and its env ConfigMaps
+- [ ] 4.2 Point the admin `ConcertModerationService` client at the admin API base URL from runtime config; leave the consumer client unchanged
+- [ ] 4.3 Tests + `make check` green
+
+## 5. Ship to production (coordinated cutover)
+
+- [ ] 5.1 Merge + apply cloud-provisioning so `api.admin.{env}` is live (Service + route + cert + DNS + health) BEFORE the frontend flips
+- [ ] 5.2 Release backend so the admin server is live (per design, optionally still dual-serving on the consumer server during the window)
+- [ ] 5.3 Release frontend so the admin console targets `api.admin`; verify approve/reject works end-to-end against the admin host in prod
+- [ ] 5.4 Follow-up: remove `ConcertModerationService` from the consumer server (if dual-served) and drop the admin origin from the consumer CORS; confirm the consumer API no longer serves admin RPCs
+- [ ] 5.5 Verify a non-admin token is rejected at the admin host, and that the consumer host returns not-found/unimplemented for the moderation procedures


### PR DESCRIPTION
## Summary

OpenSpec proposal for **`split-admin-rpc-server`** — relocate the admin moderation RPCs (`ConcertModerationService`) off the shared consumer Connect server onto a **dedicated admin Connect server** on its own port (same backend binary), and harden the boundary. This is a spec-only PR (proposal/design/specs/tasks); implementation follows via `/opsx:apply`.

## Why

Today the admin surface shares the consumer server's port, CORS allowlist, authn middleware, and interceptor chain — only an in-handler `RequireRole("admin")` separates it. A single omission exposes an admin operation to any authenticated consumer (a fan's valid JWT already passes the shared authn), and the admin surface can't be governed (origins, rate limits, a future IAP/Cloud Armor layer) independently of the public API.

## What the change proposes

- **Dedicated admin Connect server** on its own port (one binary, two listeners — consistent with the existing webhook/health servers). The consumer server stops serving admin services.
- **Boundary-level admin authorization**: a fixed admin-role interceptor on the admin server gates every admin RPC; the per-method `RequireRole` calls are removed. Because the admin server hosts only admin services, an un-gated admin RPC is impossible by construction.
- **Admin-only CORS** allowlist; the consumer `CORS_ALLOWED_ORIGINS` drops the admin origin.
- **Own ingress host** `api.admin.{env}` (Service + HTTPRoute + cert + DNS + health), symmetric with `admin-console-hosting`.
- The admin console resolves the admin API host from its runtime config.
- **No proto/BSR change** — `ConcertModerationService` only moves.

## Artifacts

- `proposal.md`, `design.md` (5 design decisions + migration/cutover), `specs/admin-rpc-server/spec.md` (new capability, 6 ADDED requirements), `tasks.md`.
- `openspec validate --strict` passes.

## Open questions (in design.md)

- Host name `api.admin.{env}` vs `admin-api.{env}`.
- Dual-serve during cutover vs coordinated single flip.
- Pin the admin org in the admin `authFunc`, or rely on the role interceptor alone.

Refs: #615
