### PR TITLE
feat(openspec): propose venue-name-localization change

### DIFF
--- a/openspec/changes/venue-name-localization/.openspec.yaml
+++ b/openspec/changes/venue-name-localization/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-29

--- a/openspec/changes/venue-name-localization/design.md
+++ b/openspec/changes/venue-name-localization/design.md
@@ -1,0 +1,84 @@
+## Context
+
+The concert data pipeline currently stores two venue name representations:
+- `venue.name` — canonical name fetched from Google Places API (stored without `languageCode`, so often English: "Nippon Budokan")
+- `listed_venue_name` — verbatim name scraped by Gemini from the artist's official site (typically Japanese for Japanese artists: "日本武道館"), stored raw with possible prefecture prefixes ("大阪・フェスティバルホール")
+
+The frontend mapper unconditionally selects `venue.name ?? listed_venue_name`, so Japanese users see English names when Places returns an English canonical.
+
+No schema change is needed: both fields are already in the proto and accessible on the frontend.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Japanese users (`preferredLanguage = ja`) see Japanese venue names where available.
+- English users (`preferredLanguage = en`) see English venue names where available.
+- New venues are stored with a locale-appropriate canonical name from Places.
+- `listed_venue_name` is clean (no prefecture prefix noise) when it reaches the frontend.
+
+**Non-Goals:**
+- Backfilling existing venues that were stored with English canonical names.
+- Adding new proto fields (no BSR gen cycle).
+- Supporting languages other than `ja` and `en` (Korean, Chinese, etc. get English fallback for now).
+- Perfect English coverage for venues that only have Japanese `listed_venue_name` and no `venue.name`.
+
+## Decisions
+
+### Decision 1: Use `listed_venue_name` as the Japanese display name, `venue.name` as English
+
+**Choice**: For `lang=ja`, prefer `listed_venue_name`; for `lang=en`, prefer `venue.name`. Cross-fallback in both directions.
+
+**Why**: `listed_venue_name` is scraped from the artist's Japanese official site — it is the most reliable Japanese source. `venue.name` from Places (once `languageCode` is fixed) will be locale-appropriate for new venues. The two fields naturally complement each other.
+
+**Alternative considered**: Add `name_en` / `name_ja` fields to the Venue proto. Rejected: requires schema change, BSR gen cycle, migration, and backfill — disproportionate cost for the immediate problem.
+
+**Alternative considered**: Pass `Accept-Language` header from frontend and have backend select the name per request. Rejected: adds per-request dynamic selection complexity; the data is already available in both representations on the wire.
+
+### Decision 2: Derive `languageCode` from the venue's country code (extracted from `admin_area`)
+
+**Choice**: Extract the ISO 3166-1 alpha-2 country code from `admin_area` (e.g., `"JP-13"` → `"JP"`), map to a BCP 47 language tag via a small static switch, and pass it as `languageCode` to the Places API `textSearch` request body.
+
+```
+JP → "ja"
+KR → "ko"
+CN → "zh-CN"
+TW → "zh-TW"
+default → "en"
+```
+
+**Why**: The mapping is a small, stable static table (~5 entries cover the realistic venue distribution). The country code is already present in `admin_area` at call time. No external lookup needed.
+
+**Alternative considered**: Hardcode `languageCode: "ja"` for all venues. Acceptable as a fallback but incorrect for future international concerts.
+
+**Why not** use the user's `preferredLanguage`: venue names should reflect the venue's locale, not the viewer's. A Japanese venue should return a Japanese name regardless of who is viewing.
+
+### Decision 3: Normalize `listed_venue_name` before storage, not only at dedup time
+
+**Choice**: Apply `entity.NormalizeVenueName()` to `sc.ListedVenueName` in `concert_creation_uc.go` before building the `StagedConcert`, so the stored value is already clean.
+
+**Why**: `NormalizeVenueName` is already used for dedup key computation. Moving it to the storage path means the frontend can use `listed_venue_name` as a display value directly, without needing to re-implement the normalization logic in TypeScript.
+
+**Idempotency**: `NormalizeVenueName` is idempotent, so dedup comparisons (`NormalizeVenueName(stored)`) remain correct.
+
+**Side effect**: `venues.listed_venue_name` (the fallback lookup key used in `GetByListedName`) will also be stored in normalized form. This is consistent because both the stored key and any future query through the same path are normalized identically.
+
+### Decision 4: Pass `lang` to the concert mapper as a parameter
+
+**Choice**: Add a `lang: string` parameter to the mapper function (or the mapper class constructor, whichever the existing pattern uses). Callers obtain the value from `UserStore.currentLanguage` (or equivalent DI).
+
+**Why**: Pure function / thin adapter — mapper should not reach into stores directly. Passing `lang` keeps the mapper testable without mocking the store.
+
+## Risks / Trade-offs
+
+- **Existing English-named venues** — Venues already in the DB with an English `venue.name` and a populated `listed_venue_name` will render correctly for `ja` users via the fallback. Venues with a null `listed_venue_name` will remain in English until re-resolved (acceptable until a future backfill pass).
+- **`listed_venue_name` null rate** — If a concert has no `listed_venue_name` (e.g., hand-entered or legacy data), the `lang=ja` path falls back to `venue.name`. This gracefully degrades to the current behavior.
+- **Places API language quality** — Google Places does not always return a localized name; some venues have only an English entry even in the `ja` response. The frontend fallback handles this.
+- **Normalization changes stored keys** — Storing normalized `listed_venue_name` means the `GetByListedName` lookup key changes for future concerts. Existing DB rows retain their raw (unnormalized) values, so a new concert with a normalized listed name that matches an old raw name will miss the DB cache and re-hit Places. This is a one-time inefficiency, not a correctness issue.
+
+## Migration Plan
+
+1. Deploy backend change (normalize before storage + languageCode in Places API). New venues from this point onward are stored correctly.
+2. Deploy frontend change (locale-aware mapper). Immediately takes effect for all concerts using the existing `listed_venue_name` data.
+3. No migration script required for existing rows. Existing venues with English `venue.name` are covered by the frontend `listed_venue_name` fallback.
+
+Rollback: both backend and frontend changes are independently safe to revert. Backend revert restores previous Places API behavior (no `languageCode`). Frontend revert restores `venue.name ?? listed_venue_name` priority.

