### PR TITLE
docs(openspec): propose add-tap-press-feedback

### DIFF
--- a/openspec/changes/add-tap-press-feedback/.openspec.yaml
+++ b/openspec/changes/add-tap-press-feedback/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-26

--- a/openspec/changes/add-tap-press-feedback/design.md
+++ b/openspec/changes/add-tap-press-feedback/design.md
@@ -1,0 +1,62 @@
+## Context
+
+The frontend (Aurelia 2, CUBE CSS, `@layer` cascade) is a touch-first PWA. An audit of ~22 files with interactive elements found only 7 defined any `:active` rule (`welcome`, `settings`, `discovery`, `consent`, `signup-prompt-banner`, `pwa-install-fab`, `event-card`). The global `:where(button)` base style in `src/styles/global.css` had no `:active` feedback, and the bottom-nav tabs (the primary navigation) had none. Because the reset sets `-webkit-tap-highlight-color: transparent` and `:hover` is inert on touch, taps feel dead.
+
+The existing press convention across the 7 components is `transform: scale(...)` (values 0.92–0.98) + a fast `~50ms ease-in` press-in. The cascade order is `reset, tokens, global, composition, utility, block, exception` (`src/styles/main.css`), so `@layer block` overrides `@layer global`.
+
+A coverage audit of the remaining tappables found that the high-traffic interaction surfaces (`artist-filter-bar`, `discovery`, `event-detail-sheet`, `page-help`) are all `<button>` elements, so a single `<button>` baseline reaches them. The genuine non-`<button>` exceptions are the nav tabs and the dashboard `.discover-cta` (both `<a>`), plus settings list rows.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Every native `<button>` gets press feedback from one baseline rule, with zero per-component edits.
+- The primary `<a>`-based tappables (nav tabs, discover CTA) and settings rows get explicit press feedback.
+- All cues honor `prefers-reduced-motion: reduce`.
+- Reuse the existing scale + fast-ease-in convention; introduce no new visual language.
+- Components with their own `:active` are untouched.
+
+**Non-Goals:**
+- Restoring `-webkit-tap-highlight-color` (rejected below).
+- Adding press feedback to plain text links (`not-found-link`, "back to dashboard" links).
+- Haptic or sonic feedback (covered separately by `discovery-tap-sonic-feedback`).
+- Any proto/backend/API change.
+
+## Decisions
+
+### `:active` press cues over restoring `-webkit-tap-highlight-color`
+The default tap highlight is a rectangular flash that ignores `border-radius` and is not on-brand. A `:active` scale respects component shape, matches the app's existing motion language, and is controllable per element. Cost is slightly more CSS, accepted for the UX gain. Alternative (restore the highlight) rejected.
+
+### Button baseline in `@layer global`, not per component
+Placing `:where(button):active:not(:disabled)` in `@layer global` covers all 20 button-bearing templates at once while staying below `@layer block`, so the 7 components that already define `:active` automatically win with no conflict. `:not(:disabled)` keeps disabled controls inert.
+
+### Explicit `:active` for the two `<a>`-based primary tappables
+The `<button>` baseline cannot reach `<a>` elements. The nav tabs (`.nav-tab`) and the dashboard `.discover-cta` are styled and used as primary buttons, so each gets a dedicated `:active`. `.discover-cta` lives in `@layer utility` (`src/styles/utilities.css`); its `:active` is added there. The remaining bare `<a>` elements are plain text links and are intentionally excluded.
+
+### Scale magnitude follows existing per-element precedent
+Large tap targets use a stronger scale (FAB `0.92`), standard buttons cluster at `0.97–0.98`. The button baseline uses a standard-button magnitude; the nav tab uses the large-target magnitude (matching the FAB). This keeps the cue proportional to control size rather than applying one global value.
+
+### List rows deepen background instead of scaling
+A full-width row reads better with a background-deepen than a scale. `.settings-row` (a `<button>`) sets `transform: none` to suppress the global scale and applies a deeper `:active` background, so button-rows and anchor-rows feel identical.
+
+### iOS activation rule is a hard constraint, not an afterthought
+iOS Safari only applies `:active` when the element (or an ancestor) has `cursor: pointer` or is an `<a href>`. All targets satisfy this: `<button>` inherits `cursor: pointer` from the reset; `.nav-tab` and `.discover-cta` are `<a href>`; `.settings-row` is a `<button>`. Verification MUST be on real iOS Safari, because DevTools touch emulation fires `:active` unconditionally and would mask a regression here.
+
+## Risks / Trade-offs
+
+- [DevTools emulation gives false confidence] → Make real-iOS-Safari verification an explicit task; document that emulation is not acceptable proof.
+- [A future `<a>`- or `<div>`-based primary control is added without `:active`] → The baseline only covers `<button>`; new non-button primary controls must add their own `:active` (captured as a spec requirement so reviewers catch it).
+- [`transform` on a press establishes a containing block / paint layer] → Targets are leaf controls with no fixed-position descendants; effect is negligible.
+- [Inconsistent reduced-motion fallbacks per element (opacity vs background)] → Acceptable: each fallback fits its element type; the single rule "drop motion, keep a non-motion cue" is captured in the spec.
+
+## Migration Plan
+
+1. Implement the four CSS edits on the existing branch `claude/ui-feedback-tap-effects-wtcgzt`.
+2. Run `make lint` (Biome + stylelint + typecheck) and `brand-vocabulary` check.
+3. Verify on real iOS Safari: nav tabs, primary buttons, icon buttons, `.discover-cta`, `.settings-row`, and the reduced-motion fallback.
+4. Open the frontend PR; merge after CI is green.
+5. Ship to prod via the standard frontend release (GitHub Release → AR retag → pin bump → ArgoCD).
+6. Rollback is trivial: revert the CSS-only commit; no data or API surface is affected.
+
+## Open Questions
+
+- None blocking. Whether to retrofit `.discover-cta`-style anchor CTAs with a shared utility `:active` (rather than per-class) can be a later cleanup if more anchor-CTAs appear.

