### PR TITLE
docs(analytics): document account.login source + mark emit-auth-events tasks done

### DIFF
--- a/docs/analytics/event-catalog.md
+++ b/docs/analytics/event-catalog.md
@@ -35,7 +35,7 @@ Conversion-critical events MAY include a `trace_id` property carrying the active
 | --- | --- | --- | --- | --- |
 | `page.viewed` | FE | page | `path`, `title`, `referrer?`, `trace_id?` | Acquisition funnel, top-of-funnel dashboard |
 | `account.signup.started` | FE | account | `source` (pre-consent: no `trace_id` per `analytics-consent` spec) | Signup funnel |
-| `account.login` | BE | account | `trace_id?` | Active user trends |
+| `account.login` | BE | account | `trace_id?` | Active user trends, returning/active-user retention cohorts |
 | `account.preferred_language.updated` | BE | account | `from_locale`, `to_locale`, `trace_id?` | Locale change rate |
 | `user.created` | BE | user | `signup_month`, `locale`, `home_region?`, `trace_id?` | Acquisition by month, signup funnel, D7/D30 retention cohort |
 | `user.deleted` | BE | user | `account_age_days_bucket`, `trace_id?` | Account-deletion analysis |
@@ -65,6 +65,11 @@ Conversion-critical events MAY include a `trace_id` property carrying the active
 | `notification.opened` | FE | notification | `notification_id`, `event_id?`, `artist_id?`, `trace_id?` | Notification CTR |
 | `notification.dismissed` | FE | notification | `notification_id`, `trace_id?` | Notification fatigue |
 | `sales_reminder.delivered` | BE | sales_reminder | `phase_stage`, `delivery_status`, `trace_id?` | Sales-reminder reach (sales-phase-timeline KPI) |
+
+### Account-event source notes
+
+- `account.login` is sourced from a Zitadel Actions v2 Execution on the `response` side of `/zitadel.session.v2.SessionService/CreateSession` (backend `/create-session` webhook → `ACCOUNT.login` NATS subject → `analytics-consumer`). A session is created once per user-initiated login and never by a silent `refresh_token` grant, so the event is emitted **exactly once per login and never on token refresh** — the login metric is never inflated by refreshes.
+- **Signup is represented by `user.created`, not a separate `account.signup.completed` event.** Signup occurs at the same instant `user.created` is emitted, so a distinct completion event would double-count signups; `account.signup.completed` is therefore an alias of `user.created` and is not emitted. (`account.signup.started` is the FE pre-consent intent event and is unrelated.)
 
 ## Funnels and dashboards
 

--- a/openspec/changes/emit-auth-events-via-webhook/tasks.md
+++ b/openspec/changes/emit-auth-events-via-webhook/tasks.md
@@ -2,49 +2,49 @@
 
 ## 1. Zitadel `CreateSession` Actions v2 resources (cloud-provisioning)
 
-- [ ] 1.1 Add a `ZitadelExecutionResponse` dynamic resource in `src/zitadel/dynamic/execution.ts` (condition `{ response: { method } }`), mirroring the existing `ZitadelExecutionRequest`. Only `function` and `request` conditions exist today; the `response` side is required by design Decision 1a.
-- [ ] 1.2 In `src/zitadel/components/actions-v2.ts`, provision a new `CreateSession` Target the same way as `pre-access-token-webhook`: `targetType: 'REST_CALL'`, `payloadType: 'PAYLOAD_TYPE_JWT'` (so the backend verifies via its JWKS validator — no HMAC secret), and `interruptOnError: false` (analytics MUST NOT block login). Point its endpoint at the new backend webhook path.
-- [ ] 1.3 Bind a `ZitadelExecutionResponse` on `/zitadel.session.v2.SessionService/CreateSession` to that Target.
-- [ ] 1.4 Wire the new endpoint URL through `src/zitadel/index.ts` / `constants.ts` alongside `PRE_ACCESS_TOKEN_PATH`.
+- [x] 1.1 Add a `ZitadelExecutionResponse` dynamic resource in `src/zitadel/dynamic/execution.ts` (condition `{ response: { method } }`), mirroring the existing `ZitadelExecutionRequest`. Only `function` and `request` conditions exist today; the `response` side is required by design Decision 1a.
+- [x] 1.2 In `src/zitadel/components/actions-v2.ts`, provision a new `CreateSession` Target the same way as `pre-access-token-webhook`: `targetType: 'REST_CALL'`, `payloadType: 'PAYLOAD_TYPE_JWT'` (so the backend verifies via its JWKS validator — no HMAC secret), and `interruptOnError: false` (analytics MUST NOT block login). Point its endpoint at the new backend webhook path.
+- [x] 1.3 Bind a `ZitadelExecutionResponse` on `/zitadel.session.v2.SessionService/CreateSession` to that Target.
+- [x] 1.4 Wire the new endpoint URL through `src/zitadel/index.ts` / `constants.ts` alongside `PRE_ACCESS_TOKEN_PATH`.
 
 ## 2. Backend `CreateSession` webhook handler
 
