### PR TITLE
docs(openspec): propose fix-concert-approval-dedup

### DIFF
--- a/openspec/changes/fix-concert-approval-dedup/.openspec.yaml
+++ b/openspec/changes/fix-concert-approval-dedup/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-25

--- a/openspec/changes/fix-concert-approval-dedup/design.md
+++ b/openspec/changes/fix-concert-approval-dedup/design.md
@@ -1,0 +1,183 @@
+## Context
+
+Discovery → staging → approval is a three-stage pipeline. Each stage dedups on a
+different key, and two of those keys are values that drift between discovery runs:
+
+| Stage | Dedup / identity key | Stable? |
+| --- | --- | --- |
+| Search (`FilterNew` vs events & pending staged) | `(local_event_date, listed_venue_name, start_at)` — raw scraped string | No — Gemini name drift |
+| Staged unique index | `(artist_id, local_date, resolved_place_id)` or `(…, listed_venue_name)` | Partly |
+| Venue identity | `google_place_id` **and** `(listed_venue_name, admin_area)` — two independent partial-unique indexes | No — Places returns multiple `place_id`s per venue |
+| Event natural key | `(venue_id, local_event_date, start_at)` `NULLS NOT DISTINCT` | Yes — resolved |
+
+Because the read-side dedup keys differ from the write-side unique constraints, the
+approval pipeline fails to recognise a venue/event it already created:
+
+- **`already_exists`**: `resolveOrCreateVenue` looks up a venue by `place_id` only;
+  when Places resolved a *different* `place_id` for an existing venue, the lookup
+  misses and the subsequent `INSERT` collides on `idx_venues_listed_name_admin_area`.
+  Confirmed in prod: 和歌山ビッグホエール exists as `place_id=ChIJGSP2Ti…` but the
+  staged rows resolved to `ChIJizoipyy…`.
+- **`failed_precondition`**: `FilterNew` compares the raw scraped `listed_venue_name`
+  against the stored event's (drifted) `listed_venue_name`; a formatting difference
+  (`フェスティバルホール` vs `大阪・フェスティバルホール`) defeats the match, so the
+  concert is re-staged, and approval then finds the event already exists at the
+  resolved `(venue_id, date, start_at)` and returns zero inserts. 16 of 19 prod
+  collision rows show this exact name drift; 18 of 19 are the same artist.
+
+Constraints: no DB migration is needed — every constraint and index already exists.
+The admin `Approve` RPC change requires a specification release → BSR codegen before
+backend/frontend can consume the generated types.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Approving a concert whose venue already exists never crashes on a unique violation.
+- Approving a concert whose event already exists gives the reviewer a clear choice
+  (keep existing vs adopt staged) instead of a dead-end error.
+- Name-drift re-discoveries are recognised before staging, so the queue stops
+  accumulating unapprovable duplicates.
+
+**Non-Goals:**
+- Canonical venue de-duplication / merging of already-split venue rows (two rows for
+  the same physical place). That is a separate data-cleanup effort.
+- Reconciling venue identity itself in the approval dialog — the duplicate-event
+  reconciliation only touches the event's venue display name and NULL-only start/open
+  fill; `venue_id`/`place_id` and the shared series title are fixed.
+- Field-level merge in the reconciliation dialog — record-level choice only.
+- Resolving start-time drift (same show discovered with a different `start_at`,
+  which currently yields a *distinct* event rather than a duplicate).
+- Catching a duplicate whose existing event belongs to a *different* artist at the same
+  venue and date. The discovery dedup (`FilterNew`) runs against `ListByArtist`, which is
+  per-artist, so a cross-artist same-venue-date collision is invisible to D2 regardless of
+  name normalization; the event natural key plus D3 reconciliation at approval are its only
+  backstop. (Observed once in the prod snapshot: 神戸国際会館.)
+- Retroactively clearing the existing stale staged rows. D2 only prevents *future*
+  name-drift re-staging; the ~19 rows already queued are cleared through the D3
+  reconciliation path or manual review (see Migration Plan / tasks).
+
+## Decisions
+
+### D1 — Venue resolution is idempotent get-or-create, `place_id`-authoritative
+
+`resolveOrCreateVenue` resolves in this order:
+
+1. If `resolved_place_id` is set, `GetByPlaceID`. Hit → return it.
+2. On miss (or no `place_id`), `GetByListedName(listed_venue_name, admin_area)`. Hit → return it.
+3. Neither → `INSERT … ON CONFLICT DO NOTHING`. If it inserted, return the new id.
+4. If `ON CONFLICT` suppressed the insert (lost race, or either unique index fired),
+   re-SELECT by `place_id` then by `(listed_venue_name, admin_area)` and return the winner.
+
+Rationale: `place_id` is the more canonical identity when present, but it is not
+reliable (proven multi-CID case), so `(listed_venue_name, admin_area)` — the identity
+the DB already enforces as unique — is the fallback. `ON CONFLICT DO NOTHING` with no
+target (not a named constraint) absorbs a violation on *either* partial-unique index,
+which a single-target clause cannot. The re-SELECT makes it race-safe.
+
+- **`admin_area` symmetry**: the lookup in step 2 and the `INSERT` in step 3 MUST derive
+  `admin_area` identically (`resolved_admin_area ?? admin_area`). Today the lookup uses
+  the raw value while the insert prefers the resolved value — an asymmetry that itself
+  produces miss-then-collide.
+- **`place_id` backfill**: when step 2 finds a venue with a NULL `place_id` and the
+  staged row carries a resolved `place_id`, backfill it. Never overwrite a non-NULL
+  `place_id` (that could collide on `idx_venues_google_place_id`).
+
+Alternatives considered: making `place_id` the single source of truth and dropping the
+`(listed_venue_name, admin_area)` unique index. Rejected — it would let the 和歌山
+multi-CID case create two venue rows for one physical place, and it needs a migration +
+data backfill. The two-key get-or-create keeps both safety nets.
+
+### D2 — Discovery dedup matches on a stable venue identity
+
+`FilterNew` (and the pending-staged dedup) SHALL compare venues on a normalized
+identity rather than the raw `listed_venue_name` string, so `フェスティバルホール` and
+`大阪・フェスティバルホール` collapse to the same venue and the second discovery is
+recognised as already-known.
+
+Two mechanisms are viable; the implementation chooses per cost:
+- **(a) Normalize the name** before comparison (trim, full/half-width fold, strip
+  leading `〈admin_area〉・` / `〈city〉公演 ＠` prefixes). Cheap, no extra API calls,
+  but heuristic.
+- **(b) Resolve venue first, dedup by `venue_id`.** Authoritative, but moves the Places
+  call ahead of dedup, increasing API cost for concerts that turn out to be duplicates.
+
+Decision: prefer (a) as the primary matcher (no added API cost, catches the observed
+drift), and keep the existing `(date, start_at)` component unchanged. (b) is a fallback
+only if normalization proves insufficient; record the choice in tasks. Either way the
+event natural key `(venue_id, …)` remains the final DB-level safety net.
+
+### D3 — Duplicate event → reviewer reconciliation, not `failed_precondition`
+
+When approval detects an existing event at the resolved `(venue_id, local_event_date,
+start_at)` (the two current zero-insert paths: exact-start duplicate, and unknown-start
+staged vs known-start existing), the `Approve` RPC returns a **duplicate-conflict**
+result carrying the existing event's display fields. The reviewer picks record-level:
+
+- **KEEP_EXISTING** → append the staged row to the rejection log with a duplicate
+  reason, delete the staged row. Auditable, mirrors a normal reject.
+- **ADOPT_STAGED** → overwrite the existing event's `listed_venue_name` from the staged
+  row, and fill `start_at`/`open_at` only where the existing value is NULL (a known time is
+  never nulled out — `title` lives on the shared `series` row and is out of scope, and the
+  unknown-start-staged case must not erase a known start); leave `venue_id`/`place_id`
+  untouched; delete the staged row.
+
+The duplicate conflict is only about which *display representation* to keep — both sides
+already resolve to the same `venue_id` (that is how the duplicate was detected), so the
+reconciliation never touches venue identity (keeps D1's scope separate from D3).
+
+### D4 — `Approve` RPC shape: one idempotent RPC, two phases
+
+`Approve` gains an optional `resolution` enum (`RESOLUTION_UNSPECIFIED`,
+`KEEP_EXISTING`, `ADOPT_STAGED`). First call omits it; if a duplicate is detected the
+response carries a `conflict` message (existing event fields + staged preview) and does
+not mutate. The console shows the dialog and re-calls `Approve` with the chosen
+`resolution`. Rationale: keeps the surface to one RPC, stays idempotent, and avoids a
+separate `ResolveConflict` verb that would duplicate the staged-id + lookup plumbing.
+
+Alternative considered: a dedicated `ResolveConflict` RPC. Rejected for surface bloat;
+the two-phase `Approve` carries no more state and reads naturally in the console.
+
+### D5 — Rollout order
+
+`already_exists` is a live prod crash and its fix (D1) needs no proto change, so it and
+the discovery-dedup fix (D2) ship first as backend-only PRs. The reconciliation (D3/D4)
+carries a schema change and follows the Cross-Repo Release Coordination protocol:
+specification PR → release → BSR codegen → backend + frontend consume generated types.
+All three are tracked in this single change; tasks are ordered so the backend-only
+fixes are not blocked on BSR.
+
+## Risks / Trade-offs
+
+- **Name normalization is heuristic (D2a)** → keep the event natural key as the DB-level
+  final safety net; if a duplicate still slips through, D3 reconciliation catches it at
+  approval instead of crashing. Log normalization decisions for tuning.
+- **ADOPT_STAGED overwrites a curated event's display fields** → scope the overwrite to
+  display fields only (never identity), and require an explicit reviewer choice; default
+  (unspecified) never mutates an existing event.
+- **`place_id` backfill could collide on `idx_venues_google_place_id`** → backfill only
+  when the existing row's `place_id` is NULL; wrap in the same `ON CONFLICT`-tolerant
+  path so a concurrent backfill degrades to a no-op.
+- **Two-phase `Approve` race** (staged row changes between phases) → the second call
+  re-reads the staged row and re-checks the conflict; if the staged row is gone, the
+  existing idempotent "already approved" success path applies.
+- **BSR gap** (backend/frontend can't build until codegen) → prepare downstream branches
+  against planned types with a swap TODO; open PRs only after the package upgrade.
+
+## Migration Plan
+
+No DB migration. Deploy order: (1) backend PR with D1+D2 (backend-only) → release → prod
+verify 和歌山 approves and stale duplicates dedup; (2) specification PR with D4 schema →
+release → BSR codegen; (3) backend PR consuming the `resolution`/`conflict` fields
+(D3/D4) + frontend PR with the dialog → releases → prod verify reconciliation end to end.
+Rollback: each PR is independently revertible; the two-phase `Approve` degrades to the
+current behavior if `resolution` is ignored, and D1 only broadens venue lookup so it is
+safe to revert to the insert-only path. Blast radius of D1 is small: `VenueRepository.Create`
+has a single caller (`createVenueFromStaged` on the approval path — confirmed), so the
+discovery/staging pipeline is unaffected by the create-path change.
+
+## Open Questions
+
+- D2: confirm during implementation whether name normalization (a) alone clears the
+  observed prod drift, or whether resolve-first-then-dedup (b) is needed for a subset.
+- Whether to run a one-off cleanup pass over the existing ~19 stale staged rows via the
+  new reconciliation path, or let reviewers clear them manually post-deploy.

--- a/openspec/changes/fix-concert-approval-dedup/proposal.md
+++ b/openspec/changes/fix-concert-approval-dedup/proposal.md
@@ -1,0 +1,76 @@
+## Why
+
+Approving discovered concerts in the admin console fails with two hard errors —
+`already_exists` (duplicate venue) and `failed_precondition` (equivalent event
+already exists) — because dedup and identity are keyed on values that are not
+stable across discovery runs. Google Places returns different `place_id`s for the
+same physical venue (confirmed in prod: 和歌山ビッグホエール has two CIDs), and
+Gemini returns the same venue under different `listed_venue_name` strings
+(`フェスティバルホール` vs `大阪・フェスティバルホール`). The result: the approval
+pipeline cannot recognise a venue/event it already created, so it crashes on the
+unique constraint or dead-ends the reviewer. In one prod snapshot, at least 19
+of 234 staged rows are stale re-discoveries that cannot be approved.
+
+## What Changes
+
+- **Venue resolution at approval becomes idempotent get-or-create.** Resolve by
+  `google_place_id` first; on miss, fall back to `(listed_venue_name, admin_area)`;
+  create only if neither matches, using `INSERT ... ON CONFLICT DO NOTHING` with a
+  re-SELECT so a lost race or either unique index resolves to the existing row
+  instead of erroring. The `admin_area` used for the fallback lookup and the insert
+  MUST be derived the same way. `place_id` is authoritative; a found venue's NULL
+  `place_id` MAY be backfilled, but an existing non-NULL `place_id` is never
+  overwritten. Fixes the `already_exists` crash.
+- **Discovery dedup keys on a stable venue identity, not the raw scraped string.**
+  The pre-staging dedup against existing events and pending staged rows SHALL match
+  on a normalized/canonical venue identity so that name-drift re-discoveries are
+  recognised as already-known and are not re-staged. Reduces stale queue growth.
+- **Approval reconciles a duplicate event instead of dead-ending.** When an
+  approved staged concert maps to an event that already exists at the same
+  `(venue_id, local_event_date, start_at)`, the reviewer is offered a choice
+  between the existing record and the staged record rather than receiving
+  `failed_precondition`. **BREAKING**: the admin `Approve` RPC gains a `resolution`
+  input and a duplicate-conflict output (a proto/schema change).
+- **Reconciliation is record-level.** Choosing "keep existing" logs the staged row
+  to the rejection log with a duplicate reason and deletes it; choosing "adopt
+  staged" overwrites the existing event's display fields
+  (`listed_venue_name`, start/open time, title) while leaving `venue_id` and
+  `place_id` untouched, then deletes the staged row.
+
+## Capabilities
+
+### New Capabilities
+<!-- none — reuse existing capabilities -->
+
+### Modified Capabilities
+- `venue-normalization`: venue lookup/create becomes an idempotent get-or-create with
+  `place_id`-authoritative identity, `(listed_venue_name, admin_area)` fallback,
+  `ON CONFLICT DO NOTHING` + re-SELECT, unified `admin_area` derivation, and NULL-only
+  `place_id` backfill.
+- `concert-search`: the concert-dedup natural key SHALL match on a stable venue
+  identity so venue-name drift across runs does not defeat dedup against existing
+  events and pending staged rows.
+- `concert-approval-queue`: approval SHALL resolve venues idempotently and SHALL
+  reconcile a duplicate existing event via reviewer choice instead of failing;
+  "keep existing" logs+deletes the staged row, "adopt staged" overwrites the
+  existing event's display fields.
+- `admin-concert-management`: the admin `ConcertService.Approve` RPC SHALL accept a
+  `resolution` selector and SHALL return a duplicate-conflict result carrying the
+  existing event's fields when an unresolved duplicate is detected.
+
+## Impact
+
+- **Schema (specification repo / BSR)**: `rpc/admin/v1` `ConcertService.Approve`
+  request/response messages gain conflict + resolution fields. Requires a
+  specification release → BSR codegen before backend/frontend can consume the
+  generated types (Cross-Repo Release Coordination).
+- **Backend (Go)**: `resolveOrCreateVenue` / `createVenueFromStaged` in
+  `internal/usecase/concert_admin_uc.go`; `VenueRepository.Create`/lookups in
+  `internal/infrastructure/database/rdb/venue_repo.go`; `SearchNewConcerts` dedup in
+  `internal/usecase/concert_uc.go` + `internal/entity/concert.go` (`FilterNew`);
+  the admin `Approve` handler + usecase. No DB migration required (constraints and
+  indexes already exist).
+- **Frontend (Aurelia/TypeScript)**: admin console approval action gains a
+  duplicate-reconciliation dialog (record-level keep-existing / adopt-staged).
+- **Data**: existing stale staged rows become approvable/clearable through the new
+  reconciliation path.

--- a/openspec/changes/fix-concert-approval-dedup/specs/admin-concert-management/spec.md
+++ b/openspec/changes/fix-concert-approval-dedup/specs/admin-concert-management/spec.md
@@ -1,0 +1,46 @@
+## ADDED Requirements
+
+### Requirement: Approve resolves duplicate-event conflicts via a resolution selector
+
+The admin `liverty_music.rpc.admin.v1.ConcertService.Approve` RPC SHALL accept an optional
+`resolution` selector with the values `RESOLUTION_UNSPECIFIED`, `KEEP_EXISTING`, and
+`ADOPT_STAGED`. When invoked with `RESOLUTION_UNSPECIFIED` (or the field unset) and the
+staged concert maps onto an already-published event at the resolved
+`(venue_id, local_event_date, start_at)`, the response SHALL carry a duplicate-conflict
+result describing the existing event (its display fields) alongside the staged preview, and
+the call SHALL NOT mutate state. When invoked with `KEEP_EXISTING` or `ADOPT_STAGED`, the
+RPC SHALL apply the corresponding reconciliation outcome and complete the approval. A
+non-duplicate approval SHALL behave exactly as before regardless of the `resolution` value.
+The RPC SHALL remain idempotent and SHALL stay a single verb (`Approve`); no separate
+conflict-resolution RPC is introduced. The RPC SHALL capture the calling reviewer's identity
+so that a `KEEP_EXISTING` outcome can record it on the `rejected_concerts_log` entry.
+
+#### Scenario: First approve of a duplicate returns a conflict
+
+- **WHEN** an admin invokes `Approve` for a staged concert with `resolution` unset
+- **AND** the staged concert maps onto an already-existing event
+- **THEN** the response SHALL contain a duplicate-conflict result with the existing event's
+  display fields and the staged preview
+- **AND** the call SHALL NOT mutate the event or the staged row
+
+#### Scenario: Approve with KEEP_EXISTING resolves the conflict
+
+- **WHEN** an admin invokes `Approve` for the same staged concert with
+  `resolution = KEEP_EXISTING`
+- **THEN** the system SHALL apply the keep-existing reconciliation outcome
+- **AND** the response SHALL indicate the staged row was cleared without changing the event
+
+#### Scenario: Approve with ADOPT_STAGED resolves the conflict
+
+- **WHEN** an admin invokes `Approve` for the same staged concert with
+  `resolution = ADOPT_STAGED`
+- **THEN** the system SHALL apply the adopt-staged reconciliation outcome
+- **AND** the response SHALL indicate the existing event's `listed_venue_name` was updated
+  (and any NULL start/open time filled), leaving `venue_id`, `google_place_id`, and series
+  title unchanged
+
+#### Scenario: Non-duplicate approve is unaffected by the selector
+
+- **WHEN** an admin invokes `Approve` for a staged concert whose event does not yet exist
+- **THEN** the concert SHALL be published normally
+- **AND** the `resolution` value SHALL have no effect on the outcome

--- a/openspec/changes/fix-concert-approval-dedup/specs/concert-approval-queue/spec.md
+++ b/openspec/changes/fix-concert-approval-dedup/specs/concert-approval-queue/spec.md
@@ -1,0 +1,87 @@
+## MODIFIED Requirements
+
+### Requirement: Approval publishes the concert
+
+The system SHALL provide an approval operation that, given a `pending` staged concert,
+resolves the venue idempotently (see the venue get-or-create requirement), inserts the
+published `series`/`events`/`event_performers` rows (reusing the existing bulk-insert and
+natural-key UPSERT behavior), removes the staged row, and publishes `CONCERT.created`.
+When approval maps the staged concert onto an event that already exists at the resolved
+`(venue_id, local_event_date, start_at)`, the operation SHALL NOT dead-end with
+`failed_precondition`; instead it SHALL return a duplicate-conflict outcome for reviewer
+reconciliation (see the duplicate-event reconciliation requirement).
+
+#### Scenario: Approve publishes and notifies
+
+- **WHEN** a developer approves a `pending` staged concert whose event does not yet exist
+- **THEN** the system SHALL insert the published event (and its series and performers)
+- **AND** SHALL delete the staged row
+- **AND** SHALL publish `CONCERT.created` so downstream notification consumers run
+
+#### Scenario: Approve is idempotent
+
+- **WHEN** an approve operation targets a staged concert that no longer exists (already
+  approved or rejected)
+- **THEN** the operation SHALL succeed without error and SHALL NOT create a duplicate event
+
+#### Scenario: Approve of an existing-event duplicate does not crash
+
+- **WHEN** an approve operation maps a staged concert onto an event that already exists at
+  the resolved `(venue_id, local_event_date, start_at)`
+- **THEN** the operation SHALL NOT return `already_exists` or `failed_precondition`
+- **AND** SHALL surface a duplicate-conflict outcome instead
+
+## ADDED Requirements
+
+### Requirement: Approval reconciles a duplicate existing event
+
+The system SHALL, when approval detects that a staged concert corresponds to an
+already-published event at the same resolved `(venue_id, local_event_date, start_at)` —
+covering both the exact-start duplicate and the unknown-start staged versus known-start
+existing case — present the reviewer a record-level choice between the existing event and
+the staged record and apply exactly one of two outcomes. The reconciliation SHALL only affect the
+event's venue display name and any missing start/open time; it SHALL NOT change `venue_id`,
+`google_place_id`, or the series title, because both sides already resolve to the same venue
+and the title is shared across every member event of the series. On a keep-existing choice the
+system SHALL append the staged row to the `rejected_concerts_log` with a duplicate reason and
+SHALL delete the staged row, leaving the existing event unchanged; the reviewer identity SHALL
+be captured on the log entry. On an adopt-staged choice the system SHALL overwrite the existing
+event's `listed_venue_name` from the staged record and SHALL fill `start_at`/`open_at` only
+where the existing value is NULL (a known start/open time SHALL NEVER be overwritten with a
+staged NULL); it SHALL leave `venue_id`, `google_place_id`, and the series title unchanged, and
+SHALL delete the staged row. An approval that reaches this path without an explicit reviewer
+choice SHALL make no mutation and SHALL report the conflict.
+
+#### Scenario: Reviewer keeps the existing event
+
+- **WHEN** a duplicate existing event is detected and the reviewer chooses to keep the
+  existing record
+- **THEN** the system SHALL append the staged row to the `rejected_concerts_log` with a
+  duplicate reason and the reviewer identity
+- **AND** SHALL delete the staged row
+- **AND** SHALL leave the existing event unchanged
+
+#### Scenario: Reviewer adopts the staged record
+
+- **WHEN** a duplicate existing event is detected and the reviewer chooses to adopt the
+  staged record
+- **THEN** the system SHALL overwrite the existing event's `listed_venue_name` from the
+  staged record
+- **AND** SHALL fill `start_at`/`open_at` only where the existing value is NULL
+- **AND** SHALL leave the event's `venue_id`, `google_place_id`, and series title unchanged
+- **AND** SHALL delete the staged row
+
+#### Scenario: Adopt never overwrites a known start time with a staged NULL
+
+- **WHEN** the existing event has a known `start_at` and the staged record has a NULL
+  `start_at`
+- **AND** the reviewer chooses to adopt the staged record
+- **THEN** the system SHALL keep the existing known `start_at`
+- **AND** SHALL still update the `listed_venue_name` from the staged record
+
+#### Scenario: Conflict without a choice makes no change
+
+- **WHEN** approval detects a duplicate existing event but the caller supplied no
+  reconciliation choice
+- **THEN** the system SHALL NOT mutate the event or the staged row
+- **AND** SHALL report the duplicate conflict with the existing event's fields for review

--- a/openspec/changes/fix-concert-approval-dedup/specs/concert-search/spec.md
+++ b/openspec/changes/fix-concert-approval-dedup/specs/concert-search/spec.md
@@ -1,0 +1,38 @@
+## ADDED Requirements
+
+### Requirement: Dedup Tolerates Venue Name Drift
+
+The concert dedup natural key SHALL compare its `listed_venue_name` component (as defined by
+the "Concert Deduplication Natural Key" requirement) on a normalized form rather than as a raw
+string, so that the same physical venue reported
+under different surface strings across discovery runs (for example
+`フェスティバルホール` vs `大阪・フェスティバルホール`, or `新潟テルサ` vs
+`新潟・新潟テルサ`) is recognised as the same venue and does not defeat deduplication
+against existing events or pending staged rows. Normalization SHALL at minimum fold
+whitespace and full/half-width variants and strip leading administrative-area or
+city-prefix decorations (e.g. `〈admin_area〉・`, `〈city〉公演 ＠`). The `(local_event_date,
+start_at)` components of the natural key SHALL be unchanged. The event natural key
+`(venue_id, local_event_date, start_at)` SHALL remain the final database-level safety net
+when normalization is insufficient.
+
+#### Scenario: Prefixed venue name matches the same unprefixed venue
+
+- **WHEN** a scraped concert has `listed_venue_name = "フェスティバルホール"`
+- **AND** an existing event at the same `local_event_date` and `start_at` was stored with
+  `listed_venue_name = "大阪・フェスティバルホール"`
+- **THEN** the scraped concert SHALL be treated as a duplicate after name normalization
+- **AND** SHALL NOT be published in the `concert.discovered.v1` event
+
+#### Scenario: Normalization does not merge genuinely different venues
+
+- **WHEN** two scraped concerts share `local_event_date` and `start_at`
+- **AND** their venue names normalize to different values
+- **THEN** they SHALL remain distinct events
+- **AND** both SHALL be eligible for publication
+
+#### Scenario: Drifted name recognised against a pending staged row
+
+- **WHEN** a scraped concert normalizes to the same venue, date, and start as a concert
+  already present in the approval queue in `pending` state
+- **THEN** the scraped concert SHALL be treated as already-known
+- **AND** SHALL NOT be re-staged

--- a/openspec/changes/fix-concert-approval-dedup/specs/venue-normalization/spec.md
+++ b/openspec/changes/fix-concert-approval-dedup/specs/venue-normalization/spec.md
@@ -1,0 +1,70 @@
+## ADDED Requirements
+
+### Requirement: Idempotent venue get-or-create with place_id-authoritative identity
+
+The venue lookup-or-create path SHALL be idempotent and SHALL NOT fail when a venue
+matching the resolved identity already exists. This path runs only when a staged concert is
+approved (the sole caller that creates a `venues` row), and it supersedes the insert-only
+create step described by the "Venue Resolution During Concert Creation" requirement. Identity
+SHALL be resolved in this order:
+(1) by `google_place_id` when the staged/scraped concert carries one; (2) on miss, by
+`(listed_venue_name, admin_area)`; (3) only when neither matches SHALL a new `venues`
+row be created. Creation SHALL use `INSERT … ON CONFLICT DO NOTHING` (untargeted, so a
+violation on either the `google_place_id` partial-unique index or the
+`(listed_venue_name, admin_area)` partial-unique index is absorbed) followed by a
+re-SELECT on the same keys, so a lost race or a divergent identity resolves to the
+existing row rather than surfacing an `already_exists` error.
+
+The `admin_area` used for the `(listed_venue_name, admin_area)` fallback lookup and the
+`admin_area` written on insert SHALL be derived identically (the resolved admin_area when
+present, otherwise the raw scraped admin_area), so the read key and the write key never
+diverge.
+
+When the fallback lookup finds a venue whose `google_place_id` is NULL and the incoming
+concert carries a resolved `google_place_id`, the system MAY backfill that value; it
+SHALL NEVER overwrite an existing non-NULL `google_place_id`.
+
+#### Scenario: No existing venue — a new row is created
+
+- **WHEN** neither `google_place_id` nor `(listed_venue_name, admin_area)` matches an
+  existing venue
+- **THEN** the system SHALL insert a new `venues` row for the resolved identity
+- **AND** SHALL return the newly created venue id
+
+#### Scenario: Existing venue found by place_id
+
+- **WHEN** a venue with the resolved `google_place_id` already exists
+- **THEN** the system SHALL return that venue
+- **AND** SHALL NOT attempt an insert
+
+#### Scenario: place_id miss falls back to listed name and admin_area
+
+- **WHEN** the resolved `google_place_id` does not match any existing venue
+- **AND** a venue with the same `(listed_venue_name, admin_area)` already exists (with a
+  different or NULL `google_place_id`)
+- **THEN** the system SHALL return that existing venue
+- **AND** SHALL NOT attempt to insert a new venue row
+- **AND** SHALL NOT raise `already_exists`
+
+#### Scenario: Concurrent create resolves to a single row
+
+- **WHEN** two approvals resolve the same venue identity concurrently and both reach the
+  insert step
+- **THEN** the `ON CONFLICT DO NOTHING` insert SHALL suppress the losing insert
+- **AND** the losing path SHALL re-SELECT by `google_place_id` then by
+  `(listed_venue_name, admin_area)` and return the surviving row
+
+#### Scenario: Fallback lookup and insert use the same admin_area
+
+- **WHEN** a concert has a raw `admin_area` and no resolved `admin_area`
+- **THEN** the fallback lookup and any subsequent insert SHALL both use the raw
+  `admin_area`
+- **AND** the lookup SHALL therefore match a row the insert would have collided with
+
+#### Scenario: NULL place_id backfilled, non-NULL never overwritten
+
+- **WHEN** the fallback finds an existing venue whose `google_place_id` is NULL
+- **AND** the incoming concert carries a resolved `google_place_id`
+- **THEN** the system MAY set the existing row's `google_place_id` to the resolved value
+- **WHEN** the existing venue already has a non-NULL `google_place_id`
+- **THEN** the system SHALL leave it unchanged

--- a/openspec/changes/fix-concert-approval-dedup/tasks.md
+++ b/openspec/changes/fix-concert-approval-dedup/tasks.md
@@ -1,0 +1,45 @@
+## 1. Backend — venue get-or-create (A-1, no proto, ships first)
+
+- [ ] 1.1 Extract a single `admin_area` derivation helper (`resolved_admin_area ?? admin_area`) and use it for both the `(listed_venue_name, admin_area)` lookup and the insert in `internal/usecase/concert_admin_uc.go`
+- [ ] 1.2 In `resolveOrCreateVenue`, on `GetByPlaceID` miss fall back to `GetByListedName(listed_venue_name, admin_area)` before creating (covers the different-place_id case)
+- [ ] 1.3 Change `VenueRepository.Create` to `INSERT … ON CONFLICT DO NOTHING` (untargeted) with a re-SELECT by `google_place_id` then `(listed_venue_name, admin_area)` on suppressed insert; return the surviving row id in `internal/infrastructure/database/rdb/venue_repo.go` — this changes the method signature to return the id, so update the repo interface and the `createVenueFromStaged` caller
+- [ ] 1.4 Backfill `google_place_id` only when the found venue's value is NULL; never overwrite a non-NULL value. The backfill UPDATE cannot use untargeted `ON CONFLICT`, so catch a unique violation on `idx_venues_google_place_id` and degrade to a no-op (concurrent backfill)
+- [ ] 1.5 Unit/integration tests: different place_id → returns existing venue; concurrent create → single row; admin_area symmetry; NULL-only backfill (follow go-tester conventions, use local docker compose postgres)
+- [ ] 1.6 `make check` green; open backend PR for A-1 as a standalone fix
+
+## 2. Backend — discovery dedup tolerates name drift (B, no proto)
+
+- [ ] 2.1 Add a venue-name normalization function (fold whitespace + full/half-width, strip leading `〈admin_area〉・` / `〈city〉公演 ＠` prefixes) with unit tests over the observed prod drift cases
+- [ ] 2.2 Apply normalization to the `listed_venue_name` component of the dedup key on BOTH sides of the comparison (scraped concert and the existing event/pending-staged name) in `entity.ScrapedConcerts.FilterNew` and the pending-staged dedup in `SearchNewConcerts`, keeping `(local_event_date, start_at)` unchanged
+- [ ] 2.3 Tests: prefixed vs unprefixed name dedups; genuinely different venues stay distinct; drifted name matches a pending staged row
+- [ ] 2.4 Confirm during implementation whether normalization alone clears the prod drift; if not, record the resolve-first-then-dedup fallback decision (design D2b) in this change
+- [ ] 2.5 `make check` green; open backend PR for B (may bundle with A-1 or ship separately)
+
+## 3. Specification — Approve RPC resolution + conflict (A-2 schema)
+
+- [ ] 3.1 Add a `resolution` enum (`RESOLUTION_UNSPECIFIED`, `KEEP_EXISTING`, `ADOPT_STAGED`) to the admin `ConcertService.Approve` request in the `rpc/admin/v1` proto
+- [ ] 3.2 Add a duplicate-conflict result to the `Approve` response carrying the existing event's display fields plus the staged preview; add protovalidate constraints; buf lint/format/breaking clean
+- [ ] 3.3 Open specification PR; after review + CI, merge and publish a GitHub Release to trigger BSR codegen (CI-only — do not run buf push/generate locally)
+- [ ] 3.4 Monitor `buf-release.yml` until BSR codegen completes
+
+## 4. Backend — approval reconciliation (A-2, consumes generated types)
+
+- [ ] 4.1 Upgrade the generated schema package (`go get buf.build/gen/go/liverty-music/schema/...@vX.Y.Z`, `go mod tidy`)
+- [ ] 4.2 In the admin `Approve` handler + usecase, replace the zero-insert `FailedPrecondition` path: when a duplicate existing event is detected and `resolution` is unset, return the duplicate-conflict result without mutating
+- [ ] 4.3 Implement `KEEP_EXISTING`: append staged row to `rejected_concerts_log` with a duplicate reason and the calling reviewer's identity (thread reviewer id through the `Approve` handler like `Reject` already does), delete staged row, leave event unchanged
+- [ ] 4.4 Implement `ADOPT_STAGED`: overwrite existing event `listed_venue_name`, fill `start_at`/`open_at` via COALESCE only where currently NULL (never null out a known time), leave `venue_id`/`google_place_id` and the shared `series.title` unchanged, delete staged row
+- [ ] 4.5 Ensure two-phase idempotency: second call re-reads the staged row and re-checks the conflict; missing staged row hits the existing "already approved" success path
+- [ ] 4.6 Tests for all three resolution paths + no-choice conflict; `make check` green
+
+## 5. Frontend — reconciliation dialog (A-2, consumes generated types)
+
+- [ ] 5.1 Upgrade the generated schema package (`npm install @buf/liverty-music_schema.connectrpc_es@latest`)
+- [ ] 5.2 In the admin console approval action, when `Approve` returns a duplicate-conflict, open a record-level dialog showing existing vs staged (venue display name, start/open time, title)
+- [ ] 5.3 Wire the two choices to re-call `Approve` with `KEEP_EXISTING` / `ADOPT_STAGED`; refresh the queue on success
+- [ ] 5.4 Component/e2e coverage per frontend testing conventions; `make check` green
+
+## 6. Release & prod verification
+
+- [ ] 6.1 Release backend A-1/B; verify in prod that 和歌山ビッグホエール approves without `already_exists` and drift duplicates dedup at discovery
+- [ ] 6.2 Release backend A-2 + frontend A-2 (after BSR); verify the reconciliation dialog end to end in prod (keep-existing clears + logs; adopt-staged updates display fields)
+- [ ] 6.3 Decide and execute cleanup of the existing ~19 stale staged rows (via the new reconciliation path or manual review); confirm the pending queue no longer holds unapprovable duplicates


### PR DESCRIPTION
## 🔗 Related Issue

Closes #703

## 📝 Summary of Changes

Adds the OpenSpec change **`fix-concert-approval-dedup`** (proposal, design, delta specs, tasks). No proto edits in this PR — the schema change is scoped as a task and lands in a follow-up specification PR per the cross-repo release flow.

### Why

Admin console approve fails with two hard errors — `already_exists` (duplicate venue) and `failed_precondition` (equivalent event exists) — because dedup and identity are keyed on values that drift across discovery runs. Verified against prod: Google Places returns two different `place_id`s for 和歌山ビッグホエール, and Gemini returns the same venue under different `listed_venue_name` strings (`フェスティバルホール` vs `大阪・フェスティバルホール`). At least 19 of 234 staged rows are stale, unapprovable duplicates.

### What the change specifies

- **A-1 — idempotent venue get-or-create** (`venue-normalization`): resolve by `google_place_id`, fall back to `(listed_venue_name, admin_area)`, create via `INSERT … ON CONFLICT DO NOTHING` + re-SELECT. `place_id`-authoritative, unified `admin_area` derivation, NULL-only `place_id` backfill. Fixes `already_exists`. No proto.
- **B — discovery dedup tolerates name drift** (`concert-search`): compare the `listed_venue_name` component of the dedup key on a normalized form so re-discoveries are recognised as known. No proto.
- **A-2 — approval reconciles a duplicate event** (`concert-approval-queue`, `admin-concert-management`): when an approved concert maps to an existing event, offer the reviewer a record-level choice (keep-existing → log + delete staged; adopt-staged → overwrite venue display name, NULL-only start/open fill, never touch `venue_id` / `place_id` / series title) instead of failing. **The admin `Approve` RPC gains a `resolution` input and a duplicate-conflict output** (schema change, scoped as a task).

### Scope / rollout

A-1 and B are backend-only and ship first; A-2 follows the specification → BSR → backend/frontend order. This PR contains specification artifacts only.

## ✅ Self-Checklist

- [x] I have linked the related issue.
- [x] OpenSpec artifacts validate (`openspec validate fix-concert-approval-dedup --strict`).
- [ ] `buf lint` / `buf format` — N/A, no proto changes in this PR.
- [x] Breaking changes documented — the `Approve` RPC change is scoped as a task, not made in this PR.
