### PR TITLE
docs(openspec): archive localize-push-notification-text

### DIFF
--- a/openspec/changes/archive/2026-06-24-localize-push-notification-text/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-24-localize-push-notification-text/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-23

--- a/openspec/changes/archive/2026-06-24-localize-push-notification-text/design.md
+++ b/openspec/changes/archive/2026-06-24-localize-push-notification-text/design.md
@@ -1,0 +1,63 @@
+## Context
+
+The backend sends three kinds of Web Push notifications:
+
+| Notification | Pipeline | Current copy |
+|---|---|---|
+| Sales reminders | time-based scan → event → push | Already localized (en/ja) — reference pattern |
+| Concert discovery | concert search → follower fan-out push | Hardcoded English |
+| Sales-phase announcement | phase discovery → event → push | Hardcoded English |
+
+The `sales-reminders` Notification Content requirement already mandates that the discovery announcement and every reminder stage be localized per recipient using `users.preferred_language` (default `en`). The reminder path complies; the announcement path drifted (a code comment states personalization is "intentionally omitted"). The concert-discovery notification has never been specified and is English-only.
+
+The reference implementation is `internal/usecase/sales_reminder_uc.go`: `buildReminderPayload` reads `lang := user.PreferredLanguage` (normalizing empty → `en`) and uses unexported `map[lang]string` helpers (`stageTitle`, `stageBody`, `channelDisplayName`, `formatLocalTime`). `users.preferred_language` is an ISO-639-1 string, empty when unset; no schema change is needed.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Concert-discovery and sales-phase-announcement notification copy rendered in the recipient's `preferred_language`, defaulting to `en`.
+- Reuse the existing `NotificationPayload` and Web Push delivery path — no proto, RPC, or DB change.
+- Avoid per-subscription marshalling cost when fanning out to many recipients.
+
+**Non-Goals:**
+- No new supported languages beyond the existing `en`/`ja` set.
+- No frontend, proto schema, or migration work.
+- No extraction of a shared i18n package — copy stays local to each notification builder.
+
+## Decisions
+
+### Resolve recipient language at the delivery use case, not the transport
+
+The language is resolved where the recipient is known (the use case), and the resolved copy is baked into the `NotificationPayload` before marshalling. The Web Push sender stays language-agnostic. This mirrors the reminder path and keeps the transport layer unchanged.
+
+### Concert discovery: surface `preferred_language` via the follower query
+
+`NotifyNewConcerts` already loads followers via `followRepo.ListFollowers(artistID)`, whose query JOINs `users`. We extend that query to also select `COALESCE(u.preferred_language, '')` and populate `Follower.User.PreferredLanguage`.
+
+- **Alternative considered:** per-recipient `userRepo.Get` (N+1). Rejected — the follower JOIN already exists, so adding one column is free and avoids N point reads for popular artists.
+- `ListFollowers` has a single caller, so the additive column is low-risk.
+
+### Sales-phase announcement: hydrate recipients via `userRepo`
+
+The announcement use case currently resolves only user IDs and lists subscriptions; it has no `userRepo`. We add a `userRepo entity.UserRepository` dependency and hydrate each recipient with the same warn-and-skip loop the reminder path uses (`userRepo.Get` per ID; a failed read skips that recipient without aborting the batch). DI in `internal/di/consumer.go` constructs `rdb.NewUserRepository(db)` and passes it in.
+
+- **Alternative considered:** add `preferred_language` to the audience-resolution query (`ResolveSalesPhaseAudience` / ticket-journey join). Rejected for now — it would change a shared query's shape for one consumer; the hydrate loop matches the established reminder pattern and keeps blast radius small. Batched `ListByIDs` is a known future perf improvement shared with the reminder path.
+
+### Build at most one payload per distinct language
+
+Both fan-out paths iterate subscriptions (`sub.UserID`), not recipients. To avoid re-marshalling per subscription, each path builds a `map[userID]lang` during recipient resolution and a `map[lang][]byte` payload cache, lazily marshalling a payload the first time each language is needed (≤2 marshals for en+ja). The send loop picks bytes by the subscription's resolved language, defaulting to `en` if a subscription's user is unexpectedly absent from the map.
+
+### Localization copy stays local to each builder
+
+The three notification types have non-overlapping copy. The concert body table lives inside `NewConcertNotificationPayload(artist, count, lang)` in `internal/entity/push_notification.go`; the announcement uses two small unexported helpers (`announcementTitle(lang)` / `announcementBody(lang)`) in its use-case file, matching the reminder helpers' `map[lang]string` + `en`-fallback shape. A shared i18n package is deferred until a fourth notification type appears.
+
+## Risks / Trade-offs
+
+- **Per-subscription marshalling cost** → mitigated by the `map[lang][]byte` cache (≤2 marshals regardless of subscription count).
+- **`ListFollowers` query change blast radius** → single caller confirmed; the added column is `COALESCE`'d so no NULL-scan panic.
+- **Announcement now performs N user reads** (previously zero) → same pattern and cost profile as the reminder path; warn-and-skip prevents one bad recipient from dropping the whole batch.
+- **Empty/unsupported language fallback** → normalized to `en` in exactly one place per builder (entity constructor for concerts, helper for announcement) to prevent a missed empty string producing blank copy.
+
+## Migration Plan
+
+Pure code change, no data migration. Deploy via the normal backend release; rollback is reverting the backend image. Notification copy language is the only observable behavior change.

