### PR TITLE
feat(admin/concert): Approve resolution selector and duplicate-conflict result

### DIFF
--- a/openspec/changes/fix-concert-approval-dedup/design.md
+++ b/openspec/changes/fix-concert-approval-dedup/design.md
@@ -179,5 +179,13 @@ discovery/staging pipeline is unaffected by the create-path change.
 
 - D2: confirm during implementation whether name normalization (a) alone clears the
   observed prod drift, or whether resolve-first-then-dedup (b) is needed for a subset.
+  - **Resolved (2026-07-25): normalization (a) alone is sufficient; D2b is NOT taken.**
+    `entity.NormalizeVenueName` (NFKC full/half-width fold, whitespace collapse, and
+    stripping of the `〈admin_area〉・` and `〈city〉公演 ＠` location prefixes) collapses
+    all observed prod-drift cases — including `フェスティバルホール` ⇄
+    `大阪・フェスティバルホール` (16 of 19 collision rows). Resolve-first-then-dedup (b)
+    would add a Places call ahead of dedup for concerts that turn out to be duplicates,
+    so it is deferred; the event natural key remains the DB-level safety net and D3
+    reconciliation catches anything the heuristic misses at approval.
 - Whether to run a one-off cleanup pass over the existing ~19 stale staged rows via the
   new reconciliation path, or let reviewers clear them manually post-deploy.

--- a/openspec/changes/fix-concert-approval-dedup/tasks.md
+++ b/openspec/changes/fix-concert-approval-dedup/tasks.md
@@ -1,24 +1,24 @@
 ## 1. Backend — venue get-or-create (A-1, no proto, ships first)
 
-- [ ] 1.1 Extract a single `admin_area` derivation helper (`resolved_admin_area ?? admin_area`) and use it for both the `(listed_venue_name, admin_area)` lookup and the insert in `internal/usecase/concert_admin_uc.go`
-- [ ] 1.2 In `resolveOrCreateVenue`, on `GetByPlaceID` miss fall back to `GetByListedName(listed_venue_name, admin_area)` before creating (covers the different-place_id case)
-- [ ] 1.3 Change `VenueRepository.Create` to `INSERT … ON CONFLICT DO NOTHING` (untargeted) with a re-SELECT by `google_place_id` then `(listed_venue_name, admin_area)` on suppressed insert; return the surviving row id in `internal/infrastructure/database/rdb/venue_repo.go` — this changes the method signature to return the id, so update the repo interface and the `createVenueFromStaged` caller
-- [ ] 1.4 Backfill `google_place_id` only when the found venue's value is NULL; never overwrite a non-NULL value. The backfill UPDATE cannot use untargeted `ON CONFLICT`, so catch a unique violation on `idx_venues_google_place_id` and degrade to a no-op (concurrent backfill)
-- [ ] 1.5 Unit/integration tests: different place_id → returns existing venue; concurrent create → single row; admin_area symmetry; NULL-only backfill (follow go-tester conventions, use local docker compose postgres)
+- [x] 1.1 Extract a single `admin_area` derivation helper (`resolved_admin_area ?? admin_area`) and use it for both the `(listed_venue_name, admin_area)` lookup and the insert in `internal/usecase/concert_admin_uc.go`
+- [x] 1.2 In `resolveOrCreateVenue`, on `GetByPlaceID` miss fall back to `GetByListedName(listed_venue_name, admin_area)` before creating (covers the different-place_id case)
+- [x] 1.3 Change `VenueRepository.Create` to `INSERT … ON CONFLICT DO NOTHING` (untargeted) with a re-SELECT by `google_place_id` then `(listed_venue_name, admin_area)` on suppressed insert; return the surviving row id in `internal/infrastructure/database/rdb/venue_repo.go` — this changes the method signature to return the id, so update the repo interface and the `createVenueFromStaged` caller
+- [x] 1.4 Backfill `google_place_id` only when the found venue's value is NULL; never overwrite a non-NULL value. The backfill UPDATE cannot use untargeted `ON CONFLICT`, so catch a unique violation on `idx_venues_google_place_id` and degrade to a no-op (concurrent backfill)
+- [x] 1.5 Unit/integration tests: different place_id → returns existing venue; concurrent create → single row; admin_area symmetry; NULL-only backfill (follow go-tester conventions, use local docker compose postgres)
 - [ ] 1.6 `make check` green; open backend PR for A-1 as a standalone fix
 
 ## 2. Backend — discovery dedup tolerates name drift (B, no proto)
 
