### PR TITLE
docs(openspec): propose fix-pwa-app-shell-scroll-lock

### DIFF
--- a/openspec/changes/fix-pwa-app-shell-scroll-lock/.openspec.yaml
+++ b/openspec/changes/fix-pwa-app-shell-scroll-lock/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-24

--- a/openspec/changes/fix-pwa-app-shell-scroll-lock/design.md
+++ b/openspec/changes/fix-pwa-app-shell-scroll-lock/design.md
@@ -1,0 +1,57 @@
+## Context
+
+The `app-shell` uses a `100dvh` CSS Grid (`"viewport" 1fr / "nav" auto`) with a non-fixed bottom nav bar — a standard-conformant app-shell skeleton. `viewport-fit=cover` and `env(safe-area-inset-*)` are already handled. Scrolling is intended to happen only inside the concert list (`minmax(0, 1fr)` track → inner scroller).
+
+However, the document root can still scroll:
+
+- `reset.css` sets `body { min-block-size: 100dvh }` with no `overflow` control on `html`/`body`.
+- No `overscroll-behavior` is declared at the root.
+
+Because `app-shell` is exactly `100dvh` and `body` is `min-block-size: 100dvh`, any transient where the dynamic viewport unit resolves larger than the visible area (which the standalone pull-to-refresh / overscroll gesture induces) leaves `body` with a few pixels of scroll range. With no root scroll lock and no `overscroll-behavior`, that scrolled state persists: the shell becomes taller than the visible viewport and the header row and the bottom nav become mutually exclusive on screen.
+
+The web-standard remedy for this (per modern CSS layout guidance: viewport-unit mechanics + `overscroll-behavior`) is the "fixed app shell + single inner scroller" pattern: make the document root a non-scrolling frame and confine all scrolling to one inner container.
+
+## Goals / Non-Goals
+
+**Goals:**
+- The bottom nav bar and header remain simultaneously visible and pinned regardless of pull-to-refresh / overscroll in the installed standalone PWA.
+- The document root (`html`/`body`) is never a scroll source.
+- All scrolling is confined to the single inner concert scroller; scroll chaining never reaches the document.
+
+**Non-Goals:**
+- No change to the `app-shell` grid structure, `100dvh` sizing, `viewport-fit=cover`, or safe-area handling — those are already standard-conformant.
+- No change to page-transition animations, nav visibility logic, or route structure.
+- No new data-refresh UI to replace the disabled native pull-to-refresh (out of scope; the app already has its own reload paths).
+
+## Decisions
+
+- **Root scroll lock over per-element patching.** Set `html, body { block-size: 100%; overflow: hidden; overscroll-behavior: none; }` and remove `body { min-block-size: 100dvh }`. Making the root a fixed frame is the robust, standard pattern; it removes the scroll source entirely rather than chasing `dvh` fluctuations.
+  - Alternative considered: keep `body` scrollable but add only `overscroll-behavior: none`. Rejected — it neutralizes the gesture but leaves `body` able to scroll whenever `dvh` momentarily exceeds the visible viewport, so the shift can still occur.
+  - Alternative considered: `app-shell { position: fixed; inset: 0 }`. Rejected as more invasive than a root lock and redundant once the root cannot scroll; the existing `100dvh` grid already owns height correctly.
+
+- **Keep `app-shell` height as the single height owner.** With the root locked, `body { min-block-size: 100dvh }` is redundant and is the concrete scroll source, so it is removed. `app-shell` keeps `block-size: 100dvh`.
+
+- **`overscroll-behavior: contain` on the inner scroller.** Add it to the concert list scroll container (`.concert-scroll`) so a scroll-boundary bounce never chains into the (now non-scrolling) document. This is defense-in-depth alongside the root lock.
+
+- **`overscroll-behavior: none` at root disables native pull-to-refresh.** This is intentional and acceptable: the product is an installed home-screen PWA and the accidental full reload from pull-to-refresh is itself a source of the reported bug.
+
+## Risks / Trade-offs
+
+- [Native pull-to-refresh reload is disabled in the standalone PWA] → Acceptable and intended; the app provides its own data-refresh paths. If an explicit refresh affordance is later desired, add it as in-app UI (separate change).
+- [`overflow: hidden` on `html`/`body` could clip a route that (incorrectly) relies on document scroll] → All routes already delegate scrolling to inner containers per the existing shell-layout requirements; verify no route depends on document-level scroll during QA.
+- [`dvh` behavior differs across iOS Safari (home-screen) vs Android Chrome (installed)] → The root lock makes the fix independent of `dvh` dynamics, so both targets are covered; still verify on both during rollout.
+
+## Migration Plan
+
+1. Edit `src/styles/reset.css`: add root scroll-lock rule on `html, body`; remove `body { min-block-size: 100dvh }`.
+2. Add `overscroll-behavior: contain` to `.concert-scroll`.
+3. Confirm `app-shell.css` remains the height owner (`block-size: 100dvh`), no change required.
+4. Extend layout/shell E2E assertions to verify nav+header stay pinned after an overscroll gesture in a standalone-emulated viewport.
+5. `make check` (Biome + stylelint + typecheck + tests), then ship via the frontend PR → release path.
+
+Rollback: revert the CSS change (single-commit, no data or API impact).
+
+## Open Questions
+
+- Which element is the canonical inner scroller in the current tree — `.concert-scroll` (as in `shell-layout` spec) vs the live-highway variant found in code? Confirm during apply and attach `overscroll-behavior: contain` to the actual scroll container.
+- Should other scrollable routes (e.g., settings, my-artists lists) also receive `overscroll-behavior: contain`, or is the root lock sufficient for them? Default: root lock covers them; add per-container only if a boundary-bounce artifact is observed.

