### PR TITLE
docs(openspec): add optimize-concert-searcher-cost change

### DIFF
--- a/openspec/changes/optimize-concert-searcher-cost/.openspec.yaml
+++ b/openspec/changes/optimize-concert-searcher-cost/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-25

--- a/openspec/changes/optimize-concert-searcher-cost/design.md
+++ b/openspec/changes/optimize-concert-searcher-cost/design.md
@@ -1,0 +1,80 @@
+## Context
+
+`ConcertSearcher.Search` runs a two-step Gemini pipeline. Step 1 (grounded extract) currently fans out into three parallel slices (`tours_near`, `tours_far`, `standalones`) on `gemini-3.5-flash` with `{GoogleSearch, URLContext}` enabled. Production billing analysis (Cloud Billing Export ↔ Cloud Logging) established:
+
+- The `google_search` tool performs invisible automatic query expansion: **~22x** metered "search query" units per request on `gemini-3.5-flash`, none surfaced in `groundingMetadata.webSearchQueries`. `flash-lite` features fan out only ~2x.
+- Search-query charges are **~59–69%** of total Gemini spend (June ¥3,298; recurring in July after the cap reset and free-tier exhaustion).
+- Concert discovery is **~97%** of search-query volume, because the fan-out (~22x) is multiplied by the 3-slice design.
+- `google_search` cannot be removed: an artist's official top page does not enumerate all concerts, so live search is required for coverage.
+
+Constraints: no proto/API change; prompts and code comments in English (repo global constraint); prod verification via the billing-export SKU (dev env is intentionally stopped).
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Cut the Step 1 search-query fan-out and token cost while preserving discovery recall/precision.
+- Move the extract step to `gemini-3.6-flash` (cheaper output, better efficiency/accuracy).
+- Collapse the 3-slice fan-out to a single grounded call.
+- Replace the tour/standalone split prompts with one consolidated, optimized English prompt.
+- Decide the thinking level empirically via the existing A/B harness.
+
+**Non-Goals:**
+
+- No change to `SalesPhaseSearcher` or `MerchSearcher`.
+- No change to Step 2 (parse) model or schema.
+- Not removing `google_search` (required for coverage).
+- Not resolving the platform-side billing/observability defect (tracked separately via Google support).
+
+## Decisions
+
+### D1: Extract model `gemini-3.5-flash` → `gemini-3.6-flash`
+
+3.6-flash has lower output price ($9→$7.50 /1M), better token efficiency, and higher benchmark accuracy per the model card, at the same input price. It stays a flash-class model, so extraction quality should hold or improve. Alternative considered: `gemini-3.1-flash-lite` (as sales uses) — rejected for this change because the user prioritizes discovery quality; lite remains a possible future A/B arm.
+
+Note: the per-query grounding price is a gemini-3 family SKU and is **model-independent**, so the model swap does NOT by itself reduce search-query cost — only the token portion. Whether 3.6-flash fans out less than 3.5-flash is unknown and is a primary A/B measurement.
+
+### D2: Consolidate Step 1 to a single slice
+
+`defaultStep1Slices` goes from three entries to one that extracts both tours and standalones over an open-ended window. This removes the 3x slice multiplier directly. Alternative: keep 3 slices but lite-ize — rejected (quality priority + still pays 3x). The fan-out mechanism (`sync.WaitGroup` slice loop) is retained so slice count stays configurable.
+
+### D3: Open-ended (start-date-only) window
+
+The prompt supplies a start date and no end date; the near/far range split is removed. Rationale: concert discovery wants all future concerts from "now" onward; a fixed far boundary added a slice without clear benefit. Drops the `to_date` placeholder from the template.
+
+### D4: One consolidated English prompt with explicit coverage rules
+
+A single `systemInstructionStep1` extracts `<tour>` and `<standalone>` in one envelope, instructs discovery via `url_context` + `google_search` including off-domain tour pages, and excludes multi-artist festivals (a 2–4 act named co-headliner bill stays a standalone). All extraction rules (verbatim copy, page-context year inference, `(local_date, venue, start_time)` dedup, XML-only output) are preserved. Prompts authored in English (Japanese draft agreed).
+
+### D5: A/B over `thinking ∈ {low, medium}` before prod
+
+Use `GEMINI_AB_EVAL=1` against the frozen ground-truth fixture. Fixed axes: model `gemini-3.6-flash`, 1 slice, `{GoogleSearch, URLContext}`. Variable: thinking. Metrics measurable per run: **recall/precision** vs ground truth and **token cost** (from `usageMetadata`). The search-query **fan-out is NOT reliably measurable per A/B run** — it never appears in the API response (`webSearchQueries` is empty) and the billing export is ~24h-lagged and hourly-bucketed, so it cannot be attributed to a short ad-hoc run. Fan-out reduction is therefore validated **post-deploy** via the billing-export SKU trend (see Migration Plan), not in the A/B. Ship the thinking setting that holds recall at the lowest token cost.
+
+## Risks / Trade-offs
+
+- **Recall drop from merging near/far + tour/standalone** → A/B recall gate against the frozen fixture; do not ship if recall regresses.
+- **Fan-out rebound**: a single broader request may expand to more internal queries, partially offsetting the 3x slice saving. This cannot be measured in the A/B (fan-out is invisible in the response and billing is lagged/bucketed) → validate post-deploy via the billing SKU trend; if the SKU does not drop as expected, revisit slice/thinking config.
+- **3.6-flash search behavior unknown** → measured in A/B; if fan-out stays ~22x, the token saving still lands and slice-consolidation (3x) still applies.
+- **Entity misclassification (tour vs standalone) in the merged prompt** → A/B precision gate; keep explicit definitions in the instruction.
+- **Prompt regression risk** (rewrite touches the highest-value path) → keep Step 2 and the dedup/parse logic unchanged; only Step 1 instruction/slice/model change.
+
+## Migration Plan
+
+1. Implement backend changes (config default, single slice, consolidated English prompt, drop `to_date`); keep old constants removable only after A/B.
+2. Run the A/B matrix locally/in a bounded run; record recall/precision + cost per thinking level.
+3. Choose the winning thinking level; set it and `GCP_GEMINI_SEARCH_MODEL_EXTRACT=gemini-3.6-flash` for the concert-discovery job.
+4. Ship backend, then update the cloud-provisioning prod overlay (model + thinking env); re-tighten the spend cap as an interim guardrail.
+5. Verify post-deploy: the "search query gemini 3 paid" SKU drops in the billing export and discovery recall holds in prod.
+
+Rollback: revert `GCP_GEMINI_SEARCH_MODEL_EXTRACT` / thinking env and the `defaultStep1Slices` change; the pipeline shape (two-step, tools) is unchanged so rollback is config + code revert with no data migration.
+
+## Resolved by A/B (2026-07-27, dev key, refreshed fixture: Vaundy + SUPER BEAVER)
+
+- **Thinking level → `medium`.** `low` truncated Vaundy's long 2027-2028 tour (one run dropped 10 real 2028 dates); `medium` enumerated the full tour every run, with only 2 unmatchable "会場未定/TBD" placeholder misses (effectively perfect discovery). SUPER BEAVER: 0.99 (medium) vs 0.97 (low). Medium is required for long-tour completeness.
+- **3.6-flash token efficiency confirmed**: extract-step thinking tokens 94–1,253 vs 3.5-flash's 4,000–5,500 per slice.
+- **Fan-out remains unmeasurable in the A/B**: all cells returned `webSearchQueries=0` and the harness `total_cost=$0`, so the search-query fan-out (the dominant cost) cannot be observed per run — deferred to post-deploy billing verification (task 6.2). Open risk: `medium`'s deeper reasoning may increase the invisible fan-out vs `low`.
+
+## Open Questions
+
+- Does `gemini-3.6-flash` (with `medium` thinking) reduce the ~22x fan-out vs 3.5-flash, or only the token cost? Only answerable post-deploy via the billing SKU (task 6.2).
+- The single open-ended window did not produce far-future speculative dates in the A/B (precision held); keep watching precision in prod.

