### PR TITLE
docs(openspec): add improve-pwa-install-signup change artifacts

### DIFF
--- a/openspec/changes/improve-pwa-install-signup/.openspec.yaml
+++ b/openspec/changes/improve-pwa-install-signup/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-22

--- a/openspec/changes/improve-pwa-install-signup/design.md
+++ b/openspec/changes/improve-pwa-install-signup/design.md
@@ -1,0 +1,63 @@
+## Context
+
+The PostSignupDialog is shown once to new users after sign-up. It currently offers a PWA install row when `PwaInstallService.canShowFab` is true — a condition that requires both onboarding completion and a captured `beforeinstallprompt` event.
+
+Two problems compound to cause the install row to intermittently not appear:
+
+**Problem 1 — Construction race**: `PwaInstallService` is a lazily-resolved DI singleton, first constructed when `PwaInstallFab` binds. `PwaInstallFab` is guarded by `if.bind="showNav"` which is `false` during the `/auth/callback` route. Chrome fires `beforeinstallprompt` early during the page load that lands on `/auth/callback` — before `PwaInstallFab` binds or `PwaInstallService` is constructed. The event is silently lost.
+
+**Problem 2 — Condition over-restriction**: Even when the event is not captured (Chrome engagement cooldown, previous dismissal, etc.), the current design hides the install row entirely. Users with a PWA-capable browser have no install path in the dialog.
+
+The `PwaInstallFab` is unaffected — it shows whenever `canShowFab` is true. FAB semantics are preserved.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Register the `beforeinstallprompt` listener before any routing by eagerly constructing `PwaInstallService` in `AppShell`
+- Show the install row in the PostSignupDialog for all PWA-capable browsers (Chrome/Edge) regardless of whether the native prompt has been captured
+- Show browser menu install instructions as fallback when the native prompt is unavailable
+- Reliably update the dialog row when the native prompt arrives after the dialog opens
+
+**Non-Goals:**
+- Change FAB behavior or `canShowFab` semantics
+- Add install guidance for browsers without `BeforeInstallPromptEvent` (Firefox, etc.)
+- Introduce a new screen or route for install instructions
+
+## Decisions
+
+### Decision: Eager construction via AppShell
+
+`AppShell` resolves `IPwaInstallService` in its class body (a private field used only for construction side-effect). `AppShell` activates before any routing, so the `beforeinstallprompt` event listener is registered before Chrome can fire the event.
+
+**Alternative considered**: Register the listener in `main.ts` before Aurelia bootstraps, storing the event in a module-level buffer. Rejected — it splits the service's construction and event handling, and `AppShell` activation already reliably precedes routing in Aurelia's lifecycle.
+
+### Decision: New `canShowInstallOption` getter — decouple dialog condition from `canShowFab`
+
+A new `canShowInstallOption` getter is added to `PwaInstallService`:
+
+```
+browserSupportsPwa     = 'BeforeInstallPromptEvent' in window
+canShowInstallOption   = !installed && browserSupportsPwa
+```
+
+The PostSignupDialog uses `canShowInstallOption` for row visibility; `canShowFab` is unchanged for the FAB. iOS is automatically excluded because iOS browsers lack `BeforeInstallPromptEvent` (`browserSupportsPwa = false`), so `!isIos` becomes implicit and no separate iOS guard is needed in the dialog.
+
+**Alternative considered**: Relax the `deferredPrompt !== null` requirement inside `canShowFab`. Rejected because `canShowFab` drives the FAB, and a FAB without `deferredPrompt` would silently no-op on tap for non-iOS. The FAB and dialog have legitimately different semantics.
+
+### Decision: Inline instruction expansion, no new bottom-sheet
+
+When the native prompt is unavailable, the install row shows a "How to add" button. Tapping it expands numbered instructions inline (browser menu → Add to Home Screen). No nested bottom-sheet.
+
+**Alternative considered**: Reuse `pwa-install-fab`'s iOS instruction sheet. Rejected — the dialog is itself a bottom-sheet; nesting creates z-index complexity. Inline expansion is simpler and consistent with the dialog's visual register.
+
+### Decision: Explicit `@watch` on `canShowFab` in PostSignupDialog
+
+`PostSignupDialog` adds `@watch((vm) => vm.pwaInstall.canShowFab)` to drive an `@observable canInstallNatively` field. The template binds to `canInstallNatively` rather than a plain getter.
+
+**Why**: `if.bind` / attribute bindings on a plain getter that traverses an injected service's `@observable` property depend on Aurelia's expression observer tracking the cross-object dependency. Explicit `@watch` on a ViewModel is guaranteed to fire synchronously on change; dirty-check polling is not.
+
+## Risks / Trade-offs
+
+- **AppShell `_pwaInstall` is "dead" from the template's perspective** — a reviewer may flag it as unused. A brief comment explains the construction-side-effect intent.
+- **Instruction row visible even during Chrome's 3-month prompt cooldown** — the fallback instructions appear, which is correct UX (the user can still install manually). The row does not promise a one-tap experience when the prompt is suppressed.
+- **Instruction steps are Chrome/Edge-centric** — Samsung Internet and other `BeforeInstallPromptEvent` browsers have similar enough menu flows ("Add to Home Screen") that the generic steps are usable.