--- a/openspec/changes/fix-pwa-app-shell-scroll-lock/proposal.md
+++ b/openspec/changes/fix-pwa-app-shell-scroll-lock/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+In the installed (standalone) PWA, a pull-to-refresh / overscroll gesture makes the whole document scroll: the bottom navigation bar drops off-screen, and scrolling the dashboard to the bottom brings the nav back but pushes the header (the "Timetable" title row) off the top. The root cause is that the document root (`html`/`body`) is allowed to be a scroll source — there is no root scroll lock and no `overscroll-behavior`, so the native pull-to-refresh gesture shifts the fixed shell chrome. This is the classic PWA app-shell "the whole document scrolls" bug and it degrades core navigation on the primary install target (mobile home-screen PWA).
+
+## What Changes
+
+- Lock the document root as a non-scrolling frame: `html`/`body` get a definite height, `overflow: hidden`, and `overscroll-behavior: none` so the document is never a scroll source and the standalone pull-to-refresh gesture cannot shift the shell.
+- Remove `body { min-block-size: 100dvh }` — with the `app-shell` grid owning height (`100dvh`), the `min-block-size` on `body` is a redundant scroll source that `dvh` fluctuation can push past the visible viewport.
+- Add `overscroll-behavior: contain` to the single inner scroll container (the concert list scroller) so reaching a scroll boundary never chains into the document.
+- Keep the existing standard-conformant parts unchanged: the `100dvh` grid shell, `viewport-fit=cover`, and `env(safe-area-inset-*)` handling remain as-is.
+
+## Capabilities
+
+### New Capabilities
+<!-- None: this is a bug fix to existing shell layout behavior. -->
+
+### Modified Capabilities
+- `shell-layout`: Add a requirement that the document root is a non-scrolling frame (root scroll lock + `overscroll-behavior` neutralization), and strengthen the bottom-nav-pinning requirement to hold under a standalone PWA pull-to-refresh / overscroll gesture, with scroll confined to the single inner container.
+
+## Impact
+
+- Affected code (frontend):
+  - `src/styles/reset.css` — root scroll lock on `html`/`body`; remove `body { min-block-size: 100dvh }`.
+  - `src/app-shell.css` — shell grid height unchanged (`100dvh`); verify it remains the height owner.
+  - The inner concert scroll container (`.concert-scroll`) — add `overscroll-behavior: contain`.
+- No proto/BSR, backend, or API changes. Frontend-only CSS change.
+- Testing: extend the existing layout/shell E2E assertions to cover nav-pinned-after-overscroll in a standalone-emulated viewport.
+- Risk: root `overflow: hidden` disables native pull-to-refresh reload in the browser tab; acceptable because the app is designed as an installed PWA and provides its own data-refresh paths.

