### PR TITLE
feat(admin)!: rename admin ConcertService and add published-concert management

### DIFF
--- a/openspec/changes/admin-console-concert-management/.openspec.yaml
+++ b/openspec/changes/admin-console-concert-management/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-20

--- a/openspec/changes/admin-console-concert-management/design.md
+++ b/openspec/changes/admin-console-concert-management/design.md
@@ -1,0 +1,156 @@
+## Context
+
+The admin console (split onto a dedicated admin Connect server by `admin-rpc-server`)
+currently exposes only the concert approval queue via
+`liverty_music.rpc.admin.v1.ConcertModerationService` (`ListPendingConcerts`,
+`ApproveConcert`, `RejectConcert`). Backend logic lives in a standalone
+`ConcertApprovalUseCase` (`concert_approval_uc.go`), called by
+`ConcertModerationHandler`. There is no surface for managing concerts **after**
+they are published — a wrongly-approved concert is permanent from the console.
+
+Two layers are conflated in the discussion and must be kept separate:
+- **RPC service / server boundary** — about authorization, host, CORS. Admin RPCs
+  live in `rpc/admin/v1` and are served on the admin Connect server, gated by a
+  boundary `RequireRoleInterceptor("admin")`. This boundary is preserved.
+- **Use-case layer** — auth-agnostic business logic. Authorization is *not* a
+  use-case concern, so the use-case layer is free to be organized by capability,
+  not by audience.
+
+Published concerts and their dependents are linked by `ON DELETE CASCADE` foreign
+keys: deleting an `events` row cascades to `event_performers`, `concerts`,
+`tickets` (on-chain SBT records), `ticket_journeys`, `ticket_emails`, `merkle_tree`,
+and — via the parent `series` — `sales_phases` / `sales_phase_reminders`.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Give operators a way to list every published concert (grouped by artist) and
+  hard-delete mistakes.
+- Rename the admin concert service to `ConcertService` with bare-verb methods,
+  matching the consumer service shape and the established convention.
+- Remove use-case duplication: a single concrete concert use case, with reuse at
+  the repository layer and capability-segregated interfaces at the handler layer.
+
+**Non-Goals:**
+- Delete guards, soft-delete, impact preview, or audit logging (deferred; this is
+  an unconditional operator correction tool).
+- Burning the on-chain ERC-5192 tokens for cascade-deleted `tickets` rows.
+- Any change to the consumer `liverty_music.rpc.concert.v1.ConcertService`.
+- Renaming the admin server's port/host/CORS or the boundary auth layer.
+
+## Decisions
+
+### D1: Rename `ConcertModerationService` → `admin.v1.ConcertService` (breaking)
+
+The package `liverty_music.rpc.admin.v1` already conveys the admin audience, so a
+`Moderation`/`Admin` qualifier on the service is redundant — and inaccurate once the
+service also lists and deletes published concerts. The fully-qualified name
+disambiguates it from the consumer `rpc.concert.v1.ConcertService` with no
+collision. Methods drop the entity suffix the service already carries:
+`ListPendingConcerts`→`ListPending`, `ApproveConcert`→`Approve`,
+`RejectConcert`→`Reject`, plus new `List` and `Delete`. The proto file is renamed
+`concert_moderation_service.proto`→`concert_service.proto`.
+
+- *Alternative — additive only (keep the old name, just add `List`/`Delete`):*
+  non-breaking and faster, but locks in a name that misdescribes the surface and
+  perpetuates the verbose method style. Rejected: naming hygiene is worth one
+  coordinated breaking release on an internal, pre-launch surface.
+- *Alternative — fold admin concert RPCs into the consumer `ConcertService`:*
+  rejected earlier — it would move admin methods onto the consumer server/host/CORS
+  and outside the boundary interceptor, reintroducing the per-method-auth fragility
+  `admin-rpc-server` removed.
+
+### D2: Merge `ConcertApprovalUseCase` into the single `concertUseCase`
+
+`concertUseCase` already holds every dependency the approval use case needs except
+two (`rejectedConcertRepo`, `seriesRepo`). Merging removes a parallel use case
+whose reads would otherwise duplicate concert-read logic. Auth is handled by the
+interceptor, so a unified use case does not weaken any boundary.
+
+- *Alternative — keep two use cases:* rejected; organizing use cases by audience
+  (admin vs consumer) is the duplication source, and the dependency overlap here is
+  near-total, so the merge is cheap.
+
+### D3: Interface Segregation, not one fat interface
+
+One concrete `concertUseCase` implements two interfaces consumed where needed:
+- The consumer `ConcertHandler` depends on the existing read-only `ConcertUseCase`
+  interface — **unchanged**, so it never sees `Delete`/`Approve` (least privilege).
+- The admin handler depends on a new admin interface
+  (`ListPending`/`Approve`/`Reject`/`List`/`Delete`).
+
+This yields DRY (one implementation, read logic shared via `ConcertRepository`) and
+least privilege (the consumer handler structurally cannot delete). In Go the
+interfaces live next to the use case; the concrete struct satisfies both.
+
+### D4: Go handler naming under a shared package
+
+Both concert handlers live in the single Go package `internal/adapter/rpc`, so the
+proto-level symmetry (both services named `ConcertService`) cannot extend to the Go
+structs. The consumer handler stays `ConcertHandler`; the admin handler is renamed
+`ConcertModerationHandler`→`AdminConcertHandler`. The admin-server registration
+switches to the renamed generated `ConcertServiceHandler` constructor.
+
+### D5: Reuse at the repository layer
+
+Add `ConcertRepository.List(ctx)` (all published concerts, hydrated like the other
+list methods) and `ConcertRepository.Delete(ctx, eventID)` (a single
+`DELETE FROM events WHERE id = $1`, relying on the existing FK cascade — no manual
+multi-table deletes). Both admin and any future caller reuse these; the use-case
+layer stays thin over them.
+
+### D6: Client-side artist grouping
+
+`List` returns a flat slice; the admin SPA groups by performing artist in the view
+model. This keeps the proto minimal (no nested `ArtistGroup` message) and mirrors
+how the existing approval queue maps flat rows.
+
+## Risks / Trade-offs
+
+- **Breaking rename leaves a cutover gap** → The admin console's old client calls
+  dead RPC paths once the backend serves the renamed service. Mitigation: release
+  backend and frontend close together; the surface is admin-only, consumer-impact-
+  free, and pre-launch, so the worst case is a brief internal-tool outage with no
+  security exposure (same shape as the `admin-rpc-server` cutover).
+- **Unconditional delete cascades into fan-owned data** → On a populated database,
+  `Delete` would silently remove `ticket_journeys`/`tickets`. Mitigation (accepted,
+  not engineered): pre-launch there is no real fan data; guards/soft-delete are an
+  explicit follow-up if/when the catalog carries live tickets. Documented as a
+  Non-Goal so the gap is a known decision, not an oversight.
+- **Orphaned on-chain SBTs** → Deleting a `tickets` row does not burn the ERC-5192
+  token on Base Sepolia, leaving a token pointing at a deleted event. Mitigation:
+  out of scope pre-launch; revisit alongside any real ticketing launch.
+- **Merged use case grows two dependencies** → `concertUseCase` gains
+  `rejectedConcertRepo` + `seriesRepo`. Trade-off accepted: still far smaller than
+  maintaining a parallel use case, and the struct remains capability-cohesive.
+
+## Migration Plan
+
+Follows the cross-repo release coordination workflow (breaking proto change):
+1. **specification**: rename service + methods, add `List`/`Delete`, rename proto
+   file; `buf lint`/`format`; confirm `buf breaking` reports only the intended
+   service/method renames. Open PR with this OpenSpec change; merge after review/CI.
+2. **specification Release**: publish GitHub Release `vX.Y.Z` → `buf-release.yml`
+   pushes to BSR; monitor to success.
+3. **backend** (prepared in parallel against the planned shape, finalized after BSR
+   gen): merge the use case, add repo `List`/`Delete`, rename handler to
+   `AdminConcertHandler`, swap to the regenerated `ConcertServiceHandler`; bump the
+   BSR package; `make check` green; open PR; merge.
+4. **frontend** (likewise): new `admin/approved-concerts/` route + view model,
+   rename `concert-moderation-client.ts`, re-point at the regenerated admin
+   `ConcertService`; `make check` green; open PR; merge.
+5. **Ship to prod**: backend Release `vX.Y.Z` (retag dev AR image), then frontend
+   Release; release the two close together to minimize the admin-tool cutover gap.
+   Verify in prod: `List` returns published concerts, `Delete` removes a test
+   concert end-to-end, and the approval queue (`ListPending`/`Approve`/`Reject`)
+   still works under the new names.
+
+**Rollback**: revert the backend/frontend deploys to the prior pinned versions; the
+old `ConcertModerationService` paths return. The BSR schema is additive-forward, so
+a downstream revert is a version pin change, not a schema rollback.
+
+## Open Questions
+
+- None blocking. (Deferred design — guards, soft-delete, impact preview, audit log,
+  SBT burn — is captured as Non-Goals and follow-up, not open questions for this
+  change.)

