### PR TITLE
docs(analytics): prune phantom, redundant, and double-counting events

### DIFF
--- a/openspec/changes/prune-analytics-event-collection/.openspec.yaml
+++ b/openspec/changes/prune-analytics-event-collection/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-07

--- a/openspec/changes/prune-analytics-event-collection/design.md
+++ b/openspec/changes/prune-analytics-event-collection/design.md
@@ -1,0 +1,57 @@
+## Context
+
+The analytics event set was built ahead of the product across three prior changes (`introduce-analytics-tool`, `reconcile-analytics-catalogue`, `emit-notification-analytics-events`) plus the ticket-system MVP work. A per-call-site audit of the live code (not the catalogue) revealed that the collected set has drifted from what actually fires and from what the current product can observe:
+
+- **Phantoms** — `account.signup.started` (FE) and `user.deleted` (BE) have no emission call site; the never-wired ticket-sales constants (`ticket.lottery.entry.accepted/.rejected`, `ticket.lottery.result.assigned`, `ticket.purchase.completed/.failed`) exist only as name constants.
+- **Redundancy** — `artist.discovery.viewed` fires 1:1 with `artist.follow.requested` (same `artist_id`, `source`, instant) and measures no impressions; the FE `artist.follow.requested` duplicates backend `artist.follow.completed` for a single-tap action.
+- **Double-count** — a successful sales-reminder push emits `notification.delivered` (`type = "sales_reminder"`) via `NotificationUseCase` **and** `sales_reminder.delivered` via `salesReminderDeliveryUseCase`, counting one delivery twice.
+- **Firehose** — `page.viewed` fires on every `au:router:navigation-end`; highest volume, lowest insight, and the signup form it might have measured lives on the Zitadel hosted-login domain where FE page views cannot reach.
+- **Wrong altitude** — `account.preferred_language.updated` models user *state* as an *action* event.
+
+Constraints: the ticket-sales platform is deferred indefinitely; `ticket.email.parsed` (and the email-driven `ticket.journey` promotion path) is disabled by an OS-side issue; the login event is mid-redesign (`redesign-account-login-event-handler`) and reverted from production, so it has **zero** production history. `trace_id` correlation across the NATS boundary is intact (watermill-opentelemetry propagation), so no correlation work is required here.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Delete events that never fire, duplicate another event, or double-count the same signal.
+- Rename `account.login` → `account.signin` while it has no production history.
+- Demote `preferred_language` from an event to a person property without losing its segmentation value.
+- Distinguish `dormant` (wired, will fire when a feature ships) from `deleted` (removed) in the catalogue, and prevent future phantoms with a verified-call-site requirement.
+- Preserve sales-reminder delivery-failure visibility operationally after removing its analytics event.
+
+**Non-Goals:**
+- Person-property enrichment beyond `preferred_language`, and Group Analytics — deferred to Change 2.
+- Dashboard/funnel construction and event-volume governance tooling — Change 3.
+- Any re-enablement of ticket sales, ZK entry, minting, or email import.
+
+## Decisions
+
+**D1 — Delete vs. dormant is decided by "does a call site exist?"** An event with no emitter is deleted (phantom); an event with a real emitter that is inactive only because its feature is deferred or externally blocked is kept as `dormant`. This keeps the catalogue an honest inventory: `entry.zk_proof.*`, `ticket.mint.completed`, `ticket.email.parsed`, and the FE intent events `ticket.purchase.initiated` / `entry.checkin.attempted` stay as `dormant`; the never-wired lottery/purchase BE constants are deleted. *Alternative considered:* keep all deferred constants for "future-proofing" — rejected because indistinguishable dead constants are exactly how the phantoms accumulated.
+
+**D2 — Unify delivery reach on `notification.delivered`; delete `sales_reminder.delivered`.** `notification.delivered.type` already carries `sales_reminder`, so reach is fully recoverable by filtering on `type`. The only unique signal in `sales_reminder.delivered` was the non-success outcomes (`no_subscription`, `failed`) per `phase_stage`, which is a *delivery-reliability* concern that belongs in operational telemetry, not product analytics. *Alternative considered:* rescope `sales_reminder.delivered` to failures only — rejected as it keeps a bespoke product-analytics event for an ops metric and still risks double-reading against `notification.delivered`.
+
+**D3 — Rename now, accept the discontinuity as zero.** Renaming `account.login` → `account.signin` is normally a breaking, history-splitting change (PostHog best practice: keep names static). It is free here precisely because the event is mid-redesign and has no production data. Doing it now avoids a permanent `login`/`signup` vocabulary mismatch. *Alternative considered:* keep `account.login` — rejected for lasting inconsistency at no offsetting benefit.
+
+**D4 — `preferred_language` becomes a `$set` person property, not an event.** Language is durable user state; as a person property it powers segmentation (e.g., retention by locale) without per-change event noise. The demotion is wired in Change 2's identify enrichment; this change removes the *event* (`HandleUserPreferredLanguageUpdated` forwarding) and, after confirming no non-analytics consumer subscribes to `USER.preferred_language_updated`, its publish. *Alternative considered:* keep both event and property — rejected as redundant.
+
+**D5 — Prevent recurrence with a verified-call-site requirement.** The audit only found the phantoms because it read call sites. Encode that as a `product-analytics` requirement so future reviews check the emitter, not just the catalogue row.
+
+## Risks / Trade-offs
+
+- **Loss of sales-reminder delivery-failure breakdown in PostHog** → Mitigation: add a log-based metric (`no_subscription` / `failed` per stage) in the ops follow-up task before or with the deletion; delivery failures are already logged.
+- **Renaming `account.login` after some data exists** (if a release shipped it between audit and merge) → Mitigation: verify zero production events for `account.login` at implementation time; if any exist, add a PostHog alias rather than a hard rename.
+- **Removing `USER.preferred_language_updated` publish could break an unknown consumer** → Mitigation: grep all consumers before removing the publish; if any non-analytics consumer exists, remove only the analytics forwarding and keep the publish.
+- **Deleting FE `artist.follow.requested` drops follow `source` attribution** → Accepted: `source` (orb vs. search) is a one-off analysis, not a standing metric; backend `artist.follow.completed` intentionally does not carry `source`.
+- **CI catalogue check** may fail transiently while code constants and the catalogue are edited in separate repos → Mitigation: land the specification catalogue update first, then the FE/BE constant removals reference it.
+
+## Migration Plan
+
+1. Land the specification change: catalogue rows removed, collection-status column added, funnel #1 re-cut, `account.signin` documented.
+2. Backend: remove deleted/phantom constants from `knownBackendEvents`; rename the login constant and subject; drop `sales_reminder.delivered` emission and `HandleUserPreferredLanguageUpdated`; add the ops log-based metric for reminder delivery failures.
+3. Frontend: remove `PageViewed`, `AccountSignupStarted`, `ArtistDiscoveryViewed`, `ArtistFollowRequested` from `Events`/`EventPropsMap` and delete their capture call sites.
+4. Rollback: the change is additive-safe to revert — restoring the deleted constants and catalogue rows re-enables the prior (noisier) set; no data migration is required because deleted events simply stop being sent.
+
+## Open Questions
+
+- Confirm at implementation time that `USER.preferred_language_updated` has no non-analytics subscriber (determines whether the publish is removed or only its analytics forwarding).
+- Confirm `account.login` has zero production events at merge time (hard rename vs. alias).

