### PR TITLE
docs(analytics): narrow scope — exclude unoffered ticket flows & defer session replay (Decision 12)

### DIFF
--- a/openspec/changes/introduce-analytics-tool/design.md
+++ b/openspec/changes/introduce-analytics-tool/design.md
@@ -179,6 +179,22 @@ This repo already runs the generate-from-one-source pattern for its API: `buf.ge
 
 **Rationale:** The principled options are "delete the drift class" (Paradigm B) or "don't have it yet" (hand-maintained + PR review). The middle ground — building cross-repo CI machinery to guard a deliberately drift-prone structure — is the one option hard to justify on either cost or principle. We take "don't have it yet" now, with Paradigm B pre-analysed so adoption is a small, well-scoped step rather than a redesign.
 
+### Decision 12: Scope is narrowed to live product surface — unoffered ticket flows and session replay are excluded
+
+The original scope instrumented the full envisioned product, including flows that the live service does not yet offer and a session-replay capability that the shipped frontend never enabled. This decision aligns the scope with what is actually in production, verified against `main` and the running prod consumer.
+
+**Excluded — ticket flows not offered as a service:**
+
+- **Ticket lottery** (`ticket.lottery.*`; task 5.4) and **ticket purchase** (`ticket.purchase.*`; task 5.5) have no frontend route and no backend handler on `main`. There is nothing to instrument. These events, their backend constants, and their catalogue rows are out of scope until the corresponding product features exist. The ticket surface that *does* exist — email import, journey tracking, sales-phase, and **entry/ZK-proof verification** — stays in scope (the prod consumer already forwards `ENTRY.zk_proof_verified`/`rejected`).
+- Decision 5's "paired events for major conversion steps" is correspondingly reduced to **artist follow** only (the one paired flow whose endpoints both exist); lottery and purchase pairs are deferred with their features.
+
+**Excluded — session replay (and therefore sampling):**
+
+- The shipped `AnalyticsService` initialises with `disable_session_recording: true` and `autocapture: false`; **session replay is not enabled in production.** Replay sampling (task 8.5) exists only to bound replay's free-tier cost, so with replay off it is moot — sampling is **not needed in current scope**. The replay-dependent work — masking config (8.1), the PII-DOM tagging it would protect (5.8, 8.2, 8.3), and the recording audit runbook (8.4) — is **dormant by consequence** and deferred until replay is deliberately enabled (a separate product + free-tier-cost decision).
+- This reconciles the earlier design wording ("session replay is enabled … but sampled") with the shipped reality (replay disabled). Enabling replay later re-activates this whole cluster as one scoped unit.
+
+**Rationale:** Instrumenting non-existent flows produces dead constants and catalogue entries that read as coverage while emitting nothing; carrying a sampling/PII-masking apparatus for a disabled capability is pure carrying cost. Scope tracks the live surface; deferred items re-enter scope with the feature or capability that makes them real.
+
 ## Risks / Trade-offs
 
 - **[Risk] Opt-out model draws privacy complaints or a higher-than-expected opt-out rate → Mitigation**: per Decision 7 analytics is on by default (cleared by EU adequacy) but the opt-out is always available in settings and surfaced by a non-blocking onboarding transparency notice; 要配慮 data is excluded structurally and minor-user legality is deferred to legal review (task 11.4). Measure post-launch the opt-out rate and complaint volume; if the opt-out rate is high, improve the transparency copy and the perceived value exchange rather than reverting to opt-in.

--- a/openspec/changes/introduce-analytics-tool/specs/product-analytics/spec.md
+++ b/openspec/changes/introduce-analytics-tool/specs/product-analytics/spec.md
@@ -126,6 +126,8 @@ The frontend SHALL initialise PostHog with `autocapture: false`, `capture_pagevi
 ### Requirement: Session replay masks PII by default
 Session replay SHALL be enabled with `maskAllInputs: true` so that the contents of every `<input>` and `<textarea>` are masked. Elements containing PII outside form inputs SHALL be marked with `data-pii` to extend masking. Sensitive sections (payment forms, ZK proof entry screens) and any 要配慮個人情報 / minor-identifying region SHALL be marked with `.ph-no-capture` to suppress recording entirely.
 
+> **Deferred — not in current scope (design Decision 12).** The shipped frontend runs with session replay disabled (`disable_session_recording: true`); the requirements in this section apply only once replay is deliberately enabled. Replay sampling is consequently not configured in current scope.
+
 Session replay SHALL be sampled rather than recorded for every session. The PostHog free tier permits ~5,000 recordings/month, which at 100% capture is exhausted at roughly 600–1,000 monthly active users — far below the ~5,000 MAU the 1M-event tier supports — so the binding free-tier constraint is replay, not event volume. The application SHALL configure a session-recording sample rate (initial target ~10%) so replay coverage scales to a comparable MAU ceiling as event capture.
 
 #### Scenario: Only a sampled fraction of sessions is recorded

--- a/openspec/changes/introduce-analytics-tool/tasks.md
+++ b/openspec/changes/introduce-analytics-tool/tasks.md
@@ -37,11 +37,11 @@
 - [ ] 5.1 Invoke `AnalyticsService.identify(user.id.value, properties)` after `UserService.GetMe()` returns on app start when the user is authenticated and consent is granted
 - [ ] 5.2 Instrument the artist-discovery flow (`artist.discovery.viewed`, `artist.search`, `artist.follow.requested`)
 - [ ] 5.3 Instrument the concert-detail flow (`concert.detail.viewed`, `concert.recommendation.clicked`)
