### PR TITLE
chore(openspec): archive add-open-time-to-approval-queue + sync spec

### DIFF
--- a/openspec/changes/add-open-time-to-approval-queue/tasks.md
+++ b/openspec/changes/add-open-time-to-approval-queue/tasks.md
@@ -2,37 +2,37 @@
 
 - [x] 1.1 Add `open_time = 10` field (type `entity.v1.OpenTime`, optional) to `PendingConcert` in `proto/liverty_music/rpc/admin/v1/concert_service.proto`
 - [x] 1.2 Run `buf lint`, `buf format -w`, and `buf breaking --against '.git#branch=main'` to verify no proto issues
-- [ ] 1.3 Open a PR for the specification change and merge it
-- [ ] 1.4 Create a GitHub Release tag on the specification repo to trigger BSR code generation
-- [ ] 1.5 Confirm `buf-release.yml` CI completes successfully and the new package version is available on BSR
+- [x] 1.3 Open a PR for the specification change and merge it
+- [x] 1.4 Create a GitHub Release tag on the specification repo to trigger BSR code generation
+- [x] 1.5 Confirm `buf-release.yml` CI completes successfully and the new package version is available on BSR
 
 ## 2. Backend
 
 > **Requires task 1.5 to be complete first.** Do not run 2.1 until `buf-release.yml` has finished and the new BSR package version is confirmed available — otherwise `go get` resolves the pre-change schema.
 
-- [ ] 2.1 Upgrade the generated Go package: `go get buf.build/gen/go/liverty-music/schema/...` then `go mod tidy`
-- [ ] 2.2 Add `OpenTime` mapping to `PendingConcertToProto` in `internal/adapter/rpc/mapper/pending_concert.go` (follow the `StartTime` pattern at lines 31–33)
-- [ ] 2.3 Create `internal/adapter/rpc/mapper/pending_concert_test.go` with a `TestPendingConcertToProto` function covering `open_time` present and absent (note: `concert_test.go` tests `ConcertToProto` — the new tests belong in a dedicated file for the `PendingConcert` mapper)
-- [ ] 2.4 Run `make check` and confirm it passes
-- [ ] 2.5 Open a PR for the backend change, confirm CI green, and merge
+- [x] 2.1 Upgrade the generated Go package: `go get buf.build/gen/go/liverty-music/schema/...` then `go mod tidy`
+- [x] 2.2 Add `OpenTime` mapping to `PendingConcertToProto` in `internal/adapter/rpc/mapper/pending_concert.go` (follow the `StartTime` pattern at lines 31–33)
+- [x] 2.3 Create `internal/adapter/rpc/mapper/pending_concert_test.go` with a `TestPendingConcertToProto` function covering `open_time` present and absent (note: `concert_test.go` tests `ConcertToProto` — the new tests belong in a dedicated file for the `PendingConcert` mapper)
+- [x] 2.4 Run `make check` and confirm it passes
+- [x] 2.5 Open a PR for the backend change, confirm CI green, and merge
 
 ## 3. Frontend
 
 > **Requires task 1.5 to be complete first.** BSR-generated npm packages use timestamped pre-release version strings (e.g., `^1.10.0-20260725094030-xxx.1`); `@latest` does not reliably resolve to them. After 1.5 completes, find the new version by running `npm view @buf/liverty-music_schema.bufbuild_es versions --json` or checking the BSR release page, then pin to that version.
 