--- a/openspec/changes/venue-name-localization/design.md
+++ b/openspec/changes/venue-name-localization/design.md
@@ -12,15 +12,14 @@ No schema change is needed: both fields are already in the proto and accessible 
 
 **Goals:**
 - Japanese users (`preferredLanguage = ja`) see Japanese venue names where available.
-- English users (`preferredLanguage = en`) see English venue names where available.
 - New venues are stored with a locale-appropriate canonical name from Places.
-- `listed_venue_name` is clean (no prefecture prefix noise) when it reaches the frontend.
+- `listed_venue_name` is clean (no prefecture prefix noise) — both for new rows (write-path normalization) and existing rows (one-time DB migration).
 
 **Non-Goals:**
-- Backfilling existing venues that were stored with English canonical names.
+- Backfilling existing venues that were stored with English `venue.name`.
 - Adding new proto fields (no BSR gen cycle).
 - Supporting languages other than `ja` and `en` (Korean, Chinese, etc. get English fallback for now).
-- Perfect English coverage for venues that only have Japanese `listed_venue_name` and no `venue.name`.
+- Perfect English coverage for venues in non-English-speaking countries: since `venue.name` reflects the venue's locale (not the viewer's language), English-preference users viewing Japanese venues may see Japanese canonical names. This is an acceptable edge case given the system's primary Japanese user base; true English-preference coverage requires a separate `name_en` field.
 
 ## Decisions
 
