### PR TITLE
docs(openspec): archive discovery-bubble-cache

### DIFF
--- a/openspec/changes/archive/2026-07-28-discovery-bubble-cache/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-28-discovery-bubble-cache/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-28

--- a/openspec/changes/archive/2026-07-28-discovery-bubble-cache/design.md
+++ b/openspec/changes/archive/2026-07-28-discovery-bubble-cache/design.md
@@ -1,0 +1,19 @@
+## Context
+
+Dashboard の `ConcertStore.lastDateGroups` パターンの直接適用。`DiscoveryRoute` はナビゲーションのたびに再インスタンス化されるが、`ArtistStore` は DI シングルトンとしてアプリ寿命で存在する。最後に生成したバブルプールをシングルトンに保持すれば、次回の `DiscoveryRoute` インスタンスが即座にそれを読み取れる。
+
+## Decisions
+
+- **保存するのは最終出力 `Artist[]` であり中間データ（listSimilar 結果 など）ではない。** Dashboard での教訓: 中間データの組み合わせは条件 mismatch のリスクが高い。最終プール（dedup・トップアップ処理済み）をそのまま保存する。
+
+- **キャッシュヒット時はゴーストバブルをスキップ。** 画面が一瞬でも半透明バブルに切り替わることを避け、前回のリアルアーティストが即描画されるべき。
+
+- **バックグラウンド更新はキャッシュヒット時のみ発動。** 初回訪問では `loadInitialBubbles()` がコールドロードを担う（ゴースト→リアルの切り替えアニメーションが走る）。
+
+- **`setBubbles()` は `loadInitialBubbles()` 完了後に呼ぶ。** 失敗・中断時は前回のキャッシュを保持したままとし、古いデータで次回再入場できるようにする。
+
+## Migration
+
+1. `ArtistStore` に `lastBubbles` + `peekBubbles()` + `setBubbles()` を追加。
+2. `DiscoveryRoute.loading()` にキャッシュ分岐を追加。
+3. `loadInitialBubbles()` 完了時に `setBubbles()` を呼ぶ。

--- a/openspec/changes/archive/2026-07-28-discovery-bubble-cache/proposal.md
+++ b/openspec/changes/archive/2026-07-28-discovery-bubble-cache/proposal.md
@@ -1,0 +1,17 @@
+## Why
+
+Discovery ページに遷移するたびに `BubbleManager` が再インスタンス化されてバブルプールが空になるため、フォロー済みアーティストを持つユーザーでも毎回 `listSimilar` ネットワーク RPC が発生し、バブルが表示されるまで 1〜3 秒の空白が生じる。フォローなしユーザーは `ArtistStore.listTop` のキャッシュで即時返るが、フォローありの一般ユーザーでは再入場のたびにスピナーと同等の待ち時間が発生する。
+
+Dashboard の `ConcertStore.lastDateGroups` パターンと同様に、最後に生成されたバブルプール（`Artist[]`）を `ArtistStore` シングルトンに保持することで、再入場時にゴーストバブルをスキップして即座にリアルアーティストを表示できる。
+
+## What Changes
+
+- `ArtistStore` シングルトンに `lastBubbles: Artist[] | null` を追加し `peekBubbles()` / `setBubbles()` を公開。
+- `DiscoveryRoute.loading()` でキャッシュ確認: `peekBubbles()` が non-null なら即座にリアルアーティストでプールを初期化（ゴーストバブル不要）し、バックグラウンドで `loadInitialBubbles()` を実行して更新。null の場合（初回訪問）はゴーストバブルを使う現行フロー。
+- `loadInitialBubbles()` 完了後に `setBubbles(pool.availableBubbles)` でシングルトンを更新。
+
+## Impact
+
+- Frontend のみ。proto / BSR / backend / API 変更なし。
+- 再入場: ゴーストバブルなし → キャッシュからリアルアーティストが即描画 → バックグラウンド更新。
+- 初回訪問: ゴーストバブル → ネットワーク取得 → リアルアーティストに切り替え（現行フロー維持）。

--- a/openspec/changes/archive/2026-07-28-discovery-bubble-cache/specs/discovery-bubble-cache/spec.md
+++ b/openspec/changes/archive/2026-07-28-discovery-bubble-cache/specs/discovery-bubble-cache/spec.md
@@ -1,0 +1,20 @@
+## ADDED Requirements
+
+### Requirement: Discovery bubble pool is cached in ArtistStore singleton
+`ArtistStore` SHALL cache the last successfully generated bubble pool (`Artist[]`) so that `DiscoveryRoute` re-entries can paint real artists immediately without waiting on network RPCs.
+
+#### Scenario: Re-entry paints cached artists instantly
+- **WHEN** the user navigates to Discovery after a prior visit
+- **THEN** the bubble pool SHALL be initialized from the cached artists synchronously during `loading()`
+- **AND** no ghost bubbles SHALL be shown
+- **AND** `loadInitialBubbles()` SHALL run in the background to refresh the pool
+
+#### Scenario: Cold visit uses ghost bubbles
+- **WHEN** no cached artists exist (first visit or cache cleared)
+- **THEN** the route SHALL initialize with ghost placeholder bubbles as the current behavior
+- **AND** switch to real artists when `loadInitialBubbles()` completes
+
+#### Scenario: Cache is updated after each successful load
+- **WHEN** `loadInitialBubbles()` completes successfully
+- **THEN** `ArtistStore.setBubbles(pool.availableBubbles)` SHALL be called to persist the pool
+- **AND** the next re-entry SHALL use the updated pool

--- a/openspec/changes/archive/2026-07-28-discovery-bubble-cache/tasks.md
+++ b/openspec/changes/archive/2026-07-28-discovery-bubble-cache/tasks.md
@@ -1,0 +1,20 @@
+## 1. ArtistStore にバブルキャッシュを追加
+
+- [x] 1.1 `ArtistStore` に `lastBubbles: Artist[] | null = null` フィールド、`peekBubbles(): Artist[] | null`、`setBubbles(artists: Artist[]): void` を追加する。
+
+## 2. DiscoveryRoute のキャッシュ分岐
+
+- [x] 2.1 `DiscoveryRoute.loading()` でキャッシュ確認を追加する: `artistClient.peekBubbles()` が non-null なら pool をリアルアーティストで初期化しゴーストをスキップ。null の場合はゴーストバブルを使う現行フロー。
+- [x] 2.2 `loadInitialBubbles()` 完了後に `artistClient.setBubbles(bubbles.pool.availableBubbles)` を呼んでシングルトンを更新する。
+
+## 3. テスト
+
+- [x] 3.1 `DiscoveryRoute.loading()` のキャッシュヒット分岐ユニットテスト: peekBubbles non-null → ゴーストなし・即描画。
+- [x] 3.2 `ArtistStore.peekBubbles() / setBubbles()` ユニットテスト。
+
+## 4. 検証・出荷
+
+- [x] 4.1 `make check` グリーン確認。
+- [x] 4.2 localhost で再入場時にゴーストなし・即描画されることを確認。
+- [x] 4.3 frontend PR → CI グリーン → マージ → Release → prod ロール確認。
+- [x] 4.4 OpenSpec change をアーカイブ。