--- a/openspec/changes/improve-pwa-install-signup/proposal.md
+++ b/openspec/changes/improve-pwa-install-signup/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+The PWA install button in the PostSignupDialog intermittently fails to appear after sign-up because `PwaInstallService` is constructed too late to capture the browser's `beforeinstallprompt` event, and the current design entirely hides the install row when the event hasn't been received — leaving users with no install path even when their browser fully supports it.
+
+## What Changes
+
+- `PwaInstallService` gains two new public getters (`browserSupportsPwa`, `canShowInstallOption`) that expose install capability independently of whether `beforeinstallprompt` has fired yet
+- `AppShell` eagerly resolves `PwaInstallService` on activation to register the `beforeinstallprompt` listener before any routing occurs (fixing the timing race)
+- `PostSignupDialog` changes its install-row condition from `canShowFab` (requires captured prompt) to `canShowInstallOption` (requires only browser support), showing a fallback instruction UI when the native prompt is unavailable
+- `PostSignupDialog` adds an explicit `@watch` on `canShowFab` to ensure reliable reactivity when the native prompt arrives after the dialog opens
+- Translation keys added for the Chrome/Edge install instruction steps
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `post-signup-dialog`: PWA install row condition changes from requiring a captured `beforeinstallprompt` event to requiring only that the browser supports the PWA install API; row shows native prompt or manual instructions depending on availability.
+
+## Impact
+
+- **Frontend only** — no backend, proto, or cloud-provisioning changes
+- `src/services/pwa-install-service.ts` — two new public getters
+- `src/app-shell.ts` — one new DI resolve for eager construction
+- `src/components/post-signup-dialog/post-signup-dialog.ts` — condition and watcher changes
+- `src/components/post-signup-dialog/post-signup-dialog.html` — conditional button/instruction rendering
+- `src/locales/ja/translation.json`, `src/locales/en/translation.json` — new `postSignup.pwaInstallGuide`, `postSignup.pwaGuideStep1-3` keys
+- Existing `pwa-install-fab` behavior is unchanged; `PwaInstallService.canShowFab` semantics are preserved for the FAB

