### PR TITLE
docs(openspec): add optimize-sales-phase-searcher change artifacts

### DIFF
--- a/openspec/changes/optimize-sales-phase-searcher/.openspec.yaml
+++ b/openspec/changes/optimize-sales-phase-searcher/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-19

--- a/openspec/changes/optimize-sales-phase-searcher/design.md
+++ b/openspec/changes/optimize-sales-phase-searcher/design.md
@@ -1,0 +1,72 @@
+## Context
+
+The sales-phase searcher discovers ticket-sale windows for the upcoming series of followed artists. It currently runs a two-step Gemini pipeline **per series**: Step 1 is a grounded extract (`gemini-3.1-flash-lite`, tools = `GoogleSearch` + `URLContext`, thinking=high) returning a verbatim XML envelope; Step 2 coerces dates to RFC 3339. Production telemetry (2026-06-18 run) exposed two structural failures:
+
+1. **Grounding never fires.** All 99 calls logged `grounding.fired=false`, `tool_use≈0`, and produced 0 final phases. Per Google's docs, when `GoogleSearch` + `URLContext` are combined the model first answers from its own knowledge or a *provided* URL and only falls back to Google Search if it cannot. We enable `URLContext` but pass **no URL**, so the model answers from memory (hallucinated or empty) and Search never fires. `timeRangeFilter` is also unreliable (known bug python-genai #1207).
+2. **Cost scales with series, not artists.** One grounded billing per series (~$0.035 each) × 99 series ≈ the ¥637 spike, and series fragmentation (one Bruno Mars tour = 31 `series_id`s) multiplies it for zero added value.
+
+The rest of the feature (series-level `SalesPhase`, `(series_id, apply_start_time)` convergence, `Tracking`-journey audience, KEDA delivery) is shipped and correct; it just starves because discovery yields nothing.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Make grounding actually fire by seeding the artist's official-site URL into `URLContext`.
+- Cut grounding billings ~8× by batching one Gemini call per artist instead of per series.
+- Use no recency window at all (no `timeRangeFilter`, no announcement-date cutoff) — only the application-window filter; re-reading the live official site is safe under the idempotent upsert.
+- Preserve the shipped series-level model, upsert convergence, audience, and KEDA wiring unchanged.
+
+**Non-Goals:**
+- No protobuf/BSR change (`SalesPhase` entity is unchanged; the searcher is backend-internal).
+- No duplicate-series dedup (separate session). Artist batching mitigates its cost but does not fix fragmentation.
+- No change to the series-level `SalesPhase` shape, the `(series_id, apply_start_time)` upsert, the `Tracking`-journey audience, or notification content.
+
+## Decisions
+
+### D1. One Gemini call per artist, with the artist's series passed as input
+
+`SalesPhaseSearcher` changes from `SearchSalesPhases(artistName, seriesTitle, seriesID)` to a per-artist call that receives the artist plus an array of that artist's known upcoming series (`series_id`, title, known event dates). The structured output is an array of `{ series_id, phases[] }`; the model attributes each discovered sale to the correct `series_id` using the supplied titles/dates. The discovery use case groups upcoming series by artist (it already lists concerts per artist) and calls the searcher once per artist.
+
+- **Why:** an artist's official/FC/play-guide pages list all their tours together, so one grounded fetch per artist is both cheaper (99 → ~12 grounded billings) and more natural for grounding. It also collapses fragmented duplicate series into one call.
+- **Alternative — keep per-series, add caching:** rejected; still pays per-series grounding and does not address fragmentation.
+- **Disambiguation:** the model maps phases to `series_id` from the input array (title + known dates). A phase it cannot confidently map is dropped (never guessed onto a wrong series).
+
+### D2. Seed the official-site URL into URLContext to force real grounding
+
+Pass the artist's official-site URL (from the artist's `official_site`) in the prompt and instruct the model to extract ticket-sales info from that page (and linked ticketing pages). With a concrete URL, `URLContext` fetches real content instead of the model answering from memory.
+
+- **Why:** matches the documented combined-tool behavior — provide the URL so the model reads it rather than falling through to (non-firing) memory.
+- **URL availability:** when an artist has no official_site URL (or an empty one), skip the artist benignly (Warn) without calling the searcher — no grounding seed means no value, and the followed-artist set is not guaranteed to all have a site.
+- **`timeRangeFilter`:** keep it off / best-effort only; do not depend on it (buggy). Recency is a prompt instruction.
+
+### D3. No recency window — re-read the live official site every run
+
+The searcher does NOT filter by announcement date and does NOT use `timeRangeFilter`. The only date filter is the **application window** ("exclude sales whose application deadline is before today"), a correctness requirement (don't surface dead sales), not a freshness optimization.
+
+- **Why no incremental window:** the official site read via URLContext is a **live full-state source**, not a delta feed — an announcement-date filter would only trim the OUTPUT, not what is fetched. The dominant cost (grounding requests) is already solved by per-artist batching (D1), and the `(series_id, apply_start_time)` upsert is idempotent + last-write-wins, so re-reading the same phases every run is safe (no duplicate announcement). A hard cutoff would add a permanent-suppression risk (a phase missed once could fall outside the window forever) for negligible token savings.
+- **Considered and dropped — persisted per-artist last-searched timestamp + overlap margin:** rejected as unnecessary complexity (no search-log table, no `since`, no margin). Revisit only if output-token cost is later shown to matter, as a soft "prioritize new" hint rather than a hard cutoff. Both `timeRangeFilter` and a prompt `since` implement the same axis; neither is used.
+
+### D4. No proto change; keep everything downstream identical
+
+The searcher's input/output are backend-internal. `liverty_music.entity.v1.SalesPhase`, the `(series_id, apply_start_time)` upsert, the `Tracking`-journey audience, and KEDA wiring are untouched.
+
+- **Why:** this is a discovery-efficiency/efficacy change, not a contract change.
+
+## Risks / Trade-offs
+
+- **Artist-batched call must correctly attribute phases to `series_id`** → mitigated by passing titles + known dates and dropping unmappable phases (never guess).
+- **Larger prompt/response per call** (all series for an artist) → watch `MaxOutputTokens` (currently 16384); chunk an artist with many series if needed.
+- **Grounding may still under-fire even with a URL** (model/SDK behavior) → verify in prod with the cap raised; if so, escalate model (flash-lite → flash) as a follow-up.
+- **Prod verification needs the Gemini spend cap genuinely raised** (the prior raise did not take effect; project is at ¥2,292/¥2,000).
+
+## Migration Plan
+
+1. **backend**: refactor `SalesPhaseSearcher` to per-artist (new input/output schema, URL seeding, prompt rework, drop `timeRangeFilter` dependence); update the discovery use case to group by artist and skip artists without an official-site URL; update unit tests; `make check`.
+2. Open the backend PR; merge after CI; release `v1.10.0`; confirm the auto pin-bump (and the sales cronjobs) move to `v1.10.0`.
+3. **Prod verification** (cap raised): a discovery run grounds (>=1 `grounding.fired=true`), yields phases for tracked artists' series, publishes `SALES_PHASE.discovered`, KEDA scales the consumer, and a `Tracking` fan receives the announcement; confirm grounding billings dropped to ~1/artist.
+4. **Rollback**: revert the backend change; no schema or proto dependency downstream.
+
+## Resolved Decisions
+
+- **Recency window**: none. No `timeRangeFilter`, no announcement-date cutoff, no search-log table — only the application-window filter. (The incremental-window idea was dropped as unnecessary; see D3.)
+- **Seed URL**: resolved from the artist's `official_site`; an artist without one (or with an empty URL) is skipped benignly (the searcher is not called).
+- **Output size / chunking**: the searcher returns ONLY series for which a phase was discovered (it does not echo back all input series), so the output stays small and no per-artist chunking is required.

--- a/openspec/changes/optimize-sales-phase-searcher/proposal.md
+++ b/openspec/changes/optimize-sales-phase-searcher/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+The sales-phase searcher is both **expensive and ineffective** in production. It fires one grounded Gemini call **per series**, and prod analysis of the 2026-06-18 run showed 99 series → 99 GoogleSearch grounding billings (~¥637 for that single run) with `grounding.fired=false` on every call and **0 phases produced**. The root cause is confirmed against Google's docs: `URLContext` is enabled but no URL is ever passed, and Google Search only fires as a *fallback* when the model cannot answer from its own knowledge or a provided URL — so the model answers from memory and never grounds. Cost is further multiplied by series fragmentation (e.g. one Bruno Mars tour split across 31 `series_id`s, each separately billed).
+
+The downstream pipeline (series-level `SalesPhase`, `(series_id, apply_start_time)` convergence, `Tracking`-journey audience, KEDA-driven consumer delivery) is already shipped and correct — it just never receives real phases because discovery produces nothing. Fixing the searcher is the last missing piece for fans to actually receive sale notifications.
+
+## What Changes
+
+- **Artist-level batching**: replace the per-series Gemini call with **one call per artist**. The call receives the artist plus the artist's known upcoming series as an array (`series_id`, title, known event dates) and returns discovered sale phases mapped back to the correct `series_id`. This cuts grounding billings ~8× (99 → ~12) and collapses duplicate/fragmented series into a single call.
+- **Real grounding via seed URL + URLContext**: pass the artist's official-site URL into the prompt so `URLContext` fetches actual pages, and instruct the model to extract ticket-sales information from that source. This fixes `grounding.fired=false` / 0 results. An artist without a usable official-site URL is skipped (no seed → no value).
+- **No recency window**: drop `timeRangeFilter` (unreliable; known bug python-genai #1207) and use no announcement-date cutoff at all. The official site is a live full-state source and the `(series_id, apply_start_time)` upsert is idempotent, so re-reading every run is safe; only the application-window filter (exclude already-closed sales) applies. Gemini instructions are written in English.
+- Keep the series-level `SalesPhase` model, `(series_id, apply_start_time)` upsert convergence, `Tracking`-journey audience, and KEDA wiring exactly as shipped.
+
+## Capabilities
+
+### New Capabilities
+<!-- None: this change modifies the existing sales-phase-discovery capability only. -->
+
+### Modified Capabilities
+- `sales-phase-discovery`: the searcher changes from one grounded call **per series** to one grounded call **per artist**, taking the artist's known series as input and returning phases mapped to each `series_id`; grounding is driven by a seeded official-site URL through `URLContext` (not memory); no recency window is used (no `timeRangeFilter`, no announcement-date cutoff) and an artist without a usable official-site URL is skipped. The discovery upsert, series-level model, and announcement audience are unchanged.
+
+## Impact
+
+- **Backend**: `SalesPhaseSearcher` interface + Gemini implementation (per-artist call, English prompt, per-phase `series_id` attribution against the supplied series, URL seeding via the artist's official site, remove `timeRangeFilter`); discovery use case (group upcoming series by artist, resolve the seed URL, skip artists without one); unit tests.
+- **Database**: none (no new table or migration).
+- **cloud-provisioning**: no manifest change expected (same cronjob); confirm config keys (models/thinking) still apply.
+- **No protobuf/BSR change**: the searcher interface and entities are backend-internal; `liverty_music.entity.v1.SalesPhase` is unchanged.
+- **Cost/efficacy**: ~8× fewer grounding billings AND non-zero phase yield, so the already-wired discovery → announce/reminder → KEDA → delivery path finally produces real notifications to `Tracking` fans. (Prod verification requires the Gemini spend cap to be genuinely raised.)
+- **Out of scope**: duplicate-series dedup is investigated in a separate session; artist-level batching mitigates its cost impact but does not fix the underlying fragmentation.

--- a/openspec/changes/optimize-sales-phase-searcher/specs/sales-phase-discovery/spec.md
+++ b/openspec/changes/optimize-sales-phase-searcher/specs/sales-phase-discovery/spec.md
@@ -1,0 +1,58 @@
+## MODIFIED Requirements
+
+### Requirement: Dedicated Sales-Phase Searcher
+
+The system SHALL provide a sales-phase searcher, separate from the concert searcher, that discovers a followed artist's ticket-sales phases as series-level records. The searcher SHALL operate **per artist** (not per series): it takes an artist, the artist's seed source URL(s), and the artist's known upcoming series as input, and returns the discovered sale phases mapped back to the correct `series_id`. It SHALL NOT resolve which individual events a phase covers.
+
+The searcher SHALL ground its extraction on a **seeded source URL** (the artist's official site) supplied through the URL-context tool, rather than relying on the model's own memory. It SHALL NOT depend on the Gemini search time-range filter, and SHALL NOT restrict by announcement date — the official site is a live full-state source and re-discovered phases converge idempotently on `(series_id, apply_start_time)`, so only the application-window filter (exclude sales whose application deadline is before today) applies.
+
+#### Scenario: Search sales phases per artist
+
+- **WHEN** the searcher is invoked for an artist with that artist's known upcoming series
+- **THEN** it SHALL issue a single grounded Gemini call for the artist (not one call per series)
+- **AND** it SHALL ground the call on the artist's seeded source URL via the URL-context tool
+- **AND** it SHALL return the discovered sale phases as series-level records, each attributed to one of the supplied `series_id`s
+
+#### Scenario: Map discovered phases to the correct series
+
+- **WHEN** the searcher extracts a sale phase from the grounded source
+- **THEN** it SHALL attribute the phase to the matching input `series_id` using the supplied series titles and known event dates
+- **AND** a phase that cannot be confidently attributed to a known series SHALL be dropped rather than guessed onto a wrong series
+
+#### Scenario: No covered-event resolution
+
+- **WHEN** the searcher extracts a sale phase
+- **THEN** it SHALL NOT extract per-phase covered dates nor resolve them to the series' `event_id`s
+- **AND** each extracted phase SHALL carry only its series-level attributes (`apply_start_time` and the descriptive fields)
+
+#### Scenario: One call per artist
+
+- **WHEN** discovery processes multiple artists
+- **THEN** the searcher SHALL issue one Gemini call per artist, looping over artists (not over series)
+
+### Requirement: Scheduled Sales-Phase Discovery Job
+
+The system SHALL run a scheduled job that discovers sales phases for the upcoming series of followed artists and upserts them into storage, batching the search per artist.
+
+#### Scenario: Scheduled execution batches by artist
+
+- **WHEN** the discovery job runs on its schedule
+- **THEN** it SHALL enumerate followed artists that have upcoming series
+- **AND** for each artist, resolve the artist's official-site URL and invoke the sales-phase searcher once with that artist's known upcoming series
+- **AND** upsert the resulting sales phases, converging on `(series_id, apply_start_time)`
+
+#### Scenario: Artist without a usable official-site URL is skipped
+
+- **WHEN** an artist has no official-site URL (or an empty one)
+- **THEN** the job SHALL skip that artist without invoking the searcher (no grounding seed → no value), as a benign skip rather than an error
+
+#### Scenario: Idempotent re-run
+
+- **WHEN** the discovery job runs again over the same artists
+- **THEN** previously discovered phases SHALL converge to the same rows by matching on `(series_id, apply_start_time)`
+- **AND** no duplicate sales phases SHALL be created
+
+#### Scenario: Empty extraction does not delete
+
+- **WHEN** a run produces no phases for an artist (e.g. nothing new, grounding failure, or page unavailable)
+- **THEN** the job SHALL NOT delete previously persisted phases for that artist's series (upsert-only semantics)

--- a/openspec/changes/optimize-sales-phase-searcher/tasks.md
+++ b/openspec/changes/optimize-sales-phase-searcher/tasks.md
@@ -1,0 +1,28 @@
+## 1. Backend — searcher (per-artist + seed-URL grounding)
+
+- [x] 1.1 Change `SalesPhaseSearcher` interface from per-series to **per-artist**: input = artist name + official-site URL + the artist's known upcoming series array (`series_id`, title, known event dates); output = phases mapped to `series_id`
+- [x] 1.2 Seed the artist's official-site URL into the Step-1 prompt and pass it through the `URLContext` tool so grounding fetches real pages (fixes `grounding.fired=false`); remove the `timeRangeFilter` (unreliable, googleapis/python-genai#1207) — no recency window is used
+- [x] 1.3 Rework the Step-1 prompt: extract series-level sale phases from the seeded URL, attribute each to a supplied `series_id` (by title/known dates); keep only the application-window filter (exclude sales whose deadline is before today). Keep Step-2 date coercion (RFC 3339)
+- [x] 1.4 Add a `series_id` attribution/validation step: drop any phase that cannot be confidently mapped to a supplied series (never guess)
+- [x] 1.5 Return ONLY series for which a sale phase was discovered (do not echo back all input series); output stays small — no chunking needed
+- [x] 1.6 Author the Gemini instructions in **English** (keeping the Japanese token values the parser maps, e.g. `抽選`/`ファンクラブ`)
+
+## 2. Backend — discovery use case
+
+- [x] 2.1 Group upcoming series by **artist**; build the per-artist series array and resolve each artist's seed URL from `official_site`
+- [x] 2.2 If the artist has no official-site URL (NotFound) or an empty URL, **skip the artist benignly** (Warn) without calling the searcher; only genuine infra errors propagate
+- [x] 2.3 Call the searcher once per artist; upsert returned phases with the unchanged `(series_id, apply_start_time)` convergence; publish `SALES_PHASE.discovered` only for newly inserted phases (unchanged)
+
+## 3. Backend — tests & verification
+
+- [x] 3.1 Update searcher unit tests for the per-artist input/output and `series_id` attribution (incl. unknown-series drop)
+- [x] 3.2 Update discovery use-case tests for artist-batched invocation and the no-official-site / empty-URL skip paths
+- [x] 3.3 Run `make check` (build, vet, unit + integration tests) until green
+
+## 4. Ship to production
+
+- [ ] 4.1 Open the backend PR; merge after review and CI pass
+- [ ] 4.2 Publish the backend GitHub Release (tag `v1.10.0`); confirm the auto pin-bump moves the prod overlay — including the `sales-phase-discovery` / `sales-reminders` cronjobs — to `v1.10.0` (manually bump the two sales cronjobs if the auto pin-bump still omits them)
+- [ ] 4.3 Ensure the Gemini spend cap is genuinely raised (prior raise did not take effect; project was at ¥2,292/¥2,000) before prod verification
+- [ ] 4.4 Verify in prod: a discovery run grounds (`grounding.fired=true` ≥ 1), yields phases for tracked artists' series, publishes `SALES_PHASE.discovered`, KEDA scales the consumer, and a `Tracking` fan receives the announcement
+- [ ] 4.5 Confirm grounding billings dropped to ~1 per artist (≈8× fewer) by cross-referencing the Gemini spend with the discovery logs


### PR DESCRIPTION
## Summary

Adds the OpenSpec change artifacts for **optimize-sales-phase-searcher**, which was already implemented and shipped in backend `v1.10.0`. This is a docs-only record-keeping PR — no proto or schema changes.

## Changes

`openspec/changes/optimize-sales-phase-searcher/`:
- `proposal.md` — why/what (per-artist batching, seed-URL grounding, no recency window)
- `design.md` — design decisions
- `specs/sales-phase-discovery/spec.md` — delta spec for the modified capability
- `tasks.md` — implementation tasks (complete)

The change itself (shipped in v1.10.0):
- **Per-artist Gemini batching** — one grounded call per artist instead of per series (~8× fewer GoogleSearch billings).
- **Seed-URL + URLContext grounding** — pass the artist's official-site URL so the model fetches real pages, fixing `grounding.fired=false` / 0 results.
- **No recency window** — drop the unreliable `timeRangeFilter`; rely on the idempotent `(series_id, apply_start_time)` upsert. Gemini prompts in English.

The series-level `SalesPhase` model, upsert convergence, Tracking-journey audience, and KEDA wiring are unchanged.

## Testing

Docs only — no code. The implementation was verified in prod (notification delivered end-to-end to a tracking fan).

Refs: #571