--- a/openspec/changes/archive/2026-06-24-localize-push-notification-text/proposal.md
+++ b/openspec/changes/archive/2026-06-24-localize-push-notification-text/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+Web Push notification copy is not consistently rendered in the recipient's preferred language. Sales reminders are already localized, but **concert-discovery notifications** ("N new concerts found") are hardcoded English, and the **sales-phase announcement** ("New Ticket Sales Phase") is also hardcoded English even though the `sales-reminders` Notification Content requirement already mandates that the discovery announcement be localized per recipient. Japanese-preferring fans receive English notification text, breaking the personalized experience.
+
+## What Changes
+
+- Concert-discovery follower notifications SHALL select title/body copy by the recipient's `preferred_language`, defaulting to `en` when unset. Body covers singular/plural ("1 new concert found" / "N new concerts found") with a Japanese equivalent.
+- The sales-phase discovery announcement SHALL be built per recipient and localized (default `en`), aligning the implementation with the existing `sales-reminders` Notification Content requirement (it currently omits personalization).
+- A cross-cutting rule is established: every user-facing Web Push notification selects copy by the recipient's `preferred_language` with an `en` fallback, reusing the existing `NotificationPayload` shape.
+- No proto/schema change, no new RPC, no DB migration — localization happens in the backend delivery path using the existing `users.preferred_language` column.
+
+## Capabilities
+
+### New Capabilities
+- `push-notification-localization`: Cross-cutting requirement that all user-facing Web Push notification copy is selected by the recipient's `preferred_language` (default `en`), plus the specific content contract for the concert-discovery follower notification (artist name + new-concert count) which is currently unspecified and English-only.
+
+### Modified Capabilities
+- `sales-phase-discovery`: The "Event-Driven Announcement on New Phase" requirement is strengthened to state that the announcement is built per recipient and localized to `preferred_language` (default `en`), preventing the implementation drift that left it English-only.
+
+## Impact
+
+- Backend only (`liverty-music/backend`):
+  - `internal/entity/push_notification.go` — `NewConcertNotificationPayload` gains a `lang` parameter and localized body.
+  - `internal/usecase/push_notification_uc.go` — `NotifyNewConcerts` maps each recipient to a language and marshals one payload per language.
+  - `internal/usecase/sales_phase_announcement_uc.go` — gains a `userRepo` dependency to hydrate recipients and localize the announcement.
+  - `internal/infrastructure/database/rdb/follow_repo.go` — `ListFollowers` query/scan surfaces `preferred_language`.
+  - `internal/di/consumer.go` — wires `userRepo` into the announcement use case.
+- No frontend, specification proto, or cloud-provisioning change.
+- No breaking changes; behavior change is notification copy language only.

