### PR TITLE
docs(analytics): reconcile task ledger with merged implementation

### DIFF
--- a/openspec/changes/introduce-analytics-tool/tasks.md
+++ b/openspec/changes/introduce-analytics-tool/tasks.md
@@ -109,7 +109,7 @@
 
 ## 13. Backend event-coverage gap (publishers for catalogued-but-unpublished events)
 
-> Gap analysis: 10 of 17 catalogued BE events are defined in `analytics_events.go` but have **no publisher**, so the funnel tail is empty. Of those, **9 are actionable now** and enumerated below (§13.1–13.5). The 10th, `user.deleted`, has no deletion feature yet and is deferred to the `manage-analytics-data-rights` change. Closing this gap is the largest funnel-completeness lever; the `analytics-consumer` (§3) is inert without these upstream signals.
+> Gap analysis: 10 of 17 catalogued BE events are defined in `analytics_events.go` but have **no publisher**, so the funnel tail is empty. Of those, **4 are actionable now** — §13.1 (`account.signup.completed`, `account.login`), §13.2 (`notification.delivered`), and §13.5 (`concert.recommendation.served`). §13.3–13.4 (5 events: the 3 lottery + 2 purchase events) are **out of scope per Decision 12** (no lottery/purchase feature offered) and re-enter scope with those features. The remaining `user.deleted` has no deletion feature yet and is deferred to the `manage-analytics-data-rights` change. Closing the actionable gap is the largest funnel-completeness lever; the `analytics-consumer` (§3) is inert without these upstream signals.
 
 - [ ] 13.1 Publish `account.signup.completed` and `account.login` — neither is observable today (Zitadel OIDC bypasses the backend). Add a hook (e.g. RPC-context first-seen detection or a Zitadel event) so login/signup become backend-emitted events
 - [ ] 13.2 Emit `notification.delivered` from the push sender (`push_notification_uc.go` `NotifyNewConcerts`) using the send result already in hand

--- a/openspec/changes/introduce-analytics-tool/tasks.md
+++ b/openspec/changes/introduce-analytics-tool/tasks.md
@@ -1,9 +1,9 @@
 ## 1. Infrastructure & secrets
 
-- [ ] 1.1 Create PostHog Cloud EU project and capture the public project API key, the personal API key (for definitions sync), and the EU API host URL
-- [ ] 1.2 Add PostHog project API key and personal API key as GCP Secret Manager secrets in the dev, staging, and prod environments
-- [ ] 1.3 Update Pulumi stacks in cloud-provisioning to grant the backend service account read access to the new PostHog secrets
-- [ ] 1.4 Add backend ConfigMap entries (`POSTHOG_API_HOST`, `POSTHOG_PROJECT_KEY_SECRET_REF`) under cloud-provisioning/k8s overlays
+- [~] 1.1 Create PostHog Cloud EU project and capture the public project API key, the personal API key (for definitions sync), and the EU API host URL — PARTIAL: dev + prod projects exist and public `phc_` project keys are captured (live in the consumer/frontend ConfigMaps); the **personal** API key (flag-definition sync) is not captured/provisioned — pending until backend feature flags are actually used (see 7.3, DI deferred).
+- [~] 1.2 Add PostHog project API key and personal API key as GCP Secret Manager secrets in the dev, staging, and prod environments — PARTIAL: public project key provisioned (`posthog-public-project-key` GSM secret + plaintext ConfigMap, acceptable for a public key); the **personal** key is not in GSM and no ExternalSecret sync exists — deferred with 1.1.
+- [x] 1.3 Update Pulumi stacks in cloud-provisioning to grant the backend service account read access to the new PostHog secrets — `src/gcp/components/kubernetes.ts` binds the backend-app SA to the PostHog secret via `SecretManager.SecretAccessor` (per-secret, minimal scope).
+- [x] 1.4 Add backend ConfigMap entries (`POSTHOG_API_HOST`, `POSTHOG_PROJECT_KEY_SECRET_REF`) under cloud-provisioning/k8s overlays — `POSTHOG_API_HOST` + `POSTHOG_PROJECT_API_KEY` present in dev and prod `consumer/configmap.env`. (Delivered as the plaintext public `phc_` value rather than a `*_SECRET_REF`, which is correct for a public key.)
 - [x] 1.5 Document the secret-rotation runbook for PostHog API keys
 
 ## 2. Backend dependencies & domain types
