### PR TITLE
docs(openspec): propose add-discovery-job-error-alerting

### DIFF
--- a/openspec/changes/add-discovery-job-error-alerting/.openspec.yaml
+++ b/openspec/changes/add-discovery-job-error-alerting/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-28

--- a/openspec/changes/add-discovery-job-error-alerting/design.md
+++ b/openspec/changes/add-discovery-job-error-alerting/design.md
@@ -17,7 +17,7 @@ The pod `app` labels are already correct and consistent: `kubectl get cronjob` s
 - Retrying transient infra faults (e.g., a DB ping timeout) inside the job before giving up. That is a separate reliability improvement, orthogonal to alert coverage, and is deliberately deferred.
 - Changing the exit-0 semantics themselves (they are intentional; this change reinforces them).
 - Grounding-consistency / recall work for the sales-phase searcher (tracked under #639).
-- Job-level Kubernetes failure alerting (e.g., `kube_job_failed`) — the jobs exit 0 by design, so a Job-status alert would never fire; ERROR-log alerting is the correct layer.
+- Job-level Kubernetes failure alerting (e.g., `kube_job_failed`) — on the *handled*-failure path the jobs exit 0 by design, so a Job-status alert would not fire and ERROR-log alerting is the correct layer. NOTE: this holds only for handled failures. Abrupt-termination failures (OOM-kill, image-pull failure, node preemption/eviction) DO report the Job as failed and emit no ERROR log, so they are covered by neither mechanism — a separate, currently-uncovered gap this change deliberately does not close (a future Job-status alert would be the right layer for it).
 
 ## Decisions
 

--- a/openspec/changes/add-discovery-job-error-alerting/design.md
+++ b/openspec/changes/add-discovery-job-error-alerting/design.md
@@ -1,0 +1,51 @@
+## Context
+
+Backend workload failures are surfaced through per-workload Cloud Monitoring Log-Based Alert Policies defined in `cloud-provisioning/src/gcp/components/monitoring.ts`. Each policy matches `severity="ERROR"` logs for one `labels.k8s-pod/app` value and opens an Incident routed to Slack + Google Chat. The `app-error-log-alerting` capability enumerates coverage for `server`, `consumer`, and `concert-discovery`.
+
+The discovery CronJobs are designed to exit 0 on failure. `cmd/job/merch-discovery/main.go` documents the rationale explicitly ("a systemic failure should not make the CronJob retry into the same fault. Monitoring relies on ERROR logs."); `cmd/job/sales-phase-discovery/main.go` has the identical behavior but no comment. Because the Job always reports `succeeded=1`, the ERROR-log alert is the sole failure signal — yet `sales-phase-discovery` and `merch-discovery` were never added to the alert-policy list. On 2026-07-28 a `sales-phase-discovery` run failed at startup with a database ping timeout, exited 0, and opened no Incident, confirming the gap in production.
+
+The pod `app` labels are already correct and consistent: `kubectl get cronjob` shows `sales-phase-discovery-app → app=sales-phase-discovery` and `merch-discovery-app → app=merch-discovery` (same shape as `concert-discovery`), so no label plumbing is required.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Every backend discovery CronJob has an ERROR-log Alert Policy, so a failed run (which exits 0) reliably opens an Incident.
+- Encode the exit-0-on-failure ⇒ alert-coverage-mandatory relationship at the capability level so the gap cannot silently recur when a future discovery job is added.
+- Make the `sales-phase-discovery` entrypoint self-document its exit-0 design, matching `merch-discovery`.
+
+**Non-Goals:**
+- Retrying transient infra faults (e.g., a DB ping timeout) inside the job before giving up. That is a separate reliability improvement, orthogonal to alert coverage, and is deliberately deferred.
+- Changing the exit-0 semantics themselves (they are intentional; this change reinforces them).
+- Grounding-consistency / recall work for the sales-phase searcher (tracked under #639).
+- Job-level Kubernetes failure alerting (e.g., `kube_job_failed`) — the jobs exit 0 by design, so a Job-status alert would never fire; ERROR-log alerting is the correct layer.
+
+## Decisions
+
+**Decision: Reuse the existing per-workload `workloads[]` array rather than a bespoke policy.**
+The two new jobs share the exact filter shape, label extractors, rate limit (12h), auto-close (1h), and notification channels of the existing policies. Adding two entries to the `workloads` array produces two more `AlertPolicy` resources with zero new code paths. Alternative considered: a single combined policy matching all discovery jobs via a regex on `labels.k8s-pod/app` — rejected because it loses per-workload Incident separation and the per-workload `displayName` that operators rely on, and diverges from the established one-policy-per-workload pattern.
+
+**Decision: Encode the exit-0 ⇒ alert-coverage invariant as a new capability requirement.**
+The root cause is not two missing entries but a missing invariant: discovery jobs exit 0, so alert coverage is their only failure signal, yet nothing in the spec said coverage was mandatory. The new "Discovery CronJob failure observability" requirement makes adding a discovery job without a policy a spec violation, closing the class of gap. Alternative considered: just add the two workloads and file an issue — rejected because it fixes the instances but not the recurrence risk.
+
+**Decision: Add the rationale comment to `sales-phase-discovery/main.go` (documentation only).**
+The behavior is already correct and intentional; the divergence is that only merch documents it. Copying the comment removes the "is this a bug?" ambiguity for future readers without any behavior change.
+
+## Risks / Trade-offs
+
+- **New AlertPolicy for a not-yet-ingested metric/label could fail `pulumi up`** → These are Log-Based (conditionMatchedLog) policies, not metric-threshold policies; they do not require a pre-existing ingested metric, so the not-yet-ingested-metric failure class (seen with GMP metric-threshold policies) does not apply. The `k8s-pod/app` labels already exist on running pods.
+- **Alert noise from benign per-artist errors** → The 12-hour `notificationRateLimit` and 1-hour `autoClose` already bound noise to at most one notification per policy per 12h, matching the existing workloads. Benign, expected non-errors (no upcoming series, missing official site) are logged at INFO/WARN, not ERROR, so they do not trigger the policy.
+- **prod deploy is a manual Pulumi console `up`** → Merging the cloud-provisioning PR only runs `pulumi preview` for prod. The policies must be applied via the prod Pulumi Cloud console `up` after merge; the task list calls this out so coverage is actually live, not just merged.
+
+## Migration Plan
+
+1. Merge the specification change (delta → `app-error-log-alerting` spec on archive).
+2. Merge the cloud-provisioning PR adding the two `workloads` entries; dev applies automatically via Pulumi Cloud Deployments.
+3. Trigger the prod Pulumi console `up`; confirm the two new `AlertPolicy` resources exist and are enabled.
+4. Merge the backend comment-only change (rides the next routine backend release; no release needed solely for a comment).
+5. Verify: emit or locate a real ERROR log from each job and confirm an Incident opens (or validate the policy filter against a historical ERROR entry, e.g., the 2026-07-28 DB-ping failure).
+
+**Rollback:** remove the two `workloads` entries and re-run `pulumi up`; the policies are deleted. No data or behavior impact.
+
+## Open Questions
+
+- None blocking. (Whether to also add transient-fault retry inside the jobs is intentionally out of scope and left to a follow-up.)

--- a/openspec/changes/add-discovery-job-error-alerting/proposal.md
+++ b/openspec/changes/add-discovery-job-error-alerting/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+The `sales-phase-discovery` and `merch-discovery` CronJobs intentionally exit 0 on failure (to avoid a broken run retrying into the same fault), relying on ERROR-log alerting as the sole failure-detection mechanism. But the `app-error-log-alerting` capability enumerates alert coverage for only `server`, `consumer`, and `concert-discovery` — the two newer discovery jobs were never added. As a result their failures are completely silent: the process exits 0, Kubernetes reports the Job as succeeded, and no Incident opens. A live example was observed on 2026-07-28, when a `sales-phase-discovery` run failed at startup with a database ping timeout, exited 0, and produced no alert — the design's stated compensating control did not exist for that job.
+
+## What Changes
+
+- Extend ERROR-log alert coverage to the `sales-phase-discovery` and `merch-discovery` CronJob workloads, so an ERROR-level log entry from either opens an Incident with Slack + Google Chat notification (identical filter, rate-limit, auto-close, and label-extractor behavior as the existing per-workload policies).
+- Make explicit, at the capability level, that every backend discovery CronJob exits 0 on failure by design and therefore MUST have ERROR-log alert coverage — so adding a new discovery job without alert coverage is a spec violation, not a silent omission. This closes the class of gap rather than just the two current instances.
+- Align the implementation: add the two workloads to the Pulumi alert-policy list, and document the deliberate exit-0-on-failure semantics in `sales-phase-discovery`'s job entrypoint (it currently lacks the explanatory comment that `merch-discovery` already carries).
+
+## Capabilities
+
+### New Capabilities
+<!-- none -->
+
+### Modified Capabilities
+- `app-error-log-alerting`: The "Error log detection per workload" requirement's enumerated workload set changes from `(server, consumer, concert-discovery)` to also include `sales-phase-discovery` and `merch-discovery`, with a scenario for each. A new requirement is added mandating ERROR-log alert coverage for every backend discovery CronJob, on the basis that these jobs exit 0 on failure by design.
+
+## Impact
+
+- **Capability spec**: `openspec/specs/app-error-log-alerting/spec.md` (modified requirement + new requirement).
+- **cloud-provisioning**: `src/gcp/components/monitoring.ts` — add `{ displayName: 'Sales Phase Discovery', appLabel: 'sales-phase-discovery' }` and `{ displayName: 'Merch Discovery', appLabel: 'merch-discovery' }` to the per-workload alert-policy list. Two new `gcp.monitoring.AlertPolicy` resources are created on `pulumi up` (prod is a manual console `up`).
+- **backend**: `cmd/job/sales-phase-discovery/main.go` — add the exit-0-on-failure rationale comment to match `cmd/job/merch-discovery/main.go` (documentation only; no behavior change).
+- **Out of scope** (tracked separately): retrying transient infra faults (e.g., DB ping timeout) inside the job before giving up, and the grounding-consistency work already tracked under #639. This change is scoped to closing the alerting-coverage gap for the exit-0 design.

--- a/openspec/changes/add-discovery-job-error-alerting/specs/app-error-log-alerting/spec.md
+++ b/openspec/changes/add-discovery-job-error-alerting/specs/app-error-log-alerting/spec.md
@@ -1,0 +1,60 @@
+## MODIFIED Requirements
+
+### Requirement: Error log detection per workload
+
+The system SHALL detect ERROR-level log entries from each backend workload (server, consumer, concert-discovery, sales-phase-discovery, merch-discovery) independently using Cloud Monitoring Log-Based Alert Policies.
+
+Each Alert Policy SHALL filter logs by:
+- `resource.type = "k8s_container"`
+- `resource.labels.namespace_name = "backend"`
+- `labels.k8s-pod/app` matching the specific workload name
+- `severity = "ERROR"`
+
+#### Scenario: Server emits an ERROR log
+
+- **WHEN** the server workload emits a log entry with severity ERROR
+- **THEN** the server-specific Alert Policy detects the log entry and opens an Incident
+
+#### Scenario: Consumer emits an ERROR log
+
+- **WHEN** the consumer workload emits a log entry with severity ERROR
+- **THEN** the consumer-specific Alert Policy detects the log entry and opens an Incident
+
+#### Scenario: Concert-discovery CronJob emits an ERROR log
+
+- **WHEN** the concert-discovery CronJob emits a log entry with severity ERROR
+- **THEN** the concert-discovery-specific Alert Policy detects the log entry and opens an Incident
+
+#### Scenario: Sales-phase-discovery CronJob emits an ERROR log
+
+- **WHEN** the sales-phase-discovery CronJob emits a log entry with severity ERROR (for example, a startup database ping failure or a per-artist searcher failure)
+- **THEN** the sales-phase-discovery-specific Alert Policy detects the log entry and opens an Incident
+
+#### Scenario: Merch-discovery CronJob emits an ERROR log
+
+- **WHEN** the merch-discovery CronJob emits a log entry with severity ERROR
+- **THEN** the merch-discovery-specific Alert Policy detects the log entry and opens an Incident
+
+#### Scenario: WARN-level log does not trigger alert
+
+- **WHEN** any workload emits a log entry with severity WARNING
+- **THEN** no Alert Policy SHALL fire
+
+## ADDED Requirements
+
+### Requirement: Discovery CronJob failure observability
+
+Backend discovery CronJobs (`concert-discovery`, `sales-phase-discovery`, `merch-discovery`) exit with status 0 even when a run fails, so that a broken run does not retry into the same persistent fault and exhaust downstream API quota. Because the Kubernetes Job is therefore always reported as succeeded, an ERROR-level log entry is the ONLY failure signal. Every backend discovery CronJob SHALL therefore have ERROR-log alert coverage under "Error log detection per workload". Introducing a new discovery CronJob without a corresponding Alert Policy is a violation of this requirement.
+
+#### Scenario: Discovery job fails but exits 0
+
+- **WHEN** a discovery CronJob encounters a fatal error (for example, DI initialization or a database ping timeout)
+- **THEN** the process SHALL log the failure at severity ERROR
+- **AND** the process SHALL exit 0 (the Job is reported as succeeded and is NOT retried)
+- **AND** the workload's ERROR-log Alert Policy SHALL open an Incident from that ERROR log
+
+#### Scenario: New discovery CronJob is introduced
+
+- **WHEN** a new backend discovery CronJob is added
+- **THEN** a per-workload ERROR-log Alert Policy SHALL be created for it in the same `pulumi up` that deploys the job
+- **AND** the absence of such a policy SHALL be treated as a spec violation

--- a/openspec/changes/add-discovery-job-error-alerting/specs/app-error-log-alerting/spec.md
+++ b/openspec/changes/add-discovery-job-error-alerting/specs/app-error-log-alerting/spec.md
@@ -44,14 +44,22 @@ Each Alert Policy SHALL filter logs by:
 
 ### Requirement: Discovery CronJob failure observability
 
-Backend discovery CronJobs (`concert-discovery`, `sales-phase-discovery`, `merch-discovery`) exit with status 0 even when a run fails, so that a broken run does not retry into the same persistent fault and exhaust downstream API quota. Because the Kubernetes Job is therefore always reported as succeeded, an ERROR-level log entry is the ONLY failure signal. Every backend discovery CronJob SHALL therefore have ERROR-log alert coverage under "Error log detection per workload". Introducing a new discovery CronJob without a corresponding Alert Policy is a violation of this requirement.
+Backend discovery CronJobs (`concert-discovery`, `sales-phase-discovery`, `merch-discovery`) handle their own errors and exit with status 0 even when a run fails, so that a broken run does not retry into the same persistent fault and exhaust downstream API quota. On this *handled*-failure path the process catches the error, logs it at severity ERROR, and exits 0 — so the Kubernetes Job is reported as succeeded and the ERROR log is the only failure signal. ERROR-log alerting is therefore the correct layer for the handled path, and every backend discovery CronJob SHALL have ERROR-log alert coverage under "Error log detection per workload". Introducing a new discovery CronJob without a corresponding Alert Policy is a violation of this requirement.
 
-#### Scenario: Discovery job fails but exits 0
+This requirement covers ONLY the handled-failure path. Abrupt-termination failures (OOM-kill, image-pull failure, node preemption/eviction) do not reach the handler: the container is killed before it can log an ERROR, and the Job is reported as failed rather than succeeded. Such failures are caught by neither ERROR-log alerting nor (deliberately excluded) Job-level alerting, and remain a separate, currently-uncovered observability gap tracked outside this change.
 
-- **WHEN** a discovery CronJob encounters a fatal error (for example, DI initialization or a database ping timeout)
+#### Scenario: Handled failure — job logs ERROR and exits 0
+
+- **WHEN** a discovery CronJob encounters a handled fatal error (for example, DI initialization or a database ping timeout)
 - **THEN** the process SHALL log the failure at severity ERROR
 - **AND** the process SHALL exit 0 (the Job is reported as succeeded and is NOT retried)
 - **AND** the workload's ERROR-log Alert Policy SHALL open an Incident from that ERROR log
+
+#### Scenario: Abrupt termination is out of scope
+
+- **WHEN** a discovery CronJob is abruptly terminated (OOM-kill, image-pull failure, node preemption) before it can log an ERROR
+- **THEN** the ERROR-log Alert Policy SHALL NOT be expected to fire (no ERROR log exists)
+- **AND** this failure class is acknowledged as a separate, currently-uncovered gap, not addressed by this requirement
 
 #### Scenario: New discovery CronJob is introduced
 

--- a/openspec/changes/add-discovery-job-error-alerting/tasks.md
+++ b/openspec/changes/add-discovery-job-error-alerting/tasks.md
@@ -16,5 +16,5 @@
 ## 4. Verification & close-out
 
 - [ ] 4.1 Confirm both new Alert Policies exist in prod Cloud Monitoring with the correct filter (`labels.k8s-pod/app` = `sales-phase-discovery` / `merch-discovery`, `severity="ERROR"`, namespace `backend`).
-- [ ] 4.2 Validate the filter against a real ERROR entry (e.g., the 2026-07-28 `sales-phase-discovery` DB-ping failure) or by triggering a controlled ERROR, and confirm an Incident opens and notifies Slack + Google Chat.
+- [ ] 4.2 Validate coverage via ONE of (these are genuine alternatives — a log-based `conditionMatchedLog` policy only evaluates entries ingested AFTER it is created, so a pre-existing historical entry can never retroactively open an Incident): (a) trigger a controlled ERROR (or emit/locate a real one after the policy exists) and confirm an Incident opens and notifies Slack + Google Chat; OR (b) validate the policy filter matches a historical entry (e.g., the 2026-07-28 `sales-phase-discovery` DB-ping failure) in Logs Explorer, WITHOUT requiring a new Incident.
 - [ ] 4.3 Verify the change (`/opsx:verify`) and archive it once all tasks are complete and shipped to prod.

--- a/openspec/changes/add-discovery-job-error-alerting/tasks.md
+++ b/openspec/changes/add-discovery-job-error-alerting/tasks.md
@@ -1,0 +1,20 @@
+## 1. cloud-provisioning — alert coverage
+
+- [ ] 1.1 In `src/gcp/components/monitoring.ts`, add two entries to the per-workload `workloads[]` array: `{ displayName: 'Sales Phase Discovery', appLabel: 'sales-phase-discovery' }` and `{ displayName: 'Merch Discovery', appLabel: 'merch-discovery' }`.
+- [ ] 1.2 Run `make lint-ts` (biome + tsc) and confirm `pulumi preview` (dev) shows exactly two new `gcp.monitoring.AlertPolicy` resources (`alert-error-log-sales-phase-discovery`, `alert-error-log-merch-discovery`) and no unintended diffs.
+- [ ] 1.3 Open the cloud-provisioning PR; on merge, dev applies automatically via Pulumi Cloud Deployments.
+
+## 2. backend — document exit-0 design
+
+- [ ] 2.1 In `cmd/job/sales-phase-discovery/main.go`, add the exit-0-on-failure rationale comment inside `main()` (mirroring `cmd/job/merch-discovery/main.go`): a systemic failure must not retry into the same fault; monitoring relies on ERROR logs. Documentation only — no behavior change.
+- [ ] 2.2 Run `make check` (lint + unit tests) green. This rides the next routine backend release; do NOT cut a release solely for a comment.
+
+## 3. prod rollout
+
+- [ ] 3.1 After the cloud-provisioning PR merges, trigger the prod Pulumi Cloud console `up` (prod does not auto-apply on merge). Confirm the two new `AlertPolicy` resources are created and enabled with Slack + Google Chat notification channels attached.
+
+## 4. Verification & close-out
+
+- [ ] 4.1 Confirm both new Alert Policies exist in prod Cloud Monitoring with the correct filter (`labels.k8s-pod/app` = `sales-phase-discovery` / `merch-discovery`, `severity="ERROR"`, namespace `backend`).
+- [ ] 4.2 Validate the filter against a real ERROR entry (e.g., the 2026-07-28 `sales-phase-discovery` DB-ping failure) or by triggering a controlled ERROR, and confirm an Incident opens and notifies Slack + Google Chat.
+- [ ] 4.3 Verify the change (`/opsx:verify`) and archive it once all tasks are complete and shipped to prod.


### PR DESCRIPTION
## Summary

Proposes the OpenSpec change `add-discovery-job-error-alerting`, closing a silent-failure gap in discovery-job observability.

The `sales-phase-discovery` and `merch-discovery` CronJobs exit 0 on failure by design (so a broken run does not retry into the same persistent fault), relying on ERROR-log alerting as the only failure signal. But the `app-error-log-alerting` capability enumerates per-workload ERROR-log Alert Policies for only `server`, `consumer`, and `concert-discovery` — the two newer discovery jobs were never added. As a result their failures are completely silent: the process exits 0, Kubernetes reports the Job as `succeeded=1`, and no Incident opens.

Observed live in prod on 2026-07-28: a `sales-phase-discovery` run failed at startup with a database ping timeout, logged the failure at ERROR, exited 0, and produced no alert.

## Changes (proposal only — no implementation in this PR)

- **proposal.md** — why the gap exists and what changes.
- **design.md** — reuse the existing per-workload `workloads[]` array (two new `AlertPolicy` resources, zero new code paths); encode the exit-0 ⇒ alert-coverage invariant at the capability level; prod is a manual Pulumi console `up`.
- **specs/app-error-log-alerting/spec.md** (delta):
  - **MODIFIED** "Error log detection per workload" — enumerated workloads extended to `(server, consumer, concert-discovery, sales-phase-discovery, merch-discovery)` with a scenario for each.
  - **ADDED** "Discovery CronJob failure observability" — because discovery jobs exit 0 by design, every backend discovery CronJob MUST have ERROR-log alert coverage; adding one without a policy is a spec violation.
- **tasks.md** — cloud-provisioning `monitoring.ts` (two `workloads[]` entries) → backend `sales-phase-discovery/main.go` exit-0 rationale comment → prod console `up` → verification.

## Testing

- `openspec validate add-discovery-job-error-alerting --strict` → valid.
- Pod `k8s-pod/app` labels confirmed against prod: `sales-phase-discovery`, `merch-discovery` (same shape as `concert-discovery`), so no label plumbing is required.

## Scope

Proposal only. Implementation (cloud-provisioning + backend) lands after this merges, via `/opsx:apply`. Transient-fault retry inside the jobs and grounding-consistency (#639) are explicitly out of scope.

close: #717