--- a/openspec/changes/prune-analytics-event-collection/design.md
+++ b/openspec/changes/prune-analytics-event-collection/design.md
@@ -20,7 +20,7 @@ Constraints: the ticket-sales platform is deferred indefinitely; `ticket.email.p
 - Preserve sales-reminder delivery-failure visibility operationally after removing its analytics event.
 
 **Non-Goals:**
-- Person-property enrichment beyond `preferred_language`, and Group Analytics — deferred to Change 2.
+- Person-property enrichment (including `preferred_language`'s `$set` wiring), and Group Analytics — deferred to Change 2.
 - Dashboard/funnel construction and event-volume governance tooling — Change 3.
 - Any re-enablement of ticket sales, ZK entry, minting, or email import.
 
@@ -32,7 +32,7 @@ Constraints: the ticket-sales platform is deferred indefinitely; `ticket.email.p
 
 **D3 — Rename now, accept the discontinuity as zero.** Renaming `account.login` → `account.signin` is normally a breaking, history-splitting change (PostHog best practice: keep names static). It is free here precisely because the event is mid-redesign and has no production data. Doing it now avoids a permanent `login`/`signup` vocabulary mismatch. *Alternative considered:* keep `account.login` — rejected for lasting inconsistency at no offsetting benefit.
 
-**D4 — `preferred_language` becomes a `$set` person property, not an event.** Language is durable user state; as a person property it powers segmentation (e.g., retention by locale) without per-change event noise. The demotion is wired in Change 2's identify enrichment; this change removes the *event* (`HandleUserPreferredLanguageUpdated` forwarding) and, after confirming no non-analytics consumer subscribes to `USER.preferred_language_updated`, its publish. *Alternative considered:* keep both event and property — rejected as redundant.
+**D4 — Delete the `preferred_language` event here; defer the person property to Change 2.** Language is durable user state, better modelled as a person property that powers segmentation (e.g., retention by locale) than as a per-change event. This change removes only the *event* (`HandleUserPreferredLanguageUpdated` forwarding) and, after confirming no non-analytics consumer subscribes to `USER.preferred_language_updated`, its publish. The replacement `preferred_language` person property is wired in Change 2's identify enrichment, not here, so the language signal is intentionally uncaptured in the interval between the two changes. *Alternative considered:* wire the person property in this same change — rejected to keep Change 1 a pure deletion and all person-property work in one place (Change 2).
 
 **D5 — Prevent recurrence with a verified-call-site requirement.** The audit only found the phantoms because it read call sites. Encode that as a `product-analytics` requirement so future reviews check the emitter, not just the catalogue row.
 