--- a/openspec/changes/archive/2026-07-28-pwa-version-management/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-28-pwa-version-management/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-27

--- a/openspec/changes/archive/2026-07-28-pwa-version-management/design.md
+++ b/openspec/changes/archive/2026-07-28-pwa-version-management/design.md
@@ -1,0 +1,94 @@
+## Context
+
+The frontend is a vite-plugin-pwa (injectManifest strategy) PWA. The current SW registration is a bare `navigator.serviceWorker.register('/sw.js')` in `main.ts` with no update lifecycle handling. A waiting service worker sits indefinitely until the user force-quits — especially problematic on installed standalone PWAs. The existing `Snack` component (with `action` and `duration` options) and `ResumeRevalidator` (visibilitychange hook) are reusable building blocks.
+
+Release version identity is split: the build-time image digest is available as a git SHA at build time, but the semver release label (`v1.26.0`) is only determined at release time (retag via `crane copy`). The per-environment `config.json` ConfigMap is the correct carrier for the release label because the pin-bump workflow already touches cloud-provisioning on each release.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Users running an outdated installed PWA receive and can apply updates without force-quitting.
+- Users can see the current release version and build identity in Settings for support purposes.
+- The update UX never interrupts an ongoing interaction (no modal, no surprise reload).
+- Boot-time: if a waiting SW is detected before any user interaction, apply silently (nothing to lose).
+
+**Non-Goals:**
+- Kill-switch / forced minimum-version enforcement (deferred; hybrid flow makes it unnecessary for now).
+- "What's new" release notes UI (separate future capability).
+- Offline app-shell fallback (intentional non-goal per the `frontend-runtime-config` spec rationale).
+- iOS Safari quirks beyond standard SW lifecycle (no additional workarounds in scope).
+
+## Decisions
+
+### D1 — Use `virtual:pwa-register` for client-side SW management
+
+**Decision:** Replace the bare `navigator.serviceWorker.register()` in `main.ts` with `registerSW` from `virtual:pwa-register` (already available via the installed `vite-plugin-pwa`), with `registerType: 'prompt'`.
+
+**Rationale:** The virtual module handles `updatefound → statechange → installed+controller` detection, the single-shot page reload on update (via an internal `controlling` event listener that calls `window.location.reload()` when `isUpdate: true`), and the `SKIP_WAITING` postMessage round-trip — all of which are correct-but-subtle to hand-roll. The injectManifest strategy still keeps the hand-written `sw.ts`; only the client-side registration moves to the virtual module. No new dependency is introduced.
+
+**Critical implication:** Because `virtual:pwa-register` already wires the `controlling` → `location.reload()` handler internally, **no manual `controllerchange` listener should be added**. Adding one alongside the library's handler causes a double-reload on every SW update.
+
+**Alternative considered:** Continue with hand-written registration + custom updatefound listener. Rejected: the reload-once guard and the detection chain (updatefound → statechange → installed && controller) are boilerplate we do not need to maintain, and hand-rolling the guard is a common source of reloop bugs.
+
+SW-side additions required in `sw.ts`:
+```
+// In message handler: if (e.data?.type === 'SKIP_WAITING') self.skipWaiting()
+// In activate handler: event.waitUntil(Promise.all([self.clients.claim(), flushInteractionStash()]))
+// NOTE: Promise.all is required — replacing the existing waitUntil call drops flushInteractionStash
+```
+
+### D2 — Update UX: persistent Snack with [更新] action, silent apply on boot only
+
+**Decision:** When a waiting SW is detected after user interaction has begun, publish a non-auto-dismissing `Snack` with severity `'info'`, `duration: Infinity`, and an action `{ label: '更新', callback: updateSW }`. When the user taps [更新], `updateSW(true)` is called (SKIP_WAITING → SW activates → `virtual:pwa-register`'s internal `controlling` handler reloads the page once). Boot-time exception: if `onNeedRefresh` fires before the first `pointerdown`/`touchstart` event, apply silently (no toast, no user action required).
+
+**Prerequisite:** `snack-bar.ts` must guard `if (durationMs === Infinity)` before setting the auto-dismiss `setTimeout`. Without this guard, `setTimeout(fn, Infinity)` coerces to `setTimeout(fn, 0)` (ToInt32 overflow → 0) and the toast auto-dismisses on the next tick.
+
+**Rationale:** The existing `Snack` component already supports `action` and `duration` options — no new component needed. Non-blocking toast matches Material/web.dev best practices. The boot-time exception covers the case where the app was just opened and the old SW was already waiting; there is no in-progress work to interrupt.
+
+**Alternative considered:** Reload silently on "safe routes" (no form input). Rejected: "safe" is hard to define correctly, and reload during any active reading/scrolling session causes unnecessary surprise per UX review in exploration.
+
+### D3 — Build SHA injected at build time via vite `define`
+
+**Decision:** Add `define: { __BUILD_SHA__: JSON.stringify(process.env.GITHUB_SHA?.slice(0, 7) ?? 'dev') }` to `vite.config.ts`. The 7-character prefix is sufficient for disambiguation and matches the convention used in GitHub URLs.
+
+**Rationale:** The SHA identifies the exact code artifact independently of the release label. It is the most reliable fingerprint for debugging (unlike `releaseVersion` which is added post-retag). It is available at `npm run build` time via `GITHUB_SHA` in CI; local dev falls back to the literal string `'dev'`.
+
+**Alternative considered:** Use `package.json` version as the build-time identifier. Rejected: `package.json` version is `0.1.0` (a placeholder, not bumped per release); the git SHA is the true build identity.
+
+### D4 — `releaseVersion` carried in config.json, written by pin-bump workflow
+
+**Decision:** Add an optional `releaseVersion?: string` field to the `AppConfig` TypeScript interface and to all per-environment config.json ConfigMaps in cloud-provisioning. The prod pin-bump workflow writes `"releaseVersion": "vX.Y.Z"` (including the `v` prefix, matching the git tag format). The dev ConfigMap receives `"releaseVersion": "dev"` as a static placeholder.
+
+**Rationale:** The retag-based release pipeline means the semver tag is only known at release time, after the image is already built. config.json is the correct place: it is per-environment, served NetworkOnly (always fresh), and already touched by the pin-bump workflow on every release. The field is optional (frontend renders gracefully when absent, e.g., during the rollout window before cloud-provisioning catches up).
+
+**Alternative considered:** Bake the version into the bundle via `vite define`. Rejected: the build runs before the release tag exists (retag architecture), so `RELEASE_VERSION` would be empty or wrong at build time.
+
+### D5 — Settings version row: display only, copy-to-clipboard for support
+
+**Decision:** Add a read-only row to the Settings screen ("アプリ情報" section, placed last) showing the release version from `AppConfig.releaseVersion` and the build SHA from `__BUILD_SHA__`. Tapping the row copies the combined string (`v1.26.0 (abc1234)`) to the clipboard. No navigation. Authenticated and guest users both see it.
+
+**Rationale:** A copy-to-clipboard affordance directly addresses the support use-case (bug report context) without requiring a dedicated detail page. "アプリ情報" as the section title is familiar iOS/Android convention.
+
+### D6 — `update()` triggered on boot and visibilitychange
+
+**Decision:** Pass an `onRegisteredSW` callback to `registerSW` that sets up a periodic `registration.update()` on `visibilitychange:visible` (reusing the pattern already established by `ResumeRevalidator`). No additional interval timer — visibilitychange-driven polling is sufficient for the always-on PWA use case.
+
+**Rationale:** Without explicit `update()` calls, the browser defers the SW check by up to 24 hours. Installed PWAs that are never fully quit would then go a full day before receiving updates. Piggybacking on `visibilitychange` keeps the update check free and avoids a polling timer.
+
+## Risks / Trade-offs
+
+- **[Risk] `clients.claim()` in activate takes control of already-open pages instantly.** A page loaded under the old SW and then `claim()`ed by the new SW could mix old HTML routes with new precache, causing a brief inconsistency window. → **Mitigation:** `clients.claim()` is safe here because we only reach activate after the user explicitly tapped [更新] (or the boot-time silent path, where no page state exists yet). The controllerchange listener reloads immediately, so the inconsistency window is sub-second.
+- **[Risk] `duration: Infinity` Snacks accumulate if update events fire repeatedly.** → **Mitigation:** Store the `SnackHandle` returned after the EA publish. A non-null handle means a toast is already showing; on a second `onNeedRefresh`, call `handle.dismiss()` before publishing the replacement. Do NOT add a separate boolean flag — the handle itself is the authoritative state (a separate flag can drift if the snack-bar dismisses the toast externally).
+- **[Risk] config.json `releaseVersion` lags during the pin-bump rollout window.** Between a GH Release being created and the cloud-provisioning PR merging + ArgoCD syncing, the running pods still serve the old config.json (without or with stale `releaseVersion`). → **Mitigation:** The field is optional in TypeScript; the Settings row renders `—` or omits the version when absent, without error.
+- **[Risk] `GITHUB_SHA` is not set in local dev builds.** → **Mitigation:** The `vite define` expression falls back to the literal string `'dev'`, which is a clear and harmless placeholder.
+
+## Migration Plan
+
+1. **frontend PR first:** Add `__BUILD_SHA__` define, switch to `registerSW`, add SW-side SKIP_WAITING + clients.claim, add Settings version row reading `config?.releaseVersion ?? '—'`. The field is optional so frontend ships without waiting for CP.
+2. **cloud-provisioning PR:** Add `releaseVersion` to dev and prod config.json ConfigMaps, update pin-bump workflow to write the field on each release.
+3. **No rollback complexity:** The config.json change is additive; removing `releaseVersion` later is safe (frontend already handles absence). The SW changes are isolated to registration and SW internals with no protocol changes.
+
+## Open Questions
+
+- The update Snack message copy ("新しいバージョンが利用可能です") and the [更新] button label need i18n keys — confirm with the standard `settings.*` or `common.*` namespace convention used elsewhere.
+- Should the build SHA row be visible only in dev/staging, or in prod too? (Current design: always visible — useful for prod bug reports. Revisit if product decides it is noise for end users.)

--- a/openspec/changes/archive/2026-07-28-pwa-version-management/proposal.md
+++ b/openspec/changes/archive/2026-07-28-pwa-version-management/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+Installed PWA users can be silently stuck on outdated code indefinitely — the current implementation uses a bare `navigator.serviceWorker.register()` with no update lifecycle handling, so a waiting service worker never activates until the user force-quits the app. Users also have no way to know what version they are running, which makes bug reports and support conversations harder than they need to be.
+
+## What Changes
+
+- Replace the bare SW registration in `main.ts` with `virtual:pwa-register` from `vite-plugin-pwa`, which handles update detection, `controllerchange`-based single-shot reload, and reloop guarding out of the box.
+- Add `SKIP_WAITING` message handler and `clients.claim()` to `sw.ts` to complete the update handoff on the SW side.
+- Show a persistent non-blocking update toast ("新しいバージョンが利用可能です [更新]") when a waiting SW is detected; the user controls when reload happens.
+- Silent auto-apply only on first paint before any user interaction (no controller = initial install or brand-new tab; nothing to lose).
+- Trigger `registration.update()` on boot and on `visibilitychange:visible` so PWA users who never close the app still receive updates promptly.
+- Add `releaseVersion` field to the `AppConfig` schema and to every per-environment `config.json` ConfigMap; the prod pin-bump workflow writes the version automatically.
+- Add a version display row to the Settings screen showing `releaseVersion` (from config.json) and a build-time SHA (injected via vite `define`).
+
+## Capabilities
+
+### New Capabilities
+
+- `pwa-update-lifecycle`: Service worker update detection, user-controlled apply flow, and boot-time silent apply.
+
+### Modified Capabilities
+
+- `frontend-runtime-config`: Add `releaseVersion` field to the `AppConfig` schema.
+- `settings`: Add app version display (release version + build SHA) to the Settings screen.
+- `prod-image-pipeline`: Pin-bump workflow writes `releaseVersion` to config.json ConfigMaps as part of each release.
+
+## Impact
+
+- **frontend repo**: `main.ts` (SW registration), `sw.ts` (SKIP_WAITING + clients.claim), `vite.config.ts` (`define: __BUILD_SHA__`), `settings-route.ts/.html`, `shared/config/app-config.ts` (AppConfig shape), new update-toast component or snack variant, `virtual:pwa-register` import.
+- **cloud-provisioning repo**: Per-environment `config.json` ConfigMaps (dev + prod) gain `releaseVersion` field; prod pin-bump workflow (`bump-prod-pin.yaml` or equivalent) writes the new field on each release.
+- **No backend proto changes.** No new RPC. No BSR publish required.

--- a/openspec/changes/archive/2026-07-28-pwa-version-management/specs/frontend-runtime-config/spec.md
+++ b/openspec/changes/archive/2026-07-28-pwa-version-management/specs/frontend-runtime-config/spec.md
@@ -1,0 +1,35 @@
+## MODIFIED Requirements
+
+### Requirement: `/config.json` SHALL conform to the AppConfig schema
+
+The runtime configuration document SHALL be a JSON object whose top-level shape exactly matches the TypeScript `AppConfig` interface declared in `frontend/shared/config/app-config.ts`. The interface SHALL be the single source of truth for the contract between the SPA bundle and any environment that serves `/config.json`. The schema fields SHALL include: `environment` (one of `dev | staging | prod`), `apiBaseUrl` (absolute https URL), `zitadelIssuer` (absolute https URL), `zitadelClientId` (non-empty string), `zitadelOrgId` (non-empty string), `vapidPublicKey` (non-empty string), `circuitBaseUrl` (string, MAY be empty when ZK circuits are unavailable in the environment), `previewArtistIds` (string array), `previewArtistNames` (string array, same length as `previewArtistIds`), `logLevel` (one of `trace | debug | info | warn | error`), and `releaseVersion` (optional string — the semver release tag for the deployed image, e.g. `"v1.26.0"`). All fields except `circuitBaseUrl` (which MAY be empty), the two `previewArtist*` arrays (which MAY be empty), and `releaseVersion` (which is optional) are required-and-non-empty; the spec's "MAY be empty" and "optional" carve-outs are exhaustive.
+
+#### Scenario: Bootstrap validates required fields
+
+- **WHEN** `/config.json` is fetched and parsed
+- **AND** any of `apiBaseUrl`, `zitadelIssuer`, `zitadelClientId`, `zitadelOrgId`, `vapidPublicKey`, `environment`, or `logLevel` is missing, empty, or not a string of the expected shape
+- **THEN** bootstrap SHALL throw an error naming the offending field
+- **AND** the SPA SHALL NOT call `Aurelia.start()`
+- **AND** the page SHALL render a minimal static error notice that surfaces the validation failure to the user
+
+#### Scenario: Empty-string `circuitBaseUrl` disables ZK features
+
+- **WHEN** `circuitBaseUrl` is present in the parsed config but is the empty string
+- **THEN** bootstrap SHALL succeed (the field is required-present but MAY be empty per the schema)
+- **AND** the `ProofService` (or equivalent ZK-using service) SHALL treat the empty value as "circuits unavailable in this environment" and disable ZK features at the call sites without attempting any circuit fetch
+
+#### Scenario: `previewArtistIds` and `previewArtistNames` length mismatch is rejected
+
+- **WHEN** `/config.json` parses successfully
+- **AND** `previewArtistIds.length` does not equal `previewArtistNames.length`
+- **THEN** bootstrap SHALL throw an error naming the length-mismatch invariant
+- **AND** the SPA SHALL NOT call `Aurelia.start()`
+- **AND** the rendered error page SHALL state the observed lengths so the operator can correct the ConfigMap
+
+#### Scenario: Absent `releaseVersion` is tolerated
+
+- **WHEN** `/config.json` is fetched and parsed
+- **AND** the `releaseVersion` field is absent or `undefined`
+- **THEN** bootstrap SHALL succeed
+- **AND** `AppConfig.releaseVersion` SHALL be `undefined`
+- **AND** any UI that would display `releaseVersion` SHALL render a safe placeholder (e.g., `—`) without throwing

--- a/openspec/changes/archive/2026-07-28-pwa-version-management/specs/prod-image-pipeline/spec.md
+++ b/openspec/changes/archive/2026-07-28-pwa-version-management/specs/prod-image-pipeline/spec.md
@@ -1,0 +1,25 @@
+## ADDED Requirements
+
+### Requirement: The pin-bump workflow SHALL write `releaseVersion` to the frontend config.json ConfigMap
+
+When the `bump-prod-pin.yml` workflow in `cloud-provisioning` processes a `frontend` component pin-bump event (dispatched by the frontend `push-image.yaml` release path), it SHALL also update the `releaseVersion` field inside the `config.json` JSON blob embedded in the `web-app-runtime-config` ConfigMap YAML file (`k8s/namespaces/frontend/overlays/prod/configmap.yaml`). The value written SHALL be the full release tag including the `v` prefix (e.g., `"v1.26.0"`). The `releaseVersion` field format (optional string, `v`-prefixed semver) is defined in the `frontend-runtime-config` capability spec — that spec is the single source of truth for the field's schema and absence-tolerance contract; this spec governs only the write-side workflow invariant. The update SHALL occur in the same commit as the `kustomization.yaml` image-pin rewrite, so the ConfigMap and the image tag are always in sync.
+
+#### Scenario: Pin-bump commit includes releaseVersion update
+
+- **WHEN** the `bump-prod-pin.yml` workflow runs for `component=frontend` with `tag=v1.26.0`
+- **THEN** the workflow SHALL update `releaseVersion` in `k8s/namespaces/frontend/overlays/prod/configmap.yaml` to `"v1.26.0"`
+- **AND** the `kustomization.yaml` image tag rewrite SHALL be in the same commit
+- **AND** the resulting PR SHALL include both file changes together
+
+#### Scenario: releaseVersion in configmap matches kustomization image tag after pin-bump
+
+- **WHEN** inspecting the merged cloud-provisioning prod overlay after a frontend release
+- **THEN** the `releaseVersion` value in `k8s/namespaces/frontend/overlays/prod/configmap.yaml` SHALL equal `"v<X.Y.Z>"`
+- **AND** the `newTag` in `k8s/namespaces/frontend/overlays/prod/kustomization.yaml` for `web-app` SHALL equal `v<X.Y.Z>`
+- **AND** both values SHALL reference the same release
+
+#### Scenario: No-downgrade guard also protects releaseVersion write
+
+- **WHEN** the `bump-prod-pin.yml` no-downgrade guard blocks the pin-bump (incoming tag is lower than current)
+- **THEN** the `configmap.yaml` `releaseVersion` field SHALL NOT be modified
+- **AND** the workflow SHALL fail before writing any file change

--- a/openspec/changes/archive/2026-07-28-pwa-version-management/specs/pwa-update-lifecycle/spec.md
+++ b/openspec/changes/archive/2026-07-28-pwa-version-management/specs/pwa-update-lifecycle/spec.md
@@ -1,0 +1,96 @@
+## ADDED Requirements
+
+### Requirement: The SPA SHALL register its Service Worker via `virtual:pwa-register`
+
+The SPA SHALL use the `registerSW` function from `virtual:pwa-register` (provided by `vite-plugin-pwa`) in place of the bare `navigator.serviceWorker.register()` call. The `registerType` configuration SHALL be set to `'prompt'`. The registration SHALL be invoked in the SPA bootstrap entry point and SHALL be guarded against non-production environments (`import.meta.env.DEV`).
+
+#### Scenario: SW is registered via virtual module in production
+
+- **WHEN** the SPA loads in a browser where `import.meta.env.DEV` is `false`
+- **THEN** `registerSW` from `virtual:pwa-register` SHALL be invoked
+- **AND** the bare `navigator.serviceWorker.register('/sw.js')` call SHALL NOT exist in the entry point
+
+#### Scenario: SW registration is skipped in dev mode
+
+- **WHEN** the SPA loads under the Vite dev server (`import.meta.env.DEV === true`)
+- **THEN** `registerSW` SHALL NOT be called
+- **AND** no service worker SHALL be registered
+
+### Requirement: The Service Worker SHALL handle `SKIP_WAITING` messages and claim clients on activate
+
+The Service Worker (`sw.ts`) SHALL listen for `{type: 'SKIP_WAITING'}` messages and invoke `self.skipWaiting()` in response. On the `activate` event, the SW SHALL invoke `self.clients.claim()` so that pages loaded under the previous SW controller are immediately transferred to the new SW after a reload.
+
+#### Scenario: SW activates on SKIP_WAITING message
+
+- **WHEN** the SW is in the `installed` (waiting) state
+- **AND** the page sends `{type: 'SKIP_WAITING'}` via `postMessage`
+- **THEN** the SW SHALL call `self.skipWaiting()`
+- **AND** the SW SHALL transition to `activating` then `activated` without requiring all tabs to close
+
+#### Scenario: SW claims open clients on activate
+
+- **WHEN** the SW transitions to `activated`
+- **THEN** `self.clients.claim()` SHALL be called within `event.waitUntil()` combined with the existing `flushInteractionStash()` call — specifically `event.waitUntil(Promise.all([self.clients.claim(), flushInteractionStash()]))`
+- **AND** any page previously controlled by the outgoing SW SHALL be transferred to the new SW
+- **AND** the existing `flushInteractionStash()` call SHALL NOT be removed or replaced (dropping it silently loses offline-stashed notification interaction analytics)
+
+### Requirement: The SPA SHALL show a persistent update toast when a waiting SW is detected after user interaction
+
+When `vite-plugin-pwa` detects a waiting SW (`onNeedRefresh` callback) after the user has begun interacting with the page, the SPA SHALL publish a non-auto-dismissing `Snack` notification with an action button that, when tapped, sends `SKIP_WAITING` to the waiting SW, triggering a `controllerchange` event and a single-shot page reload.
+
+#### Scenario: Update toast shown after user interaction
+
+- **WHEN** a new Service Worker reaches the `installed` (waiting) state
+- **AND** the user has already performed at least one pointer or keyboard interaction with the page
+- **THEN** the SPA SHALL publish a `Snack` event via `IEventAggregator` with:
+  - severity: `info`
+  - `duration: Infinity` (no auto-dismiss)
+  - an `action` button labelled with the i18n key `pwa.updateAction`
+- **AND** at most one update `Snack` SHALL be active at a time
+
+#### Scenario: Tapping the update action triggers reload
+
+- **WHEN** the user taps the [更新] action on the update Snack
+- **THEN** `updateSW(true)` SHALL be called (dispatches `SKIP_WAITING` to the waiting SW)
+- **AND** the page SHALL reload exactly once via `controllerchange`
+- **AND** after reload the page SHALL be controlled by the new Service Worker
+
+#### Scenario: No duplicate reloads (reloop guard)
+
+- **WHEN** `controllerchange` fires
+- **THEN** `location.reload()` SHALL be called at most once per lifecycle
+- **AND** a subsequent `controllerchange` event (e.g., from another tab's skipWaiting) SHALL NOT trigger a second reload on the same page
+
+### Requirement: The SPA SHALL apply a waiting SW silently on boot before user interaction
+
+If a waiting SW is detected (`onNeedRefresh`) before the user's first `pointerdown` or `touchstart` event (i.e., the app just started and has not yet received any interaction), the SPA SHALL apply the update silently — without showing a toast — by immediately calling `updateSW(true)`, then reloading via `controllerchange`.
+
+#### Scenario: Silent apply on first load with a waiting SW
+
+- **WHEN** `onNeedRefresh` fires during the boot sequence
+- **AND** no `pointerdown` or `touchstart` event has been recorded on `window` yet
+- **THEN** `updateSW(true)` SHALL be called immediately (no toast)
+- **AND** the page SHALL reload once after `controllerchange`
+
+#### Scenario: Toast shown when update detected after interaction has begun
+
+- **WHEN** `onNeedRefresh` fires
+- **AND** at least one `pointerdown` or `touchstart` event has already been recorded
+- **THEN** the SPA SHALL show the update toast (per "Update toast shown after user interaction" above)
+- **AND** SHALL NOT reload without user confirmation
+
+### Requirement: The SPA SHALL trigger SW update checks on boot and on page resume
+
+The SPA SHALL call `registration.update()` on SW registration completion and on every `visibilitychange` event where `document.visibilityState === 'visible'`. This ensures that installed PWA users who never fully quit the app receive SW updates promptly rather than waiting up to 24 hours for the browser's default check interval.
+
+#### Scenario: Update check on registration
+
+- **WHEN** `registerSW` calls the `onRegisteredSW` callback with the SW URL and a non-undefined registration
+- **THEN** `registration.update()` SHALL be called once immediately
+- **AND** when `onRegisteredSW` is called with `registration === undefined` (SW registration failed), the callback SHALL return without calling `update()` — a `TypeError` on `undefined.update()` SHALL NOT be thrown
+
+#### Scenario: Update check on resume
+
+- **WHEN** `document.visibilityState` transitions to `'visible'`
+- **THEN** `registration.update()` SHALL be called
+- **AND** if a new SW is found, `updatefound` → `statechange` → `onNeedRefresh` SHALL fire normally

--- a/openspec/changes/archive/2026-07-28-pwa-version-management/specs/settings/spec.md
+++ b/openspec/changes/archive/2026-07-28-pwa-version-management/specs/settings/spec.md
@@ -1,0 +1,29 @@
+## ADDED Requirements
+
+### Requirement: Settings SHALL display the app release version in the About section
+
+The Settings screen's existing "情報" (About) section SHALL include a version row as its last item, after the OSS Licenses row. The row SHALL display the release version sourced from `AppConfig.releaseVersion`. Both authenticated and guest users SHALL see this row. The row SHALL be read-only — no navigation occurs on tap — but tapping it SHALL copy the `releaseVersion` string to the clipboard as a support affordance.
+
+#### Scenario: Version row displays release version
+
+- **WHEN** the Settings page is rendered
+- **AND** `AppConfig.releaseVersion` is present (e.g., `"v1.28.0"`)
+- **THEN** the About section SHALL display a "バージョン / Version" label and the release version string (e.g., `v1.28.0`) as the last row
+
+#### Scenario: Version row displays placeholder when releaseVersion is absent
+
+- **WHEN** the Settings page is rendered
+- **AND** `AppConfig.releaseVersion` is `undefined` or absent
+- **THEN** the version display SHALL show `—` (em dash) as a placeholder
+
+#### Scenario: Tapping version row copies version string to clipboard
+
+- **WHEN** the user taps the version row
+- **THEN** `releaseVersion` (or `—` if absent) SHALL be written to the system clipboard via `navigator.clipboard.writeText`
+- **AND** a confirmation Snack SHALL be published
+
+#### Scenario: Version row is visible for guest users
+
+- **WHEN** the Settings page is rendered for an unauthenticated (guest) user
+- **THEN** the version row SHALL be visible
+- **AND** the version information SHALL be displayed identically to the authenticated user view

--- a/openspec/changes/archive/2026-07-28-pwa-version-management/tasks.md
+++ b/openspec/changes/archive/2026-07-28-pwa-version-management/tasks.md
@@ -1,0 +1,57 @@
+## 1. Service Worker: SKIP_WAITING + clients.claim (frontend)
+
+- [x] 1.1 Add `{type: 'SKIP_WAITING'}` message handler to `src/sw.ts` that calls `self.skipWaiting()`
+- [x] 1.2 Combine `self.clients.claim()` with the existing `flushInteractionStash()` call in the `activate` handler: `event.waitUntil(Promise.all([self.clients.claim(), flushInteractionStash()]))` — do NOT replace the existing `waitUntil` call, as dropping `flushInteractionStash()` silently loses offline-stashed notification interaction analytics
+- [x] 1.3 Verify `make check` passes (TypeScript + unit tests)
+
+## 2. Build SHA injection (frontend)
+
+- [x] 2.1 Add `define: { __BUILD_SHA__: JSON.stringify(process.env.GITHUB_SHA?.slice(0, 7) ?? 'dev') }` to `vite.config.ts`
+- [x] 2.2 Add `declare const __BUILD_SHA__: string` to `src/vite-env.d.ts` (or equivalent global types file) so TypeScript resolves the constant
+
+## 3. SW registration: switch to `virtual:pwa-register` (frontend)
+
+- [x] 3.1 Remove the bare `navigator.serviceWorker.register('/sw.js')` block from `src/main.ts`
+- [x] 3.2 Import `registerSW` from `virtual:pwa-register` in `src/main.ts`
+- [x] 3.3 Set `registerType: 'prompt'` in the `VitePWA({})` options in `vite.config.ts` (document: this sets the virtual module's behaviour, not the manifest)
+- [x] 3.4 Implement boot-time interaction tracking: attach a one-time `pointerdown`/`touchstart` listener on `window` to set a `hasInteracted` flag
+- [x] 3.5 Implement `onNeedRefresh` callback: if `!hasInteracted`, call `updateSW(true)` silently; otherwise publish the update Snack
+- [x] 3.6 Implement `onRegisteredSW` callback: guard against `undefined` registration (`if (!registration) return`), then call `registration.update()` immediately, and add a `visibilitychange` listener that calls `registration.update()` when `document.visibilityState === 'visible'`
+
+## 4. Update toast (frontend)
+
+- [x] 4.1 Add a persistent-duration guard to `src/components/snack-bar/snack-bar.ts`: before calling `setTimeout(dismiss, event.durationMs)`, skip the timer entirely when `event.durationMs === Infinity` — without this guard, `setTimeout(fn, Infinity)` coerces to `setTimeout(fn, 0)` (ToInt32 overflow) and the toast auto-dismisses immediately
+- [x] 4.2 Add i18n keys `pwa.updateAvailable` and `pwa.updateAction` to the English and Japanese translation files
+- [x] 4.3 Implement the update Snack publication in `onNeedRefresh`: `new Snack(i18n.tr('pwa.updateAvailable'), 'info', { duration: Infinity, action: { label: i18n.tr('pwa.updateAction'), callback: () => updateSW(true) } })`
+- [x] 4.4 Track the active update Snack via its `SnackHandle` (store the `snack.handle` value returned after EA publish) — if `onNeedRefresh` fires again while a handle is non-null, call `handle.dismiss()` before publishing the replacement; do NOT add a separate boolean flag alongside the handle (handle non-null ≡ toast is showing)
+
+## 5. AppConfig: `releaseVersion` field (frontend + cloud-provisioning)
+
+- [x] 5.1 Add `readonly releaseVersion?: string` to the `AppConfig` interface in `shared/config/app-config.ts`
+- [x] 5.2 Confirm `validateAppConfig` in `app-config.ts` treats `releaseVersion` as optional (no validation failure when absent)
+- [x] 5.3 Add `"releaseVersion": "dev"` to `frontend/public/config.json` (dev fallback)
+- [x] 5.4 Add `"releaseVersion": "dev"` to the dev ConfigMap in `cloud-provisioning/k8s/namespaces/frontend/overlays/dev/configmap.yaml`
+- [x] 5.5 Add `"releaseVersion": "v<current-tag>"` to the prod ConfigMap in `cloud-provisioning/k8s/namespaces/frontend/overlays/prod/configmap.yaml` (use the current prod tag, e.g. `v1.26.0`)
+
+## 6. Pin-bump workflow: write `releaseVersion` to configmap (cloud-provisioning)
+
+- [x] 6.1 In `bump-prod-pin.yml`, after the `kustomization.yaml` rewrite step for `component=frontend`, add a `yq -i` (or `jq` + `sed`) step that writes the tag value into the `releaseVersion` field inside the `config.json` JSON blob in `k8s/namespaces/frontend/overlays/prod/configmap.yaml`
+- [x] 6.2 Verify the no-downgrade guard executes before the ConfigMap write step so a blocked pin-bump leaves configmap.yaml untouched
+- [x] 6.3 Confirm the PR created by the workflow includes both the `kustomization.yaml` and `configmap.yaml` changes in the same commit
+
+## 7. Settings: app version display (frontend)
+
+- [x] 7.1 Add an "アプリ情報" section to `src/routes/settings/settings-route.html` at the bottom of the `<main>` scroll area
+- [x] 7.2 Add `releaseVersion` and `buildSha` getters to `SettingsRoute` in `settings-route.ts`: `releaseVersion` reads `IAppConfig.releaseVersion ?? '—'`; `buildSha` reads `__BUILD_SHA__`
+- [x] 7.3 Implement the copy-to-clipboard handler: `navigator.clipboard.writeText(`${this.releaseVersion} (${this.buildSha})`)` on row tap
+- [x] 7.4 Add i18n key `settings.appInfo` (section title) and `settings.copyVersionSuccess` (optional success feedback)
+- [x] 7.5 Add accessible label for the version row (e.g., `aria-label` combining version + copy affordance hint)
+
+## 8. Verification
+
+- [x] 8.1 Run `make check` in `frontend` repo — TypeScript compilation, unit tests, and build-template verification all pass
+- [x] 8.2 Manually install the PWA (Chrome + Android or desktop), deploy a new version, and confirm: (a) the update toast appears, (b) tapping [更新] reloads to the new version, (c) Settings shows the updated `releaseVersion`
+- [x] 8.3 Verify boot-time silent apply: open a fresh browser tab to the app while a waiting SW exists — confirm reload happens without a toast
+- [x] 8.4 Confirm no double-reload (reloop) occurs by opening two tabs and applying the update from one
+- [x] 8.5 After a frontend release and cloud-provisioning pin-bump PR merges, confirm the prod `config.json` served at `https://liverty-music.app/config.json` contains the correct `releaseVersion`
+- [x] 8.6 Ship to prod (frontend release + cloud-provisioning pin-bump) and verify in Settings

--- a/openspec/changes/optimize-sales-merch-searcher-cost/tasks.md
+++ b/openspec/changes/optimize-sales-merch-searcher-cost/tasks.md
@@ -17,13 +17,13 @@
 
 ## 4. Prod rollout
 
-- [ ] 4.1 Cut a backend release (next minor) including the merch defaults + fixtures. merch-discovery inherits the new defaults; verify a dev AR image exists before release.
-- [ ] 4.2 In cloud-provisioning `sales-phase-discovery` configmap.env: set `GCP_GEMINI_SEARCH_MODEL_EXTRACT=gemini-3.6-flash` and `GCP_GEMINI_SEARCH_THINKING_EXTRACT=medium`; keep `GCP_GEMINI_SEARCH_MODEL_PARSE=gemini-3.1-flash-lite`. Bump the sales-phase-discovery job pin (auto pin-bump may omit it — verify/bump manually).
-- [ ] 4.3 Confirm merch-discovery prod job picks up the new backend image (its pin bumps with the release); it has no env override so it inherits `gemini-3.6-flash` / `medium`.
+- [x] 4.1 Cut a backend release (next minor) including the merch defaults + fixtures. merch-discovery inherits the new defaults; verify a dev AR image exists before release. (v1.25.0, dev AR built for 54b28aa before release.)
+- [x] 4.2 In cloud-provisioning `sales-phase-discovery` configmap.env: set `GCP_GEMINI_SEARCH_MODEL_EXTRACT=gemini-3.6-flash` and `GCP_GEMINI_SEARCH_THINKING_EXTRACT=medium`; keep `GCP_GEMINI_SEARCH_MODEL_PARSE=gemini-3.1-flash-lite`. Bump the sales-phase-discovery job pin (auto pin-bump may omit it — verify/bump manually). (CP #397; manually bumped sales-phase-discovery + sales-reminders v1.23.0→v1.25.0.)
+- [x] 4.3 Confirm merch-discovery prod job picks up the new backend image (its pin bumps with the release); it has no env override so it inherits `gemini-3.6-flash` / `medium`. (Live cronjob = v1.25.0, no configmap override.)
 
 ## 5. Verification & close-out
 
-- [ ] 5.1 Confirm ArgoCD syncs; sales-phase-discovery and merch-discovery jobs run the new model (`model_grounded`/`model=gemini-3.6-flash` in logs).
+- [x] 5.1 Confirm ArgoCD syncs; sales-phase-discovery and merch-discovery jobs run the new model (`model_grounded`/`model=gemini-3.6-flash` in logs). (ArgoCD backend Synced/Healthy at 8b1a85f; live sales-phase configmap = gemini-3.6-flash/medium, all three cronjobs = v1.25.0. Log confirmation on next scheduled run: merch 11:00 UTC, sales-phase 12:00 UTC.)
 - [ ] 5.2 Verify in the billing export that the "search query gemini 3 paid" SKU drops for the sales/merch run hours after rollout.
 - [ ] 5.3 Spot-check discovery quality: sales-phase surfaces current/post-cutoff sale phases; merch resolves correct official URLs (no fabricated deep links).
 - [ ] 5.4 Verify the change (`/opsx:verify`) and archive it once all tasks are complete and shipped.

--- a/openspec/specs/discovery-bubble-cache/spec.md
+++ b/openspec/specs/discovery-bubble-cache/spec.md
@@ -1,0 +1,24 @@
+# discovery-bubble-cache Specification
+
+## Purpose
+TBD - created by archiving change discovery-bubble-cache. Update Purpose after archive.
+## Requirements
+### Requirement: Discovery bubble pool is cached in ArtistStore singleton
+`ArtistStore` SHALL cache the last successfully generated bubble pool (`Artist[]`) so that `DiscoveryRoute` re-entries can paint real artists immediately without waiting on network RPCs.
+
+#### Scenario: Re-entry paints cached artists instantly
+- **WHEN** the user navigates to Discovery after a prior visit
+- **THEN** the bubble pool SHALL be initialized from the cached artists synchronously during `loading()`
+- **AND** no ghost bubbles SHALL be shown
+- **AND** `loadInitialBubbles()` SHALL run in the background to refresh the pool
+
+#### Scenario: Cold visit uses ghost bubbles
+- **WHEN** no cached artists exist (first visit or cache cleared)
+- **THEN** the route SHALL initialize with ghost placeholder bubbles as the current behavior
+- **AND** switch to real artists when `loadInitialBubbles()` completes
+
+#### Scenario: Cache is updated after each successful load
+- **WHEN** `loadInitialBubbles()` completes successfully
+- **THEN** `ArtistStore.setBubbles(pool.availableBubbles)` SHALL be called to persist the pool
+- **AND** the next re-entry SHALL use the updated pool
+

--- a/openspec/specs/pwa-update-lifecycle/spec.md
+++ b/openspec/specs/pwa-update-lifecycle/spec.md
@@ -1,0 +1,102 @@
+# PWA Update Lifecycle
+
+## Purpose
+
+Defines the Service Worker registration and update lifecycle for the Aurelia 2 frontend PWA. This capability specifies how the SPA registers its SW via `vite-plugin-pwa`, detects available updates, applies them silently on boot (pre-interaction) or presents a user-confirmable toast (post-interaction), and ensures that installed-PWA users receive SW updates promptly rather than waiting up to 24 hours for the browser's default check interval.
+
+## Requirements
+
+### Requirement: The SPA SHALL register its Service Worker via `virtual:pwa-register`
+
+The SPA SHALL use the `registerSW` function from `virtual:pwa-register` (provided by `vite-plugin-pwa`) in place of the bare `navigator.serviceWorker.register()` call. The `registerType` configuration SHALL be set to `'prompt'`. The registration SHALL be invoked in the SPA bootstrap entry point and SHALL be guarded against non-production environments (`import.meta.env.DEV`).
+
+#### Scenario: SW is registered via virtual module in production
+
+- **WHEN** the SPA loads in a browser where `import.meta.env.DEV` is `false`
+- **THEN** `registerSW` from `virtual:pwa-register` SHALL be invoked
+- **AND** the bare `navigator.serviceWorker.register('/sw.js')` call SHALL NOT exist in the entry point
+
+#### Scenario: SW registration is skipped in dev mode
+
+- **WHEN** the SPA loads under the Vite dev server (`import.meta.env.DEV === true`)
+- **THEN** `registerSW` SHALL NOT be called
+- **AND** no service worker SHALL be registered
+
+### Requirement: The Service Worker SHALL handle `SKIP_WAITING` messages and claim clients on activate
+
+The Service Worker (`sw.ts`) SHALL listen for `{type: 'SKIP_WAITING'}` messages and invoke `self.skipWaiting()` in response. On the `activate` event, the SW SHALL invoke `self.clients.claim()` so that pages loaded under the previous SW controller are immediately transferred to the new SW after a reload.
+
+#### Scenario: SW activates on SKIP_WAITING message
+
+- **WHEN** the SW is in the `installed` (waiting) state
+- **AND** the page sends `{type: 'SKIP_WAITING'}` via `postMessage`
+- **THEN** the SW SHALL call `self.skipWaiting()`
+- **AND** the SW SHALL transition to `activating` then `activated` without requiring all tabs to close
+
+#### Scenario: SW claims open clients on activate
+
+- **WHEN** the SW transitions to `activated`
+- **THEN** `self.clients.claim()` SHALL be called within `event.waitUntil()` combined with the existing `flushInteractionStash()` call — specifically `event.waitUntil(Promise.all([self.clients.claim(), flushInteractionStash()]))`
+- **AND** any page previously controlled by the outgoing SW SHALL be transferred to the new SW
+- **AND** the existing `flushInteractionStash()` call SHALL NOT be removed or replaced (dropping it silently loses offline-stashed notification interaction analytics)
+
+### Requirement: The SPA SHALL show a persistent update toast when a waiting SW is detected after user interaction
+
+When `vite-plugin-pwa` detects a waiting SW (`onNeedRefresh` callback) after the user has begun interacting with the page, the SPA SHALL publish a non-auto-dismissing `Snack` notification with an action button that, when tapped, sends `SKIP_WAITING` to the waiting SW, triggering a `controllerchange` event and a single-shot page reload.
+
+#### Scenario: Update toast shown after user interaction
+
+- **WHEN** a new Service Worker reaches the `installed` (waiting) state
+- **AND** the user has already performed at least one pointer or keyboard interaction with the page
+- **THEN** the SPA SHALL publish a `Snack` event via `IEventAggregator` with:
+  - severity: `info`
+  - `duration: Infinity` (no auto-dismiss)
+  - an `action` button labelled with the i18n key `pwa.updateAction`
+- **AND** at most one update `Snack` SHALL be active at a time
+
+#### Scenario: Tapping the update action triggers reload
+
+- **WHEN** the user taps the [更新] action on the update Snack
+- **THEN** `updateSW(true)` SHALL be called (dispatches `SKIP_WAITING` to the waiting SW)
+- **AND** the page SHALL reload exactly once via `controllerchange`
+- **AND** after reload the page SHALL be controlled by the new Service Worker
+
+#### Scenario: No duplicate reloads (reloop guard)
+
+- **WHEN** `controllerchange` fires
+- **THEN** `location.reload()` SHALL be called at most once per lifecycle
+- **AND** a subsequent `controllerchange` event (e.g., from another tab's skipWaiting) SHALL NOT trigger a second reload on the same page
+
+### Requirement: The SPA SHALL apply a waiting SW silently on boot before user interaction
+
+If a waiting SW is detected (`onNeedRefresh`) before the user's first `pointerdown` or `touchstart` event (i.e., the app just started and has not yet received any interaction), the SPA SHALL apply the update silently — without showing a toast — by immediately calling `updateSW(true)`, then reloading via `controllerchange`.
+
+#### Scenario: Silent apply on first load with a waiting SW
+
+- **WHEN** `onNeedRefresh` fires during the boot sequence
+- **AND** no `pointerdown` or `touchstart` event has been recorded on `window` yet
+- **THEN** `updateSW(true)` SHALL be called immediately (no toast)
+- **AND** the page SHALL reload once after `controllerchange`
+
+#### Scenario: Toast shown when update detected after interaction has begun
+
+- **WHEN** `onNeedRefresh` fires
+- **AND** at least one `pointerdown` or `touchstart` event has already been recorded
+- **THEN** the SPA SHALL show the update toast (per "Update toast shown after user interaction" above)
+- **AND** SHALL NOT reload without user confirmation
+
+### Requirement: The SPA SHALL trigger SW update checks on boot and on page resume
+
+The SPA SHALL call `registration.update()` on SW registration completion and on every `visibilitychange` event where `document.visibilityState === 'visible'`. This ensures that installed PWA users who never fully quit the app receive SW updates promptly rather than waiting up to 24 hours for the browser's default check interval.
+
+#### Scenario: Update check on registration
+
+- **WHEN** `registerSW` calls the `onRegisteredSW` callback with the SW URL and a non-undefined registration
+- **THEN** `registration.update()` SHALL be called once immediately
+- **AND** when `onRegisteredSW` is called with `registration === undefined` (SW registration failed), the callback SHALL return without calling `update()` — a `TypeError` on `undefined.update()` SHALL NOT be thrown
+
+#### Scenario: Update check on resume
+
+- **WHEN** `document.visibilityState` transitions to `'visible'`
+- **THEN** `registration.update()` SHALL be called
+- **AND** if a new SW is found, `updatefound` → `statechange` → `onNeedRefresh` SHALL fire normally


### PR DESCRIPTION
## Spec sync
- **New capability** `discovery-bubble-cache` — ArtistStore シングルトンにバブルプールをキャッシュし、Discovery 再入場を即時描画する要件。

## Shipping evidence
- frontend PR #495 マージ、Release **v1.30.0**、prod `web-app:v1.30.0` Running 確認済み (2026-07-28)。

Refs: liverty-music/frontend#495