### PR TITLE
docs(openspec): add fix-pwa-auth-token-refresh-race change

### DIFF
--- a/openspec/changes/fix-pwa-auth-token-refresh-race/.openspec.yaml
+++ b/openspec/changes/fix-pwa-auth-token-refresh-race/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-28

--- a/openspec/changes/fix-pwa-auth-token-refresh-race/design.md
+++ b/openspec/changes/fix-pwa-auth-token-refresh-race/design.md
@@ -1,0 +1,68 @@
+## Context
+
+The app uses `oidc-client-ts` with Zitadel (self-hosted) for OIDC authentication. Zitadel enforces **refresh token rotation** — each use of a refresh token issues a new one and invalidates the old. The frontend PWA is served by a Vite PWA service worker that triggers `location.reload()` on SW update.
+
+Current auth flow:
+- `AuthService` creates a `UserManager` with default `automaticSilentRenew: true`
+- A background timer fires 60 seconds before access token expiry, calling `signinSilent()` (refresh token grant)
+- On-demand refresh also happens via `createAuthRetryInterceptor` in `grpc-transport.ts` when any RPC returns `Unauthenticated`
+- `restoreSession()` at boot calls `signinSilent()` if the stored token is already expired
+
+Two race conditions both result in `RefreshTokenInvalid (400)` from Zitadel, triggering forced logout.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Eliminate `RefreshTokenInvalid` errors caused by concurrent use of the same refresh token
+- Preserve seamless session continuity for authenticated users
+- Keep the existing on-demand refresh path (`connect-error-router`) as the sole refresh mechanism
+
+**Non-Goals:**
+- Change the Zitadel session policy or token lifetime configuration
+- Implement offline token storage or token caching beyond what oidc-client-ts provides
+- Fix the admin console (`admin/`) — it has a separate transport and is unaffected
+
+## Decisions
+
+### D1: Disable automaticSilentRenew
+
+Set `automaticSilentRenew: false` in `createSettings()` in `shared/services/auth-service.ts`.
+
+This removes the background timer entirely, eliminating Race 1. Token refresh only occurs at two well-defined, non-overlapping points:
+- **Boot**: `restoreSession()` — synchronous with respect to the app lifecycle (runs once, before routes load)
+- **On-demand**: `connect-error-router` — triggered by a specific 401 response
+
+**Rationale**: The RFC 9700 OAuth 2.0 Security BCP recommends treating the refresh token as a one-shot credential per request. Proactive background renewal is at odds with strict rotation because the timer cannot coordinate with page reloads. The `connect-error-router` retry pattern already handles the 401 case gracefully, making the timer redundant.
+
+**Trade-off**: The first RPC call after access token expiry will fail and be retried with a fresh token. This adds one round trip per expiry cycle (every AT TTL, typically 5–10 minutes). The retry is transparent to the user — `connect-error-router` retries the original request with the new token before propagating the error.
+
+### D2: Singleton refresh promise in connect-error-router
+
+Introduce a module-level `let refreshPromise: Promise<User | null> | null = null` in `connect-error-router.ts`. The interceptor checks this variable before calling `signinSilent()`:
+
+```
+if (refreshPromise === null) {
+  refreshPromise = auth.getUserManager().signinSilent()
+    .catch(() => null)
+    .finally(() => { refreshPromise = null })
+}
+const user = await refreshPromise
+```
+
+All concurrent 401 interceptors await the **same** promise. Only one `POST /oauth/v2/token` request is sent to Zitadel per expiry cycle. The refresh token is used exactly once.
+
+**Rationale**: Even with `automaticSilentRenew: false`, Race 2 remains possible if multiple RPCs are in-flight when the access token expires (e.g., dashboard initial load). The singleton pattern is the standard deduplication technique for this problem.
+
+**Trade-off**: The singleton is module-scoped (not DI-scoped), meaning it is shared across all `createAuthRetryInterceptor` instances. Since the interceptor is created once per transport and all transports use the same singleton, this is the correct scope. If the refresh fails, all concurrent requests receive the same error and `connect-error-router` redirects to `/welcome` once (the first caller to complete the `.finally()` reset could race, but `window.location.href = '/welcome'` is idempotent).
+
+### D3: No change to restoreSession
+
+`restoreSession()` already handles boot-time token expiry correctly: it calls `signinSilent()` once, synchronously with the bootstrap sequence, before any routes load. With `automaticSilentRenew: false`, there is no background timer competing with it, so no additional changes are needed.
+
+## Risks / Trade-offs
+
+| Risk | Likelihood | Mitigation |
+|------|-----------|------------|
+| One extra RPC round trip per AT expiry cycle | Certain | Transparent retry in `connect-error-router`; no visible user impact |
+| Refresh token expires (long session inactivity) | Low | Zitadel session policy controls RT lifetime; existing logout-on-failure behavior is correct |
+| Admin console unaffected by Fix A | N/A | Admin has its own `admin-transport.ts`; its token management is independent |

