### PR TITLE
feat(openspec): add restore-journey-status-ui change

### DIFF
--- a/openspec/changes/restore-journey-status-ui/.openspec.yaml
+++ b/openspec/changes/restore-journey-status-ui/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-30

--- a/openspec/changes/restore-journey-status-ui/design.md
+++ b/openspec/changes/restore-journey-status-ui/design.md
@@ -1,0 +1,52 @@
+## Context
+
+Commit `0245f03` deleted HTML template content from two components while leaving all backing layers intact:
+- `EventCard` ViewModel: `journeyConfig` getter (reads from `JOURNEY_STATUS_CONFIG_MAP`)
+- `EventDetailSheet` ViewModel: full journey state machine (`status`, `nodeStates`, `setJourneyStatus`, `removeJourney`, `onJourneyKeydown`, `outcomePending`, `successDimmed`, `failureDimmed`)
+- `event-card.css`: `.journey-badge` styles
+- `event-detail-sheet.css`: all `.sheet-journey`, `.journey-node`, `.journey-phase` styles
+- `TicketJourneyStore`: observable `journeyMap`, `load`, `setStatus`, `delete`
+- Backend `TicketJourneyService`: deployed and operational
+
+The only missing pieces are the HTML binding points in the two template files.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Restore the journey badge `<span>` in `event-card.html` so the card corner shows the user's current status icon
+- Restore the full `<section class="sheet-journey">` block in `event-detail-sheet.html` so authenticated users can set/update/remove their journey status from the concert detail sheet
+- Satisfy the existing requirements in `ticket-journey` and `journey-status-presentation` specs
+
+**Non-Goals:**
+- Restoring the Tickets bottom-nav tab (`path: 'tickets'`) — that tab leads to the ZK proof entry feature which is a separate, unrelated capability
+- Any changes to ViewModel logic, CSS, services, backend, or proto
+- New unit or E2E tests — existing `EventDetailSheet` spec already covers journey store interaction
+
+## Decisions
+
+### Exact revert of deleted HTML
+
+The deleted HTML is restored verbatim from `0245f03`. No redesign is needed because:
+- The ViewModel API is identical to what the template was calling
+- The CSS classes are still defined in `event-detail-sheet.css` and `event-card.css`
+- i18n keys (`eventDetail.ticketStatus`, `eventDetail.journeyPhase.*`, `eventDetail.journeyStatus.*`, `eventDetail.stopTracking`) are still present
+
+Restoring verbatim minimises diff noise and avoids reintroducing regressions.
+
+### Insertion position in event-detail-sheet.html
+
+The journey `<section>` is inserted between the closing `</section>` of `.sheet-details` and the opening `<footer class="sheet-actions">`. This matches the original layout order and the CSS `border-block-start` separator on `.sheet-journey` that creates a visual divider from the details above.
+
+## Risks / Trade-offs
+
+- **No risk**: The ViewModel, CSS, store, and backend are all intact and tested. The template additions are purely binding existing, verified logic to the DOM.
+- **Stale CSS custom properties**: `event-detail-sheet.css` references `--_node-faint` which is derived from per-status tokens. These tokens are defined via `@scope` in the existing CSS, still present, so there is no gap.
+
+## Migration Plan
+
+1. Restore the 8-line journey badge block in `event-card.html`
+2. Restore the 128-line journey section block in `event-detail-sheet.html`
+3. Run `make check` (lint + unit tests) — no failures expected
+4. Open PR against `frontend` → merge → release as a patch version
+
+Rollback: revert the two HTML files to their current state.

--- a/openspec/changes/restore-journey-status-ui/proposal.md
+++ b/openspec/changes/restore-journey-status-ui/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+Commit `0245f03` removed the journey status badge from the event card and the journey selection section from the event detail sheet under the assumption that the entire ticket feature was not service-ready. However, journey status (user self-reporting of ticket acquisition state: tracking → applied → paid/lost) is functionally independent of ticket sales — the backend `TicketJourneyService` is already deployed and operational. The removal broke a working user-facing feature.
+
+## What Changes
+
+- **Restore** the journey badge in the event card (`event-card.html`), showing the user's current journey status as an emoji icon in the card's corner.
+- **Restore** the journey selection section in the event detail sheet (`event-detail-sheet.html`), allowing authenticated users to set/update/remove their ticket acquisition status for a concert.
+- The Tickets bottom-nav tab (ZK proof entry feature) remains hidden — it is a separate, unrelated feature.
+
+## Capabilities
+
+### New Capabilities
+
+None. This change restores previously removed UI backed by existing, already-shipped capabilities.
+
+### Modified Capabilities
+
+- `ticket-journey`: The UI requirements for `Ticket Status UI visibility` and the full journey selection control (two-phase layout, cumulative progress, radiogroup accessibility) were effectively un-rendered by the deletion. Restoring the HTML makes these requirements active again — no spec text changes are needed, the existing requirements are simply being satisfied again.
+- `journey-status-presentation`: The `Consistent rendering across components` requirement specifies that the concert-card badge must be present. Restoring the badge makes this requirement satisfied again.
+
+## Impact
+
+- **Frontend only** — no backend, proto, or BSR changes required.
+- Changed files: `src/components/live-highway/event-card.html`, `src/components/live-highway/event-detail-sheet.html`
+- All ViewModel logic (`EventDetailSheet`, `EventCard`), CSS, `TicketJourneyStore`, and backend RPC are already intact.
+- Unit tests for `EventDetailSheet` and `EventCard` already cover journey behavior and continue to pass without modification.