-- [ ] 3.1 Upgrade the generated npm packages: `npm install @buf/liverty-music_schema.bufbuild_es@<new-version> @buf/liverty-music_schema.connectrpc_es@<new-version>`
-- [ ] 3.2 Add `readonly openTime: string` to the `QueueRow` interface in `admin/approval-queue/approval-queue-route.ts`
-- [ ] 3.3 Add `openTime: formatTimeOfDay(concert.openTime?.value)` to `toRow()` in `approval-queue-route.ts`
-- [ ] 3.4 Add `readonly stagedOpenTime: string` to the `ConflictView` interface
-- [ ] 3.5 Set `stagedOpenTime: row.openTime` in `toConflictView()` (replaces the hardcoded `—`)
-- [ ] 3.6 Add an **Open time** `<th>` and `<td>` column to the approval queue table in `approval-queue-route.html`, positioned after Start time
-- [ ] 3.7 Replace the hardcoded `${'—'}` for staged open time in the conflict dialog with `${conflictView.stagedOpenTime}`
-- [ ] 3.8 In `test/admin/approval-queue/approval-queue-route.spec.ts`, add test cases covering: (a) `toRow()` maps `concert.openTime?.value` via `formatTimeOfDay` correctly for present and absent values; (b) `toConflictView()` sets `stagedOpenTime` from `row.openTime`
-- [ ] 3.9 Run `make check` and confirm it passes
-- [ ] 3.10 Open a PR for the frontend change, confirm CI green, and merge
+- [x] 3.1 Upgrade the generated npm packages: `npm install @buf/liverty-music_schema.bufbuild_es@<new-version> @buf/liverty-music_schema.connectrpc_es@<new-version>`
+- [x] 3.2 Add `readonly openTime: string` to the `QueueRow` interface in `admin/approval-queue/approval-queue-route.ts`
+- [x] 3.3 Add `openTime: formatTimeOfDay(concert.openTime?.value)` to `toRow()` in `approval-queue-route.ts`
+- [x] 3.4 Add `readonly stagedOpenTime: string` to the `ConflictView` interface
+- [x] 3.5 Set `stagedOpenTime: row.openTime` in `toConflictView()` (replaces the hardcoded `—`)
+- [x] 3.6 Add an **Open time** `<th>` and `<td>` column to the approval queue table in `approval-queue-route.html`, positioned after Start time
+- [x] 3.7 Replace the hardcoded `${'—'}` for staged open time in the conflict dialog with `${conflictView.stagedOpenTime}`
+- [x] 3.8 In `test/admin/approval-queue/approval-queue-route.spec.ts`, add test cases covering: (a) `toRow()` maps `concert.openTime?.value` via `formatTimeOfDay` correctly for present and absent values; (b) `toConflictView()` sets `stagedOpenTime` from `row.openTime`
+- [x] 3.9 Run `make check` and confirm it passes
+- [x] 3.10 Open a PR for the frontend change, confirm CI green, and merge
 
 ## 4. Ship to Production
 
-- [ ] 4.1 Create a GitHub Release for the backend repo to publish to prod
-- [ ] 4.2 Create a GitHub Release for the frontend repo to publish to prod
-- [ ] 4.3 Confirm prod deployment completes and the Open time column is visible in the approval queue
+- [x] 4.1 Create a GitHub Release for the backend repo to publish to prod
+- [x] 4.2 Create a GitHub Release for the frontend repo to publish to prod
+- [x] 4.3 Confirm prod deployment completes and the Open time column is visible in the approval queue

--- a/openspec/changes/archive/2026-07-29-add-open-time-to-approval-queue/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-29-add-open-time-to-approval-queue/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-29