@@ -73,12 +72,12 @@ default → "en"
 - **Existing English-named venues** — Venues already in the DB with an English `venue.name` and a populated `listed_venue_name` will render correctly for `ja` users via the fallback. Venues with a null `listed_venue_name` will remain in English until re-resolved (acceptable until a future backfill pass).
 - **`listed_venue_name` null rate** — If a concert has no `listed_venue_name` (e.g., hand-entered or legacy data), the `lang=ja` path falls back to `venue.name`. This gracefully degrades to the current behavior.
 - **Places API language quality** — Google Places does not always return a localized name; some venues have only an English entry even in the `ja` response. The frontend fallback handles this.
-- **Normalization changes stored keys** — Storing normalized `listed_venue_name` means the `GetByListedName` lookup key changes for future concerts. Existing DB rows retain their raw (unnormalized) values, so a new concert with a normalized listed name that matches an old raw name will miss the DB cache and re-hit Places. This is a one-time inefficiency, not a correctness issue.
+- **Normalization changes stored keys** — After the one-time migration normalizes existing rows, the `GetByListedName` lookup key is consistent across old and new rows. During the window between deploying the write-path normalization and running the migration, a new concert with a normalized listed name may miss the DB cache for an old raw-value match and re-hit Places — a one-time inefficiency, not a correctness issue.
 
 ## Migration Plan
 
 1. Deploy backend change (normalize before storage + languageCode in Places API). New venues from this point onward are stored correctly.
-2. Deploy frontend change (locale-aware mapper). Immediately takes effect for all concerts using the existing `listed_venue_name` data.
-3. No migration script required for existing rows. Existing venues with English `venue.name` are covered by the frontend `listed_venue_name` fallback.
+2. Run one-time DB migration to normalize existing `listed_venue_name` values in `staged_concerts` and `concerts` tables — strip prefecture-dot prefixes using the same `NormalizeVenueName` logic (implemented as a Go migration job). This brings existing rows in line with the write-path normalization applied going forward.
+3. Deploy frontend change (locale-aware mapper). After step 2, all rows are clean and `listed_venue_name` can be used as a safe display value for `ja` users.
 
 Rollback: both backend and frontend changes are independently safe to revert. Backend revert restores previous Places API behavior (no `languageCode`). Frontend revert restores `venue.name ?? listed_venue_name` priority.

--- a/openspec/changes/venue-name-localization/proposal.md
+++ b/openspec/changes/venue-name-localization/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+Concert venue names are displayed in English regardless of the user's preferred language because the Google Places API is called without a `languageCode` parameter, causing English canonical names (e.g., "Nippon Budokan") to be stored and surfaced — even though the Gemini scraper already captures the correct Japanese names in `listed_venue_name`. Users with a Japanese preference see English venue names on event cards and detail sheets.
+
+## What Changes
+
+- The Google Places API `SearchPlace` call will include a `languageCode` derived from the venue's country code (extracted from `admin_area`, e.g. `"JP-13"` → `"ja"`), so newly resolved venues are stored with locale-appropriate canonical names.
+- `listed_venue_name` will be normalized (prefecture prefixes stripped) before being stored in `staged_concerts`, so the frontend can use it as a clean display value.
+- The frontend concert mapper will select the venue name based on the user's current language: prefer `listed_venue_name` for `ja`, prefer `venue.name` for `en`, with cross-fallback.
+
+## Capabilities
+
+### New Capabilities
+
+- `venue-name-localization`: Locale-aware venue name display — how the frontend selects between `listed_venue_name` and `venue.name` based on `currentLanguage`, and the fallback chain when either field is absent.
+
+### Modified Capabilities
+
+- `venue-normalization`: Two new requirements — (1) the Places API call MUST include a `languageCode` derived from the venue's country code; (2) `listed_venue_name` MUST be normalized via `NormalizeVenueName` before being persisted to `staged_concerts`.
+
+## Impact
+
+- **Backend**: `internal/infrastructure/maps/google/client.go` (add `languageCode` to Places request), `internal/usecase/concert_creation_uc.go` (normalize `listed_venue_name` before storage), new helper function for country-code → language-code mapping.
+- **Frontend**: `src/adapter/rpc/mapper/concert-mapper.ts` (locale-aware `venueName` selection), caller sites that instantiate or invoke the mapper must pass `currentLanguage`.
+- **No schema change**: existing proto fields (`venue.name`, `listed_venue_name`) are sufficient; no BSR gen cycle required.
+- **Existing venues**: venues already stored with English canonical names are covered by the frontend fallback to `listed_venue_name`. Venues without `listed_venue_name` will remain in English until re-resolved.