--- a/openspec/changes/archive/2026-06-24-localize-push-notification-text/specs/push-notification-localization/spec.md
+++ b/openspec/changes/archive/2026-06-24-localize-push-notification-text/specs/push-notification-localization/spec.md
@@ -1,0 +1,47 @@
+## ADDED Requirements
+
+### Requirement: Localized Notification Copy
+
+The system SHALL select the user-facing copy of every Web Push notification by the recipient's `preferred_language`, defaulting to `en` when the recipient has no language set. Localization SHALL reuse the existing `NotificationPayload` shape (`title`, `body`, `url`, `tag`); only the human-readable `title` and `body` are language-dependent, while `url` and `tag` remain language-independent.
+
+#### Scenario: Recipient has a preferred language
+
+- **WHEN** a Web Push notification is built for a recipient whose `preferred_language` is a supported code (e.g. `ja`)
+- **THEN** the notification `title` and `body` SHALL be rendered in that language
+
+#### Scenario: Recipient has no preferred language
+
+- **WHEN** a Web Push notification is built for a recipient whose `preferred_language` is unset or empty
+- **THEN** the notification `title` and `body` SHALL be rendered in `en`
+
+#### Scenario: Recipient has an unsupported preferred language
+
+- **WHEN** a Web Push notification is built for a recipient whose `preferred_language` is a code with no localized copy available
+- **THEN** the notification `title` and `body` SHALL fall back to `en`
+
+#### Scenario: Mixed-language audience for one notification event
+
+- **WHEN** a single notification event fans out to recipients with differing `preferred_language` values
+- **THEN** each recipient SHALL receive copy in their own resolved language
+- **AND** the system SHALL build at most one payload per distinct resolved language rather than one per recipient subscription
+
+### Requirement: Concert Discovery Notification Content
+
+The system SHALL localize the concert-discovery follower notification that is sent when new concerts are found for a followed artist. The `title` SHALL be the artist name (language-independent) and the `body` SHALL state the count of newly discovered concerts in the recipient's resolved language.
+
+#### Scenario: Body in English
+
+- **WHEN** newly discovered concerts are notified to a recipient resolved to `en`
+- **THEN** the `body` SHALL read "1 new concert found" for a single concert
+- **AND** the `body` SHALL read "N new concerts found" for N concerts where N is greater than one
+
+#### Scenario: Body in Japanese
+
+- **WHEN** newly discovered concerts are notified to a recipient resolved to `ja`
+- **THEN** the `body` SHALL state the new-concert count in Japanese (e.g. "新しいライブが N 件見つかりました")
+
+#### Scenario: Title and deep-link unaffected by language
+
+- **WHEN** a concert-discovery notification is built for any recipient
+- **THEN** the `title` SHALL be the artist name regardless of language
+- **AND** the `url` SHALL deep-link to the artist's concerts and the `tag` SHALL deduplicate per artist, both regardless of language

--- a/openspec/changes/archive/2026-06-24-localize-push-notification-text/specs/sales-phase-discovery/spec.md
+++ b/openspec/changes/archive/2026-06-24-localize-push-notification-text/specs/sales-phase-discovery/spec.md
@@ -1,0 +1,22 @@
+## MODIFIED Requirements
+
+### Requirement: Event-Driven Announcement on New Phase
+
+The system SHALL push an announcement when a newly discovered sales phase is persisted, reusing the existing discovery→event→push pipeline. This announcement is event-driven and distinct from the time-based reminders. The announcement SHALL be built per recipient and localized to the recipient's `preferred_language` (default `en`), consistent with the `sales-reminders` Notification Content requirement.
+
+#### Scenario: New phase announced
+
+- **WHEN** the discovery job persists a sales phase that did not previously exist
+- **THEN** it SHALL publish a sales-phase-discovered event
+- **AND** a consumer SHALL push an announcement to the followers of the performers of the phase's covered events, applying the existing hype-level filter
+
+#### Scenario: Re-discovered phase is not re-announced
+
+- **WHEN** the discovery job re-encounters an already-known phase (only updating its fields)
+- **THEN** it SHALL NOT publish a new announcement for that phase
+
+#### Scenario: Announcement copy localized per recipient
+
+- **WHEN** the announcement is built for a recipient
+- **THEN** its `title` and `body` SHALL be rendered in the recipient's `preferred_language`
+- **AND** when the recipient has no `preferred_language` set, the copy SHALL default to `en`