--- a/openspec/changes/fix-pwa-auth-token-refresh-race/proposal.md
+++ b/openspec/changes/fix-pwa-auth-token-refresh-race/proposal.md
@@ -1,0 +1,38 @@
+## Why
+
+Users experience forced logout after every PWA update. Zitadel logs confirm two occurrences of `Errors.OIDCSession.RefreshTokenInvalid (400)` at 06:31 and 07:39 on 2026-07-28, both coinciding exactly with SW deployments.
+
+Two independent refresh token rotation races are responsible:
+
+**Race 1 — SW reload vs automaticSilentRenew timer**
+
+`oidc-client-ts` runs `automaticSilentRenew` (default `true`) — a background timer that fires 60 seconds before the access token expires. When a new SW is deployed:
+
+1. The timer fires on the old page, sending a `POST /oauth/v2/token` (refresh_token grant).
+2. The old page is simultaneously being unloaded by the SW reload.
+3. The new page starts, `restoreSession()` finds an expired token, and calls `signinSilent()` with the **same** refresh token still in localStorage (the old page's async request hasn't updated it yet).
+4. Zitadel rotates the refresh token on first use and rejects the second with `RefreshTokenInvalid`.
+
+**Race 2 — Parallel RPC 401s in connect-error-router**
+
+`createAuthRetryInterceptor` calls `signinSilent()` independently for each in-flight RPC that receives `Unauthenticated`. If the access token expires while multiple requests are in flight, all interceptors fire `signinSilent()` concurrently. The first use rotates the refresh token; subsequent uses receive `RefreshTokenInvalid`.
+
+## What Changes
+
+**Fix A**: Disable `automaticSilentRenew` in the `UserManager` settings. The background timer is removed entirely. Token refresh moves to on-demand only: `restoreSession()` at boot and `connect-error-router` on 401. This is the RFC 9700 refresh-on-demand pattern, consistent with PWA best practices when combined with refresh token rotation.
+
+**Fix B**: Add a singleton refresh promise to `connect-error-router`. When a `signinSilent()` is already in progress, concurrent 401 interceptors await the same promise rather than issuing a new refresh request. The promise is cleared in `.finally()` so the next expiry cycle can start fresh.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `authentication`: Silent token refresh strategy changes from proactive timer-based (`automaticSilentRenew`) to reactive on-demand only (401 → `signinSilent`).
+- `http-retry`: The auth retry interceptor gains deduplication — concurrent 401s share a single `signinSilent()` call instead of each issuing an independent refresh request.
+
+## Impact
+
+- `shared/services/auth-service.ts`: add `automaticSilentRenew: false` to `createSettings()`
+- `src/services/connect-error-router.ts`: introduce module-level `refreshPromise` singleton
+- No backend changes; no proto changes; no cloud-provisioning changes
+- Admin console (`admin/`) has its own `admin-transport.ts` and is unaffected

--- a/openspec/changes/fix-pwa-auth-token-refresh-race/specs/authentication/spec.md
+++ b/openspec/changes/fix-pwa-auth-token-refresh-race/specs/authentication/spec.md
@@ -1,0 +1,21 @@
+## MODIFIED Requirements
+
+### Requirement: Silent token refresh strategy
+The frontend SHALL use on-demand token refresh only. Proactive background refresh (`automaticSilentRenew`) SHALL be disabled. Token refresh occurs at exactly two points: (1) at boot if the stored access token is already expired, (2) when an RPC returns `Unauthenticated`.
+
+**Rationale**: With Zitadel refresh token rotation, proactive background renewal running concurrently with a service worker page reload causes both the old and new page to use the same refresh token, resulting in `RefreshTokenInvalid (400)` and forced logout.
+
+#### Scenario: Boot with valid access token
+- **WHEN** the app boots and the stored access token is not expired
+- **THEN** the app SHALL proceed without calling `signinSilent()`
+
+#### Scenario: Boot with expired access token
+- **WHEN** the app boots and the stored access token is expired
+- **THEN** the app SHALL call `signinSilent()` once via `restoreSession()`
+- **AND** if `signinSilent()` succeeds, the user session SHALL be restored transparently
+- **AND** if `signinSilent()` fails, the user SHALL start the session unauthenticated
+
+#### Scenario: No background timer
+- **WHEN** the access token is about to expire during an active session
+- **THEN** the app SHALL NOT proactively refresh the token
+- **AND** the token SHALL be refreshed on the next RPC call that receives `Unauthenticated`