--- a/openspec/changes/venue-name-localization/specs/venue-name-localization/spec.md
+++ b/openspec/changes/venue-name-localization/specs/venue-name-localization/spec.md
@@ -1,0 +1,39 @@
+## ADDED Requirements
+
+### Requirement: Venue Name Display Respects User's Preferred Language
+
+The concert mapper SHALL select the venue display name based on the user's current language setting. For Japanese users, `listed_venue_name` (scraped from the artist's official site, typically Japanese) SHALL be preferred over `venue.name` (Google Places canonical). For English users, `venue.name` SHALL be preferred. Either direction SHALL fall back to the other field when the preferred field is absent.
+
+#### Scenario: Japanese user sees listed_venue_name when available
+
+- **WHEN** the concert mapper resolves the venue display name
+- **AND** the user's current language is `ja`
+- **AND** the concert has a non-empty `listed_venue_name`
+- **THEN** the mapper SHALL use `listed_venue_name` as the venue display name
+
+#### Scenario: Japanese user falls back to venue.name when listed_venue_name is absent
+
+- **WHEN** the concert mapper resolves the venue display name
+- **AND** the user's current language is `ja`
+- **AND** the concert has no `listed_venue_name` (null or empty)
+- **THEN** the mapper SHALL use `venue.name` as the venue display name
+
+#### Scenario: English user sees venue.name when available
+
+- **WHEN** the concert mapper resolves the venue display name
+- **AND** the user's current language is `en`
+- **AND** the concert's embedded venue has a non-empty `name`
+- **THEN** the mapper SHALL use `venue.name` as the venue display name
+
+#### Scenario: English user falls back to listed_venue_name when venue.name is absent
+
+- **WHEN** the concert mapper resolves the venue display name
+- **AND** the user's current language is `en`
+- **AND** the concert's embedded venue has no name
+- **THEN** the mapper SHALL use `listed_venue_name` as the venue display name
+
+#### Scenario: Language parameter is injected into the mapper
+
+- **WHEN** the concert mapper function (or class) is invoked
+- **THEN** it SHALL accept the current language as an explicit parameter
+- **AND** it SHALL NOT read the language directly from a global store or singleton