--- a/openspec/changes/add-tap-press-feedback/proposal.md
+++ b/openspec/changes/add-tap-press-feedback/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+The frontend is a touch-first PWA, but tapping a button or tab gives no press feedback. `:hover` styling is rich yet does nothing on touch, the actual touch press state `:active` is missing on most controls, and the reset clears `-webkit-tap-highlight-color`, so the browser's default tap flash is gone too. The net effect is that primary controls — the bottom-nav tabs and the guest dashboard's "Discover" CTA — feel dead and unresponsive on the exact devices the app targets.
+
+## What Changes
+
+- Introduce an app-wide press-feedback baseline so every native `<button>` responds to `:active` without per-component code.
+- Add press feedback to the primary tappables the button baseline cannot reach because they are `<a>` elements: the bottom-nav tabs (`.nav-tab`) and the dashboard guest/empty-state primary CTA (`.discover-cta`).
+- Add an `:active` cue to settings list rows (`.settings-row`) where a full-width background-deepen reads better than a scale.
+- Every press cue honors `prefers-reduced-motion: reduce` with a non-motion fallback.
+- Reuse the project's existing press convention (`transform: scale(...)` + a fast `~50ms ease-in` press-in) rather than inventing a new pattern; components that already define `:active` keep their behavior (`@layer block` > `@layer global`).
+- No proto, backend, or API change. No **BREAKING** changes.
+
+## Capabilities
+
+### New Capabilities
+- `tap-press-feedback`: The cross-cutting convention that every interactive control gives an immediate, touch-visible press response on `:active`, with a global `<button>` baseline, explicit coverage for non-`<button>` tappables, and a reduced-motion fallback.
+
+### Modified Capabilities
+<!-- None. The change reuses existing design-system tokens (--color-brand-accent, --transition-fast) and the @layer cascade (modern-css-platform / cube-css) without changing their requirements. -->
+
+## Impact
+
+- Frontend only. CSS-only change across four files:
+  - `src/styles/global.css` — `:where(button):active` baseline + reduced-motion fallback
+  - `src/components/bottom-nav-bar/bottom-nav-bar.css` — `.nav-tab` press feedback
+  - `src/styles/utilities.css` — `.discover-cta` press feedback (anchor-based CTA)
+  - `src/routes/settings/settings-route.css` — `.settings-row` press feedback
+- No new dependencies. Verified on real iOS Safari is required (DevTools touch emulation cannot reproduce Safari's `:active` activation rule).
+- Ships through the standard frontend release path to prod.

--- a/openspec/changes/add-tap-press-feedback/specs/tap-press-feedback/spec.md
+++ b/openspec/changes/add-tap-press-feedback/specs/tap-press-feedback/spec.md
@@ -1,0 +1,70 @@
+## ADDED Requirements
+
+### Requirement: Global button press feedback baseline
+Every native `<button>` SHALL give an immediate, touch-visible press response on `:active` from an app-wide baseline, so no per-component code is needed for plain buttons. The baseline SHALL live in `@layer global` so component `:active` rules in `@layer block` keep precedence.
+
+#### Scenario: Plain button responds on press
+- **WHEN** a user presses a native `<button>` that defines no `:active` rule of its own
+- **THEN** the button SHALL render a brief scale-down press cue (`transform: scale(<0.98..0.97>)`)
+- **AND** the press-in SHALL use a fast (~50ms) `ease-in` transition consistent with the existing component convention
+
+#### Scenario: Disabled button gives no feedback
+- **WHEN** a user presses a `<button disabled>`
+- **THEN** no press cue SHALL be applied (the baseline targets `:active:not(:disabled)`)
+
+#### Scenario: Component-defined press feedback wins
+- **WHEN** a component already defines its own `:active` rule in `@layer block`
+- **THEN** the component rule SHALL take precedence over the global baseline
+- **AND** the component's existing press behavior SHALL be unchanged
+
+### Requirement: Non-button primary tappables give press feedback
+Primary tappables that are rendered as `<a>` elements — which the `<button>` baseline cannot reach — SHALL define their own `:active` press feedback. Plain text navigation links are exempt.
+
+#### Scenario: Bottom navigation tab responds on press
+- **WHEN** a user taps a bottom-nav tab (`<a class="nav-tab">`)
+- **THEN** the tab SHALL render a press cue at the moment of tap, distinct from the persistent selected-tab state
+
+#### Scenario: Dashboard discover CTA responds on press
+- **WHEN** a user taps the guest/empty-state primary CTA (`.discover-cta`), an `<a>` styled as a button
+- **THEN** the CTA SHALL render a press cue consistent with the button baseline
+
+#### Scenario: Plain text links are exempt
+- **WHEN** an `<a>` is a plain text navigation link (e.g., a "back to dashboard" link, the not-found link)
+- **THEN** no press scale cue is required, as a press scale is not expected for text links
+
+### Requirement: List rows give press feedback
+Full-width list rows SHALL acknowledge a tap with a background-deepen rather than a scale, so the cue reads correctly across the full row width regardless of whether the row is a `<button>` or an `<a>`.
+
+#### Scenario: Settings row responds on press
+- **WHEN** a user taps a settings list row (`.settings-row`)
+- **THEN** the row SHALL deepen its background on `:active`
+- **AND** the global button scale SHALL be suppressed (`transform: none`) so button-rows and anchor-rows feel identical
+
+### Requirement: Reduced motion fallback for press feedback
+Under `prefers-reduced-motion: reduce`, every press cue SHALL drop the motion (scale) but keep a non-motion acknowledgement so the tap still registers.
+
+#### Scenario: Button press under reduced motion
+- **WHEN** `prefers-reduced-motion: reduce` is active and a user presses a button
+- **THEN** the scale cue SHALL be suppressed
+- **AND** a non-motion cue (e.g., reduced opacity) SHALL acknowledge the press
+
+#### Scenario: Nav tab press under reduced motion
+- **WHEN** `prefers-reduced-motion: reduce` is active and a user taps a nav tab
+- **THEN** the scale cue SHALL be suppressed
+- **AND** a non-motion cue (e.g., a brief accent-tinted background) SHALL acknowledge the tap
+
+### Requirement: Touch activation reliability on iOS Safari
+Press feedback SHALL be applied only via `:active` on elements that satisfy iOS Safari's `:active` activation rule (the element or an ancestor has `cursor: pointer`, or the element is an `<a href>`), and this SHALL be confirmed on real iOS Safari rather than DevTools touch emulation.
+
+#### Scenario: Button satisfies the iOS activation rule
+- **WHEN** the targeted element is a native `<button>`
+- **THEN** it SHALL inherit `cursor: pointer` from the reset, so iOS Safari applies `:active` on tap
+
+#### Scenario: Anchor tappables satisfy the iOS activation rule
+- **WHEN** the targeted element is an `<a>` tappable (nav tab, discover CTA)
+- **THEN** it SHALL carry an `href`, so iOS Safari applies `:active` on tap
+
+#### Scenario: Verification is performed on a real device
+- **WHEN** the change is verified
+- **THEN** the press feedback SHALL be confirmed on real iOS Safari
+- **AND** DevTools touch emulation alone SHALL NOT be accepted as proof, because it fires `:active` unconditionally and does not reproduce Safari's activation rule

--- a/openspec/changes/add-tap-press-feedback/tasks.md
+++ b/openspec/changes/add-tap-press-feedback/tasks.md
@@ -1,0 +1,27 @@
+## 1. Implementation (frontend, branch `claude/ui-feedback-tap-effects-wtcgzt`)
+
+- [ ] 1.1 `src/styles/global.css`: add `:where(button):active:not(:disabled)` scale baseline + add `transform` to the `:where(button)` transition list
+- [ ] 1.2 `src/styles/global.css`: add `prefers-reduced-motion: reduce` fallback for the button baseline (drop scale, keep a non-motion cue)
+- [ ] 1.3 `src/components/bottom-nav-bar/bottom-nav-bar.css`: add `.nav-tab:active` press cue + `transform` transition, distinct from the persistent selected state
+- [ ] 1.4 `src/components/bottom-nav-bar/bottom-nav-bar.css`: add `prefers-reduced-motion` fallback for `.nav-tab` (accent-tinted background)
+- [ ] 1.5 `src/styles/utilities.css`: add `.discover-cta:active` press cue (scale + ~50ms ease-in) + `prefers-reduced-motion` fallback — the anchor-based primary CTA the button baseline cannot reach
+- [ ] 1.6 `src/routes/settings/settings-route.css`: add `.settings-row:active` background-deepen with `transform: none` to suppress the global scale
+
+## 2. Local checks
+
+- [ ] 2.1 Run `make lint` (Biome + stylelint + typecheck) — green
+- [ ] 2.2 Run the `brand-vocabulary` check — green
+- [ ] 2.3 Confirm `@layer block` components with existing `:active` are visually unchanged (no cascade regression)
+
+## 3. Real-device verification (iOS Safari — emulation not accepted)
+
+- [ ] 3.1 On real iOS Safari, confirm press feedback on: nav tabs, a plain `<button>`, an icon button, `.discover-cta`, `.settings-row`
+- [ ] 3.2 On real iOS Safari with `prefers-reduced-motion: reduce`, confirm each control shows its non-motion fallback (no scale)
+- [ ] 3.3 Confirm a `<button disabled>` shows no press cue
+
+## 4. Ship
+
+- [ ] 4.1 Open the frontend PR (Conventional Commit, body explains why, `Refs: #470`); merge after CI is green
+- [ ] 4.2 Cut the frontend GitHub Release → AR retag → automated prod pin bump → ArgoCD sync
+- [ ] 4.3 Verify the press feedback live on prod (`dashboard` CTA + bottom-nav) on a real device
+- [ ] 4.4 Archive this OpenSpec change once shipped and verified


### PR DESCRIPTION
## 🔗 Related Issue

Tracking issue: liverty-music/frontend#470 (frontend repo — closed by the frontend implementation PR, not this spec PR).

## 📝 Summary of Changes

Adds an OpenSpec change `add-tap-press-feedback` that specifies the touch press-feedback convention for the frontend, so the behavior is captured as a spec rather than living only on an implementation branch.

**Motivation.** The app is a touch-first PWA, but the global `<button>` base style and the bottom-nav tabs had no `:active` press feedback, and the reset clears `-webkit-tap-highlight-color` — so taps feel dead. `:hover` is inert on touch.

**Technical approach (documented in the artifacts).**
- New capability `tap-press-feedback` with testable requirements: a global `<button>` `:active` baseline (`@layer global`, below `@layer block` so existing component `:active` rules win), explicit feedback for the `<a>`-based primary tappables, list-row feedback, a reduced-motion fallback, and an iOS-activation reliability requirement.
- Reuses the existing `transform: scale(...)` + fast `~50ms ease-in` convention; introduces no new visual language.

**Two gaps from a critical review of the draft fix, now folded into the spec:**
- `.discover-cta` — the dashboard guest/empty-state primary CTA is an `<a>` styled as a button, so the `<button>` baseline cannot reach it; it needs its own `:active`.
- DevTools touch emulation fires `:active` unconditionally and cannot reproduce iOS Safari's activation rule, so real-device verification is mandatory.

Artifacts: `proposal.md`, `design.md`, `specs/tap-press-feedback/spec.md`, `tasks.md`. `openspec validate --strict` passes. No proto/backend/API change.

## ✅ Self-Checklist

- [x] I have linked the related issue.
- [x] I have updated the relevant documentation (OpenSpec artifacts).
- [ ] ~~`buf lint` / `buf format`~~ — N/A, no proto changes (docs only).
- [ ] ~~proto style guidelines~~ — N/A, no proto changes.
- [ ] ~~Breaking changes~~ — N/A, none.
