### PR TITLE
chore(openspec): remove empty improve-consumer-observability stub

### DIFF
--- a/openspec/changes/improve-consumer-observability/.openspec.yaml
+++ b/openspec/changes/improve-consumer-observability/.openspec.yaml
@@ -1,2 +1,0 @@
-schema: spec-driven
-created: 2026-03-30


### PR DESCRIPTION
## Why

`improve-consumer-observability` was an **empty OpenSpec stub** — created 2026-03-30 with only `.openspec.yaml`, no proposal/design/specs/tasks ever written, no tracking issue. It showed up as an active change (`0/0 no-tasks`) purely as noise.

Analysis ([/opsx:explore]) concluded it is not worth introducing as-is right now:
- The consumer-app already has solid observability: otel telemetry, structured `slog`, health/readiness probes, `BusinessMetrics` + `OTelAnalyticsConsumerMetrics`, and dedicated `analyze-*` diagnostic CLIs (plus the approval-queue `rejected_concerts_log`).
- Adding more always-on metrics now would fight the just-completed `prod-cost-optimization` (Cloud Monitoring 150 MiB free-tier defense).
- The consumer is KEDA scale-to-zero (max 1 replica), so there is little to observe today.

## What

- Remove the contentless stub directory.

If the consumer is later scaled up to run the discovery→staging pipeline at volume, a focused proposal (NATS consumer lag / redelivery / DLQ metrics, per-stage trace spans, staging-success SLO — cost-consciously favouring traces/logs over high-cardinality metrics) can be re-created.

No proto/spec/code impact.