### PR TITLE
docs(openspec): propose optimize-concert-highway-beam-tracking

### DIFF
--- a/openspec/changes/optimize-concert-highway-beam-tracking/.openspec.yaml
+++ b/openspec/changes/optimize-concert-highway-beam-tracking/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-09

--- a/openspec/changes/optimize-concert-highway-beam-tracking/design.md
+++ b/openspec/changes/optimize-concert-highway-beam-tracking/design.md
@@ -1,0 +1,57 @@
+## Context
+
+`<concert-highway>` renders laser beams (one per matched event card) as `position: fixed` overlay triangles whose height and `clip-path` apex track each card's viewport position. The tracking runs in `updateBeamPositions()`, scheduled by a passive scroll listener via `requestAnimationFrame`:
+
+```
+for (const beamEl of beamEls) {
+  const card = this.element.querySelector(`[data-beam-index="${idx}"]`) // per-frame, per-beam DOM query
+  const rect = card.getBoundingClientRect()                            // READ  (layout)
+  beamEl.style.setProperty('--beam-h', `${rect.bottom}px`)             // WRITE
+  beamEl.style.setProperty('--beam-top-pct', ...)                      // WRITE
+}
+```
+
+Two implementation costs, both on the dashboard + Welcome-preview hot path:
+
+1. **Per-frame `querySelector`** — N matched beams × every scroll frame, re-querying the same stable card elements.
+2. **Read/write interleave** — `getBoundingClientRect` (read) and `setProperty` (write) alternate within one loop. Beams live in a `position: fixed` overlay (a separate layout subtree), so the practical forced-reflow risk is bounded, but the shape is the canonical layout-thrash anti-pattern and trivially avoidable.
+
+An exploration confirmed the beams were **never** driven by CSS scroll-driven animations (`animation-timeline` has no history in `live-highway`), and the `@keyframes beam-descend` in `event-card.css` is dead decorative code from the festival-spotlight change, never referenced.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Remove the per-frame `querySelector` by caching a beam-anchor → card `HTMLElement` map, rebuilt only when `dateGroups` / the beam index map change (the same triggers that rebuild `laserBeams`).
+- Split each rAF update into a read phase (collect all `getBoundingClientRect` results) followed by a write phase (apply all `setProperty` writes) — no interleave.
+- Preserve pixel-identical beam output and the existing `requestAnimationFrame` cadence.
+- Remove the dead `@keyframes beam-descend`.
+
+**Non-Goals:**
+- Replacing the JS tracking with CSS scroll-driven animations (`animation-timeline: view()`). Deferred: needs a geometry redesign (the non-linear `--beam-top-pct = rect.top/rect.bottom` resists linear keyframe interpolation), dynamic per-card `view-timeline-name` + `timeline-scope`, and a mandatory `@supports` fallback for iOS/Safari (no browser-support policy is declared, so scroll-driven animations are not assumed Baseline). Benefit is also unmeasured.
+- Any change to beam appearance, `clip-path` geometry, hue, or the fixed-overlay containing-block rule.
+
+## Decisions
+
+**D1 — Cache the anchor→element map, keyed by beam-anchor index.**
+Build a `Map<number, HTMLElement>` (or an array indexed by anchor) alongside `laserBeams`/`beamIndexMap`, populated by querying `[data-beam-index]` once per rebuild. `updateBeamPositions` reads from the cache instead of querying per frame. Rationale: the card elements are stable between rebuilds; the existing `buildBeamIndexMap()` already runs on exactly the change events that would invalidate the cache, so it is the natural rebuild point. Alternative considered: `ref`/binding-collected element list — rejected as more invasive to the template for no gain over a single post-render query.
+Cache-miss safety: a stale/missing entry (element not yet in DOM) is skipped for that frame exactly as the current `if (!card) continue` does.
+
+**D2 — Two-phase read-then-write per rAF.**
+Iterate once to collect `{ beamEl, rect | offscreen }` into a local array (reads only), then iterate the collected results to apply `--beam-h` / `--beam-top-pct` (writes only). Rationale: guarantees all layout reads complete before any style mutation, eliminating any read-after-write forced reflow regardless of how the browser scopes invalidation. Alternative: rely on the fixed-overlay subtree isolation and leave the interleave — rejected; the batched form is strictly safer and the same line count.
+
+**D3 — Encode the invariant as a spec requirement, not just a code comment.**
+The `concert-highway-ce` "Laser beam effects" scenario gains an efficiency clause (cached resolution + batched read-before-write). Rationale: prevents a future edit from reintroducing the per-frame query / interleave; the behavior itself is unchanged so this is a MODIFIED scenario, not new behavior.
+
+## Risks / Trade-offs
+
+- **[Cache goes stale if cards re-render without a rebuild trigger]** → The cache is rebuilt in the same `buildBeamIndexMap()` path that already reruns on `dateGroups` / attach; a missing entry degrades gracefully (skip that beam for the frame, next rebuild repairs it) exactly as today's null-guard. No new failure mode.
+- **[Behavior drift vs. current visuals]** → Output must be byte-for-byte identical; guarded by the existing `concert-highway.spec.ts` plus a manual scroll check. Reads and writes compute the same values, only reordered.
+- **[Perf win is modest / unmeasured]** → Accepted. This is low-risk hygiene (fewer queries, no interleave, dead-code removal), not a promised metric. The full CSS rewrite that could yield a larger win is explicitly deferred pending measurement and an iOS fallback decision.
+
+## Migration Plan
+
+Pure frontend refactor, no data or API migration. Deploy path: merge to `frontend` main → frontend Release (retag → prod AR → automated prod pin-bump → ArgoCD) onto the healthy v1.24.0 baseline. Rollback: revert the frontend PR (or re-pin the prior release); no state to unwind.
+
+## Open Questions
+
+- Should beam-update cost be measured (DevTools Performance on a beam-dense dashboard) to decide whether the deferred CSS scroll-driven redesign is ever worth pursuing? Out of scope here; noted for a follow-up.

