### PR TITLE
docs(openspec): add optimize-sales-merch-searcher-cost change

### DIFF
--- a/openspec/changes/optimize-sales-merch-searcher-cost/.openspec.yaml
+++ b/openspec/changes/optimize-sales-merch-searcher-cost/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-28

--- a/openspec/changes/optimize-sales-merch-searcher-cost/design.md
+++ b/openspec/changes/optimize-sales-merch-searcher-cost/design.md
@@ -1,0 +1,62 @@
+## Context
+
+`sales-phase-discovery` and `merch-discovery` both run the Gemini searcher on `gemini-3.1-flash-lite`. Post-concert-migration, they are the remaining "search query gemini 3 paid" cost (~¥448/day, ~2x fan-out). The `optimize-concert-searcher-cost` change proved that `gemini-3.6-flash` (a) grounds correctly while reporting `tool_use=0`/`webSearchQueries=0` in metadata (verified via post-cutoff data), and (b) bills that grounding as cheap tokens rather than per-search-query fan-out.
+
+Constraint: metadata cannot be trusted to judge grounding (see the concert change) — quality is judged by whether the searcher extracts **post-training-cutoff** data.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Migrate `sales-phase-discovery` and `merch-discovery` extract to `gemini-3.6-flash` + thinking `medium`.
+- Improve grounding quality (flash-lite under-grounds sales phases and hallucinates merch URLs).
+- Reduce the remaining per-search-query billing to token billing.
+- Keep the change lean: merch = code default change; sales = prod-overlay env change; both inherit the concert change's `defaultSearchModelExtract`.
+
+**Non-Goals:**
+
+- No change to `ConcertSearcher` (already 3.6-flash) or the email parser (Vertex, no grounding).
+- Step 2 parse stays `gemini-3.1-flash-lite` (mechanical JSON coercion; schema-bounded).
+- No proto/API change.
+
+## Decisions
+
+### D1: merch default model `gemini-3.1-flash-lite` → `gemini-3.6-flash`, thinking `high` → `medium`
+
+merch has no env override, so changing the code defaults migrates it. A/B evidence below.
+
+### D2: sales-phase extract → `gemini-3.6-flash`, thinking `high` → `medium`
+
+sales-phase overrides the extract model to flash-lite via its configmap; switching that env (or dropping it to inherit the `gemini-3.6-flash` default) migrates it with no backend code change. Parse stays flash-lite.
+
+### D3: thinking = `medium` (fixed)
+
+Matches the concert decision; the A/B below used `medium` and it grounded correctly for both searchers. (flash-lite's prod default was `high` and still under-grounded.)
+
+### D4: refresh the integration-test fixtures to current Vaundy data
+
+The sales-phase fixture (HORO Feb–Mar 2026 presales) was stale/closed; refreshed to the `ぴあ抽選先行` phase (announced 2026-07-16, post-cutoff) so the test is a real grounding/freshness discriminator. The merch Vaundy case series was refreshed to the current tour; a goods-having artist (ヨルシカ) is the merch discriminator (Vaundy has no tour goods page).
+
+## A/B evidence (local, dev key, thinking=medium, 2026-07-27)
+
+| Searcher | `gemini-3.1-flash-lite` | `gemini-3.6-flash` |
+|---|---|---|
+| sales-phase (Vaundy `ぴあ抽選先行`) | 0 phases found (under-grounded) | 1/1 exact — apply/result/payment dates + pia URL correct |
+| merch (ヨルシカ「一人称」) | hallucinated `.../category_id=3428` (fake) | correct `store.plusmember.jp/yorushika/` |
+
+Both flash-lite failures are quality defects, not just cost. 3.6-flash grounded post-cutoff data with `tool_use=0` (metadata under-reports, as with concert).
+
+## Risks / Trade-offs
+
+- **Token cost up on 3.6-flash** (sales ~5k vs ~1.9k tokens) → but flash-lite's cheap tokens produce wrong/empty results; and the per-search-query fan-out (the dominant cost) is expected to drop. Net verified via post-deploy billing.
+- **Fan-out not measurable pre-deploy** (metadata invisible) → verify via the billing SKU after rollout.
+- **Small A/B sample** (one artist per searcher) → the failure/success contrast is stark and consistent with the concert result; monitor prod discovery after rollout.
+
+## Migration Plan
+
+1. Backend: change merch defaults + config test; commit the refreshed integration-test fixtures. `make check` green.
+2. Release backend (next minor); merch inherits the new defaults.
+3. cloud-provisioning: sales-phase-discovery configmap → extract `gemini-3.6-flash` + thinking `medium`; bump the job pin (auto pin-bump may cover it; verify).
+4. Verify post-deploy: billing "search query gemini 3 paid" SKU drops; sales-phase/merch discovery output still fresh and correct.
+
+Rollback: revert the merch defaults / sales-phase env; no data migration.

--- a/openspec/changes/optimize-sales-merch-searcher-cost/proposal.md
+++ b/openspec/changes/optimize-sales-merch-searcher-cost/proposal.md
@@ -1,0 +1,36 @@
+## Why
+
+After the concert-searcher migration to `gemini-3.6-flash` (`optimize-concert-searcher-cost`, backend v1.24.0), the remaining Gemini search-query cost is `sales-phase-discovery` + `merch-discovery`, both on `gemini-3.1-flash-lite` (~¥448/day "search query gemini 3 paid"). A local A/B (thinking=medium, refreshed Vaundy fixture) shows flash-lite is not just costly but **lower quality**:
+
+- **sales-phase**: flash-lite returned **0 phases** for Vaundy's current `ぴあ抽選先行` (JAPAN ARENA TOUR 2027-2028, announced 2026-07-16 — after the model cutoff), i.e. it under-grounded and found nothing. `gemini-3.6-flash` returned it **exactly** (apply 07-16→08-02, lottery result 08-08, payment 08-11, correct pia URL) — grounding live post-cutoff data.
+- **merch**: flash-lite **hallucinated a non-existent deep link** (`.../products/list.php?category_id=3428`); `gemini-3.6-flash` returned the **correct official store URL** (`store.plusmember.jp/yorushika/`).
+
+Per the concert finding, `gemini-3.6-flash` also bills grounding as cheap tokens rather than per-search-query fan-out — so this is a quality **and** cost win.
+
+## What Changes
+
+- **merch-discovery**: default model `gemini-3.1-flash-lite` → `gemini-3.6-flash`; default thinking `high` → `medium`.
+- **sales-phase-discovery**: switch the Step 1 extract model from the `gemini-3.1-flash-lite` env override to `gemini-3.6-flash` (inherit the `defaultSearchModelExtract`), and thinking extract `high` → `medium`. The Step 2 parse model stays `gemini-3.1-flash-lite` (cheap, mechanical).
+- **Test fixtures**: refresh the sales-phase and merch integration-test ground truth to current Vaundy data (a post-cutoff sale phase as the grounding/freshness discriminator).
+- **Verify** post-deploy: the "search query gemini 3 paid" billing SKU drops further and discovery quality holds/improves.
+
+Non-goals: no change to `ConcertSearcher` (already on 3.6-flash) or the email parser (Vertex AI, no grounding). No proto/API change.
+
+## Capabilities
+
+### New Capabilities
+
+_None._
+
+### Modified Capabilities
+
+- `gemini-searcher-config`: add the merch-searcher model and thinking default constants (`defaultMerchModel = "gemini-3.6-flash"`, `defaultMerchThinkingLevel = "medium"`). The sales-phase extract model is not a new spec field — it uses the existing `SearchModelExtract()` resolution, so migrating it is a prod-overlay env change only.
+
+## Impact
+
+- **backend** (`liverty-music/backend`):
+  - `pkg/config` — `defaultMerchModel` → `gemini-3.6-flash`, `defaultMerchThinkingLevel` → `medium`; update the config test.
+  - `internal/infrastructure/gcp/gemini/{sales_phase,merch}_searcher_integration_test.go` — refreshed fixtures (current Vaundy tour / sale phase / official store).
+- **cloud-provisioning**: `sales-phase-discovery` configmap.env — set `GCP_GEMINI_SEARCH_MODEL_EXTRACT=gemini-3.6-flash` (or drop the flash-lite override to inherit the default) and `GCP_GEMINI_SEARCH_THINKING_EXTRACT=medium`; keep `GCP_GEMINI_SEARCH_MODEL_PARSE=gemini-3.1-flash-lite`. merch-discovery inherits the new backend defaults (no env override today).
+- **Verification**: post-deploy billing (search-query SKU) + spot-check sales-phase/merch discovery output freshness.
+- No breaking API change; no BSR/proto change.

--- a/openspec/changes/optimize-sales-merch-searcher-cost/specs/gemini-searcher-config/spec.md
+++ b/openspec/changes/optimize-sales-merch-searcher-cost/specs/gemini-searcher-config/spec.md
@@ -1,0 +1,27 @@
+## ADDED Requirements
+
+### Requirement: GCPConfig exposes merch-searcher model and thinking fields
+
+`pkg/config.GCPConfig` SHALL expose a merch-searcher model field and a merch-searcher thinking field, each populated from a dedicated environment variable with a fallback to a default constant:
+
+| Field | Env var | Default constant |
+|-------|---------|------------------|
+| `GeminiMerchModel` | `GCP_GEMINI_MERCH_MODEL` | `defaultMerchModel = "gemini-3.6-flash"` |
+| `GeminiMerchThinkingLevel` | `GCP_GEMINI_MERCH_THINKING_LEVEL` | `defaultMerchThinkingLevel = "medium"` |
+
+`GCPConfig` SHALL expose helper methods `MerchModel() string` and `MerchThinking() string` that resolve env override → default. The `MerchSearcher` SHALL read the model and thinking level exclusively via these accessors (threaded through DI into `gemini.MerchConfig`).
+
+#### Scenario: Merch model default applied when env unset
+
+- **WHEN** `GeminiMerchModel` is empty and `MerchModel()` is called
+- **THEN** the method SHALL return `"gemini-3.6-flash"`
+
+#### Scenario: Merch thinking default applied when env unset
+
+- **WHEN** `GeminiMerchThinkingLevel` is empty and `MerchThinking()` is called
+- **THEN** the method SHALL return `"medium"`
+
+#### Scenario: Merch env override honoured
+
+- **WHEN** the environment provides `GCP_GEMINI_MERCH_MODEL=gemini-3.1-flash-lite`
+- **THEN** `MerchModel()` SHALL return `"gemini-3.1-flash-lite"`

--- a/openspec/changes/optimize-sales-merch-searcher-cost/tasks.md
+++ b/openspec/changes/optimize-sales-merch-searcher-cost/tasks.md
@@ -1,0 +1,29 @@
+## 1. Backend — merch defaults
+
+- [x] 1.1 In `pkg/config`, change `defaultMerchModel` from `gemini-3.1-flash-lite` to `gemini-3.6-flash` and `defaultMerchThinkingLevel` from `high` to `medium`; update the merch model/thinking comments accordingly.
+- [x] 1.2 Add/adjust config unit tests asserting `MerchModel()` defaults to `gemini-3.6-flash` and `MerchThinking()` defaults to `medium`.
+
+## 2. Backend — test fixtures (already drafted locally)
+
+- [x] 2.1 Commit the refreshed `sales_phase_searcher_integration_test.go` fixture: series `Vaundy JAPAN ARENA TOUR 2027-2028`, ground truth = `ぴあ抽選先行` (apply_start 2026-07-16 12:00 JST), thinking loop = `{medium}`, `SALES_PHASE_TEST_MODEL_EXTRACT` override retained.
+- [x] 2.2 Commit the refreshed `merch_searcher_integration_test.go` Vaundy case series (`Vaundy JAPAN ARENA TOUR 2027-2028`).
+- [x] 2.3 Run `make check` (lint + unit tests) green.
+
+## 3. A/B validation (done — record here)
+
+- [x] 3.1 Local A/B (dev key, thinking=medium): sales-phase flash-lite 0 phases vs 3.6-flash 1/1 exact (`ぴあ抽選先行`, post-cutoff, apply/result/payment + pia URL correct).
+- [x] 3.2 Local A/B: merch flash-lite hallucinated `.../category_id=3428` vs 3.6-flash correct `store.plusmember.jp/yorushika/`.
+- [x] 3.3 Decision: migrate both sales-phase and merch extract to `gemini-3.6-flash` + thinking `medium`. Fan-out cost drop verified post-deploy (metadata invisible).
+
+## 4. Prod rollout
+
+- [ ] 4.1 Cut a backend release (next minor) including the merch defaults + fixtures. merch-discovery inherits the new defaults; verify a dev AR image exists before release.
+- [ ] 4.2 In cloud-provisioning `sales-phase-discovery` configmap.env: set `GCP_GEMINI_SEARCH_MODEL_EXTRACT=gemini-3.6-flash` and `GCP_GEMINI_SEARCH_THINKING_EXTRACT=medium`; keep `GCP_GEMINI_SEARCH_MODEL_PARSE=gemini-3.1-flash-lite`. Bump the sales-phase-discovery job pin (auto pin-bump may omit it — verify/bump manually).
+- [ ] 4.3 Confirm merch-discovery prod job picks up the new backend image (its pin bumps with the release); it has no env override so it inherits `gemini-3.6-flash` / `medium`.
+
+## 5. Verification & close-out
+
+- [ ] 5.1 Confirm ArgoCD syncs; sales-phase-discovery and merch-discovery jobs run the new model (`model_grounded`/`model=gemini-3.6-flash` in logs).
+- [ ] 5.2 Verify in the billing export that the "search query gemini 3 paid" SKU drops for the sales/merch run hours after rollout.
+- [ ] 5.3 Spot-check discovery quality: sales-phase surfaces current/post-cutoff sale phases; merch resolves correct official URLs (no fabricated deep links).
+- [ ] 5.4 Verify the change (`/opsx:verify`) and archive it once all tasks are complete and shipped.


### PR DESCRIPTION
## Summary

OpenSpec change **`optimize-sales-merch-searcher-cost`** (docs only — no proto).

Migrate `sales-phase-discovery` + `merch-discovery` from `gemini-3.1-flash-lite`
to `gemini-3.6-flash` + `medium` thinking (mirrors the concert migration). Local
A/B (thinking=medium, Vaundy):
- sales-phase: flash-lite **0 phases** vs 3.6-flash **1/1 exact** (`ぴあ抽選先行`, announced 2026-07-16 = post-cutoff)
- merch: flash-lite **fabricated** `.../category_id=3428` vs 3.6-flash **correct** `store.plusmember.jp/yorushika/`

Artifacts: proposal, design (A/B evidence), delta spec (`gemini-searcher-config` merch defaults), tasks.

Backend implementation: liverty-music/backend `optimize-sales-merch-searcher-cost`. Refs liverty-music/backend#323.