-- [ ] 2.1 Add a venue-name normalization function (fold whitespace + full/half-width, strip leading `〈admin_area〉・` / `〈city〉公演 ＠` prefixes) with unit tests over the observed prod drift cases
-- [ ] 2.2 Apply normalization to the `listed_venue_name` component of the dedup key on BOTH sides of the comparison (scraped concert and the existing event/pending-staged name) in `entity.ScrapedConcerts.FilterNew` and the pending-staged dedup in `SearchNewConcerts`, keeping `(local_event_date, start_at)` unchanged
-- [ ] 2.3 Tests: prefixed vs unprefixed name dedups; genuinely different venues stay distinct; drifted name matches a pending staged row
-- [ ] 2.4 Confirm during implementation whether normalization alone clears the prod drift; if not, record the resolve-first-then-dedup fallback decision (design D2b) in this change
+- [x] 2.1 Add a venue-name normalization function (fold whitespace + full/half-width, strip leading `〈admin_area〉・` / `〈city〉公演 ＠` prefixes) with unit tests over the observed prod drift cases
+- [x] 2.2 Apply normalization to the `listed_venue_name` component of the dedup key on BOTH sides of the comparison (scraped concert and the existing event/pending-staged name) in `entity.ScrapedConcerts.FilterNew` and the pending-staged dedup in `SearchNewConcerts`, keeping `(local_event_date, start_at)` unchanged
+- [x] 2.3 Tests: prefixed vs unprefixed name dedups; genuinely different venues stay distinct; drifted name matches a pending staged row
+- [x] 2.4 Confirm during implementation whether normalization alone clears the prod drift; if not, record the resolve-first-then-dedup fallback decision (design D2b) in this change — resolved: normalization (a) is sufficient, D2b deferred (design.md Open Questions)
 - [ ] 2.5 `make check` green; open backend PR for B (may bundle with A-1 or ship separately)
 
 ## 3. Specification — Approve RPC resolution + conflict (A-2 schema)
 
-- [ ] 3.1 Add a `resolution` enum (`RESOLUTION_UNSPECIFIED`, `KEEP_EXISTING`, `ADOPT_STAGED`) to the admin `ConcertService.Approve` request in the `rpc/admin/v1` proto
-- [ ] 3.2 Add a duplicate-conflict result to the `Approve` response carrying the existing event's display fields plus the staged preview; add protovalidate constraints; buf lint/format/breaking clean
+- [x] 3.1 Add a `resolution` enum (`RESOLUTION_UNSPECIFIED`, `KEEP_EXISTING`, `ADOPT_STAGED`) to the admin `ConcertService.Approve` request in the `rpc/admin/v1` proto
+- [x] 3.2 Add a duplicate-conflict result to the `Approve` response carrying the existing event's display fields plus the staged preview; add protovalidate constraints; buf lint/format/breaking clean
 - [ ] 3.3 Open specification PR; after review + CI, merge and publish a GitHub Release to trigger BSR codegen (CI-only — do not run buf push/generate locally)
 - [ ] 3.4 Monitor `buf-release.yml` until BSR codegen completes
 

