### PR TITLE
docs(openspec): add group-approval-queue-by-series change artifacts

### DIFF
--- a/openspec/changes/group-approval-queue-by-series/.openspec.yaml
+++ b/openspec/changes/group-approval-queue-by-series/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-22

--- a/openspec/changes/group-approval-queue-by-series/design.md
+++ b/openspec/changes/group-approval-queue-by-series/design.md
@@ -1,0 +1,84 @@
+## Context
+
+The approval-queue screen (`admin/approval-queue/`) renders a flat `<table>` over a
+`QueueRow[]` array derived from `PendingConcert[]`. The approved-concerts screen
+(`admin/approved-concerts/`) already groups a flat `Concert[]` list into
+`ArtistGroup → SeriesGroup → ConcertRow[]` using `groupByArtistAndSeries()` and
+renders it with `<details>` elements.
+
+`PendingConcert` exposes `performer.name` (artist) and `title` (tour/show name), which
+serve as natural grouping keys equivalent to `performers[0].name` and `series.title`
+used in the approved-concerts page. No `series.id` is present on `PendingConcert`
+because series entities are created during approval; the title is the only series
+identity available at staging time.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Group pending concerts by artist then by title in the approval-queue UI.
+- Show unresolved-venue count per series in the collapsed summary so reviewers can
+  triage without expanding every group.
+- Preserve per-row Approve / Reject (with reason inline form) unchanged.
+- Reuse the `<details>` / `<summary>` pattern already established on approved-concerts.
+
+**Non-Goals:**
+- Bulk approve-all / reject-all per series (deferred; adds rubber-stamp risk).
+- Proto or backend changes (no new fields needed).
+- Grouping by series ID (unavailable on `PendingConcert`; title is sufficient).
+
+## Decisions
+
+### Decision: Group by `title` as series proxy (no proto change)
+
+**Choice:** Use `PendingConcert.title.value` as the series grouping key within each
+artist bucket, mirroring how `Concert.series.title` is used on approved-concerts.
+
+**Rationale:** `title` is described in the proto comment as "the tour or show name"
+and is set from the AI-extracted series title at staging time. Introducing a
+`series_id` on `PendingConcert` would require a proto change, BSR generation, and a
+backend join — disproportionate cost for a display-only feature. Title-based grouping
+is consistent with how approved-concerts falls back when `series.id` is absent.
+
+**Risk:** AI extraction may produce slightly different title strings for the same tour
+across separate discovery runs (e.g., casing or punctuation variation). In practice,
+concerts from a single discovery batch share a normalised title; cross-batch variation
+is rare and the grouping degrades gracefully (two groups instead of one).
+
+### Decision: `unresolvedCount` surfaced in series summary
+
+**Choice:** Compute the count of rows without a resolved venue (`hasResolvedVenue === false`)
+at group-build time and display it in the `<summary>` (e.g., "⚠ 2 unresolved venues").
+
+**Rationale:** Unresolved venues are the primary reason a reviewer needs to inspect
+individual rows. Surfacing the count at the collapsed level lets a reviewer skip
+fully-resolved series quickly.
+
+### Decision: No `<details open>` by default
+
+**Choice:** All series groups are collapsed on load.
+
+**Rationale:** The queue may contain many series. Expanding all by default re-creates
+the cognitive load problem the grouping is meant to solve. A reviewer opens only the
+series they need to inspect.
+
+### Decision: Reuse `groupByArtistAndSeries` pattern, not the function itself
+
+**Choice:** Implement a parallel `groupQueueByArtistAndSeries` function in
+`approval-queue-route.ts` rather than extracting a shared utility.
+
+**Rationale:** The two pages have different row types (`QueueRow` vs `ConcertRow`) and
+different source types (`PendingConcert` vs `Concert`). A shared generic would require
+type parameters or duck-typing that adds complexity without proportional benefit.
+The algorithm is short (~30 lines); duplication is intentional here.
+
+## Risks / Trade-offs
+
+- **Title variation across discovery batches** → Degrades to extra groups rather than
+  breaking; acceptable given the queue lifecycle (batches are reviewed promptly).
+- **Large queue size** → Collapse-by-default mitigates; no virtual-scroll needed at
+  expected queue sizes.
+
+## Migration Plan
+
+Frontend-only change; no database migration or proto release required. Deployed as a
+standard frontend release.