--- a/openspec/changes/venue-name-localization/specs/venue-normalization/spec.md
+++ b/openspec/changes/venue-name-localization/specs/venue-normalization/spec.md
@@ -1,0 +1,45 @@
+## ADDED Requirements
+
+### Requirement: Google Places API Request Includes Language Code
+
+When the concert creation pipeline calls Google Places `SearchPlace`, the request SHALL include a `languageCode` field derived from the venue's country code. The country code SHALL be extracted from the ISO 3166-2 `admin_area` field (e.g., `"JP-13"` → `"JP"`). The mapping from country code to BCP 47 language tag SHALL follow a static lookup table with `"en"` as the default.
+
+#### Scenario: Japanese venue resolves with Japanese language code
+
+- **WHEN** the concert creation pipeline calls `SearchPlace` for a venue with `admin_area` starting with `"JP"`
+- **THEN** the Places API request SHALL include `languageCode: "ja"`
+- **AND** the returned canonical `venue.name` SHALL be in Japanese when available
+
+#### Scenario: Korean venue resolves with Korean language code
+
+- **WHEN** the concert creation pipeline calls `SearchPlace` for a venue with `admin_area` starting with `"KR"`
+- **THEN** the Places API request SHALL include `languageCode: "ko"`
+
+#### Scenario: Unknown country defaults to English language code
+
+- **WHEN** the concert creation pipeline calls `SearchPlace` for a venue whose country code is not in the static mapping
+- **THEN** the Places API request SHALL include `languageCode: "en"`
+
+#### Scenario: Absent admin_area defaults to English language code
+
+- **WHEN** the concert creation pipeline calls `SearchPlace` for a venue with no `admin_area`
+- **THEN** the Places API request SHALL include `languageCode: "en"`
+
+### Requirement: listed_venue_name Is Normalized Before Storage
+
+The concert creation pipeline SHALL apply `NormalizeVenueName` to the scraped `listed_venue_name` before storing it in the `staged_concerts` row. The raw (unnormalized) value SHALL NOT be persisted.
+
+#### Scenario: Prefecture prefix stripped before storage
+
+- **WHEN** the concert creation pipeline processes a scraped concert with `listed_venue_name` equal to `"大阪・フェスティバルホール"`
+- **THEN** the stored `listed_venue_name` SHALL be `"フェスティバルホール"`
+
+#### Scenario: Whitespace-only listed_venue_name is rejected
+
+- **WHEN** `NormalizeVenueName` reduces the scraped venue name to an empty string after normalization
+- **THEN** the concert SHALL be treated the same as having a missing `listed_venue_name`
+
+#### Scenario: Already-normalized name is stored unchanged
+
+- **WHEN** the concert creation pipeline processes a scraped concert with `listed_venue_name` equal to `"日本武道館"`
+- **THEN** the stored `listed_venue_name` SHALL be `"日本武道館"` (unchanged, normalization is idempotent)

--- a/openspec/changes/venue-name-localization/tasks.md
+++ b/openspec/changes/venue-name-localization/tasks.md
@@ -1,25 +1,30 @@
-## 1. Backend — listed_venue_name normalization before storage
+## 1. Backend — one-time listed_venue_name normalization migration
 
-- [ ] 1.1 In `internal/usecase/concert_creation_uc.go`, apply `entity.NormalizeVenueName(sc.ListedVenueName)` before assigning to `StagedConcert.ListedVenueName`
-- [ ] 1.2 Verify existing unit tests for `concert_creation_uc.go` still pass; update any test fixtures that assert the raw (unnormalized) listed venue name
+- [ ] 1.1 Write a Go migration job (or Atlas migration) that iterates over all rows in `staged_concerts` and `concerts` (or the equivalent table) where `listed_venue_name IS NOT NULL`, applies `entity.NormalizeVenueName`, and updates the row in place
+- [ ] 1.2 Run the migration against the production DB and verify row counts and sample values
 
-## 2. Backend — languageCode in Google Places API
+## 2. Backend — listed_venue_name normalization before storage
 
-- [ ] 2.1 Add a `countryCodeToLanguage(cc string) string` helper function (in `internal/infrastructure/maps/google/` or `internal/entity/`) implementing the static country → BCP 47 map (`JP→ja`, `KR→ko`, `CN→zh-CN`, `TW→zh-TW`, default `en`)
-- [ ] 2.2 Add `LanguageCode string` field to `textSearchRequest` struct in `internal/infrastructure/maps/google/client.go`
-- [ ] 2.3 In `SearchPlace`, extract the country code from `adminArea` (split on `"-"`, take first element) and pass `countryCodeToLanguage(country)` as `LanguageCode` in the request body
-- [ ] 2.4 Add unit tests for `countryCodeToLanguage` covering `JP`, `KR`, `CN`, `TW`, empty string, and unknown country code
+- [ ] 2.1 In `internal/usecase/concert_creation_uc.go`, apply `entity.NormalizeVenueName(sc.ListedVenueName)` before assigning to `StagedConcert.ListedVenueName`
+- [ ] 2.2 Verify existing unit tests for `concert_creation_uc.go` still pass; update any test fixtures that assert the raw (unnormalized) listed venue name
 
-## 3. Frontend — locale-aware venue name in concert mapper
+## 3. Backend — languageCode in Google Places API
 
