### PR TITLE
docs(openspec): propose extend-auth-session-lifetime

### DIFF
--- a/openspec/changes/extend-auth-session-lifetime/.openspec.yaml
+++ b/openspec/changes/extend-auth-session-lifetime/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-24

--- a/openspec/changes/extend-auth-session-lifetime/design.md
+++ b/openspec/changes/extend-auth-session-lifetime/design.md
@@ -65,7 +65,7 @@ This is an **instance-level** (not org-level) setting, applied once per environm
 
 - **[`signinSilent()` adds latency to cold boot]** → It only fires when the access token is expired (the long-gap reopen case), and runs concurrently with app bootstrap behind the existing `ready` barrier that routes already await. The common warm-reopen path (token still valid) skips it entirely.
 - **[Disabling `monitorSession` delays IdP-side logout detection]** → Bounded by the 30m access-token lifetime; the next refresh against a revoked session fails and signs the user out. Acceptable for a consumer notification app.
-- **[Longer refresh-token absolute lifetime (90d) widens the re-auth window]** → Offset by the much shorter 30m access token (was 12h), which is the actually-revocation-relevant exposure; net security posture improves.
+- **[Refresh-token lifetimes (idle 30d / absolute 90d) keep the re-auth window long]** → These match Zitadel's existing defaults, so this change does not widen the window; it only pins the values explicitly. The actual posture change is the much shorter 30m access token (was 12h), which is the revocation-relevant exposure; net security posture improves.
 - **[`idTokenLifetime` left at 12h while access is 30m]** → Harmless: the ID token is reissued on every silent renew; its lifetime only bounds staleness of the cached profile between renewals.
 - **[Changing instance OIDC defaults affects all OIDC apps in the instance (frontend SPA, admin console)]** → Intended; all first-party apps benefit from the same posture. No app currently depends on the 12h access default.
 