@@ -12,40 +12,42 @@
 - [x] 2.2 Add `backend/internal/usecase/analytics_events.go` defining the canonical event-name constants emitted by the backend (placed flat under `usecase/` to match repo convention, not under a new sub-package)
 - [x] 2.3 Define the `AnalyticsClient` interface in `backend/internal/usecase/analytics_client.go` covering `Enqueue(distinctID, eventName, properties)` and `Close(ctx)` semantics
 - [x] 2.4 Implement `PostHogAnalyticsClient` under `backend/internal/infrastructure/analytics/posthog/` against the `AnalyticsClient` interface using `posthog-go` (placed under `infrastructure/` to match repo convention for outbound dependencies; the design.md `adapter/analytics/` path was inconsistent with the existing `infrastructure/messaging/`, `infrastructure/webpush/` etc. pattern)
-- [ ] 2.5 Wire the `AnalyticsClient` binding in the manual DI graph (`internal/di/provider.go` — note: repo uses hand-written DI, not Google Wire) with environment-driven configuration — **deferred to Batch 2b together with the `analytics-consumer` worker so the wiring has an actual consumer at the same time**
+- [x] 2.5 Wire the `AnalyticsClient` binding in the manual DI graph (`internal/di/provider.go` — note: repo uses hand-written DI, not Google Wire) with environment-driven configuration — `internal/di/consumer.go` constructs `posthog.New(APIHost, ProjectAPIKey, logger)` when the project key is non-empty and registers `Close` with the shutdown manager.
 
 ## 3. Backend `analytics-consumer` worker
 
 - [x] 3.1 Create the `analytics-consumer` adapter at `backend/internal/adapter/event/analytics_consumer.go` (flat layout matching the existing `*_consumer.go` files in that directory, NOT a new sub-package) with one `Handle*` method per subscribed NATS subject. NATS subjects follow the pre-existing UPPERCASE two-segment convention (e.g. `USER.created`); each `Handle*` method maps its subject to the corresponding lowercase catalogue event name. Initial subscription set: `USER.created` (mapped to `user.created`). Additional subscriptions land in follow-up commits as the corresponding catalogue events become reachable through new publishers.
-- [ ] 3.2 Implement per-subject message decoders that transform NATS payloads into PostHog-shaped events with sanitised properties
-- [ ] 3.3 Implement exponential-backoff retry for transient PostHog errors and structured logging for permanent failures
-- [ ] 3.4 Add OTel `trace_id` propagation from NATS message headers onto outbound PostHog events
-- [ ] 3.5 Add `analytics-consumer` to the backend cmd entrypoint and the Kubernetes Deployment manifest with appropriate resource requests/limits
-- [ ] 3.6 Add Prometheus metrics for `analytics_consumer_messages_total`, `analytics_consumer_errors_total`, and `analytics_consumer_lag_seconds`
+- [x] 3.2 Implement per-subject message decoders that transform NATS payloads into PostHog-shaped events with sanitised properties — `analytics_consumer.go` `Handle*` methods decode each CloudEvent payload and enqueue sanitised properties.
+- [x] 3.3 Implement exponential-backoff retry for transient PostHog errors and structured logging for permanent failures — permanent failures are logged and recorded as error-status metrics; transient retry is delegated to the posthog-go async worker per the non-blocking `AnalyticsClient` contract (Decision 6), so the consumer never blocks. No consumer-level blocking retry by design.
+- [x] 3.4 Add OTel `trace_id` propagation from NATS message headers onto outbound PostHog events — `posthog_client.go buildSDKProperties` injects the active span's `trace_id`.
+- [x] 3.5 Add `analytics-consumer` to the backend cmd entrypoint and the Kubernetes Deployment manifest with appropriate resource requests/limits — wired in `cmd/consumer` via `internal/di/consumer.go` (7 analytics handlers) and `k8s/namespaces/backend/base/consumer/deployment.yaml`; confirmed Running in prod.
+- [x] 3.6 Add Prometheus metrics for `analytics_consumer_messages_total`, `analytics_consumer_errors_total`, and `analytics_consumer_lag_seconds` — `internal/infrastructure/telemetry/analytics_consumer_metrics.go` emits `messages_total` (status-labelled; error statuses are the `errors_total` equivalent) and `lag_seconds`, wired in `di/consumer.go`.
 
 ## 4. Frontend dependencies & analytics primitives
 