-- [ ] 3.1 Identify how the concert mapper is currently called (function vs class, where `currentLanguage` is available) by reading `src/adapter/rpc/mapper/concert-mapper.ts` and its call sites
-- [ ] 3.2 Add a `lang: string` parameter to the concert mapper (function signature or constructor/method) and thread it from `UserStore.currentLanguage` at the call site(s)
-- [ ] 3.3 Replace the unconditional `venue?.name?.value ?? listedVenueName?.value` expression with locale-aware selection: `ja` prefers `listed_venue_name`, `en` prefers `venue.name`, with cross-fallback
-- [ ] 3.4 Update or add unit tests for the concert mapper covering: ja with both fields, ja with only venue.name, en with both fields, en with only listed_venue_name
+- [ ] 3.1 Add a `countryCodeToLanguage(cc string) string` helper function (in `internal/infrastructure/maps/google/` or `internal/entity/`) implementing the static country → BCP 47 map (`JP→ja`, `KR→ko`, `CN→zh-CN`, `TW→zh-TW`, default `en`)
+- [ ] 3.2 Add `LanguageCode string` field to `textSearchRequest` struct in `internal/infrastructure/maps/google/client.go`
+- [ ] 3.3 In `SearchPlace`, extract the country code from `adminArea` (split on `"-"`, take first element) and pass `countryCodeToLanguage(country)` as `LanguageCode` in the request body
+- [ ] 3.4 Add unit tests for `countryCodeToLanguage` covering `JP`, `KR`, `CN`, `TW`, empty string, and unknown country code
 
-## 4. Verification
+## 4. Frontend — locale-aware venue name in concert mapper
 
-- [ ] 4.1 Run `make check` in the backend repo and confirm all tests pass
-- [ ] 4.2 Run `make check` in the frontend repo and confirm all tests pass
-- [ ] 4.3 Open the dashboard as a Japanese user and confirm a Mrs. Green Apple (or similar Japanese artist) tour shows Japanese venue names on event cards and detail sheets
-- [ ] 4.4 Ship to prod
+- [ ] 4.1 Identify how the concert mapper is currently called (function vs class, where `currentLanguage` is available) by reading `src/adapter/rpc/mapper/concert-mapper.ts` and its call sites
+- [ ] 4.2 Add a `lang: string` parameter to the concert mapper (function signature or constructor/method) and thread it from `UserStore.currentLanguage` at the call site(s)
+- [ ] 4.3 Replace the unconditional `venue?.name?.value ?? listedVenueName?.value` expression with locale-aware selection: `ja` prefers `listed_venue_name`, `en` prefers `venue.name`, with cross-fallback
+- [ ] 4.4 Update or add unit tests for the concert mapper covering: ja with both fields, ja with only venue.name, en with both fields, en with only listed_venue_name
+
+## 5. Verification
+
+- [ ] 5.1 Run `make check` in the backend repo and confirm all tests pass
+- [ ] 5.2 Run `make check` in the frontend repo and confirm all tests pass
+- [ ] 5.3 Open the dashboard as a Japanese user and confirm a Mrs. Green Apple (or similar Japanese artist) tour shows Japanese venue names on event cards and detail sheets
+- [ ] 5.4 Ship to prod

