### PR TITLE
docs(openspec): propose zitadel-watchdog-readonly-probe

### DIFF
--- a/openspec/changes/zitadel-watchdog-readonly-probe/.openspec.yaml
+++ b/openspec/changes/zitadel-watchdog-readonly-probe/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-23

--- a/openspec/changes/zitadel-watchdog-readonly-probe/design.md
+++ b/openspec/changes/zitadel-watchdog-readonly-probe/design.md
@@ -1,0 +1,69 @@
+## Context
+
+The shipped watchdog (`zitadel-wedge-self-healing`) probes `/oauth/v2/authorize` with valid prod-consumer params: healthy → `302`, wedged → hang. It works, but:
+- It is a **write** — each healthy probe creates an OIDC auth request; Zitadel does **not** auto-clean auth requests, so ~1440/day accumulate in the eventstore on `db-f1-micro`, and the probe loads the projection path that wedges.
+- It hardcodes the consumer `client_id` + `redirect_uri`.
+
+Source investigation (zitadel v4.14.0) established:
+- `internal/query/project_role.go`: `searchProjectRoles` is read-only and, when `shouldTriggerBulk=true`, calls `projection.ProjectRoleProjection.Trigger(ctx, handler.WithAwaitRunning())` before the SELECT — the same trigger family that wedged on 2026-06-23.
+- `internal/api/grpc/project/v2/query.go`: `ListProjectRoles` calls `q.SearchProjectRoles(ctx, true, …)` → triggers on every call, as a pure read.
+- Prod check: `POST https://api.liverty-music.app/zitadel.project.v2.ProjectService/ListProjectRoles` returns `401` in ~0.15s unauthenticated → auth is enforced **before** the trigger, so a valid credential is required to reach (and thus detect) the wedge.
+- No official escape: no config disables trigger-on-read; `#10103` is open/unfixed; `/debug/healthz` + `/debug/ready` are generic process checks (no projection-health/lag/self-heal). So a probe-based watchdog stays necessary; this change only makes it read-only.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Eliminate the probe's eventstore write side-effect (pure read).
+- Remove the consumer-client coupling (subsumes the earlier "dedicated probe client" follow-up).
+- Preserve detection fidelity (trigger the projection that actually wedges) and all false-restart guards.
+- Keep the watchdog a clearly-annotated stopgap until upstream removes the read-projections.
+
+**Non-Goals:**
+- Fixing `#10103` (upstream) or right-sizing Cloud SQL (a frequency lever, tracked separately).
+- Changing the restart mechanism, the 2-replica posture, or the conservative guards.
+- A notification alert (explicitly dropped).
+
+## Decisions
+
+### D1. Probe = read-only `ProjectService/ListProjectRoles` against a static project id
+Connect HTTP+JSON: `POST /zitadel.project.v2.ProjectService/ListProjectRoles` with `Authorization: Bearer <PAT>`, `Content-Type: application/json`, body `{"projectId":"<static-id>"}`. Healthy → `200` fast; wedged → hang (curl `--max-time` → HTTP 000). Chosen over alternatives:
+- `/oauth/v2/authorize` (current) — **rejected**: write side-effect + consumer-client coupling.
+- `GetAuthRequest` (read-only, triggers `AuthRequestProjection`) — **rejected**: needs a live auth-request id (periodic write to mint) + login-client auth; more state than a static project id.
+- A no-credential read endpoint — **does not exist**: every wedge-triggering read path is auth-gated (verified `401` before trigger).
+
+The static `projectId` is config (analogous to the old `client_id`); any existing project works (e.g. the ZITADEL project or the app's own project).
+
+### D2. Credential = dedicated least-privilege watchdog machine user + PAT
+Provision (Pulumi, zitadel provider) a `MachineUser` (e.g. `watchdog-probe`) granted only what `ListProjectRoles` requires (project/role read on the target project — least privilege; NOT iam-admin), and a `PersonalAccessToken`. Export the token to GSM; sync to the `zitadel` namespace with External Secrets; mount into the CronJob. Rejected:
+- Reusing the `login-client` / `iam-admin` PAT — over-privileged and `LoginClientPatPath` is null (not exported), so not readily available.
+- An OIDC client-credentials token minted per run — extra token-endpoint round-trip (and itself a write/cache); a long-lived PAT is simpler for a 1/min job.
+
+### D3. Probe-credential failure is fail-safe and must be monitored
+An invalid/expired/over-revoked PAT makes `ListProjectRoles` return `401` fast → the watchdog reads "responded quickly" = healthy → it **stops detecting** but never false-restarts. To avoid silently going blind, the PAT SHALL be long-lived (multi-year, like the existing bootstrap PATs) and its expiry tracked; optionally the probe treats a `401`/`403` distinctly (log a loud "watchdog credential invalid" line) so a future log-based check can catch it. (No alerting in this change — logging only.)
+
+### D4. Everything else unchanged
+N-of-N in-run hangs, `/debug/healthz`==200 precondition, `concurrencyPolicy: Forbid`, dedicated restart RBAC, 2 replicas, `WATCHDOG_DRY_RUN` toggle, and the `until-upstream-zitadel-10103-fix` annotation all carry over. Ship the new probe in dry-run first, soak, then activate (same rollout discipline as the original).
+
+## Risks / Trade-offs
+
+- **PAT lifecycle (store/rotate/expire)** → Mitigation: long-lived PAT in GSM via ESO; document expiry; fail-safe means an expired PAT degrades to "no detection", not an outage or restart-loop.
+- **PAT over-privilege** → Mitigation: dedicated machine user scoped to project-role read only; never reuse iam-admin.
+- **Detection-coverage shift** (authorize triggered `AuthRequestProjection`; this triggers `ProjectRoleProjection`) → Mitigation: 2026-06-23 wedged BOTH simultaneously (shared trigger-infra deadlock hypothesis), so `ProjectRoleProjection` is a faithful detector; if a future wedge variant somehow spares ProjectRole, revisit (could probe both).
+- **Connect endpoint/JSON contract drift on Zitadel upgrade** → Mitigation: pin the service path in the manifest + runbook; re-verify on major Zitadel bumps (same discipline as the authorize path).
+- **Static `projectId` deleted** → Mitigation: use a stable, always-present project (ZITADEL instance project); document it.
+
+## Migration Plan
+
+1. Pulumi: create the watchdog machine user + PAT + GSM secret (no behavior change yet).
+2. K8s: add the `ExternalSecret`; rewrite the CronJob probe to `ListProjectRoles` in **dry-run** (`WATCHDOG_DRY_RUN=true`); keep the old authorize env removed.
+3. Soak dry-run; confirm healthy → no action and that the probe authenticates (200, not 401).
+4. Flip to active; confirm a healthy run still takes no action.
+5. Refresh the runbook.
+
+Rollback: revert the CronJob to the authorize probe (previous manifest) or `suspend: true`; the machine user/secret can remain (harmless) or be removed.
+
+## Open Questions
+
+- Which static `projectId` to pin — the ZITADEL instance project vs the consumer app's project? (Pick the most stable / least likely to be deleted.)
+- Does the chosen machine user need an explicit project authorization/grant for `ListProjectRoles` to return `200` (vs `403`)? Confirm the minimal role grant during apply.
+- Is the prod `api.liverty-music.app` host or the in-cluster Service the better probe target (gateway-path coverage vs fewer moving parts)? Current lean: keep the public host for parity with real traffic, guarded by the `/debug/healthz` precondition.

--- a/openspec/changes/zitadel-watchdog-readonly-probe/proposal.md
+++ b/openspec/changes/zitadel-watchdog-readonly-probe/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+The self-healing watchdog (shipped in `zitadel-wedge-self-healing`) detects the projection-trigger wedge by probing `/oauth/v2/authorize` with valid OIDC params. That works, but the probe is a **write**: each healthy probe creates a throwaway OIDC auth request, and Zitadel **never auto-cleans auth requests** (confirmed in the docs), so on the small prod `db-f1-micro` this is unbounded eventstore growth (~1440 event-streams/day) plus steady load on the very projection path that wedges. It also hardcodes the prod consumer `client_id` + `redirect_uri`.
+
+A source-level investigation found a clean read-only alternative: the v2 `ProjectService/ListProjectRoles` gRPC method calls `SearchProjectRoles(ctx, true, …)`, which triggers `ProjectRoleProjection.Trigger(WithAwaitRunning())` — the **exact projection that wedged on 2026-06-23** — on every call, as a pure read (no eventstore write). Verified against prod: the endpoint is reachable and unauthenticated calls return `401` fast (auth is enforced before the trigger), so the probe must carry a valid credential to reach the wedge path.
+
+This change swaps the probe to that read-only call, eliminating the write side-effect and the consumer-client coupling, while keeping (and slightly improving) wedge-detection fidelity. Zitadel offers no official mechanism for this (no config to disable trigger-on-read, no projection-health endpoint/metric, no self-healing, and `#10103` is still open), so the watchdog remains the right tool — this change just makes it side-effect-free.
+
+## What Changes
+
+- **Swap the watchdog probe** from `POST`/`GET /oauth/v2/authorize` (write) to the read-only Connect/gRPC `zitadel.project.v2.ProjectService/ListProjectRoles` over HTTP+JSON, against a **static project id**, returning quickly when healthy and hanging when wedged.
+- **Provision a dedicated, minimal-scope machine user + Personal Access Token** for the watchdog (read access to project roles only), export the PAT to GSM, and sync it into the `zitadel` namespace via External Secrets; mount it in the watchdog CronJob as a bearer token.
+- **Remove** the hardcoded consumer `client_id` / `redirect_uri` from the watchdog (this resolves the earlier "decouple from the consumer app" follow-up — the coupling moves to the watchdog's own PAT, not a product client).
+- **Keep all conservative guards** (N-of-N in-run hangs, `/debug/healthz`==200 precondition, `concurrencyPolicy: Forbid`) and the `until-upstream-zitadel-10103-fix` stopgap annotation.
+- **Refresh the runbook** (`docs/runbooks/zitadel-hang.md`) to reflect self-healing + the read-only probe and the "check the watchdog first, verify via an auth-flow probe (not `/debug/healthz`)" flow.
+
+## Capabilities
+
+### New Capabilities
+<!-- none — this refines the existing self-healing watchdog requirement. -->
+
+### Modified Capabilities
+- `zitadel-self-hosted-deployment`: change the "Self-healing watchdog auto-restarts a wedged Zitadel API" requirement so the detection signal is the read-only `ProjectService/ListProjectRoles` call authenticated by a dedicated watchdog machine-user PAT (instead of the write-bearing `/oauth/v2/authorize` probe with a consumer client id), and require the PAT to be least-privilege and delivered via GSM + External Secrets.
+
+## Impact
+
+- **Repo**: `cloud-provisioning` only.
+  - Pulumi (`src/zitadel/…`): a new `zitadel.MachineUser` + `PersonalAccessToken` (read-project-roles scope) and a GSM secret holding the token.
+  - K8s (`k8s/namespaces/zitadel/overlays/prod/`): an `ExternalSecret` syncing the PAT into the namespace; the watchdog CronJob rewritten to `curl` the Connect endpoint with `Authorization: Bearer` and parse hang-vs-response; drop the authorize URL/client env.
+- **Behavior**: zero eventstore writes from probing (was ~1440/day); detection now exercises `ProjectRoleProjection` (the observed wedge). No change to login behavior or to the 2-replica posture.
+- **New dependency / risk**: a long-lived watchdog PAT that must be stored, rotated before expiry, and least-privilege. Fail-safe is preserved — an invalid/expired PAT yields a fast `401` (read as "healthy"), so it stops detecting rather than false-restarting; this MUST be covered by PAT-expiry monitoring or a long/auto-rotated token.
+- **Stopgap**: unchanged — when upstream removes the auth-request/project-role read-projections (`#10103` and siblings), the wedge disappears and the whole watchdog can be retired.

--- a/openspec/changes/zitadel-watchdog-readonly-probe/specs/zitadel-self-hosted-deployment/spec.md
+++ b/openspec/changes/zitadel-watchdog-readonly-probe/specs/zitadel-self-hosted-deployment/spec.md
@@ -1,0 +1,46 @@
+## MODIFIED Requirements
+
+### Requirement: Self-healing watchdog auto-restarts a wedged Zitadel API
+
+The prod environment SHALL run an in-cluster watchdog that detects the Zitadel projection-trigger wedge (zitadel/zitadel#10103) and automatically restarts the `zitadel-api` Deployment without operator action. The watchdog SHALL be a Kubernetes `CronJob` modeled on the existing dev restart CronJob pattern (a container image carrying `curl` and `kubectl`, plus a dedicated ServiceAccount and a `Role`/`RoleBinding` scoped to `get`/`patch` on the `zitadel-api` Deployment in the `zitadel` namespace only) — NOT a compiled application.
+
+The watchdog SHALL detect the wedge using a **read-only call that exercises the wedged trigger-on-read path**, NOT a `/debug/healthz` or `/debug/ready` check (both return 200 during the wedge). The reference signal is the Connect/gRPC `zitadel.project.v2.ProjectService/ListProjectRoles` method (HTTP+JSON `POST`) against a static project id, which calls `SearchProjectRoles(…, shouldTriggerBulk=true, …)` and so triggers `ProjectRoleProjection.Trigger(WithAwaitRunning())` — the projection observed wedging on 2026-06-23 — as a pure read (no eventstore write). The call returns quickly when healthy and hangs past the gateway timeout when wedged. The probe MUST present a valid credential: unauthenticated calls return `401` before the trigger runs and cannot detect the wedge. The probe SHALL NOT use a write endpoint (e.g. `/oauth/v2/authorize`) and SHALL NOT hardcode a product/consumer OIDC client id.
+
+The probe credential SHALL be a **dedicated, least-privilege machine-user Personal Access Token** (scoped only to the project-role read needed by `ListProjectRoles`, never a shared admin identity), provisioned out of band, stored in Google Secret Manager, synced into the `zitadel` namespace via External Secrets, and mounted into the CronJob as a bearer token. The credential failure mode SHALL be fail-safe: an invalid/expired PAT returns a fast `401` that the watchdog treats as "responded" (no false restart); to avoid silently losing detection, the PAT SHALL be long-lived and its expiry tracked, and a `401`/`403` from the probe SHALL be logged distinctly.
+
+The watchdog SHALL be **conservative against false restarts**:
+- It SHALL restart only after **N consecutive hanging probes within a single run** (no single transient blip triggers a restart).
+- It SHALL restart only when `/debug/healthz` returns `200` at probe time (the wedge signature is "core healthy AND the read-only trigger path hung"); if core health is also failing it SHALL NOT restart, since the fault is not the wedge.
+- It SHALL use `concurrencyPolicy: Forbid` so runs never overlap.
+
+#### Scenario: Wedged pod is auto-restarted
+
+- **WHEN** the authenticated `ListProjectRoles` probe hangs past the gateway timeout for N consecutive probes in one run while `/debug/healthz` returns 200
+- **THEN** the watchdog SHALL run the equivalent of `kubectl rollout restart deploy/zitadel-api` in the `zitadel` namespace
+- **AND** a fresh `ListProjectRoles` probe SHALL return a normal response within normal latency after the new pod becomes Ready
+
+#### Scenario: Probe is read-only (no auth-request writes)
+
+- **WHEN** the watchdog runs its healthy probes over time
+- **THEN** it SHALL create no OIDC auth requests or other eventstore writes (the probe is a read query)
+
+#### Scenario: Transient blip does not trigger a restart
+
+- **WHEN** a single probe in a run hangs but the remaining probes in the same run return normally
+- **THEN** the watchdog SHALL NOT restart the Deployment
+
+#### Scenario: Full outage (core health down) does not trigger a restart
+
+- **WHEN** the probe fails AND `/debug/healthz` does not return 200 (e.g. gateway/DNS outage, pod not running)
+- **THEN** the watchdog SHALL NOT restart the Deployment, because the fault is not the in-process wedge
+
+#### Scenario: Invalid credential is fail-safe (no false restart)
+
+- **WHEN** the watchdog's PAT is missing, expired, or unauthorized so the probe returns `401`/`403` quickly
+- **THEN** the watchdog SHALL treat the fast response as "not wedged" and SHALL NOT restart the Deployment
+- **AND** it SHALL log the credential failure distinctly so the loss of detection is discoverable
+
+#### Scenario: Healthy steady state issues no restart
+
+- **WHEN** the `ListProjectRoles` probe returns normally within normal latency on every probe
+- **THEN** the watchdog SHALL take no action

--- a/openspec/changes/zitadel-watchdog-readonly-probe/tasks.md
+++ b/openspec/changes/zitadel-watchdog-readonly-probe/tasks.md
@@ -1,0 +1,35 @@
+## 1. Provision the watchdog credential (Pulumi)
+
+- [ ] 1.1 Add a dedicated `zitadel.MachineUser` (e.g. `watchdog-probe`) in `cloud-provisioning/src/zitadel/…`, least-privilege
+- [ ] 1.2 Grant it only the project/role read needed for `ListProjectRoles` on the chosen static project (confirm whether an explicit project authorization/grant is required to get `200` not `403`) — resolves design.md Open Question 2
+- [ ] 1.3 Create a `PersonalAccessToken` (long-lived) for that machine user and write the token to a GSM secret (follow the `zitadel-machine-key-for-<principal>` naming convention spirit)
+- [ ] 1.4 `pulumi preview` clean; confirm the GSM secret is created and holds a usable PAT
+
+## 2. Sync the PAT into the cluster (External Secrets)
+
+- [ ] 2.1 Add an `ExternalSecret` (prod overlay) that syncs the GSM PAT into a `zitadel`-namespace Secret
+- [ ] 2.2 `kustomize build --enable-helm` renders cleanly; confirm the ESO `SecretStore`/refresh wiring matches existing patterns
+
+## 3. Rewrite the watchdog probe (read-only)
+
+- [ ] 3.1 Pick the static `projectId` to probe (stable, always-present — e.g. the ZITADEL instance project); document it inline — resolves design.md Open Question 1
+- [ ] 3.2 Rewrite the CronJob script: `POST {host}/zitadel.project.v2.ProjectService/ListProjectRoles` with `Authorization: Bearer $PAT`, `Content-Type: application/json`, body `{"projectId":"…"}`, `--max-time` above normal latency / below gateway timeout; HTTP 000 (hang) = wedge signal; `401`/`403` = log "watchdog credential invalid" and treat as healthy (no restart)
+- [ ] 3.3 Mount the PAT secret as an env/file; drop the old `WATCHDOG_AUTHZ_URL` + consumer `client_id`/`redirect_uri`
+- [ ] 3.4 Keep all guards unchanged: `/debug/healthz`==200 precondition, 3/3 in-run hangs, `concurrencyPolicy: Forbid`, dedicated restart RBAC, `until-upstream-zitadel-10103-fix` annotation
+- [ ] 3.5 Decide probe host (public `api.liverty-music.app` vs in-cluster Service) — resolves design.md Open Question 3
+- [ ] 3.6 Ship in **dry-run** (`WATCHDOG_DRY_RUN=true`) first; `make lint-k8s` passes
+
+## 4. Roll out + verify
+
+- [ ] 4.1 PR → merge → ArgoCD sync; confirm the watchdog run authenticates (probe `200`, not `401`) and healthy → no action in dry-run
+- [ ] 4.2 Confirm zero auth-request writes from probing (the side-effect is gone) — spot-check the eventstore/auth-request volume vs the old probe
+- [ ] 4.3 Flip to active; confirm a healthy run still takes no action
+- [ ] 4.4 `make lint-k8s` + `openspec validate zitadel-watchdog-readonly-probe --strict` pass
+
+## 5. Runbook
+
+- [ ] 5.1 Refresh `cloud-provisioning/docs/runbooks/zitadel-hang.md`: self-healing-first flow, the read-only `ListProjectRoles` probe, "verify recovery via an auth-flow probe, NOT `/debug/healthz`", and the new wedge signature (authorize/searchProjectRoles, DB clean, `num_backends` flat)
+
+## 6. Ship + archive
+
+- [ ] 6.1 After prod rollout + verification, archive the change (recovery on a real wedge remains an opportunistic monitoring item, as in the prior change)


### PR DESCRIPTION
## Summary

Proposes the OpenSpec change `zitadel-watchdog-readonly-probe`: make the shipped self-healing watchdog probe **read-only**, removing its eventstore write side-effect and consumer-client coupling.

## Why

The active watchdog (from `zitadel-wedge-self-healing`) detects the projection-trigger wedge by probing `/oauth/v2/authorize` with valid params — a **write** that creates a throwaway OIDC auth request on every healthy run. Zitadel never auto-cleans auth requests, so on the prod `db-f1-micro` this is unbounded eventstore growth (~1440/day) plus steady load on the very projection path that wedges. It also hardcodes the prod consumer `client_id` / `redirect_uri`.

## Changes (spec only)

Modifies the `zitadel-self-hosted-deployment` "Self-healing watchdog" requirement so the probe is the read-only Connect call `zitadel.project.v2.ProjectService/ListProjectRoles` (which calls `SearchProjectRoles(ctx, true, …)` → triggers `ProjectRoleProjection.Trigger(WithAwaitRunning())`, the projection that wedged on 2026-06-23, as a pure read) against a static project id, authenticated by a **dedicated least-privilege machine-user PAT** (GSM → External Secrets → mounted bearer).

- Eliminates all probe writes; removes the consumer-client coupling (subsumes the earlier "dedicated probe client" follow-up).
- Keeps every conservative guard (N/N in-run hangs, `/debug/healthz`==200 precondition, `concurrencyPolicy: Forbid`) and the `until-upstream-zitadel-10103-fix` stopgap framing.
- Adds fail-safe credential handling (an expired PAT → fast `401` → "healthy", no false restart; detection just stops, so the PAT must be long-lived + tracked).

## Context

Source + live investigation confirmed: unauthenticated `ListProjectRoles` returns `401` before the trigger (so a valid PAT is required), and Zitadel offers no official alternative — no config to disable trigger-on-read, `#10103` still open, health endpoints don't detect the wedge, no projection-health metric/self-heal. So the watchdog stays the right tool; this change just makes it side-effect-free.

Artifacts: proposal, design (decisions + 3 open questions resolved at apply time), spec delta, tasks. Implementation lands separately in `cloud-provisioning` (Pulumi machine user + PAT + GSM; k8s ESO + CronJob rewrite).

Refs: liverty-music/cloud-provisioning#368