--- a/openspec/changes/admin-console-concert-management/proposal.md
+++ b/openspec/changes/admin-console-concert-management/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+The admin console can review the discovery queue (approve/reject pending concerts) but has no way to see or correct **already-published** concerts. A wrongly-approved concert — wrong artist, duplicate, bad date — is currently permanent from the console's side. Operators need to list approved concerts per artist and remove mistakes.
+
+In building this, the admin concert RPC surface also stops fitting its name: `ConcertModerationService` was scoped to moderation (approve/reject), but it now also lists and deletes published concerts. The package `liverty_music.rpc.admin.v1` already conveys the admin audience, so the `Moderation` qualifier is redundant and the verbose method names (`ListPendingConcerts`, `ApproveConcert`) duplicate context the service already carries.
+
+## What Changes
+
+- **BREAKING** Rename `liverty_music.rpc.admin.v1.ConcertModerationService` to `ConcertService`, mirroring the consumer `liverty_music.rpc.concert.v1.ConcertService` (package disambiguates the two). Rename the proto file `concert_moderation_service.proto` → `concert_service.proto`.
+- **BREAKING** Simplify the existing methods to bare verbs now that the service name carries the entity: `ListPendingConcerts` → `ListPending`, `ApproveConcert` → `Approve`, `RejectConcert` → `Reject`.
+- Add `List` — returns every published concert (no follower/proximity filter), carrying the `event_id` needed for deletion. Grouping by artist is done client-side.
+- Add `Delete` — hard-deletes a published concert by `event_id`. The delete cascades through the existing `ON DELETE CASCADE` foreign keys (`event_performers`, `tickets`, `ticket_journeys`, `ticket_emails`, `merkle_tree`, and `sales_phases` via the series). **No guard**: deletion is unconditional, intended as an operator correction tool on a pre-launch internal surface where published rows have no real fan-owned data yet.
+- Add a frontend admin route (`admin/approved-concerts/`) that lists approved concerts grouped by artist with a per-row manual delete (confirm dialog only).
+- Backend (implementation, see design): merge `ConcertApprovalUseCase` into the single `concertUseCase` implementation (gaining `rejectedConcertRepo` + `seriesRepo`), exposed through segregated interfaces so the consumer handler keeps a read-only view and the admin handler gets the admin view; add `ConcertRepository.List` and `ConcertRepository.Delete`.
+
+## Capabilities
+
+### New Capabilities
+- `admin-concert-management`: the admin `ConcertService` surface for managing **published** concerts — listing every approved concert (with the identifiers needed for follow-up actions) and hard-deleting a concert by event id with full database cascade and no precondition guard. Establishes the renamed, bare-verb admin concert RPC service as the home for admin concert operations.
+
+### Modified Capabilities
+- `admin-rpc-server`: the admin-scoped service registered on the admin server's mux (and targeted by the admin console's RPC client) is renamed from `ConcertModerationService` to `ConcertService`; scenarios that name the service are updated. The boundary admin-role authorization, dedicated port/host/CORS, and consumer-exclusion guarantees are unchanged.
+
+## Impact
+
+- **specification**: Breaking proto change (service + three method renames, two added methods, file rename) → requires the cross-repo release coordination workflow (specification PR → merge → GitHub Release `vX.Y.Z` → BSR gen) before backend/frontend can build.
+- **backend**: Merge `ConcertApprovalUseCase` into `concertUseCase`; delete the standalone approval use case + interface; add a segregated admin use-case interface consumed by the renamed `AdminConcertHandler` (the Go handler struct keeps an admin-distinct name to avoid colliding with the consumer `ConcertHandler` in the shared `rpc` package). Add `ConcertRepository.List` (all published) and `Delete` (cascade). Update admin-server handler registration to the renamed generated `ConcertServiceHandler`.
+- **frontend**: New `admin/approved-concerts/` route + view-model; rename `concert-moderation-client.ts` and re-point it at the renamed generated `ConcertService` client; client-side artist grouping; confirm-dialog delete.
+- **cutover**: Breaking rename means the admin console's old client calls dead RPC paths once the backend swaps; backend and frontend release close together (admin-only, consumer-impact-free, pre-launch) so the gap is a brief internal-tool outage with no security exposure.
+- **Out of scope**: delete guards / soft-delete / impact preview / audit log (explicitly deferred — operator correction tool only); on-chain SBT burn for cascade-deleted tickets (pre-launch, no real minted tickets); any consumer `ConcertService` change.