--- a/openspec/changes/improve-pwa-install-signup/specs/post-signup-dialog/spec.md
+++ b/openspec/changes/improve-pwa-install-signup/specs/post-signup-dialog/spec.md
@@ -1,0 +1,118 @@
+## MODIFIED Requirements
+
+### Requirement: Post-Signup Dialog on First Authentication
+
+The system SHALL display a dialog after the first successful signup that consolidates a celebration message with optional power-up actions (notification permission, PWA install), without front-loading guidance for features the user has not yet encountered.
+
+#### Scenario: Dialog shown after first signup
+
+- **WHEN** the auth-callback route completes `provisionUser()` for a new user
+- **AND** `localStorage['liverty:postSignup:shown']` is not set
+- **THEN** the system SHALL set `localStorage['liverty:postSignup:shown']` to `'1'`
+- **AND** the system SHALL navigate to `/dashboard`
+- **AND** the Dashboard SHALL display the `PostSignupDialog` on load
+
+#### Scenario: Dialog not shown on subsequent logins
+
+- **WHEN** the auth-callback route completes for a returning user
+- **AND** `localStorage['liverty:postSignup:shown']` is already set
+- **THEN** the system SHALL NOT show the `PostSignupDialog`
+
+#### Scenario: Dialog content leads with celebration
+
+- **WHEN** the PostSignupDialog is displayed
+- **THEN** the first content row SHALL be a celebration message acknowledging completion of onboarding
+- **AND** it SHALL offer a notification opt-in action if `notificationManager.permission === 'default'`
+- **AND** it SHALL show a notification denied message if `notificationManager.permission === 'denied'`
+- **AND** it SHALL offer a PWA install action if `PwaInstallService.canShowInstallOption` is `true`
+- **AND** it SHALL provide a dismiss/close action in the footer
+
+#### Scenario: Footer button label when all actions are complete
+
+- **WHEN** the PostSignupDialog is displayed
+- **AND** `PwaInstallService.canShowInstallOption` is `false` (PWA already installed or browser not capable)
+- **AND** `notificationManager.permission` is `'granted'`
+- **THEN** the footer button SHALL display the label "Close"
+
+#### Scenario: Footer button label when actions remain
+
+- **WHEN** the PostSignupDialog is displayed
+- **AND** either `PwaInstallService.canShowInstallOption` is `true` OR `notificationManager.permission` is not `'granted'`
+- **THEN** the footer button SHALL display the label "Later"
+
+#### Scenario: Notification opt-in from dialog
+
+- **WHEN** the user taps the notification opt-in button in the PostSignupDialog
+- **THEN** the system SHALL call `PushService.create()` (backed by `PushNotificationService.Create` RPC)
+- **AND** the system SHALL NOT write any `localStorage` flag for push notification enabled state
+- **AND** on success, the notification row SHALL show a confirmed state
+- **AND** on failure or denial, the notification row SHALL show an error state
+- **AND** the settings page SHALL subsequently derive the toggle state from the backend via `PushNotificationService.Get` without relying on any `localStorage` flag
+
+#### Scenario: PWA install from dialog — native prompt
+
+- **WHEN** the user taps the install button in the PostSignupDialog
+- **AND** `PwaInstallService.canShowFab` is `true` (native prompt captured)
+- **THEN** the system SHALL trigger the deferred `beforeinstallprompt` event
+
+#### Scenario: PWA install row hidden on iOS Safari
+
+- **WHEN** the PostSignupDialog is displayed
+- **AND** `PwaInstallService.browserSupportsPwa` is `false` (browser lacks `BeforeInstallPromptEvent`, i.e. iOS Safari)
+- **THEN** the PWA install row SHALL NOT be shown in the dialog
+- **AND** the persistent FAB instruction sheet provides the iOS install path instead
+
+#### Scenario: Dialog dismissed
+
+- **WHEN** the user taps the dismiss button
+- **THEN** the PostSignupDialog SHALL close
+- **AND** the notification prompt SHALL NOT be shown again in the same session (coordinated via `IPromptCoordinator`)
+- **AND** the PWA install FAB SHALL remain visible (it is not affected by PostSignupDialog dismissal)
+
+## ADDED Requirements
+
+### Requirement: PWA Install Row Shows Fallback Instructions When Native Prompt Unavailable
+
+When the browser supports PWA install but the native prompt has not been captured, the PostSignupDialog SHALL show a manual install guide rather than hiding the row.
+
+#### Scenario: Install row shows "How to add" button when deferredPrompt is absent
+
+- **WHEN** the PostSignupDialog is displayed
+- **AND** `PwaInstallService.canShowInstallOption` is `true` (browser supports PWA install)
+- **AND** `PwaInstallService.canShowFab` is `false` (native prompt not yet captured)
+- **THEN** the install row SHALL display a "How to add" button instead of the native install button
+
+#### Scenario: Tapping "How to add" reveals inline instructions
+
+- **WHEN** the user taps the "How to add" button in the install row
+- **THEN** the install row SHALL expand to show numbered steps for browser-menu-based installation:
+  1. Open the browser menu (⋮)
+  2. Select "Add to Home Screen"
+  3. Tap "Add" to finish
+- **AND** the "How to add" button SHALL be replaced by the expanded steps
+
+#### Scenario: Install row reactively upgrades to native button on prompt arrival
+
+- **WHEN** the PostSignupDialog is open
+- **AND** the browser fires `beforeinstallprompt` (native prompt arrives after dialog opened)
+- **THEN** `PwaInstallService.canShowFab` becomes `true`
+- **AND** the install row SHALL update reactively to show the native install button
+- **AND** the fallback instruction content SHALL be replaced by the native install button
+
+### Requirement: PwaInstallService Registers beforeinstallprompt Listener Before Routing
+
+The `PwaInstallService` event listener for `beforeinstallprompt` SHALL be registered before any route navigation begins, so that the event is not missed during the OIDC auth-callback page load.
+
+#### Scenario: Listener registered before auth-callback navigation
+
+- **WHEN** the application boots and `AppShell` activates
+- **THEN** `PwaInstallService` SHALL be constructed as part of `AppShell` activation
+- **AND** the `beforeinstallprompt` event listener SHALL be registered before any route transition begins
+- **AND** any `beforeinstallprompt` event fired during the `/auth/callback` route SHALL be captured
+
+#### Scenario: Install row shows native button when prompt captured during auth-callback
+
+- **WHEN** Chrome fires `beforeinstallprompt` during the `/auth/callback` page load
+- **AND** the user completes sign-up and the PostSignupDialog opens on the dashboard
+- **THEN** `PwaInstallService.canShowFab` SHALL be `true`
+- **AND** the PostSignupDialog SHALL display the native install button in the install row