-- [ ] 4.1 Add `posthog-js` to frontend package.json and pin the version
+- [x] 4.1 Add `posthog-js` to frontend package.json and pin the version — pinned in `package.json`.
 - [x] 4.2 Create `frontend/src/services/analytics-events.ts` defining the canonical `Events` constant object with typed property shapes per event (placed flat under `services/` to match repo convention, not under a new `lib/analytics/` directory)
-- [ ] 4.3 Implement `AnalyticsService` under `frontend/src/lib/analytics/analytics-service.ts` with deferred initialisation via `requestIdleCallback`, in-memory queue, and typed `capture`/`identify`/`reset`/`getFeatureFlag` methods
-- [ ] 4.4 Register `AnalyticsService` in the Aurelia 2 DI container via `main.ts`
-- [ ] 4.5 Wire page-view emission to the Aurelia router `au:router:navigation-end` event from the app root
-- [ ] 4.6 Add Vite environment variables (`VITE_POSTHOG_KEY`, `VITE_POSTHOG_HOST`) and configure injection through the frontend-runtime-config flow
+- [x] 4.3 Implement `AnalyticsService` under `frontend/src/lib/analytics/analytics-service.ts` with deferred initialisation via `requestIdleCallback`, in-memory queue, and typed `capture`/`identify`/`reset`/`getFeatureFlag` methods — implemented as described.
+- [x] 4.4 Register `AnalyticsService` in the Aurelia 2 DI container via `main.ts` — registered via `IAnalyticsService` in `main.ts`.
+- [x] 4.5 Wire page-view emission to the Aurelia router `au:router:navigation-end` event from the app root — `app-shell.ts` emits `Events.PageViewed` on router navigation.
+- [x] 4.6 Add Vite environment variables (`VITE_POSTHOG_KEY`, `VITE_POSTHOG_HOST`) and configure injection through the frontend-runtime-config flow — DONE via divergence: config is delivered through the runtime `/config.json` flow (`posthogApiHost`/`posthogProjectKey` read by `shared/config/app-config.ts`), not `VITE_*` build-time env. This matches how the frontend-runtime-config flow injects other runtime config and avoids baking keys into the build.
 
 ## 5. Frontend identification & instrumentation
 
-- [ ] 5.1 Invoke `AnalyticsService.identify(user.id.value, properties)` after `UserService.GetMe()` returns on app start when the user is authenticated and consent is granted
-- [ ] 5.2 Instrument the artist-discovery flow (`artist.discovery.viewed`, `artist.search`, `artist.follow.requested`)
-- [ ] 5.3 Instrument the concert-detail flow (`concert.detail.viewed`, `concert.recommendation.clicked`)
+- [x] 5.1 Invoke `AnalyticsService.identify(user.id.value, properties)` after `UserService.GetMe()` returns on app start when the user is authenticated and consent is granted — `user-hydration-task.ts` calls `identify` after hydration; consent gating is enforced inside `AnalyticsService`.
+- [x] 5.2 Instrument the artist-discovery flow (`artist.discovery.viewed`, `artist.search`, `artist.follow.requested`) — emitted from `discovery-route.ts`.
+- [x] 5.3 Instrument the concert-detail flow (`concert.detail.viewed`, `concert.recommendation.clicked`) — `event-detail-sheet.ts` + `event-card.ts`.
 - [~] 5.4 Instrument the ticket-lottery flow (`ticket.lottery.entry.submitted`) — OUT OF SCOPE per Decision 12: no lottery feature is offered (no FE route, no BE handler on `main`). Re-enters scope with the feature.
 - [~] 5.5 Instrument the ticket-purchase flow (`ticket.purchase.initiated`) — OUT OF SCOPE per Decision 12: no purchase feature is offered. Re-enters scope with the feature.