--- a/openspec/changes/prune-analytics-event-collection/proposal.md
+++ b/openspec/changes/prune-analytics-event-collection/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+A ground-truth audit of every emitted analytics event — verified at each call site, not from the catalogue — found that a large fraction of the collected events carry no analytical value: two are defined but never fire (phantoms), several duplicate other events, one double-counts the same push, one is a per-navigation firehose, and one is a niche settings action better modelled as a person property. At the same time the product's ticket-sales platform is deferred indefinitely and the ticket-email import is disabled by an OS-side issue, so their funnels cannot be built. Pruning now — while the renamed login event has zero production history — keeps the catalogue honest, cuts event volume against the PostHog free-tier ceiling, and lets the remaining events describe the one loop that is actually observable: register artists → deliver notifications → engagement → retention.
+
+## What Changes
+
+- **Delete phantom events that never fire** (no emission call site exists): `account.signup.started` (FE), `user.deleted` (BE), and the never-wired ticket-sales constants `ticket.lottery.entry.accepted`, `ticket.lottery.entry.rejected`, `ticket.lottery.result.assigned`, `ticket.purchase.completed`, `ticket.purchase.failed`.
+- **Delete redundant / low-value events**: `page.viewed` (per-navigation firehose, highest volume, lowest insight), `artist.discovery.viewed` (fires 1:1 with `artist.follow.requested`; measures no impressions), `artist.follow.requested` FE half (redundant with backend `artist.follow.completed`).
+- **Delete the double-counting event** `sales_reminder.delivered`: a successful sales-reminder push already emits `notification.delivered` with `type = "sales_reminder"`, so delivery reach is unified onto `notification.delivered`. Sales-reminder delivery-failure visibility moves to an operational (log-based) metric, not product analytics.
+- **BREAKING — rename** `account.login` → `account.signin` for vocabulary consistency with the surviving `account.*` namespace. Safe now because the login event is mid-redesign and has no production history yet.
+- **Demote** `account.preferred_language.updated` from an event to a PostHog person property (`preferred_language` via `$set`): language is user state, not an action worth an event.
+- **Relabel the deferred set as dormant, not deleted** (wired implementations that will fire when their feature ships): `entry.zk_proof.verified`, `entry.zk_proof.rejected`, `ticket.mint.completed`, `ticket.email.parsed` (OS-blocked), and the FE intent events `ticket.purchase.initiated`, `entry.checkin.attempted`.
+- **Add a collection-status column** to the event catalogue (`active` / `dormant` / `deleted`) and re-cut the primary conversion funnel to terminate at `concert.detail.viewed` (the last observable step) instead of `entry.zk_proof.verified`.
+
+## Capabilities
+
+### New Capabilities
+<!-- none -->
+
+### Modified Capabilities
+- `product-analytics`: the collected event set is pruned to the observable notification-and-discovery loop; requirement examples that reference deleted events (`artist.discovery.viewed`, `page.viewed`, the lottery paired-event example) are updated; the login event is renamed to `account.signin`; `preferred_language` becomes a person property rather than an event; a new requirement forbids catalogued active events without a verified emission call site (anti-phantom); the catalogue gains a per-event collection status and a re-cut primary funnel.
+- `analytics-consent`: the anonymous pre-identification capture scenarios that name now-deleted events (`page.viewed`, `account.signup.started`, `artist.discovery.viewed`, `ticket.purchase.completed`) are re-illustrated with surviving catalogue events so the consent model examples stay valid.
+
+## Impact
+
+- **specification**: `docs/analytics/event-catalog.md` (source of truth) — remove deleted rows, add collection-status column, re-cut funnel #1; `openspec/specs/product-analytics/spec.md` delta.
+- **frontend**: `src/services/analytics-events.ts` (remove `PageViewed`, `AccountSignupStarted`, `ArtistDiscoveryViewed`, `ArtistFollowRequested` from `Events`/`EventPropsMap`); delete their capture call sites in `app-shell.ts` and `discovery/discovery-route.ts`; keep `identify()` path (person property added by Change 2).
+- **backend**: `internal/usecase/analytics_events.go` (remove phantom + deleted constants from `knownBackendEvents`); rename `EventAccountLogin`/`account.login` → `account.signin`; remove `HandleUserPreferredLanguageUpdated` analytics forwarding and `sales_reminder.delivered` emission (`sales_reminder_delivery_uc.go`, `analytics_consumer.go`, `event_data.go` subjects); confirm no non-analytics consumer depends on `USER.preferred_language_updated` before removing its publish.
+- **ops follow-up**: add a log-based metric for sales-reminder delivery failures (`no_subscription` / `failed`) so the visibility lost by deleting `sales_reminder.delivered` is preserved operationally.
+- **Non-goals**: person-property enrichment and Group Analytics (Change 2), dashboards (Change 3), and any ticket-sales re-enablement.

--- a/openspec/changes/prune-analytics-event-collection/proposal.md
+++ b/openspec/changes/prune-analytics-event-collection/proposal.md
@@ -8,7 +8,7 @@ A ground-truth audit of every emitted analytics event — verified at each call 
 - **Delete redundant / low-value events**: `page.viewed` (per-navigation firehose, highest volume, lowest insight), `artist.discovery.viewed` (fires 1:1 with `artist.follow.requested`; measures no impressions), `artist.follow.requested` FE half (redundant with backend `artist.follow.completed`).
 - **Delete the double-counting event** `sales_reminder.delivered`: a successful sales-reminder push already emits `notification.delivered` with `type = "sales_reminder"`, so delivery reach is unified onto `notification.delivered`. Sales-reminder delivery-failure visibility moves to an operational (log-based) metric, not product analytics.
 - **BREAKING — rename** `account.login` → `account.signin` for vocabulary consistency with the surviving `account.*` namespace. Safe now because the login event is mid-redesign and has no production history yet.