--- a/openspec/changes/venue-name-localization/tasks.md
+++ b/openspec/changes/venue-name-localization/tasks.md
@@ -1,0 +1,25 @@
+## 1. Backend — listed_venue_name normalization before storage
+
+- [ ] 1.1 In `internal/usecase/concert_creation_uc.go`, apply `entity.NormalizeVenueName(sc.ListedVenueName)` before assigning to `StagedConcert.ListedVenueName`
+- [ ] 1.2 Verify existing unit tests for `concert_creation_uc.go` still pass; update any test fixtures that assert the raw (unnormalized) listed venue name
+
+## 2. Backend — languageCode in Google Places API
+
+- [ ] 2.1 Add a `countryCodeToLanguage(cc string) string` helper function (in `internal/infrastructure/maps/google/` or `internal/entity/`) implementing the static country → BCP 47 map (`JP→ja`, `KR→ko`, `CN→zh-CN`, `TW→zh-TW`, default `en`)
+- [ ] 2.2 Add `LanguageCode string` field to `textSearchRequest` struct in `internal/infrastructure/maps/google/client.go`
+- [ ] 2.3 In `SearchPlace`, extract the country code from `adminArea` (split on `"-"`, take first element) and pass `countryCodeToLanguage(country)` as `LanguageCode` in the request body
+- [ ] 2.4 Add unit tests for `countryCodeToLanguage` covering `JP`, `KR`, `CN`, `TW`, empty string, and unknown country code
+
+## 3. Frontend — locale-aware venue name in concert mapper
+
+- [ ] 3.1 Identify how the concert mapper is currently called (function vs class, where `currentLanguage` is available) by reading `src/adapter/rpc/mapper/concert-mapper.ts` and its call sites
+- [ ] 3.2 Add a `lang: string` parameter to the concert mapper (function signature or constructor/method) and thread it from `UserStore.currentLanguage` at the call site(s)
+- [ ] 3.3 Replace the unconditional `venue?.name?.value ?? listedVenueName?.value` expression with locale-aware selection: `ja` prefers `listed_venue_name`, `en` prefers `venue.name`, with cross-fallback
+- [ ] 3.4 Update or add unit tests for the concert mapper covering: ja with both fields, ja with only venue.name, en with both fields, en with only listed_venue_name
+
+## 4. Verification
+
+- [ ] 4.1 Run `make check` in the backend repo and confirm all tests pass
+- [ ] 4.2 Run `make check` in the frontend repo and confirm all tests pass
+- [ ] 4.3 Open the dashboard as a Japanese user and confirm a Mrs. Green Apple (or similar Japanese artist) tour shows Japanese venue names on event cards and detail sheets
+- [ ] 4.4 Ship to prod


### PR DESCRIPTION
## 🔗 Related Issue

Closes #723

## 📝 Summary of Changes

Concert venue names display in English regardless of user preferred language. Root cause: `SearchPlace` in `maps/google/client.go` calls the Google Places API without `languageCode`, so venues like 日本武道館 get stored as "Nippon Budokan". Meanwhile, Gemini already scrapes the correct Japanese name into `listed_venue_name`, but the frontend mapper unconditionally prefers `venue.name`.

This change proposes a three-point fix (no schema change, no BSR gen cycle):

| Layer | File | Change |
|-------|------|--------|
| Backend | `concert_creation_uc.go` | Apply `NormalizeVenueName` to `listed_venue_name` before storing in `staged_concerts` (strips prefecture prefixes like "大阪・") |
| Backend | `maps/google/client.go` | Add `languageCode` to Places API request, derived from the venue's country code extracted from `admin_area` (e.g. `JP-13` → `ja`) |
| Frontend | `concert-mapper.ts` | Select venue name based on `currentLanguage`: prefer `listed_venue_name` for `ja`, prefer `venue.name` for `en`, with cross-fallback |

### Artifacts

- `proposal.md` — motivation and capability list
- `design.md` — four key technical decisions with rationale and trade-offs
- `specs/venue-name-localization/spec.md` — new capability: locale-aware venue name selection in the frontend mapper
- `specs/venue-normalization/spec.md` — delta: two added requirements (languageCode in Places API + pre-storage normalization)
- `tasks.md` — 14 implementation tasks across 4 groups

## ✅ Self-Checklist

- [x] I have linked the related issue.
- [x] I have updated the relevant documentation if needed.
- [x] I have run `buf lint` and `buf format` locally and all checks have passed. (No `.proto` files changed — buf checks are trivially satisfied.)
- [x] My proto definitions follow the project's style guidelines and validation rules. (No proto changes in this PR.)
- [x] Breaking changes have been justified and documented if applicable. (No breaking changes.)