--- a/openspec/changes/optimize-concert-highway-beam-tracking/proposal.md
+++ b/openspec/changes/optimize-concert-highway-beam-tracking/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+The `<concert-highway>` laser-beam scroll tracking is the heaviest runtime JavaScript on the dashboard and Welcome-preview hot path (surfaced during a NoLoJS review). Its per-frame update does a per-beam `querySelector` DOM lookup and interleaves layout reads (`getBoundingClientRect`) with style writes (`setProperty`) inside one loop — a classic layout-thrash shape that costs INP on mobile for no visual benefit. A full move to CSS scroll-driven animations was evaluated and rejected (non-linear beam geometry, dynamic per-card timelines, and a mandatory iOS/Safari `@supports` fallback since no browser-support policy is declared), so this change instead removes the JS inefficiencies directly, with zero behavior change.
+
+## What Changes
+
+- Refine the beam-tracking rendering contract so each `requestAnimationFrame` update: (a) resolves each beam's anchor card via a **cached anchor→element map** rebuilt only when inputs change, instead of a per-frame `querySelector`; and (b) performs **all layout reads before any style writes** (no read/write interleave). Visual output is identical.
+- Remove the dead `@keyframes beam-descend` from `event-card.css` (added by the festival-spotlight change, never referenced by any `animation:` — confirmed via repo-wide grep). Housekeeping only.
+
+Non-goals (explicitly deferred): replacing the JS beam tracking with CSS scroll-driven animations (`animation-timeline: view()`), altering beam appearance/geometry, or changing the `clip-path` cone.
+
+## Capabilities
+
+### New Capabilities
+
+<!-- none — no new capability is introduced. -->
+
+### Modified Capabilities
+
+- `concert-highway-ce`: refine the "Laser beam effects for matched events" scenario to add a rendering-efficiency invariant (cached anchor→element resolution and batched read-before-write per rAF). The observable beam behavior is unchanged; the requirement pins the non-functional guarantee so the optimization cannot silently regress.
+
+## Impact
+
+- `frontend`: `src/components/live-highway/concert-highway.ts` (`updateBeamPositions`, beam-map lifecycle), `src/components/live-highway/event-card.css` (dead keyframe removal).
+- No API, proto, or backend impact. No dependency changes.
+- Performance: fewer DOM queries and no interleaved forced reflow per scroll frame on the dashboard + Welcome preview (INP hygiene).
+- Ship target: merged and released to prod (frontend release), consistent with the healthy v1.24.0 baseline.