-- **Demote** `account.preferred_language.updated` from an event to a PostHog person property (`preferred_language` via `$set`): language is user state, not an action worth an event.
+- **Delete** `account.preferred_language.updated`: language is durable user *state*, not an action worth an event. The replacement `preferred_language` person property is added in Change 2's identify enrichment, not here, so this change removes the event without adding the property.
 - **Relabel the deferred set as dormant, not deleted** (wired implementations that will fire when their feature ships): `entry.zk_proof.verified`, `entry.zk_proof.rejected`, `ticket.mint.completed`, `ticket.email.parsed` (OS-blocked), and the FE intent events `ticket.purchase.initiated`, `entry.checkin.attempted`.
 - **Add a collection-status column** to the event catalogue (`active` / `dormant` / `deleted`) and re-cut the primary conversion funnel to terminate at `concert.detail.viewed` (the last observable step) instead of `entry.zk_proof.verified`.
 
@@ -18,7 +18,7 @@ A ground-truth audit of every emitted analytics event — verified at each call 
 <!-- none -->
 
 ### Modified Capabilities
-- `product-analytics`: the collected event set is pruned to the observable notification-and-discovery loop; requirement examples that reference deleted events (`artist.discovery.viewed`, `page.viewed`, the lottery paired-event example) are updated; the login event is renamed to `account.signin`; `preferred_language` becomes a person property rather than an event; a new requirement forbids catalogued active events without a verified emission call site (anti-phantom); the catalogue gains a per-event collection status and a re-cut primary funnel.
+- `product-analytics`: the collected event set is pruned to the observable notification-and-discovery loop; requirement examples that reference deleted events (`artist.discovery.viewed`, `page.viewed`, the lottery paired-event example) are updated; the login event is renamed to `account.signin`; the `preferred_language` event is removed (its replacement person property is added in Change 2, not here); a new requirement forbids catalogued active events without a verified emission call site (anti-phantom); the catalogue gains a per-event collection status and a re-cut primary funnel.
 - `analytics-consent`: the anonymous pre-identification capture scenarios that name now-deleted events (`page.viewed`, `account.signup.started`, `artist.discovery.viewed`, `ticket.purchase.completed`) are re-illustrated with surviving catalogue events so the consent model examples stay valid.
 
 ## Impact

--- a/openspec/changes/prune-analytics-event-collection/proposal.md
+++ b/openspec/changes/prune-analytics-event-collection/proposal.md
@@ -10,7 +10,7 @@ A ground-truth audit of every emitted analytics event — verified at each call 
 - **BREAKING — rename** `account.login` → `account.signin` for vocabulary consistency with the surviving `account.*` namespace. Safe now because the login event is mid-redesign and has no production history yet.
 - **Delete** `account.preferred_language.updated`: language is durable user *state*, not an action worth an event. The replacement `preferred_language` person property is added in Change 2's identify enrichment, not here, so this change removes the event without adding the property.
 - **Relabel the deferred set as dormant, not deleted** (wired implementations that will fire when their feature ships): `entry.zk_proof.verified`, `entry.zk_proof.rejected`, `ticket.mint.completed`, `ticket.email.parsed` (OS-blocked), and the FE intent events `ticket.purchase.initiated`, `entry.checkin.attempted`.
-- **Add a collection-status column** to the event catalogue (`active` / `dormant` / `deleted`) and re-cut the primary conversion funnel to terminate at `concert.detail.viewed` (the last observable step) instead of `entry.zk_proof.verified`.
+- **Add a collection-status column** to the event catalogue (`active` / `dormant`), record removed events in a separate Removed events section with their reason (rather than a per-row `deleted` status, which would keep dead rows in the live table), and re-cut the primary conversion funnel to terminate at `concert.detail.viewed` (the last observable step) instead of `entry.zk_proof.verified`.
 
 ## Capabilities
 

--- a/openspec/changes/prune-analytics-event-collection/specs/analytics-consent/spec.md
+++ b/openspec/changes/prune-analytics-event-collection/specs/analytics-consent/spec.md
@@ -1,0 +1,28 @@
+## MODIFIED Requirements
+
+### Requirement: Full non-PII catalogue is captured anonymously before identification
+Before a user is identified — anonymous visitors who have not opted out — the application SHALL capture the **full non-PII event catalogue** (not a restricted allowlist), subject to: no property linking the events to a real account SHALL be sent, and the events SHALL carry no `distinct_id` mapped to a user identity. Persistence MAY use `localStorage` with an anonymous identifier so anonymous funnels survive page reloads. There is no pre-consent allowlist: every `active`, non-PII catalogue event is eligible for anonymous capture.
+
+This requirement covers only the pre-identification anonymous state. A user who has explicitly opted out is a different state: `opt_out_capturing()` suppresses all capture, so an opted-out user emits no telemetry of any kind (see "Analytics opt-out state is persisted and user-controllable from settings").
+
+#### Scenario: Anonymous visitor's full discovery behaviour is captured
+- **WHEN** an unidentified visitor who has not opted out searches artists and opens a concert detail sheet
+- **THEN** the application MAY emit `artist.search`, `concert.detail.viewed`, `notification.requested`, and any other `active` non-PII catalogue event with an anonymous identifier
+- **AND** the application MAY persist the anonymous identifier in `localStorage`
+- **AND** no event SHALL include the user's email, Zitadel `sub`, `UserId`, or any other account-mapped identifier
+
+#### Scenario: Opted-out authenticated user generates no telemetry
+- **WHEN** an authenticated user has turned the Analytics toggle off
+- **THEN** the application SHALL have called `posthog.opt_out_capturing()`, which suppresses all capture
+- **AND** the application SHALL NOT emit any PostHog event — neither identified nor anonymous — while opted out
+- **AND** the application SHALL NOT call `posthog.identify` with the user's `UserId`
+- **AND** persistence SHALL be memory-only (no anonymous identifier persisted to `localStorage`)
+- **AND** no link SHALL be created between the user's identity and any PostHog profile
+
+### Requirement: Anonymous behaviour is merged into the identified profile on login
+When a previously-anonymous user is identified (login or signup, analytics not opted out), the application SHALL call `posthog.identify(user.id.value, ...)` such that the pre-identification anonymous event history is **merged into** the identified profile, so pre-signup discovery behaviour stays connected to post-signup conversion. The application SHALL NOT call `posthog.reset()` on the normal identify path; `reset()` is reserved for sign-out and for analytics opt-out, where severing the identity link is the intended effect.
+
+#### Scenario: Pre-signup discovery connects to post-signup conversion
+- **WHEN** an anonymous visitor searches and opens concert details, then signs up and is identified
+- **THEN** the anonymous events captured before signup SHALL be attributed to the identified `UserId` profile
+- **AND** a funnel from anonymous `artist.search` / `concert.detail.viewed` to identified `artist.follow.completed` SHALL be constructible for that user