--- a/openspec/changes/group-approval-queue-by-series/proposal.md
+++ b/openspec/changes/group-approval-queue-by-series/proposal.md
@@ -1,0 +1,36 @@
+## Why
+
+The approval-queue screen presents pending concerts as a flat table, so a 20-date tour
+from the same artist appears as 20 separate rows with repeated Artist and Title columns.
+This makes triage slow: a reviewer must scroll through identical context to find the
+one row whose resolved venue needs attention. The approved-concerts screen already solves
+this with artist → series grouping, and the same pattern should apply to the queue.
+
+## What Changes
+
+- The approval-queue UI groups `PendingConcert` rows by performing artist and then by
+  title (which serves as the series proxy for staged concerts).
+- Each series is a collapsible `<details>` element whose summary shows the series title,
+  date count, and an unresolved-venue count so reviewers can prioritise without expanding.
+- The Artist and Title columns are removed from the inner table and promoted to group
+  headers, making the per-row data narrower and easier to scan.
+- Per-row Approve and Reject (with reason) actions are preserved unchanged; no bulk
+  series-level actions are introduced.
+
+## Capabilities
+
+### New Capabilities
+
+_(none)_
+
+### Modified Capabilities
+
+- `concert-approval-queue`: The admin console UI requirement changes to require that
+  pending concerts are displayed grouped by artist and then by series title, matching the
+  approved-concerts grouping pattern.
+
+## Impact
+
+- **Frontend** (`admin/approval-queue/`): `approval-queue-route.ts`, `.html`, `.css` —
+  grouping logic and template restructured; no RPC changes.
+- **Backend / specification / proto**: no changes.

--- a/openspec/changes/group-approval-queue-by-series/specs/concert-approval-queue/spec.md
+++ b/openspec/changes/group-approval-queue-by-series/specs/concert-approval-queue/spec.md
@@ -1,0 +1,48 @@
+## MODIFIED Requirements
+
+### Requirement: Admin console approval-queue UI
+
+The admin console SHALL provide a reviewer screen that lists pending concerts grouped
+first by performing artist and then by series title, and offers per-concert approve and
+reject (with reason) actions. The screen SHALL live in the bundle-isolated `admin/` app
+and SHALL consume the admin `ConcertService`. Grouping SHALL be computed client-side
+from the flat `ListPending` result using the `PendingConcert.performer.name` and
+`PendingConcert.title` fields as grouping keys (artist and series proxy respectively).
+
+Each series group SHALL be presented as a collapsible disclosure. The collapsed summary
+SHALL show the series title, the count of pending concerts in the group, and the count
+of concerts with an unresolved venue. Individual concert rows within an expanded group
+SHALL retain the full set of reviewable fields (local date, start time, listed venue
+name, resolved venue, source URL, discovered timestamp) and their per-row approve and
+reject controls. The Artist and Title columns SHALL NOT be repeated inside the group
+table; they are conveyed by the group headers.
+
+#### Scenario: Reviewer sees pending concerts grouped by artist and series
+
+- **WHEN** an authenticated developer opens the approval-queue screen
+- **THEN** the pending concerts SHALL be displayed grouped first by performing artist
+- **AND** within each artist they SHALL be grouped into collapsible series using the
+  concert title as the series proxy
+- **AND** each collapsed series summary SHALL show the series title, the number of
+  pending concerts in the group, and the number with an unresolved venue
+
+#### Scenario: Expanding a series reveals per-concert review rows
+
+- **WHEN** the developer expands a series group
+- **THEN** each pending concert in that series SHALL be listed showing local date,
+  start time, listed venue name, resolved venue (or unresolved indicator), source
+  URL, and discovered timestamp
+- **AND** each row SHALL expose Approve and Reject controls
+
+#### Scenario: Reviewer approves an item
+
+- **WHEN** the developer approves a pending concert
+- **THEN** the UI SHALL call `Approve` and remove the row from its series group on success
+- **AND** if the series group becomes empty it SHALL be removed from the UI
+
+#### Scenario: Reviewer rejects an item with a reason
+
+- **WHEN** the developer rejects a pending concert and provides a reason
+- **THEN** the UI SHALL call `Reject` with that reason and remove the row from its
+  series group on success
+- **AND** if the series group becomes empty it SHALL be removed from the UI

--- a/openspec/changes/group-approval-queue-by-series/tasks.md
+++ b/openspec/changes/group-approval-queue-by-series/tasks.md
@@ -1,7 +1,7 @@
 ## 1. ViewModel — grouping logic
 
 - [ ] 1.1 Add `PendingSeriesGroup` and `PendingArtistGroup` interfaces to `approval-queue-route.ts`