--- a/openspec/changes/extend-auth-session-lifetime/design.md
+++ b/openspec/changes/extend-auth-session-lifetime/design.md
@@ -1,0 +1,81 @@
+## Context
+
+Users report being signed out when reopening the installed PWA the day after sign-up, despite a 30-day refresh token. Investigation found three contributing factors:
+
+1. **oidc-client-ts issue #2012** — `automaticSilentRenew` schedules renewal relative to a *not-yet-expired* access token. On a cold start with an *already-expired* access token, the library drops the renewal timer based on the access token alone and never consults the still-valid refresh token. The user lands unauthenticated.
+2. **OIDC token lifetimes are unset in IaC** — `cloud-provisioning` configures Zitadel login-policy lifetimes (`passwordCheckLifetime`, etc.) but never the instance-level OIDC token lifetimes. Access tokens run on Zitadel's 12h built-in default; refresh tokens on 30d/90d defaults.
+3. **`monitorSession` enabled in prod** — `auth-service.ts` sets `monitorSession: !import.meta.env.DEV`. The self-hosted Zitadel serves `check_session_iframe` with `frame-ancestors 'none'`, so the hidden iframe cannot load and can fire spurious `userUnloaded` events. Dev already disables it; prod does not.
+
+Current code: `frontend/shared/services/auth-service.ts` (constructor calls `getUser()` then resolves `ready` immediately). Zitadel IaC: `cloud-provisioning/src/zitadel/` using `@pulumiverse/zitadel` `^0.2.0`, which exposes `zitadel.DefaultOidcSettings`.
+
+## Goals / Non-Goals
+
+**Goals:**
+- A returning user with a valid refresh token is transparently re-authenticated on cold start, with no signed-out flash, regardless of how long the app was closed (within refresh-token validity).
+- OIDC token lifetimes are explicit and reviewable in IaC: access 30m, refresh idle 30d, refresh absolute 90d.
+- Remove the prod-only `monitorSession` iframe conflict.
+
+**Non-Goals:**
+- Real-time cross-app / IdP-side logout detection (deferred to next-refresh detection by disabling `monitorSession`).
+- Refresh-token rotation policy changes beyond lifetimes.
+- Any backend JWT-validation change — the backend already validates `exp`; a 30m access token simply expires sooner.
+- Forking or patching `oidc-client-ts` to fix #2012 upstream.
+
+## Decisions
+
+### Decision 1: Boot-time silent renewal in the AuthService constructor
+
+Gate the `ready` promise on a boot-time renewal attempt. In the constructor's `getUser()` continuation, if `user && user.expired`, call `signinSilent()` and only resolve `ready` after it settles; on success use the renewed user, on failure fall back to `null` (signed out).
+
+```
+user = await getUser()
+if (user?.expired) {
+  try { user = await userManager.signinSilent() }
+  catch { user = null }
+}
+updateState(user)
+readyResolve()
+```
+
+**Why over alternatives:**
+- *Rely on `automaticSilentRenew` alone* — rejected: that is exactly what #2012 breaks for the cold-start-expired case.
+- *Patch/fork oidc-client-ts* — rejected: maintenance burden; the public `signinSilent()` API already does the right thing when called explicitly.
+- *Lazily renew on first 401 from the API* — rejected: the UI would still flash signed-out during boot, and not every landing route makes an immediate API call. Gating `ready` keeps `AuthHook` and route VMs observing a settled state.
+
+`AuthHook.canLoad` already `await this.authService.ready`, so gating `ready` on the renewal is sufficient — no route-guard change needed.
+
+### Decision 2: `monitorSession: false` in all environments
+
+Replace `monitorSession: !import.meta.env.DEV` with `monitorSession: false`. Session-change detection degrades from ~2s iframe polling to next-token-refresh detection (≤30m), which is acceptable for this product and is the standard posture for SPAs against a Zitadel that blocks iframe embedding.
+
+### Decision 3: Instance-level `DefaultOidcSettings` via Pulumi
+
+Add a single `zitadel.DefaultOidcSettings` resource bound to the existing Zitadel provider. **All four fields are required inputs** in `@pulumiverse/zitadel` `^0.2.0` (`accessTokenLifetime`, `idTokenLifetime`, `refreshTokenExpiration`, `refreshTokenIdleExpiration`), so the resource must specify every one even though only three are behavior-relevant to this change:
+
+| Field | Value |
+|---|---|
+| `accessTokenLifetime` | `30m0s` |
+| `idTokenLifetime` | `12h0m0s` (keep Zitadel default — ID token is refreshed alongside access on silent renew; no need to shorten) |
+| `refreshTokenExpiration` | `2160h0m0s` (90d) |
+| `refreshTokenIdleExpiration` | `720h0m0s` (30d) |
+
+This is an **instance-level** (not org-level) setting, applied once per environment stack.
+
+## Risks / Trade-offs
+
+- **[`signinSilent()` adds latency to cold boot]** → It only fires when the access token is expired (the long-gap reopen case), and runs concurrently with app bootstrap behind the existing `ready` barrier that routes already await. The common warm-reopen path (token still valid) skips it entirely.
+- **[Disabling `monitorSession` delays IdP-side logout detection]** → Bounded by the 30m access-token lifetime; the next refresh against a revoked session fails and signs the user out. Acceptable for a consumer notification app.
+- **[Longer refresh-token absolute lifetime (90d) widens the re-auth window]** → Offset by the much shorter 30m access token (was 12h), which is the actually-revocation-relevant exposure; net security posture improves.
+- **[`idTokenLifetime` left at 12h while access is 30m]** → Harmless: the ID token is reissued on every silent renew; its lifetime only bounds staleness of the cached profile between renewals.
+- **[Changing instance OIDC defaults affects all OIDC apps in the instance (frontend SPA, admin console)]** → Intended; all first-party apps benefit from the same posture. No app currently depends on the 12h access default.
+
+## Migration Plan
+
+1. **frontend** PR: boot-time silent renew + `monitorSession: false` + unit tests. No proto/BSR dependency.
+2. **cloud-provisioning** PR: add `DefaultOidcSettings` resource. Apply to dev stack first (note: dev env is intentionally stopped — verify via `pulumi preview` / apply when the stack is reachable), then prod.
+3. Order is independent — neither PR blocks the other; both can merge in parallel.
+4. **Rollback**: frontend — revert the commit (behavior returns to immediate `ready` resolve). cloud-provisioning — `pulumi destroy` the `DefaultOidcSettings` resource reverts to Zitadel built-in defaults.
+
+## Open Questions
+
+- None blocking. Confirm whether prod Zitadel stack is currently reachable for `pulumi up`, or whether the OIDC-settings apply must wait for an env window (per the stopped-dev-env constraint).