--- a/openspec/changes/fix-pwa-app-shell-scroll-lock/specs/shell-layout/spec.md
+++ b/openspec/changes/fix-pwa-app-shell-scroll-lock/specs/shell-layout/spec.md
@@ -1,0 +1,58 @@
+## ADDED Requirements
+
+### Requirement: Document root is a non-scrolling frame
+The document root (`html` and `body`) SHALL be a non-scrolling frame so that it is never a scroll source and native overscroll gestures (pull-to-refresh) in a standalone PWA cannot shift the shell chrome. All scrolling SHALL be confined to inner scroll containers.
+
+#### Scenario: Root elements do not scroll
+- **WHEN** the application is loaded in any route
+- **THEN** `html` and `body` SHALL declare a definite height (`block-size: 100%`)
+- **AND** `html` and `body` SHALL declare `overflow: hidden`
+- **AND** `body` SHALL NOT declare `min-block-size: 100dvh` (or any rule that makes `body` taller than the visible viewport and thus a scroll source)
+- **AND** the `app-shell` grid SHALL remain the single height owner at `block-size: 100dvh`
+
+#### Scenario: Overscroll gesture does not chain to the document
+- **WHEN** the user performs a pull-to-refresh or overscroll gesture in the installed standalone PWA
+- **THEN** `html` and `body` SHALL declare `overscroll-behavior: none`
+- **AND** the document SHALL NOT scroll, bounce, or trigger a native pull-to-refresh reload
+- **AND** the bottom navigation bar and the page header SHALL both remain visible and pinned in their positions
+
+#### Scenario: Inner scroll container contains its overscroll
+- **WHEN** the user scrolls the concert list to its top or bottom boundary
+- **THEN** the concert scroll container SHALL declare `overscroll-behavior: contain`
+- **AND** the scroll SHALL NOT chain into the document root
+
+## MODIFIED Requirements
+
+### Requirement: Overlay elements excluded from grid flow
+All overlay custom elements (`pwa-install-prompt`, `notification-prompt`, `toast-notification`, `error-banner`, `coach-mark`) SHALL be removed from normal document flow so they do not create implicit CSS Grid rows in the `app-shell` shell layout. The bottom navigation bar and page header SHALL stay pinned even under a standalone PWA pull-to-refresh / overscroll gesture, because the document root is a non-scrolling frame and scrolling is confined to the single inner container.
+
+#### Scenario: Bottom nav stays at viewport bottom
+- **WHEN** the dashboard page has enough events to require scrolling (20+ concerts across multiple dates)
+- **THEN** `bottom-nav-bar` SHALL remain visible and pinned at the bottom of the viewport at all times
+- **AND** the `dashboard-route` CE SHALL constrain all descendants to viewport height via a 2-layer height chain: `dashboard-route` (grid, `block-size: 100%`) → `<main>` (scroll container, `overflow-block: auto`)
+- **AND** no intermediate element between `au-viewport` and the scroll container SHALL have a rendered height exceeding the `au-viewport` height
+
+#### Scenario: Bottom nav and header stay pinned after a pull-to-refresh gesture
+- **WHEN** the app is running as an installed standalone PWA on the dashboard
+- **AND** the user performs a pull-to-refresh / downward overscroll gesture
+- **THEN** the bottom navigation bar SHALL remain visible and pinned at the bottom of the viewport
+- **AND** the page header (the "Timetable" title row) SHALL remain visible and pinned at the top of the viewport
+- **AND** the document root SHALL NOT scroll to make the header and the bottom nav bar mutually exclusive on screen
+
+#### Scenario: Stage header stays fixed above scrollable content
+- **WHEN** the user scrolls the concert list downward
+- **THEN** the stage header (HOME STAGE / NEAR STAGE / AWAY STAGE) SHALL remain fixed above the scrollable content
+- **AND** the stage header SHALL be a `<header>` element that is a direct child of `dashboard-route`, outside the `<main>` scroll container
+- **AND** `dashboard-route` SHALL use CSS Grid with named areas via the `grid-template` shorthand: `"stage-home stage-near stage-away" auto` / `"lane-home lane-near lane-away" minmax(0, 1fr)` / `1fr 1fr 1fr`
+- **AND** the stage header SHALL use `grid-template-columns: subgrid` with `grid-column: stage-home / stage-away` (named area implicit lines)
+- **AND** the scroll container and all intermediate elements (`.concert-scroll`, `.date-group-list`, `li`, `.lane-grid`) SHALL use `grid-template-columns: subgrid` to propagate the 3-column layout from the root grid
+
+#### Scenario: Scroll container is properly constrained
+- **WHEN** concert data overflows the viewport
+- **THEN** the `<main .concert-scroll>` element's `scrollHeight` SHALL be greater than its `clientHeight`
+- **AND** the scroll container SHALL be the only scrollable element in the height chain
+- **AND** the scroll container SHALL declare `overscroll-behavior: contain` so a scroll-boundary bounce does not chain into the document root
+
+#### Scenario: Overlay elements remain functional
+- **WHEN** an overlay element activates (e.g., toast notification, coach-mark spotlight)
+- **THEN** the overlay SHALL render correctly via the browser top-layer API, unaffected by the flow removal