--- a/openspec/changes/prune-analytics-event-collection/specs/product-analytics/spec.md
+++ b/openspec/changes/prune-analytics-event-collection/specs/product-analytics/spec.md
@@ -1,0 +1,62 @@
+## MODIFIED Requirements
+
+### Requirement: Event sourcing is partitioned between frontend and backend
+The system SHALL emit each event from the side that is the source of truth for that signal: UI exploration and user intent from the frontend, trust-critical state changes (financial transactions, identity verification, push delivery confirmation) from the backend. A small set of paired events SHALL be emitted from both sides to measure the gap between user intent and server-confirmed outcome.
+
+#### Scenario: Trust-critical event is emitted from backend only
+- **WHEN** a push notification reaches the delivered state and `notification.delivered` needs to be recorded
+- **THEN** the backend SHALL emit the event via `analytics-consumer`
+- **AND** the frontend SHALL NOT emit a duplicate `notification.delivered` event
+- **AND** the frontend MAY emit a `notification.requested` intent event when the user opts in
+
+#### Scenario: UI exploration event is emitted from frontend only
+- **WHEN** the user opens a concert's detail sheet
+- **THEN** the frontend SHALL emit `concert.detail.viewed` with `event_id`, `artist_id`, and `source` properties
+- **AND** the backend SHALL NOT emit a duplicate event for the same detail view
+
+#### Scenario: Paired event captures intent-to-completion gap
+- **WHEN** the user taps the enable-notifications control
+- **THEN** the frontend SHALL emit `notification.requested` immediately on tap, before the asynchronous permission flow
+- **AND** the backend SHALL emit `notification.subscribed` after the Web Push subscription is persisted
+- **AND** both events SHALL be attributable to the same `distinct_id` (the platform `UserId` UUID) so the opt-in drop-off from OS/browser permission denial is measurable
+
+### Requirement: Frontend disables autocapture and automatic page-view capture
+The frontend SHALL initialise PostHog with `autocapture: false`, `capture_pageview: false`, and `capture_pageleave: false`. Every catalogue event SHALL be emitted manually through the typed `AnalyticsService`. The application SHALL NOT emit a per-navigation page-view event: route navigation is not a catalogued analytics signal, because the analytically meaningful surfaces are already instrumented by explicit events (`concert.detail.viewed`, `artist.search`, notification events) and a per-navigation firehose is the largest event-volume source with the lowest per-event insight.
+
+#### Scenario: Click on an arbitrary element does not produce an autocapture event
+- **WHEN** the user clicks any element that is not explicitly instrumented
+- **THEN** no `$autocapture` event SHALL appear in PostHog
+- **AND** the only events recorded SHALL be those emitted via `AnalyticsService.capture`
+
+#### Scenario: Router navigation does not emit a page-view event
+- **WHEN** the Aurelia router completes a navigation and fires `au:router:navigation-end`
+- **THEN** the application SHALL NOT emit any `page.viewed` event
+- **AND** active-user and session metrics SHALL be derived from the explicit catalogue events that PostHog already receives, not from per-navigation page views
+
+## ADDED Requirements
+
+### Requirement: Every active catalogue event has a verified emission call site
+An event catalogued with collection status `active` SHALL have at least one verified emission call site in the frontend or backend codebase. The catalogue SHALL NOT list an `active` event whose only presence is a name constant or type declaration with no code path that emits it. A defined-but-unemitted event SHALL either be removed from the catalogue or catalogued as `dormant` with a note describing the feature or fix that will activate it.
+
+#### Scenario: A name constant with no emitter is not an active event
+- **WHEN** an event name is declared in `frontend/src/services/analytics-events.ts` or `backend/internal/usecase/analytics_events.go` but no `capture(...)` or `PublishEvent(...)` call site emits it
+- **THEN** the event SHALL NOT be catalogued with status `active`
+- **AND** the event SHALL be either removed or catalogued as `dormant` with an activation note
+
+#### Scenario: Pull-request review checks the call site, not only the catalogue row
+- **WHEN** a pull request adds or changes a catalogued `active` event
+- **THEN** review SHALL confirm a concrete emission call site exists for that event
+- **AND** an event whose emitter was removed SHALL be dropped from the catalogue in the same change
+
+### Requirement: The event catalogue records a per-event collection status
+The event catalogue SHALL record, for every event, a collection status of `active` (currently emitted and consumed), `dormant` (implemented or defined but not currently emitting, pending a deferred feature or an external fix), or `deleted` (removed; retained only as historical note). Dashboards and funnels SHALL be built only on `active` events. The primary conversion funnel SHALL terminate at the last observable step given the current active set — `concert.detail.viewed` — rather than at a `dormant` ticketing or entry event.
+
+#### Scenario: Dashboard is built only on active events
+- **WHEN** a dashboard or funnel is defined in PostHog
+- **THEN** every step SHALL reference an event catalogued as `active`
+- **AND** a step SHALL NOT reference a `dormant` event such as `entry.zk_proof.verified` or `ticket.email.parsed`
+
+#### Scenario: Deferred ticketing events are dormant, not deleted
+- **WHEN** the catalogue lists an implemented-but-inactive event such as `entry.zk_proof.verified`, `ticket.mint.completed`, or `ticket.email.parsed`
+- **THEN** the event SHALL be catalogued with status `dormant` and an activation note
+- **AND** the event SHALL NOT be counted toward active event volume or listed on any live dashboard