--- a/openspec/changes/fix-pwa-auth-token-refresh-race/specs/http-retry/spec.md
+++ b/openspec/changes/fix-pwa-auth-token-refresh-race/specs/http-retry/spec.md
@@ -1,0 +1,24 @@
+## MODIFIED Requirements
+
+### Requirement: Deduplicated auth token refresh on concurrent 401s
+The auth retry interceptor SHALL deduplicate concurrent `signinSilent()` calls. If a token refresh is already in progress when a second `Unauthenticated` error is received, the second interceptor SHALL await the in-progress refresh rather than issuing a new one.
+
+**Rationale**: With Zitadel refresh token rotation, concurrent `signinSilent()` calls using the same refresh token result in `RefreshTokenInvalid (400)` — the first use rotates the token and the second is rejected. A singleton promise ensures the refresh token is used at most once per expiry cycle.
+
+#### Scenario: Single RPC gets Unauthenticated
+- **WHEN** one RPC returns `Unauthenticated` and no refresh is in progress
+- **THEN** the interceptor SHALL call `signinSilent()` and await the result
+- **AND** on success, retry the original RPC with the new access token
+- **AND** on failure, clear the user session and redirect to `/welcome`
+
+#### Scenario: Multiple concurrent RPCs all get Unauthenticated
+- **WHEN** two or more in-flight RPCs simultaneously receive `Unauthenticated`
+- **THEN** exactly one `signinSilent()` request SHALL be sent to Zitadel
+- **AND** all concurrent interceptors SHALL await the same refresh promise
+- **AND** on success, each interceptor SHALL retry its original RPC with the new token
+- **AND** on failure, the user session SHALL be cleared and the user redirected to `/welcome`
+
+#### Scenario: Subsequent expiry after refresh completes
+- **WHEN** a token refresh completes and the singleton promise is cleared
+- **AND** the new access token later expires
+- **THEN** the next `Unauthenticated` response SHALL start a new `signinSilent()` call

--- a/openspec/changes/fix-pwa-auth-token-refresh-race/tasks.md
+++ b/openspec/changes/fix-pwa-auth-token-refresh-race/tasks.md
@@ -1,0 +1,20 @@
+## 1. Fix A — Disable automaticSilentRenew
+
+- [ ] 1.1 Add `automaticSilentRenew: false` to `createSettings()` in `shared/services/auth-service.ts`
+- [ ] 1.2 Remove the stale comment referencing `automaticSilentRenew` behaviour from `restoreSession()` if it no longer applies
+- [ ] 1.3 Run `make check` in the frontend repo and confirm no type errors or test failures
+
+## 2. Fix B — Singleton refresh promise in connect-error-router
+
+- [ ] 2.1 Add module-level `let refreshPromise: Promise<User | null> | null = null` to `src/services/connect-error-router.ts`
+- [ ] 2.2 Replace the inline `signinSilent()` call in `createAuthRetryInterceptor` with the singleton pattern: check `refreshPromise`, start if null, always await the shared promise, clear in `.finally()`
+- [ ] 2.3 Update `test/services/connect-error-router.spec.ts` to cover the concurrent-401 deduplication scenario (two simultaneous Unauthenticated errors → one `signinSilent()` call)
+- [ ] 2.4 Run `make check` in the frontend repo and confirm all tests pass
+
+## 3. Ship to prod
+
+- [ ] 3.1 Run pre-commit review (`/pre-commit-review`), fix any findings
+- [ ] 3.2 Commit both fixes following the Liverty-Music commit convention (body + `Refs:` footer)
+- [ ] 3.3 Open PR, wait for CI green, merge
+- [ ] 3.4 Cut a release tag (PATCH bump from current) and confirm `dispatch-prod-pin` and `Bump Prod Pin` CI complete successfully
+- [ ] 3.5 Verify in prod: open the PWA, confirm no `RefreshTokenInvalid` in Zitadel logs after SW update, and confirm update snack bar appears and reload completes without forced logout


### PR DESCRIPTION
## Summary

- PWA ユーザーが SW 更新後に強制ログアウトされる問題の OpenSpec change を追加
- Zitadel ログで `RefreshTokenInvalid (400)` を 2026-07-28 に 2 件確認（06:31、07:39、両方ともデプロイ直後）
- 2 つの refresh token rotation race を特定し、設計・要件・実装タスクを記述

## Changes

- `openspec/changes/fix-pwa-auth-token-refresh-race/proposal.md` — 問題の背景と修正方針（Fix A / Fix B）
- `openspec/changes/fix-pwa-auth-token-refresh-race/design.md` — D1: `automaticSilentRenew: false`、D2: singleton refresh promise 設計
- `openspec/changes/fix-pwa-auth-token-refresh-race/specs/authentication/spec.md` — on-demand 専用リフレッシュ要件
- `openspec/changes/fix-pwa-auth-token-refresh-race/specs/http-retry/spec.md` — 並行 401 デデュプリケーション要件
- `openspec/changes/fix-pwa-auth-token-refresh-race/tasks.md` — 実装タスク（3グループ・9タスク）

## Testing

実装は frontend リポジトリで別 PR として行われる（`/opsx:apply` で実施予定）。