-- [ ] 2.1 Add a handler in `backend/internal/adapter/webhook/` that verifies the `PAYLOAD_TYPE_JWT` body via the existing `auth.WebhookValidator.ValidateWebhookToken` (JWKS signature) — reuse the exact pattern from `pre_access_token_handler.go`; do NOT introduce HMAC verification.
-- [ ] 2.2 Parse `request.checks.user.userId` from the JWT private claims (round-trip `token.PrivateClaims()` through JSON, as the existing handler does for `user.human.email`).
-- [ ] 2.3 Register the handler on a new route on the existing internal-only webhook listener (`server.NewWebhookServer` map in `internal/di/provider.go`), using a second `WebhookValidator` sharing the JWKS cache.
+- [x] 2.1 Add a handler in `backend/internal/adapter/webhook/` that verifies the `PAYLOAD_TYPE_JWT` body via the existing `auth.WebhookValidator.ValidateWebhookToken` (JWKS signature) — reuse the exact pattern from `pre_access_token_handler.go`; do NOT introduce HMAC verification.
+- [x] 2.2 Parse `request.checks.user.userId` from the JWT private claims (round-trip `token.PrivateClaims()` through JSON, as the existing handler does for `user.human.email`).
+- [x] 2.3 Register the handler on a new route on the existing internal-only webhook listener (`server.NewWebhookServer` map in `internal/di/provider.go`), using a second `WebhookValidator` sharing the JWKS cache.
 
 ## 3. Backend `sub → UserId` mapping + non-blocking publish
 
-- [ ] 3.1 Inject `UserUseCase` (or a narrow lookup interface) into the handler via DI; regenerate mocks (`mockery`) as needed.
-- [ ] 3.2 Resolve the Zitadel `sub` (`request.checks.user.userId`) to the platform `UserId` via `UserUseCase.GetByExternalID`. On lookup miss / transient error OR when `request.checks.user.userId` is absent, log and skip the analytics emission — never fail the request (always return a success response so `CreateSession` is unaffected).
-- [ ] 3.3 Inject the `EventPublisher`; on a resolved login publish the new `ACCOUNT.login` subject carrying the resolved `UserId` (and non-PII `login_method` when available). Make the publish best-effort: log and swallow failures so login is unaffected.
+- [x] 3.1 Inject `UserUseCase` (or a narrow lookup interface) into the handler via DI; regenerate mocks (`mockery`) as needed.
+- [x] 3.2 Resolve the Zitadel `sub` (`request.checks.user.userId`) to the platform `UserId` via `UserUseCase.GetByExternalID`. On lookup miss / transient error OR when `request.checks.user.userId` is absent, log and skip the analytics emission — never fail the request (always return a success response so `CreateSession` is unaffected).
+- [x] 3.3 Inject the `EventPublisher`; on a resolved login publish the new `ACCOUNT.login` subject carrying the resolved `UserId` (and non-PII `login_method` when available). Make the publish best-effort: log and swallow failures so login is unaffected.
 
 ## 4. Backend messaging: `ACCOUNT` stream + subject + consumer method
 
-- [ ] 4.1 Add `SubjectAccountLogin = "ACCOUNT.login"` to `backend/internal/entity/event_data.go` and define its CloudEvent data type (`AccountLoginData` carrying `user_id`), mirroring `UserCreatedData`.
-- [ ] 4.2 Add the `ACCOUNT` JetStream stream (`Subjects: ["ACCOUNT.*"]`) to `streams.go`, alongside the existing `USER`/`ARTIST`/… streams.
-- [ ] 4.3 Implement `AnalyticsConsumer.HandleAccountLogin` mirroring `HandleUserCreated`: parse data, skip on nil client / empty `UserId`, then `Enqueue(ctx, userID, usecase.EventAccountLogin, properties)`; record consumer metrics.
-- [ ] 4.4 Subscribe `HandleAccountLogin` to `entity.SubjectAccountLogin` in `internal/di/consumer.go`'s `AddConsumerHandler` registration.
+- [x] 4.1 Add `SubjectAccountLogin = "ACCOUNT.login"` to `backend/internal/entity/event_data.go` and define its CloudEvent data type (`AccountLoginData` carrying `user_id`), mirroring `UserCreatedData`.
+- [x] 4.2 Add the `ACCOUNT` JetStream stream (`Subjects: ["ACCOUNT.*"]`) to `streams.go`, alongside the existing `USER`/`ARTIST`/… streams.
+- [x] 4.3 Implement `AnalyticsConsumer.HandleAccountLogin` mirroring `HandleUserCreated`: parse data, skip on nil client / empty `UserId`, then `Enqueue(ctx, userID, usecase.EventAccountLogin, properties)`; record consumer metrics.
+- [x] 4.4 Subscribe `HandleAccountLogin` to `entity.SubjectAccountLogin` in `internal/di/consumer.go`'s `AddConsumerHandler` registration.
 
 ## 5. cloud-provisioning: KEDA trigger for the new consumer
 