--- a/openspec/changes/prune-analytics-event-collection/specs/product-analytics/spec.md
+++ b/openspec/changes/prune-analytics-event-collection/specs/product-analytics/spec.md
@@ -36,12 +36,12 @@ The frontend SHALL initialise PostHog with `autocapture: false`, `capture_pagevi
 ## ADDED Requirements
 
 ### Requirement: Every active catalogue event has a verified emission call site
-An event catalogued with collection status `active` SHALL have at least one verified emission call site in the frontend or backend codebase. The catalogue SHALL NOT list an `active` event whose only presence is a name constant or type declaration with no code path that emits it. A defined-but-unemitted event SHALL either be removed from the catalogue or catalogued as `dormant` with a note describing the feature or fix that will activate it.
+An event catalogued with collection status `active` SHALL have at least one verified emission call site in the frontend or backend codebase. The catalogue SHALL NOT list an `active` event whose only presence is a name constant or type declaration with no code path that emits it. An event with no emission call site SHALL be removed from the live catalogue and recorded in the Removed events section; it SHALL NOT be catalogued as `dormant`, because `dormant` is reserved for events that have a real emitter and are inactive only because a feature is deferred or externally blocked.
 
 #### Scenario: A name constant with no emitter is not an active event
 - **WHEN** an event name is declared in `frontend/src/services/analytics-events.ts` or `backend/internal/usecase/analytics_events.go` but no `capture(...)` or `PublishEvent(...)` call site emits it
 - **THEN** the event SHALL NOT be catalogued with status `active`
-- **AND** the event SHALL be either removed or catalogued as `dormant` with an activation note
+- **AND** the event SHALL be removed from the live catalogue and recorded under Removed events, NOT catalogued as `dormant`, because `dormant` requires a real emitter
 
 #### Scenario: Pull-request review checks the call site, not only the catalogue row
 - **WHEN** a pull request adds or changes a catalogued `active` event
@@ -49,7 +49,7 @@ An event catalogued with collection status `active` SHALL have at least one veri
 - **AND** an event whose emitter was removed SHALL be dropped from the catalogue in the same change
 
 ### Requirement: The event catalogue records a per-event collection status
-The event catalogue SHALL record, for every event, a collection status of `active` (currently emitted and consumed), `dormant` (implemented or defined but not currently emitting, pending a deferred feature or an external fix), or `deleted` (removed; retained only as historical note). Dashboards and funnels SHALL be built only on `active` events. The primary conversion funnel SHALL terminate at the last observable step given the current active set — `concert.detail.viewed` — rather than at a `dormant` ticketing or entry event.
+The event catalogue SHALL record, for every listed event, a collection status of `active` (currently emitted and consumed) or `dormant` (has a real emitter but is not currently emitting, pending a deferred feature or an external fix). A removed event SHALL NOT remain in the live catalogue table; it SHALL instead be recorded in a dedicated Removed events section together with the reason for removal, so the deletion is documented without reopening the phantom pattern. Dashboards and funnels SHALL be built only on `active` events. The primary conversion funnel SHALL terminate at the last observable step given the current active set — `concert.detail.viewed` — rather than at a `dormant` ticketing or entry event.
 
 #### Scenario: Dashboard is built only on active events
 - **WHEN** a dashboard or funnel is defined in PostHog
@@ -60,3 +60,8 @@ The event catalogue SHALL record, for every event, a collection status of `activ
 - **WHEN** the catalogue lists an implemented-but-inactive event such as `entry.zk_proof.verified`, `ticket.mint.completed`, or `ticket.email.parsed`
 - **THEN** the event SHALL be catalogued with status `dormant` and an activation note
 - **AND** the event SHALL NOT be counted toward active event volume or listed on any live dashboard
