### PR TITLE
docs(analytics): tick 14.2 + 14.6 ticket events

### DIFF
--- a/openspec/changes/introduce-analytics-tool/tasks.md
+++ b/openspec/changes/introduce-analytics-tool/tasks.md
@@ -123,11 +123,11 @@
 > Domain signals that were entirely uninstrumented; added to the event catalogue in this change.
 
 - [x] 14.1 `ticket.journey.status.changed` from `ticket_journey_uc.go` `SetStatus` (interest-tier progression) — done in backend PR #347: `SetStatus` reads the prior status and, only on change, publishes `TICKET_JOURNEY.status_changed` (non-fatal); the analytics-consumer forwards it to PostHog with `{event_id, from_status, to_status}` per user. New `TicketJourneyRepository.Get` supplies `from_status` (new journey = `UNSPECIFIED`). Establishes the publisher+forwarder template for 14.2–14.6.
-- [ ] 14.2 `ticket.email.parsed` from `ticket_email_uc.go` (email-ingestion data quality: type, parse status, field count)
+- [x] 14.2 `ticket.email.parsed` from `ticket_email_uc.go` (email-ingestion data quality: type, parse status, field count) — done in backend PR #348: `Create` publishes `TICKET_EMAIL.parsed` on both parse success and failure (non-fatal), forwarded with `{email_type, parse_status, field_count}`.
 - [ ] 14.3 `notification.unsubscribed` from `push_notification_uc.go` `Delete` (churn vs. cache-clear)
 - [ ] 14.4 `sales_reminder.delivered` from `sales_reminder_delivery_uc.go` `DeliverReminder` (sales-phase-timeline KPI)
 - [ ] 14.5 `concert.search.completed` from `concert_uc.go` `SearchNewConcerts` (Gemini discovery success rate)
-- [ ] 14.6 `ticket.mint.completed` from `ticket_uc.go` `MintTicket` (SBT issuance)
+- [x] 14.6 `ticket.mint.completed` from `ticket_uc.go` `MintTicket` (SBT issuance) — done in backend PR #348: `MintTicket` publishes `TICKET.mint_completed` after persist (fresh-mint + concurrent-reconcile paths, non-fatal), forwarded with `{event_id}`.
 
 ## 15. Internal & E2E traffic exclusion
 


### PR DESCRIPTION
## 🔗 Related Issue

Refs #532

## 📝 Summary of Changes

Ticks tasks **14.2** (`ticket.email.parsed`) and **14.6** (`ticket.mint.completed`) — backend PR #348 shipped both publishers + analytics-consumer forwarders on the 14.1 template. Doc-only.

## ✅ Self-Checklist
- [x] Linked the related issue.
- [x] Updated the task ledger (`openspec validate --strict` passes).
- [x] N/A — no proto.
- [x] No breaking changes.