-- [ ] 5.6 Instrument the entry/check-in flow (`entry.checkin.attempted`)
-- [ ] 5.7 Instrument push subscription opt-in (`notification.requested`) and notification interaction (`notification.opened`, `notification.dismissed`)
+- [~] 5.6 Instrument the entry/check-in flow (`entry.checkin.attempted`) — PARTIAL: the `entry.checkin.attempted` event type/constant is defined in `analytics-events.ts` but no FE call site emits it. The BE side of entry (`ENTRY.zk_proof_verified/rejected`) is forwarded by the consumer; the FE intent event needs the check-in screen to emit it. Instrument when the entry/check-in UI is confirmed present.
+- [~] 5.7 Instrument push subscription opt-in (`notification.requested`) and notification interaction (`notification.opened`, `notification.dismissed`) — PARTIAL: `notification.requested` IS emitted (`notification-prompt.ts`). `notification.opened`/`notification.dismissed` are NOT instrumented — they require a service-worker `notificationclick`/`close` handler. This is the main remaining in-scope FE gap.
 - [~] 5.8 Tag PII-sensitive DOM elements with `data-pii` and high-risk regions with `.ph-no-capture` — DEFERRED per Decision 12: only meaningful under session replay/autocapture, both disabled in prod. Re-enters scope when replay is enabled.
 
 ## 6. Opt-out model & consent integration
 
 > Reworked from the original opt-in design to the EU-adequacy opt-out model. The existing `ConsentService` and settings toggles (built opt-in) are refactored, not discarded.
+
+> **§6 needs spec-vs-impl verification (not yet ticked).** A consent layer is merged and live (`consent-service.ts`, `consent-route.ts`, `settings-route.ts`, pre-consent `persistence:'memory'`/`ip:false`), so the *capability* exists. But §6 was reworded to the **opt-out** model (Decision 7: default-on, `marketingMeasurement → sessionReplay`, transparency-notice instead of a consent gate, anonymous→identified **merge** with no `reset()` on the identify path). The merged code still carries the earlier `marketingMeasurement` field and opt-in-style screen, so it may not yet match the reworded requirements. Resolve via `/opsx:verify` before ticking 6.1–6.7.
 
 - [ ] 6.1 Refactor `ConsentService` under `frontend/src/lib/consent/` to opt-out semantics: rename field `marketingMeasurement → sessionReplay`, default both purposes **on** for authenticated users, bump persisted-state version and migrate `v1` payloads. (Pre-launch: no opt-in/decline records to preserve.)
 - [ ] 6.2 Replace the planned signup consent screen with a one-time, non-blocking **analytics transparency notice** as the final onboarding step: names PostHog + cross-border purpose, links to privacy policy and settings opt-out, never gates progression or default-on state
@@ -58,7 +60,7 @@
 ## 7. Feature-flag operations
 
 - [x] 7.1 Document the flag申告 template (`OWNER`, `HYPOTHESIS`, `KPI`, `KILL_DATE`, `ISSUE`) in `specification/docs/analytics/feature-flag-policy.md`
-- [ ] 7.2 Implement frontend `AnalyticsService.getFeatureFlag(key, defaultValue)` with `localStorage` bootstrap of last-known values and asynchronous refresh
+- [x] 7.2 Implement frontend `AnalyticsService.getFeatureFlag(key, defaultValue)` with `localStorage` bootstrap of last-known values and asynchronous refresh — implemented on `AnalyticsService`.
 - [x] 7.3 Implement the backend flag evaluation helper that wraps `posthog-go` local evaluation and always requires a default value at the call site. Implemented as the `usecase.FeatureFlagEvaluator` interface plus a `posthog` adapter; placed in `internal/usecase/` + `internal/infrastructure/analytics/posthog/` to match repo convention rather than a new `featureflag/` sub-package. `IsEnabled`/`Variant` require a default and never return an error (a PostHog outage degrades to the default). Merged via backend PR #344; DI wiring deferred until a first flag consumer exists.
 - [~] 7.4 Add a CI check that fails when any feature-flag evaluation in the frontend or backend codebase omits a default value — DESCOPED per Decision 11: defaults are enforced at the **type level** instead (backend `FeatureFlagEvaluator.IsEnabled/Variant` take a required default param; frontend `getFeatureFlag(key, defaultValue)` likewise), which is strictly stronger than a CI lint. Residual gap (bypassing the helper to call the SDK directly) is a within-repo import-restriction lint, deferred until a flag is actually in use.
 - [x] 7.5 Schedule the monthly stale-flag review as a recurring GitHub issue with a checklist template. Implemented as the scheduled workflow `.github/workflows/stale-flag-review.yml` (monthly `cron` + `workflow_dispatch`): it opens a `feature-flag-review`-labelled issue assigned to the OWNER, carrying the four review-checklist items from `docs/analytics/feature-flag-policy.md`.