--- a/openspec/changes/optimize-concert-highway-beam-tracking/specs/concert-highway-ce/spec.md
+++ b/openspec/changes/optimize-concert-highway-beam-tracking/specs/concert-highway-ce/spec.md
@@ -1,0 +1,24 @@
+## ADDED Requirements
+
+### Requirement: Beam tracking updates efficiently per frame
+
+The laser-beam scroll tracking SHALL update without per-frame DOM element queries and without interleaving layout reads with style writes, so that the effect adds minimal INP cost on the dashboard and Welcome-preview hot paths. This constrains only HOW the beams update; the observable beam appearance and cadence defined by the "Laser beam effects for matched events" scenario are unchanged.
+
+#### Scenario: Cached anchor-to-element resolution
+
+- **WHEN** the beam overlay updates in response to a scroll frame
+- **THEN** each beam's anchor card SHALL be resolved from a precomputed anchor→element map
+- **AND** the component SHALL NOT perform a per-beam element query (e.g. `querySelector`) inside the per-frame update
+- **AND** the map SHALL be (re)built when the `dateGroups` binding or the beam index map changes, i.e. on the same triggers that rebuild the beam set
+
+#### Scenario: Batched read-before-write per frame
+
+- **WHEN** the beam overlay updates in response to a scroll frame
+- **THEN** the component SHALL complete all card geometry reads (`getBoundingClientRect`) before applying any beam style writes (`--beam-h` / `--beam-top-pct`)
+- **AND** the resulting beam geometry SHALL be identical to computing each beam's values independently (the reorder is transparent)
+
+#### Scenario: Missing anchor element degrades gracefully
+
+- **WHEN** a beam's anchor card is absent from the cached map (e.g. not yet mounted)
+- **THEN** that beam SHALL be skipped for the current frame without error
+- **AND** the beam SHALL resume tracking once a rebuild repopulates its cache entry

--- a/openspec/changes/optimize-concert-highway-beam-tracking/tasks.md
+++ b/openspec/changes/optimize-concert-highway-beam-tracking/tasks.md
@@ -1,0 +1,26 @@
+## 1. JS beam-tracking optimization (frontend)
+
+- [ ] 1.1 In `concert-highway.ts`, add a cached anchor→element map (`Map<number, HTMLElement>` keyed by beam-anchor index); populate it in `buildBeamIndexMap()` by querying `[data-beam-index]` once per rebuild, and clear/rebuild it on `dateGroupsChanged` and `detaching`.
+- [ ] 1.2 Rewrite `updateBeamPositions()` to read from the cached map instead of a per-frame `querySelector`, preserving the existing missing-element skip.
+- [ ] 1.3 Split `updateBeamPositions()` into a read phase (collect all `getBoundingClientRect` results into a local array) followed by a write phase (apply all `--beam-h` / `--beam-top-pct` writes) — no read/write interleave.
+- [ ] 1.4 Confirm computed `--beam-h` / `--beam-top-pct` values are byte-identical to the previous implementation (same formulas, only reordered).
+
+## 2. Dead-code cleanup (frontend)
+
+- [ ] 2.1 Remove the unused `@keyframes beam-descend` from `event-card.css`; grep the repo to confirm no `animation:` reference remains.
+
+## 3. Tests & local verification
+
+- [ ] 3.1 Update/extend `concert-highway.spec.ts` to assert the cached anchor→element map is built on `dateGroups` change and that `updateBeamPositions` resolves cards from it (no per-frame query); keep the existing detach/cancel assertions.
+- [ ] 3.2 `make check` (lint + unit) passes; run the existing dashboard/welcome E2E projects to confirm no regression.
+- [ ] 3.3 Manual scroll check on the Welcome preview (beam-dense) confirming visually identical beam behavior.
+
+## 4. Ship to prod
+
+- [ ] 4.1 Open the frontend PR, drive CI green (Test/Smoke/E2E/Lint/Visual), address any review, and merge.
+- [ ] 4.2 Cut the frontend Release (next patch after v1.24.0) from the merge commit; confirm the automated prod pin-bump lands and ArgoCD reports Synced/Healthy on the new tag.
+- [ ] 4.3 Verify prod is healthy (web-app pod on the new tag, HTTP 200) and beams render on the live dashboard/Welcome preview.
+
+## 5. Archive
+
+- [ ] 5.1 After prod verification, run `openspec archive optimize-concert-highway-beam-tracking` (via verify-before-archive) to fold the `concert-highway-ce` delta into the main spec.


