### PR TITLE
docs(openspec): propose frontend-store-cache-and-consistency

### DIFF
--- a/openspec/changes/frontend-store-cache-and-consistency/.openspec.yaml
+++ b/openspec/changes/frontend-store-cache-and-consistency/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-25

--- a/openspec/changes/frontend-store-cache-and-consistency/design.md
+++ b/openspec/changes/frontend-store-cache-and-consistency/design.md
@@ -1,0 +1,92 @@
+## Context
+
+The frontend is an Aurelia 2 PWA whose client state is owned by DI singleton stores (per the `entity-store-layer` capability: each store owns its entity's observable state and MAY cache read-only resources). Today only `ConcertServiceClient.listByFollower()` is cached — a bespoke in-store 24h TTL with in-flight coalescing and manual `invalidateFollowerCache()` (see `dashboard-concert-cache`). Every other read re-fetches on each route entry, and nothing revalidates when the installed PWA is resumed from the background.
+
+Two concrete problems motivated an audit of every frontend data resource:
+
+1. **Slow tab re-entry / staleness.** Route entry awaits RPCs before painting; a long-lived PWA tab can show stale data with no refresh trigger (the only `visibilitychange` listener today pauses the Discovery canvas animation, not data).
+2. **Journey inconsistency.** `ITicketJourneyService` is a stateless RPC pass-through. The Dashboard fetches a `journeyMap` once into non-observable local state; the detail sheet writes via `SetStatus` and mutates only its own `event` reference. The Dashboard does not reflect the change until the route is re-entered — the two hold **separate copies**.
+
+The audit (recorded here so the change is self-contained) classified all resources into three tiers:
+
+```
+TIER 1 — cache (value comes from cross-route re-entry, not intra-session repeats)
+   listByFollower (already), listWithProximity, listTop (key: country+tag+limit),
+   listTickets, User.get (idempotent)
+TIER 2 — client-owned localStorage state (NOT server cache): onboarding, consent,
+   pwa-install, help-seen flags, guest follows/home  → untouched
+TIER 3 — network-first, never cache: TicketJourney.listByUser (freshness),
+   Entry.getMerklePath (single-use crypto), Push.*, Artist.search
+DROPPED — listConcerts / listSimilar: per-artistId, each queried at most once per
+   session (guards prevent re-tap; bubbles evicted) → ~zero cache hits, so uncached
+```
+
+## Goals / Non-Goals
+
+**Goals:**
+- Fast tab re-entry: paint cached state instantly, revalidate in the background.
+- Never stale on resume: revalidate on route entry and on PWA foreground (`visibilitychange`/resume).
+- One reusable mechanism: a shared stale-while-revalidate primitive that stores compose internally, replacing the one bespoke cache.
+- Journey consistency: a single observable source of truth so a sheet write reflects on the Dashboard with no re-fetch.
+- Single source of truth everywhere: exactly one copy of each resource, owned by its store; components read only the store.
+
+**Non-Goals:**
+- No Service-Worker/HTTP-layer caching of RPC responses (see Decisions — Connect-RPC is POST).
+- No caching of the Discovery bubble component instance (fights the Aurelia router lifecycle; dropped earlier).
+- No caching of TIER 2 client-owned state or TIER 3 network-first resources.
+- No cold-start persistence (IndexedDB warm cache) — a possible future layer, out of scope.
+- No `reconnect` (online/offline) revalidation trigger this iteration.
+- No change to journey display mapping (`journey-status-presentation`) or backend `ticket-journey` semantics.
+
+## Decisions
+
+- **A shared in-app SWR primitive, composed inside stores (not a parallel state layer).** Introduce a small `RevalidatingCache<T>` (working name) utility. It holds one copy of a resource keyed by a cache key, records `staleTime` + timestamp, coalesces concurrent fetches (one in-flight promise per key), and exposes `get(key, fetcher, opts)`, `invalidate(key)`, and revalidation hooks. Stores use it **internally**; the store's `@observable` remains the sole public read surface. Components never import or read the cache.
+  - *Why:* generalizes the proven `concert-store` pattern into one place; avoids duplicating TTL/dedup/invalidation across stores.
+  - *Alternative — per-store ad-hoc caching:* rejected. The target state has 4–5 stores needing the same TTL + revalidation + invalidation; duplicating it invites divergence and invalidation bugs.
+  - *Alternative — a query library (TanStack-style):* rejected for now. Adds a dependency and a second state model; the singleton-store pattern already exists and a thin utility fits it. Revisit only if the primitive grows beyond a small utility.
+  - **No double management:** the data lives in exactly one place (inside the store, via the primitive). The primitive is bookkeeping + orchestration, not a second source components read from. This directly answers the "won't this duplicate store state?" concern.
+
+- **`staleTime` is the single knob; it unifies speed and consistency.** A long `staleTime` yields SWR (serve cache, rarely refetch) → speed. `staleTime = 0` yields always-revalidate — and when paired with a write-through observable store, gives consistency. Same abstraction, different setting.
+  ```
+  staleTime = long  → SWR: listByFollower / listWithProximity / listTop / listTickets
+  staleTime = 0     → single source of truth: TicketJourney (write-through, observable)
+  ```
+
+- **Revalidation triggers: route entry + PWA resume only.** On route entry the consuming store revalidates in the background (cache paints first). A single app-level `visibilitychange`/resume hook triggers revalidation of the active/foreground stores. No `reconnect` trigger this iteration.
+  - *Why:* route entry is the core "fast tab" win; resume covers the one real staleness gap (installed PWA reopened after long background). Long `staleTime` is safe precisely because resume re-checks.
+
+- **Cache keys must be complete.** `listTop` is keyed by `country + tag + limit` (the audit found `limit` varies — `MAX_BUBBLES` vs `MAX_BUBBLES/seedCount` — so a `country+tag`-only key would serve the wrong result size). `listWithProximity` is keyed by `sorted(artistIds) + countryCode + level1`. `listByFollower` stays user/region scoped.
+
+- **Bounded memory.** Remaining caches are few-key (`listTop`: a handful of country/tag/limit tuples; `listByFollower`/`listTickets`: user-scoped). Only `listWithProximity` (keyed by the guest artist-id set) can grow if that set varies — apply a small LRU cap (~20–30) if observed; the dropped per-artist reads removed the main unbounded-key risk. (`User.get` is out of scope — it keeps its own single-entry idempotent recovery and is not on the primitive.)
+
+- **Journey becomes a write-through observable store (single source of truth).** Add a `TicketJourneyStore` singleton owning `@observable journeyMap: Map<eventId, JourneyStatus>`. `setStatus`/`delete` call the RPC then mutate the map. Dashboard and detail sheet both read the store; the observable mutation triggers re-render. `listByUser` populates it on load (`staleTime = 0` — always fresh). The store clears `journeyMap` on sign-out.
+  - *Why:* the inconsistency is caused by two copies; one observable owner removes it without any TTL cache or extra re-fetch.
+  - *Alternative — return updated state from `setStatus` and re-assign `dateGroups`:* rejected — still two copies; brittle re-render trigger.
+
+- **No Service-Worker caching for this data.** The real blocker is that Connect-RPC unary is a **POST** request, which the Cache API cannot key/cache; SW-caching would also store raw bytes, still requiring an in-app deserialized observable store — i.e. a second copy. (Today the SW only routes `ArtistService` and `FollowService` explicitly as `NetworkOnly` for BackgroundSync; `Concert`/`TicketJourney`/`User`/`Ticket` RPCs are simply not intercepted and go to network by default — either way nothing SW-caches RPC responses.) The SW remains responsible for what it is uniquely good at (static assets, ZK `.wasm`/`.zkey`, offline POST queueing) and is unchanged. (Artist image GETs, if any, are a separate SW-runtime-cache candidate — noted, not in this change.)
+
+## Risks / Trade-offs
+
+- **[Wrong cache key serves wrong data]** → key `listTop` on `country+tag+limit` and `listWithProximity` on `sorted(artistIds)+country+level1`; cover keying in unit tests.
+- **[Stale-flash / layout jump on revalidation swap]** → swap fresh data into the store non-destructively (in place), preserve scroll position; never full-reload.
+- **[Unbounded memory from per-key caches]** → remaining keys are few; add a small LRU only to `listWithProximity` if filter-combo growth is observed.
+- **[Journey store leaks across accounts]** → clear `journeyMap` on sign-out (covered by a requirement + test).
+- **[Over-caching hides real freshness needs]** → TIER 3 stays strictly network-first; the primitive is applied only to the audited TIER 1 set.
+- **[Premature optimization]** → first task is a route-entry latency spike; only wire SWR where entry actually blocks on RPC.
+
+## Migration Plan
+
+1. Add the `RevalidatingCache<T>` utility with unit tests (staleTime, in-flight coalescing, invalidate).
+2. Refactor `concert-store.ts` to obtain `listByFollower` caching from the primitive (behavior-preserving: same 24h) and add route-entry + resume revalidation.
+3. Extend the primitive to `listWithProximity`, `listTop` (complete key), `listTickets`.
+4. Add `TicketJourneyStore` (write-through observable) and migrate `dashboard-route.ts` + `event-detail-sheet.ts` to read/write it; clear on sign-out.
+5. Wire the app-level `visibilitychange`/resume revalidation hook.
+6. `make check`; ship via the frontend PR → release path.
+
+Rollback: the primitive and journey store are additive; revert the change (no data/schema/API impact).
+
+## Open Questions
+
+- Exact `staleTime` values per resource (proposed: `listTop`/`listSimilar-n.a.`/`listTickets`/`listByFollower` long ≈ 24h; `listWithProximity` medium–long). Confirm during apply; they are safe to set long because resume revalidates.
+- Whether `listWithProximity` needs the LRU now or only after observing filter-combo growth (default: add only if observed).
+- Whether to fold the artist-image SW-runtime-cache candidate into a separate follow-up (default: separate change).

--- a/openspec/changes/frontend-store-cache-and-consistency/proposal.md
+++ b/openspec/changes/frontend-store-cache-and-consistency/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+Tab-to-tab navigation re-issues RPCs and paints only after they resolve, so revisiting a page (Dashboard, Discovery, Tickets) feels slow even when the underlying data barely changed. Today only `ConcertServiceClient.listByFollower()` has an in-memory cache (a bespoke 24h TTL); every other read re-fetches on each route entry, there is no revalidation when the installed PWA is resumed from the background (so a long-lived tab can show stale data), and there is no shared caching mechanism — the one cache is hand-rolled and cannot be reused. Separately, ticket-journey status is held as **separate copies** in the Dashboard and the detail sheet, so setting a status in the sheet does not update the Dashboard until the route is re-entered.
+
+The fix is a single, standard **stale-while-revalidate (SWR)** discipline expressed through the existing Aurelia singleton stores: serve cached state instantly for fast navigation, revalidate in the background (on route entry and on PWA resume) so it never goes stale, and make each cacheable resource a **single source of truth** owned by one observable store — which also removes the journey inconsistency.
+
+## What Changes
+
+- Introduce a shared, in-app **revalidating-cache primitive** (stale-while-revalidate) that singleton stores compose internally. It owns one copy of each resource, tracks per-resource `staleTime`, coalesces in-flight requests, exposes explicit invalidation, and revalidates on **route entry** and on **`visibilitychange`/resume (PWA foreground)**. It is an internal store collaborator — components keep reading only the store's observable state (no second state layer, no double management).
+- Generalize the existing bespoke 24h concert cache to use the shared primitive, and add PWA-resume/route-entry revalidation so the Dashboard concert list refreshes when the installed app is reopened.
+- Extend caching to a small, verified set of read resources whose value comes from **cross-route re-entry** (not intra-session repeats): `Concert.listWithProximity` (the guest concert path, re-fetched on Dashboard/Welcome re-entry — note the authenticated Dashboard uses `listByFollower` and filters client-side, so this is a guest-path win, not a filter-toggle one), `Artist.listTop` (Discovery re-entry — cache key MUST include `country + tag + limit`), and `Ticket.listTickets` (near-immutable). `User.get` is **unchanged and out of scope**: it keeps its existing idempotent get-or-create recovery (in-memory + localStorage) and is not migrated onto the shared primitive.
+- Make ticket-journey status a **single source of truth**: a singleton store owns an observable journey map; `SetStatus`/`Delete` are write-through (update the store, not a local copy); Dashboard and detail sheet both read the store, so a status change reflects everywhere without a re-fetch. The store clears its journey state on sign-out.
+- **Explicitly NOT changed / out of scope**: per-artist one-shot reads `Concert.listConcerts` and `Artist.listSimilar` stay uncached (each artistId is requested at most once per session — an audit found ~zero cache hits); network-first resources stay network-first (`TicketJourney.listByUser` freshness, `Entry.getMerklePath`, `Push.*`, `Artist.search`); client-owned localStorage state (onboarding, consent, PWA-install, help flags, guest follows/home) is not server-cache and is untouched; Service-Worker/HTTP-layer caching of RPC responses is out (Connect-RPC uses POST — not cacheable by the Cache API — and would create a second copy); and caching the Discovery bubble component instance is dropped (fights the Aurelia router lifecycle).
+
+## Capabilities
+
+### New Capabilities
+- `frontend-store-cache`: A shared stale-while-revalidate primitive that Aurelia singleton stores use to cache read-only RPC resources — per-resource `staleTime`, in-flight coalescing, explicit invalidation, and revalidation on route entry and PWA resume — while keeping the store the single source of truth (no parallel state).
+
+### Modified Capabilities
+- `dashboard-concert-cache`: The `listByFollower` cache is re-expressed via the shared primitive and gains revalidation on route entry and PWA resume (previously it only had a passive 24h TTL with no refresh trigger).
+- `entity-store-layer`: Add a journey single-source-of-truth requirement (a store owns the observable journey status; writes are write-through; readers share it; cleared on sign-out) and clarify that cache-only stores obtain caching via the shared `frontend-store-cache` primitive rather than bespoke per-store logic.
+
+## Impact
+
+- Frontend only. No proto/BSR, backend, or API changes; no new runtime dependency (the primitive is a small in-repo utility).
+- Affected code: a new revalidating-cache utility (e.g. `src/services/cache/`); `concert-store.ts` (generalize existing TTL + add revalidation triggers); the artist/top and proximity read paths; a new journey store plus its consumers (`dashboard-route.ts`, `event-detail-sheet.ts`); route-entry and `visibilitychange` wiring.
+- Risk: incorrect cache keys serving wrong data (mitigated by keying `listTop` on `country+tag+limit`); stale-flash on revalidation (mitigated by non-destructive in-place swap preserving scroll); memory growth (bounded — remaining caches are few-key; a small LRU only if `listWithProximity` filter combos grow).
+- Testing: unit tests for the primitive (staleTime, in-flight coalescing, invalidation), a journey write-through consistency test (sheet write reflects on dashboard without re-entry), and a revalidation-on-resume test.
+- Recommended first task: a quick spike measuring current route-entry latency to confirm which pages actually block on RPC before wiring SWR.

--- a/openspec/changes/frontend-store-cache-and-consistency/specs/dashboard-concert-cache/spec.md
+++ b/openspec/changes/frontend-store-cache-and-consistency/specs/dashboard-concert-cache/spec.md
@@ -1,0 +1,34 @@
+## MODIFIED Requirements
+
+### Requirement: listByFollower results are cached in memory for the session
+`ConcertServiceClient` SHALL cache the result of `listByFollower()` in memory within the Aurelia singleton service, obtaining the caching behavior from the shared `frontend-store-cache` primitive rather than bespoke per-store logic. The cache SHALL use a `staleTime` of 24 hours. While the cached value is within `staleTime`, subsequent calls to `listByFollower()` SHALL return the cached value without issuing an RPC. In addition, the store SHALL revalidate the cached value in the background on Dashboard route entry and when the installed PWA returns to the foreground, so a long-lived session refreshes without a manual reload.
+
+#### Scenario: Cache hit on Dashboard re-entry
+- **WHEN** the user navigates to Dashboard a second time within 24 hours without having followed or unfollowed any artists
+- **THEN** `listByFollower()` SHALL return the cached result immediately without blocking on an RPC
+- **AND** the store SHALL revalidate the value in the background
+
+#### Scenario: Cache miss on first load
+- **WHEN** `listByFollower()` is called and no cached value exists
+- **THEN** the RPC SHALL be issued and the result SHALL be stored in the cache with the current timestamp
+
+#### Scenario: Cache expiry after 24 hours
+- **WHEN** `listByFollower()` is called more than 24 hours after the cache was last populated
+- **THEN** the cached value SHALL be served immediately and the RPC SHALL be issued in the background to refresh the cache
+
+#### Scenario: Revalidation on PWA resume
+- **WHEN** the installed PWA returns to the foreground on the Dashboard after being backgrounded
+- **THEN** the store SHALL revalidate `listByFollower()` in the background
+- **AND** the refreshed value SHALL replace the cached value in place without a full document reload
+
+### Requirement: Concert cache is invalidated on follow
+`ConcertServiceClient` SHALL invalidate the follower-scoped concert cache through the shared `frontend-store-cache` primitive (rather than a bespoke `invalidateFollowerCache()` field), and `FollowServiceClient.follow()`/`unfollow()`/`setHype()` SHALL trigger that invalidation after the RPC succeeds, so the next dashboard load fetches fresh concert data. The invalidation SHALL NOT occur when the mutation RPC fails.
+
+#### Scenario: Cache invalidated after follow
+- **WHEN** the user successfully follows or unfollows an artist, or changes an artist's hype
+- **THEN** the `listByFollower()` cache SHALL be invalidated via the primitive
+- **AND** the next call to `listByFollower()` SHALL issue an RPC
+
+#### Scenario: Cache not invalidated on follow RPC failure
+- **WHEN** the `follow()`/`unfollow()`/`setHype()` RPC call fails with an error
+- **THEN** the `listByFollower()` cache SHALL remain valid

--- a/openspec/changes/frontend-store-cache-and-consistency/specs/entity-store-layer/spec.md
+++ b/openspec/changes/frontend-store-cache-and-consistency/specs/entity-store-layer/spec.md
@@ -1,0 +1,72 @@
+## MODIFIED Requirements
+
+### Requirement: Per-Entity Store Ownership
+
+Client-side state SHALL be owned by observable **stores** organized by
+entity/aggregate, not by authentication state. Each store SHALL own the
+observable state for its entity, SHALL internally resolve its source
+(guest localStorage vs authenticated backend), and SHALL obtain any read-only
+resource caching from the shared `frontend-store-cache` primitive rather than a
+bespoke per-store TTL, in-flight coalescing, or invalidation implementation. The
+store SHALL remain the single source of truth for its resource; the primitive is
+an internal collaborator, and callers SHALL read state only from the store's
+exposed observable. Callers SHALL read state from the store and SHALL NOT branch
+on `auth.isAuthenticated` to select a guest-vs-authed source.
+
+#### Scenario: Caller reads without auth branching
+- **WHEN** a view model or service needs an entity value owned by a store
+- **THEN** it SHALL read the store's exposed observable
+- **AND** it SHALL NOT inspect `auth.isAuthenticated` to choose between a guest
+  store and an authenticated entity
+
+#### Scenario: UserStore owns home and language for both auth states
+- **WHEN** the current user's home area or preferred language is read
+- **THEN** it SHALL be sourced from `UserStore`
+- **AND** for an authenticated user `UserStore` SHALL surface the backend `User`
+  entity values
+- **AND** for a guest `UserStore` SHALL surface a synthesized current-user view
+  sourced from guest localStorage
+- **AND** the exposed value SHALL be observable so dependent bindings
+  re-evaluate on change
+
+#### Scenario: Cache-only stores own no guest/authed duality
+- **WHEN** a store owns read-only resources (e.g. a top-artists list)
+- **THEN** it SHALL cache those resources
+- **AND** it SHALL NOT participate in guest→authed transition or sign-out clear
+
+#### Scenario: Caching goes through the shared primitive
+- **WHEN** a store needs to cache a read-only resource
+- **THEN** it SHALL use the shared `frontend-store-cache` primitive for storage,
+  staleness, in-flight coalescing, and invalidation
+- **AND** it SHALL NOT hand-roll a separate TTL cache
+- **AND** exactly one copy of the resource SHALL exist, owned by the store, with
+  consumers reading it only through the store's observable state
+
+## ADDED Requirements
+
+### Requirement: Ticket-journey status is a single source of truth
+Ticket-journey status SHALL be owned by a single observable store (a `TicketJourneyStore`) exposing an observable map of event id to journey status. Reads (`listByUser`) SHALL populate the store and SHALL be treated as always-fresh (network-first, no stale window). Writes (`SetStatus`, `Delete`) SHALL be write-through: they SHALL issue the RPC and then update the store's observable map. All consumers — the Dashboard and the event detail sheet — SHALL read journey status from this store, so a status change from any surface is reflected everywhere without a re-fetch or route re-entry. The store SHALL clear its journey state on sign-out.
+
+#### Scenario: Sheet write reflects on the Dashboard without re-entry
+- **WHEN** the user changes a journey status in the event detail sheet
+- **THEN** the store's observable journey map SHALL be updated after the write RPC succeeds
+- **AND** the Dashboard's rendering of that event's status SHALL update without re-fetching or re-entering the route
+
+#### Scenario: Single shared journey state
+- **WHEN** both the Dashboard and the detail sheet render a journey status for the same event
+- **THEN** both SHALL read from the same `TicketJourneyStore` observable map
+- **AND** they SHALL NOT hold separate copies of the status
+
+#### Scenario: Journey read is always fresh
+- **WHEN** the Dashboard loads and requests journey status via the store
+- **THEN** the store SHALL fetch `listByUser` fresh (no stale window)
+- **AND** it SHALL surface the result via its observable map
+
+#### Scenario: Write failure does not desync the store
+- **WHEN** a journey `SetStatus`/`Delete` RPC fails
+- **THEN** the store's observable map SHALL NOT be updated to the attempted value
+
+#### Scenario: Journey state cleared on sign-out
+- **WHEN** the user signs out
+- **THEN** the `TicketJourneyStore` SHALL clear its journey map
+- **AND** no prior user's journey status SHALL be readable afterward

--- a/openspec/changes/frontend-store-cache-and-consistency/specs/frontend-store-cache/spec.md
+++ b/openspec/changes/frontend-store-cache-and-consistency/specs/frontend-store-cache/spec.md
@@ -1,0 +1,106 @@
+## ADDED Requirements
+
+### Requirement: Shared stale-while-revalidate cache primitive
+The frontend SHALL provide a single shared revalidating-cache primitive that Aurelia singleton stores use to cache read-only RPC resources. The primitive SHALL, for a given cache key, return any cached value immediately (stale-while-revalidate) and issue the underlying fetcher only when no value exists or the cached value is older than the resource's configured `staleTime`. The primitive SHALL be an internal collaborator of a store: the store's observable state SHALL remain the single public read surface, and no component SHALL read the cache directly.
+
+#### Scenario: Cached value served immediately while fresh
+- **WHEN** a store requests a resource whose cached value is within its `staleTime`
+- **THEN** the primitive SHALL return the cached value
+- **AND** it SHALL NOT issue the fetcher
+
+#### Scenario: Stale value served then revalidated
+- **WHEN** a store requests a resource whose cached value is older than its `staleTime`
+- **THEN** the primitive SHALL return the cached value immediately
+- **AND** it SHALL issue the fetcher in the background and replace the cached value when it resolves
+
+#### Scenario: Miss issues the fetcher
+- **WHEN** a store requests a resource for which no cached value exists
+- **THEN** the primitive SHALL issue the fetcher and store the result with the current timestamp under its cache key
+
+#### Scenario: Single copy, no parallel state
+- **WHEN** a resource is cached via the primitive
+- **THEN** exactly one copy of that resource SHALL exist, owned by its store
+- **AND** components SHALL read that resource only through the store's observable state, never from the cache directly
+
+### Requirement: In-flight request coalescing
+The primitive SHALL coalesce concurrent requests for the same cache key into a single in-flight fetch, so that simultaneous callers share one RPC and one result.
+
+#### Scenario: Concurrent callers share one fetch
+- **WHEN** two callers request the same cache key while a fetch for that key is already in flight
+- **THEN** both callers SHALL receive the result of the single in-flight fetch
+- **AND** no second RPC SHALL be issued for that key
+
+### Requirement: Complete cache keys
+Each cached resource SHALL be keyed by every input that changes its result. `Artist.listTop` SHALL be keyed by `country + tag + limit`. `Concert.listWithProximity` SHALL be keyed by the sorted artist-id set plus country code and level-1 area. A cache lookup SHALL NOT return a value produced for a different set of inputs.
+
+#### Scenario: listTop key includes limit
+- **WHEN** `listTop` is requested with the same country and tag but a different `limit`
+- **THEN** the primitive SHALL treat it as a distinct key
+- **AND** it SHALL NOT return a value cached for the other `limit`
+
+#### Scenario: Proximity key includes the artist set and area
+- **WHEN** `listWithProximity` is requested with a different artist-id set or a different country/level-1 area
+- **THEN** the primitive SHALL treat it as a distinct key
+
+### Requirement: Explicit invalidation on mutations
+The primitive SHALL expose explicit invalidation so that a mutation can force the next read of an affected resource to refetch. Each cached resource SHALL have its invalidating writes defined so no write leaves a stale cache:
+- A successful `follow`/`unfollow` SHALL invalidate the follower-scoped concert cache (`listByFollower`).
+- A successful `setHype` SHALL invalidate the follower-scoped concert cache (`listByFollower`), because hype is rendered from that data.
+- A successful ticket mint (a new ticket becoming available to the user) SHALL invalidate `listTickets`.
+- `listWithProximity` requires no write-side invalidation: it is keyed by the guest artist-id set, so changing the follow set produces a new key rather than a stale one.
+- `listTop` requires no write-side invalidation: it has no user-write inputs and relies on `staleTime`/resume revalidation for freshness.
+
+#### Scenario: Invalidated key refetches
+- **WHEN** a cache key is invalidated
+- **THEN** the next request for that key SHALL issue the fetcher rather than return a cached value
+
+#### Scenario: Follow or hype change invalidates follower concerts
+- **WHEN** the user successfully follows, unfollows, or changes the hype of an artist
+- **THEN** the follower-scoped concert cache (`listByFollower`) SHALL be invalidated
+- **AND** the next request for it SHALL refetch
+
+#### Scenario: New ticket invalidates the ticket list
+- **WHEN** a new ticket becomes available to the user (mint)
+- **THEN** the `listTickets` cache SHALL be invalidated
+- **AND** the next request for it SHALL refetch
+
+#### Scenario: Proximity cache needs no write-side invalidation
+- **WHEN** the guest follow set changes
+- **THEN** `listWithProximity` SHALL be requested under a new key derived from the new artist-id set
+- **AND** no explicit invalidation of the prior key SHALL be required for correctness
+
+### Requirement: Revalidation on route entry and PWA resume
+Stores that cache resources SHALL revalidate them in the background on route entry and when the installed PWA returns to the foreground. "Foreground view" SHALL mean the resources owned by the stores backing the currently active route (the route whose component is attached in the viewport at resume time); revalidation SHALL NOT fan out to stores whose route is not currently active. Foreground return SHALL be detected via the Page Visibility signal (`visibilitychange` to `visible` / resume). Revalidation SHALL be non-destructive: the cached value SHALL continue to render and SHALL be replaced in place when fresh data arrives, without a full document reload.
+
+#### Scenario: Route entry paints cache then revalidates
+- **WHEN** the user navigates to a page backed by a cached resource
+- **THEN** the store SHALL render the cached value immediately
+- **AND** it SHALL revalidate the resource in the background
+
+#### Scenario: PWA resume revalidates stale data
+- **WHEN** the installed PWA returns to the foreground after being backgrounded
+- **THEN** stale cached resources owned by the stores backing the currently active route SHALL be revalidated in the background
+- **AND** cached resources for routes that are not currently active SHALL NOT be revalidated by the resume signal
+
+#### Scenario: Revalidation does not reload or jump
+- **WHEN** a background revalidation replaces a cached value
+- **THEN** the update SHALL occur in place via the store's observable state
+- **AND** it SHALL NOT trigger a full document reload or reset scroll position
+
+### Requirement: Caching scope is limited to audited read resources
+The primitive SHALL be applied only to read-only resources whose value derives from cross-route re-entry: `Concert.listByFollower`, `Concert.listWithProximity`, `Artist.listTop`, and `Ticket.listTickets`. Resources that are requested at most once per session, are network-first for freshness, or are client-owned local state SHALL NOT be cached by the primitive. `User.get` SHALL remain out of scope: it keeps its existing idempotent get-or-create recovery (in-memory + localStorage) and SHALL NOT be migrated onto the primitive.
+
+#### Scenario: One-shot per-artist reads are not cached
+- **WHEN** `Concert.listConcerts(artistId)` or `Artist.listSimilar(artistId)` is requested
+- **THEN** it SHALL be issued as a direct pass-through
+- **AND** it SHALL NOT be stored in the primitive
+
+#### Scenario: Network-first resources are not cached
+- **WHEN** a network-first resource (`Entry.getMerklePath`, `Push.*`, `Artist.search`) is requested
+- **THEN** it SHALL be issued fresh
+- **AND** it SHALL NOT be served from the primitive
+
+#### Scenario: User.get is not migrated onto the primitive
+- **WHEN** the current user entity is read via `User.get`
+- **THEN** it SHALL be served by its existing idempotent get-or-create recovery (in-memory + localStorage)
+- **AND** it SHALL NOT be routed through the shared primitive

--- a/openspec/changes/frontend-store-cache-and-consistency/tasks.md
+++ b/openspec/changes/frontend-store-cache-and-consistency/tasks.md
@@ -1,0 +1,50 @@
+## 1. Spike: confirm the problem
+
+- [ ] 1.1 Measure current route-entry latency per data-bearing page (Dashboard, Discovery, Tickets): does painting block on RPC, and by how long? Record which pages actually benefit from SWR before wiring anything.
+- [ ] 1.2 Confirm the audited resource tiers still hold against current code (TIER1 cache set, TIER3 network-first, dropped per-artist reads); adjust scope if drifted.
+
+## 2. Shared revalidating-cache primitive
+
+- [ ] 2.1 Add the `RevalidatingCache<T>` utility (e.g. `src/services/cache/`): `get(key, fetcher, { staleTime })`, `invalidate(key)`, in-flight coalescing, timestamp/staleness bookkeeping. No component-facing API — used only inside stores.
+- [ ] 2.2 Unit tests: fresh-hit (no fetch), stale (serve + background revalidate), miss (fetch + store), in-flight coalescing (one RPC for concurrent callers), invalidate (next read refetches), complete-key behavior.
+
+## 3. Generalize the concert cache onto the primitive
+
+- [ ] 3.1 Refactor `concert-store.ts` so `listByFollower` caching comes from the primitive (behavior-preserving: 24h `staleTime`, existing `invalidateFollowerCache()` semantics on follow/unfollow).
+- [ ] 3.2 Add background revalidation on Dashboard route entry (paint cache first) and route follow/unfollow **and `setHype`** invalidation of `listByFollower` through the primitive (invalidate only after the RPC succeeds).
+
+## 4. Extend caching to the audited read resources
+
+- [ ] 4.1 Cache `Concert.listWithProximity` (the guest concert path, re-fetched on Dashboard/Welcome re-entry) via the primitive, keyed by `sorted(artistIds) + countryCode + level1`; add a small LRU cap only if the guest artist-set varies enough to grow the key space. No write-side invalidation needed (the key changes with the follow set).
+- [ ] 4.2 Cache `Artist.listTop` via the primitive, keyed by `country + tag + limit` (limit MUST be in the key). Verify Discovery re-entry reuses the cached pool without a refetch.
+- [ ] 4.3 Cache `Ticket.listTickets` via the primitive (long `staleTime`); invalidate it on a new ticket mint.
+- [ ] 4.4 Confirm `Concert.listConcerts` and `Artist.listSimilar` remain uncached pass-throughs; confirm `User.get` keeps its own idempotent recovery (NOT migrated onto the primitive); confirm TIER3 (`Entry.getMerklePath`, `Push.*`, `Artist.search`) stays network-first.
+
+## 5. Ticket-journey single source of truth
+
+- [ ] 5.1 Add `TicketJourneyStore` singleton owning `@observable journeyMap: Map<eventId, JourneyStatus>`; `listByUser` populates it (network-first, no stale window); `setStatus`/`delete` are write-through (RPC then map update; no map update on failure).
+- [ ] 5.2 Migrate `dashboard-route.ts` to read journey status from the store instead of a local `journeyMap` copy.
+- [ ] 5.3 Migrate `event-detail-sheet.ts` to write via the store (remove the local `event.journeyStatus` mutation as the source of truth).
+- [ ] 5.4 Clear `journeyMap` on sign-out (wire to the existing auth-boundary event).
+
+## 6. App-level resume revalidation
+
+- [ ] 6.1 Add a single `visibilitychange`/resume hook that triggers background revalidation of the cached resources owned by the **currently active route's stores** (not all mounted stores; no `reconnect` trigger this iteration). Ensure it does not double-fire with route-entry revalidation.
+
+## 7. Tests
+
+- [ ] 7.1 Journey write-through consistency test: a status change in the detail sheet reflects on the Dashboard without a re-fetch or route re-entry.
+- [ ] 7.2 Revalidation-on-resume test: a stale cached resource is revalidated on PWA foreground; the swap is in place (no reload / scroll reset).
+- [ ] 7.3 Sign-out clears the journey store.
+
+## 8. Verify locally
+
+- [ ] 8.1 Run `make check` (Biome + stylelint + typecheck + unit tests) and confirm green.
+- [ ] 8.2 Manually verify fast tab re-entry (cache paints immediately) and that Dashboard/Tickets/Discovery show fresh data after PWA resume.
+
+## 9. Ship to production
+
+- [ ] 9.1 Open the frontend PR, get CI green, and merge.
+- [ ] 9.2 Cut a frontend GitHub Release (SemVer tag) → automated pin-bump → ArgoCD auto-sync to prod; confirm pods roll to the new tag.
+- [ ] 9.3 Verify in prod: tab re-entry is fast, journey status is consistent across Dashboard and detail sheet, and data refreshes on PWA resume.
+- [ ] 9.4 Archive the OpenSpec change once verified in prod.


### PR DESCRIPTION
## Summary

Adds the OpenSpec change `frontend-store-cache-and-consistency` — a spec-only proposal for a **stale-while-revalidate (SWR)** store-caching strategy plus a **ticket-journey single source of truth**. No proto/BSR, backend, or API changes; the frontend implementation lands as a separate PR after this proposal merges.

**Problem:** tab re-entry re-issues RPCs and paints only after they resolve; only `listByFollower` is cached (bespoke 24h TTL); nothing revalidates on PWA resume; and ticket-journey status is held as separate copies in the Dashboard and the detail sheet, so a sheet write does not reflect on the Dashboard until re-entry.

## Contents

- **proposal.md** — why / what / scope boundaries.
- **design.md** — 3-tier resource audit, the shared revalidating-cache primitive (composed inside stores — single source of truth, no double-management), `staleTime` as the one knob unifying speed (SWR) and consistency (journey `staleTime=0`), complete cache keys (`listTop` = `country+tag+limit`), why not the Service Worker (Connect-RPC = POST), alternatives + rejections, risks, migration.
- **tasks.md** — spike → primitive + tests → concert generalization → extend caching → journey store → resume revalidation → tests → `make check` → ship to prod → archive.
- **Delta specs:**
  - `frontend-store-cache` (**ADDED**, new capability) — SWR semantics, in-flight coalescing, complete keys, mutation invalidation, route-entry + PWA-resume revalidation, scope limits.
  - `dashboard-concert-cache` (**MODIFIED**) — `listByFollower` cache re-expressed via the primitive + resume revalidation; follow/`setHype` invalidation routed through the primitive.
  - `entity-store-layer` (**MODIFIED** ownership: `MAY cache` → `SHALL cache via the shared primitive`; **ADDED** journey single-source-of-truth).

## Scope out (explicit)

Per-artist one-shot reads (`listConcerts`/`listSimilar`, ~zero cache hits), network-first resources (`getMerklePath`/`Push.*`/`Artist.search`), client-owned localStorage state, Service-Worker/HTTP caching of RPCs, and caching the Discovery bubble component instance.

## Testing

`openspec validate --strict` passes. Spec-only PR — no code/CI beyond buf checks (no `.proto` changes).

## Related Issue

close: #707