+
+#### Scenario: A removed event is recorded, not silently dropped
+- **WHEN** an event is removed from active collection (phantom, redundant, double-counting, firehose, or wrong-altitude)
+- **THEN** its row SHALL be removed from the live catalogue table
+- **AND** the event SHALL be listed in the Removed events section with the reason for its removal

--- a/openspec/changes/prune-analytics-event-collection/tasks.md
+++ b/openspec/changes/prune-analytics-event-collection/tasks.md
@@ -1,8 +1,8 @@
 ## 1. Specification: catalogue and spec deltas
 
-- [ ] 1.1 Edit `docs/analytics/event-catalog.md`: remove rows for `page.viewed`, `account.signup.started`, `artist.discovery.viewed`, `artist.follow.requested`, `user.deleted`, `sales_reminder.delivered`, `account.preferred_language.updated`, and the never-wired `ticket.lottery.entry.accepted/.rejected`, `ticket.lottery.result.assigned`, `ticket.purchase.completed/.failed`.
+- [ ] 1.1 In `docs/analytics/event-catalog.md`, remove the following rows from the live catalogue table AND record each in a new "Removed events" section with its removal reason (phantom / redundant / double-count / firehose / wrong-altitude): `page.viewed`, `account.signup.started`, `artist.discovery.viewed`, `artist.follow.requested`, `user.deleted`, `sales_reminder.delivered`, `account.preferred_language.updated`, and the never-wired `ticket.lottery.entry.accepted/.rejected`, `ticket.lottery.result.assigned`, `ticket.purchase.completed/.failed`.
 - [ ] 1.2 Rename the `account.login` row to `account.signin` (keep BE source, `trace_id?` only).
-- [ ] 1.3 Add a `Collection status` column (`active` / `dormant`) and mark `entry.zk_proof.verified/.rejected`, `ticket.mint.completed`, `ticket.email.parsed`, `ticket.purchase.initiated`, `entry.checkin.attempted` as `dormant` with an activation note.
+- [ ] 1.3 Add a `Collection status` column with two values (`active` / `dormant`) to the live table and mark `entry.zk_proof.verified/.rejected`, `ticket.mint.completed`, `ticket.email.parsed`, `ticket.purchase.initiated`, `entry.checkin.attempted` as `dormant` with an activation note (each has a real emitter; removed events live in the Removed events section from 1.1, not as a table status).
 - [ ] 1.4 Re-cut the "Funnels and dashboards" section: primary funnel terminates at `concert.detail.viewed`; note `preferred_language` is now a person property, not an event.
 - [ ] 1.5 Open the specification PR, get review + `buf-pr-checks.yml` green, merge to main.
 

--- a/openspec/changes/prune-analytics-event-collection/tasks.md
+++ b/openspec/changes/prune-analytics-event-collection/tasks.md
@@ -1,0 +1,35 @@
+## 1. Specification: catalogue and spec deltas
+
+- [ ] 1.1 Edit `docs/analytics/event-catalog.md`: remove rows for `page.viewed`, `account.signup.started`, `artist.discovery.viewed`, `artist.follow.requested`, `user.deleted`, `sales_reminder.delivered`, `account.preferred_language.updated`, and the never-wired `ticket.lottery.entry.accepted/.rejected`, `ticket.lottery.result.assigned`, `ticket.purchase.completed/.failed`.
+- [ ] 1.2 Rename the `account.login` row to `account.signin` (keep BE source, `trace_id?` only).
+- [ ] 1.3 Add a `Collection status` column (`active` / `dormant`) and mark `entry.zk_proof.verified/.rejected`, `ticket.mint.completed`, `ticket.email.parsed`, `ticket.purchase.initiated`, `entry.checkin.attempted` as `dormant` with an activation note.
+- [ ] 1.4 Re-cut the "Funnels and dashboards" section: primary funnel terminates at `concert.detail.viewed`; note `preferred_language` is now a person property, not an event.
+- [ ] 1.5 Open the specification PR, get review + `buf-pr-checks.yml` green, merge to main.
+
+## 2. Backend: remove deleted events and rename login
+
+- [ ] 2.1 In `internal/usecase/analytics_events.go`, delete the constants `EventUserDeleted`, `EventTicketLotteryEntryAccepted`, `EventTicketLotteryEntryRejected`, `EventTicketLotteryResultAssigned`, `EventTicketPurchaseCompleted`, `EventTicketPurchaseFailed` and their `knownBackendEvents` entries.
+- [ ] 2.2 Rename `EventAccountLogin` value `account.login` → `account.signin`; update the doc comment; update `SubjectAccountLogin` handling if the subject name is analytics-only.
+- [ ] 2.3 Remove `sales_reminder.delivered`: delete `publishDeliveryOutcome`'s `PublishEvent(SubjectSalesReminderDelivered, ...)`, the `HandleSalesReminderDelivered` consumer handler, `EventSalesReminderDelivered`, `SubjectSalesReminderDelivered`, `SalesReminderDeliveredData`, and their `AllSubjects`/stream/KEDA references.
+- [ ] 2.4 Remove the `preferred_language` analytics event: delete `HandleUserPreferredLanguageUpdated`, `EventAccountPreferredLanguageUpdated`; grep all consumers of `USER.preferred_language_updated` — if analytics is the only subscriber, remove the publish and subject too, otherwise keep the publish and remove only the analytics forwarding.
+- [ ] 2.5 Update `analytics_consumer_test.go` and any affected unit tests; run `make check`.
+- [ ] 2.6 Verify at merge time that PostHog has zero production `account.login` events (hard rename); if any exist, register a PostHog alias instead of a bare rename.
+
+## 3. Backend ops: preserve reminder delivery-failure visibility
+
+- [ ] 3.1 Add a log-based metric (or OTel counter) for sales-reminder delivery outcomes `no_subscription` / `failed` per `phase_stage`, replacing the visibility removed with `sales_reminder.delivered`.
+- [ ] 3.2 Confirm the metric appears in Cloud Monitoring after deploy.
+
+## 4. Frontend: remove deleted capture sites
+
+- [ ] 4.1 In `src/services/analytics-events.ts`, remove `PageViewed`, `AccountSignupStarted`, `ArtistDiscoveryViewed`, `ArtistFollowRequested` from `Events`, `EventPropsMap`, and their prop types; keep the compile-time coverage guard green.
+- [ ] 4.2 Delete the `capture(Events.PageViewed, ...)` call in `src/app-shell.ts` and the navigation-end subscription that feeds it.
+- [ ] 4.3 Delete the `ArtistDiscoveryViewed` + `ArtistFollowRequested` captures in `src/routes/discovery/discovery-route.ts` (`onArtistSelected`, `onFollowFromSearch`), keeping the follow calls themselves.
+- [ ] 4.4 Update affected specs/tests; run `make check`.
+
+## 5. Ship and verify in production
+
+- [ ] 5.1 Merge backend PR; cut a backend release; confirm ArgoCD rollout of the new consumer image.
+- [ ] 5.2 Merge frontend PR; cut a frontend release; confirm the prod pin bump + ArgoCD sync.
+- [ ] 5.3 In PostHog, confirm the deleted events stop arriving and `account.signin` arrives on login; confirm `notification.delivered` with `type = "sales_reminder"` still records reminder reach.
+- [ ] 5.4 Run `openspec validate --strict`, mark all tasks done, and archive the change.