--- a/openspec/changes/improve-pwa-install-signup/tasks.md
+++ b/openspec/changes/improve-pwa-install-signup/tasks.md
@@ -1,0 +1,58 @@
+## 1. PwaInstallService — New Public Getters
+
+- [ ] 1.1 Add `browserSupportsPwa` getter: returns `'BeforeInstallPromptEvent' in window`
+- [ ] 1.2 Add `canShowInstallOption` getter: returns `!this.installed && this.browserSupportsPwa`
+- [ ] 1.3 Add unit tests for `browserSupportsPwa` (true when `BeforeInstallPromptEvent` in window, false otherwise)
+- [ ] 1.4 Add unit tests for `canShowInstallOption` (true when not installed + browser supports; false when installed; false when browser unsupported)
+
+## 2. AppShell — Eager Construction
+
+- [ ] 2.1 Add `private readonly _pwaInstall = resolve(IPwaInstallService)` to `AppShell` class body
+- [ ] 2.2 Add a brief comment explaining the field exists to register the `beforeinstallprompt` listener before routing
+
+## 3. PostSignupDialog — Condition & Watcher Refactor
+
+- [ ] 3.1 Change `canInstallPwa` getter to use `this.pwaInstall.canShowInstallOption` (drop `canShowFab` + `!isIos`)
+- [ ] 3.2 Add `@observable public canInstallNatively = false` field
+- [ ] 3.3 Add `@watch((vm: PostSignupDialog) => vm.pwaInstall.canShowFab)` → setter that updates `canInstallNatively`
+- [ ] 3.4 Initialise `canInstallNatively` in `binding()` from `this.pwaInstall.canShowFab && !this.pwaInstall.isIos`
+- [ ] 3.5 Add `public isInstallGuideOpen = false` field
+- [ ] 3.6 Add `public onShowInstallGuide(): void` method that sets `isInstallGuideOpen = true`
+- [ ] 3.7 Update `isAllDone` getter: replace `!this.canInstallPwa` reference to use `!this.pwaInstall.canShowInstallOption`
+- [ ] 3.8 Update unit tests: add cases for `canInstallPwa = true` when `canShowInstallOption = true` but `canShowFab = false`
+- [ ] 3.9 Add unit tests for `canInstallNatively` watcher (starts false; becomes true when canShowFab changes to true)
+- [ ] 3.10 Add unit tests for `onShowInstallGuide` setting `isInstallGuideOpen = true`
+
+## 4. PostSignupDialog Template
+
+- [ ] 4.1 Update `if.bind="canInstallPwa"` on the install row (condition now driven by `canShowInstallOption`)
+- [ ] 4.2 Split install row button into two branches:
+  - Native branch: `if.bind="canInstallNatively"` → existing `busy-on-click.bind="() => onInstallPwa()"` button with `t="postSignup.pwaInstall"`
+  - Fallback branch: `if.bind="!canInstallNatively && !isInstallGuideOpen"` → button with `click.trigger="onShowInstallGuide()"` and `t="postSignup.pwaInstallGuide"`
+- [ ] 4.3 Add inline instruction list: `if.bind="isInstallGuideOpen"` with `<ol class="post-signup-install-steps">` containing three `<li>` items bound to `postSignup.pwaGuideStep1/2/3`
+
+## 5. Styles
+
+- [ ] 5.1 Add `.post-signup-install-steps` to `post-signup-dialog.css`: list-style with left padding, readable line-height, consistent font-size with other row body text
+
+## 6. Translations
+
+- [ ] 6.1 Add to `locales/ja/translation.json` under `postSignup`:
+  - `"pwaInstallGuide": "追加方法を見る"`
+  - `"pwaGuideStep1": "ブラウザ右上のメニュー（⋮）をタップ"`
+  - `"pwaGuideStep2": "「ホーム画面に追加」を選択"`
+  - `"pwaGuideStep3": "「追加」をタップして完了"`
+- [ ] 6.2 Add matching keys to `locales/en/translation.json` under `postSignup`:
+  - `"pwaInstallGuide": "How to add"`
+  - `"pwaGuideStep1": "Tap the menu (⋮) in your browser"`
+  - `"pwaGuideStep2": "Select \"Add to Home Screen\""`
+  - `"pwaGuideStep3": "Tap \"Add\" to finish"`
+
+## 7. Verification
+
+- [ ] 7.1 Run `make check` (lint + unit tests) in the frontend repo — all green
+- [ ] 7.2 Manually verify on Chrome Android (or DevTools mobile emulation): sign up → celebration → dialog shows install row → tapping "ホーム画面に追加" triggers native prompt
+- [ ] 7.3 Manually verify fallback path: clear site data, block `beforeinstallprompt` (disable in DevTools Application → Manifest → "Add to homescreen"), sign up → dialog shows "追加方法を見る" → tapping expands inline steps
+- [ ] 7.4 Manually verify iOS: sign up → dialog has no install row → FAB is visible
+- [ ] 7.5 Open PR targeting `frontend/main`, link this change
+- [ ] 7.6 Ship to prod via standard frontend release process


### PR DESCRIPTION
## Summary

- Add OpenSpec change artifacts for `improve-pwa-install-signup`
- Proposal, design, spec delta (`post-signup-dialog`), and tasks covering the two root causes of the intermittent PWA install button bug in PostSignupDialog

## Changes

**proposal.md** — defines the problem (construction timing race + over-restrictive condition) and scope (frontend-only)

**design.md** — three decisions: AppShell eager construction, new `canShowInstallOption` getter decoupled from `canShowFab`, inline instruction expansion with explicit `@watch`

**specs/post-signup-dialog/spec.md** — delta spec:
- MODIFIED: install row condition `canShowFab` → `canShowInstallOption`; footer label scenarios updated
- ADDED: fallback instruction requirement; early listener registration requirement

**tasks.md** — 22 tasks across 7 groups (service getters → AppShell → dialog TS → template → CSS → translations → verification)

## Close

close: #632