--- a/openspec/changes/extend-auth-session-lifetime/proposal.md
+++ b/openspec/changes/extend-auth-session-lifetime/proposal.md
@@ -22,4 +22,4 @@ Users who sign up and install the PWA are signed out when they reopen the app th
 - **frontend**: `shared/services/auth-service.ts` — boot-time silent-renew logic in the `AuthService` constructor (gating the `ready` promise) and the `monitorSession` setting. Associated unit tests (`test/auth-service.spec.ts`).
 - **cloud-provisioning**: Zitadel Pulumi components — add a `DefaultOidcSettings` (instance-level OIDC token-lifetime) resource.
 - **No proto / BSR changes**: This change does not touch the schema; no code generation or release of the `specification` package is required.
-- **Security posture**: Access-token exposure window shrinks from 12h to 30m; refresh-token absolute lifetime is bounded at 90d (was Zitadel default 30d) with a 30d idle window.
+- **Security posture**: Access-token exposure window shrinks from 12h to 30m; refresh-token absolute lifetime is bounded at 90d (same as Zitadel default; now set explicitly) with a 30d idle window.

--- a/openspec/changes/extend-auth-session-lifetime/proposal.md
+++ b/openspec/changes/extend-auth-session-lifetime/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+Users who sign up and install the PWA are signed out when they reopen the app the next day, even though their refresh token is still valid for 30 days. The root cause is a known `oidc-client-ts` bug ([#2012](https://github.com/authts/oidc-client-ts/issues/2012)): when the app cold-starts with an already-expired access token, the library drops the silent-renew timer based on the access token alone and never consults the still-valid refresh token, so the user lands unauthenticated. Compounding this, the OIDC token lifetimes are not configured in IaC at all — they run on Zitadel built-in defaults (access 12h) — and `monitorSession` is enabled in prod where Zitadel's `check_session_iframe` returns `frame-ancestors 'none'`, which can fire spurious `userUnloaded` events. For a never-miss-a-live notification app, staying signed in across long gaps is core to the value proposition.
+
+## What Changes
+
+- **Frontend session restoration on cold start**: On app boot, if a stored user exists but its access token is expired, the auth service SHALL attempt `signinSilent()` (refresh-token grant) and only resolve auth readiness after that attempt completes — so a valid refresh token transparently restores the session instead of presenting a signed-out UI.
+- **Disable `monitorSession` in all environments**: Remove the env-conditional and set `monitorSession: false` everywhere, eliminating the Zitadel `frame-ancestors 'none'` iframe conflict that can spuriously unload the user. Cross-app/session-level logout detection is deferred to the next token refresh.
+- **Explicit OIDC token lifetimes via IaC**: Configure Zitadel instance-level OIDC token lifetimes in Pulumi (previously unset = built-in defaults): `access_token_lifetime = 30m`, `refresh_token_idle_expiration = 30d`, `refresh_token_expiration = 90d`. Shorter access tokens improve security; the long refresh window keeps fans signed in across gaps, and the explicit values make the intent durable rather than dependent on Zitadel defaults.
+
+## Capabilities
+
+### New Capabilities
+<!-- None — both behaviors extend existing capabilities. -->
+
+### Modified Capabilities
+- `user-auth`: Add a requirement for transparent session restoration on app cold-start via silent refresh-token renewal, and specify that server-side session monitoring (`monitorSession`) is disabled in all environments.
+- `identity-management`: Add a requirement that OIDC token lifetimes are managed explicitly via IaC (access 30m, refresh idle 30d, refresh absolute 90d) rather than relying on Zitadel built-in defaults.
+
+## Impact
+
+- **frontend**: `shared/services/auth-service.ts` — boot-time silent-renew logic in the `AuthService` constructor (gating the `ready` promise) and the `monitorSession` setting. Associated unit tests (`test/auth-service.spec.ts`).
+- **cloud-provisioning**: Zitadel Pulumi components — add a `DefaultOidcSettings` (instance-level OIDC token-lifetime) resource.
+- **No proto / BSR changes**: This change does not touch the schema; no code generation or release of the `specification` package is required.
+- **Security posture**: Access-token exposure window shrinks from 12h to 30m; refresh-token absolute lifetime is bounded at 90d (was Zitadel default 30d) with a 30d idle window.

--- a/openspec/changes/extend-auth-session-lifetime/specs/identity-management/spec.md
+++ b/openspec/changes/extend-auth-session-lifetime/specs/identity-management/spec.md
@@ -1,0 +1,32 @@
+## ADDED Requirements
+
+### Requirement: Configure OIDC Token Lifetimes
+
+The system SHALL manage Zitadel instance-level OIDC token lifetimes explicitly via Infrastructure as Code, rather than relying on Zitadel built-in defaults. The configured values SHALL be:
+
+| Setting | Value | Purpose |
+|---|---|---|
+| `accessTokenLifetime` | `30m` | Short-lived access token limits exposure if leaked; cannot be revoked before expiry once issued. |
+| `refreshTokenIdleExpiration` | `30d` | Inactivity window — a refresh token unused for 30 days becomes invalid. |
+| `refreshTokenExpiration` | `90d` | Absolute lifetime — after 90 days the user must re-authenticate regardless of activity. |
+
+**Rationale**: A never-miss-a-live notification app benefits from long-lived sessions so fans stay signed in across gaps, while a short access-token lifetime keeps the security exposure window small. Pinning these values in IaC makes the intent durable and reviewable instead of implicitly inheriting whatever Zitadel ships as defaults.
+
+#### Scenario: OIDC token lifetimes provisioned via IaC
+
+- **WHEN** the Zitadel Pulumi stack is applied in an environment
+- **THEN** the instance-level OIDC settings SHALL set `accessTokenLifetime` to `30m`
+- **AND** SHALL set `refreshTokenIdleExpiration` to `30d`
+- **AND** SHALL set `refreshTokenExpiration` to `90d`
+
+#### Scenario: Access token rejected after its lifetime
+
+- **WHEN** an access token is older than `30m`
+- **THEN** the backend JWT validation SHALL reject requests bearing that token as expired
+- **AND** the client SHALL obtain a fresh access token via the refresh-token grant
+
+#### Scenario: Session ends after refresh token absolute expiry
+
+- **WHEN** a refresh token reaches its `90d` absolute expiration
+- **THEN** Zitadel SHALL reject further refresh-token grants for that token
+- **AND** the user SHALL be required to re-authenticate

--- a/openspec/changes/extend-auth-session-lifetime/specs/user-auth/spec.md
+++ b/openspec/changes/extend-auth-session-lifetime/specs/user-auth/spec.md
@@ -1,0 +1,41 @@
+## ADDED Requirements
+
+### Requirement: Session Restoration on App Cold Start
+
+The system SHALL transparently restore an authenticated session when the app cold-starts (including PWA relaunch) with a stored user whose access token has expired but whose refresh token is still valid. On boot, the auth service SHALL detect the expired-access-token condition and attempt a silent refresh-token renewal (`signinSilent()`) BEFORE resolving auth readiness, so that route guards and UI never observe a transient signed-out state for a user who can be silently re-authenticated.
+
+This requirement exists because `oidc-client-ts` `automaticSilentRenew` only schedules renewal for a not-yet-expired access token; when the app starts with an already-expired access token it abandons renewal without consulting the refresh token (oidc-client-ts issue #2012). The boot-time silent renewal closes that gap.
+
+#### Scenario: Reopen after access token expiry with valid refresh token
+
+- **WHEN** the app cold-starts and a stored user is loaded whose access token is expired
+- **AND** the user's refresh token is still within its idle and absolute expiration windows
+- **THEN** the system SHALL invoke `signinSilent()` to obtain new tokens via the refresh-token grant
+- **AND** the system SHALL resolve the auth-readiness promise only after the silent renewal attempt settles
+- **AND** the resulting auth state SHALL be authenticated
+- **AND** the UI SHALL NOT render a signed-out state for the elapsed gap
+
+#### Scenario: Reopen after refresh token has expired
+
+- **WHEN** the app cold-starts and a stored user is loaded whose access token is expired
+- **AND** the user's refresh token is no longer valid (idle or absolute expiration exceeded)
+- **THEN** the silent renewal attempt SHALL fail
+- **AND** the system SHALL resolve to an unauthenticated state
+- **AND** the user SHALL be treated as signed out (legitimate re-authentication required)
+
+#### Scenario: Reopen within access token validity
+
+- **WHEN** the app cold-starts and a stored user is loaded whose access token is still valid
+- **THEN** the system SHALL NOT trigger a boot-time silent renewal
+- **AND** the system SHALL resolve to the authenticated state using the existing tokens
+
+### Requirement: Server-Side Session Monitoring Disabled
+
+The system SHALL disable OIDC server-side session monitoring (`monitorSession`) in all environments. The hidden `check_session_iframe` polling mechanism is incompatible with the self-hosted Zitadel instance, which serves that endpoint with `Content-Security-Policy: frame-ancestors 'none'`, causing the embedded iframe to fail and `oidc-client-ts` to emit spurious `userUnloaded` events. Detection of session changes made outside the app (e.g. logout at the identity provider) is deferred to the next token refresh rather than real-time iframe polling.
+
+#### Scenario: Session monitoring is off regardless of environment
+
+- **WHEN** the OIDC `UserManager` is configured at app startup
+- **THEN** `monitorSession` SHALL be `false` in every environment (dev and prod)
+- **AND** the system SHALL NOT load the Zitadel `check_session_iframe`
+- **AND** the system SHALL NOT emit `userUnloaded` events triggered by iframe session polling

--- a/openspec/changes/extend-auth-session-lifetime/tasks.md
+++ b/openspec/changes/extend-auth-session-lifetime/tasks.md
@@ -1,0 +1,24 @@
+## 1. Frontend — Session Restoration on Cold Start
+
+- [ ] 1.1 In `shared/services/auth-service.ts`, change the constructor's `getUser()` continuation: when the loaded user exists and `user.expired` is true, await `userManager.signinSilent()` and use its result; on rejection, fall back to `null`. Resolve the `ready` promise only after this attempt settles.
+- [ ] 1.2 Set `monitorSession: false` unconditionally in `createSettings()` (remove the `!import.meta.env.DEV` conditional) and update the explanatory comment to reflect the all-environment rationale (Zitadel `check_session_iframe` `frame-ancestors 'none'`).
+- [ ] 1.3 Add/extend unit tests in `test/auth-service.spec.ts`: (a) expired access token + valid refresh → `signinSilent` invoked, ends authenticated, `ready` resolves after renewal; (b) expired access token + failed `signinSilent` → ends unauthenticated; (c) valid access token → no `signinSilent` call.
+- [ ] 1.4 Run `make check` in `frontend` and confirm lint + tests pass.
+
+## 2. Cloud-Provisioning — OIDC Token Lifetimes
+
+- [ ] 2.1 Add a `zitadel.DefaultOidcSettings` resource (instance-level) in the Zitadel Pulumi stack, bound to the existing provider, with `accessTokenLifetime: '0h30m0s'`, `idTokenLifetime: '12h0m0s'`, `refreshTokenExpiration: '2160h0m0s'` (90d), `refreshTokenIdleExpiration: '720h0m0s'` (30d). All four fields are required inputs.
+- [ ] 2.2 Run `pulumi preview` for the prod stack and confirm the only diff is the new `DefaultOidcSettings` resource (no unintended drift).
+- [ ] 2.3 Run lint / typecheck for the cloud-provisioning package and confirm it passes.
+
+## 3. Ship to Production
+
+- [ ] 3.1 Open the `frontend` PR (commit per Liverty convention with `Refs: #<issue>`); drive CI green and merge.
+- [ ] 3.2 Open the `cloud-provisioning` PR; drive CI green and merge (ArgoCD / Pulumi applies the `DefaultOidcSettings` to prod).
+- [ ] 3.3 Cut the `frontend` GitHub Release (SemVer tag) to retag the prod image and trigger the automated prod-pin bump.
+- [ ] 3.4 Verify `DefaultOidcSettings` applied to the prod Zitadel instance: `GET /admin/v1/settings/oidc` (or `pulumi stack` output) reflects access 30m / idle 30d / absolute 90d.
+
+## 4. Production Verification
+
+- [ ] 4.1 On the prod PWA: sign up, install, then reopen after the access token (30m) has expired — confirm the session is silently restored and no signed-out state is shown.
+- [ ] 4.2 Confirm browser console shows no recurring `userUnloaded` / `frame-ancestors` errors after the `monitorSession` change.


### PR DESCRIPTION
## Summary

Proposes the OpenSpec change `extend-auth-session-lifetime` to fix users being signed out when they reopen the installed PWA the next day, despite holding a valid 30-day refresh token.

## Root cause

- **oidc-client-ts [#2012](https://github.com/authts/oidc-client-ts/issues/2012)** — on cold start with an already-expired access token, `automaticSilentRenew` drops the renewal timer based on the access token alone and never consults the still-valid refresh token, so the user lands unauthenticated.
- **OIDC token lifetimes unset in IaC** — running on Zitadel built-in defaults (access 12h) rather than explicit, reviewable values.
- **`monitorSession` enabled in prod** — Zitadel's `check_session_iframe` returns `frame-ancestors 'none'`, which can fire spurious `userUnloaded` events (already disabled in dev, not prod).

## Proposed change

1. **frontend** — boot-time `signinSilent()` when the stored access token is expired, gating `auth.ready` so route guards never observe a transient signed-out state; `monitorSession: false` in all environments.
2. **cloud-provisioning** — explicit `zitadel.DefaultOidcSettings`: access `30m`, refresh idle `30d`, refresh absolute `90d`.

Net effect: access-token exposure shrinks from 12h to 30m (security ↑), while a valid refresh token transparently restores the session across long gaps (UX ↑).

## Artifacts

- `proposal.md` — why & what; modified capabilities `user-auth`, `identity-management`
- `design.md` — three decisions (boot-time silent renew, `monitorSession: false`, IaC `DefaultOidcSettings`), alternatives, risks, migration
- `specs/user-auth/spec.md`, `specs/identity-management/spec.md` — ADDED requirements
- `tasks.md` — frontend / cloud-provisioning / prod release / prod verification

No proto / BSR changes.

## Testing

- `openspec validate extend-auth-session-lifetime` passes.

close: #648