-- [ ] 1.2 Implement `groupQueueByArtistAndSeries(concerts: PendingConcert[]): PendingArtistGroup[]` in `approval-queue-route.ts`, grouping by `performer.name` then `title.value`, computing `dateRange` and `unresolvedCount` per series
+- [ ] 1.2 Implement `groupQueueByArtistAndSeries(concerts: PendingConcert[]): PendingArtistGroup[]` in `approval-queue-route.ts`, grouping by `performer.name` then `title.value`, computing `dateCount` and `unresolvedCount` per series
 - [ ] 1.3 Replace `rows: QueueRow[]` with `groups: PendingArtistGroup[]` on `ApprovalQueueRoute`; update `attached()` / `load()` to call the grouping function
 - [ ] 1.4 Update `isEmpty` getter to check `groups.length` instead of `rows.length`
 - [ ] 1.5 Update `approve()`, `startReject()`, `cancelReject()`, `confirmReject()` to remove a row and prune empty series/artist groups (mirrors `removeRow` pattern in `approved-concerts-route.ts`)

--- a/openspec/changes/group-approval-queue-by-series/tasks.md
+++ b/openspec/changes/group-approval-queue-by-series/tasks.md
@@ -1,0 +1,23 @@
+## 1. ViewModel — grouping logic
+
+- [ ] 1.1 Add `PendingSeriesGroup` and `PendingArtistGroup` interfaces to `approval-queue-route.ts`
+- [ ] 1.2 Implement `groupQueueByArtistAndSeries(concerts: PendingConcert[]): PendingArtistGroup[]` in `approval-queue-route.ts`, grouping by `performer.name` then `title.value`, computing `dateRange` and `unresolvedCount` per series
+- [ ] 1.3 Replace `rows: QueueRow[]` with `groups: PendingArtistGroup[]` on `ApprovalQueueRoute`; update `attached()` / `load()` to call the grouping function
+- [ ] 1.4 Update `isEmpty` getter to check `groups.length` instead of `rows.length`
+- [ ] 1.5 Update `approve()`, `startReject()`, `cancelReject()`, `confirmReject()` to remove a row and prune empty series/artist groups (mirrors `removeRow` pattern in `approved-concerts-route.ts`)
+
+## 2. Template — grouped layout
+
+- [ ] 2.1 Replace flat `<table repeat.for="row of rows">` with artist `<section>` / series `<details>` / inner `<table>` structure
+- [ ] 2.2 Remove Artist and Title columns from the inner table; promote them to group headers
+- [ ] 2.3 Add `<summary>` showing series title, date count, and unresolved-venue count (`⚠ N unresolved`)
+- [ ] 2.4 Preserve all remaining inner-table columns (Local date, Start time, Listed venue, Resolved venue, Source, Discovered, Actions) and the inline reject form
+
+## 3. Styles
+
+- [ ] 3.1 Add styles for artist heading, series `<details>` / `<summary>`, and unresolved-venue badge in `approval-queue-route.css` (follow the pattern in `approved-concerts-route.css`)
+
+## 4. Tests
+
+- [ ] 4.1 Update or replace the existing `approval-queue-route` unit tests to cover: grouping of concerts by artist and title, `unresolvedCount` computation, row removal pruning empty series/artist groups
+- [ ] 4.2 Run `make check` and confirm lint + tests pass


### PR DESCRIPTION
## Summary

Adds OpenSpec change artifacts for grouping the admin console approval-queue screen by artist and series, matching the pattern already in use on the approved-concerts screen.

- **Proposal**: motivates the change — flat queue makes multi-date tours hard to triage; frontend-only fix using existing `PendingConcert.performer.name` and `title` fields as grouping keys
- **Design**: documents key decisions — `title` as series proxy (no proto change needed), `unresolvedCount` in series summary, `<details>` collapsed-by-default, parallel grouping function rather than shared utility
- **Delta spec** (`concert-approval-queue`): modifies the "Admin console approval-queue UI" requirement to require artist → series grouping and unresolved-venue count in the collapsed summary
- **Tasks**: 4 phases covering ViewModel, template, CSS, and tests (12 tasks total)

## Changes

- `openspec/changes/group-approval-queue-by-series/proposal.md`
- `openspec/changes/group-approval-queue-by-series/design.md`
- `openspec/changes/group-approval-queue-by-series/specs/concert-approval-queue/spec.md`
- `openspec/changes/group-approval-queue-by-series/tasks.md`

## Testing

Specification-only change (OpenSpec artifacts). No proto files modified; `buf lint` / `buf breaking` are not exercised.

## Related

Refs: #634