--- a/openspec/changes/restore-journey-status-ui/specs/ticket-journey/spec.md
+++ b/openspec/changes/restore-journey-status-ui/specs/ticket-journey/spec.md
@@ -1,0 +1,13 @@
+## ADDED Requirements
+
+### Requirement: Ticket Journey UI is independent of ticket sales
+The Ticket Journey status UI (concert-card badge and detail-sheet status control) SHALL be available to authenticated users independently of any ticket purchase, NFT minting, ZK proof generation, or ticket sales navigation features. Hiding or removing those sales-side features SHALL NOT affect the availability of the Ticket Journey UI.
+
+#### Scenario: Journey UI visible when ticket sales nav is hidden
+- **WHEN** the Tickets bottom-nav tab is hidden (ticket sales feature not yet service-ready)
+- **THEN** the journey status badge SHALL still appear on event cards for users who have a journey status
+- **AND** the journey selection control SHALL still appear in the event detail sheet for authenticated users
+
+#### Scenario: Journey UI does not depend on ticket purchase flow
+- **WHEN** a user has not completed any ticket purchase or NFT minting
+- **THEN** the user SHALL still be able to set and view their journey status (e.g. `tracking`, `applied`, `lost`, `unpaid`, `paid`) via the UI

--- a/openspec/changes/restore-journey-status-ui/tasks.md
+++ b/openspec/changes/restore-journey-status-ui/tasks.md
@@ -1,0 +1,14 @@
+## 1. Restore event-card journey badge
+
+- [ ] 1.1 In `src/components/live-highway/event-card.html`, add back the journey badge `<span>` inside the `<article>` element, after the location-label span: `<span if.bind="journeyConfig" data-journey-status.bind="event.journeyStatus" class="journey-badge" data-testid="journey-badge" role="img" aria-label.bind="journeyConfig.labelKey | t">${journeyConfig.icon}</span>`
+
+## 2. Restore event-detail-sheet journey section
+
+- [ ] 2.1 In `src/components/live-highway/event-detail-sheet.html`, restore the `<section if.bind="isAuthenticated" class="sheet-journey">` block between the closing `</section>` of `.sheet-details` and the opening `<footer class="sheet-actions">`, containing the full journey radiogroup: process phase (tracking → applied) and outcome phase (unpaid → paid | lost), plus the remove button
+- [ ] 2.2 Verify the restored section includes: `data-testid="sheet-journey"` on the section, `data-testid="journey-btn"` on each radiogroup button, and `data-testid="journey-remove-btn"` on the remove button
+
+## 3. Verify and ship
+
+- [ ] 3.1 Run `make check` in the frontend repo — lint, typecheck, and unit tests must all pass
+- [ ] 3.2 Open a PR against `frontend` main with the two template changes
+- [ ] 3.3 Merge PR and create a patch release to ship to prod


### PR DESCRIPTION
## Summary

- Add OpenSpec change `restore-journey-status-ui` with proposal, design, specs, and tasks
- Journey status (user self-reporting of ticket acquisition state) is independent of ticket sales — commit `0245f03` incorrectly removed it alongside the ticket-sales nav
- Adds a new `ticket-journey` spec requirement making the UI/sales independence explicit to prevent recurrence

## Changes

- `openspec/changes/restore-journey-status-ui/proposal.md` — why the deletion was incorrect and what needs to be restored
- `openspec/changes/restore-journey-status-ui/design.md` — verbatim HTML revert approach; all backing layers (ViewModel, CSS, Store, backend) are already intact
- `openspec/changes/restore-journey-status-ui/specs/ticket-journey/spec.md` — ADDED: journey UI is independent of ticket sales navigation
- `openspec/changes/restore-journey-status-ui/tasks.md` — 3 tasks: event-card badge, detail-sheet section, verify + ship

## Testing

- No code changes in this PR (OpenSpec artifacts only)
- Frontend implementation tracked in tasks.md, to be applied via `/opsx:apply`

Refs: liverty-music/frontend#507