@@ -111,8 +113,8 @@
 
 - [ ] 13.1 Publish `account.signup.completed` and `account.login` — neither is observable today (Zitadel OIDC bypasses the backend). Add a hook (e.g. RPC-context first-seen detection or a Zitadel event) so login/signup become backend-emitted events
 - [ ] 13.2 Emit `notification.delivered` from the push sender (`push_notification_uc.go` `NotifyNewConcerts`) using the send result already in hand
-- [ ] 13.3 Emit the lottery funnel from `ticket_email_uc.go` parse outcomes: `ticket.lottery.entry.accepted` / `.rejected` and `ticket.lottery.result.assigned`
-- [ ] 13.4 Emit the purchase funnel: `ticket.purchase.completed` / `.failed` from the payment-confirmation parse path (and/or mint flow)
+- [~] 13.3 Emit the lottery funnel from `ticket_email_uc.go` parse outcomes: `ticket.lottery.entry.accepted` / `.rejected` and `ticket.lottery.result.assigned` — OUT OF SCOPE per Decision 12 (no lottery feature offered). Re-enters scope with the feature.
+- [~] 13.4 Emit the purchase funnel: `ticket.purchase.completed` / `.failed` from the payment-confirmation parse path (and/or mint flow) — OUT OF SCOPE per Decision 12 (no purchase feature offered). Re-enters scope with the feature.
 - [ ] 13.5 Emit `concert.recommendation.served` from the concert list/recommendation RPC paths so impressions pair with the FE `.clicked`
 - [ ] 13.6 Wire each new publisher's NATS subject into the `analytics-consumer` `Handle*` map (§3.1) and add the catalogue/CI coverage entry
 


### PR DESCRIPTION
## 🔗 Related Issue

Refs #532

## 📝 Summary of Changes

Reconciles the `introduce-analytics-tool` task ledger with the **actually-merged implementation**, based on a read-only audit of `origin/main` across backend / frontend / cloud-provisioning. The ledger had badly under-counted shipped work.

**Ticked (with file evidence) — already merged, in scope:**
- Backend: 2.5 (DI wiring), 3.2–3.6 (decoders, retry-by-design, `trace_id`, cmd+k8s deploy, Prometheus metrics)
- Frontend: 4.1/4.3–4.6 (posthog-js, AnalyticsService, DI, page-view, config via runtime `/config.json` divergence), 5.1–5.3 (identify + discovery/concert instrumentation), 7.2 (`getFeatureFlag`)
- Cloud-provisioning: 1.3 (SA secret IAM), 1.4 (ConfigMap entries)

**Annotated PARTIAL:**
- 1.1/1.2 — public project key live in dev+prod; **personal** key + ExternalSecret deferred until backend flags are used
- 5.6 — `entry.checkin.attempted` type exists but no FE call site emits it
- 5.7 — `notification.requested` done; `notification.opened`/`dismissed` need a service-worker handler

**Marked OUT OF SCOPE (Decision 12):** 13.3 / 13.4 (lottery / purchase publishers).

**Flagged for `/opsx:verify`:** §6 (consent) — a consent layer is live, but the merged code may still reflect the older opt-in/`marketingMeasurement` model rather than the reworded opt-out/`sessionReplay` requirements.

Ledger now: **29 `[x]` / 16 `[~]` (descoped/deferred/out-of-scope) / 37 `[ ]`**. `openspec validate --strict` passes. No code change.

## ✅ Self-Checklist

- [x] Linked the related issue (slice of #532).
- [x] Updated documentation (task ledger only).
- [x] `openspec validate --strict` passes; no proto.
- [x] N/A — no proto.
- [x] No breaking changes.

> The remaining `[ ]` are now a clear frontier (see PR thread / chat): §6 verify, §10 tests, §13.1/13.2/13.5/13.6 + §14 backend event coverage, §15 internal-traffic exclusion, §9/§11/§12 external (dashboards/legal/rollout — much of §12 already live in prod).