--- a/openspec/changes/fix-pwa-app-shell-scroll-lock/tasks.md
+++ b/openspec/changes/fix-pwa-app-shell-scroll-lock/tasks.md
@@ -1,0 +1,26 @@
+## 1. Confirm current structure
+
+- [ ] 1.1 Confirm `app-shell.css` remains the single height owner (`block-size: 100dvh` grid); no change needed
+- [ ] 1.2 Identify the canonical inner scroll container in the current tree (`.concert-scroll` vs the live-highway variant) that must receive `overscroll-behavior: contain`
+
+## 2. Root scroll lock (reset.css)
+
+- [ ] 2.1 Add a root rule to `src/styles/reset.css`: `html, body { block-size: 100%; overflow: hidden; overscroll-behavior: none; }`
+- [ ] 2.2 Remove `body { min-block-size: 100dvh }` from `src/styles/reset.css`
+- [ ] 2.3 Verify no route relies on document-level scroll (all routes delegate scrolling to inner containers)
+
+## 3. Inner scroller containment
+
+- [ ] 3.1 Add `overscroll-behavior: contain` to the concert scroll container (`.concert-scroll`)
+
+## 4. Tests
+
+- [ ] 4.1 Extend the layout/shell E2E (or `layout-assertions`) suite: in a standalone-emulated viewport on the dashboard, assert the bottom nav bar and header stay pinned after a downward overscroll gesture, and the document root does not scroll
+- [ ] 4.2 Run `make check` (Biome + stylelint + typecheck + unit tests) and confirm green
+
+## 5. Ship to production
+
+- [ ] 5.1 Open the frontend PR, get CI green, and merge
+- [ ] 5.2 Cut a frontend GitHub Release (SemVer tag) → automated pin-bump → ArgoCD auto-sync to prod
+- [ ] 5.3 Verify on the installed prod PWA (Android Chrome home-screen and iOS home-screen): pull-to-refresh no longer hides the bottom nav or the header
+- [ ] 5.4 Archive the OpenSpec change once verified in prod


### PR DESCRIPTION
## 🔗 Related Issue

Closes #700

## 📝 Summary of Changes

Adds the OpenSpec change `fix-pwa-app-shell-scroll-lock` proposing the fix for a standalone-PWA layout bug.

**Motivation / problem:** In the installed (standalone) PWA, a pull-to-refresh / overscroll gesture lets the document root (`html`/`body`) scroll. The bottom navigation bar drops off-screen; scrolling the dashboard to the bottom brings the nav back but pushes the header ("Timetable" title row) off the top — the two become mutually exclusive on screen. This is the classic PWA app-shell "the whole document scrolls" bug: the root is allowed to be a scroll source (`body { min-block-size: 100dvh }`, no `overflow` lock, no `overscroll-behavior`).

**Technical approach (spec-level):** Modifies the `shell-layout` capability to require the document root to be a **non-scrolling frame** (root scroll lock + `overscroll-behavior: none`, `body` no longer a scroll source), with all scrolling confined to the single inner container (`overscroll-behavior: contain`). The already standard-conformant parts — the `100dvh` grid shell, `viewport-fit=cover`, and `env(safe-area-inset-*)` — are kept unchanged.

**Contents:**
- `proposal.md` — why / what / impact (frontend-only CSS; no proto/BSR/backend/API changes).
- `design.md` — "fixed shell + single inner scroller" pattern, alternatives considered, risks.
- `specs/shell-layout/spec.md` — ADDED "Document root is a non-scrolling frame"; MODIFIED "Overlay elements excluded from grid flow" to hold under pull-to-refresh.
- `tasks.md` — implementation → E2E → prod release → archive.

**Scope:** This PR is spec-only, per the Cross-Repo Release Coordination workflow. The frontend CSS implementation lands later as a separate PR (`reset.css` root lock + remove `body { min-block-size: 100dvh }` + `.concert-scroll` `overscroll-behavior: contain`), then the change is archived.

## ✅ Self-Checklist

- [x] I have linked the related issue.
- [x] I have updated the relevant documentation (OpenSpec change artifacts).
- [ ] I have run `buf lint` and `buf format` locally — N/A: no `.proto` changes in this PR.
- [ ] My proto definitions follow the project's style guidelines — N/A: no proto changes.
- [ ] Breaking changes — N/A: no schema/proto changes.
