### PR TITLE
feat(entity)!: make SalesPhase series-level; drop event_ids

### DIFF
--- a/openspec/changes/simplify-sales-phase-model/tasks.md
+++ b/openspec/changes/simplify-sales-phase-model/tasks.md
@@ -1,33 +1,33 @@
 ## 1. Specification & Proto (specification repo)
 
-- [ ] 1.1 Remove `event_ids` and `anchor_event_id` from `liverty_music.entity.v1.SalesPhase`; update field documentation to describe a series-level phase
-- [ ] 1.2 Run buf lint/format/breaking locally (breaking is expected and intended); confirm the only breaking deltas are the two removed fields
+- [x] 1.1 Remove `event_ids` and `anchor_event_id` from `liverty_music.entity.v1.SalesPhase`; update field documentation to describe a series-level phase
+- [x] 1.2 Run buf lint/format/breaking locally (breaking is expected and intended); confirm the only breaking deltas are the two removed fields
 - [ ] 1.3 Open the specification PR with the proto change + this OpenSpec change; merge after review and CI pass
 - [ ] 1.4 Publish a GitHub Release (tag `vX.Y.Z`) to trigger `buf-release.yml` → BSR push; monitor the workflow to success
 
 ## 2. Backend — entity & repository (prepared in parallel, finalized after BSR gen)
 
-- [ ] 2.1 Remove covered-event fields from `entity.SalesPhase` and `entity.SalesPhaseCandidate` (`CoveredEventIDs`, `AnchorEventID`); drop `SalesSeriesCandidate.CandidateEvents` plumbing and `SalesPhaseCandidateEvent`
-- [ ] 2.2 Change `SalesPhaseRepository.Upsert` to match on `(series_id, apply_start_at)`: found → update descriptive fields in place (return Updated), absent → insert new id (return Inserted); remove the covered-event overlap query and channel-compatibility rule
-- [ ] 2.3 Remove `event_sales_phases` writes, `ReplaceCoveredEvents`, and covered-event hydration from the repository; keep upsert-only semantics (empty extraction never deletes)
-- [ ] 2.4 Drop the "at least one covered event" persistence guard; persist on known `apply_start_time` alone
+- [x] 2.1 Remove covered-event fields from `entity.SalesPhase` and `entity.SalesPhaseCandidate` (`CoveredEventIDs`, `AnchorEventID`); drop `SalesSeriesCandidate.CandidateEvents` plumbing and `SalesPhaseCandidateEvent`
+- [x] 2.2 Change `SalesPhaseRepository.Upsert` to match on `(series_id, apply_start_at)`: found → update descriptive fields in place (return Updated), absent → insert new id (return Inserted); remove the covered-event overlap query and channel-compatibility rule
+- [x] 2.3 Remove `event_sales_phases` writes, `ReplaceCoveredEvents`, and covered-event hydration from the repository; keep upsert-only semantics (empty extraction never deletes)
+- [x] 2.4 Drop the "at least one covered event" persistence guard; persist on known `apply_start_time` alone
 
 ## 3. Backend — searcher
 
-- [ ] 3.1 Remove Step-1 `covered_dates` from the extraction prompt/XML and the example template
-- [ ] 3.2 Remove Step-2 `covered_event_indices` resolution and helpers (`resolveCoveredEvents`, `earliestEventID`, all-performances marker); stop passing candidate events into the search
-- [ ] 3.3 Update searcher unit tests to assert series-level candidates with no covered-event resolution
+- [x] 3.1 Remove Step-1 `covered_dates` from the extraction prompt/XML and the example template
+- [x] 3.2 Remove Step-2 `covered_event_indices` resolution and helpers (`resolveCoveredEvents`, `earliestEventID`, all-performances marker); stop passing candidate events into the search
+- [x] 3.3 Update searcher unit tests to assert series-level candidates with no covered-event resolution
 
 ## 4. Backend — audience (tracking-based)
 
-- [ ] 4.1 Add `TicketJourneyRepository` reverse query: distinct user IDs with `status = Tracking` on any event of a given `series_id`
-- [ ] 4.2 Replace `ResolveSalesPhaseAudience` (covered-event performers + proximity + follower + hype) with the tracking-journey lookup keyed by the phase's `series_id`
-- [ ] 4.3 Update the announcement use case and the reminder scan to consume the new audience resolver; remove now-unused follower/hype wiring on this path
+- [x] 4.1 Add `TicketJourneyRepository` reverse query: distinct user IDs with `status = Tracking` on any event of a given `series_id`
+- [x] 4.2 Replace `ResolveSalesPhaseAudience` (covered-event performers + proximity + follower + hype) with the tracking-journey lookup keyed by the phase's `series_id`
+- [x] 4.3 Update the announcement use case and the reminder scan to consume the new audience resolver; remove now-unused follower/hype wiring on this path
 
 ## 5. Backend — database migration
 
-- [ ] 5.1 Author the migration: drop the `event_sales_phases` table and the `sales_phases.anchor_event_id` column
-- [ ] 5.2 Verify existing `sales_phases` rows remain valid under the new convergence (they retain `series_id` + `apply_start_at`); hash/validate the migration in atlas format
+- [x] 5.1 Author the migration: drop the `event_sales_phases` table and the `sales_phases.anchor_event_id` column
+- [x] 5.2 Verify existing `sales_phases` rows remain valid under the new convergence (they retain `series_id` + `apply_start_at`); hash/validate the migration in atlas format
 
 ## 6. Backend — package upgrade, swap, verification
 