-- [ ] 5.1 Add a `nats-jetstream` trigger (stream `ACCOUNT`, consumer `ACCOUNT_login`, durable = subject with dots→underscores) to `k8s/namespaces/backend/base/consumer/scaledobject.yaml`. Keep the base a complete inventory even though prod pins the consumer to `min=max=1` (trigger inert in prod).
+- [x] 5.1 Add a `nats-jetstream` trigger (stream `ACCOUNT`, consumer `ACCOUNT_login`, durable = subject with dots→underscores) to `k8s/namespaces/backend/base/consumer/scaledobject.yaml`. Keep the base a complete inventory even though prod pins the consumer to `min=max=1` (trigger inert in prod).
 
 ## 6. Signup decision (no duplicate event)
 
-- [ ] 6.1 Confirm `account.signup.completed` is NOT published anywhere; document `EventAccountSignupCompleted` as a no-op alias of `user.created` in `analytics_events.go`.
-- [ ] 6.2 Update `docs/analytics/event-catalog.md`: `account.login` → emitted (BE, source = Zitadel `CreateSession` Actions v2 Execution, refresh-excluded by construction); `account.signup.completed` → documented as an alias of `user.created`, not separately emitted.
+- [x] 6.1 Confirm `account.signup.completed` is NOT published anywhere; document `EventAccountSignupCompleted` as a no-op alias of `user.created` in `analytics_events.go`.
+- [x] 6.2 Update `docs/analytics/event-catalog.md`: `account.login` → emitted (BE, source = Zitadel `CreateSession` Actions v2 Execution, refresh-excluded by construction); `account.signup.completed` → documented as an alias of `user.created`, not separately emitted.
 
 ## 7. Tests
 
-- [ ] 7.1 Handler test: a `CreateSession` response payload with `request.checks.user.userId` → exactly one `ACCOUNT.login` publish with the resolved `UserId`.
-- [ ] 7.2 Handler test: a JWT with invalid signature → rejected (401), no publish; a payload missing `request.checks.user.userId` → skip + log, success response, no publish; a `GetByExternalID` miss → skip + log, success response, no publish.
-- [ ] 7.3 Handler test: a publish failure does not change the handler's HTTP response (login still succeeds).
-- [ ] 7.4 Consumer test for `HandleAccountLogin`: forwarded on valid payload; skipped on nil client / empty `UserId`; `Enqueue` error wrapped as `apperr.ErrInternal`.
+- [x] 7.1 Handler test: a `CreateSession` response payload with `request.checks.user.userId` → exactly one `ACCOUNT.login` publish with the resolved `UserId`.
+- [x] 7.2 Handler test: a JWT with invalid signature → rejected (401), no publish; a payload missing `request.checks.user.userId` → skip + log, success response, no publish; a `GetByExternalID` miss → skip + log, success response, no publish.
+- [x] 7.3 Handler test: a publish failure does not change the handler's HTTP response (login still succeeds).
+- [x] 7.4 Consumer test for `HandleAccountLogin`: forwarded on valid payload; skipped on nil client / empty `UserId`; `Enqueue` error wrapped as `apperr.ErrInternal`.
 
 ## 8. Verification
 
-- [ ] 8.1 `make check` (lint + test) passes in `backend/`.
-- [ ] 8.2 `make check` passes in `cloud-provisioning/` (lint-ts; k8s render for the scaledobject).
-- [ ] 8.3 `openspec validate emit-auth-events-via-webhook --strict` passes.
+- [x] 8.1 `make check` (lint + test) passes in `backend/`.
+- [x] 8.2 `make check` passes in `cloud-provisioning/` (lint-ts; k8s render for the scaledobject).
+- [x] 8.3 `openspec validate emit-auth-events-via-webhook --strict` passes.
 - [ ] 8.4 Post-rollout verification in **prod** (dev is intentionally stopped): perform a real interactive login and confirm an `account.login` event appears in PostHog Activity attributed to the platform `UserId`, and confirm the `analytics-consumer` forwarded it (consumer metrics / logs). Perform a token refresh and confirm NO `account.login` is emitted. Do NOT author dev-environment verification tasks.


### PR DESCRIPTION
## Summary

Follow-up docs for OpenSpec change **emit-auth-events-via-webhook**, now that the implementation PRs are up (backend liverty-music/backend#359, cloud-provisioning liverty-music/cloud-provisioning#377).

- **Event catalogue** ([event-catalog.md](docs/analytics/event-catalog.md)): documents that `account.login` is sourced from the Zitadel `CreateSession` Actions v2 Execution (once per user-initiated login, **never on token refresh**), and that `account.signup.completed` is an alias of `user.created` that is never separately emitted.
- **tasks.md**: marks the implementation tasks complete. Only `8.4` (post-rollout **prod** verification via PostHog Activity) stays open — it runs after the two implementation PRs deploy.

## Note

The task to "document `EventAccountSignupCompleted` as a no-op alias in `analytics_events.go`" (6.1/16) was satisfied differently: that constant had already been removed upstream, so re-adding dead code would be worse. The alias is documented here in the catalogue instead, and a grep confirms nothing emits `account.signup.completed`.

`openspec validate emit-auth-events-via-webhook --strict` passes.

Refs: liverty-music/specification#532