--- a/openspec/changes/archive/2026-07-29-add-open-time-to-approval-queue/design.md
+++ b/openspec/changes/archive/2026-07-29-add-open-time-to-approval-queue/design.md
@@ -1,0 +1,57 @@
+## Context
+
+The `StagedConcert` domain entity already stores `OpenTime *time.Time`. When a concert is
+discovered, the pipeline may capture the door-open time and persist it to `staged_concerts.open_at`.
+However, the `PendingConcert` proto message (`rpc/admin/v1/concert_service.proto`) has no
+`open_time` field, so the backend mapper drops the value and the frontend never receives it.
+
+The approved-concerts page already renders `openTime` for published events via the `Concert` entity.
+The conflict dialog's "Existing" side already shows `existingOpenTime` (from `ExistingEvent`), but
+the "Staged" side hardcodes `—` because `PendingConcert` carries no open time.
+
+This is a purely additive change with no DB migration, no behavioral logic change, and no
+breaking proto change (optional field addition is wire-compatible under proto3).
+
+## Goals / Non-Goals
+
+**Goals:**
+- Expose `open_time` in `PendingConcert` so reviewers can see it in the queue table
+- Fix the conflict dialog's staged side to show the actual staged open time
+- Keep the change minimal and fully additive
+
+**Non-Goals:**
+- Changing how open time is discovered or stored (already works)
+- Altering approval/rejection logic
+- Adding open time to the rejection log display
+
+## Decisions
+
+### Decision: Add `open_time` as field 10 on `PendingConcert`
+
+`open_time` is optional (absent when the source did not state a door-open time). Field numbers
+1–9 are already assigned; field 10 is the next available slot. Using the existing `entity.v1.OpenTime`
+wrapper type is consistent with how `StartTime` is modelled (`entity.v1.StartTime`). No
+`buf.validate` required constraint since this is genuinely optional data.
+
+Alternatives considered:
+- Embedding the timestamp directly as `google.protobuf.Timestamp` — rejected for inconsistency
+  with the rest of the entity fields, which all use typed wrapper messages.
+
+### Decision: Map in `PendingConcertToProto`, not in the handler
+
+`pending_concert.go` is the dedicated mapper for `PendingConcert`; the handler should not
+know mapping details. This is consistent with how `StartTime` is already mapped there (line 31–33).
+
+### Decision: Frontend adds `openTime` to `QueueRow` and `toConflictView`
+
+`QueueRow` precomputes all display strings so the template stays free of optional-chaining.
+Adding `openTime: string` follows the same pattern as `startTime`. The conflict view gets
+`stagedOpenTime` to replace the hardcoded `—` on the staged side.
+
+## Risks / Trade-offs
+
+| Risk | Mitigation |
+|---|---|
+| spec → BSR gen → backend/frontend pipeline adds latency | Backend and frontend can be implemented in parallel with the spec PR; only the package upgrade step gates the final push |
+| `open_at` may be NULL for most staged rows | `formatTimeOfDay` already returns `—` for absent timestamps; no special handling needed |
+| `ConflictView.stagedOpenTime` is a pre-formatted string (set in `toRow()` at page-load time) while `existingOpenTime` is formatted lazily from the raw proto `Timestamp` at conflict-display time — if `formatTimeOfDay`'s locale behavior changes in the future, both sides of the dialog will not update simultaneously | Accepted trade-off: the asymmetry mirrors the existing pattern where all `QueueRow` display strings are precomputed. A future change to `formatTimeOfDay` will require a page reload to apply on the staged side. |

--- a/openspec/changes/archive/2026-07-29-add-open-time-to-approval-queue/proposal.md
+++ b/openspec/changes/archive/2026-07-29-add-open-time-to-approval-queue/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+The concert approval queue table shows start time but omits open time (door-open time), even though the backend already captures `OpenTime` on `StagedConcert`. Reviewers cannot see this field, and the conflict dialog's staged side hardcodes `—` for open time. Exposing it makes the queue consistent with the approved-concerts page and gives reviewers complete timing context when judging a staged concert.
+
+## What Changes
+
+- Add `open_time` field to the `PendingConcert` proto message so open time is carried over the wire
+- Map `StagedConcert.OpenTime` in the backend `PendingConcertToProto` mapper
+- Add an **Open time** column to the approval queue table in the admin frontend, positioned after Start time
+- Fix the conflict dialog's staged side to display the actual staged open time instead of a hardcoded `—`
+
+## Capabilities
+
+### New Capabilities
+
+_(none)_
+
+### Modified Capabilities
+
+- `concert-approval-queue`: The approval queue SHALL display open time alongside start time in the reviewer table; the `PendingConcert` RPC message SHALL carry the `open_time` field
+
+## Impact
+
+- **specification**: `proto/liverty_music/rpc/admin/v1/concert_service.proto` — `PendingConcert` message
+- **backend**: `internal/adapter/rpc/mapper/pending_concert.go` — `PendingConcertToProto`; `internal/adapter/rpc/mapper/concert_test.go`
+- **frontend**: `admin/approval-queue/approval-queue-route.ts` (`QueueRow`, `ConflictView`, `toRow`, `toConflictView`); `admin/approval-queue/approval-queue-route.html`
+- No DB migration required (data already stored on `staged_concerts.open_at`)
+- No breaking change — adding an optional field to `PendingConcert` is wire-compatible

