### PR TITLE
docs(openspec): add simplify-sales-phase-model change

### DIFF
--- a/openspec/changes/simplify-sales-phase-model/.openspec.yaml
+++ b/openspec/changes/simplify-sales-phase-model/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-15

--- a/openspec/changes/simplify-sales-phase-model/design.md
+++ b/openspec/changes/simplify-sales-phase-model/design.md
@@ -7,7 +7,7 @@ The sales-phase feature discovers ticket-sale windows for a series via a grounde
 
 Two product decisions remove the justification for this machinery:
 - **Audience is now an explicit fan signal.** Notifications target users with a `Tracking` ticket journey on the series' events, not followers filtered by covered-event proximity.
-- **Notification content is already generic** (a title plus a `/series/{id}` link); the precise covered-event set is never surfaced to the fan.
+- **Notification content is series-level** (copy identifies the artist/tour/channel/time and links to the series, falling back to the series detail rather than a single concert); the precise covered-event set is never surfaced to the fan.
 
 With targeting and content both series-level, the covered-event refinement has no consumer, while remaining the single largest source of extraction inaccuracy. This design removes it and re-anchors identity on the one mandatory, stable attribute of a sale window: its application start time.
 

--- a/openspec/changes/simplify-sales-phase-model/design.md
+++ b/openspec/changes/simplify-sales-phase-model/design.md
@@ -1,0 +1,85 @@
+## Context
+
+The sales-phase feature discovers ticket-sale windows for a series via a grounded Gemini search, persists them, announces newly found ones, and fires a multi-stage reminder ladder. The current model treats a phase as covering a *subset* of a series' events and relies on two fragile, LLM-derived signals for correctness:
+
+1. **Covered-event resolution** — Step 1 extracts verbatim `covered_dates`, Step 2 matches those dates to known event indices. A miss silently drops a phase (the persistence guard requires at least one resolved covered event).
+2. **Covered-event overlap + channel-compatibility** as the convergence key — re-discovered phases match an existing row by overlapping `event_ids` and a channel wildcard rule. Reclassification (`UNSPECIFIED`→`FAN_CLUB`) and coverage growth are handled here.
+
+Two product decisions remove the justification for this machinery:
+- **Audience is now an explicit fan signal.** Notifications target users with a `Tracking` ticket journey on the series' events, not followers filtered by covered-event proximity.
+- **Notification content is already generic** (a title plus a `/series/{id}` link); the precise covered-event set is never surfaced to the fan.
+
+With targeting and content both series-level, the covered-event refinement has no consumer, while remaining the single largest source of extraction inaccuracy. This design removes it and re-anchors identity on the one mandatory, stable attribute of a sale window: its application start time.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Make a sales phase a series-level record; eliminate covered-event resolution from the searcher and persistence.
+- Use `(series_id, apply_start_time)` as the convergence signal — stable across `channel`/`sequence`/coverage drift, timezone-agnostic.
+- Re-target announcement and reminder audiences to `Tracking` ticket journeys on the series' events.
+- Preserve once-only announcement, once-only reminders, and reminder retention while milestones are pending.
+- Reduce the LLM-accuracy-critical surface area to "is there a sale, and when does its application open?"
+
+**Non-Goals:**
+- No confidence tiering / recall-vs-precision split. Every persisted window (apply_start known) announces and schedules whatever reminder stages have timestamps. (Considered and dropped for simplicity.)
+- No record deletion / GC. Completed phases are retained; reads filter by pending milestones.
+- No change to notification content/copy or to the reminder stage set and timing.
+- No "bootstrap" mechanism for fans who have not yet started tracking (accepted: fans track from the prior new-concert notification funnel).
+- No per-leg / per-event targeting precision (explicitly removed).
+
+## Decisions
+
+### D1. A sales phase is series-level; drop `event_ids` and `anchor_event_id`
+
+`SalesPhase` references only its `Series`. The `event_sales_phases` join table and `anchor_event_id` column are removed.
+
+- **Why:** With tracking-based audience and generic content, covered events have no consumer. Removing them deletes the most error-prone extraction step and its persistence guard.
+- **Alternative — keep covered events for future UI (event→phases reverse lookup):** rejected; the reverse lookup is satisfied via the series (an event's series → its phases), so no per-phase coverage is needed.
+
+### D2. Convergence key = `(series_id, apply_start_time)`, matched in the application layer
+
+The discovery upsert selects an existing phase by equal `series_id` and equal `apply_start_at`; found → update descriptive fields in place (silent), absent → insert + announce. `apply_start_at` is a `timestamptz` (an absolute instant), so the comparison is timezone-agnostic and works for non-JST events. `channel`, `sequence`, `method`, `provider_name`, and the other timestamps are descriptive, last-write-wins fields and never participate in identity. The surrogate `id` remains the only hard DB key and the stable handle reminders reference.
+
+- **Why `apply_start_time`:** it is the only mandatory field (a phase without it is already dropped), it is the natural identity of a sales window, and it is immune to the reclassification/coverage drift that destabilized `channel`/`sequence` and covered-event overlap.
+- **Alternative — JST-day truncation (`apply_jst_date`) to absorb time-precision drift:** rejected. Hardcoding `Asia/Tokyo` breaks overseas events, and it would collapse two same-day windows. Using the absolute instant directly is timezone-correct and keeps distinct same-day windows separate.
+- **Alternative — DB `UNIQUE(series_id, apply_start_at)` constraint:** not required. The discovery job is a single sequential cron, so application-layer match (mirroring today's overlap-match pattern) is sufficient and keeps the tolerance tunable; a unique index may be added later as a safety net.
+- **Accepted residual:** if the extracted start time drifts across runs (e.g. `7/1 10:00` one run, `7/1` the next), the window re-keys and re-announces. This is rare and the announcement is generic, so the cost is low.
+
+### D3. Searcher stops resolving covered events; persistence guard requires only a known start
+
+Remove the Step-1 `covered_dates` field and the Step-2 `covered_event_indices` resolution (`resolveCoveredEvents`, `earliestEventID`, the all-performances marker). A candidate is persisted iff `apply_start_time` is known; the "at least one resolved covered event" condition is dropped.
+
+- **Why:** date→event matching was the dominant accuracy risk and now has no downstream use.
+
+### D4. Audience = `Tracking` ticket journeys on the series' events
+
+Both the announcement consumer and the reminder scan resolve recipients via a new reverse query: distinct users with a `TicketJourneyStatus = Tracking` journey on any event whose `series_id` is the phase's series. The existing proximity/follower/hype resolution (`ResolveSalesPhaseAudience` over covered-event performers) is removed from this path.
+
+- **Why:** a `Tracking` journey is an explicit "notify me about this sale" signal — more precise than geographic proximity and independent of covered-event accuracy. Geographic relevance was already applied upstream when the fan was notified of the concert and chose to track it.
+- **Status filter:** only `Tracking` (status 1). Fans in later lifecycle states (`Applied`/`Paid`/…) are not re-targeted by sales-phase notifications for that series. (Confirmed scope decision.)
+- **Alternative — keep a follower/proximity fallback for the first announcement (bootstrap):** out of scope by decision; accepted that a sale announced before any fan tracks reaches no one until a fan tracks and later phases/reminders catch them.
+
+### D5. Upsert-only, retain while pending, no GC
+
+An empty or failed extraction never deletes rows (avoids losing reminder-bearing phases and avoids re-insert announcement storms). A phase is retained as long as any milestone is pending; the reminder scan already filters via `GREATEST(apply_start, apply_end, lottery_result) >= now - margin`. No deletion/GC job is introduced.
+
+- **Why:** correctness does not depend on physical cleanup; read-side filtering already hides completed phases. (Simplicity decision.)
+
+## Risks / Trade-offs
+
+- **Start-time drift re-announces a window** → Accepted; rare and low-cost (generic announcement). A later `UNIQUE`/tolerance refinement can mitigate if observed.
+- **Two genuinely distinct sales of one series sharing the exact same `apply_start_at`** collapse into one row (last-write-wins) → Extremely rare; generic notification + series link means the fan still sees both on the official page.
+- **Bootstrap gap: a sale announced before anyone tracks reaches no audience** → Accepted by decision; the new-concert notification funnel seeds tracking, and reminders/later phases recover the fan.
+- **Breaking proto change** (`SalesPhase` loses `event_ids`/`anchor_event_id`) → Coordinated via the standard specification → BSR release → backend/frontend upgrade flow; no consumer reads covered events for behavior today.
+- **Reminder once-only key references the surrogate `id`** → `id` stays stable because convergence updates in place on `apply_start` match; drift that mints a new `id` only risks re-announcing, not duplicate reminders (the new phase's own once-only log governs it).
+
+## Migration Plan
+
+1. **specification**: update `sales-phase`, `sales-phase-discovery`, `sales-reminders` specs (delta files in this change) and the `SalesPhase` proto (drop `event_ids`, `anchor_event_id`); open PR; merge; cut a Release to trigger BSR generation.
+2. **backend** (prepared in parallel, pushed after BSR gen): drop covered-event extraction/resolution in the searcher; change `Upsert` to `(series_id, apply_start_at)` match and stop writing `event_sales_phases`; remove `ReplaceCoveredEvents`; replace `ResolveSalesPhaseAudience` with the `Tracking`-journey lookup; add `TicketJourneyRepository` reverse query.
+3. **DB migration**: drop `event_sales_phases`; drop `sales_phases.anchor_event_id`. Existing `sales_phases` rows keep `series_id` + `apply_start_at` and remain valid under the new convergence key.
+4. **Rollback**: revert backend + proto; the dropped join table/column would need restoration from migration history if rolled back after deploy — treat as forward-only once released.
+
+## Open Questions
+
+- Should a `UNIQUE(series_id, apply_start_at)` index be added now as a concurrency/duplicate safety net, or deferred until drift is observed in production? (Leaning defer.)

--- a/openspec/changes/simplify-sales-phase-model/proposal.md
+++ b/openspec/changes/simplify-sales-phase-model/proposal.md
@@ -12,7 +12,7 @@ Because the audience is now resolved from an explicit fan signal (a `Tracking` t
 - Change the discovery upsert from covered-event overlap + channel-compatibility matching to a plain `(series_id, apply_start_time)` match: found → update in place (silent), absent → insert + announce. Keep upsert-only semantics (an empty extraction never deletes existing rows).
 - Re-target both the **announcement** and the **reminder** audience to users who have a `Tracking` ticket journey on **any event of the phase's series**. Remove follower/proximity/hype resolution from the sales-phase path.
 - Keep retaining a phase while any milestone is still pending (reminders unchanged in spirit); **no record deletion / GC** is introduced — reads filter by pending milestones.
-- **BREAKING** Drop the `event_sales_phases` join table and the `anchor_event_id` column; add a uniqueness/convergence handle on `(series_id, apply_start_at)`.
+- **BREAKING** Drop the `event_sales_phases` join table and the `anchor_event_id` column. Convergence on `(series_id, apply_start_at)` is enforced in the application layer; a `UNIQUE` index may be added later as a safety net.
 
 ## Capabilities
 
@@ -28,5 +28,5 @@ Because the audience is now resolved from an explicit fan signal (a `Tracking` t
 
 - **Protobuf (specification)**: `liverty_music.entity.v1.SalesPhase` removes `event_ids` and `anchor_event_id` — a breaking schema change requiring a new BSR release.
 - **Backend**: `entity.SalesPhase`/`SalesPhaseCandidate` (drop covered fields); `SalesPhaseRepository.Upsert` (apply_start match, drop overlap query + `event_sales_phases` writes + `ReplaceCoveredEvents`); Gemini `sales_phase_searcher` (drop Step-1 `covered_dates` and Step-2 index resolution); `ResolveSalesPhaseAudience` (replace covered-event/proximity/follower/hype with a `Tracking`-journey lookup); new `TicketJourneyRepository` reverse query (users tracking any event in a series).
-- **Database migration**: drop `event_sales_phases` table and `sales_phases.anchor_event_id`; add convergence handle on `(series_id, apply_start_at)`.
+- **Database migration**: drop `event_sales_phases` table and `sales_phases.anchor_event_id`. (Convergence is application-layer; no uniqueness index is added by this change.)
 - **No frontend behavior change** to notification content (already generic + series link); fans must have a `Tracking` journey to be notified (explicit-intent funnel).

--- a/openspec/changes/simplify-sales-phase-model/proposal.md
+++ b/openspec/changes/simplify-sales-phase-model/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+The current sales-phase model binds each phase to a *subset* of a series' events (`event_ids` / `anchor_event_id`) and converges re-discovered phases via covered-event overlap plus a channel-compatibility rule. This makes the most fragile part of the LLM pipeline — matching verbatim Japanese sale dates back to specific events, and keeping `channel`/`sequence` stable across runs — load-bearing for both deduplication and notification targeting. The result is genuine accuracy anxiety: a date-matching miss can drop a phase entirely (a fan misses a sale), and a channel reclassification can spawn a duplicate announcement.
+
+Because the audience is now resolved from an explicit fan signal (a `Tracking` ticket journey) rather than covered-event proximity, the covered-event refinement has no remaining consumer. Removing it lets the whole feature converge on the one stable, mandatory attribute of a sales window — its application start time — and collapses the accuracy-critical surface area.
+
+## What Changes
+
+- **BREAKING** Remove the covered-events relationship from `SalesPhase`: drop `event_ids` and `anchor_event_id`. A sales phase belongs to a `Series` and applies to the series as a whole.
+- Change phase identity/convergence to **same `series_id` + same `apply_start_time`** (an absolute instant; timezone-agnostic so non-JST events work). `channel`, `sequence`, `method`, `provider_name`, and the other timestamps become purely descriptive, last-write-wins fields — never identity.
+- Drop the covered-event extraction step from the Gemini searcher (no more `covered_dates` / `covered_event_indices` resolution). Phases are persisted whenever `apply_start_time` is known.
+- Change the discovery upsert from covered-event overlap + channel-compatibility matching to a plain `(series_id, apply_start_time)` match: found → update in place (silent), absent → insert + announce. Keep upsert-only semantics (an empty extraction never deletes existing rows).
+- Re-target both the **announcement** and the **reminder** audience to users who have a `Tracking` ticket journey on **any event of the phase's series**. Remove follower/proximity/hype resolution from the sales-phase path.
+- Keep retaining a phase while any milestone is still pending (reminders unchanged in spirit); **no record deletion / GC** is introduced — reads filter by pending milestones.
+- **BREAKING** Drop the `event_sales_phases` join table and the `anchor_event_id` column; add a uniqueness/convergence handle on `(series_id, apply_start_at)`.
+
+## Capabilities
+
+### New Capabilities
+<!-- None: this change modifies existing sales-phase capabilities only. -->
+
+### Modified Capabilities
+- `sales-phase`: SalesPhase entity drops `event_ids`/`anchor_event_id`; identity/convergence moves from covered-event overlap to `(series_id, apply_start_time)`; persistence guard drops the "at least one covered event" condition (only a known start is required); database schema removes the join table and anchor column.
+- `sales-phase-discovery`: searcher stops extracting/resolving covered dates; discovery upsert matches on `(series_id, apply_start_time)`; announcement audience resolves from `Tracking` ticket journeys on the series' events instead of followers of covered-event performers.
+- `sales-reminders`: reminder audience resolves from `Tracking` ticket journeys on the series' events (drops the covered-event/follower/hype resolution and the per-leg targeting scenario); once-only delivery keyed by `(user_id, sales_phase_id, stage)` is retained.
+
+## Impact
+
+- **Protobuf (specification)**: `liverty_music.entity.v1.SalesPhase` removes `event_ids` and `anchor_event_id` — a breaking schema change requiring a new BSR release.
+- **Backend**: `entity.SalesPhase`/`SalesPhaseCandidate` (drop covered fields); `SalesPhaseRepository.Upsert` (apply_start match, drop overlap query + `event_sales_phases` writes + `ReplaceCoveredEvents`); Gemini `sales_phase_searcher` (drop Step-1 `covered_dates` and Step-2 index resolution); `ResolveSalesPhaseAudience` (replace covered-event/proximity/follower/hype with a `Tracking`-journey lookup); new `TicketJourneyRepository` reverse query (users tracking any event in a series).
+- **Database migration**: drop `event_sales_phases` table and `sales_phases.anchor_event_id`; add convergence handle on `(series_id, apply_start_at)`.
+- **No frontend behavior change** to notification content (already generic + series link); fans must have a `Tracking` journey to be notified (explicit-intent funnel).

--- a/openspec/changes/simplify-sales-phase-model/proposal.md
+++ b/openspec/changes/simplify-sales-phase-model/proposal.md
@@ -22,7 +22,7 @@ Because the audience is now resolved from an explicit fan signal (a `Tracking` t
 ### Modified Capabilities
 - `sales-phase`: SalesPhase entity drops `event_ids`/`anchor_event_id`; identity/convergence moves from covered-event overlap to `(series_id, apply_start_time)`; persistence guard drops the "at least one covered event" condition (only a known start is required); database schema removes the join table and anchor column.
 - `sales-phase-discovery`: searcher stops extracting/resolving covered dates; discovery upsert matches on `(series_id, apply_start_time)`; announcement audience resolves from `Tracking` ticket journeys on the series' events instead of followers of covered-event performers.
-- `sales-reminders`: reminder audience resolves from `Tracking` ticket journeys on the series' events (drops the covered-event/follower/hype resolution and the per-leg targeting scenario); once-only delivery keyed by `(user_id, sales_phase_id, stage)` is retained.
+- `sales-reminders`: reminder audience resolves from `Tracking` ticket journeys on the series' events (drops the covered-event/follower/hype resolution and the per-leg targeting scenario); once-only delivery keyed by `(user_id, sales_phase_id, stage)` is retained; notification content's `url` fallback changes from the concert detail to the series detail (no single covered concert exists under the series-level model).
 
 ## Impact
 

--- a/openspec/changes/simplify-sales-phase-model/specs/sales-phase-discovery/spec.md
+++ b/openspec/changes/simplify-sales-phase-model/specs/sales-phase-discovery/spec.md
@@ -1,0 +1,60 @@
+## MODIFIED Requirements
+
+### Requirement: Dedicated Sales-Phase Searcher
+
+The system SHALL provide a sales-phase searcher that is separate from the concert searcher, because the concert searcher's grounding (the artist's official site) does not contain ticket sales schedules. The sales-phase searcher SHALL take an artist name and a series title as input and extract that series' sales phases as series-level records. It SHALL NOT resolve which individual events a phase covers.
+
+#### Scenario: Search sales phases for a series
+
+- **WHEN** the searcher is invoked with an artist name and a series title
+- **THEN** it SHALL issue a Gemini call grounded to find that series' ticket sales information
+- **AND** it SHALL return the extracted sales phases for that series as series-level records
+
+#### Scenario: No covered-event resolution
+
+- **WHEN** the searcher extracts a sales phase for a series
+- **THEN** it SHALL NOT extract per-phase covered dates nor resolve them to the series' `event_id`s
+- **AND** each extracted phase SHALL carry only its series-level attributes (`apply_start_time` and the descriptive fields)
+
+#### Scenario: One call per series
+
+- **WHEN** discovery processes multiple series
+- **THEN** the searcher SHALL issue one Gemini call per series, looping over the series
+
+### Requirement: Scheduled Sales-Phase Discovery Job
+
+The system SHALL run a scheduled job that discovers sales phases for the upcoming series of followed artists and upserts them into storage.
+
+#### Scenario: Scheduled execution
+
+- **WHEN** the discovery job runs on its schedule
+- **THEN** it SHALL enumerate the series of followed artists that have upcoming events
+- **AND** invoke the sales-phase searcher for each such series
+- **AND** upsert the resulting sales phases
+
+#### Scenario: Idempotent re-run
+
+- **WHEN** the discovery job runs again over the same series
+- **THEN** previously discovered phases SHALL converge to the same rows by matching on `(series_id, apply_start_time)`
+- **AND** no duplicate sales phases SHALL be created
+
+#### Scenario: Empty extraction does not delete
+
+- **WHEN** a run produces no phases for a series (e.g. grounding failure or page unavailable)
+- **THEN** the job SHALL NOT delete previously persisted phases for that series (upsert-only semantics)
+
+### Requirement: Event-Driven Announcement on New Phase
+
+The system SHALL push an announcement when a newly discovered sales phase is persisted, reusing the existing discovery→event→push pipeline. This announcement is event-driven and distinct from the time-based reminders. Its audience is resolved from explicit fan intent rather than follower proximity.
+
+#### Scenario: New phase announced to tracking fans
+
+- **WHEN** the discovery job persists a sales phase that did not previously exist
+- **THEN** it SHALL publish a sales-phase-discovered event
+- **AND** a consumer SHALL push an announcement to the users who have a `Tracking` ticket journey on any event of the phase's series
+- **AND** it SHALL NOT resolve the audience from covered-event performers, follower lists, or hype-level proximity
+
+#### Scenario: Re-discovered phase is not re-announced
+
+- **WHEN** the discovery job re-encounters an already-known phase (matched on `(series_id, apply_start_time)`, only updating its fields)
+- **THEN** it SHALL NOT publish a new announcement for that phase

--- a/openspec/changes/simplify-sales-phase-model/specs/sales-phase/spec.md
+++ b/openspec/changes/simplify-sales-phase-model/specs/sales-phase/spec.md
@@ -1,0 +1,83 @@
+## MODIFIED Requirements
+
+### Requirement: SalesPhase Entity
+
+The system SHALL define a `SalesPhase` entity representing one ticket-sales opportunity. Each sales phase belongs to a `Series` (the tour) and applies to the series as a whole; it does NOT track a per-event coverage subset. A series-level model is sufficient because notification targeting is driven by an explicit fan signal (a `Tracking` ticket journey on the series' events) and notification content is generic (a series link), so the precise set of covered dates is never consumed.
+
+#### Scenario: SalesPhase data model
+
+- **WHEN** a sales phase is represented
+- **THEN** it SHALL include `id` (SalesPhaseId), `series_id` (SeriesId), `method` (SalesMethod), `channel` (SalesChannel), `provider_name` (string), and `sequence` (int32)
+- **AND** it SHALL include `apply_start_time` (Timestamp, required — a phase is never persisted without it) and the nullable timeline fields `apply_end_time`, `lottery_result_time`, `payment_deadline_time`
+- **AND** it SHALL include a nullable `url` field reusing the `Url` value object
+- **AND** `series_id` SHALL be the only required entity reference; `apply_start_time` is also required for persistence
+- **AND** it SHALL NOT include an `event_ids` covered-event set nor an `anchor_event_id`
+
+#### Scenario: Phase applies to the whole series
+
+- **WHEN** a tour announces a sales phase
+- **THEN** the `SalesPhase` SHALL apply to its `series_id` as a whole, with no per-event coverage subset
+- **AND** the phases relevant to an `Event` SHALL be resolvable via that event's `series_id` (an event → its series → the series' phases), not via a per-phase covered-event list
+- **AND** a standalone concert (series of one event) SHALL have its phases belong to that single-event series
+
+### Requirement: Best-Effort Stable Phase Identity
+
+The system SHALL give each sales phase a surrogate `id` (UUID) as its only hard identity (the handle referenced by reminders). Re-extractions of the same real phase SHALL converge to the same row on a best-effort basis. Because the source data is LLM-extracted, `channel`, `sequence`, `provider_name`, and the later timestamps may reclassify or be refined across runs — so none of those fields is a stable identity.
+
+The primary match signal SHALL be **same `series_id` + same `apply_start_time`**. `apply_start_time` is the only mandatory field and the natural identity of a sales window; it is immune to the `channel`/`sequence` reclassification that would otherwise spawn duplicates. It is stored as an absolute instant (timezone-agnostic) so the match is correct for non-JST events. `channel`, `sequence`, `method`, `provider_name`, the other timestamps, and `url` are descriptive, last-write-wins fields and SHALL NOT participate in identity. The match SHALL be performed in the application layer (the discovery job is a single sequential runner), with the surrogate `id` as the only hard database key.
+
+The accepted residual is that (a) if the extracted `apply_start_time` drifts across runs the window re-keys and re-announces (rare; the announcement is generic), and (b) two genuinely distinct sales of one series sharing the exact same `apply_start_time` collapse into one row via last-write-wins (extremely rare).
+
+#### Scenario: Re-extraction converges to one row
+
+- **WHEN** the same real sales phase is extracted again with updated details (possibly reclassified `channel`/`sequence` or newly filled timestamps)
+- **THEN** it SHALL match the existing row by same `series_id` and same `apply_start_time`
+- **AND** its descriptive fields (`method`, `channel`, `sequence`, `provider_name`, the other timestamps, `url`) SHALL be updated last-write-wins without inserting a duplicate or re-firing the announcement
+
+#### Scenario: Reclassification does not duplicate
+
+- **WHEN** a phase first persisted as `(channel = UNSPECIFIED, sequence = 0)` is re-extracted as `(FAN_CLUB, 1)` with the same `apply_start_time`
+- **THEN** the `(series_id, apply_start_time)` match SHALL still find the existing row (channel/sequence are not match keys)
+- **AND** it SHALL update in place rather than insert a duplicate or re-fire `SALES_PHASE.discovered`
+
+#### Scenario: Distinct windows stay separate
+
+- **WHEN** a series has two sales phases with different `apply_start_time` values (e.g. an FC presale and a later general on-sale)
+- **THEN** their differing `apply_start_time` SHALL keep them as separate rows
+
+### Requirement: SalesPhase Database Schema
+
+The system SHALL store sales phases in a `sales_phases` table.
+
+#### Scenario: Table structure
+
+- **WHEN** the `sales_phases` table is created
+- **THEN** it SHALL have an `id` UUID primary key and a `series_id` foreign key referencing series
+- **AND** it SHALL store method, channel, provider_name, sequence, `apply_start_at` (NOT NULL), the three nullable timestamps (`apply_end_at`, `lottery_result_at`, `payment_deadline_at`), and url
+- **AND** the surrogate `id` SHALL be the only hard uniqueness constraint; convergence on `(series_id, apply_start_at)` is the application-level match defined in Best-Effort Stable Phase Identity, not a database unique constraint (a `UNIQUE (series_id, apply_start_at)` index MAY be added later as a safety net)
+- **AND** it SHALL NOT store an `anchor_event_id` column nor an `event_sales_phases` join table
+- **AND** the existing `ticket_emails` table SHALL NOT be modified by this change
+
+## REMOVED Requirements
+
+### Requirement: Persist Only Phases With a Known Start and Coverage
+
+**Reason**: The covered-event coverage condition is removed along with the covered-events model. A phase is now persisted on a known start alone; replaced by "Persist Only Phases With a Known Start".
+
+**Migration**: Existing `sales_phases` rows remain valid — they already carry `series_id` and `apply_start_at`. The `event_sales_phases` join table and `anchor_event_id` column are dropped; no phase is re-evaluated for coverage.
+
+## ADDED Requirements
+
+### Requirement: Persist Only Phases With a Known Start
+
+The system SHALL persist a `SalesPhase` only when its `apply_start_time` is known. A phase whose start is unknown is not actionable for a fan and cannot anchor a reminder. There is NO covered-event condition: a known start is the sole persistence requirement. Such start-less phases SHALL be dropped at search time.
+
+#### Scenario: Phase without a known start is dropped
+
+- **WHEN** an extracted phase has no concrete `apply_start_time`
+- **THEN** the system SHALL NOT persist a `SalesPhase` for it
+
+#### Scenario: Phase with a known start is persisted
+
+- **WHEN** an extracted phase has a concrete `apply_start_time`
+- **THEN** the system SHALL persist it even if `apply_end_time`, `lottery_result_time`, or `payment_deadline_time` are still null

--- a/openspec/changes/simplify-sales-phase-model/specs/sales-reminders/spec.md
+++ b/openspec/changes/simplify-sales-phase-model/specs/sales-reminders/spec.md
@@ -25,3 +25,15 @@ The system SHALL guarantee that each reminder is delivered to a given user at mo
 - **WHEN** a user has already received a reminder for a given sales phase and stage
 - **THEN** a subsequent scan SHALL NOT send that reminder again
 - **AND** the sent record SHALL be keyed by `(user_id, sales_phase_id, stage)`, referencing the phase's surrogate id — which is stable because re-discovery converges in place on the `(series_id, apply_start_time)` match
+
+### Requirement: Notification Content
+
+The system SHALL build each notification (the discovery announcement and every reminder stage) per recipient, formatting times in the recipient's `time_zone` and selecting copy by the recipient's `preferred_language` (default `en`), reusing the existing `NotificationPayload` (`title`, `body`, `url`, `tag`).
+
+#### Scenario: Payload fields per stage
+
+- **WHEN** a notification is built for a phase and stage
+- **THEN** `title` and `body` SHALL identify the artist, the tour (series) title, and the sales channel, and state the relevant time for that stage in the recipient's timezone
+- **AND** when `channel` is `UNSPECIFIED` the copy SHALL use a generic ticket label
+- **AND** `url` SHALL deep-link to the phase's application URL when present, else the series detail (a sales phase is series-level and has no single covered concert to fall back to)
+- **AND** `tag` SHALL be unique per `(sales_phase_id, stage)` to deduplicate on the browser side

--- a/openspec/changes/simplify-sales-phase-model/specs/sales-reminders/spec.md
+++ b/openspec/changes/simplify-sales-phase-model/specs/sales-reminders/spec.md
@@ -1,0 +1,27 @@
+## MODIFIED Requirements
+
+### Requirement: Reminder Audience
+
+The system SHALL target reminders to the users who have a `Tracking` ticket journey on any event of the sales phase's series. A `Tracking` journey is an explicit "notify me about this sale" signal, so reminders no longer resolve audience from covered-event performers, follower lists, or hype-level proximity. Because a phase is series-level, audience is resolved series-wide: any tracked event in the series qualifies the user.
+
+#### Scenario: Resolve audience from tracking journeys
+
+- **WHEN** a sales-phase reminder is due
+- **THEN** the system SHALL resolve the phase's `series_id` and find the users who have a `Tracking` ticket journey on any event of that series
+- **AND** deliver the reminder only to those users' push subscriptions
+- **AND** it SHALL NOT resolve audience from covered events, follower lists, or hype-level filtering
+
+#### Scenario: Non-tracking fans are not targeted
+
+- **WHEN** a fan follows the artist but has no `Tracking` ticket journey on any event of the series
+- **THEN** that fan SHALL NOT receive the sales-phase reminder
+
+### Requirement: Once-Only Delivery
+
+The system SHALL guarantee that each reminder is delivered to a given user at most once, despite overlapping scans, by recording sent reminders keyed by the sales phase's surrogate id.
+
+#### Scenario: Duplicate scan does not resend
+
+- **WHEN** a user has already received a reminder for a given sales phase and stage
+- **THEN** a subsequent scan SHALL NOT send that reminder again
+- **AND** the sent record SHALL be keyed by `(user_id, sales_phase_id, stage)`, referencing the phase's surrogate id — which is stable because re-discovery converges in place on the `(series_id, apply_start_time)` match

--- a/openspec/changes/simplify-sales-phase-model/tasks.md
+++ b/openspec/changes/simplify-sales-phase-model/tasks.md
@@ -1,0 +1,43 @@
+## 1. Specification & Proto (specification repo)
+
+- [ ] 1.1 Remove `event_ids` and `anchor_event_id` from `liverty_music.entity.v1.SalesPhase`; update field documentation to describe a series-level phase
+- [ ] 1.2 Run buf lint/format/breaking locally (breaking is expected and intended); confirm the only breaking deltas are the two removed fields
+- [ ] 1.3 Open the specification PR with the proto change + this OpenSpec change; merge after review and CI pass
+- [ ] 1.4 Publish a GitHub Release (tag `vX.Y.Z`) to trigger `buf-release.yml` → BSR push; monitor the workflow to success
+
+## 2. Backend — entity & repository (prepared in parallel, finalized after BSR gen)
+
+- [ ] 2.1 Remove covered-event fields from `entity.SalesPhase` and `entity.SalesPhaseCandidate` (`CoveredEventIDs`, `AnchorEventID`); drop `SalesSeriesCandidate.CandidateEvents` plumbing and `SalesPhaseCandidateEvent`
+- [ ] 2.2 Change `SalesPhaseRepository.Upsert` to match on `(series_id, apply_start_at)`: found → update descriptive fields in place (return Updated), absent → insert new id (return Inserted); remove the covered-event overlap query and channel-compatibility rule
+- [ ] 2.3 Remove `event_sales_phases` writes, `ReplaceCoveredEvents`, and covered-event hydration from the repository; keep upsert-only semantics (empty extraction never deletes)
+- [ ] 2.4 Drop the "at least one covered event" persistence guard; persist on known `apply_start_time` alone
+
+## 3. Backend — searcher
+
+- [ ] 3.1 Remove Step-1 `covered_dates` from the extraction prompt/XML and the example template
+- [ ] 3.2 Remove Step-2 `covered_event_indices` resolution and helpers (`resolveCoveredEvents`, `earliestEventID`, all-performances marker); stop passing candidate events into the search
+- [ ] 3.3 Update searcher unit tests to assert series-level candidates with no covered-event resolution
+
+## 4. Backend — audience (tracking-based)
+
+- [ ] 4.1 Add `TicketJourneyRepository` reverse query: distinct user IDs with `status = Tracking` on any event of a given `series_id`
+- [ ] 4.2 Replace `ResolveSalesPhaseAudience` (covered-event performers + proximity + follower + hype) with the tracking-journey lookup keyed by the phase's `series_id`
+- [ ] 4.3 Update the announcement use case and the reminder scan to consume the new audience resolver; remove now-unused follower/hype wiring on this path
+
+## 5. Backend — database migration
+
+- [ ] 5.1 Author the migration: drop the `event_sales_phases` table and the `sales_phases.anchor_event_id` column
+- [ ] 5.2 Verify existing `sales_phases` rows remain valid under the new convergence (they retain `series_id` + `apply_start_at`); hash/validate the migration in atlas format
+
+## 6. Backend — package upgrade, swap, verification
+
+- [ ] 6.1 After BSR gen completes, bump the generated schema package to `vX.Y.Z`; run `go mod tidy`
+- [ ] 6.2 Swap call sites to the generated `SalesPhase` shape (no `event_ids`/`anchor_event_id`) at the TODO markers; resolve compile errors
+- [ ] 6.3 Run `make check` (build, vet, unit tests) until green
+- [ ] 6.4 Open the backend PR only after the package upgrade + swap pass locally; merge after review and CI pass
+
+## 7. Ship to production
+
+- [ ] 7.1 Publish the backend GitHub Release (tag `vX.Y.Z`) to retag the dev AR image to prod
+- [ ] 7.2 Confirm ArgoCD syncs the new backend image and the sales-phase-discovery / sales-reminders CronJobs run on the updated code
+- [ ] 7.3 Verify in prod directly: a discovery run upserts series-level phases (no covered-event rows), announcements/reminders reach tracking fans, and no duplicate announcements occur across re-runs


### PR DESCRIPTION
## Summary

OpenSpec change proposing a redesign of the sales-phase model. Today a phase binds to a *subset* of a series' events (`event_ids` / `anchor_event_id`) and re-discovered phases converge via covered-event overlap plus a channel-compatibility rule. This makes the most fragile parts of the LLM pipeline — matching verbatim Japanese sale dates to specific events, and keeping `channel`/`sequence` stable across runs — load-bearing for both deduplication and notification targeting, which is the root of the accuracy concern.

Because the audience is now an explicit fan signal (a `Tracking` ticket journey on the series' events) and notification content is already generic (a series link), the covered-event refinement has no remaining consumer. This change makes a sales phase **series-level**, converges on the one stable mandatory attribute — `apply_start_time` — and resolves audience from tracking journeys.

This PR contains the OpenSpec change documents only (proposal, design, spec deltas, tasks). Proto and backend edits land during implementation (`/opsx:apply`), starting from these specs.

## Changes

- **proposal.md** — why/what/impact, including the breaking proto change (`SalesPhase` drops `event_ids`, `anchor_event_id`).
- **design.md** — decisions D1–D5: series-level phase; `(series_id, apply_start_time)` convergence (timezone-agnostic, rejecting JST-day truncation); searcher drops covered-event resolution; tracking-based audience; upsert-only with no GC. Includes rejected alternatives (confidence tiering, bootstrap fallback) and migration plan.
- **spec deltas**:
  - `sales-phase` — MODIFIED Entity / Best-Effort Stable Phase Identity / Database Schema; REMOVED "Persist Only Phases With a Known Start and Coverage" → ADDED "Persist Only Phases With a Known Start".
  - `sales-phase-discovery` — searcher stops covered-event resolution; idempotent re-run converges on `(series_id, apply_start_time)`; announcement audience resolves from `Tracking` journeys.
  - `sales-reminders` — reminder audience resolves from `Tracking` journeys (drops covered-event/follower/hype and per-leg targeting); once-only delivery retained.
- **tasks.md** — specification → BSR release → backend (entity/repo/searcher/audience/migration) → prod rollout.

## Testing

- `openspec validate simplify-sales-phase-model` → valid.
- No proto or code changes in this PR, so no buf/build impact yet.

Refs: #571