--- a/openspec/changes/optimize-concert-searcher-cost/proposal.md
+++ b/openspec/changes/optimize-concert-searcher-cost/proposal.md
@@ -1,0 +1,39 @@
+## Why
+
+In production, the `ConcertSearcher` Step 1 grounded call is the dominant driver of Gemini API cost. The `google_search` grounding tool performs invisible automatic query expansion (~22x metered "search query" charges per request on `gemini-3.5-flash`, none surfaced in `groundingMetadata.webSearchQueries`), and this expansion is amplified 3x by the three-slice fan-out. Grounding "search query" charges are ~59–69% of total Gemini spend (June ¥3,298, still accruing in July), and concert discovery accounts for ~97% of that search volume. We must cut this cost without degrading discovery recall/precision — `google_search` itself must stay (an artist's official top page does not list every concert).
+
+## What Changes
+
+- **Migrate the extract-step model** from `gemini-3.5-flash` to `gemini-3.6-flash` (output $9→$7.50 per 1M, better token efficiency and accuracy per the model card). Parse-step model is unchanged.
+- **Consolidate Step 1 from three parallel slices** (`tours_near`, `tours_far`, `standalones`) **into a single slice** — one grounded call per artist instead of three. This directly removes the 3x slice multiplier on search-query fan-out and token usage.
+- **Rewrite the Step 1 system instruction** into a single consolidated, optimized prompt that:
+  - extracts both tours and standalones in one pass;
+  - explicitly includes tour pages hosted on a **separate domain** from the official site;
+  - excludes **music festivals with a multi-artist lineup** (a 2–4 act named co-headliner bill stays a standalone);
+  - uses an **open-ended (start-date-only) window** — no end date.
+  - Prompts are authored in **English** in the implementation (Japanese draft is agreed; convert to idiomatic English when implementing).
+- **Keep `google_search` + `url_context`** on Step 1 (grounding is required for coverage).
+- **A/B evaluate** the new configuration across `thinking ∈ {low, medium}` using the existing harness (`GEMINI_AB_EVAL=1`) against the frozen ground-truth fixture, measuring recall/precision and cost (search-query fan-out + tokens), then ship the winning setting to prod and verify the billing SKU drop.
+
+Non-goals: `SalesPhaseSearcher` and `MerchSearcher` are unchanged in this change; no proto/API schema change.
+
+## Capabilities
+
+### New Capabilities
+
+_None._ This change modifies existing searcher capabilities only.
+
+### Modified Capabilities
+
+- `gemini-searcher-config`: the default extract-step model constant changes from `gemini-3.5-flash` to `gemini-3.6-flash`.
+- `gemini-grounded-extract-and-coerce`: Step 1 fans out into **one** slice instead of three; the consolidated slice extracts both tours and standalones via a single **English** instruction and a **three-placeholder** template; the Step 1 date window is open-ended (start-date only, no `to_date`); the extraction rules cover separate-domain tour pages and **multi-artist-festival exclusion**.
+
+## Impact
+
+- **backend** (`liverty-music/backend`):
+  - `internal/infrastructure/gcp/gemini/searcher.go` — `defaultStep1Slices` (3→1), consolidated Step 1 system instruction + prompt template (drop `to_date` placeholder), slice date-offset logic.
+  - `pkg/config` — `defaultSearchModelExtract` constant → `gemini-3.6-flash`.
+  - A/B harness (`searcher_integration_test.go`) + `testdata/` — run the `{low, medium}` thinking matrix on the new config.
+- **cloud-provisioning**: after A/B, set `GCP_GEMINI_SEARCH_MODEL_EXTRACT` / thinking env for the concert-discovery job in the prod overlay; re-tighten the spend cap as an interim guardrail.
+- **Verification**: post-deploy, confirm the "search query gemini 3 paid" SKU drops in the billing export and discovery recall holds.
+- No breaking API change; no BSR/proto change.

--- a/openspec/changes/optimize-concert-searcher-cost/specs/gemini-grounded-extract-and-coerce/spec.md
+++ b/openspec/changes/optimize-concert-searcher-cost/specs/gemini-grounded-extract-and-coerce/spec.md
@@ -1,0 +1,110 @@
+## RENAMED Requirements
+
+- FROM: `### Requirement: Step 1 fans out into three parallel slices per the default slice configuration`
+- TO: `### Requirement: Step 1 runs a single grounded slice per the default slice configuration`
+
+- FROM: `### Requirement: Step 1 instructions follow a five-step workflow in Japanese`
+- TO: `### Requirement: Step 1 uses a single consolidated English extraction instruction`
+
+- FROM: `### Requirement: Step 1 prompt template uses four positional placeholders`
+- TO: `### Requirement: Step 1 prompt template uses three positional placeholders`
+
+## MODIFIED Requirements
+
+### Requirement: ConcertSearcher executes a two-step Gemini call sequence per Search invocation
+
+The `ConcertSearcher.Search` method SHALL execute exactly two Gemini API calls per invocation under the `gemini-grounded-extract-and-coerce` capability: Step 1 (grounded extract) and Step 2 (JSON coerce). Step 1 MAY fan out into multiple parallel sub-calls (slices), though the default configuration is a single slice; regardless of slice count, Step 1 SHALL complete before Step 2 starts. The flattened result of Step 2 SHALL be merged Go-side with the Step 1 verbatim drafts and returned to the caller as `[]*entity.ScrapedConcert`, preserving the public signature.
+
+#### Scenario: Happy path — Step 1 and Step 2 both succeed
+
+- **WHEN** `Search` is called with a non-nil `OfficialSite`
+- **THEN** the searcher SHALL run Step 1 across the slices defined by `defaultStep1Slices`
+- **AND** wait for all slices to complete
+- **AND** merge each slice's `<extracted>` envelope into a single envelope via `mergeAndDedupEnvelopes`
+- **AND** parse the merged envelope into `[]EventDraft` via `parseStep1Envelope`
+- **AND** issue Step 2 with the per-event JSON payload derived from the drafts
+- **AND** merge Step 2's coerced output back with the drafts by `index`
+- **AND** return the deduplicated `[]*entity.ScrapedConcert` to the caller
+
+#### Scenario: Step 1 permanent error from any slice → Search returns the error
+
+- **WHEN** any Step 1 slice returns a permanent error (4xx, invalid argument, quota exhausted) after the retry policy
+- **THEN** Step 2 SHALL NOT run
+- **AND** the first permanent error encountered SHALL be wrapped per `toAppErr` semantics and returned
+
+#### Scenario: Step 1 transient retry exhaustion → empty envelope flows to Step 2
+
+- **WHEN** a Step 1 slice exhausts its retries with a transient error
+- **THEN** that slice's envelope SHALL be treated as empty
+- **AND** the merged envelope SHALL still flow to Step 2 with whatever content succeeded (empty overall when the sole default slice fails), yielding a deterministic result
+
+#### Scenario: Step 2 permanent error → Search returns the error
+
+- **WHEN** Step 2 returns a permanent error
+- **THEN** the wrapped error SHALL propagate to the caller
+- **AND** no partial result SHALL be returned
+
+#### Scenario: Step 2 invalid JSON → permanent error propagates
+
+- **WHEN** Step 2's response is not valid JSON or does not satisfy `responseJSONSchema`
+- **THEN** `SearchMetadata.InvalidJSON` SHALL be set to true
+- **AND** the wrapped `errInvalidJSON` SHALL propagate to the caller
+
+### Requirement: Step 1 runs a single grounded slice per the default slice configuration
+
+Step 1 SHALL use the slices defined in `defaultStep1Slices`. The default configuration SHALL contain exactly **one** slice, which extracts both tours and standalones in a single grounded call:
+
+| Name | SystemInstruction | PromptTemplate | FromMonthsOffset |
+|------|-------------------|----------------|------------------|
+| `all` | `systemInstructionStep1` | `promptTemplateStep1` | 0 |
+
+The slice SHALL fire a single Gemini call (the fan-out mechanism is retained so the slice count stays configurable, but the default is one). The slice base date SHALL be `time.Now().UTC()`; the slice's `from_date` SHALL be `baseDate.AddDate(0, FromMonthsOffset, 0)`, formatted as `2006-01-02`. Step 1 SHALL NOT supply an end date (`to_date`); the discovery window is open-ended into the future.
+
+#### Scenario: Single grounded call per Search
+
+- **WHEN** `runStep1Grounded` is entered
+- **THEN** the function SHALL execute exactly one slice from `defaultStep1Slices`
+- **AND** that slice SHALL call `runStep1Slice` with the shared base date
+- **AND** the slice SHALL extract both tours and standalones into one `<extracted>` envelope
+
+#### Scenario: Open-ended start-date substitution
+
+- **WHEN** the slice prompt is constructed and base date is 2026-05-24
+- **THEN** the prompt SHALL substitute `from_date = "2026-05-24"`, the artist's name, and the official-site host
+- **AND** the prompt SHALL NOT contain any `to_date` / end-date value
+
+### Requirement: Step 1 uses a single consolidated English extraction instruction
+
+Step 1 SHALL use one system instruction `systemInstructionStep1`, written in English, that extracts both tours and standalones in a single call. The instruction SHALL follow a numbered workflow:
+
+1. Discover the artist's concert pages from the given start date onward, using `url_context` and `google_search`, **including tour pages hosted on a domain different from the official site**.
+2. Fetch each candidate page and extract the per-field XML for both tours (`<tour>`, one `<event>` per date) and standalones (`<standalone>`, one `<event>`).
+3. Exclude music festivals with a multi-artist lineup. A 2–4 act named co-headliner bill (対バン) is NOT a festival and SHALL be extracted as a standalone.
+4. Deduplicate on the triple `(venue, local_date, start_time)`.
+5. Emit the `<extracted>` XML envelope only — no prose, no markdown.
+
+The instruction SHALL include the XML output format (with `<extracted>`, `<tour>`, `<standalone>`, `<title>`, `<source_url>`, `<event>`) as a literal example, and SHALL preserve the verbatim-copy and page-context year-inference rules.
+
+#### Scenario: Consolidated instruction structure
+
+- **WHEN** `systemInstructionStep1` is loaded
+- **THEN** the instruction text SHALL be in English
+- **AND** SHALL instruct extraction of both `<tour>` and `<standalone>` elements within one `<extracted>` envelope
+- **AND** SHALL instruct exclusion of multi-artist festivals while extracting 2–4 act co-headliner bills as standalones
+
+#### Scenario: Off-domain tour page discovery
+
+- **WHEN** an artist's tour has a dedicated page on a domain different from the official-site host
+- **THEN** the instruction SHALL direct the model to discover and extract that tour, using the off-domain page URL as `source_url`
+
+### Requirement: Step 1 prompt template uses three positional placeholders
+
+Step 1 SHALL use one prompt template `promptTemplateStep1`, written in English, accepting exactly three positional placeholders in this order: `from_date`, artist name, official-site host. Each call SHALL format the template via `fmt.Sprintf`. The template SHALL request extraction of both tours and standalones occurring on or after `from_date`, SHALL exclude multi-artist festivals, and SHALL NOT contain a `to_date` / end-date placeholder.
+
+#### Scenario: Prompt formatting
+
+- **WHEN** `promptTemplateStep1` is formatted with `("2026-05-24", "UVERworld", "www.uverworld.jp")`
+- **THEN** the result SHALL contain `2026-05-24`, `UVERworld`, and `www.uverworld.jp` literally
+- **AND** the result SHALL instruct the model to extract tours and standalones on or after the start date
+- **AND** SHALL exclude multi-artist festivals
+- **AND** SHALL NOT contain any end-date value

--- a/openspec/changes/optimize-concert-searcher-cost/specs/gemini-searcher-config/spec.md
+++ b/openspec/changes/optimize-concert-searcher-cost/specs/gemini-searcher-config/spec.md
@@ -1,0 +1,29 @@
+## MODIFIED Requirements
+
+### Requirement: GCPConfig exposes per-step Gemini search model fields
+
+`pkg/config.GCPConfig` SHALL expose exactly two per-step Gemini search model fields, each populated from a dedicated environment variable with a fallback to a step-specific default constant:
+
+| Field | Env var | Default constant |
+|-------|---------|------------------|
+| `GeminiSearchModelExtract` | `GCP_GEMINI_SEARCH_MODEL_EXTRACT` | `defaultSearchModelExtract = "gemini-3.6-flash"` |
+| `GeminiSearchModelParse` | `GCP_GEMINI_SEARCH_MODEL_PARSE` | `defaultSearchModelParse = "gemini-3.1-flash-lite"` |
+
+No `GeminiSearchModelDiscovery` field SHALL exist on `GCPConfig`. No `defaultSearchModelDiscovery` constant SHALL exist. No `GCP_GEMINI_SEARCH_MODEL_DISCOVERY` env var SHALL be read.
+
+#### Scenario: Field set populated from env
+
+- **WHEN** the environment provides `GCP_GEMINI_SEARCH_MODEL_EXTRACT=gemini-3.6-flash` and `GCP_GEMINI_SEARCH_MODEL_PARSE=gemini-3.1-flash-lite`
+- **THEN** `GCPConfig.GeminiSearchModelExtract` SHALL be `"gemini-3.6-flash"`
+- **AND** `GCPConfig.GeminiSearchModelParse` SHALL be `"gemini-3.1-flash-lite"`
+
+#### Scenario: Discovery env var is unread
+
+- **WHEN** the environment provides `GCP_GEMINI_SEARCH_MODEL_DISCOVERY=anything`
+- **THEN** no `GCPConfig` field SHALL be populated from that variable
+- **AND** the variable SHALL be ignored
+
+#### Scenario: Extract-step default is gemini-3.6-flash
+
+- **WHEN** `GeminiSearchModelExtract` is empty and `SearchModelExtract()` is called
+- **THEN** the method SHALL return `"gemini-3.6-flash"`

--- a/openspec/changes/optimize-concert-searcher-cost/tasks.md
+++ b/openspec/changes/optimize-concert-searcher-cost/tasks.md
@@ -1,0 +1,39 @@
+## 1. Backend — config & model
+
+- [x] 1.1 Change `defaultSearchModelExtract` in `pkg/config` from `gemini-3.5-flash` to `gemini-3.6-flash`; update the config unit test asserting the extract-step default.
+- [x] 1.2 Confirm DI wiring (`internal/di/{provider,job}.go`) still threads `SearchModelExtract()` into `gemini.Config.ModelExtract` (no code change expected; verify).
+
+## 2. Backend — single-slice consolidation
+
+- [x] 2.1 Replace the three-entry `defaultStep1Slices` (`tours_near`, `tours_far`, `standalones`) with a single `all` slice (`FromMonthsOffset = 0`, no end offset).
+- [x] 2.2 Drop the `to_date` placeholder from the Step 1 prompt template and remove the `to_date` computation in `runStep1Slice` (open-ended, start-date-only window).
+- [x] 2.3 Update `assertStepInvariants` / any slice-count assumptions to accept a single slice; keep the `{GoogleSearch, URLContext}` tool invariant unchanged.
+
+## 3. Backend — consolidated English prompt
+
+- [x] 3.1 Merge `systemInstructionStep1Tour` + `systemInstructionStep1Standalone` into one `systemInstructionStep1` (English) that extracts both `<tour>` and `<standalone>` in one `<extracted>` envelope, preserving verbatim-copy / page-context year-inference / dedup / XML-only rules.
+- [x] 3.2 Add the coverage rules to the prompt: discover via `url_context` + `google_search` including tour pages on a domain different from the official site; exclude music festivals with a multi-artist lineup (keep 2–4 act named co-headliner bills as standalones).
+- [x] 3.3 Collapse the two prompt templates into one `promptTemplateStep1` (English): "extract tours and standalones on/after `<from_date>` for `<artist>`; exclude multi-artist festivals; official-site host: `<host>`".
+- [x] 3.4 Verify Step 1 envelope parsing (`parseStep1Envelope`, `mergeAndDedupEnvelopes`) still handles a single merged envelope with both element types; adjust if the merge assumed multiple slices.
+- [x] 3.5 Run `make check` (lint + unit tests) green.
+
+## 4. A/B evaluation
+
+- [x] 4.1 Update the A/B harness matrix (`searcher_integration_test.go`, `GEMINI_AB_EVAL=1`) to fix extract model=`gemini-3.6-flash` (parse fixed to `gemini-3.1-flash-lite`), 1 slice, `{GoogleSearch, URLContext}`, and vary `thinking ∈ {low, medium}`; Vaundy-only via `GEMINI_AB_EVAL_ARTISTS=Vaundy`.
+- [x] 4.2 Ran the harness (dev Gemini key) against the refreshed fixture (Vaundy + SUPER BEAVER, eval_from 2026-07-27, 12 cells). Result: SUPER BEAVER recall≈0.97(low)/0.99(medium); Vaundy recall 0.77(low, unstable — one run 0.61)/0.89(medium, stable). All cells `webSearchQueries=0` (grounding stays invisible on 3.6-flash too).
+- [x] 4.3 Captured per-run token cost. thinking tokens: 3.6-flash 94–1,253 (vs 3.5-flash 4,000–5,500) — much lower. Harness `total_cost=$0` and `webSearchQueries=0` confirm the search-query fan-out is NOT observable per run (verified post-deploy in 6.2).
+- [x] 4.4 **Chosen: thinking=medium.** Failure analysis: with `low`, one Vaundy run truncated the long 2027-2028 tour (dropped 10 real 2028 dates); `medium` enumerated the full tour every run — its only misses were 2 unmatchable "会場未定/TBD" placeholder venues (fixture artifact), i.e. effectively perfect discovery. No recall regression: `medium` finds all matchable events. Caveat: medium's deeper reasoning may raise the (invisible) fan-out — confirm via billing in 6.2.
+
+## 5. Prod rollout
+
+- [ ] 5.1 Cut a backend release including the config/model/prompt changes (verify a dev AR image exists for the concert-discovery job image before release).
+- [ ] 5.2 concert-discovery has NO `GCP_GEMINI_SEARCH_MODEL_EXTRACT` override, so it inherits the new `gemini-3.6-flash` default from the backend image (sales-phase-discovery explicitly overrides to flash-lite and is unaffected). In cloud-provisioning concert-discovery configmap.env: set `GCP_GEMINI_SEARCH_THINKING_EXTRACT=medium` (A/B-chosen value; confirm this is the effective thinking level vs the code default) and, for explicitness, optionally pin `GCP_GEMINI_SEARCH_MODEL_EXTRACT=gemini-3.6-flash`; bump the job image pin (auto pin-bump may omit discovery cronjobs — bump manually).
+- [ ] 5.3 Re-tighten the Gemini spend cap as an interim guardrail; note who raised it and the new value.
+
+## 6. Verification & close-out
+
+- [ ] 6.1 Confirm ArgoCD syncs the prod overlay and the concert-discovery job runs the new image/config.
+- [ ] 6.2 Verify in the billing export that the "Generate content search query gemini 3 paid" SKU drops on the next concert-discovery run (fan-out × 3-slice removed).
+- [ ] 6.3 Verify discovery recall holds in prod (spot-check newly discovered concerts vs known announcements).
+- [ ] 6.4 Update the Google support case with the deployed fix as evidence of remediation.
+- [ ] 6.5 Verify the change (`/opsx:verify`) and archive it once all tasks are complete and shipped.


### PR DESCRIPTION
## 🔗 Related Issue

Refs liverty-music/backend#323

## 📝 Summary

Adds the OpenSpec change **`optimize-concert-searcher-cost`** (docs only — no proto changes).

Captures the concert-searcher cost-optimization work:
- migrate the Step 1 extract model `gemini-3.5-flash` → `gemini-3.6-flash`;
- consolidate the three grounded slices into a single English prompt over an open-ended window;
- A/B-tune the thinking level (result: **medium** — `low` truncated Vaundy's long 2027-2028 tour).

Artifacts: `proposal.md`, `design.md`, delta specs (`gemini-searcher-config`,
`gemini-grounded-extract-and-coerce`), `tasks.md` (with the A/B result recorded).

Implementation PR: liverty-music/backend#373.
