### PR TITLE
docs(openspec): propose 3 analytics-followup changes (post DA review)

### DIFF
--- a/openspec/changes/disclose-posthog-in-privacy-policy/.openspec.yaml
+++ b/openspec/changes/disclose-posthog-in-privacy-policy/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-26

--- a/openspec/changes/disclose-posthog-in-privacy-policy/design.md
+++ b/openspec/changes/disclose-posthog-in-privacy-policy/design.md
@@ -1,0 +1,41 @@
+# Design — Disclose PostHog in the in-app Privacy Policy
+
+## Context
+
+The Privacy Policy is an in-app route at `/legal/privacy`, rendered by the `legal-document` Aurelia 2 component (`frontend/src/components/legal-document/`). The component reads its content from the i18n resource bundle: it resolves `legal.privacy.title`, `legal.privacy.intro`, `legal.privacy.lastUpdated`, and a variable-length `legal.privacy.sections[]` array (each `{ heading, body[] }`) via `@aurelia/i18n` with `returnObjects: true`. Content therefore lives entirely in `frontend/src/locales/{en,ja}/translation.json` and follows the active locale, with Japanese as the primary legal locale.
+
+The archived `introduce-analytics-tool` change discharged the in-app consent/settings UI (FE PR #465) but deferred the policy-page edit (tasks 11.1/11.2) as "EXTERNAL", believing the policy lived at `https://liverty.me/privacy`. That domain does not exist. The consent notice and settings screen both link to that dead URL, while the real policy is the in-app route. The `analytics-consent` capability already requires that "the privacy policy SHALL name PostHog (Klant Solutions B.V., Netherlands) as the third-party recipient and enumerate the purpose of the cross-border transfer" — this change makes that page actually satisfy it and removes the broken links.
+
+## Goals / Non-Goals
+
+Goals:
+- The in-app Privacy Policy content names PostHog (Klant Solutions B.V., Netherlands) as a named third-party cross-border recipient under APPI Article 28.
+- The policy enumerates the categories of data transferred to PostHog and the purpose of that transfer.
+- The two in-app links that currently point at `https://liverty.me/privacy` resolve to the in-app `/legal/privacy` route.
+- The `legal-documents` spec records both obligations so future integrations keep the disclosure honest.
+
+Non-Goals:
+- No new analytics behaviour, no consent-gating change (the opt-out model under EU adequacy is unchanged; see `analytics-consent`).
+- No new legal route, component, or i18n mechanism — content rides the existing `legal.privacy.sections[]` shape.
+- No backend / proto / schema change.
+- Not a substitute for legal counsel sign-off on the minor-user question (deferred elsewhere); this change discharges only the Article 28 disclosure.
+
+## Decisions
+
+- **Edit i18n content, not the component.** The `legal-document` component already renders an arbitrary `sections[]` array, so the disclosure is added by editing the en/ja `legal.privacy.sections` entries (the existing sections 4 "Provision to Third Parties", 5 "External Transmission", and 6 "Cross-Border Transfer" are the natural homes). No `.ts`/`.html`/`.css` change to the component is needed. Bump `legal.privacy.lastUpdated`.
+- **Name the recipient explicitly.** The cross-border section states the recipient legal entity and country: PostHog Cloud EU, operated by Klant Solutions B.V., Netherlands. We disclose the named entity + country + categories + purpose as a matter of transparency; whether a generic "PostHog (EU)" mention would have legally sufficed under APPI Article 28 is a counsel judgement, not an engineering one (see Open Questions).
+- **Enumerate categories + purpose.** The policy lists the data categories transferred to PostHog (interaction/usage events captured via cookies and localStorage — the non-PII catalogue) and the purpose (product analytics: improving the Service / measuring effectiveness). This satisfies 11.2.
+- **In-app links, not external — reconcile, don't duplicate.** `settings-route.html` already has a working Privacy Policy link in the ABOUT section (~line 230) that calls `openLegal('/legal/privacy')` via the root router. The broken `href="https://liverty.me/privacy"` is a *separate* anchor (~line 201) attached to the analytics opt-out toggles. The fix is therefore to *reconcile / dedupe* the two: route the broken analytics-section anchor through the same existing `openLegal('/legal/privacy')` mechanism rather than adding a second link, and drop its `target="_blank"`/`rel="noopener noreferrer"` external treatment. `consent-route.html` has its own dead `https://liverty.me/privacy` anchor (~line 35) which is likewise re-pointed at in-app `/legal/privacy` navigation. Because the targets are in-app routes, the external-link treatment is no longer appropriate; use the app's normal in-app navigation.
+- **Keep ja as the authoritative legal locale.** Author the ja copy as the source of truth and mirror it in en, consistent with the "Japanese is the primary locale for the legal content" requirement.
+
+## Open Questions
+
+- **Processor vs. third-party recipient — unestablished, blocks final copy.** Whether PostHog (Klant Solutions B.V.) acts as a *processor handling personal data on Liverty's behalf* or as an independent *third-party recipient* is not yet established. This classification materially changes the required disclosure wording (a processor relationship and a third-party provision are disclosed differently under APPI). This change drafts the disclosure naming the entity, country, categories, and purpose — facts that hold under either reading — but does NOT assert the classification as settled. The policy owner / legal counsel MUST confirm the classification before the copy is finalized and released. Engineering does not decide this.
+- **APPI Article 28 sufficiency.** Whether the chosen wording legally satisfies APPI Article 28 (and which sub-clauses apply given the classification above) is for counsel to confirm; the spec deliberately does not encode a sufficiency judgement.
+
+## Risks / Trade-offs
+
+- **Legal accuracy.** The disclosure wording is a compliance artifact, and the processor-vs-recipient classification (see Open Questions) is unresolved. Mitigation: a task requires the policy owner / counsel to confirm the classification and review the copy before release; engineering provides the structurally-correct draft (recipient named, country + categories + purpose enumerated) but does not finalize legal wording or assert the legal classification unilaterally.
+- **ja/en drift.** Editing two locale files risks the disclosures diverging. Mitigation: change both in the same edit and keep the section structure parallel; `make lint`/build covers JSON validity.
+- **Link-treatment regression.** Switching from an external `<a target="_blank">` to in-app navigation changes the markup; Aurelia routing must resolve `/legal/privacy`. Mitigation: the route already exists and is a registered public route (per `legal-documents` spec); verify via build + a manual click.
+- **Spec already references PostHog Cloud EU.** `analytics-consent` and the existing `legal-documents` Privacy Policy requirement already mention the EU transfer; this change tightens "PostHog Cloud EU" to the named legal entity, so the two specs stay consistent rather than contradicting.

--- a/openspec/changes/disclose-posthog-in-privacy-policy/proposal.md
+++ b/openspec/changes/disclose-posthog-in-privacy-policy/proposal.md
@@ -1,0 +1,34 @@
+# Disclose PostHog in the in-app Privacy Policy
+
+## Why
+
+PostHog product analytics is now live and transfers usage data to PostHog Cloud EU, operated by Klant Solutions B.V. in the Netherlands. This is a cross-border transfer of usage data to a recipient in a foreign country, which carries a disclosure obligation (APPI Article 28 is the likely basis; the exact characterization — processor vs. independent recipient — is for counsel to confirm): the privacy policy should name the recipient and its country and enumerate the data categories transferred and the purpose of the transfer.
+
+The archived `introduce-analytics-tool` change marked tasks 11.1 and 11.2 as `[~]` EXTERNAL, on the assumption that the privacy policy lived off-repo at `https://liverty.me/privacy`. That assumption is wrong: `liverty.me` does not exist, and the Privacy Policy is an in-app route (`/legal/privacy`) rendered by the `legal-document` component from the i18n resource bundle. So the obligation was never actually discharged, and the in-app consent notice and settings link to a dead URL.
+
+This change discharges the APPI Article 28 disclosure in the place it actually lives — the in-app Privacy Policy content — and fixes the two broken external links to point at the real in-app route. It completes 11.1/11.2 and makes the `analytics-consent` capability's "Purpose of use is published rather than gated" requirement true in fact, not just in intent.
+
+## What Changes
+
+- Update the in-app Privacy Policy i18n content (`frontend/src/locales/{en,ja}/translation.json`, under `legal.privacy.sections`) so it explicitly names PostHog (operated by Klant Solutions B.V., Netherlands) as a cross-border recipient of usage analytics data, and enumerates the recipient's country, the categories of data transferred, and the purpose of the transfer. (Whether the wording legally suffices under APPI Article 28, and whether PostHog is a processor or an independent recipient, is confirmed by the policy owner / counsel — see design.md Open Questions.)
+- Fix a bug: the onboarding consent notice (`frontend/src/routes/consent/consent-route.html`, dead anchor ~line 35) and the analytics opt-out anchor in the settings page (`frontend/src/routes/settings/settings-route.html`, ~line 201) link to the non-existent `https://liverty.me/privacy`. The settings ABOUT-section link (~line 230) already navigates in-app via `openLegal('/legal/privacy')`; reconcile / dedupe the broken anchor to reuse that same in-app mechanism rather than adding a second link, and re-point the consent anchor at the in-app `/legal/privacy` route.
+- No backend, proto, or schema changes; this is frontend content plus a link fix.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `legal-documents` — the Privacy Policy disclosure requirement is strengthened to mandate naming third-party cross-border recipients (incl. PostHog / Klant Solutions B.V.) with the recipient's country (NL), the transferred data categories, and the purpose; the legal-sufficiency judgement under APPI Article 28 is left to counsel rather than encoded as normative spec text. A new requirement mandates that in-app legal links resolve to the in-app legal routes rather than external or broken domains.
+
+## Impact
+
+- Affected specs: `legal-documents`.
+- Affected code:
+  - `frontend/src/locales/en/translation.json`, `frontend/src/locales/ja/translation.json` (Privacy Policy content)
+  - `frontend/src/routes/consent/consent-route.html` (broken link)
+  - `frontend/src/routes/settings/settings-route.html` (broken link)
+- Discharges a live APPI Article 28 disclosure obligation. The legal copy SHALL be reviewed by the policy owner before release.

--- a/openspec/changes/disclose-posthog-in-privacy-policy/specs/legal-documents/spec.md
+++ b/openspec/changes/disclose-posthog-in-privacy-policy/specs/legal-documents/spec.md
@@ -1,0 +1,46 @@
+# legal-documents
+
+## MODIFIED Requirements
+
+### Requirement: Privacy Policy discloses the actual data practices
+
+The Privacy Policy SHALL accurately disclose, at minimum: the categories of personal data collected; the purposes of use; third-party processors and any cross-border transfer; how to withdraw analytics consent; and the contact channel for disclosure / correction / deletion requests. The disclosure SHALL reflect the system's real integrations and SHALL be revised when a new third-party data integration is added.
+
+For cross-border transfers, the Privacy Policy SHALL name each third-party recipient that receives personal data in a foreign country — including PostHog (operated by Klant Solutions B.V., Netherlands), to which usage analytics data is transferred (PostHog Cloud EU) — and SHALL, for that transfer, state the recipient's country (Netherlands), enumerate the categories of data transferred (interaction / usage events captured via cookies and localStorage), and state the purpose of the transfer (product analytics: improving the Service and measuring effectiveness). Whether any particular wording legally suffices under APPI Article 28 is a matter for the policy owner / legal counsel to confirm and is out of scope for this spec.
+
+#### Scenario: Collected data and purposes are stated
+
+- **WHEN** the Privacy Policy is displayed
+- **THEN** it SHALL list the collected personal data categories (account identity, home area, follows, language preference, push subscription, analytics events) and the purpose of each use
+
+#### Scenario: Third-party transfer and cross-border processing are disclosed
+
+- **WHEN** the Privacy Policy is displayed
+- **THEN** it SHALL identify third-party recipients / processors (analytics, email, push, search, artist-metadata)
+- **AND** it SHALL disclose the cross-border transfer of analytics data to PostHog Cloud EU
+
+#### Scenario: PostHog is named as a cross-border recipient with country, categories, and purpose
+
+- **WHEN** the Privacy Policy is displayed
+- **THEN** it SHALL name PostHog (operated by Klant Solutions B.V.) as the recipient of a cross-border transfer of usage analytics data
+- **AND** it SHALL state the recipient's country (Netherlands)
+- **AND** it SHALL enumerate the categories of data transferred to PostHog (interaction / usage events captured via cookies and localStorage)
+- **AND** it SHALL state the purpose of that transfer (product analytics: improving the Service and measuring effectiveness)
+
+#### Scenario: Consent withdrawal and rights are explained
+
+- **WHEN** the Privacy Policy is displayed
+- **THEN** it SHALL explain that analytics consent can be withdrawn via the Settings privacy toggles
+- **AND** it SHALL provide a contact channel for disclosure / correction / deletion requests
+
+## ADDED Requirements
+
+### Requirement: In-app legal links resolve to in-app legal routes
+
+In-app references to a legal document (Terms of Service, Privacy Policy, OSS Licenses) — including the onboarding consent notice and the settings screen — SHALL link to the corresponding in-app legal route (`/legal/terms`, `/legal/privacy`, `/legal/licenses`). They SHALL NOT link to an external domain or to a URL that does not resolve (such as `https://liverty.me/privacy`, which does not exist). Because the target is an in-app route, the link SHALL use in-app navigation rather than opening a new browser tab as an external link.
+
+#### Scenario: Consent notice and settings link to the in-app Privacy Policy
+
+- **WHEN** a user activates the Privacy Policy link in the onboarding consent notice or on the settings screen
+- **THEN** the application SHALL navigate to the in-app `/legal/privacy` route
+- **AND** the link SHALL NOT target the non-existent external `https://liverty.me/privacy` URL

--- a/openspec/changes/disclose-posthog-in-privacy-policy/tasks.md
+++ b/openspec/changes/disclose-posthog-in-privacy-policy/tasks.md
@@ -1,0 +1,24 @@
+# Tasks — Disclose PostHog in the in-app Privacy Policy
+
+## 1. Privacy Policy content (APPI Article 28 disclosure)
+
+- [ ] 1.1 Update the English Privacy Policy content (`frontend/src/locales/en/translation.json`, under `legal.privacy.sections`) so the cross-border / third-party sections name PostHog as operated by Klant Solutions B.V., Netherlands, as a named cross-border recipient under APPI Article 28.
+- [ ] 1.2 In the English content, enumerate the categories of data transferred to PostHog (interaction / usage events captured via cookies and localStorage) and the purpose (product analytics: improving the Service and measuring effectiveness) in the data-category / external-transmission listing.
+- [ ] 1.3 Mirror 1.1 and 1.2 in the Japanese Privacy Policy content (`frontend/src/locales/ja/translation.json`), keeping ja as the authoritative legal locale and the section structure parallel to en.
+- [ ] 1.4 Bump `legal.privacy.lastUpdated` in both en and ja.
+
+## 2. Fix broken legal links
+
+- [ ] 2.1 In `frontend/src/routes/consent/consent-route.html` (the `https://liverty.me/privacy` anchor at ~line 35), route the link through in-app navigation to the `/legal/privacy` route instead of the dead external URL (drop the external `target="_blank"` / `rel="noopener noreferrer"` treatment), using the route's existing in-app navigation mechanism.
+- [ ] 2.2 In `frontend/src/routes/settings/settings-route.html`, reconcile / dedupe the two Privacy Policy links: the ABOUT-section row at ~line 230 already calls `openLegal('/legal/privacy')` correctly, while the analytics opt-out anchor at ~line 201 still points at the dead `https://liverty.me/privacy`. Route the broken one through the existing `openLegal('/legal/privacy')` mechanism (do NOT introduce a second external link), and reconcile the two so there is a single consistent in-app navigation path; drop the external-link treatment on the fixed anchor. Confirm whether both links are still warranted or whether the analytics-section reference can simply reuse/point to the same handler.
+
+## 3. Verify
+
+- [ ] 3.1 Run `make lint` in `frontend/` and fix any lint / format / typecheck issues.
+- [ ] 3.2 Run the frontend build (`npm run build`) and confirm it succeeds; manually verify the consent and settings links navigate to `/legal/privacy`.
+
+## 4. Review
+
+- [ ] 4.1 Have the policy owner review the legal copy (en + ja) before release; engineering provides the structurally-correct draft (recipient named, country + categories + purpose enumerated), legal finalizes wording.
+- [ ] 4.2 Have the policy owner / legal counsel confirm the PostHog (Klant Solutions B.V.) classification — *processor acting on Liverty's behalf* vs *independent third-party recipient* — before finalizing the copy, since the classification changes the required disclosure wording (see design.md Open Questions). Do not finalize copy until this is confirmed.
+- [ ] 4.3 Have the policy owner / legal counsel confirm that the finalized wording satisfies APPI Article 28 (this sufficiency judgement is deliberately not encoded in the spec; engineering does not decide it).

--- a/openspec/changes/emit-auth-events-via-webhook/.openspec.yaml
+++ b/openspec/changes/emit-auth-events-via-webhook/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-26

--- a/openspec/changes/emit-auth-events-via-webhook/design.md
+++ b/openspec/changes/emit-auth-events-via-webhook/design.md
@@ -1,0 +1,81 @@
+## Context
+
+`introduce-analytics-tool` (archived) built the backend analytics path: Connect-RPC handlers / use cases publish UPPERCASE two-segment NATS subjects (`USER.created`, `ARTIST.followed`, …); an `analytics-consumer` (`backend/internal/adapter/event/analytics_consumer.go`) subscribes, and each `Handle*` method maps its subject to a lowercase catalogue event and calls `AnalyticsClient.Enqueue(ctx, userID, eventName, properties)`. `Enqueue` requires the platform `UserId` (UUID) as `distinct_id` and rejects an empty/non-UUID value — the Zitadel `sub` claim is explicitly NOT a valid `distinct_id`.
+
+That change's Decision 15 descoped the two `account.*` auth events:
+
+- `account.signup.completed` fired at the same instant as `user.created` (`user_uc.go` already publishes `SubjectUserCreated` on user creation, and the consumer already forwards it as `user.created`). A second event would double-count signups.
+- `account.login` had no clean signal. The existing `pre_access_token` webhook handler (`backend/internal/adapter/webhook/pre_access_token_handler.go`) fires on **every access-token mint, including silent refresh-token grants**, so emitting `account.login` there over-counts logins.
+
+The product owner has reversed the *deferral* of `account.login` (it is the primary returning-active-user signal for retention cohorts). The reasoning that a refresh is not a login, and that signup must not be double-counted, still holds. This change must satisfy the owner's request without regressing analytics correctness.
+
+The Zitadel webhook already in production is an Actions v2 **Target** invoked with a `PAYLOAD_TYPE_JWT` body: the request body is a JWT whose private claims carry the Actions v2 function payload (`user`, `org`, …). The existing handler verifies that JWT against a webhook-specific audience and reads nested fields (e.g. `user.human.email`). Any login signal must be derivable from this same payload, or from a different Action invocation point Zitadel offers.
+
+**Unverified-assumption hazard (the reason for the spike below).** The production `pre_access_token` handler (`pre_access_token_handler.go`) models the payload as **user/org resource context** only — concretely `user.human.email`. It carries *who* the token is for, not *how* this particular grant was obtained. Whether the `pre_access_token` Actions v2 payload also exposes an OIDC *grant* discriminator — `amr`, a fresh `auth_time`, or an explicit refresh-token-grant indicator — is **NOT verified**. The shape of the existing payload (resource context, no grant context) is strong evidence those fields are ABSENT. This is load-bearing: if they are absent, a handler that "discriminates fresh-vs-refresh" on this payload has nothing to discriminate on, and degrades into one of two failure modes — emit `account.login` on every mint (the over-count Decision 15 deferred the event to avoid), or, under a "suppress when uncertain" rule, emit `account.login` on every mint as *uncertain* and therefore emit **zero** (an unmet goal with no signal). Neither is acceptable. The design below therefore makes verifying this assumption the **first, gating** step, and makes the structurally-login-specific session Action the **primary** design.
+
+## Goals / Non-Goals
+
+**Goals**
+
+- Emit `account.login` exactly once per **user-initiated login**, attributed to the platform `UserId`.
+- Guarantee a token **refresh** does NOT emit `account.login`.
+- Keep the analytics path non-fatal and non-blocking on the login/token-issuance critical path.
+- Resolve `account.signup.completed` without emitting a duplicate of `user.created`.
+- Reuse the established publisher → NATS subject → `analytics-consumer` `Handle*` → PostHog pattern; do not call PostHog from the webhook handler directly.
+
+**Non-Goals**
+
+- No new Connect-RPC, no proto change, no DB schema change.
+- No frontend emission of `account.login` (BE-sourced / trust-critical per the catalogue).
+- No backfill of historical logins; instrumentation is forward-only.
+- No reopening of the broader analytics taxonomy beyond these two account events.
+
+## Decisions
+
+### Decision 0 (gating): Spike the actual `pre_access_token` payload BEFORE choosing the login signal
+
+This change does not begin with implementation. It begins with a **payload spike** that resolves the unverified assumption above: does the `pre_access_token` Actions v2 payload, as delivered on **dev Zitadel**, actually expose a usable fresh-vs-refresh discriminator (`amr`, a fresh `auth_time`, or an explicit refresh-token-grant indicator)?
+
+Concretely: temporarily dump the full decoded private-claims payload from the existing handler on a dev Zitadel instance, exercise both flows — a fresh interactive login AND a silent `refresh_token` grant — and compare the two payloads for any field that reliably differs between them.
+
+The spike has exactly two outcomes, and it **gates** which design ships:
+
+- **Outcome A — a reliable discriminator IS present.** The `pre_access_token` payload contains a field that deterministically separates fresh auth from refresh. Then the option in Decision 1 (extend the existing webhook) is permitted, because the discrimination is real rather than assumed.
+- **Outcome B — no reliable discriminator is present** (the expected outcome, given the resource-context shape of the production payload). Then the `pre_access_token` webhook **cannot** carry login semantics, and the session-created Action (Decision 1, primary) is the only sound source.
+
+This is a **build-time** decision made once from spike evidence — never a per-request runtime guess. The spike output (the two payloads and the diff) is the recorded justification for the path taken.
+
+### Decision 1: PRIMARY — emit `account.login` from a Zitadel session-created Action; use the `pre_access_token` webhook ONLY if the spike proves a discriminator exists
+
+Two candidate signals were considered:
+
+- **(i) A dedicated Zitadel *session-created* Action (PRIMARY).** A session is created on a user-initiated login and **structurally cannot fire on a silent `refresh_token` grant** — a refresh reuses the existing session and creates no new one. This makes the signal login-specific *by construction*: there is nothing to discriminate, so there is no fresh-vs-refresh ambiguity to get wrong. It needs net-new Zitadel Action configuration (a session-created Target, its own webhook audience, a second handler), but that cost buys correctness that does not depend on an unverified payload shape.
+- **(ii) Reuse the existing `pre_access_token` webhook and discriminate fresh-auth vs refresh (CONDITIONAL — only if the spike's Outcome A holds).** The existing Target, its JWT-audience validator, DI wiring, and deployment are already in production on the login path, so reusing them is cheaper *if and only if* the payload actually exposes a grant discriminator (`amr` / fresh `auth_time` / refresh indicator). Per Decision 0 this is unverified and, given the production payload models only `user.human.email` (resource context, not grant context), is expected to be **false**. This option is therefore conditional on the spike, not the default.
+
+**Chosen: (i) — the session-created Action is PRIMARY.** Rationale: the session-created hook is immune to the refresh ambiguity by construction, so it satisfies the goal regardless of how the `pre_access_token` payload is shaped. Option (ii) is selected only if Decision 0's spike yields Outcome A (a real discriminator); otherwise it is structurally unable to separate login from refresh and is discarded. We deliberately reverse the cheaper-reuse default in favour of the signal that cannot silently under- or over-count.
+
+**No runtime "suppress when uncertain" rule.** An earlier framing suppressed the event at runtime whenever discrimination was uncertain. That is rejected: on a payload with no discriminator, *every* request is uncertain, so the rule emits **zero** `account.login` events — an unmet goal that ships silently with no error and no signal to detect it. Uncertainty about whether a payload can discriminate at all is resolved **once, at build time, by Decision 0's spike**, not re-litigated per request. The shipped handler — whichever source it uses — operates on a signal already proven login-specific; it does not guess.
+
+### Decision 2: `sub → UserId` lookup on the login path
+
+`Enqueue` needs the platform `UserId`; the Action payload carries the Zitadel `sub` (the IdP subject). The handler resolves `sub → UserId` via the existing `UserUseCase.GetByExternalID` (already defined in `user_uc.go`, "retrieves a user by identity provider ID (Zitadel sub claim)"). The lookup runs only on the login signal chosen by Decision 1 — which, under the primary session-created Action, fires only on a user-initiated login and never on refresh, so refreshes incur no extra query at all. The resolved `UserId` becomes the NATS event payload's `user_id` and ultimately the PostHog `distinct_id`. If the lookup fails (user not yet provisioned, or transient error), the handler logs and skips the analytics emission — it never fails the login / token-issuance flow.
+
+### Decision 3: `account.signup.completed` is an alias of `user.created`; no new event is emitted
+
+Per Decision 15's still-valid first half, signup and `user.created` are the same instant. This change emits **no** `account.signup.completed`. `user.created` remains the canonical signup signal (already published by `user_uc.go` and forwarded by `AnalyticsConsumer.HandleUserCreated`). The `EventAccountSignupCompleted` constant is retained only as a documented alias/no-op so dashboards referring to "signup" resolve to `user.created`; no publisher is wired for it. This avoids double-counting signups in any summed funnel.
+
+### Decision 4: Analytics wiring is publish-to-NATS, non-blocking, via a new `ACCOUNT.login` subject and `HandleAccountLogin`
+
+The login handler does **not** call PostHog (consistent with "Connect-RPC handlers / webhook handlers MUST NOT call the PostHog SDK directly"). On a login it publishes a new subject `ACCOUNT.login` (new `ACCOUNT` stream, following the UPPERCASE two-segment convention in `entity/event_data.go`) carrying the resolved `UserId`. The `analytics-consumer` gains `HandleAccountLogin`, which mirrors `HandleUserCreated`: parse the CloudEvent data, skip on nil client / empty `UserId`, then `client.Enqueue(ctx, userID, usecase.EventAccountLogin, properties)`. The publish is fire-and-forget on the login path: a publish failure is logged and swallowed so login latency and success are unaffected. This keeps the login-specificity concern (the source Action, Decision 1) and the delivery concern (forwarding at the consumer) in two clean layers, matching the rest of the analytics backend.
+
+The properties payload stays minimal and non-PII (e.g. `login_method` from the Action payload when available); no email or `sub` is ever placed in properties.
+
+## Risks / Trade-offs
+
+- **[Risk] The `pre_access_token` payload has no fresh-vs-refresh discriminator — so it cannot carry login semantics at all.** The production handler models the payload as resource context (`user.human.email`) with no `amr` / `auth_time` / refresh indicator. If, despite that, the `pre_access_token` webhook were used as the login source, it would either emit `account.login` on every token mint (over-count — the exact failure Decision 15 deferred the event to avoid) or, under a misguided "suppress when uncertain" runtime rule, emit zero (unmet goal, silent). **Mitigation:** this risk is *eliminated by design*, not mitigated at runtime: Decision 0's spike resolves payload capability once at build time, and Decision 1 makes the session-created Action — which structurally never fires on refresh — the primary source. The `pre_access_token` webhook is used only if the spike proves a real discriminator exists (Outcome A). There is no runtime suppression heuristic to get wrong.
+
+- **[Risk] Login-event delivery reliability bounds login-count completeness.** The analytics publish is intentionally best-effort and non-blocking, so a NATS publish failure silently drops that one login event. **Mitigation:** accept eventual under-count for analytics (never block login); the consumer's existing retry/backoff handles PostHog-side transients once the NATS message exists; `analytics_consumer_*` metrics surface drops. Note that under-count here is a *delivery* gap (a genuinely-login event that failed to publish), categorically different from the now-eliminated *discrimination* gap (mis-classifying refresh as login).
+
+- **[Trade-off] The primary session-created Action adds net-new Zitadel/infra surface** (a new Target, a new webhook audience, a second handler) versus reusing the already-deployed `pre_access_token` Target. We accept this cost deliberately: the session-created hook is login-specific by construction, so it meets the goal without depending on an unverified payload shape. Reuse of the existing Target is taken only when the spike (Decision 0) proves it can actually discriminate — paying for cheap reuse with a correctness assumption we have not validated is the trade we refuse.
+
+- **[Trade-off] No `account.signup.completed` event** means any external consumer expecting that literal name must map to `user.created`. Accepted: a single canonical signup signal is strictly better than two names for one instant, and the catalogue documents the alias.

--- a/openspec/changes/emit-auth-events-via-webhook/proposal.md
+++ b/openspec/changes/emit-auth-events-via-webhook/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+The archived `introduce-analytics-tool` change shipped the full conversion funnel but deliberately descoped its two account-auth signals (Decision 15): `account.signup.completed` was redundant with the already-emitted `user.created`, and `account.login` had no clean backend hook — the only login-adjacent touchpoint, the `pre_access_token` webhook, fires on *every* access-token mint including silent refresh-token grants, so emitting there over-counts logins.
+
+The product owner now wants login instrumented anyway: `account.login` is the single best **active-user / returning-user signal** for retention cohorts (D7/D30 by signup month already exist, but they need a recurring "this user came back" event to be meaningful). Decision 15's *deferral* is reversed; its *reasoning* is not. This change therefore MUST solve the over-count problem (a refresh is not a login) and MUST avoid re-introducing the signup redundancy — emitting a misleading login count or a double-counted signup is worse than emitting nothing.
+
+## What Changes
+
+- Emit `account.login` server-side **once per user-initiated login**, attributed to the platform `UserId` (UUID), via a Zitadel Actions login signal that is structurally login-specific — explicitly NOT on token refresh.
+- **Gate the design on a payload spike first (Decision 0):** before any implementation, dump the actual `pre_access_token` Actions v2 payload on dev Zitadel and check whether it exposes a usable fresh-vs-refresh discriminator (`amr` / `auth_time` / refresh indicator). The production handler models only `user.human.email` (user/org resource context, not OIDC grant context), so this discriminator is expected to be ABSENT.
+- **Make the session-created Action the PRIMARY login source** — a session is created on login and cannot be created by a silent `refresh_token` grant, so it is login-specific by construction with nothing to discriminate. Reuse the existing `pre_access_token` webhook with payload discrimination ONLY if the spike proves the needed fields are present. The earlier "discriminate inside the `pre_access_token` handler, suppress at runtime when uncertain" framing is replaced: undiscriminability is resolved once at build time by the spike, not silently suppressed per request (which would emit zero logins and fail the goal with no signal).
+- Map the Zitadel `sub` claim carried in the Action payload to the platform `UserId` via the existing `GetByExternalID` lookup, because `AnalyticsClient.Enqueue` requires the platform `UserId` as `distinct_id` (never the IdP `sub`).
+- Wire the analytics path into the login handler **non-fatal and non-blocking**: publish a domain event to NATS and let the `analytics-consumer` forward it to PostHog, matching the existing publisher → consumer → PostHog pattern. A failure on the analytics path MUST NOT break token issuance / login.
+- Add a new NATS subject (`ACCOUNT.login`) and a corresponding `analytics-consumer` `HandleAccountLogin` method that forwards it as the `account.login` catalogue event.
+- Resolve `account.signup.completed` by **aliasing signup analytics to the existing `user.created`** — no new event is emitted. The unused `EventAccountSignupCompleted` constant remains a no-op alias documented as such; `user.created` is the canonical signup signal.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `product-analytics`: account authentication events are now emitted server-side. `account.login` is login-specific (one event per user-initiated login, never on token refresh) and attributed to the platform `UserId`; signup continues to be represented by `user.created` with no duplicate `account.signup.completed`.
+
+## Impact
+
+- **Spike first (gating)**: a throwaway payload dump on dev Zitadel decides the source; the spike output (fresh-login vs refresh payload diff) is the recorded justification for the path taken.
+- **New backend login handler (primary path)**: a session-created Zitadel Actions Target handler (`backend/internal/adapter/webhook/`) publishes a non-blocking `account.login` analytics event; it needs a new webhook audience and DI wiring. (If — and only if — the spike proves a discriminator, the existing `pre_access_token` handler is extended instead, reusing its deployed Target.)
+- **New NATS subject + consumer method**: `ACCOUNT.login` subject (new `ACCOUNT` stream) and `AnalyticsConsumer.HandleAccountLogin`.
+- **New user lookup on the login path**: `sub → UserId` via the existing `GetByExternalID`, run on a user-initiated login only.
+- **No new RPC, no proto change, no DB schema change**: this rides the existing Zitadel Actions webhook + NATS + analytics-consumer + PostHog infrastructure introduced by `introduce-analytics-tool` (the primary path adds one session-created Target alongside the deployed `pre_access_token` Target).
+- **No frontend change**: `account.login` is BE-sourced / trust-critical per the event catalogue; the frontend does not emit it.
+- **Event catalogue**: `account.login` moves from "defined but no publisher" to "emitted"; `account.signup.completed` is documented as an alias of `user.created` (not separately emitted).
+- **Risk surface**: the discrimination risk is *eliminated by design* — the primary session-created Action cannot fire on refresh, and the spike (not a runtime heuristic) decides whether the `pre_access_token` payload may be used at all. The remaining risk is best-effort delivery bounding login-count completeness (acceptable under-count). Both are addressed in design.md.

--- a/openspec/changes/emit-auth-events-via-webhook/specs/product-analytics/spec.md
+++ b/openspec/changes/emit-auth-events-via-webhook/specs/product-analytics/spec.md
@@ -1,0 +1,36 @@
+## ADDED Requirements
+
+### Requirement: Account authentication events are emitted server-side
+
+The system SHALL emit account authentication analytics events from the backend, attributed to the platform-internal `UserId` (UUID), not the Zitadel `sub` claim.
+
+`account.login` SHALL be emitted **once per user-initiated login** and SHALL NOT be emitted on a token refresh (a silent `refresh_token` grant is not a login). The login signal SHALL be derived from a backend source that is login-specific — preferably one that structurally cannot fire on a token refresh (e.g. a Zitadel login-specific session-created Action). A token-issuance webhook (e.g. `pre_access_token`) MAY be used as the source ONLY where its payload is verified to expose a reliable discriminator that separates fresh interactive authentication from a `refresh_token` grant. The choice of source SHALL be a build-time decision grounded in verified payload capability, NOT a per-request runtime guess; the login metric SHALL never be inflated by refreshes.
+
+Account signup SHALL be represented by the existing `user.created` event. The system SHALL NOT emit a separate `account.signup.completed` event, because signup occurs at the same instant as `user.created`; emitting both would double-count signups.
+
+The webhook handler on the login path SHALL NOT call the PostHog SDK directly. It SHALL publish a domain event (NATS subject `ACCOUNT.login`) that the `analytics-consumer` forwards to PostHog, and the publish SHALL be non-blocking and non-fatal so that a failure on the analytics path does not break token issuance or login.
+
+#### Scenario: A user-initiated login emits `account.login` exactly once
+
+- **WHEN** a user completes an interactive (fresh) authentication and the backend mints the resulting access token
+- **THEN** the backend SHALL resolve the Zitadel `sub` to the platform `UserId` (via the existing user lookup)
+- **AND** the backend SHALL emit exactly one `account.login` event with `distinct_id` set to that `UserId`
+- **AND** the event SHALL NOT carry the Zitadel `sub`, the user's email, or any other PII in its properties
+
+#### Scenario: A token refresh does NOT emit `account.login`
+
+- **WHEN** the backend mints an access token via a silent `refresh_token` grant (no fresh interactive authentication)
+- **THEN** the backend SHALL NOT emit an `account.login` event
+- **AND** the login count in analytics SHALL reflect user-initiated logins only, excluding refreshes
+
+#### Scenario: Signup is represented by `user.created`, not a duplicate event
+
+- **WHEN** a new user record is created at signup
+- **THEN** the backend SHALL emit `user.created` as the signup signal
+- **AND** the backend SHALL NOT emit a separate `account.signup.completed` event for the same signup
+
+#### Scenario: Analytics failure on the login path does not break login
+
+- **WHEN** the analytics publish (NATS) on the fresh-authentication path fails
+- **THEN** the webhook handler SHALL log the failure and continue
+- **AND** token issuance / login SHALL succeed unaffected by the analytics-path failure

--- a/openspec/changes/emit-auth-events-via-webhook/tasks.md
+++ b/openspec/changes/emit-auth-events-via-webhook/tasks.md
@@ -1,0 +1,51 @@
+# Tasks
+
+## 1. Payload spike + gating design decision (do this FIRST)
+
+- [ ] 1.1 On a dev Zitadel instance, temporarily dump the full decoded `pre_access_token` private-claims payload from the existing handler.
+- [ ] 1.2 Exercise BOTH flows and capture both payloads: (a) a fresh interactive login, (b) a silent `refresh_token` grant. Diff them for any field that reliably differs (`amr`, a fresh `auth_time` ≈ now, or an explicit refresh-grant indicator).
+- [ ] 1.3 Record the spike outcome as the build-time decision (Decision 0):
+  - **Outcome A** — a reliable discriminator IS present → the `pre_access_token` webhook MAY be used (path in task group 3-alt).
+  - **Outcome B** (expected, given the resource-context payload shape) — NO reliable discriminator → the `pre_access_token` webhook CANNOT carry login semantics; use the session-created Action (default path, task group 3).
+- [ ] 1.4 Remove the temporary payload dump from the handler before shipping. There is NO runtime "suppress when uncertain" code path — undiscriminability was resolved here, once, not per request.
+
+## 2. `sub → UserId` mapping on the login path (source-agnostic)
+
+- [ ] 2.1 On a user-initiated login only, resolve the Zitadel `sub` to the platform `UserId` via the existing `UserUseCase.GetByExternalID`.
+- [ ] 2.2 Handle lookup miss / transient error by logging and skipping the analytics emission — never fail the login / token-issuance flow.
+- [ ] 2.3 Wire the `UserUseCase` (or a narrow lookup interface) into the login handler via DI; regenerate mocks (`mockery`) as needed.
+
+## 3. PRIMARY path — session-created Action login handler (default, use unless spike Outcome A)
+
+- [ ] 3.1 Register a Zitadel session-created Actions v2 Target and its webhook-specific audience; this hook fires on user-initiated login and structurally cannot fire on a `refresh_token` grant.
+- [ ] 3.2 Add a session-created handler in `backend/internal/adapter/webhook/` that validates the JWT against the new audience and parses `sub` from the payload; wire it into the server routing and DI.
+- [ ] 3.3 Inject the `EventPublisher`; on a login, publish the new `ACCOUNT.login` subject carrying the resolved `UserId` (and non-PII `login_method` when available). Make the publish best-effort: log and swallow failures so login is unaffected.
+- [ ] 3.4 Unit-test: a session-created payload → exactly one `ACCOUNT.login` publish; a publish failure does not change the handler's HTTP response (login still succeeds).
+
+## 3-alt. CONDITIONAL path — extend `pre_access_token` discrimination (ONLY if spike Outcome A)
+
+- [ ] 3a.1 Extend the `pre_access_token` payload model to parse the discriminator field the spike proved present; implement the fresh-auth predicate from that field (no guessing — the field is known to exist).
+- [ ] 3a.2 On fresh auth only, publish `ACCOUNT.login` (resolved `UserId`, non-PII `login_method`) best-effort as in 3.3; on refresh, publish nothing.
+- [ ] 3a.3 Unit-test: fresh-auth payload → exactly one publish; refresh payload → zero publishes; publish failure does not affect token issuance.
+
+## 4. NATS subject + analytics-consumer Handle method
+
+- [ ] 4.1 Add `SubjectAccountLogin = "ACCOUNT.login"` to `backend/internal/entity/event_data.go` and define its CloudEvent data type (carrying `user_id`).
+- [ ] 4.2 Provision the new `ACCOUNT` JetStream stream alongside the existing `USER`/`ARTIST`/… streams.
+- [ ] 4.3 Implement `AnalyticsConsumer.HandleAccountLogin` mirroring `HandleUserCreated`: parse data, skip on nil client / empty `UserId`, then `Enqueue(ctx, userID, usecase.EventAccountLogin, properties)`; record consumer metrics.
+- [ ] 4.4 Subscribe `HandleAccountLogin` to `ACCOUNT.login` in the consumer's registration.
+
+## 5. Signup decision (no duplicate event)
+
+- [ ] 5.1 Confirm `account.signup.completed` is NOT published anywhere; document `EventAccountSignupCompleted` as a no-op alias of `user.created` in `analytics_events.go`.
+- [ ] 5.2 Update `docs/analytics/event-catalog.md`: `account.login` → emitted (BE, source = Zitadel webhook, refresh-excluded); `account.signup.completed` → documented as an alias of `user.created`, not separately emitted.
+
+## 6. Tests
+
+- [ ] 6.1 Consumer test for `HandleAccountLogin`: forwarded on valid payload; skipped on nil client / empty `UserId`; `Enqueue` error wrapped as `apperr.ErrInternal`.
+- [ ] 6.2 End-to-end-style handler test for the chosen source: a user-initiated login → exactly one `ACCOUNT.login` publish with the resolved `UserId`. Under the primary session-created path, also assert no second login handler exists on the refresh path; under the conditional `pre_access_token` path, assert a refresh payload → zero publishes.
+
+## 7. Verification
+
+- [ ] 7.1 `make check` (lint + test) passes in `backend/`.
+- [ ] 7.2 `openspec validate emit-auth-events-via-webhook --strict` passes.

--- a/openspec/changes/reconcile-analytics-catalogue/.openspec.yaml
+++ b/openspec/changes/reconcile-analytics-catalogue/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-26

--- a/openspec/changes/reconcile-analytics-catalogue/design.md
+++ b/openspec/changes/reconcile-analytics-catalogue/design.md
@@ -1,0 +1,56 @@
+# Design — Reconcile the analytics catalogue
+
+## Context
+
+The archived `introduce-analytics-tool` change established PostHog Cloud EU as the sole product-analytics platform and codified `docs/analytics/event-catalog.md` as the single source of truth (the `product-analytics` capability). Two follow-up catalogue cleanups were drafted independently:
+
+1. Remove the recommendation events, which appeared to describe a recommendation engine that does not exist.
+2. Move `concert.search.completed` out of PostHog because it is user-less pipeline telemetry.
+
+A devil's-advocate review of (1) inspected the actual frontend code and found `concert.recommendation.clicked` is a live, position-keyed click-through signal on the dashboard feed — only its name lies. The review also found that both cleanups edit the same four files, so shipping them as separate changes would create a catalogue/spec merge collision. Hence one combined reconciliation.
+
+Grounding facts from the code:
+
+- `dashboard-route.ts:369` — the dashboard concert list is the recommendation feed; the detail sheet is opened with `source: 'recommendation'` so FE clicks can be joined to a (then-planned) impression signal.
+- `event-card.ts:57-67` — fires the click event position-keyed, guarded by `if (this.position !== null)` so a null position never emits `0` and skews CTR.
+- `analytics_events.go:59,165` — `EventConcertRecommendationServed` constant and its `knownBackendEvents` allowlist entry exist with no publisher.
+- `business_metrics.go:28-46` — `concert.search.count` OTel counter, `RecordConcertSearch(ctx, status)` records `status` only; `concert_uc.go` `executeSearch` calls it with `"success"`/`"error"` in a deferred handler.
+
+## Goals
+
+- Make the catalogue honest: every listed event is real and named for what it actually measures.
+- Preserve the live feed-CTR signal through a rename, not a deletion.
+- Remove the genuine phantom (`concert.recommendation.served`) so the BE allowlist matches reality.
+- Keep user-less pipeline health entirely in OTel, and complete that signal with a `zero_results` outcome.
+- Ship both cleanups together so the shared files are edited once, coherently.
+
+## Non-Goals
+
+- Building a recommendation engine or any server-side impression event.
+- Migrating or back-filling the old `concert.recommendation.clicked` PostHog series into the new name.
+- Changing the OTel export pipeline, sampling, or any other counter.
+- Touching proto schema or triggering BSR regeneration.
+
+## Decisions
+
+### Rename, do not delete, the feed click-through event
+
+The signal is real and valuable (feed CTR), so deleting it would lose a metric. The only defect is the name: `recommendation` implies an engine that does not exist. Renaming to `concert.feed.card.tapped` keeps the behaviour (position-keyed capture, null-position guard, `position` property) while telling the truth — the user tapped a card in the concert feed. The `EventSource` union member `'recommendation'` is renamed to `'feed'` to match.
+
+### Search-pipeline health is OTel, not PostHog
+
+Per Decisions 10 and 13 of `introduce-analytics-tool`, product analytics (PostHog) carries user-attributed product events, and system/pipeline observability (OTel) carries traces, metrics, and logs; the only bridge is `trace_id`. `concert.search.completed` is user-less — a Gemini discovery cron outcome with no `distinct_id` — so it never belonged in the catalogue. It already has an OTel home (`concert.search.count`) and never had a PostHog publisher. Removing the catalogue row aligns the catalogue with the existing implementation rather than introducing a new publisher.
+
+### Add `zero_results` to the OTel counter (real work, not a confirmation)
+
+Today `RecordConcertSearch` is called with only `"success"`/`"error"`. A search that completes but finds no new concerts is currently indistinguishable from a fruitful one, yet it is the most interesting pipeline-health case (quota burned, nothing discovered). Adding a `zero_results` outcome — recorded in `executeSearch` when a successful run yields an empty concert set — makes the OTel view complete and is the search-health home that justifies dropping the PostHog row.
+
+### Combine the two cleanups into one change
+
+Both edit `docs/analytics/event-catalog.md`, the `product-analytics` spec, and the FE/BE event constants. Separate changes would collide on these files and on the same two requirements. One change edits each file once and reproduces each modified requirement coherently.
+
+## Risks / Trade-offs
+
+- **PostHog series discontinuity.** Renaming `concert.recommendation.clicked` to `concert.feed.card.tapped` means PostHog treats it as a brand-new event name; the historical series under the old name does not carry forward, and any saved insight/funnel referencing the old name must be repointed. This is accepted: the old name was actively misleading, the volume to date is small, and honest vocabulary is worth the break. Note the cutover date when the rename ships so analysts can stitch the two series manually if needed.
+- **Allowlist drift in reverse.** Deleting `EventConcertRecommendationServed` is safe only because nothing publishes it; the BE allowlist guard would reject it anyway. Verified by grep — no publisher references the constant.
+- **OTel label cardinality.** Adding one bounded outcome value (`zero_results`) to an existing low-cardinality `status` attribute is negligible; the attribute already carries `success`/`error`.

--- a/openspec/changes/reconcile-analytics-catalogue/proposal.md
+++ b/openspec/changes/reconcile-analytics-catalogue/proposal.md
@@ -1,0 +1,35 @@
+# Reconcile the analytics catalogue: honest vocabulary, drop phantoms, separate pipeline health
+
+## Why
+
+A devil's-advocate review of two in-flight catalogue cleanups found they touch the same files (`docs/analytics/event-catalog.md`, the `product-analytics` spec, `analytics-events.ts`, `analytics_events.go`) and would collide if shipped separately. They are merged here into one reconciliation.
+
+The review also corrected an earlier "delete it" instinct on the recommendation events by inspecting the actual code:
+
+- `concert.recommendation.clicked` is **not** dead. The dashboard concert list *is* the recommendation feed: `frontend/src/routes/dashboard/dashboard-route.ts:369` tags the detail sheet with `source: 'recommendation'`, and `frontend/src/components/live-highway/event-card.ts:57-67` fires the event position-keyed with a null-position CTR guard. It is a real, position-keyed click-through signal — only its **name** is misleading, because there is no recommendation engine producing it. It should be **renamed**, not deleted.
+- `concert.recommendation.served` (BE) is a genuine phantom: the constant `EventConcertRecommendationServed` and its `knownBackendEvents` entry exist in `backend/internal/usecase/analytics_events.go`, but no publisher ever emits it and no recommendation engine exists to produce impressions. It should be deleted.
+- `concert.search.completed` is user-less search-pipeline telemetry. Per Decisions 10 and 13 of the archived `introduce-analytics-tool`, system/pipeline-health signals belong in OpenTelemetry, not PostHog. It has no PostHog publisher, and the OTel counter `concert.search.count` already records the same signal in `backend/internal/infrastructure/telemetry/business_metrics.go` (labelled `success`/`error`, recorded in `concert_uc.go` `executeSearch`). It should be removed from the catalogue, and its OTel counter strengthened with a `zero_results` outcome so the pipeline-health view is complete.
+
+The net effect is an honest catalogue: the live feed-CTR signal carries honest vocabulary, the phantom impression event is gone, and pipeline health is owned solely by OTel.
+
+## What Changes
+
+- **Rename** the frontend feed click-through event `concert.recommendation.clicked` → `concert.feed.card.tapped`, preserving its `position` property and the null-position CTR guard.
+- **Delete** the backend phantom event `concert.recommendation.served` (constant + allowlist entry); it has no publisher and no engine.
+- **Remove** `concert.search.completed` from the catalogue; it is user-less pipeline health that already lives in OTel.
+- **Add** a `zero_results` outcome label to the existing `concert.search.count` OTel counter (today only `success`/`error`), so a successful-but-empty search is distinguishable from a fruitful one.
+- **Update** `docs/analytics/event-catalog.md`: drop the two recommendation rows and the search row, add the `concert.feed.card.tapped` row, and rename the "Recommendation effectiveness" funnel to a feed-CTR funnel.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `product-analytics`
+
+## Impact
+
+- **Frontend** (`frontend/src/services/analytics-events.ts`): rename the `ConcertRecommendationClicked` event constant, the `ConcertRecommendationClickedProps` type, the props-map entry, the `'recommendation'` member of the `EventSource` union (→ `'feed'`), and the doc comments. Call site `frontend/src/components/live-highway/event-card.ts:57-67` and the source tag at `frontend/src/routes/dashboard/dashboard-route.ts:369` follow the rename. Behaviour (position-keyed capture, null-position guard) is unchanged.
+- **Backend** (`backend/internal/usecase/analytics_events.go`): delete the `EventConcertRecommendationServed` constant and its `knownBackendEvents` entry. No publisher referenced it, so no call site changes.
+- **Backend** (`backend/internal/infrastructure/telemetry/business_metrics.go` + `internal/usecase/concert_uc.go`): add `zero_results` to the set of values `RecordConcertSearch` accepts, and record it in `executeSearch` when a successful search yields no concerts.
+- **Catalogue** (`docs/analytics/event-catalog.md`): three row edits (remove two, add one) and one funnel rename.
+- **No proto changes**, no BSR regeneration, no migration. PostHog will see the renamed event as a new name — a known, accepted discontinuity from the old `concert.recommendation.clicked` series.

--- a/openspec/changes/reconcile-analytics-catalogue/specs/product-analytics/spec.md
+++ b/openspec/changes/reconcile-analytics-catalogue/specs/product-analytics/spec.md
@@ -1,0 +1,39 @@
+# product-analytics — delta for reconcile-analytics-catalogue
+
+## MODIFIED Requirements
+
+### Requirement: Event catalogue is the single source of truth
+The system SHALL maintain `docs/analytics/event-catalog.md` in the specification repository as the canonical inventory of every emitted event. Frontend and backend event constants SHALL be reviewed against the catalogue during pull-request review. The catalogue SHALL list `concert.feed.card.tapped` (the frontend feed click-through event), and SHALL NOT list a recommendation impression event (`concert.recommendation.served`), a recommendation click event (`concert.recommendation.clicked`), or `concert.search.completed`, because no recommendation engine exists and search-pipeline health is recorded in OpenTelemetry rather than PostHog.
+
+#### Scenario: Pull request adds an event without catalogue update
+- **WHEN** a pull request introduces a new event constant in `frontend/src/services/analytics-events.ts` or `backend/internal/usecase/analytics_events.go`
+- **THEN** the pull request SHALL also update `docs/analytics/event-catalog.md` with the event's domain, action, outcome (if any), source (FE/BE), required properties, and at least one consuming dashboard or KPI
+- **AND** the pull request SHALL NOT be approved without that update
+
+#### Scenario: Catalogue lists the feed click-through event under honest vocabulary
+- **WHEN** the catalogue is reviewed for the concert feed click-through signal
+- **THEN** it SHALL contain a `concert.feed.card.tapped` row sourced FE with properties `concert_id`, `artist_id`, `position`, and `trace_id?`
+- **AND** it SHALL NOT contain a `concert.recommendation.served` row or a `concert.recommendation.clicked` row
+- **AND** it SHALL NOT contain a `concert.search.completed` row
+- **AND** the frontend constant `Events.ConcertFeedCardTapped` SHALL map to the catalogue's `concert.feed.card.tapped` name
+
+---
+
+### Requirement: Product analytics and OpenTelemetry remain separated; only `trace_id` bridges
+PostHog SHALL receive product-domain events only. OpenTelemetry SHALL receive request traces, metrics, and logs only. No system-observability data SHALL be emitted to PostHog; no product-analytics event SHALL be emitted as an OTel span, log, or metric. User-less pipeline-health signals — such as the success, failure, or empty-result outcome of the concert-discovery search pipeline — SHALL be recorded as OpenTelemetry metrics and SHALL NOT be catalogued as PostHog events. The single permitted bridge SHALL be including the active OTel `trace_id` as a property on conversion-critical analytics events.
+
+#### Scenario: HTTP request latency is recorded in OTel, not PostHog
+- **WHEN** the frontend makes a Connect-RPC call
+- **THEN** the fetch instrumentation SHALL record an OTel span describing the request
+- **AND** PostHog SHALL NOT receive an event describing the request unless the request also represents a product action (e.g. `ticket.purchase.initiated`)
+
+#### Scenario: Conversion event carries `trace_id`
+- **WHEN** the backend `analytics-consumer` forwards a `ticket.purchase.completed` event
+- **THEN** if a current OTel span context is available, the consumer SHALL include `trace_id` in the event properties
+- **AND** the value SHALL match the same trace ID recorded in the corresponding Cloud Trace span
+
+#### Scenario: Search-pipeline health is an OTel metric, not a catalogue event
+- **WHEN** the concert-discovery search pipeline completes a run (successfully, with no results, or with an error)
+- **THEN** the backend SHALL record the outcome on the `concert.search.count` OpenTelemetry counter using the `success`, `zero_results`, or `error` label
+- **AND** the system SHALL NOT emit a PostHog event such as `concert.search.completed` for that run
+- **AND** the event catalogue SHALL NOT list any search-pipeline-health event

--- a/openspec/changes/reconcile-analytics-catalogue/tasks.md
+++ b/openspec/changes/reconcile-analytics-catalogue/tasks.md
@@ -1,0 +1,35 @@
+# Tasks — Reconcile the analytics catalogue
+
+## 1. Frontend: rename the feed click-through event
+
+- [ ] 1.1 In `frontend/src/services/analytics-events.ts`, rename the event constant `ConcertRecommendationClicked` → `ConcertFeedCardTapped` and its value `'concert.recommendation.clicked'` → `'concert.feed.card.tapped'`.
+- [ ] 1.2 Rename the `ConcertRecommendationClickedProps` type → `ConcertFeedCardTappedProps`, keeping the `position` property.
+- [ ] 1.3 Update the props-map entry key `'concert.recommendation.clicked'` → `'concert.feed.card.tapped'` to point at the renamed props type.
+- [ ] 1.4 Rename the `EventSource` union member `'recommendation'` → `'feed'`.
+- [ ] 1.5 Update the doc comments that describe the event as a recommendation click so they describe a concert-feed card tap.
+- [ ] 1.6 In `frontend/src/components/live-highway/event-card.ts` (call site ~L57-67), update `Events.ConcertRecommendationClicked` → `Events.ConcertFeedCardTapped`, preserving the `position` property and the `if (this.position !== null)` CTR guard.
+- [ ] 1.7 In `frontend/src/routes/dashboard/dashboard-route.ts` (~L369), update the source tag `'recommendation'` → `'feed'`.
+
+## 2. Backend: delete the phantom impression event
+
+- [ ] 2.1 In `backend/internal/usecase/analytics_events.go`, delete the `EventConcertRecommendationServed` constant (and its doc comment).
+- [ ] 2.2 Delete the `EventConcertRecommendationServed` entry from the `knownBackendEvents` allowlist.
+- [ ] 2.3 Confirm by grep that no publisher references the deleted constant.
+
+## 3. Backend: add the `zero_results` OTel outcome
+
+- [ ] 3.1 In `backend/internal/infrastructure/telemetry/business_metrics.go`, document that `RecordConcertSearch` accepts `success`, `zero_results`, and `error` for the `status` attribute on `concert.search.count`.
+- [ ] 3.2 In `backend/internal/usecase/concert_uc.go` `executeSearch`, record `zero_results` instead of `success` when a successful run yields no new concerts, keeping `error` for failures and `success` for non-empty results.
+
+## 4. Catalogue edits
+
+- [ ] 4.1 In `docs/analytics/event-catalog.md`, remove the `concert.recommendation.served` row.
+- [ ] 4.2 Replace the `concert.recommendation.clicked` row with a `concert.feed.card.tapped` row (FE; properties `concert_id`, `artist_id`, `position`, `trace_id?`; consumer: feed CTR).
+- [ ] 4.3 Remove the `concert.search.completed` row.
+- [ ] 4.4 Rename the "Recommendation effectiveness" funnel to a feed-CTR funnel built on `concert.feed.card.tapped` → `concert.detail.viewed`.
+
+## 5. Verification
+
+- [ ] 5.1 Frontend: `make check` passes (lint + typecheck + tests) with the renamed event and source union.
+- [ ] 5.2 Backend: `make check` passes with the deleted constant and the new `zero_results` outcome.
+- [ ] 5.3 `openspec validate reconcile-analytics-catalogue --strict` is green.


### PR DESCRIPTION
## 📝 Summary

Three **OpenSpec change proposals** (artifacts only — not implemented), defined from the deferred items of the archived `introduce-analytics-tool` and **revised after an adversarial devil's-advocate review**.

### Changes
- **`reconcile-analytics-catalogue`** — RENAME the live FE feed-CTR event `concert.recommendation.clicked` → `concert.feed.card.tapped` (keep `position`); DELETE the BE phantom `concert.recommendation.served`; REMOVE the misplaced `concert.search.completed` catalogue row (it's the existing OTel `concert.search.count` metric; add a `zero_results` label). _Merges the former remove-recommendation + move-search — they collided on the catalogue + `product-analytics` spec._
- **`emit-auth-events-via-webhook`** — emit `account.login` from a login-specific signal. **Spike-gated**: dump the `pre_access_token` payload first; the **session-created Action is PRIMARY** (cannot fire on refresh), `pre_access_token` only if the spike proves it can discriminate. Signup = `user.created` (no duplicate).
- **`disclose-posthog-in-privacy-policy`** — add the PostHog cross-border disclosure to the in-app `/legal/privacy` page + fix the broken `liverty.me` links. Spec requires naming **recipient/country/categories/purpose** without freezing an APPI Art. 28 sufficiency judgement (left to counsel); processor-vs-recipient flagged as an open question.

### Devil's-advocate fixes applied
- ③ **rename, not delete** — the FE `.clicked` is a real position-keyed CTR signal (`dashboard-route.ts:369`, `event-card.ts:57-67`), not a misnomer; deleting would lose live data.
- ④ **spike + session-Action primary** — the `pre_access_token` discrimination premise was unverified and the prod handler suggests it's false (over-count / silent-zero risk).
- ② **legal SHALL softened** + **settings privacy-link dedupe** (a working in-app link already exists at l.230).

All three pass `openspec validate --strict`. (Sibling proposal `introduce-notification-service` is PR #665.) Run `/opsx:apply <name>` to implement.

## ✅ Self-Checklist
- [x] `openspec validate --strict` passes (×3).
- [x] No proto / code changes (proposals only; the stray catalogue edit was reverted).