### PR DESCRIPTION
## Summary

OpenSpec change `prune-analytics-event-collection`. A per-call-site audit of every emitted analytics event — verified against the live code, not the catalogue — found that a large fraction of the collected set carries no analytical value. This change prunes the event set to the loop the product can actually observe (register artists → deliver notifications → engagement → retention) and adds a guard against the recurrence of "phantom" events.

## Why

- **Phantoms** (defined but never fire): `account.signup.started` (FE, no capture site), `user.deleted` (BE, `Delete` but no publish), and the never-wired ticket-sales constants (`ticket.lottery.entry.accepted/.rejected`, `ticket.lottery.result.assigned`, `ticket.purchase.completed/.failed`).
- **Redundant**: `artist.discovery.viewed` fires 1:1 with `artist.follow.requested` and measures no impressions; the FE `artist.follow.requested` duplicates backend `artist.follow.completed`.
- **Double-count**: a successful sales-reminder push emits `notification.delivered` (`type = "sales_reminder"`) **and** `sales_reminder.delivered` — one delivery counted twice.
- **Firehose**: `page.viewed` fires on every router navigation; highest volume, lowest insight.
- **Wrong altitude**: `account.preferred_language.updated` models user *state* as an *action*.

Context: the ticket-sales platform is deferred indefinitely, `ticket.email.parsed` is OS-blocked, and `account.login` is mid-redesign with **zero** production history — the ideal moment to rename it.

## Changes

- **Delete** the phantom, redundant, double-counting, firehose, and wrong-altitude events (10 total).
- **BREAKING** — rename `account.login` → `account.signin` for vocabulary consistency with `account.signup` (safe: no production history).
- **Demote** `preferred_language` from an event to a PostHog person property (`$set`).
- **Relabel** the deferred-but-wired set as `dormant`, not deleted: `entry.zk_proof.verified/.rejected`, `ticket.mint.completed`, `ticket.email.parsed`, and the FE intent events `ticket.purchase.initiated`, `entry.checkin.attempted`.
- **New requirement**: every `active` catalogue event must have a verified emission call site (anti-phantom); catalogue gains a per-event collection status; primary funnel re-cut to terminate at `concert.detail.viewed`.

Spec deltas: `product-analytics` (MODIFIED event-sourcing + page-view requirements; ADDED verified-call-site + collection-status) and `analytics-consent` (MODIFIED anonymous-capture scenarios that named deleted events).

## Artifacts

| File | Purpose |
| --- | --- |
| `proposal.md` | Why / what / capabilities / impact |
| `design.md` | Decisions D1–D5, risks, migration, open questions |
| `specs/product-analytics/spec.md` | 2 MODIFIED + 2 ADDED requirements |
| `specs/analytics-consent/spec.md` | 2 MODIFIED requirements |
| `tasks.md` | Spec → backend → ops → frontend → prod ship & verify |

## Testing

- `openspec validate prune-analytics-event-collection --strict` → passes.
- Docs-only change; no proto or code touched in this PR (implementation follows in the backend/frontend repos per `tasks.md`).

## Non-Goals

Person-property enrichment beyond `preferred_language` and Group Analytics (Change 2), dashboards and volume governance (Change 3), and any ticket-sales re-enablement.

Refs: #532