--- a/openspec/changes/archive/2026-06-24-localize-push-notification-text/tasks.md
+++ b/openspec/changes/archive/2026-06-24-localize-push-notification-text/tasks.md
@@ -1,0 +1,27 @@
+## 1. Concert-discovery notification: surface recipient language
+
+- [x] 1.1 Extend `followListFollowersQuery` in `internal/infrastructure/database/rdb/follow_repo.go` to select `COALESCE(u.preferred_language, '')`
+- [x] 1.2 Scan the new column in `ListFollowers` and set `Follower.User.PreferredLanguage`; update the `ListFollowers` doc comment and the `FollowRepository.ListFollowers` interface doc in `internal/entity/follow.go`
+- [x] 1.3 Add/extend an integration test in `internal/infrastructure/database/rdb/follow_repo_test.go` asserting `ListFollowers` returns `preferred_language` (set via UPDATE) and empty string when unset
+
+## 2. Concert-discovery notification: localized payload
+
+- [x] 2.1 Change `NewConcertNotificationPayload` in `internal/entity/push_notification.go` to accept a `lang` parameter, normalize empty/unsupported → `en`, and render an en/ja body with singular/plural handling ("1 new concert found" / "N new concerts found" / "新しいライブが N 件見つかりました")
+- [x] 2.2 Add table-driven unit tests in `internal/entity/push_notification_test.go` covering en, ja, empty-lang fallback, and singular vs plural
+- [x] 2.3 In `NotifyNewConcerts` (`internal/usecase/push_notification_uc.go`), build a `map[userID]lang` during follower filtering and a `map[lang][]byte` payload cache, marshalling at most once per distinct language; send the per-language payload to each subscription (default `en` when a sub's user is absent), leaving 410-gone cleanup, metrics, and error handling unchanged
+- [x] 2.4 Extend `internal/usecase/push_notification_uc_test.go` to assert ja vs en bodies from captured payload bytes for a mixed-language audience, plus empty-lang → en fallback
+
+## 3. Sales-phase announcement: per-recipient localization
+
+- [x] 3.1 Add `userRepo entity.UserRepository` to the struct and constructor of `internal/usecase/sales_phase_announcement_uc.go`
+- [x] 3.2 In `AnnounceDiscoveredPhase`, hydrate recipients via `userRepo.Get` (warn-and-skip on error, mirroring `sales_reminder_uc.go`) and build a `map[userID]lang`
+- [x] 3.3 Replace the hardcoded English payload with `announcementTitle(lang)` / `announcementBody(lang)` helpers (map + en fallback) and a `map[lang][]byte` cache; remove the "personalisation intentionally omitted" comment
+- [x] 3.4 Wire `rdb.NewUserRepository(db)` into the announcement use case in `internal/di/consumer.go`
+- [x] 3.5 Add `internal/usecase/sales_phase_announcement_uc_test.go` covering en, ja, empty-lang → en, `userRepo.Get` error → skip-but-continue, and empty-audience no-op
+
+## 4. Verification and release
+
+- [x] 4.1 Run `make check` (lint + unit + integration tests) in `backend` until green
+- [x] 4.2 Open the backend PR, get CI green, and merge
+- [x] 4.3 Cut a backend release (SemVer tag + GitHub Release) and confirm the prod image is built
+- [x] 4.4 Confirm the prod rollout (ArgoCD synced/healthy) so concert-discovery and sales-phase-announcement notifications ship to prod recipients in their preferred language

--- a/openspec/specs/push-notification-localization/spec.md
+++ b/openspec/specs/push-notification-localization/spec.md
@@ -1,0 +1,51 @@
+# push-notification-localization Specification
+
+## Purpose
+TBD - created by archiving change localize-push-notification-text. Update Purpose after archive.
+## Requirements
+### Requirement: Localized Notification Copy
+
+The system SHALL select the user-facing copy of every Web Push notification by the recipient's `preferred_language`, defaulting to `en` when the recipient has no language set. Localization SHALL reuse the existing `NotificationPayload` shape (`title`, `body`, `url`, `tag`); only the human-readable `title` and `body` are language-dependent, while `url` and `tag` remain language-independent.
+
+#### Scenario: Recipient has a preferred language
+
+- **WHEN** a Web Push notification is built for a recipient whose `preferred_language` is a supported code (e.g. `ja`)
+- **THEN** the notification `title` and `body` SHALL be rendered in that language
+
+#### Scenario: Recipient has no preferred language
+
+- **WHEN** a Web Push notification is built for a recipient whose `preferred_language` is unset or empty
+- **THEN** the notification `title` and `body` SHALL be rendered in `en`
+
+#### Scenario: Recipient has an unsupported preferred language
+
+- **WHEN** a Web Push notification is built for a recipient whose `preferred_language` is a code with no localized copy available
+- **THEN** the notification `title` and `body` SHALL fall back to `en`
+
+#### Scenario: Mixed-language audience for one notification event
+
+- **WHEN** a single notification event fans out to recipients with differing `preferred_language` values
+- **THEN** each recipient SHALL receive copy in their own resolved language
+- **AND** the system SHALL build at most one payload per distinct resolved language rather than one per recipient subscription
+
+### Requirement: Concert Discovery Notification Content
+
+The system SHALL localize the concert-discovery follower notification that is sent when new concerts are found for a followed artist. The `title` SHALL be the artist name (language-independent) and the `body` SHALL state the count of newly discovered concerts in the recipient's resolved language.
+
+#### Scenario: Body in English
+
+- **WHEN** newly discovered concerts are notified to a recipient resolved to `en`
+- **THEN** the `body` SHALL read "1 new concert found" for a single concert
+- **AND** the `body` SHALL read "N new concerts found" for N concerts where N is greater than one
+
+#### Scenario: Body in Japanese
+
+- **WHEN** newly discovered concerts are notified to a recipient resolved to `ja`
+- **THEN** the `body` SHALL state the new-concert count in Japanese (e.g. "新しいライブが N 件見つかりました")
+
+#### Scenario: Title and deep-link unaffected by language
+
+- **WHEN** a concert-discovery notification is built for any recipient
+- **THEN** the `title` SHALL be the artist name regardless of language
+- **AND** the `url` SHALL deep-link to the artist's concerts and the `tag` SHALL deduplicate per artist, both regardless of language
+

--- a/openspec/specs/sales-phase-discovery/spec.md
+++ b/openspec/specs/sales-phase-discovery/spec.md
@@ -78,7 +78,7 @@ The system SHALL run a scheduled job that discovers sales phases for the upcomin
 
 ### Requirement: Event-Driven Announcement on New Phase
 
-The system SHALL push an announcement when a newly discovered sales phase is persisted, reusing the existing discovery→event→push pipeline. This announcement is event-driven and distinct from the time-based reminders.
+The system SHALL push an announcement when a newly discovered sales phase is persisted, reusing the existing discovery→event→push pipeline. This announcement is event-driven and distinct from the time-based reminders. The announcement SHALL be built per recipient and localized to the recipient's `preferred_language` (default `en`), consistent with the `sales-reminders` Notification Content requirement.
 
 #### Scenario: New phase announced
 
@@ -90,4 +90,10 @@ The system SHALL push an announcement when a newly discovered sales phase is per
 
 - **WHEN** the discovery job re-encounters an already-known phase (only updating its fields)
 - **THEN** it SHALL NOT publish a new announcement for that phase
+
+#### Scenario: Announcement copy localized per recipient
+
+- **WHEN** the announcement is built for a recipient
+- **THEN** its `title` and `body` SHALL be rendered in the recipient's `preferred_language`
+- **AND** when the recipient has no `preferred_language` set, the copy SHALL default to `en`
 


### PR DESCRIPTION
## Summary

Archive the `localize-push-notification-text` OpenSpec change. Push notification copy localization shipped to production via backend **v1.13.0** (PR liverty-music/backend#346).

## Changes

- **New spec** `push-notification-localization`: cross-cutting rule that user-facing Web Push copy is selected by the recipient's `preferred_language` (default `en`), plus the concert-discovery notification content contract (en singular/plural + ja).
- **Modified spec** `sales-phase-discovery`: the "Event-Driven Announcement on New Phase" requirement now states the announcement is built per recipient and localized (default `en`), aligning with the existing `sales-reminders` Notification Content requirement.
- Move the change to `openspec/changes/archive/2026-06-24-localize-push-notification-text/`.

Docs/spec only — no proto/schema change.

## Related

close: #345