-- [ ] 5.4 Instrument the ticket-lottery flow (`ticket.lottery.entry.submitted`)
-- [ ] 5.5 Instrument the ticket-purchase flow (`ticket.purchase.initiated`)
+- [~] 5.4 Instrument the ticket-lottery flow (`ticket.lottery.entry.submitted`) — OUT OF SCOPE per Decision 12: no lottery feature is offered (no FE route, no BE handler on `main`). Re-enters scope with the feature.
+- [~] 5.5 Instrument the ticket-purchase flow (`ticket.purchase.initiated`) — OUT OF SCOPE per Decision 12: no purchase feature is offered. Re-enters scope with the feature.
 - [ ] 5.6 Instrument the entry/check-in flow (`entry.checkin.attempted`)
 - [ ] 5.7 Instrument push subscription opt-in (`notification.requested`) and notification interaction (`notification.opened`, `notification.dismissed`)
-- [ ] 5.8 Tag PII-sensitive DOM elements with `data-pii` and high-risk regions with `.ph-no-capture`
+- [~] 5.8 Tag PII-sensitive DOM elements with `data-pii` and high-risk regions with `.ph-no-capture` — DEFERRED per Decision 12: only meaningful under session replay/autocapture, both disabled in prod. Re-enters scope when replay is enabled.
 
 ## 6. Opt-out model & consent integration
 
@@ -65,11 +65,13 @@
 
 ## 8. Session replay & PII redaction
 
-- [ ] 8.1 Configure `posthog-js` with `maskAllInputs: true`, `maskTextSelector: '[data-pii]'`, and `blockSelector: '.ph-no-capture'`
-- [ ] 8.2 Audit the existing PWA for elements rendering user-controlled text outside form inputs and tag them `data-pii`
-- [ ] 8.3 Tag the payment-form region, the ZK-proof entry region, and any 要配慮 / minor-identifying region with `.ph-no-capture`
-- [ ] 8.4 Add a monthly recording-audit runbook entry that samples 10 recordings and confirms no PII appears
-- [ ] 8.5 Configure a session-recording **sample rate** (initial ~10%) wired to the Session-replay opt-out toggle. Rationale: free-tier 5,000 recordings/month exhausts at ~600–1,000 MAU at 100% capture vs. ~5,000 MAU for events, so replay is the binding constraint and MUST be sampled from day one
+> **Section deferred per Decision 12.** The shipped `AnalyticsService` runs with `disable_session_recording: true` and `autocapture: false` — session replay is not enabled in production. This whole section re-enters scope as one unit if/when replay is deliberately enabled.
+
+- [~] 8.1 Configure `posthog-js` with `maskAllInputs: true`, `maskTextSelector: '[data-pii]'`, and `blockSelector: '.ph-no-capture'` — DEFERRED (replay not enabled)
+- [~] 8.2 Audit the existing PWA for elements rendering user-controlled text outside form inputs and tag them `data-pii` — DEFERRED (replay not enabled)
+- [~] 8.3 Tag the payment-form region, the ZK-proof entry region, and any 要配慮 / minor-identifying region with `.ph-no-capture` — DEFERRED (replay not enabled)
+- [~] 8.4 Add a monthly recording-audit runbook entry that samples 10 recordings and confirms no PII appears — DEFERRED (no replay to audit)
+- [~] 8.5 Configure a session-recording **sample rate** (initial ~10%) wired to the Session-replay opt-out toggle — NOT NEEDED in current scope per Decision 12: sampling only bounds replay's free-tier cost, and replay is disabled. Re-enters scope with replay.
 
 ## 9. Event catalogue & dashboards
 


### PR DESCRIPTION
## 🔗 Related Issue

Refs #532

## 📝 Summary of Changes

Narrows the `introduce-analytics-tool` scope to the **live product surface**, captured as **Decision 12**. Verified against `main` and the running prod consumer.

**Investigation that drove this** (read-only, prod):
- The prod `consumer-app` is Running and actively forwards `USER.created`, `USER.preferred_language_updated`, `ARTIST.followed/unfollowed`, `NOTIFICATION.subscribed`, `ENTRY.zk_proof_verified/rejected` to PostHog — the pipeline is live, not silently inert.
- **Lottery and purchase have no frontend route and no backend handler** on `main`.
- The shipped `AnalyticsService` runs with `disable_session_recording: true` — **session replay is not enabled in prod**.

**Scope decisions:**
- **Exclude unoffered ticket flows** — lottery (5.4) and purchase (5.5) are out of scope until the features exist; the paired-event set reduces to artist follow. The ticket surface that *does* exist (email import, journey, sales-phase, entry/ZK) stays in scope.
- **Defer session replay + sampling** — replay is disabled, so sampling (8.5) is not needed, and the replay-dependent PII masking / DOM tagging (5.8, 8.1–8.4) is deferred as one unit until replay is deliberately enabled (a separate product + free-tier-cost decision).

Doc-only: design.md (Decision 12), tasks.md (affected tasks marked `[~]`), spec.md (session-replay requirement annotated deferred). `openspec validate --strict` passes. No proto, no code.

## ✅ Self-Checklist

- [x] Linked the related issue (referenced; one slice of #532).
- [x] Updated documentation (Decision 12 + tasks + spec annotation).
- [x] `openspec validate --strict` passes; `buf` unaffected (no proto).
- [x] N/A — no proto definitions changed.
- [x] No breaking changes.

> Records scope decisions you gave (exclude unoffered ticket mgmt features; sampling not needed now). Please confirm the lottery/purchase exclusion and the replay-deferral framing read right before merge.
