### PR TITLE
docs(openspec): add icon-only-journey-badge change

### DIFF
--- a/openspec/changes/icon-only-journey-badge/.openspec.yaml
+++ b/openspec/changes/icon-only-journey-badge/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-19

--- a/openspec/changes/icon-only-journey-badge/design.md
+++ b/openspec/changes/icon-only-journey-badge/design.md
@@ -1,0 +1,41 @@
+## Context
+
+The concert card (`event-card`) renders a journey-status badge as an absolutely-positioned pill in the top-right corner, showing the status icon followed by the translated label (`👀 追跡中`, `💰 当選・未入金`, …). The badge derives its icon, label, and hue from the canonical `JOURNEY_STATUS_CONFIG_MAP` (the `journey-status-presentation` capability).
+
+On the dashboard timetable the cards are intentionally small and dense — three lanes (HOME / NEAR / AWAY) of fan-followed concerts. The label-bearing pill is ~75px wide and sits at the top, where the artist name also begins (the card's flex column has no `min-block-size`, so `justify-content: end` collapses and content starts at the top). The result is the badge overlapping the artist name. The label is redundant here: on a glanceable surface the icon alone conveys the status, and the full label remains in the concert-detail status control where space allows.
+
+Note: `tracking` is **not** equivalent to following an artist. Following an artist is what surfaces a concert on the dashboard at all; `tracking` is a user-initiated, per-concert journey state ("I'm watching this specific event for ticket sales"). Every journey status — including `tracking` — is meaningful information worth showing on the card.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Remove the badge/artist-name overlap on the timetable cards.
+- Keep all five journey statuses visible on the card via their canonical icon.
+- Preserve the canonical map as the single source of icon/label/hue.
+- Keep an accessible name for the badge (screen readers still announce the status).
+
+**Non-Goals:**
+- No change to the dashboard filter chips or the concert-detail status control (they keep icon + label).
+- No change to which statuses appear, the state machine, or any backend/proto/RPC surface.
+- No redesign of the card layout itself beyond the badge.
+
+## Decisions
+
+**Decision: Card badge shows icon only.**
+The icon is the directness the user asked for — emoji are recognised at a glance and carry the semantic weight. The label is dropped from the card to reclaim horizontal space. Rationale: on a dense card the label is redundant given the icon; the label still lives on the detail control. Alternative considered — keeping the label but shrinking the font: rejected, the pill still consumes width and overlaps.
+
+**Decision: Place the badge on the top-right corner, bleeding half outside the card.**
+`position: absolute` at the top-right corner plus `translate: 40% -40%` so the chip sits ON the corner, roughly half outside the card. Rationale: any in-card position can collide with the bottom-aligned artist name, because in the HOME lane there is no venue label and the centred name can fill the whole card (verified empirically — a bottom-right in-card badge overlapped the name on 4 of 5 cards). Bleeding past the corner separates the badge from the content region entirely, so it cannot collide regardless of name length. Top-right is the universal notification-badge position (zero learning), is scanned early (top + corner), and breaks the card silhouette for pre-attentive pop-out. Alternatives considered: (a) bottom-right in-card — re-creates the overlap for full-card names in the HOME lane; (b) a wrapper element (`overflow:visible` outer + `overflow:hidden` inner surface) — rejected as unnecessary DOM, and `event-card__surface` BEM naming would not match this component's plain class convention (`.artist-name`, `.journey-badge`); (c) `overflow: clip` + `overflow-clip-margin` to bleed from a single element — rejected, `overflow-clip-margin` is not Baseline (Firefox-only as of 2026, unsupported in Chrome/Edge/Safari).
+
+**Decision: Remove `overflow: hidden` from `.event-card` (no wrapper).**
+For the badge to bleed past the corner it must not be clipped by the card. The card's `overflow: hidden` turns out to be redundant: the gradient background is clipped by `border-radius`, the noise `::after` self-rounds via `border-radius: inherit`, and the matched-card beam `::before` is hidden at the corners by its own radial mask. Removing it lets the badge bleed with zero new DOM and zero new classes, and was verified to leave the card's rounded corners, gradient, noise, and matched glow/beam visually intact. The outer `.concert-scroll { overflow-inline: hidden }` still bounds the timetable horizontally; the small bleed at the outermost lanes (HOME-left / AWAY-right) is absorbed by the `.lane` padding (verified: badges on the rightmost AWAY lane are not clipped).
+
+**Decision: Bare emoji, no background pill or hue.**
+With no text and corner placement, the badge is just the status emoji — no background fill, no border, no per-status hue. The emoji is the sole, self-coloured cue. Rationale: the corner-bleed placement already makes the emoji read as a badge, and a coloured pill behind it added visual weight without extra meaning on a dense surface. Consequently both the per-status `--_journey-text` (label tint) and `--_journey-bg` (pill hue) custom properties are removed, along with the now-dead `padding`/`border-radius`/flex-centering on the chip. Trade-off accepted below: dropping the hue removes the colour half of the colour+shape double-encoding; the emoji shape (👀📝💔💰🎟️) remains a non-colour cue, so the status is still distinguishable without relying on colour.
+
+## Risks / Trade-offs
+
+- [Icon-only loses the explicit text label on the card] → The accessible name is preserved via `aria-label` (translated label), and the full label remains on the detail control and filter chips. The icon set is already designed to be meaning-bearing per the existing "Meaning survives without colour" intent.
+- [Visual regression baselines will fail] → Regenerate the dashboard/timetable visual baselines as part of shipping (known frontend flow: delete the visual-baselines artifact to force regen).
+- [Corner-bleed still overlaps the first line for a pathologically long name that fills the entire card] → Only the extreme top-right corner of line 1 is touched (a ~1px corner), and only for unrealistically long single-artist names (~60 chars). Acceptable; far better than the in-card positions which sit on the name body.
+- [Removing `overflow: hidden` could expose a future overflowing child] → Today every child is bounded (logo `max-block-size`, text `overflow-wrap: break-word`) and clipping is handled by `border-radius`/`mask`. If a future child needs hard clipping, scope it to that child rather than re-adding card-level `overflow: hidden`, which would clip the badge.

--- a/openspec/changes/icon-only-journey-badge/proposal.md
+++ b/openspec/changes/icon-only-journey-badge/proposal.md
@@ -22,6 +22,6 @@ The concert-card journey badge renders the status icon plus a full text label (e
 ## Impact
 
 - Frontend only; no proto, backend, or RPC changes.
-- `frontend/src/components/live-highway/event-card.html` — badge markup (icon only, `aria-label` for the accessible name).
+- `frontend/src/components/live-highway/event-card.html` — badge markup (emoji only, `role="img"` + `aria-label` for the accessible name).
 - `frontend/src/components/live-highway/event-card.css` — badge corner-bleed at top-right (`translate`), `overflow: hidden` removed from the card, bare emoji (no background/pill/hue), per-status `--_journey-text` and `--_journey-bg` vars removed.
 - Visual regression baselines for the dashboard/timetable will need regeneration.

--- a/openspec/changes/icon-only-journey-badge/proposal.md
+++ b/openspec/changes/icon-only-journey-badge/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+The concert-card journey badge renders the status icon plus a full text label (e.g. `👀 追跡中`) as a pill anchored to the card's top-right corner. On the dashboard timetable the cards are small — especially in the NEAR/AWAY lanes — so the ~75px wide pill overlaps the artist name and breaks the card layout. The label text is redundant on a dense, glanceable surface: the icon alone communicates status, and the full label is still available in the concert-detail status control where there is room for it.
+
+## What Changes
+
+- The concert-card journey badge SHALL render the status **emoji only** — no text label, and no background pill or hue.
+- The badge SHALL sit on the card's **top-right corner, bleeding half outside the card** (notification-badge convention), so it never collides with the bottom-aligned artist name regardless of name length or lane. This requires removing the redundant `overflow: hidden` from the card (clipping is already handled by `border-radius` / mask).
+- The dashboard filter chips and the concert-detail status control are unchanged — they keep showing icon, label, **and** hue.
+- This relaxes the cross-cutting "every rendering shows icon and text label" and "icon and hue are the same across all surfaces" rules so the compact card badge may show the emoji alone, while the canonical map remains the single source of truth.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `journey-status-presentation`: The "Meaning survives without colour" requirement currently mandates that **every** journey-status rendering present icon **and** text label. The compact concert-card badge will now show the icon only. The requirement is reframed so each surface chooses an appropriate density (icon-only for the card badge, icon+label for chips and the detail control) while every surface still relies on a non-colour cue and the canonical map.
+
+## Impact
+
+- Frontend only; no proto, backend, or RPC changes.
+- `frontend/src/components/live-highway/event-card.html` — badge markup (icon only, `aria-label` for the accessible name).
+- `frontend/src/components/live-highway/event-card.css` — badge corner-bleed at top-right (`translate`), `overflow: hidden` removed from the card, bare emoji (no background/pill/hue), per-status `--_journey-text` and `--_journey-bg` vars removed.
+- Visual regression baselines for the dashboard/timetable will need regeneration.

--- a/openspec/changes/icon-only-journey-badge/specs/journey-status-presentation/spec.md
+++ b/openspec/changes/icon-only-journey-badge/specs/journey-status-presentation/spec.md
@@ -1,0 +1,30 @@
+## MODIFIED Requirements
+
+### Requirement: Status icon and hue assignments
+Each journey status SHALL have a defined icon, and a meaning-based hue for surfaces that render the status with colour. The icon is the primary, always-present cue and SHALL be sufficient to distinguish the status on its own. The text label and the hue MAY both be omitted on compact surfaces (such as the concert-card badge) where the icon alone carries the status.
+
+#### Scenario: Icon per status
+- **WHEN** a journey status is rendered
+- **THEN** its icon SHALL be: `tracking` 👀, `applied` 📝, `unpaid` 💰, `paid` 🎟️, `lost` 💔
+
+#### Scenario: Hue per status
+- **WHEN** a journey status is rendered with a colour treatment (filter chip or detail-control node)
+- **THEN** its hue SHALL be the shared journey-hue token for that status: process (`tracking`, `applied`) neutral, `unpaid` amber, `paid` green, `lost` red
+
+#### Scenario: Meaning survives without colour
+- **WHEN** any journey status is rendered
+- **THEN** it SHALL present its icon, so the status is distinguishable without relying on colour alone
+- **AND** where a text label is shown, the label SHALL be sourced from the canonical `eventDetail.journeyStatus.*` i18n key
+
+#### Scenario: Icon-only rendering retains an accessible name
+- **WHEN** a journey status is rendered as an icon without a visible text label
+- **THEN** the rendering SHALL expose the canonical label as its accessible name (e.g. via `aria-label`) so assistive technology announces the status
+
+### Requirement: Consistent rendering across components
+A given journey status SHALL render with a consistent identity wherever it appears — the dashboard filter chips, the concert-card journey badge, and the concert-detail status control. The icon SHALL be the same across all surfaces. The hue and the visible text label SHALL appear on the filter chips and the detail control; both MAY be omitted on the concert-card badge, which renders the icon alone.
+
+#### Scenario: Same status looks the same everywhere
+- **WHEN** the same journey status appears as a filter chip, a card badge, and a detail-control node
+- **THEN** all three SHALL show the same icon sourced from the canonical map
+- **AND** the filter chip and the detail-control node SHALL show the same text label and hue sourced from the canonical map
+- **AND** the card badge MAY show the icon alone, without the text label or hue background

--- a/openspec/changes/icon-only-journey-badge/specs/journey-status-presentation/spec.md
+++ b/openspec/changes/icon-only-journey-badge/specs/journey-status-presentation/spec.md
@@ -17,8 +17,9 @@ Each journey status SHALL have a defined icon, and a meaning-based hue for surfa
 - **AND** where a text label is shown, the label SHALL be sourced from the canonical `eventDetail.journeyStatus.*` i18n key
 
 #### Scenario: Icon-only rendering retains an accessible name
-- **WHEN** a journey status is rendered as an icon without a visible text label
-- **THEN** the rendering SHALL expose the canonical label as its accessible name (e.g. via `aria-label`) so assistive technology announces the status
+- **WHEN** a journey status is rendered as an emoji without a visible text label
+- **THEN** the rendering element SHALL carry a role that permits an accessible name (e.g. `role="img"`) together with the canonical label as that name (e.g. via `aria-label`), so assistive technology announces the status
+- **AND** the canonical label SHALL NOT be exposed via `aria-label` on a bare element with an implicit `generic` role (a naming-prohibited role), since user agents do not reliably announce a name on such elements
 
 ### Requirement: Consistent rendering across components
 A given journey status SHALL render with a consistent identity wherever it appears — the dashboard filter chips, the concert-card journey badge, and the concert-detail status control. The icon SHALL be the same across all surfaces. The hue and the visible text label SHALL appear on the filter chips and the detail control; both MAY be omitted on the concert-card badge, which renders the icon alone.

--- a/openspec/changes/icon-only-journey-badge/tasks.md
+++ b/openspec/changes/icon-only-journey-badge/tasks.md
@@ -1,9 +1,9 @@
 ## 1. Card badge markup (icon-only)
 
 - [x] 1.1 In `frontend/src/components/live-highway/event-card.html`, replace the icon-wrapper + label `<span>` inside `.journey-badge` with the icon emoji only (`${journeyConfig.icon}`)
-- [x] 1.2 Add `aria-label.bind="journeyConfig.labelKey | t"` to the badge so the canonical label is the accessible name
+- [x] 1.2 Add `role="img"` + `aria-label.bind="journeyConfig.labelKey | t"` to the badge so assistive tech announces the canonical label (a bare `<span>` with implicit `generic` role would not reliably expose the name)
 
-## 2. Card badge styling (corner-bleed + square chip)
+## 2. Card badge styling (corner-bleed bare emoji)
 
 - [x] 2.1 In `frontend/src/components/live-highway/event-card.css`, anchor the badge to the top-right corner (`inset-block-start` + `inset-inline-end`) and add `translate: 40% -40%` so it bleeds half outside the card; keep `position: absolute`
 - [x] 2.2 Remove the redundant `overflow: hidden` from `.event-card` so the badge can bleed past the corner without a wrapper (clipping is already handled by `border-radius`, the noise `::after` `border-radius: inherit`, and the matched beam `::before` mask)

--- a/openspec/changes/icon-only-journey-badge/tasks.md
+++ b/openspec/changes/icon-only-journey-badge/tasks.md
@@ -1,0 +1,18 @@
+## 1. Card badge markup (icon-only)
+
+- [x] 1.1 In `frontend/src/components/live-highway/event-card.html`, replace the icon-wrapper + label `<span>` inside `.journey-badge` with the icon emoji only (`${journeyConfig.icon}`)
+- [x] 1.2 Add `aria-label.bind="journeyConfig.labelKey | t"` to the badge so the canonical label is the accessible name
+
+## 2. Card badge styling (corner-bleed + square chip)
+
+- [x] 2.1 In `frontend/src/components/live-highway/event-card.css`, anchor the badge to the top-right corner (`inset-block-start` + `inset-inline-end`) and add `translate: 40% -40%` so it bleeds half outside the card; keep `position: absolute`
+- [x] 2.2 Remove the redundant `overflow: hidden` from `.event-card` so the badge can bleed past the corner without a wrapper (clipping is already handled by `border-radius`, the noise `::after` `border-radius: inherit`, and the matched beam `::before` mask)
+- [x] 2.3 Render the badge as the bare emoji (no background pill or hue): keep only position + `translate` + `font-size` + `line-height`; remove label-only rules (`gap`, `font-weight`, `text-transform`, `letter-spacing`, `color`) and the now-dead `background`, `padding`, `border-radius`, and flex-centering
+- [x] 2.4 Remove the now-unused per-status `--_journey-text` AND `--_journey-bg` custom properties (the card badge no longer paints a hue; chips and the detail control keep their own hue)
+
+## 3. Verification
+
+- [x] 3.1 `npx stylelint` on `event-card.css` and `tsc --noEmit` for the changed files pass (admin-area TS errors are pre-existing and unrelated)
+- [x] 3.2 Confirm on the dashboard timetable that each of the five statuses renders as a bare corner-bleed emoji (no background) with no artist-name overlap — verified via a throwaway Playwright run (authenticated, mocked follow/user/concert/journey RPCs) across HOME (no venue label) and AWAY (rightmost) lanes with short/medium/very-long names; emojis 👀📝💔💰🎟️ sit on the top-right corner, short/medium names fully clear, AWAY-lane badges not clipped by `concert-scroll` (`clipped:false`), and removing `overflow:hidden` left corners/gradient/noise/matched glow+beam visually intact
+- [x] 3.3 Confirm the dashboard filter chips and concert-detail status control still show icon + label — verified statically: only `event-card.{html,css}` changed; `artist-filter-bar.html` and `event-detail-sheet.html` still render `config.icon` + `t.bind` label
+- [ ] 3.4 Regenerate the dashboard/timetable visual baselines (delete the visual-baselines CI artifact to force regen) — handled at merge time per repo flow; the authenticated badge visual spec is `.fixme` (not in CI), and the guest dashboard visual spec shows no badges, so likely a no-op


### PR DESCRIPTION
## Summary

Adds the OpenSpec change `icon-only-journey-badge` capturing the design for the dashboard journey-badge fix (frontend liverty-music/frontend#456).

The concert-card journey badge previously showed the status icon plus its full label as a pill, which overlapped the artist name on the dense timetable. The change renders the card badge as a bare corner emoji.

## Changes

- New change `icon-only-journey-badge` with proposal, design, specs delta, and tasks.
- Modifies the `journey-status-presentation` capability:
  - The status **icon** is the primary, always-present cue and is sufficient on its own.
  - The **text label** and **hue** may both be omitted on compact surfaces (the concert-card badge), which now renders the emoji alone.
  - Icon-only renderings must expose the canonical label as an accessible name (`aria-label`).
  - The filter chips and the detail-control node keep icon + label + hue.

No proto changes.

## Testing

- `openspec validate icon-only-journey-badge` passes.

Refs: #455
