### PR TITLE
docs(openspec): propose harden-jetstream-consumer-reliability

### DIFF
--- a/openspec/changes/harden-jetstream-consumer-reliability/.openspec.yaml
+++ b/openspec/changes/harden-jetstream-consumer-reliability/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-09

--- a/openspec/changes/harden-jetstream-consumer-reliability/design.md
+++ b/openspec/changes/harden-jetstream-consumer-reliability/design.md
@@ -1,0 +1,53 @@
+## Context
+
+The backend `consumer` app subscribes to NATS JetStream via watermill-nats. Durables are created lazily by the watermill router the first time it subscribes to each topic; their names and deliver groups come from one helper (`consumerName(topic)`), currently `consumer_<subject>`. JetStream never rewrites an existing durable's config, and nats.go refuses to bind a subscription whose requested config conflicts with a pre-existing consumer on the same filter subject. During the 2026-07 incident, a stale durable (old shared `deliver_group="consumer"`) made the new subscription fail; that one failure aborted the whole router's startup, every subject wedged, and nothing alerted because the pod stayed `Running` (HTTP liveness only) and emitted no ERROR/poison. Constraints: prod consumer runs `min=max=1` (KEDA); GKE Autopilot; Cloud Monitoring for alerting; watermill-nats hides consumer creation behind `QueueSubscribe`.
+
+## Goals / Non-Goals
+
+**Goals:**
+- A stalled consumer is detected within minutes, independent of logs.
+- A subscription/config failure crashes the pod (loud) instead of silently disabling consumption.
+- A wedged pod is auto-restarted by Kubernetes.
+- A durable name/config change can never again wedge on a stale durable.
+- Durable names drop the meaningless `consumer_` prefix, which also re-aligns KEDA.
+
+**Non-Goals:**
+- Redesigning the event model, streams, or moving off watermill-nats.
+- Guaranteed zero-loss replay of already-published events (streams retain 7d; lost events are re-published operationally as in the incident).
+- Multi-replica consumer scaling (stays `min=max=1` in prod).
+
+## Decisions
+
+**D1 — Startup durable reconciliation via a raw JetStream pre-flight.** Before starting the watermill router, run a reconcile step using a raw nats.go `JetStreamContext`: for each owned topic compute the desired consumer config, fetch `ConsumerInfo`, and if it is missing or drifted (name / deliver group / delivery policy differ) delete and recreate it. watermill then binds to a now-correct durable. *Alternative rejected:* relying on watermill to reconcile — it only `QueueSubscribe`s and cannot detect drift.
+
+**D2 — Fail loud.** The reconcile + subscription establishment is synchronous at startup; any error is logged at ERROR (with topic) and returns a non-zero exit so the pod crashloops. This makes the pre-existing `Consumer ERROR Log` alert fire and lets Kubernetes restart. *Alternative rejected:* logging-and-continue (today's behavior) — it hides missing consumers.
+
+**D3 — Liveness reflects consumption.** The subscriber tracks, in-process, whether every expected subscription is established and the NATS connection is up; `/healthz` reports unhealthy when the router is stopped or any expected durable is unbound (with a small failure-count grace to avoid flapping). *Alternative considered:* probe the NATS monitoring endpoint from the health handler — heavier and adds a cross-service dependency in the hot path; keep it in-process, optionally cross-checked by the backlog alert.
+
+**D4 — Backlog alert pipeline.** Add a Cloud Monitoring alert on JetStream consumer `num_pending`. Preferred source: a NATS Prometheus exporter/surveyor scraped by Google Managed Prometheus (available on Autopilot), alerting on `consumer backlog high & not decreasing` per stream. *Fallback:* a lightweight poller that reads the `:8222/jsz` endpoint KEDA already uses and emits a structured metric/log-based metric. Exact pipeline finalized in implementation; the requirement only fixes the behavior.
+
+**D5 — Drop the `consumer_` prefix → bare per-subject names.** `consumerName(topic)` returns `strings.ReplaceAll(topic, ".", "_")`. Per-subject uniqueness (what actually fixed the original shared-group bug) is preserved; only the redundant app prefix is removed. Because the KEDA triggers already reference bare names, this needs **no KEDA change** — it fixes the drift for free. *Alternative rejected:* keep `consumer_*` and rename KEDA to match — leaves a meaningless prefix and still needs a KEDA edit; the user chose removal.
+
+**D6 — Deploy strategy.** Set the consumer Deployment to `Recreate` (or `maxSurge=0, maxUnavailable=1`) so a rollout never runs two pods that fight over the single durable set.
+
+## Risks / Trade-offs
+
+- **Recreating a durable drops its pending messages (DeliverNew).** → Run the naming migration in low traffic; streams retain 7d, so critical pending can be re-published operationally (as done in the incident). Only today's events matter in practice.
+- **Bare names collide with the existing stale orphans (`CONCERT_created`).** → That is exactly what reconciliation (D1) handles: the drifted orphan is deleted and recreated with correct config; the superseded `consumer_*` durables are cleaned as no-longer-desired.
+- **Over-aggressive liveness → crashloop flapping.** → Require N consecutive failures + an initial grace period before reporting unhealthy.
+- **Backlog alert false positives on low-traffic/slow subjects.** → Per-stream threshold + sustained no-decrease window; tune after observing baselines.
+- **Phase-2 rollback re-introduces drift** (bare ↔ prefixed is itself a config change). → Reconciliation (D1) makes any direction safe; fail-loud + alert (Phase 1) remain regardless, so a bad rollback is caught, not silent.
+
+## Migration Plan
+
+1. **Phase 1 (safety first, low risk):** ship fail-loud (D2), liveness-reflects-consumption (D3), the backlog alert (D4), and the `Recreate` strategy (D6). No naming change. After this, any wedge — including the current one recurring — is detected loudly (crashloop + backlog alert); self-healing a stale-durable conflict still requires Phase 2's reconciliation (D1).
+2. **Phase 2 (naming + reconciliation):** ship startup reconciliation (D1) together with the bare-name change (D5). On rollout, reconciliation deletes drifted/stale durables and recreates correct bare-named ones; KEDA already matches. Verify all durables bound (`push_bound=true`), backlog draining, and the alert green.
+3. **Cleanup:** remove any remaining orphan durables from the incident; document the reconciliation path as the required procedure for any future durable name/config change.
+
+**Rollback:** revert the backend image pin; reconciliation on the prior image re-converges durables. Phase 1 controls are independent and safe to keep even if Phase 2 is reverted.
+
+## Open Questions
+
+- Backlog metric pipeline: NATS Prometheus exporter + Google Managed Prometheus vs. a `jsz` poller emitting a log-based metric — decide in implementation based on what is already deployed.
+- Alert threshold and sustained-window per stream (need baseline observation).
+- Whether reconciliation should also proactively delete all no-longer-desired durables, or only fix the drifted desired ones and leave harmless orphans to age out.

--- a/openspec/changes/harden-jetstream-consumer-reliability/proposal.md
+++ b/openspec/changes/harden-jetstream-consumer-reliability/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+A single mis-configured JetStream durable silently stopped **all** backend event consumption from ~2026-07-01 to 2026-07-09 (push notifications, analytics forwarding, sales reminders). Events were published fine but never consumed; the pod stayed `Running` because liveness only checks an HTTP port, and neither existing alert (`Consumer ERROR Log`, `Consumer Poison Queue Message`) could fire because the failure emitted no ERROR and produced no poison message. The outage went undetected for ~1 week until a user noticed a missing push. We need consumer stalls to be impossible to miss and safe to remediate — and to remove the naming footgun that caused it.
+
+## What Changes
+
+- **Consumer stall detection (highest priority)**: add a Cloud Monitoring alert on JetStream consumer backlog (`num_pending`) so any consumer that stops draining fires an incident within minutes. This is the one control that would have caught the outage immediately.
+- **Fail loud, not silent**: a JetStream subscription/bind failure at consumer startup MUST surface as an ERROR log and fail startup (crashloop) instead of being swallowed. This makes the pod restart and lets the existing `Consumer ERROR Log` alert fire.
+- **Liveness reflects real consumption**: the consumer health/liveness probe MUST report unhealthy when the message router is not running or expected durables are not bound, so Kubernetes auto-restarts a wedged pod instead of leaving it `Running`.
+- **Safe durable config changes**: consumer startup MUST reconcile durables — when a durable's server-stored config has drifted from the desired config (name, deliver group, policy), delete and recreate it — so a naming/config change can never again wedge on a stale pre-existing durable.
+- **Remove the redundant `consumer_` prefix** from durable and deliver-group names, reverting to bare per-subject names (`CONCERT_created`, `ARTIST_followed`, …). All event consumption is done by the single consumer app, so the prefix carries no information; removing it also re-aligns the KEDA triggers (which already reference bare names) and cleans up the stale orphan durables. **BREAKING**: requires a durable migration, executed via the new reconciliation path above — must ship only after fail-loud + detection are in place.
+- **Reconcile KEDA ScaledObject triggers** with the live durable names so autoscaling reads real backlog in dev/staging.
+
+## Capabilities
+
+### New Capabilities
+- `jetstream-consumer-reliability`: how the backend consumer subscribes to, names, health-checks, and reconciles JetStream durables so a stalled or mis-configured consumer is detected, self-heals, and remains safe to reconfigure — plus the backlog alert and KEDA trigger alignment that make stalls observable.
+
+### Modified Capabilities
+<!-- No existing spec's requirements change. The existing `app-error-log-alerting` consumer-ERROR requirement is reused as-is: the fail-loud behavior makes the consumer actually emit an ERROR on subscribe failure, satisfying that requirement without changing it. -->
+
+## Impact
+
+- **backend** (Go): `internal/infrastructure/messaging/subscriber.go` (drop prefix, surface subscribe errors, startup reconciliation), consumer health endpoint (`/healthz`/`/readyz` on :8081), `internal/di/consumer.go` startup wiring.
+- **cloud-provisioning** (Pulumi/GCP + K8s): new Cloud Monitoring alert policy for consumer backlog; consumer `ScaledObject` trigger `consumer` names; consumer Deployment liveness/readiness probe config.
+- **Operational**: a one-time durable migration (delete stale orphans + prefix removal) run through the new reconciliation path; documented runbook step for future durable config changes.
+- No proto/schema change; no BSR release required.

--- a/openspec/changes/harden-jetstream-consumer-reliability/specs/jetstream-consumer-reliability/spec.md
+++ b/openspec/changes/harden-jetstream-consumer-reliability/specs/jetstream-consumer-reliability/spec.md
@@ -1,0 +1,87 @@
+## ADDED Requirements
+
+### Requirement: Consumer backlog stall is detected and alerted
+
+The system SHALL detect when any backend JetStream consumer stops draining its backlog and open an incident via Cloud Monitoring, independent of whether the consumer emits ERROR logs or poison messages.
+
+The alert SHALL be based on the JetStream consumer backlog metric (`num_pending` / unprocessed message count, exposed by the NATS monitoring endpoint) and SHALL fire when a consumer's backlog stays above a threshold and is not decreasing for a sustained window.
+
+#### Scenario: A consumer stops draining while events keep arriving
+
+- **WHEN** a backend JetStream consumer's unprocessed backlog stays above the configured threshold and does not decrease for the configured window
+- **THEN** a Cloud Monitoring alert policy SHALL open an incident naming the affected stream/consumer
+
+#### Scenario: A healthy draining consumer does not alert
+
+- **WHEN** a consumer's backlog rises transiently but is drained back down within the window
+- **THEN** no incident SHALL be opened
+
+#### Scenario: Silent stall with no ERROR log still alerts
+
+- **WHEN** a consumer stops consuming without emitting any ERROR log or poison-queue message
+- **THEN** the backlog alert SHALL still fire, because it depends on backlog metrics, not on logs
+
+### Requirement: Subscription failure fails loud
+
+The consumer SHALL treat a failure to establish any of its JetStream subscriptions at startup as fatal: it SHALL log the failure at ERROR level (identifying the topic) and SHALL fail startup rather than continuing to serve traffic with missing subscriptions.
+
+#### Scenario: A durable cannot be created or bound at startup
+
+- **WHEN** the consumer cannot create or bind the durable for one of its topics
+- **THEN** it SHALL emit an ERROR log for that topic AND terminate startup (non-zero exit / crashloop) instead of reporting healthy
+
+#### Scenario: One failing subscription does not silently disable the rest
+
+- **WHEN** a single topic's subscription fails
+- **THEN** the consumer SHALL NOT continue running with the remaining topics silently unsubscribed
+
+### Requirement: Liveness reflects consumption health
+
+The consumer's liveness and readiness probes SHALL report unhealthy when the message router is not running or when its expected durables are not actively bound, so that Kubernetes restarts a wedged pod instead of leaving it `Running`.
+
+#### Scenario: Router is not consuming
+
+- **WHEN** the message router has stopped or its expected durables are not bound to an active subscription
+- **THEN** the liveness probe SHALL report unhealthy and Kubernetes SHALL restart the pod
+
+#### Scenario: Fully consuming pod stays healthy
+
+- **WHEN** the router is running and all expected durables are bound
+- **THEN** the liveness and readiness probes SHALL report healthy
+
+### Requirement: Durable configuration is reconciled on startup
+
+The consumer SHALL reconcile each durable it owns against the desired configuration at startup. When a durable's server-stored configuration (name, deliver group, or delivery policy) has drifted from the desired configuration, the consumer SHALL recreate the durable so that a configuration or naming change cannot wedge on a stale pre-existing durable.
+
+#### Scenario: A pre-existing durable has drifted configuration
+
+- **WHEN** a durable exists on the server with a configuration that differs from the consumer's desired configuration
+- **THEN** the consumer SHALL delete and recreate that durable to match the desired configuration before consuming
+
+#### Scenario: An already-correct durable is left untouched
+
+- **WHEN** a durable already matches the desired configuration
+- **THEN** the consumer SHALL bind to it without deleting or recreating it
+
+### Requirement: Durable names carry no consumer-app prefix
+
+Durable and deliver-group names SHALL be derived from the subject alone, per subject, without an app-level prefix (e.g. `CONCERT.created` maps to `CONCERT_created`). Because all event consumption is performed by the single consumer application, an app prefix carries no information.
+
+#### Scenario: Durable name is derived from the subject only
+
+- **WHEN** the consumer subscribes to subject `CONCERT.created`
+- **THEN** the durable and deliver-group names SHALL be `CONCERT_created` with no additional prefix
+
+#### Scenario: Each subject keeps a unique deliver group
+
+- **WHEN** two different subjects reside in the same stream
+- **THEN** each SHALL use its own per-subject deliver group so their consumers cannot collide
+
+### Requirement: KEDA triggers reference the live durable names
+
+The consumer autoscaler (KEDA ScaledObject) triggers SHALL reference the same durable/consumer names the application actually creates, so autoscaling reads the real backlog.
+
+#### Scenario: Trigger name matches the live durable
+
+- **WHEN** the consumer creates a durable for a subject
+- **THEN** the corresponding KEDA trigger SHALL reference that exact durable name

--- a/openspec/changes/harden-jetstream-consumer-reliability/tasks.md
+++ b/openspec/changes/harden-jetstream-consumer-reliability/tasks.md
@@ -1,0 +1,46 @@
+## 1. Phase 1 — Backend: fail loud + liveness
+
+- [ ] 1.1 Make consumer startup establish subscriptions synchronously; on any subscribe/bind error, log ERROR with the topic and exit non-zero (crashloop) instead of continuing (`internal/di/consumer.go`, `internal/infrastructure/messaging/subscriber.go`)
+- [ ] 1.2 Track in-process the set of expected subscriptions and their bound state + NATS connection status in the subscriber
+- [ ] 1.3 Update the consumer `/healthz` (:8081) to report unhealthy when the router is stopped or any expected durable is unbound, with an N-failure grace to avoid flapping
+- [ ] 1.4 Unit tests: subscribe error aborts startup; health handler returns unhealthy when a subscription is missing / connection down
+- [ ] 1.5 `make check` passes
+
+## 2. Phase 1 — cloud-provisioning: backlog alert + deploy strategy
+
+- [ ] 2.1 Decide the backlog metric pipeline (NATS Prometheus exporter + Google Managed Prometheus vs. `jsz` poller → log-based metric) and wire the metric source
+- [ ] 2.2 Add a Cloud Monitoring alert policy: JetStream consumer backlog high and not decreasing for a sustained window, per stream/consumer
+- [ ] 2.3 Set the consumer Deployment update strategy to `Recreate` (or `maxSurge=0, maxUnavailable=1`) so rollouts never run two pods over one durable set
+- [ ] 2.4 Confirm the liveness/readiness probe config points at the consumption-aware endpoint from task 1.3
+
+## 3. Phase 1 — Ship to prod & verify
+
+- [ ] 3.1 Open backend PR (fail-loud + liveness), pass CI, merge, cut release, bump prod pin
+- [ ] 3.2 Open cloud-provisioning PR (alert + strategy), pass CI, merge; confirm ArgoCD syncs
+- [ ] 3.3 Verify in prod: consumer healthy and draining; then force a transient stall (e.g. temporarily remove a durable) and confirm the backlog alert opens an incident and the pod fails loud / restarts; restore
+
+## 4. Phase 2 — Backend: startup reconciliation + bare durable names
+
+- [ ] 4.1 Add a raw JetStream pre-flight reconcile in consumer startup: for each topic, compare desired vs. existing `ConsumerInfo` and delete+recreate on drift (name / deliver group / delivery policy)
+- [ ] 4.2 Change `consumerName(topic)` to return the bare per-subject name (drop the `consumer_` prefix); keep per-subject uniqueness for durable and deliver group
+- [ ] 4.3 Ensure reconciliation removes superseded/no-longer-desired durables (the `consumer_*` and stale bare orphans) or documents which are left to age out
+- [ ] 4.4 Unit tests: reconcile recreates a drifted durable, leaves a matching one untouched; name helper produces bare names
+- [ ] 4.5 `make check` passes
+
+## 5. Phase 2 — cloud-provisioning: KEDA + probes
+
+- [ ] 5.1 Confirm KEDA ScaledObject triggers reference the bare durable names (already the case) and are consistent with the app after the rename; adjust any that drifted
+- [ ] 5.2 Confirm probe config still valid after the naming change
+
+## 6. Phase 2 — Ship to prod, migrate durables & verify
+
+- [ ] 6.1 Open backend PR (reconciliation + bare names), pass CI, merge, cut release, bump prod pin (ship only after Phase 1 is live so any issue fails loud + alerts)
+- [ ] 6.2 During the rollout, verify reconciliation converges: all durables bare-named, `push_bound=true`, backlog draining, KEDA reading real backlog
+- [ ] 6.3 Re-publish any critical events left pending by the migration if needed (stream 7d retention), as in the incident recovery
+- [ ] 6.4 Confirm the backlog alert is green and no orphan durables remain
+
+## 7. Cleanup & runbook
+
+- [ ] 7.1 Remove any leftover orphan durables from the 2026-07 incident
+- [ ] 7.2 Document the durable-reconciliation path as the required procedure for any future durable name/config change (release runbook)
+- [ ] 7.3 Update the incident memory / postmortem reference with the shipped controls


### PR DESCRIPTION
## Summary

Adds the OpenSpec change **`harden-jetstream-consumer-reliability`** — a proposal (proposal / design / specs / tasks) to prevent a recurrence of the 2026-07 silent consumer stall, where one mis-configured NATS JetStream durable halted **all** backend event consumption (push notifications, analytics, sales reminders) for ~a week with no alert able to fire.

This PR adds specification artifacts only; implementation lands in later PRs (backend + cloud-provisioning) via `/opsx:apply`.

## Changes

- `openspec/changes/harden-jetstream-consumer-reliability/proposal.md` — why & what, introduces the `jetstream-consumer-reliability` capability, marks the `consumer_` prefix removal as BREAKING.
- `.../specs/jetstream-consumer-reliability/spec.md` — 6 requirements: backlog stall detection, fail-loud subscription, consumption-aware liveness, startup durable reconciliation, prefix-less per-subject durable names, KEDA trigger alignment.
- `.../design.md` — decisions (D1–D6), 2-phase migration (safety net first, then naming + reconciliation), risks/mitigations. Note: going to bare names re-aligns KEDA with **no** KEDA edit.
- `.../tasks.md` — phased implementation through prod rollout and durable migration.

## Testing

- `openspec validate harden-jetstream-consumer-reliability --strict` passes.
- All 4 artifacts complete.

## Issue

Tracked by liverty-music/specification#695 (kept open — implementation is pending).