--- a/proto/liverty_music/entity/v1/sales_phase.proto
+++ b/proto/liverty_music/entity/v1/sales_phase.proto
@@ -7,7 +7,6 @@ import "buf/validate/validate.proto";
 import "google/api/field_behavior.proto";
 import "google/protobuf/timestamp.proto";
 import "liverty_music/entity/v1/entity.proto";
-import "liverty_music/entity/v1/event.proto";
 import "liverty_music/entity/v1/series.proto";
 
 option go_package = "github.com/liverty-music/specification/gen/go/liverty_music/entity/v1;entityv1";
@@ -67,38 +66,33 @@ enum SalesChannel {
 
 // SalesPhase models one ticket-sales opportunity for a series (tour). A single
 // tour can announce several phases — distinct rounds (fan-club presale, general
-// on-sale) and distinct legs (first-half dates vs. second-half dates) — so each
-// phase belongs to one Series but covers only the subset of that series' events
-// it actually sells, expressed by `event_ids`.
+// on-sale) — and each phase belongs to one Series and applies to that series as
+// a whole. There is no per-event coverage subset: notification targeting is
+// driven by an explicit fan signal (a `Tracking` ticket journey on the series'
+// events) and notification content is generic (a series link), so the precise
+// set of covered events is never consumed.
 //
 // The row's existence signals "this phase is happening"; a null timeline field
 // unambiguously means "that date is not yet announced", so no separate
-// to-be-determined flag is needed. `apply_start_time` and at least one covered
-// event are mandatory because a phase with no known start cannot anchor a
-// reminder and a phase with no resolved event has no audience.
+// to-be-determined flag is needed. `apply_start_time` is mandatory because a
+// phase with no known start cannot anchor a reminder and signals the phase is
+// not yet actionable for a fan.
 message SalesPhase {
   // The unique identifier for this sales phase. Server-generated surrogate id;
-  // it is the phase's only hard identity (re-discovery converges to it via
-  // best-effort covered-event overlap, not via any business-field equality).
+  // it is the phase's only hard identity. Re-discovery converges to it on a
+  // best-effort basis via the `(series_id, apply_start_time)` match, not via any
+  // other business-field equality.
   SalesPhaseId id = 1 [
     (google.api.field_behavior) = OUTPUT_ONLY,
     (buf.validate.field).required = true
   ];
 
   // The series (tour) this phase belongs to. The only required entity reference;
-  // it scopes the phase and bounds the candidate events its coverage resolves to.
+  // a phase applies to its series as a whole, and the phases relevant to an event
+  // are resolved via that event's series (event → series → the series' phases).
   SeriesId series_id = 2 [
     (google.api.field_behavior) = REQUIRED,
     (buf.validate.field).required = true
-  ];
-
-  // The events this phase sells, all belonging to `series_id`. At least one is
-  // required: coverage is how a per-leg phase notifies only the followers of its
-  // own dates. Immutable event ids are also the primary signal that converges
-  // re-discovery of the same real phase onto one row.
-  repeated EventId event_ids = 3 [
-    (google.api.field_behavior) = REQUIRED,
-    (buf.validate.field).repeated.min_items = 1
   ];
 
   // How tickets are allocated. Optional: UNSPECIFIED means "not yet determined"
@@ -151,6 +145,12 @@ message SalesPhase {
 
   // The application URL fans follow to apply for this phase. Optional: a nil
   // wrapper skips inner-Url validation (matching Series.source_url semantics),
-  // and notifications deep-link here when present, else to the concert detail.
+  // and notifications deep-link here when present, else to the series detail
+  // (a phase is series-level and has no single covered concert to fall back to).
   Url url = 12 [(google.api.field_behavior) = OPTIONAL];
+
+  // Field 3 was `repeated EventId event_ids` (per-event coverage subset),
+  // removed when the phase became series-level. Reserved to prevent reuse.
+  reserved 3;
+  reserved "event_ids";
 }


### PR DESCRIPTION
## Why

The current sales-phase model binds each phase to a *subset* of a series' events (`event_ids` / `anchor_event_id`) and converges re-discovered phases via covered-event overlap plus a channel-compatibility rule. This makes the most fragile part of the LLM pipeline — matching verbatim Japanese sale dates back to specific events — load-bearing for both dedup and notification targeting: a date-matching miss can drop a phase (a fan misses a sale), and a channel reclassification can spawn a duplicate announcement.

Because the audience is now resolved from an explicit fan signal (a `Tracking` ticket journey) and notification content is series-level, the covered-event refinement has no remaining consumer. Removing it collapses the accuracy-critical surface to the one stable, mandatory attribute of a sale window: its application start time.

## What changes

- **BREAKING** `liverty_music.entity.v1.SalesPhase` drops field 3 `event_ids` (field number reserved). A sales phase belongs to a `Series` and applies to it as a whole.
- Identity/convergence moves to **`(series_id, apply_start_time)`** (an absolute instant; timezone-agnostic). `channel`, `sequence`, `method`, `provider_name`, and the other timestamps become purely descriptive, last-write-wins fields.
- Docs rewritten to describe the series-level model; `url` fallback is now the series detail.

Also updates the `simplify-sales-phase-model` OpenSpec change `tasks.md` (spec + backend tasks ticked; release/prod tasks pending).

## Breaking change handling

This is an intended breaking change. The **`buf skip breaking`** label is applied so `buf-pr-checks.yml` does not block. No consumer reads covered events for behavior today.

## Release flow

After merge → publish a GitHub Release (`vX.Y.Z`) → `buf-release.yml` pushes to BSR → backend upgrades the generated package and opens its PR.

Refs: #571