### PR DESCRIPTION
## 🔗 Related Issue

Tracked by #697 (kept open — implementation is pending).

## 📝 Summary of Changes

Adds the OpenSpec change **`optimize-concert-highway-beam-tracking`** — a proposal (proposal / design / specs / tasks) for two safe, **no-behavior-change** frontend improvements to the `<concert-highway>` laser-beam scroll tracking, surfaced during a NoLoJS review as the heaviest runtime JS on the dashboard + Welcome-preview hot path.

This PR adds specification artifacts only; implementation lands in a later frontend PR via `/opsx:apply`.

**Motivation:** `updateBeamPositions()` (rAF-driven) does a per-beam `querySelector` DOM lookup every frame and interleaves layout reads (`getBoundingClientRect`) with style writes (`setProperty`) — a layout-thrash shape for no visual benefit.

**Scope (2 changes):**
1. **JS optimization** — cache a beam-anchor→card element map (rebuilt on `dateGroups` change) to drop the per-frame `querySelector`, and split each rAF update into a read phase then a write phase (no interleave). Pixel-identical output.
2. **Dead-code cleanup** — remove the unused `@keyframes beam-descend` from `event-card.css` (never referenced by any `animation:`).

**Technical approach:** the observable beam behavior is unchanged, so instead of a MODIFIED requirement this pins the efficiency guarantee as an **ADDED requirement** on `concert-highway-ce` (cached anchor→element resolution, batched read-before-write, graceful skip on missing anchor) to prevent regression.

**Explicit non-goal:** replacing the JS with CSS scroll-driven animations (`animation-timeline: view()`) — deferred; needs a geometry redesign (the non-linear `--beam-top-pct` resists linear keyframe interpolation), dynamic per-card `view-timeline-name` + `timeline-scope`, and a mandatory iOS/Safari `@supports` fallback (no browser-support policy is declared). Benefit is unmeasured; captured as an Open Question in design.md.

## Artifacts

| File | Purpose |
| --- | --- |
| `proposal.md` | Why / what / capabilities / impact |
| `design.md` | Decisions D1–D3, risks, migration, deferred CSS-rewrite rationale |
| `specs/concert-highway-ce/spec.md` | 1 ADDED requirement (per-frame efficiency invariant, 3 scenarios) |
| `tasks.md` | JS optimization → dead-code cleanup → tests → prod release → archive |

## ✅ Self-Checklist

- [x] I have linked the related issue.
- [x] I have updated the relevant documentation (OpenSpec artifacts) if needed.
- [ ] I have run `buf lint` and `buf format` locally — N/A, no proto changes (OpenSpec markdown only).
- [x] My proto definitions follow the project's style guidelines — N/A, no proto changes; `openspec validate --strict` passes.
- [ ] Breaking changes have been justified — N/A, no breaking changes.

## Testing

- `openspec validate optimize-concert-highway-beam-tracking --strict` → **valid** (4/4 artifacts complete).
- Docs/spec-only PR; no code touched here (frontend implementation follows via `/opsx:apply`).