--- a/proto/liverty_music/rpc/admin/v1/concert_service.proto
+++ b/proto/liverty_music/rpc/admin/v1/concert_service.proto
@@ -55,6 +55,15 @@ service ConcertService {
   // notification. The operation is idempotent: approving a staged concert that no
   // longer exists succeeds without creating a duplicate.
   //
+  // Approve is two-phase for duplicate events. When the staged concert maps onto
+  // an already-published event at the same resolved (venue, date, start time) and
+  // the request's `resolution` is unset, the response carries a
+  // `DuplicateConflict` (the existing event's display fields plus the staged
+  // preview) and NO state is mutated; the reviewer then re-invokes Approve with a
+  // `resolution` of `RESOLUTION_KEEP_EXISTING` or `RESOLUTION_ADOPT_STAGED`. A
+  // non-duplicate approval publishes normally regardless of the `resolution`
+  // value.
+  //
   // Possible errors:
   // - PERMISSION_DENIED: The caller is not a member of the admin organization.
   // - INVALID_ARGUMENT: The staged concert id is missing or malformed.
@@ -157,14 +166,81 @@ message ListPendingResponse {
   repeated PendingConcert pending_concerts = 1;
 }
 
-// ApproveRequest identifies the staged concert to publish.
+// Resolution selects how Approve reconciles a staged concert that duplicates an
+// already-published event. It is only consulted when a duplicate is detected; a
+// non-duplicate approval ignores it.
+enum Resolution {
+  // Default: no reconciliation choice. On a duplicate, Approve returns a
+  // DuplicateConflict without mutating state; otherwise it publishes normally.
+  RESOLUTION_UNSPECIFIED = 0;
+
+  // Keep the existing event unchanged: record the staged row in the rejection log
+  // with a duplicate reason (attributed to the calling reviewer) and clear it from
+  // the queue.
+  RESOLUTION_KEEP_EXISTING = 1;
+
+  // Adopt the staged row's display representation: overwrite the existing event's
+  // listed venue name and fill its start/open time only where currently unset,
+  // leaving venue identity (venue_id, place_id) and the shared series title
+  // untouched, then clear the staged row.
+  RESOLUTION_ADOPT_STAGED = 2;
+}
+
+// ExistingEvent is the display-field preview of an already-published event that a
+// staged concert collides with. It carries only what the reviewer needs to choose
+// a resolution; venue identity is intentionally omitted because reconciliation
+// never changes it.
+message ExistingEvent {
+  // The unique identifier of the already-published event.
+  entity.v1.EventId event_id = 1 [(buf.validate.field).required = true];
+
+  // The descriptive title of the existing event (from its shared series).
+  entity.v1.Title title = 2 [(buf.validate.field).required = true];
+
+  // The venue name currently stored on the existing event (its display field,
+  // the one ADOPT_STAGED would overwrite).
+  entity.v1.ListedVenueName listed_venue_name = 3 [(buf.validate.field).required = true];
+
+  // The local calendar date of the existing event.
+  entity.v1.LocalDate local_date = 4 [(buf.validate.field).required = true];
+
+  // The existing event's start time. Absent when the stored start time is unknown.
+  entity.v1.StartTime start_time = 5;
+
+  // The existing event's door-open time. Absent when the stored open time is unknown.
+  entity.v1.OpenTime open_time = 6;
+}
+
+// DuplicateConflict describes a staged concert that maps onto an already-published
+// event, offering the reviewer both records so they can choose a resolution.
+message DuplicateConflict {
+  // The already-published event the staged concert collides with.
+  ExistingEvent existing = 1 [(buf.validate.field).required = true];
+
+  // The staged concert the reviewer proposed to publish.
+  PendingConcert staged = 2 [(buf.validate.field).required = true];
+}
+
+// ApproveRequest identifies the staged concert to publish and, on a second pass,
+// how to reconcile a detected duplicate.
 message ApproveRequest {
   // Required. The unique identifier of the staged concert to approve.
   entity.v1.StagedConcertId staged_id = 1 [(buf.validate.field).required = true];
+
+  // Optional. How to reconcile a duplicate existing event. Left unset on the first
+  // call; set to a concrete choice when re-invoking after a DuplicateConflict.
+  Resolution resolution = 2 [(buf.validate.field).enum.defined_only = true];
 }
 
-// ApproveResponse is returned upon successful approval.
-message ApproveResponse {}
+// ApproveResponse is returned upon successful approval, or carries a
+// DuplicateConflict when the first pass detected an unresolved duplicate.
+message ApproveResponse {
+  // Set only when the staged concert duplicates an existing event and the request
+  // carried `RESOLUTION_UNSPECIFIED`; in that case no state was mutated and the
+  // reviewer must re-invoke Approve with a resolution. Absent on a successful
+  // approval or reconciliation.
+  DuplicateConflict conflict = 1;
+}
 
 // RejectRequest identifies the staged concert to drop and the reason why.
 message RejectRequest {


### PR DESCRIPTION
## Summary

Schema change (phase A-2) for OpenSpec change `fix-concert-approval-dedup`. Approving a staged concert that maps onto an already-published event currently dead-ends the reviewer with `failed_precondition`. This adds the RPC surface for a record-level reviewer choice (keep existing vs adopt staged) so approval can reconcile the duplicate instead of failing.

Backend-only fixes A-1 (idempotent venue get-or-create) and B (normalized-name discovery dedup) ship separately in liverty-music/backend#371 — they need no schema change.

## Changes

`liverty_music.rpc.admin.v1.ConcertService.Approve`:
- **`Resolution` enum** — `RESOLUTION_UNSPECIFIED`, `RESOLUTION_KEEP_EXISTING`, `RESOLUTION_ADOPT_STAGED`.
- **`ApproveRequest.resolution`** — optional selector (`enum.defined_only`), left unset on the first pass.
- **`ApproveResponse.conflict`** — a `DuplicateConflict` set only when the first pass detects an unresolved duplicate; no state is mutated in that case.
- **`DuplicateConflict` / `ExistingEvent`** — the existing event's display fields (event id, title, listed venue name, local date, optional start/open time) plus the staged `PendingConcert` preview. Venue identity is intentionally omitted — reconciliation never changes it.

Adding fields/messages/enum is wire-compatible: `buf lint`, `buf format`, and `buf breaking` are clean, so **no `buf skip breaking` label is needed**.

Also included: the D2a normalization decision recorded in the change's `design.md`, and the completed backend/proto task checkboxes ticked in `tasks.md`.

## Release

On merge, publish a GitHub Release (tag `vX.Y.Z`) to trigger `buf-release.yml` → BSR codegen, which unblocks the backend reconciliation handler (A-2) and the frontend dialog.

## Related

Refs: #703