--- a/openspec/changes/archive/2026-07-29-add-open-time-to-approval-queue/specs/concert-approval-queue/spec.md
+++ b/openspec/changes/archive/2026-07-29-add-open-time-to-approval-queue/specs/concert-approval-queue/spec.md
@@ -1,0 +1,79 @@
+## MODIFIED Requirements
+
+### Requirement: Admin-scoped moderation RPCs
+
+The system SHALL expose a `ConcertModerationService` whose RPCs are authorized only for the admin
+org, consistent with the admin console authentication boundary. The service SHALL provide
+operations to list pending concerts, approve a pending concert, and reject a pending concert with
+a reason.
+
+#### Scenario: Admin lists pending concerts
+
+- **WHEN** an authenticated admin-org caller invokes `ListPendingConcerts`
+- **THEN** the response SHALL contain each pending concert's staged id, performing artist, title,
+  local date, start time, open time, raw `listed_venue_name`, resolved venue (name, admin_area,
+  place id), source URL, and discovered-time timestamp
+
+#### Scenario: Non-admin caller is denied
+
+- **WHEN** a caller outside the admin org invokes any `ConcertModerationService` RPC
+- **THEN** the call SHALL be rejected with a permission error and SHALL NOT mutate state
+
+#### Scenario: Approve and reject act on the identified staged concert
+
+- **WHEN** an admin invokes `ApproveConcert` or `RejectConcert` with a staged concert id
+- **THEN** the system SHALL apply the corresponding approval or rejection behavior to that staged
+  concert
+
+### Requirement: Admin console approval-queue UI
+
+The admin console SHALL provide a reviewer screen that lists pending concerts grouped
+first by performing artist and then by series title, and offers per-concert approve and
+reject (with reason) actions. The screen SHALL live in the bundle-isolated `admin/` app
+and SHALL consume the admin `ConcertService`. Grouping SHALL be computed client-side
+from the flat `ListPending` result using the `PendingConcert.performer.name` and
+`PendingConcert.title` fields as grouping keys (artist and series proxy respectively).
+
+Each series group SHALL be presented as a collapsible disclosure. The collapsed summary
+SHALL show the series title, the count of pending concerts in the group, and the count
+of concerts with an unresolved venue. Individual concert rows within an expanded group
+SHALL retain the full set of reviewable fields (local date, start time, open time, listed
+venue name, resolved venue, source URL, discovered timestamp) and their per-row approve and
+reject controls. The Artist and Title columns SHALL NOT be repeated inside the group
+table; they are conveyed by the group headers.
+
+#### Scenario: Reviewer sees pending concerts grouped by artist and series
+
+- **WHEN** an authenticated developer opens the approval-queue screen
+- **THEN** the pending concerts SHALL be displayed grouped first by performing artist
+- **AND** within each artist they SHALL be grouped into collapsible series using the
+  concert title as the series proxy
+- **AND** each collapsed series summary SHALL show the series title, the number of
+  pending concerts in the group, and the number with an unresolved venue
+
+#### Scenario: Expanding a series reveals per-concert review rows
+
+- **WHEN** the developer expands a series group
+- **THEN** each pending concert in that series SHALL be listed showing local date,
+  start time, open time, listed venue name, resolved venue (or unresolved indicator),
+  source URL, and discovered timestamp
+- **AND** each row SHALL expose Approve and Reject controls
+
+#### Scenario: Reviewer approves an item
+
+- **WHEN** the developer approves a pending concert
+- **THEN** the UI SHALL call `Approve` and remove the row from its series group on success
+- **AND** if the series group becomes empty it SHALL be removed from the UI
+
+#### Scenario: Reviewer rejects an item with a reason
+
+- **WHEN** the developer rejects a pending concert and provides a reason
+- **THEN** the UI SHALL call `Reject` with that reason and remove the row from its
+  series group on success
+- **AND** if the series group becomes empty it SHALL be removed from the UI
+
+#### Scenario: Conflict dialog shows open time for both staged and existing
+
+- **WHEN** approval detects a duplicate and presents the conflict dialog
+- **THEN** the dialog SHALL show the open time for both the staged and the existing event
+- **AND** absent open time values SHALL be displayed as a dash placeholder