--- a/openspec/changes/admin-console-concert-management/specs/admin-concert-management/spec.md
+++ b/openspec/changes/admin-console-concert-management/specs/admin-concert-management/spec.md
@@ -1,0 +1,101 @@
+## ADDED Requirements
+
+### Requirement: Admin concert operations are served by a single ConcertService
+
+The admin-scoped concert operations SHALL be served by a single
+`liverty_music.rpc.admin.v1.ConcertService` — listing published concerts, listing
+the pending review queue, approving, rejecting, and deleting. This service is distinct from
+the consumer `liverty_music.rpc.concert.v1.ConcertService`; the proto package is
+the sole disambiguator and the `admin.v1` package conveys the admin audience, so
+the service name SHALL NOT carry an audience or role qualifier. Method names SHALL
+be bare verbs (`List`, `ListPending`, `Approve`, `Reject`, `Delete`) because the
+service name already carries the `Concert` entity.
+
+#### Scenario: Admin concert service identity
+
+- **WHEN** the admin concert RPC surface is defined
+- **THEN** it SHALL be the service `liverty_music.rpc.admin.v1.ConcertService`
+- **AND** its methods SHALL be `List`, `ListPending`, `Approve`, `Reject`, and `Delete`
+
+#### Scenario: No collision with the consumer concert service
+
+- **WHEN** both the consumer and admin concert services exist
+- **THEN** they SHALL be distinguished by proto package
+  (`rpc.concert.v1` vs `rpc.admin.v1`)
+- **AND** neither service's fully-qualified name SHALL depend on a role suffix
+
+### Requirement: Admin lists every published concert
+
+The admin `ConcertService` SHALL provide a `List` operation that returns every
+published concert, with no follower, proximity, or personalization filtering, so an
+operator can review the full published catalog. Each returned concert SHALL carry
+the identifiers required for follow-up actions (the published event id, the
+performing artist, and human-readable date/venue/title fields). `List` SHALL NOT
+return concerts that are still pending review (those are returned by `ListPending`).
+
+#### Scenario: List returns all published concerts
+
+- **WHEN** an admin calls `List`
+- **THEN** every published concert SHALL be returned regardless of any follow or
+  proximity relationship
+- **AND** each entry SHALL include its published event id and performing artist
+
+#### Scenario: Pending concerts are excluded from List
+
+- **WHEN** concerts exist in both the published catalog and the pending review queue
+- **THEN** `List` SHALL return only the published concerts
+- **AND** the pending concerts SHALL be returned only by `ListPending`
+
+### Requirement: Admin hard-deletes a published concert
+
+The admin `ConcertService` SHALL provide a `Delete` operation that permanently
+removes a published concert identified by its event id. The deletion SHALL cascade
+through the database's referential integrity to every row that references the
+event (performers, tickets, ticket journeys, ticket emails, merkle tree nodes, and
+the series' sales phases). The operation SHALL be unconditional: it SHALL NOT be
+blocked by the presence of dependent rows such as minted tickets or fan ticket
+journeys. This is an operator correction tool; the absence of a guard is
+intentional for the pre-launch internal surface.
+
+#### Scenario: Delete removes the concert and cascades
+
+- **WHEN** an admin calls `Delete` with a published concert's event id
+- **THEN** the event and its concert record SHALL be removed
+- **AND** all rows referencing that event SHALL be removed by database cascade
+
+#### Scenario: Delete is unconditional
+
+- **WHEN** an admin calls `Delete` on a concert that has dependent rows
+  (e.g. ticket journeys or minted tickets)
+- **THEN** the deletion SHALL proceed and remove those dependent rows
+- **AND** the operation SHALL NOT be rejected on account of the dependents
+
+#### Scenario: Delete is idempotent
+
+- **WHEN** a `Delete` targets an event id that no longer exists
+- **THEN** the operation SHALL succeed without error
+
+#### Scenario: Malformed event id is rejected
+
+- **WHEN** a `Delete` is called with a missing or malformed event id
+- **THEN** it SHALL be rejected with `INVALID_ARGUMENT`
+- **AND** no concert SHALL be deleted
+
+### Requirement: Admin console presents approved concerts grouped by artist
+
+The admin console SHALL present the published concerts returned by `List` grouped by
+performing artist, with a per-concert manual delete control. Grouping SHALL be
+performed client-side from the flat `List` result. Triggering delete SHALL require
+an explicit confirmation step before the `Delete` call is issued.
+
+#### Scenario: Concerts shown grouped by artist
+
+- **WHEN** an operator opens the approved-concerts screen
+- **THEN** the published concerts SHALL be displayed grouped by performing artist
+- **AND** each concert row SHALL expose a manual delete control
+
+#### Scenario: Delete requires confirmation
+
+- **WHEN** an operator activates a concert's delete control
+- **THEN** an explicit confirmation SHALL be required
+- **AND** the `Delete` RPC SHALL be issued only after the operator confirms

--- a/openspec/changes/admin-console-concert-management/specs/admin-rpc-server/spec.md
+++ b/openspec/changes/admin-console-concert-management/specs/admin-rpc-server/spec.md
@@ -1,0 +1,47 @@
+## MODIFIED Requirements
+
+### Requirement: Dedicated admin Connect server
+
+The backend SHALL serve admin-scoped RPCs from a dedicated Connect server bound to
+its own port, separate from the consumer-facing Connect server. Both servers MAY
+run in the same backend binary. The admin server SHALL serve ONLY admin-scoped
+services, and the consumer server SHALL NOT serve any admin-scoped service.
+
+#### Scenario: Admin service served only on the admin port
+
+- **WHEN** the backend starts
+- **THEN** the admin `liverty_music.rpc.admin.v1.ConcertService` is registered on
+  the admin server's mux
+- **AND** it is NOT registered on the consumer server's mux
+
+#### Scenario: Consumer service served only on the consumer port
+
+- **WHEN** the backend starts
+- **THEN** consumer services (e.g. `UserService`, `ArtistService`, and the consumer
+  `liverty_music.rpc.concert.v1.ConcertService`) are registered on the consumer
+  server
+- **AND** they are NOT registered on the admin server
+
+#### Scenario: Both servers drain on shutdown
+
+- **WHEN** the backend receives a shutdown signal
+- **THEN** both the consumer and admin servers SHALL drain in-flight requests
+  during the shutdown Drain phase
+
+### Requirement: Admin console resolves the admin API host from runtime config
+
+The admin console SHALL obtain the admin API base URL from its per-host runtime
+configuration and direct its admin RPC client (the admin
+`liverty_music.rpc.admin.v1.ConcertService`) to `api.admin.{env-base-domain}`. The
+consumer SPA SHALL continue to call the consumer API host. Neither app SHALL
+conditionally rewrite the other's host.
+
+#### Scenario: Admin client targets the admin API host
+
+- **WHEN** the admin console boots and reads its runtime config
+- **THEN** its admin RPC client base URL SHALL be the admin API host for that environment
+
+#### Scenario: Consumer client unchanged
+
+- **WHEN** the consumer SPA boots
+- **THEN** its RPC client SHALL continue to target the consumer API host

--- a/openspec/changes/admin-console-concert-management/tasks.md
+++ b/openspec/changes/admin-console-concert-management/tasks.md
@@ -1,0 +1,38 @@
+## 1. Specification & Proto (specification repo)
+
+- [x] 1.1 Rename `proto/liverty_music/rpc/admin/v1/concert_moderation_service.proto` → `concert_service.proto` (git mv); rename `service ConcertModerationService` → `service ConcertService`; update package-level and service doc comments to describe admin concert management (not just moderation)
+- [x] 1.2 Rename methods to bare verbs: `ListPendingConcerts`→`ListPending`, `ApproveConcert`→`Approve`, `RejectConcert`→`Reject` (keep request/response message names coherent, e.g. `ListPendingRequest`/`Response`); preserve existing field shapes and validation
+- [x] 1.3 Add `List` (request: empty; response: `repeated` published concert with event id, performer, title, local date, start time, listed/resolved venue) and `Delete` (request: required `entity.v1.EventId`; response: empty) with doc comments stating cascade + unconditional semantics and the `INVALID_ARGUMENT`/idempotent-on-missing error contract
+- [x] 1.4 Run `buf lint` + `buf format`; run `buf breaking` and confirm the only breaking deltas are the service rename + the three method renames (no unexpected message/field breakage)
+- [ ] 1.5 Open the specification PR with the proto change + this OpenSpec change; merge after review and CI (`buf-pr-checks.yml`) pass
+- [ ] 1.6 Publish a GitHub Release (tag `vX.Y.Z`) to trigger `buf-release.yml` → BSR push; monitor `buf-release.yml` to success
+
+## 2. Backend — use-case merge & interface segregation (prepared in parallel, finalized after BSR gen)
+
+- [ ] 2.1 Merge `ConcertApprovalUseCase` logic into the concrete `concertUseCase`: add `rejectedConcertRepo` + `seriesRepo` to the struct and `NewConcertUseCase` constructor; move `ListPending`, `Approve`, `Reject` method bodies over; delete `concert_approval_uc.go` and the `ConcertApprovalUseCase` interface + its mock
+- [ ] 2.2 Define the segregated admin use-case interface (e.g. `AdminConcertUseCase`) exposing `ListPending`/`Approve`/`Reject`/`List`/`Delete`; keep the existing read-only `ConcertUseCase` interface for the consumer handler unchanged; assert `concertUseCase` satisfies both; regenerate mocks
+- [ ] 2.3 Add `ConcertRepository.List(ctx)` returning all published concerts hydrated like the other list methods; implement against the existing concert/event/venue/performer joins
+- [ ] 2.4 Add `ConcertRepository.Delete(ctx, eventID)` as a single `DELETE FROM events WHERE id = $1` relying on FK cascade; return success when zero rows matched (idempotent); add a focused integration test asserting cascade removes dependent rows
+- [ ] 2.5 Implement use-case `List` (passthrough to repo) and `Delete` (validate id → repo delete; map missing→success, malformed→`INVALID_ARGUMENT`)
+
+## 3. Backend — handler & DI rename (finalized after BSR gen)
+
+- [ ] 3.1 Bump the generated schema package to `vX.Y.Z`; `go mod tidy`
+- [ ] 3.2 Rename `ConcertModerationHandler` → `AdminConcertHandler`; update it to the regenerated `ConcertService` method set (`ListPending`/`Approve`/`Reject` renamed, add `List`/`Delete`); depend on the `AdminConcertUseCase` interface
+- [ ] 3.3 Update admin-server DI registration to the regenerated `adminv1connect` `ConcertServiceHandler` constructor; wire the merged use case + new repos; remove the deleted approval use-case provider
+- [ ] 3.4 Update/extend unit tests (handler + use case): `List` returns published only, `Delete` cascades/idempotent/`INVALID_ARGUMENT`, approval methods still pass under new names; `make check` green
+
+## 4. Frontend — admin approved-concerts route (finalized after BSR gen)
+
+- [ ] 4.1 Bump the BSR-generated package to the version carrying `admin.v1.ConcertService`; rename `admin/services/concert-moderation-client.ts` → `concert-client.ts` and re-point it at the regenerated `ConcertService` client; update method calls to the bare-verb names and add `list()` / `delete(eventId)`
+- [ ] 4.2 Add `admin/approved-concerts/` route + view model: load via `list()`, group rows by performing artist client-side, render per-artist sections
+- [ ] 4.3 Add a per-row delete control with a confirm step that issues `delete(eventId)` only on confirmation; on success remove the row, on failure surface a per-row error
+- [ ] 4.4 Register the route in the admin shell/nav; add unit tests (grouping, confirm-gated delete, error surfacing); `make check` green
+
+## 5. Ship to production (coordinated cutover)
+
+- [ ] 5.1 Open the backend PR only after the package upgrade + rename compile and `make check` pass locally; merge after review/CI
+- [ ] 5.2 Open the frontend PR likewise; merge after review/CI
+- [ ] 5.3 Publish the backend GitHub Release (tag `vX.Y.Z`) to retag the dev AR image to prod; confirm ArgoCD syncs the new backend image
+- [ ] 5.4 Publish the frontend Release close behind the backend to minimize the admin-tool cutover gap; confirm the automated prod-pin bump + ArgoCD sync
+- [ ] 5.5 Verify in prod directly: `List` returns published concerts grouped by artist in the console, `Delete` removes a test concert end-to-end (with cascade), and the approval queue (`ListPending`/`Approve`/`Reject`) still works under the renamed service; a non-admin token is still rejected at the admin host

--- a/proto/liverty_music/rpc/admin/v1/concert_service.proto
+++ b/proto/liverty_music/rpc/admin/v1/concert_service.proto
@@ -1,57 +1,85 @@
 syntax = "proto3";
 
 // Package liverty_music.rpc.admin.v1 provides admin-only gRPC service definitions
-// for internal moderation tooling exposed through the developer admin console.
+// for internal tooling exposed through the developer admin console.
 //
 // These services are authorized solely for the admin organization and are never
-// reachable by the consumer product. The first capability is concert moderation:
-// reviewing AI-discovered concerts before they are published to fans.
+// reachable by the consumer product. The first capability is concert management:
+// reviewing AI-discovered concerts before they are published to fans, and
+// managing the published catalog thereafter.
 package liverty_music.rpc.admin.v1;
 
 import "buf/validate/validate.proto";
 import "google/protobuf/timestamp.proto";
 import "liverty_music/entity/v1/artist.proto";
+import "liverty_music/entity/v1/concert.proto";
 import "liverty_music/entity/v1/coordinates.proto";
 import "liverty_music/entity/v1/entity.proto";
+import "liverty_music/entity/v1/event.proto";
 import "liverty_music/entity/v1/staged_concert.proto";
 import "liverty_music/entity/v1/venue.proto";
 
-// ConcertModerationService lets internal developers review concerts discovered by
-// the generative-AI search pipeline before they become visible to fans.
+// ConcertService is the admin-side counterpart to the consumer
+// liverty_music.rpc.concert.v1.ConcertService: it manages concerts across their
+// full lifecycle for internal developers. The proto package (admin.v1) conveys
+// the admin audience, so the service name carries no role qualifier and the two
+// ConcertService definitions are distinguished by package alone.
 //
 // Discovered concerts are held in a staging queue in a pending state. A developer
 // approves a concert to publish it (and trigger the new-concert notification) or
 // rejects it to drop it. Rejection is not permanent: a later discovery run may
 // re-surface the same concert for re-review, and every rejection is recorded for
-// search-quality analysis.
+// search-quality analysis. Once published, a concert can be listed and, if it was
+// approved in error, deleted.
 //
 // All RPCs are authorized only for the admin organization; callers outside it are
-// rejected with PERMISSION_DENIED.
-service ConcertModerationService {
-  // ListPendingConcerts returns every concert currently awaiting review, including
-  // the resolved-venue preview so the reviewer can judge venue accuracy.
+// rejected with PERMISSION_DENIED at the admin server boundary.
+service ConcertService {
+  // List returns every published concert, with no follower or proximity
+  // filtering, so an operator can review the full catalog and act on it. Each
+  // concert carries its event id (for deletion) and performing artists (for
+  // client-side grouping).
   //
   // Possible errors:
   // - PERMISSION_DENIED: The caller is not a member of the admin organization.
-  rpc ListPendingConcerts(ListPendingConcertsRequest) returns (ListPendingConcertsResponse);
+  rpc List(ListRequest) returns (ListResponse);
 
-  // ApproveConcert publishes a pending concert to fans and emits the new-concert
+  // ListPending returns every concert currently awaiting review, including the
+  // resolved-venue preview so the reviewer can judge venue accuracy.
+  //
+  // Possible errors:
+  // - PERMISSION_DENIED: The caller is not a member of the admin organization.
+  rpc ListPending(ListPendingRequest) returns (ListPendingResponse);
+
+  // Approve publishes a pending concert to fans and emits the new-concert
   // notification. The operation is idempotent: approving a staged concert that no
   // longer exists succeeds without creating a duplicate.
   //
   // Possible errors:
   // - PERMISSION_DENIED: The caller is not a member of the admin organization.
   // - INVALID_ARGUMENT: The staged concert id is missing or malformed.
-  rpc ApproveConcert(ApproveConcertRequest) returns (ApproveConcertResponse);
+  rpc Approve(ApproveRequest) returns (ApproveResponse);
 
-  // RejectConcert drops a pending concert and records the rejection (with reason)
-  // for search-quality analysis. The operation is idempotent: rejecting a staged
+  // Reject drops a pending concert and records the rejection (with reason) for
+  // search-quality analysis. The operation is idempotent: rejecting a staged
   // concert that no longer exists succeeds.
   //
   // Possible errors:
   // - PERMISSION_DENIED: The caller is not a member of the admin organization.
   // - INVALID_ARGUMENT: The staged concert id is missing, or the reason is empty.
-  rpc RejectConcert(RejectConcertRequest) returns (RejectConcertResponse);
+  rpc Reject(RejectRequest) returns (RejectResponse);
+
+  // Delete permanently removes a published concert by its event id. The deletion
+  // cascades through the database's referential integrity to every row that
+  // references the event (performers, tickets, ticket journeys, ticket emails,
+  // merkle tree nodes, and the series' sales phases). It is unconditional: it is
+  // NOT blocked by dependent rows such as minted tickets or fan ticket journeys.
+  // The operation is idempotent: deleting an event that no longer exists succeeds.
+  //
+  // Possible errors:
+  // - PERMISSION_DENIED: The caller is not a member of the admin organization.
+  // - INVALID_ARGUMENT: The event id is missing or malformed.
+  rpc Delete(DeleteRequest) returns (DeleteResponse);
 }
 
 // ResolvedVenue is the venue preview produced by resolving the raw scraped venue
@@ -108,27 +136,38 @@ message PendingConcert {
   google.protobuf.Timestamp discovered_time = 9 [(buf.validate.field).required = true];
 }
 
-// ListPendingConcertsRequest is the request for retrieving all concerts awaiting
-// review. It takes no parameters; the full pending queue is returned.
-message ListPendingConcertsRequest {}
+// ListRequest is the request for retrieving all published concerts. It takes no
+// parameters; the full published catalog is returned.
+message ListRequest {}
 
-// ListPendingConcertsResponse contains the concerts currently awaiting review.
-message ListPendingConcertsResponse {
+// ListResponse contains the published concerts. Each concert carries its event id
+// and performing artists; the admin console groups by artist client-side.
+message ListResponse {
+  // The published concerts, in catalog order.
+  repeated entity.v1.Concert concerts = 1;
+}
+
+// ListPendingRequest is the request for retrieving all concerts awaiting review.
+// It takes no parameters; the full pending queue is returned.
+message ListPendingRequest {}
+
+// ListPendingResponse contains the concerts currently awaiting review.
+message ListPendingResponse {
   // The concerts currently in the approval queue, in discovery order.
   repeated PendingConcert pending_concerts = 1;
 }
 
-// ApproveConcertRequest identifies the staged concert to publish.
-message ApproveConcertRequest {
+// ApproveRequest identifies the staged concert to publish.
+message ApproveRequest {
   // Required. The unique identifier of the staged concert to approve.
   entity.v1.StagedConcertId staged_id = 1 [(buf.validate.field).required = true];
 }
 
-// ApproveConcertResponse is returned upon successful approval.
-message ApproveConcertResponse {}
+// ApproveResponse is returned upon successful approval.
+message ApproveResponse {}
 
-// RejectConcertRequest identifies the staged concert to drop and the reason why.
-message RejectConcertRequest {
+// RejectRequest identifies the staged concert to drop and the reason why.
+message RejectRequest {
   // Required. The unique identifier of the staged concert to reject.
   entity.v1.StagedConcertId staged_id = 1 [(buf.validate.field).required = true];
 
@@ -140,5 +179,16 @@ message RejectConcertRequest {
   ];
 }
 
-// RejectConcertResponse is returned upon successful rejection.
-message RejectConcertResponse {}
+// RejectResponse is returned upon successful rejection.
+message RejectResponse {}
+
+// DeleteRequest identifies the published concert to delete by its event id.
+message DeleteRequest {
+  // Required. The unique identifier of the published event to delete. The
+  // deletion cascades to all rows referencing this event.
+  entity.v1.EventId event_id = 1 [(buf.validate.field).required = true];
+}
+
+// DeleteResponse is returned upon successful deletion (including the idempotent
+// case where the event was already absent).
+message DeleteResponse {}


### PR DESCRIPTION
## Summary

Rename the admin concert RPC surface and extend it with published-concert management. The `admin.v1` package already conveys the admin audience, so `ConcertModerationService` is renamed to `ConcertService` (distinguished from the consumer `rpc.concert.v1.ConcertService` by package alone), and the surface gains operations to list and delete already-published concerts — not just moderate the discovery queue.

OpenSpec change: `admin-console-concert-management`.

## Changes

- **BREAKING** Rename `proto/liverty_music/rpc/admin/v1/concert_moderation_service.proto` → `concert_service.proto`; `service ConcertModerationService` → `service ConcertService`.
- **BREAKING** Simplify existing methods to bare verbs (the service name carries the entity): `ListPendingConcerts` → `ListPending`, `ApproveConcert` → `Approve`, `RejectConcert` → `Reject` (request/response messages renamed to match).
- Add `List` — returns every published concert (`repeated entity.v1.Concert`); the admin console groups by artist client-side.
- Add `Delete` — hard-deletes a published concert by `entity.v1.EventId`; cascades through the DB's `ON DELETE CASCADE` graph and is unconditional + idempotent-on-missing (operator correction tool).
- Adds the `admin-concert-management` OpenSpec capability and a `admin-rpc-server` delta (the admin service it names is renamed).

## Why

The admin console can review the discovery queue but has no way to see or correct already-published concerts; a wrongly-approved concert is currently permanent. The `Moderation` name and verbose method names also no longer match a surface that lists and deletes.

## Breaking change

Intentional — service + method renames (via file rename). `buf skip breaking` label applied. Per the cross-repo release protocol, this merges → GitHub Release `vX.Y.Z` → BSR gen, then backend and frontend (prepared in parallel) swap to the regenerated `ConcertService`.

## Testing

- `buf lint` ✓ / `buf format` ✓
- `buf breaking` reports only the intended renamed-file deletion (no unexpected message/field breakage).

Refs: #628
