### PR TITLE
feat(admin): add open_time field to PendingConcert proto

### DIFF
--- a/openspec/changes/add-open-time-to-approval-queue/tasks.md
+++ b/openspec/changes/add-open-time-to-approval-queue/tasks.md
@@ -1,7 +1,7 @@
 ## 1. Specification
 
-- [ ] 1.1 Add `open_time = 10` field (type `entity.v1.OpenTime`, optional) to `PendingConcert` in `proto/liverty_music/rpc/admin/v1/concert_service.proto`
-- [ ] 1.2 Run `buf lint`, `buf format -w`, and `buf breaking --against '.git#branch=main'` to verify no proto issues
+- [x] 1.1 Add `open_time = 10` field (type `entity.v1.OpenTime`, optional) to `PendingConcert` in `proto/liverty_music/rpc/admin/v1/concert_service.proto`
+- [x] 1.2 Run `buf lint`, `buf format -w`, and `buf breaking --against '.git#branch=main'` to verify no proto issues
 - [ ] 1.3 Open a PR for the specification change and merge it
 - [ ] 1.4 Create a GitHub Release tag on the specification repo to trigger BSR code generation
 - [ ] 1.5 Confirm `buf-release.yml` CI completes successfully and the new package version is available on BSR

--- a/proto/liverty_music/rpc/admin/v1/concert_service.proto
+++ b/proto/liverty_music/rpc/admin/v1/concert_service.proto
@@ -143,6 +143,9 @@ message PendingConcert {
 
   // The time at which the discovery pipeline staged this concert.
   google.protobuf.Timestamp discovered_time = 9 [(buf.validate.field).required = true];
+
+  // The scheduled door-open time. Optional; omitted when the source did not state one.
+  entity.v1.OpenTime open_time = 10;
 }
 
 // ListRequest is the request for retrieving all published concerts. It takes no


### PR DESCRIPTION
## 🔗 Related Issue

Closes #726

## 📝 Summary of Changes

The approval queue table already stores `OpenTime` on `StagedConcert` (from the discovery pipeline), but `PendingConcert` had no `open_time` proto field — so the backend mapper dropped the value and admin reviewers never saw it.

This adds `open_time = 10` (type `entity.v1.OpenTime`, optional) to `PendingConcert`:

- Field 10 is the next available slot after `discovered_time = 9`
- `entity.v1.OpenTime` is the established wrapper type — already used in `ExistingEvent.open_time = 6` in the same file
- No `buf.validate` required constraint: absent open time is a valid state when the source did not state one
- Purely additive; wire-compatible under proto3 (`buf breaking` confirmed)

Backend mapper (`PendingConcertToProto`) and frontend rendering (Open time column + conflict dialog) are covered by follow-up tasks in the `add-open-time-to-approval-queue` OpenSpec change.

## ✅ Self-Checklist

- [x] I have linked the related issue.
- [x] I have updated the relevant documentation (e.g., `README.md`) if needed.
- [x] I have run `buf lint` and `buf format` locally and all checks have passed.
- [x] My proto definitions follow the project's style guidelines and validation rules.
- [x] Breaking changes have been justified and documented if applicable.