--- a/openspec/changes/archive/2026-07-29-add-open-time-to-approval-queue/tasks.md
+++ b/openspec/changes/archive/2026-07-29-add-open-time-to-approval-queue/tasks.md
@@ -1,0 +1,38 @@
+## 1. Specification
+
+- [x] 1.1 Add `open_time = 10` field (type `entity.v1.OpenTime`, optional) to `PendingConcert` in `proto/liverty_music/rpc/admin/v1/concert_service.proto`
+- [x] 1.2 Run `buf lint`, `buf format -w`, and `buf breaking --against '.git#branch=main'` to verify no proto issues
+- [x] 1.3 Open a PR for the specification change and merge it
+- [x] 1.4 Create a GitHub Release tag on the specification repo to trigger BSR code generation
+- [x] 1.5 Confirm `buf-release.yml` CI completes successfully and the new package version is available on BSR
+
+## 2. Backend
+
+> **Requires task 1.5 to be complete first.** Do not run 2.1 until `buf-release.yml` has finished and the new BSR package version is confirmed available — otherwise `go get` resolves the pre-change schema.
+
+- [x] 2.1 Upgrade the generated Go package: `go get buf.build/gen/go/liverty-music/schema/...` then `go mod tidy`
+- [x] 2.2 Add `OpenTime` mapping to `PendingConcertToProto` in `internal/adapter/rpc/mapper/pending_concert.go` (follow the `StartTime` pattern at lines 31–33)
+- [x] 2.3 Create `internal/adapter/rpc/mapper/pending_concert_test.go` with a `TestPendingConcertToProto` function covering `open_time` present and absent (note: `concert_test.go` tests `ConcertToProto` — the new tests belong in a dedicated file for the `PendingConcert` mapper)
+- [x] 2.4 Run `make check` and confirm it passes
+- [x] 2.5 Open a PR for the backend change, confirm CI green, and merge
+
+## 3. Frontend
+
+> **Requires task 1.5 to be complete first.** BSR-generated npm packages use timestamped pre-release version strings (e.g., `^1.10.0-20260725094030-xxx.1`); `@latest` does not reliably resolve to them. After 1.5 completes, find the new version by running `npm view @buf/liverty-music_schema.bufbuild_es versions --json` or checking the BSR release page, then pin to that version.
+
+- [x] 3.1 Upgrade the generated npm packages: `npm install @buf/liverty-music_schema.bufbuild_es@<new-version> @buf/liverty-music_schema.connectrpc_es@<new-version>`
+- [x] 3.2 Add `readonly openTime: string` to the `QueueRow` interface in `admin/approval-queue/approval-queue-route.ts`
+- [x] 3.3 Add `openTime: formatTimeOfDay(concert.openTime?.value)` to `toRow()` in `approval-queue-route.ts`
+- [x] 3.4 Add `readonly stagedOpenTime: string` to the `ConflictView` interface
+- [x] 3.5 Set `stagedOpenTime: row.openTime` in `toConflictView()` (replaces the hardcoded `—`)
+- [x] 3.6 Add an **Open time** `<th>` and `<td>` column to the approval queue table in `approval-queue-route.html`, positioned after Start time
+- [x] 3.7 Replace the hardcoded `${'—'}` for staged open time in the conflict dialog with `${conflictView.stagedOpenTime}`
+- [x] 3.8 In `test/admin/approval-queue/approval-queue-route.spec.ts`, add test cases covering: (a) `toRow()` maps `concert.openTime?.value` via `formatTimeOfDay` correctly for present and absent values; (b) `toConflictView()` sets `stagedOpenTime` from `row.openTime`
+- [x] 3.9 Run `make check` and confirm it passes
+- [x] 3.10 Open a PR for the frontend change, confirm CI green, and merge
+
+## 4. Ship to Production
+
+- [x] 4.1 Create a GitHub Release for the backend repo to publish to prod
+- [x] 4.2 Create a GitHub Release for the frontend repo to publish to prod
+- [x] 4.3 Confirm prod deployment completes and the Open time column is visible in the approval queue

