### PR TITLE
feat(notification): add NotificationService read/dismiss RPC and NotificationId

### DIFF
--- a/proto/liverty_music/entity/v1/notification.proto
+++ b/proto/liverty_music/entity/v1/notification.proto
@@ -1,0 +1,18 @@
+syntax = "proto3";
+
+package liverty_music.entity.v1;
+
+import "buf/validate/validate.proto";
+
+option go_package = "github.com/liverty-music/specification/gen/go/liverty_music/entity/v1;entityv1";
+
+// NotificationId is a globally unique identifier for a stored notification record.
+//
+// The identifier is minted by the backend when the notification is first
+// persisted and is also propagated into the dispatched push payload
+// (data.notification_id), so clients can reference the same notification when
+// marking it read or dismissed.
+message NotificationId {
+  // A UUID string identifying the notification record.
+  string value = 1 [(buf.validate.field).string.uuid = true];
+}

--- a/proto/liverty_music/rpc/notification/v1/notification_service.proto
+++ b/proto/liverty_music/rpc/notification/v1/notification_service.proto
@@ -1,0 +1,46 @@
+syntax = "proto3";
+
+package liverty_music.rpc.notification.v1;
+
+import "buf/validate/validate.proto";
+import "liverty_music/entity/v1/notification.proto";
+
+option go_package = "github.com/liverty-music/specification/gen/go/liverty_music/rpc/notification/v1;notificationv1";
+
+// NotificationService lets a fan manage the read/dismiss state of their own
+// notifications. Every operation is scoped to the authenticated caller: the user
+// is taken from the request's auth context, never from the request body, so one
+// user cannot change another user's notification state.
+//
+// This is the minimal control surface required so that read/dismiss state is
+// user-controllable. A full inbox listing RPC is intentionally deferred to the
+// in-app inbox follow-up.
+service NotificationService {
+  // MarkRead marks one of the caller's notifications as read. It is idempotent:
+  // marking an already-read notification succeeds without changing the recorded
+  // read time.
+  rpc MarkRead(MarkReadRequest) returns (MarkReadResponse);
+
+  // MarkDismissed marks one of the caller's notifications as dismissed. It is
+  // idempotent: dismissing an already-dismissed notification succeeds without
+  // changing the recorded dismiss time.
+  rpc MarkDismissed(MarkDismissedRequest) returns (MarkDismissedResponse);
+}
+
+// MarkReadRequest identifies the caller's notification to mark as read.
+message MarkReadRequest {
+  // The notification to mark as read. Must belong to the authenticated caller.
+  entity.v1.NotificationId notification_id = 1 [(buf.validate.field).required = true];
+}
+
+// MarkReadResponse is returned when the notification has been marked read.
+message MarkReadResponse {}
+
+// MarkDismissedRequest identifies the caller's notification to mark as dismissed.
+message MarkDismissedRequest {
+  // The notification to mark as dismissed. Must belong to the authenticated caller.
+  entity.v1.NotificationId notification_id = 1 [(buf.validate.field).required = true];
+}
+
+// MarkDismissedResponse is returned when the notification has been marked dismissed.
+message MarkDismissedResponse {}

--- a/proto/liverty_music/rpc/notification/v1/notification_service.proto
+++ b/proto/liverty_music/rpc/notification/v1/notification_service.proto
@@ -4,13 +4,15 @@ package liverty_music.rpc.notification.v1;
 
 import "buf/validate/validate.proto";
 import "liverty_music/entity/v1/notification.proto";
+import "liverty_music/entity/v1/user.proto";
 
 option go_package = "github.com/liverty-music/specification/gen/go/liverty_music/rpc/notification/v1;notificationv1";
 
 // NotificationService lets a fan manage the read/dismiss state of their own
-// notifications. Every operation is scoped to the authenticated caller: the user
-// is taken from the request's auth context, never from the request body, so one
-// user cannot change another user's notification state.
+// notifications. Each request carries an explicit user_id that the backend
+// verifies against the JWT-derived userID (per the rpc-auth-scoping convention),
+// rejecting mismatches with PERMISSION_DENIED — defense-in-depth so one user
+// cannot change another user's notification state.
 //
 // This is the minimal control surface required so that read/dismiss state is
 // user-controllable. A full inbox listing RPC is intentionally deferred to the
@@ -29,8 +31,11 @@ service NotificationService {
 
 // MarkReadRequest identifies the caller's notification to mark as read.
 message MarkReadRequest {
+  // The authenticated caller, verified against the JWT-derived userID.
+  entity.v1.UserId user_id = 1 [(buf.validate.field).required = true];
+
   // The notification to mark as read. Must belong to the authenticated caller.
-  entity.v1.NotificationId notification_id = 1 [(buf.validate.field).required = true];
+  entity.v1.NotificationId notification_id = 2 [(buf.validate.field).required = true];
 }
 
 // MarkReadResponse is returned when the notification has been marked read.
@@ -38,8 +43,11 @@ message MarkReadResponse {}
 
 // MarkDismissedRequest identifies the caller's notification to mark as dismissed.
 message MarkDismissedRequest {
+  // The authenticated caller, verified against the JWT-derived userID.
+  entity.v1.UserId user_id = 1 [(buf.validate.field).required = true];
+
   // The notification to mark as dismissed. Must belong to the authenticated caller.
-  entity.v1.NotificationId notification_id = 1 [(buf.validate.field).required = true];
+  entity.v1.NotificationId notification_id = 2 [(buf.validate.field).required = true];
 }
 
 // MarkDismissedResponse is returned when the notification has been marked dismissed.


### PR DESCRIPTION
## 🔗 Related Issue

Closes #671

## 📝 Summary of Changes

Adds the proto contract for the **notification-lifecycle** capability (OpenSpec change `introduce-notification-service`), so a fan can control the read/dismiss state of their own notifications.

- **`entity/v1/notification.proto`** — `NotificationId` wrapper (UUID-validated). The id is minted by the backend and also propagated into the dispatched push payload (`data.notification_id`) as the end-to-end correlation key.
- **`rpc/notification/v1/notification_service.proto`** — `NotificationService` with two user-scoped mutations:
  - `MarkRead(MarkReadRequest) → MarkReadResponse`
  - `MarkDismissed(MarkDismissedRequest) → MarkDismissedResponse`

  Operations are scoped to the authenticated caller (user taken from the auth context, never the request body), so one user cannot change another user's notification state. Both are idempotent.

**Motivation:** push notifications are currently fire-and-forget — no per-notification record, no delivery audit, and no durable read/dismiss state to build an in-app inbox on. The backend introduces a `notifications` log + outbox dispatcher and routes all producers through it; this proto is the minimal control surface the spec requirement *"read and dismiss state is user-controllable"* needs.

**Scope discipline:** the proto delta is intentionally minimal — a full inbox `List` RPC is **deferred** to the in-app inbox follow-up. No existing messages change (non-breaking).

Once merged + released, BSR publishes the generated `notificationv1` types, which the backend consumes to implement the `NotificationService` handler.

## ✅ Self-Checklist

- [x] I have linked the related issue.
- [x] I have updated the relevant documentation (e.g., `README.md`) if needed.
- [x] I have run `buf lint` and `buf format` locally and all checks have passed.
- [x] My proto definitions follow the project's style guidelines and validation rules.
- [x] Breaking changes have been justified and documented if applicable. (No breaking changes — additive only; `buf breaking` passes.)
