### PR TITLE
docs(openspec): add zitadel-wedge-self-healing change

### DIFF
--- a/openspec/changes/zitadel-wedge-self-healing/.openspec.yaml
+++ b/openspec/changes/zitadel-wedge-self-healing/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-23

--- a/openspec/changes/zitadel-wedge-self-healing/design.md
+++ b/openspec/changes/zitadel-wedge-self-healing/design.md
@@ -1,0 +1,76 @@
+## Context
+
+Self-hosted Zitadel (`ghcr.io/zitadel/zitadel:v4.14.0`, 1 prod replica, `db-f1-micro` Cloud SQL) periodically hits an in-process projection-trigger wedge (zitadel/zitadel#10103). When wedged, every auth-flow query that triggers-on-read a projection hangs until the gateway times out (504), but all health/diagnostic surfaces stay green:
+
+```
+healthy & green during wedge          wedged (hangs 20s → 504)
+/debug/healthz       200 0.1s         /oauth/v2/authorize   (auth-request projection)
+/debug/ready         200 0.1s         searchProjectRoles    (project_roles projection)
+/.well-known/openid  200 0.1s         → token/userinfo role assertion
+```
+
+Because liveness/readiness only check `/debug/*`, Kubernetes never restarts the wedged pod; recovery is a manual `kubectl rollout restart`. The 2026-06-23 incident ran ~13 min until a human restarted. This design adds an in-cluster self-healing loop so the wedge auto-recovers, and removes the single-replica SPOF — entirely in `cloud-provisioning` (no runtime code change).
+
+Empirical findings that shaped the design (verified 2026-06-23 against prod):
+- `/oauth/v2/authorize` with **valid** params (prod consumer client `373015520582107291`, redirect `https://liverty-music.app/auth/callback`) returns **302 in ~0.2s** healthy and **hangs ≥ gateway timeout** when wedged.
+- The same endpoint with **invalid/missing** params returns **400 in ~0.15s** — param validation runs *before* the wedged projection code, so a probe must use valid params to reach (and detect) the wedge.
+- The OTLP collector's `filter/drop_workload_noise` drops `^rpc\.server\..*$`, and the dormant OIDCService latency alert is commented out because the metric is absent and a missing-metric AlertPolicy 404s the whole prod `pulumi up`. → a metric-based notification alert is not viable cheaply; deferred.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Auto-recover from the wedge without human action, target time-to-recovery ≤ ~2 min.
+- Detect the wedge via a signal that actually exercises the wedged auth-flow path (not `/debug/*`).
+- Limit blast radius to a single pod (prod ≥2 replicas, non-disruptive restarts).
+- Be conservative: no restart-looping of a healthy pod; reuse the proven dev CronJob pattern; introduce no compiled application.
+
+**Non-Goals:**
+- Fixing zitadel#10103 upstream (tracked separately; this bounds impact only).
+- A notification AlertPolicy (deferred — see Context; the metric is dropped at the collector).
+- Changing Cloud SQL tier (`db-f1-micro`) — confirmed not the cause (DB clean, connections flat).
+- Any `backend`/`frontend`/`specification`-runtime change.
+
+## Decisions
+
+### D1. Detection signal: `curl /oauth/v2/authorize` with valid params, guarded by `/debug/healthz`
+The watchdog issues `curl --max-time T` to `/oauth/v2/authorize?...` with valid prod-consumer params and treats a **timeout (curl exit / HTTP 000)** as the wedge signal; a `302` is healthy. To avoid restarting during unrelated outages, it first confirms `/debug/healthz` returns `200` — the wedge signature is specifically "core health green **and** authorize hung". Alternatives considered:
+- `/debug/healthz` / `/debug/ready` only — **rejected**: stay 200 during the wedge (root of the gap).
+- `/oauth/v2/authorize` with *invalid* params — **rejected**: returns 400 *before* the wedged code, so it can never detect the wedge.
+- Pointing a **Kubernetes liveness probe** at authorize — **rejected**: an httpGet liveness treats `400` as failure (so a misconfigured/expired client → restart loop), cannot distinguish a hang from a fast error, and fires a write side-effect every probe period. A CronJob with `curl` can match the *hang* specifically and probe far less often.
+
+### D2. Remediation mechanism: small CronJob (curl + kubectl), reusing the dev restart pattern
+A CronJob runs every ~1 min (`concurrencyPolicy: Forbid`), probes N times within one run (e.g. 3 probes ~5s apart), and runs `kubectl rollout restart deploy/zitadel-api` only if **all N hang**. It is the same shape as the existing dev `cronjob-restart-zitadel.yaml` (image with `kubectl`, dedicated ServiceAccount + Role scoped to `deployments` get/patch in the `zitadel` namespace) — just trigger-on-hang instead of weekly-timer. No compiled application. Rejected: a separate controller/Deployment (heavier, stateful) and an alert-driven webhook remediation (depends on the dropped-metric alert path).
+
+### D3. False-restart guards (stateless)
+- **N-of-N in-run hangs** (a single transient blip never restarts).
+- **`/debug/healthz`=200 precondition** (don't restart during a full outage / network failure where restart wouldn't help).
+- **`concurrencyPolicy: Forbid`** (no overlapping runs).
+- No stateful cooldown/counter: a `rollout restart` reliably clears #10103, and `maxUnavailable: 0` rolling on 2 replicas keeps it non-disruptive, so a re-run after a genuine still-wedged state legitimately restarts again rather than masking a persistent failure.
+
+### D4. Prod replica posture: explicit ≥2 replicas
+The prod overlay SHALL explicitly set `replicaCount: 2` and PDB `minAvailable: 1` (base is single-replica for dev cost-simplicity). Anti-affinity is *not* required for this change: the wedge is per-process, so two replicas on any node(s) already give login redundancy; node-failure topology is a separate concern (and base dropped anti-affinity due to the Autopilot CPU-≥500m constraint at this resource size). Note the nuance: readiness (`/debug/ready`) does **not** drain a wedged-but-ready pod, so 2 replicas alone do not auto-heal — they bound blast radius and make the watchdog's rolling restart non-disruptive. Replicas and watchdog are complementary.
+
+### D5. No notification alert (this change)
+Dropped per Context: the latency metric is filtered at the collector and the AlertPolicy 404s the prod stack when the metric is absent. With the watchdog auto-recovering, notification is deferred to a follow-up that can use a viable signal (e.g. a log-based metric on the watchdog's restart action, or Gateway 504 rate).
+
+## Risks / Trade-offs
+
+- **Watchdog restart-loops a healthy pod** → Mitigation: N-of-N in-run hangs + `/debug/healthz`=200 guard + `concurrencyPolicy: Forbid`; probe timeout tuned above normal latency (~0.2s) but below the gateway timeout.
+- **Probe side-effect: ~1440 throwaway auth-request event-streams/day** in the eventstore, adding minor load to the very projection path that wedges → Mitigation: 1/min cadence (not per-liveness-tick); read-only probe target is a documented follow-up.
+- **Hardcoded prod consumer `client_id`/`redirect_uri`** could break the probe if the consumer app is reprovisioned → Mitigation: documented in the manifest + runbook; a dedicated long-lived "probe" OIDC client is a possible hardening.
+- **Probe goes through the public gateway**, so a gateway/DNS outage reads as a hang → Mitigation: the `/debug/healthz`=200 guard (served over the same gateway) gates the restart; if the gateway is down, healthz also fails and no restart fires.
+- **New container image** (needs both `curl` and `kubectl`) → Mitigation: pin a well-known image at the cluster k8s minor (e.g. `alpine/k8s:1.32.x`), matching the dev CronJob's intent.
+
+## Migration Plan
+
+1. Bump prod `zitadel-api` to 2 replicas + PDB `minAvailable: 1` (independent, low risk).
+2. Add the watchdog CronJob + RBAC to the prod overlay in **dry-run/observe mode** (probe + log the decision, but skip the `rollout restart`) for one soak window to confirm zero false positives.
+3. Flip the watchdog to active (restart-enabled) once dry-run shows clean probing.
+
+Rollback: each step is independently revertible — scale back to 1, or `suspend: true` the CronJob to disable auto-restart instantly without deleting it.
+
+## Open Questions
+
+- Read-only probe target that still triggers the wedged projection (to eliminate the auth-request side-effect)?
+- Should the follow-up notification alert use a watchdog-restart log-based metric or Gateway 504 rate?
+- Is a dedicated long-lived "probe" OIDC client worth provisioning to decouple the watchdog from the consumer app's `client_id`?

--- a/openspec/changes/zitadel-wedge-self-healing/proposal.md
+++ b/openspec/changes/zitadel-wedge-self-healing/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+On 2026-06-23 production hosted login was fully down for ~13 minutes (05:47–06:00 UTC): the self-hosted Zitadel API hit a projection-trigger wedge (upstream zitadel/zitadel#10103, unfixed in v4.14.0) where an in-process trigger-on-read deadlock hung every auth-flow query (`/oauth/v2/authorize`, `searchProjectRoles`) while `/debug/healthz`, `/debug/ready`, OIDC discovery, and static assets all stayed 200/fast. Two latent gaps turned a known, self-recoverable bug into a manual outage:
+
+1. **No self-healing** — the wedge clears only on `kubectl rollout restart deploy/zitadel-api`. Liveness (`/debug/healthz`) and readiness (`/debug/ready`) both keep returning 200 during the wedge, so Kubernetes never restarts the wedged pod. Recovery required a human; the outage ran until one restarted it by hand.
+2. **Single point of failure** — prod `zitadel-api` runs **1 replica**, so a single wedged process = total login outage with no replica to absorb traffic during recovery.
+
+This is the second recurrence of this incident class; restarting by hand when a user complains is not an acceptable steady state.
+
+## What Changes
+
+- Add a **self-healing watchdog** — a small in-cluster CronJob (the same pattern as the existing dev weekly-restart CronJob: `curl` + `kubectl`, no compiled application) that probes a real auth-flow endpoint and, on a sustained hang, automatically runs `rollout restart deploy/zitadel-api`. This converts a multi-minute manual outage into unattended recovery within ~2 minutes.
+- Bring **prod `zitadel-api` to ≥2 replicas** so a single-process wedge degrades rather than fully outages login, and the watchdog's rolling restart is non-disruptive.
+
+Explicitly **out of scope** (decided during exploration): a notification AlertPolicy. The previously-specced OIDCService p99-latency alert depends on `rpc.server.duration`, which the OTLP collector intentionally drops for cost (`filter/drop_workload_noise`), so it cannot fire without re-enabling that metric; with the watchdog auto-recovering, a notification alert is deferred to a follow-up.
+
+## Capabilities
+
+### New Capabilities
+<!-- none — the self-healing behavior extends the existing deployment capability rather than introducing a new bounded capability. -->
+
+### Modified Capabilities
+- `zitadel-self-hosted-deployment`: add a requirement for the in-cluster self-healing watchdog (auth-flow hang probe → automatic `zitadel-api` restart), and tighten the resilient-scheduling requirement so the **prod** overlay explicitly runs ≥2 `zitadel-api` replicas and so wedge-recovery is delegated to the watchdog (readiness cannot detect the wedge).
+
+## Impact
+
+- **Repo**: `cloud-provisioning` only (Kustomize overlay for `zitadel` prod: a watchdog CronJob + RBAC, and a `replicaCount`/PDB bump). No `backend`/`frontend`/`specification`-runtime code changes.
+- **Cluster**: prod `zitadel` namespace — one new CronJob workload + a dedicated ServiceAccount/Role/RoleBinding scoped to restarting the `zitadel-api` Deployment, plus a second `zitadel-api` replica.
+- **Cost**: marginal (a 1/min short-lived CronJob pod + one extra zitadel-api replica on the shared Spot pool).
+- **Side effect**: the probe hits `/oauth/v2/authorize` with valid params, creating a short-lived throwaway auth request per probe (~1440/day) in the eventstore. Acceptable pre-launch; a read-only probe target is a documented follow-up.
+- **Risk**: a mis-tuned watchdog could restart-loop. Mitigated by requiring N consecutive in-run hangs, a `/debug/healthz`=200 guard (only the wedge signature triggers a restart), and `concurrencyPolicy: Forbid`. Detailed in design.md.
+- **Upstream**: does not fix zitadel#10103; it bounds the operational impact until an upstream fix is pinned.

--- a/openspec/changes/zitadel-wedge-self-healing/specs/zitadel-self-hosted-deployment/spec.md
+++ b/openspec/changes/zitadel-wedge-self-healing/specs/zitadel-self-hosted-deployment/spec.md
@@ -1,0 +1,69 @@
+## ADDED Requirements
+
+### Requirement: Self-healing watchdog auto-restarts a wedged Zitadel API
+
+The prod environment SHALL run an in-cluster watchdog that detects the Zitadel projection-trigger wedge (zitadel/zitadel#10103) and automatically restarts the `zitadel-api` Deployment without operator action. The watchdog SHALL be a Kubernetes `CronJob` modeled on the existing dev restart CronJob pattern (a container image carrying `curl` and `kubectl`, plus a dedicated ServiceAccount and a `Role`/`RoleBinding` scoped to `get`/`patch` on the `zitadel-api` Deployment in the `zitadel` namespace only) — NOT a compiled application.
+
+The watchdog SHALL detect the wedge using an **auth-flow signal that exercises the wedged trigger-on-read path**, NOT a `/debug/healthz` or `/debug/ready` check (both return 200 during the wedge). The reference signal is an HTTP `GET` to `/oauth/v2/authorize` with **valid** OIDC parameters (a registered prod client id + redirect uri) that returns a `302` quickly when healthy and hangs past the gateway timeout when wedged. Invalid parameters SHALL NOT be used because they return `400` before the wedged code path and cannot detect the wedge.
+
+The watchdog SHALL be **conservative against false restarts**:
+- It SHALL restart only after **N consecutive hanging probes within a single run** (no single transient blip triggers a restart).
+- It SHALL restart only when `/debug/healthz` returns `200` at probe time (the wedge signature is "core healthy AND auth-flow hung"); if core health is also failing it SHALL NOT restart, since the fault is not the wedge.
+- It SHALL use `concurrencyPolicy: Forbid` so runs never overlap.
+
+#### Scenario: Wedged pod is auto-restarted
+
+- **WHEN** `/oauth/v2/authorize` (valid params) hangs past the gateway timeout for N consecutive probes in one run while `/debug/healthz` returns 200
+- **THEN** the watchdog SHALL run the equivalent of `kubectl rollout restart deploy/zitadel-api` in the `zitadel` namespace
+- **AND** a fresh `/oauth/v2/authorize` SHALL return `302` within normal latency after the new pod becomes Ready
+
+#### Scenario: Transient blip does not trigger a restart
+
+- **WHEN** a single probe in a run hangs but the remaining probes in the same run return `302`
+- **THEN** the watchdog SHALL NOT restart the Deployment
+
+#### Scenario: Full outage (core health down) does not trigger a restart
+
+- **WHEN** the authorize probe fails AND `/debug/healthz` does not return 200 (e.g. gateway/DNS outage, pod not running)
+- **THEN** the watchdog SHALL NOT restart the Deployment, because the fault is not the in-process wedge
+
+#### Scenario: Healthy steady state issues no restart
+
+- **WHEN** `/oauth/v2/authorize` returns `302` within normal latency on every probe
+- **THEN** the watchdog SHALL take no action
+
+## MODIFIED Requirements
+
+### Requirement: Resilient Scheduling on Shared Spot Node Pool
+
+The Zitadel API (`zitadel-api`) and Web (`zitadel-web`) Deployments SHALL each be authored against the base manifest with a `PodDisruptionBudget`, a readiness probe pointed at the component's health endpoint (`/debug/ready` for API; `/ui/v2/login` for Web), and a rolling update strategy of `maxUnavailable: 0`. The base manifest MAY be single-replica for cost-simplicity; the `dev` overlay MAY run `replicaCount: 1` with PDB `minAvailable: 0` per the `optimize-dev-gke-cost` change. The **`prod` overlay SHALL explicitly set `replicaCount: 2` and PDB `minAvailable: 1`** for `zitadel-api`, and the running prod state SHALL match it — a prod `zitadel-api` observed at `replicas: 1` is a drift to be corrected, not an accepted posture. `podAntiAffinity` is OPTIONAL at the current resource size (GKE Autopilot rejects it below the CPU floor); it is a node-failure concern separate from the per-process wedge that ≥2 replicas address.
+
+The readiness probe (`/debug/ready`) protects traffic against **startup and migration** unreadiness only. It SHALL NOT be relied upon to remove a pod suffering the in-process projection-trigger wedge (zitadel/zitadel#10103): a wedged pod keeps `/debug/ready` and `/debug/healthz` at 200 while auth-flow requests hang. Recovery from that wedge is delegated to the self-healing watchdog (see "Self-healing watchdog auto-restarts a wedged Zitadel API"); the prod ≥2-replica posture exists to bound the wedge blast radius to a single pod and to make the watchdog's rolling restart non-disruptive.
+
+**Rationale**: Both overlays target the shared Spot node pool pre-launch. In `dev`, the `optimize-dev-gke-cost` change runs a single replica with a relaxed PDB and accepts a brief auth outage per node event for cost savings. The 2026-06-23 prod outage showed that a single wedged replica (prod was running 1) takes down all login because readiness cannot detect the wedge — hence the explicit prod `replicaCount: 2` clause and the delegation of wedge-recovery to the watchdog. Two replicas alone do not auto-heal (a wedged-but-ready pod still serves and hangs ~half of logins), but they keep one replica serving while the watchdog restarts the other.
+
+#### Scenario: Prod runs two replicas
+
+- **WHEN** an operator inspects the running `zitadel-api` Deployment in `prod`
+- **THEN** its `spec.replicas` SHALL be 2 and its PDB `minAvailable` SHALL be 1
+- **AND** a value of 1 SHALL be treated as drift and reconciled
+
+#### Scenario: Single-replica dev Deployment drains cleanly during node upgrade
+
+- **WHEN** the `dev` overlay runs `replicaCount: 1` with PDB `minAvailable: 0`
+- **AND** a node upgrade evicts the node hosting the Zitadel pod
+- **THEN** the eviction SHALL succeed (PDB does not block)
+- **AND** the Deployment SHALL re-schedule the pod onto another spot node
+- **AND** the auth outage during this gap SHALL be acceptable per the dev cost posture
+
+#### Scenario: Unready pod is excluded from Gateway backend
+
+- **WHEN** a Zitadel pod is starting or running a migration
+- **THEN** its readiness probe SHALL return non-200 until ready
+- **AND** the Gateway SHALL NOT route traffic to that pod until the probe succeeds
+
+#### Scenario: Wedged-but-ready pod is recovered by the watchdog, not readiness
+
+- **WHEN** a `zitadel-api` pod is suffering the projection-trigger wedge (auth-flow requests hang) but `/debug/ready` still returns 200
+- **THEN** the Gateway SHALL continue routing to that pod (readiness does not detect the wedge)
+- **AND** recovery SHALL come from the self-healing watchdog restarting the pod, with the second replica absorbing traffic during the rolling restart

--- a/openspec/changes/zitadel-wedge-self-healing/tasks.md
+++ b/openspec/changes/zitadel-wedge-self-healing/tasks.md
@@ -1,0 +1,28 @@
+## 1. Restore prod replica posture (bound blast radius)
+
+- [x] 1.1 In the `zitadel` prod overlay, explicitly set `replicaCount: 2` and PDB `minAvailable: 1` for `zitadel-api`, reconciling the observed `replicas: 1` drift
+- [x] 1.2 `kustomize build` the prod overlay and confirm the rendered `zitadel-api` Deployment has `replicas: 2` and the PDB has `minAvailable: 1`
+
+## 2. Self-healing watchdog CronJob (prod)
+
+- [x] 2.1 Add a watchdog `CronJob` manifest to the `zitadel` prod overlay, modeled on `overlays/dev/cronjob-restart-zitadel.yaml`: every ~1 min, `concurrencyPolicy: Forbid`, an image carrying both `curl` and `kubectl` (e.g. `alpine/k8s:1.32.x`), Spot `nodeSelector`, minimal resources
+- [x] 2.2 Add a dedicated `ServiceAccount` + `Role` (`get`/`patch` on `deployments`, restricted to `zitadel-api`) + `RoleBinding` in the `zitadel` namespace, mirroring the dev restart RBAC
+- [x] 2.3 Implement the probe script: guard on `/debug/healthz`==200; probe `/oauth/v2/authorize` with valid prod params (`client_id=373015520582107291`, `redirect_uri=https://liverty-music.app/auth/callback`, `response_type=code&scope=openid` + PKCE) N times (~3 × 5s) with `--max-time` above normal latency but below the gateway timeout; restart only if all N hang (HTTP 000)
+- [x] 2.4 Ship the CronJob in **dry-run/observe mode** first (log the restart decision, skip the actual `rollout restart`); document how to flip to active (remove the dry-run guard / `suspend: false`)
+- [x] 2.5 Wire the new manifests into the prod overlay `kustomization.yaml` resources; `kustomize build` cleanly
+- [x] 2.6 Add an inline comment + runbook note recording the hardcoded prod `client_id`/`redirect_uri` coupling and the eventstore side-effect (per design.md Open Questions)
+
+## 3. Validate & ship
+
+- [x] 3.1 `make lint-k8s` (or repo equivalent) passes for the zitadel prod overlay
+- [ ] 3.2 Open the `cloud-provisioning` PR; after merge, confirm ArgoCD syncs the replica bump + watchdog (dry-run) in prod
+- [ ] 3.3 Soak the dry-run watchdog for one window; confirm zero false-positive restart decisions in its logs
+- [ ] 3.4 Flip the watchdog to active (restart-enabled) via a follow-up commit once the dry-run is clean
+- [ ] 3.5 Validate recovery: confirm prod `zitadel-api` is at 2 replicas, and (on the next genuine wedge, or a controlled one) the watchdog auto-restarts within ~2 min and a fresh `/oauth/v2/authorize` returns `302`
+- [ ] 3.6 Run `openspec validate zitadel-wedge-self-healing --strict`; archive once shipped to prod and verified
+
+## 4. Deferred follow-ups (tracked, not implemented here)
+
+- [ ] 4.1 Evaluate a read-only probe target that still triggers the wedged projection (eliminate the auth-request side-effect)
+- [ ] 4.2 Add a notification alert via a viable signal (watchdog-restart log-based metric, or Gateway 504 rate) — the OIDCService latency metric is dropped at the OTLP collector and cannot be used as-is
+- [ ] 4.3 Refresh `docs/runbooks/zitadel-hang.md` to reflect self-healing + the authorize-based verification (don't rely on `/debug/healthz`=200 as proof of recovery)


### PR DESCRIPTION
## Why

Captures the OpenSpec change behind the prod login-outage remediation: on **2026-06-23** the self-hosted Zitadel API hit the in-process projection-trigger wedge (zitadel/zitadel#10103) and login was down ~13 min because nothing auto-restarts the wedged pod (`/debug/*` stays 200 during the wedge).

## What

OpenSpec change `zitadel-wedge-self-healing` (proposal / design / spec deltas / tasks):
- **ADD** a self-healing watchdog requirement to `zitadel-self-hosted-deployment` — an in-cluster CronJob detects the wedge via an auth-flow hang probe (`/oauth/v2/authorize`) and auto-restarts `zitadel-api`, with conservative false-restart guards.
- **MODIFY** the resilient-scheduling requirement — prod explicitly runs 2 `zitadel-api` replicas, and wedge-recovery is delegated to the watchdog because readiness can't detect the wedge.

Design decisions captured: CronJob over liveness-probe (the latter restart-loops on `400`), notification alert deferred (the OIDCService latency metric is dropped at the OTLP collector), the auth-request probe side-effect, and read-only-probe / dedicated-probe-client open questions.

Implementation PR: liverty-music/cloud-provisioning#366

Refs: liverty-music/cloud-provisioning#365