--- a/openspec/specs/concert-approval-queue/spec.md
+++ b/openspec/specs/concert-approval-queue/spec.md
@@ -160,8 +160,8 @@ a reason.
 
 - **WHEN** an authenticated admin-org caller invokes `ListPendingConcerts`
 - **THEN** the response SHALL contain each pending concert's staged id, performing artist, title,
-  local date, start time, raw `listed_venue_name`, resolved venue (name, admin_area, place id),
-  source URL, and discovered-time timestamp
+  local date, start time, open time, raw `listed_venue_name`, resolved venue (name, admin_area,
+  place id), source URL, and discovered-time timestamp
 
 #### Scenario: Non-admin caller is denied
 
@@ -186,8 +186,8 @@ from the flat `ListPending` result using the `PendingConcert.performer.name` and
 Each series group SHALL be presented as a collapsible disclosure. The collapsed summary
 SHALL show the series title, the count of pending concerts in the group, and the count
 of concerts with an unresolved venue. Individual concert rows within an expanded group
-SHALL retain the full set of reviewable fields (local date, start time, listed venue
-name, resolved venue, source URL, discovered timestamp) and their per-row approve and
+SHALL retain the full set of reviewable fields (local date, start time, open time, listed
+venue name, resolved venue, source URL, discovered timestamp) and their per-row approve and
 reject controls. The Artist and Title columns SHALL NOT be repeated inside the group
 table; they are conveyed by the group headers.
 
@@ -204,8 +204,8 @@ table; they are conveyed by the group headers.
 
 - **WHEN** the developer expands a series group
 - **THEN** each pending concert in that series SHALL be listed showing local date,
-  start time, listed venue name, resolved venue (or unresolved indicator), source
-  URL, and discovered timestamp
+  start time, open time, listed venue name, resolved venue (or unresolved indicator),
+  source URL, and discovered timestamp
 - **AND** each row SHALL expose Approve and Reject controls
 
 #### Scenario: Reviewer approves an item
@@ -220,6 +220,12 @@ table; they are conveyed by the group headers.
 - **THEN** the UI SHALL call `Reject` with that reason and remove the row from its
   series group on success
 - **AND** if the series group becomes empty it SHALL be removed from the UI
+
+#### Scenario: Conflict dialog shows open time for both staged and existing
+
+- **WHEN** approval detects a duplicate and presents the conflict dialog
+- **THEN** the dialog SHALL show the open time for both the staged and the existing event
+- **AND** absent open time values SHALL be displayed as a dash placeholder
 
 ### Requirement: Approval reconciles a duplicate existing event
 


### PR DESCRIPTION
## 🔗 Related Issue

Closes #726

## 📝 Summary of Changes

Archives the `add-open-time-to-approval-queue` OpenSpec change after full prod shipment (spec v0.49.0 / backend v1.26.0 / frontend v1.35.0) and syncs the delta spec additions to the canonical `concert-approval-queue` spec.

**Spec sync applied:**
- Added `open time` to the "Admin lists pending concerts" scenario field list
- Added `open time` to the approval-queue UI reviewable fields description (2 places)
- Added new "Conflict dialog shows open time for both staged and existing" scenario

## ✅ Self-Checklist

- [x] I have linked the related issue.
- [x] I have updated the relevant documentation (e.g., `README.md`) if needed.
- [x] I have run `buf lint` and `buf format` locally and all checks have passed.
- [x] My proto definitions follow the project's style guidelines and validation rules.
- [x] Breaking changes have been justified and documented if applicable.
