### PR TITLE
feat(openspec): passive concert discovery — GeoLocation entity + ListByLocation RPC

### DIFF
--- a/openspec/changes/passive-concert-discovery/.openspec.yaml
+++ b/openspec/changes/passive-concert-discovery/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-30

--- a/openspec/changes/passive-concert-discovery/design.md
+++ b/openspec/changes/passive-concert-discovery/design.md
@@ -1,0 +1,103 @@
+## Context
+
+The Dashboard today calls `ConcertService.ListByFollower` (authenticated) or `ConcertService.ListWithProximity` (unauthenticated guest path) and renders the result as a `ConcertHighway` with HOME/NEARBY/AWAY lanes. The proximity model (Haversine 200 km, `admin_area` HOME match) is already implemented end-to-end and shared via `entity.GroupByDateAndProximity`.
+
+Concert data coverage is bounded by follows: only artists that at least one user follows have concerts in the DB. The new feature intentionally works within this constraint — data richness grows as the user base grows.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Let users browse all concerts in the DB near a geographic reference point, filtered by a date range
+- Reuse the existing proximity model, `ProximityGroup` response format, and `ConcertHighway` UI without duplication
+- Introduce `entity.v1.GeoLocation` as a clean, semantically neutral parameter type (not user-specific like `Home`)
+- Refactor `UserHomeSelector` so selection and persistence are separate responsibilities
+
+**Non-Goals:**
+- Proactive regional AI crawling (discovery is limited to concerts already in the DB)
+- Map or calendar display modes (list only for MVP)
+- AWAY-tier results in the All Nearby view
+- Pagination (result sets are small at current scale)
+- Persisting the user's area override selection across sessions
+
+## Decisions
+
+### D1 — Dashboard toggle, not a new nav tab
+
+**Decision:** Add a "My Timetable / All Nearby" segment toggle to the Dashboard rather than a fifth nav tab.
+
+**Rationale:** The Discovery tab's identity is artist-first (bubble UI); inserting a list view there would be jarring. A fifth tab is the hardest pattern to discover — users open the Dashboard daily, so the toggle is immediately visible. The visual similarity between the two modes (same `ConcertHighway` component) is a feature: it signals continuity, not a context switch.
+
+**Alternative considered:** Discovery tab integration — rejected because of the visual mismatch (bubbles vs. list) and intent mismatch (artist discovery vs. concert discovery).
+
+### D2 — `entity.v1.GeoLocation` as a new proto entity
+
+**Decision:** Define a new `entity.v1.GeoLocation` message `{ double latitude, double longitude, string admin_area }` as the `ListByLocation` parameter type.
+
+**Rationale:** `entity.v1.Home` is semantically tied to "where the user lives" — using it as a generic location parameter would mean the RPC implicitly assumes caller intent. `Proximity` is an output classification enum (HOME/NEARBY/AWAY), not an input concept, so `ListByProximity` would conflate input and output domains. `GeoLocation` is neutral: it is a geographic reference point that any caller can construct from any source.
+
+`latitude/longitude` fields are required in the message (FE resolves centroid before the call); `admin_area` is used server-side for HOME-tier classification (exact `venue.admin_area` match). This avoids a server-side reverse-geocoding step while keeping the server free of ISO 3166-2 centroid-resolution logic.
+
+**Alternative considered:** Pass `string level_1` only and let the server resolve the centroid via `geo.ResolveCentroid` — simpler for the caller but ties the RPC to an ISO 3166-2-aware server contract. Rejected in favour of a purely spatial input.
+
+### D3 — FE owns centroid resolution
+
+**Decision:** The frontend resolves prefecture centroid coordinates from a bundled constant table (47 JP prefectures) before calling `ListByLocation`.
+
+**Rationale:** `user.home.centroid.latitude/longitude` (via the nested `Coordinates` sub-message on `Home`) are already present on the `User` proto response, so the default (user's home area) requires no extra lookup. Note: `centroid_latitude` and `centroid_longitude` are reserved field names on `Home` proto and must not be used; the correct path is `home.centroid.latitude` / `home.centroid.longitude`. For the area-override case, a 47-entry constant is negligible bundle cost and avoids adding a new RPC or embedding geography logic on the server for this path.
+
+### D4 — `ListWithProximity` renamed to `ListByArtists`
+
+**Decision:** Rename the existing RPC. The primary filter is `artist_ids`; "WithProximity" described the output format, not the filter axis, creating ambiguity next to the new `ListByLocation`.
+
+**Migration:** The rename is a breaking proto change. It will be guarded behind a BSR major version bump. The frontend is the only current caller — both the old and new name will be emitted during the transition window if needed, but since specification and frontend are released together, a clean cut is preferred.
+
+### D5 — `UserHomeSelector` responsibility split
+
+**Decision:** Remove `IUserStore` and persistence logic from `UserHomeSelector`. The component emits `onHomeSelected(code: string)` only; callers own the save/no-save decision.
+
+**Rationale:** The current design mixes selection UI and account-write side-effects in one component, making it untestable in isolation and impossible to reuse for the area-override filter (which must not write to the account). Splitting makes the component a pure UI primitive.
+
+**Affected callers:** Settings page (must call `userStore.updateHome(code)` in its `onHomeSelected` handler), Onboarding flow (same), new Dashboard "All Nearby" area selector (updates local route state only).
+
+### D6 — Date range: FE computes, RPC accepts explicit `from`/`to`
+
+**Decision:** The frontend computes concrete `LocalDate` pairs from preset labels (今週末, 7日以内, 30日以内, カスタム) and passes them to `ListByLocation`. The server enforces a 30-day maximum (`to - from ≤ 30 days`) via protovalidate.
+
+**Rationale:** Preset semantics (e.g., "今週末" = next Sat–Sun relative to today) are a UI concern. The RPC stays stateless and timezone-agnostic; the FE already knows the user's locale context.
+
+### D7 — AWAY concerts excluded from All Nearby response
+
+**Decision:** `ListByLocation` returns only HOME and NEARBY concerts; AWAY-only `ProximityGroup` entries are stripped from the result of `GroupByDateAndProximity` by the use-case layer.
+
+**Rationale:** The feature answers "what's on near me?" — venues beyond 200 km and outside the home admin_area are not "near" by definition. Including them would dilute the signal and require a third lane the UI doesn't show.
+
+### D8 — Follow CTA in EventDetailSheet, not on concert card
+
+**Decision:** The "Follow this artist" button appears in the `EventDetailSheet` (opened on card tap) rather than inline on the card.
+
+**Rationale:** Inline action buttons on every card in a dense list create visual noise and accidental taps. The detail sheet is already the place for action: ticket journey, source URL. Adding follow there is consistent and preserves the card as a pure information surface.
+
+## Risks / Trade-offs
+
+**[Sparse results for new users]** → Users with few follows see few concerts. Mitigation: empty-state copy links to Discover tab with clear explanation ("Follow more artists to see more concerts here").
+
+**[HOME-tier classification depends on caller-supplied `admin_area`]** → A caller passing wrong coordinates + wrong admin_area gets incorrect HOME classification. Mitigation: the FE always derives `admin_area` from the same ISO 3166-2 code that drives the centroid lookup; the mapping is deterministic.
+
+**[Breaking rename of `ListWithProximity`]** → Requires a BSR major bump and coordinated frontend deploy. Mitigation: spec and frontend are released together under the same change; no external consumers of this RPC exist today.
+
+**[`UserHomeSelector` refactor touches onboarding and settings]** → Risk of regression in home-setting flows. Mitigation: the component's `onHomeSelected` callback already exists; callers add one line (`userStore.updateHome(code)`). Covered by existing E2E smoke tests.
+
+## Migration Plan
+
+1. Merge specification PR (proto changes, new entity, rename, new RPC)
+2. Publish GitHub Release → BSR gen
+3. Backend: implement `ListByLocation` handler + `ListByArtists` rename; upgrade generated package; `make check`
+4. Frontend: refactor `UserHomeSelector`; add centroid constants; implement Dashboard toggle + All Nearby mode; upgrade generated package; `make check`
+5. Open BE + FE PRs after local `make check` passes (no draft PRs before BSR gen completes)
+6. Merge in dependency order: BE → FE (FE depends on no BE state, but deploy ordering is cleaner)
+
+**Rollback:** Revert FE to previous tag (toggle disappears); BE `ListByArtists` is additive, old name is gone but no external callers exist.
+
+## Open Questions
+
+- None blocking implementation. The explore-mode discussion resolved all major design questions.

--- a/openspec/changes/passive-concert-discovery/proposal.md
+++ b/openspec/changes/passive-concert-discovery/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+Users can already see upcoming concerts for artists they follow, but have no way to passively discover concerts happening near them — the "I wonder what's on this weekend?" use case is unaddressed. Adding location-and-date-driven concert browsing directly into the Dashboard covers this gap without introducing a new navigation tab.
+
+## What Changes
+
+- Dashboard gains a "My Timetable / All Nearby" toggle; "All Nearby" mode shows all concerts in the DB within 200 km of a chosen location and date range
+- New `entity.v1.GeoLocation` proto message — a geographic reference point (lat/lng + admin_area) distinct from the user-specific `Home` entity
+- New RPC `ConcertService.ListByLocation` — returns concerts near a `GeoLocation` within a date range, grouped by proximity, no auth required
+- **BREAKING**: `ConcertService.ListWithProximity` renamed to `ListByArtists` — its primary filter has always been `artist_ids`; "WithProximity" described the output format, not the filter
+- `UserHomeSelector` component refactored — selection and persistence responsibilities separated so the component is reusable without saving to account
+
+## Capabilities
+
+### New Capabilities
+
+- `geo-location`: Introduces `entity.v1.GeoLocation` proto message (latitude, longitude, admin_area) as a reusable geographic reference point for proximity-based queries
+- `passive-concert-discovery`: `ConcertService.ListByLocation` RPC and the "All Nearby" Dashboard mode — date-range and location-driven concert browsing for all artists in the DB
+
+### Modified Capabilities
+
+- `concert-service`: Adds `ListByLocation` RPC; renames `ListWithProximity` → `ListByArtists` (**BREAKING**)
+- `dashboard-concert-cache`: Dashboard view gains a mode toggle; "All Nearby" mode introduces date-preset and area-override filters
+- `artist-following`: `UserHomeSelector` responsibility split — caller now owns persistence; follow CTA moves to `EventDetailSheet`
+
+## Impact
+
+- **Proto / BSR**: New `entity/v1/geo_location.proto`; `concert/v1/concert_service.proto` updated (new RPC + rename) → minor BSR version bump, breaking rename requires semver major or buf lint suppression with deprecation comment
+- **Backend**: New `ConcertRepository.ListByLocation` query (date + proximity filter); new `ConcertService` handler; `ListByArtists` handler (rename only)
+- **Frontend**: Dashboard route updated (toggle, filters, `ListByLocation` call); `UserHomeSelector` refactored; `EventDetailSheet` gains follow CTA for unfollowed artists; FE centroid constants added for 47 JP prefectures
+- **Spec repo**: `concert/v1`, `entity/v1` proto files

--- a/openspec/changes/passive-concert-discovery/specs/artist-following/spec.md
+++ b/openspec/changes/passive-concert-discovery/specs/artist-following/spec.md
@@ -1,0 +1,42 @@
+## ADDED Requirements
+
+### Requirement: Follow CTA in Event Detail Sheet
+
+When a user views a concert in the All Nearby mode, the `EventDetailSheet` SHALL provide a follow action for artists the user has not yet followed. This surfaces artist following as a natural outcome of passive concert discovery, without requiring users to navigate to the Discovery tab.
+
+#### Scenario: Follow button visible for unfollowed artist in All Nearby context
+
+- **WHEN** the user opens the `EventDetailSheet` for a concert in All Nearby mode
+- **AND** the concert's artist is not in the user's followed artists list
+- **THEN** the sheet SHALL display a "Follow this artist" button
+
+#### Scenario: Follow button hidden in My Timetable context
+
+- **WHEN** the user opens the `EventDetailSheet` for a concert in My Timetable mode
+- **THEN** the follow button SHALL NOT be displayed regardless of follow status
+- **AND** the sheet behavior SHALL be unchanged from the pre-feature state
+
+#### Scenario: Follow action from detail sheet
+
+- **WHEN** the user taps "Follow this artist" in the `EventDetailSheet`
+- **THEN** `ArtistService.Follow` SHALL be called via `FollowStore.follow(artist)`
+- **AND** the button SHALL transition to a "Following" indicator
+- **AND** the DNA Orb absorption animation SHALL NOT play (reserved for the Discovery context)
+
+#### Scenario: Follow button absent when artist data is unresolved
+
+- **WHEN** the `EventDetailSheet` is opened for a concert whose `artist` field is `undefined` (performer not yet resolved)
+- **THEN** the follow button SHALL NOT be displayed
+- **AND** no error SHALL be thrown
+
+#### Scenario: No follow button for already-followed artist
+
+- **WHEN** the user opens the `EventDetailSheet` for a concert in All Nearby mode
+- **AND** the concert's artist is already followed
+- **THEN** the follow button SHALL NOT be displayed
+
+#### Scenario: Follow prompt for unauthenticated user
+
+- **WHEN** an unauthenticated user taps "Follow this artist" in the `EventDetailSheet`
+- **THEN** the system SHALL surface the sign-up prompt banner
+- **AND** `ArtistService.Follow` SHALL NOT be called

--- a/openspec/changes/passive-concert-discovery/specs/concert-service/spec.md
+++ b/openspec/changes/passive-concert-discovery/specs/concert-service/spec.md
@@ -1,0 +1,79 @@
+## ADDED Requirements
+
+### Requirement: ListByLocation RPC
+
+The system SHALL provide an unauthenticated RPC `ConcertService.ListByLocation` that accepts a `GeoLocation` reference point and a date range, returning all concerts in the DB whose venues are HOME or NEARBY relative to the reference point, grouped by date and proximity.
+
+#### Scenario: Successful proximity-grouped listing
+
+- **WHEN** `ListByLocation` is called with a valid `GeoLocation` and a `from`/`to` date range
+- **THEN** it SHALL return concerts grouped by date using `ProximityGroup` messages
+- **AND** each `ProximityGroup` SHALL contain concerts classified into `home` and `nearby` fields based on `Concert.ProximityTo(GeoLocation)`
+- **AND** the `away` field SHALL always be empty (AWAY concerts are excluded from the response)
+- **AND** each concert SHALL include a resolved `Venue` with `name`, `admin_area`, and coordinates
+- **AND** each concert SHALL include `listed_venue_name` with the raw scraped venue name
+- **AND** groups SHALL be ordered by date ascending
+
+#### Scenario: Date range validation — range exceeds 30 days
+
+- **WHEN** `ListByLocation` is called with `to - from > 30 days`
+- **THEN** it SHALL return an `INVALID_ARGUMENT` error via protovalidate
+
+#### Scenario: Date range validation — from after to (inverted range)
+
+- **WHEN** `ListByLocation` is called with `from > to` (e.g., `from = 2026-08-15, to = 2026-08-01`)
+- **THEN** it SHALL return an `INVALID_ARGUMENT` error
+- **AND** the validation SHALL be enforced via a CEL cross-field constraint on `ListByLocationRequest` (`message_level cel: "this.from <= this.to"`) because `to - from` is negative and the 30-day check alone does not catch inverted ranges
+
+#### Scenario: No concerts found
+
+- **WHEN** `ListByLocation` is called with a valid request
+- **AND** no concerts exist within 200 km of the reference point in the given date range
+- **THEN** it SHALL return an empty `groups` list without error
+
+#### Scenario: GeoLocation HOME classification
+
+- **WHEN** a concert's venue `admin_area` matches `location.admin_area`
+- **THEN** the concert SHALL be classified as HOME regardless of Haversine distance
+
+#### Scenario: GeoLocation NEARBY classification
+
+- **WHEN** a concert's venue `admin_area` does not match `location.admin_area`
+- **AND** the Haversine distance between `(location.latitude, location.longitude)` and the venue coordinates is ≤ 200 km
+- **THEN** the concert SHALL be classified as NEARBY
+
+#### Scenario: AWAY concerts excluded
+
+- **WHEN** a concert's venue is beyond 200 km from the reference point and has a different `admin_area`
+- **THEN** the concert SHALL NOT appear in the response
+
+#### Scenario: Unauthenticated access
+
+- **WHEN** `ListByLocation` is called without authentication headers
+- **THEN** it SHALL return a valid response (no `UNAUTHENTICATED` error)
+
+#### Scenario: ConcertRepository.ListByLocation query
+
+- **WHEN** the use case calls the repository layer
+- **THEN** the repository SHALL execute a query filtering `e.local_event_date BETWEEN $from AND $to`
+- **AND** the query SHALL pre-filter venues using a bounding box (`v.latitude BETWEEN (location.latitude - 1.8) AND (location.latitude + 1.8)`, `v.longitude BETWEEN (location.longitude - 2.6) AND (location.longitude + 2.6)`) to avoid full-table scans; the longitude margin of ±2.6° is conservative enough to cover 200 km at all latitudes in Japan including Hokkaido (43°N+); the ±2.3° value is insufficient above 38.6°N
+- **AND** the bounding box pre-filter SHALL include all venues whose `admin_area` matches `location.admin_area` regardless of coordinates
+- **AND** final Haversine filtering to 200 km SHALL be applied in the Go use-case layer on bounding-box candidates by calling `entity.GroupByDateAndProximity`; since that function accepts `*entity.Home`, the use case SHALL construct a transient `entity.Home{Level1: location.AdminArea, Centroid: &entity.Coordinates{Latitude: location.Latitude, Longitude: location.Longitude}}` as the proximity reference — this adapter is the responsibility of the use-case layer, not the entity layer
+- **AND** AWAY-tier `ProximityGroup` entries (where `len(Home)+len(Nearby)==0` after classification) SHALL be stripped from the result before returning; entire date-group entries with no HOME or NEARBY concerts SHALL be omitted, not returned as empty rows
+
+---
+
+## RENAMED Requirements
+
+### Requirement: List Concerts with Proximity for Unauthenticated Users
+
+FROM: `ListWithProximity`
+TO: `ListByArtists`
+
+The RPC signature, parameter types, and behavior are unchanged. Only the RPC name changes. The rename reflects that the primary filter axis is `artist_ids`, not proximity; proximity grouping is a feature of the response format, not the filter.
+
+#### Scenario: Existing behavior preserved after rename
+
+- **WHEN** `ListByArtists` is called with one or more `artist_ids` and a valid `Home`
+- **THEN** it SHALL behave identically to the former `ListWithProximity`
+- **AND** return `ProximityGroup[]` grouped by date and classified by proximity to `home`

--- a/openspec/changes/passive-concert-discovery/specs/dashboard-concert-cache/spec.md
+++ b/openspec/changes/passive-concert-discovery/specs/dashboard-concert-cache/spec.md
@@ -1,0 +1,23 @@
+## ADDED Requirements
+
+### Requirement: All Nearby mode uses ListByLocation
+
+The Dashboard concert cache SHALL support an "All Nearby" mode that calls `ConcertService.ListByLocation` and caches its result separately from the My Timetable result.
+
+#### Scenario: All Nearby result cached independently
+
+- **WHEN** the user switches to All Nearby mode and `ListByLocation` returns a result
+- **THEN** the result SHALL be stored in route-local state separate from the My Timetable cache
+- **AND** switching back to My Timetable and then to All Nearby again SHALL reuse the cached All Nearby result if the location and date range have not changed
+
+#### Scenario: Cache invalidated on filter change
+
+- **WHEN** the user changes the area or date preset in All Nearby mode
+- **THEN** the All Nearby cache SHALL be invalidated
+- **AND** `ListByLocation` SHALL be called again with the new parameters
+
+#### Scenario: My Timetable cache unaffected by All Nearby mode
+
+- **WHEN** the user switches between My Timetable and All Nearby mode
+- **THEN** the My Timetable concert cache SHALL remain intact
+- **AND** switching back to My Timetable SHALL display the previously loaded result without an additional network call

--- a/openspec/changes/passive-concert-discovery/specs/geo-location/spec.md
+++ b/openspec/changes/passive-concert-discovery/specs/geo-location/spec.md
@@ -1,0 +1,47 @@
+## ADDED Requirements
+
+### Requirement: GeoLocation Proto Entity
+
+The system SHALL define `entity.v1.GeoLocation` in `proto/liverty_music/entity/v1/geo_location.proto` as a reusable geographic reference point for proximity-based queries. This message is semantically neutral — it is not tied to any user concept such as "home area".
+
+#### Scenario: GeoLocation message definition
+
+- **WHEN** the `entity.v1.GeoLocation` proto message is defined
+- **THEN** it SHALL contain a `double latitude` field representing the WGS 84 latitude of the reference point
+- **AND** a `double longitude` field representing the WGS 84 longitude
+- **AND** a `string admin_area` field for the ISO 3166-2 subdivision code used for HOME-tier classification (e.g., `JP-13`)
+- **AND** all three fields SHALL be required (non-optional)
+
+#### Scenario: GeoLocation used as proximity reference
+
+- **WHEN** a caller passes a `GeoLocation` to a proximity-based RPC
+- **THEN** the server SHALL use `latitude` and `longitude` for Haversine distance calculation (NEARBY tier: ≤ 200 km)
+- **AND** the server SHALL use `admin_area` for exact `venue.admin_area` match (HOME tier)
+
+#### Scenario: GeoLocation is caller-agnostic
+
+- **WHEN** `GeoLocation` is used as an RPC parameter
+- **THEN** the message SHALL carry no semantic assumption about whether the coordinates represent the caller's home, current GPS location, or any other concept
+- **AND** the caller is responsible for providing accurate coordinates and admin_area for the desired reference point
+
+### Requirement: GeoLocation Field Validation
+
+The `GeoLocation` proto message SHALL include protovalidate constraints to reject clearly invalid values before the server processes them.
+
+#### Scenario: Latitude range enforced
+
+- **WHEN** `ListByLocation` is called with `location.latitude < -90.0` or `location.latitude > 90.0`
+- **THEN** it SHALL return an `INVALID_ARGUMENT` error via protovalidate
+- **AND** the proto definition SHALL include `(buf.validate.field).double = { gte: -90.0, lte: 90.0 }` on the `latitude` field
+
+#### Scenario: Longitude range enforced
+
+- **WHEN** `ListByLocation` is called with `location.longitude < -180.0` or `location.longitude > 180.0`
+- **THEN** it SHALL return an `INVALID_ARGUMENT` error via protovalidate
+- **AND** the proto definition SHALL include `(buf.validate.field).double = { gte: -180.0, lte: 180.0 }` on the `longitude` field
+
+#### Scenario: admin_area must be non-empty
+
+- **WHEN** `ListByLocation` is called with `location.admin_area = ""`
+- **THEN** it SHALL return an `INVALID_ARGUMENT` error via protovalidate
+- **AND** the proto definition SHALL include `(buf.validate.field).string.min_len = 1` on the `admin_area` field

--- a/openspec/changes/passive-concert-discovery/specs/passive-concert-discovery/spec.md
+++ b/openspec/changes/passive-concert-discovery/specs/passive-concert-discovery/spec.md
@@ -1,0 +1,156 @@
+## ADDED Requirements
+
+### Requirement: Dashboard Mode Toggle
+
+The Dashboard SHALL provide a segment toggle control that switches between "My Timetable" mode (current behavior — concerts for followed artists) and "All Nearby" mode (new — all concerts in the DB near a given location within a date range).
+
+#### Scenario: Default mode is My Timetable
+
+- **WHEN** the Dashboard loads or the page is reloaded
+- **THEN** the active mode SHALL default to "My Timetable"
+- **AND** the toggle SHALL visually indicate My Timetable as the selected mode
+
+#### Scenario: Mode-specific filters appear only in All Nearby
+
+- **WHEN** the user switches to "All Nearby" mode
+- **THEN** a date-preset selector and an area selector SHALL appear below the toggle
+- **WHEN** the user switches back to "My Timetable" mode
+- **THEN** the date-preset selector and area selector SHALL be hidden
+
+#### Scenario: Switching modes replaces the concert list
+
+- **WHEN** the user switches from My Timetable to All Nearby
+- **THEN** the Dashboard SHALL call `ConcertService.ListByLocation` with the current location and date range
+- **AND** the resulting `ProximityGroup[]` SHALL replace the concert list
+- **WHEN** the user switches back to My Timetable
+- **THEN** the Dashboard SHALL revert to the cached `ListByFollower` / `ListByArtists` result
+
+---
+
+### Requirement: Date Preset Selector
+
+The All Nearby mode SHALL provide four date presets for filtering the concert date range.
+
+#### Scenario: Available presets
+
+- **WHEN** the date-preset selector is displayed
+- **THEN** it SHALL offer exactly four options: 今週末, 7日以内, 30日以内, カスタム
+
+#### Scenario: 今週末 preset date range
+
+- **WHEN** the user selects 今週末
+- **AND** today is Monday through Friday
+- **THEN** `from` SHALL be set to the next Saturday and `to` to the next Sunday
+
+#### Scenario: 今週末 when today is Saturday or Sunday
+
+- **WHEN** the user selects 今週末
+- **AND** today is Saturday
+- **THEN** `from` SHALL be today and `to` SHALL be the next day (Sunday)
+- **WHEN** the user selects 今週末
+- **AND** today is Sunday
+- **THEN** `from` and `to` SHALL both be today
+
+#### Scenario: 7日以内 preset date range
+
+- **WHEN** the user selects 7日以内
+- **THEN** `from` SHALL be today and `to` SHALL be today + 6 days (inclusive 7-day window)
+
+#### Scenario: 30日以内 preset date range
+
+- **WHEN** the user selects 30日以内
+- **THEN** `from` SHALL be today and `to` SHALL be today + 29 days (inclusive 30-day window)
+
+#### Scenario: カスタム preset shows date inputs
+
+- **WHEN** the user selects カスタム
+- **THEN** two date input fields SHALL appear for explicit `from` and `to` selection
+- **AND** the UI SHALL prevent `to` from being set earlier than `from`
+- **AND** the UI SHALL prevent the range from exceeding 30 days
+
+---
+
+### Requirement: Area Selector in All Nearby Mode
+
+The All Nearby mode SHALL display the current reference area and allow the user to override it for the duration of the session.
+
+#### Scenario: Default area is user home
+
+- **WHEN** All Nearby mode activates for an authenticated user who has set a home area
+- **THEN** the area selector SHALL display the user's home area name (prefecture display name)
+- **AND** the `GeoLocation` passed to `ListByLocation` SHALL use `user.home.centroid.latitude`, `user.home.centroid.longitude`, and `user.home.level_1` as `admin_area` (`centroid` is the nested `Coordinates` sub-message on the `Home` proto; `centroid_latitude`/`centroid_longitude` are reserved field names)
+
+#### Scenario: Area override via UserHomeSelector
+
+- **WHEN** the user taps the area selector
+- **THEN** the `user-home-selector` component SHALL open
+- **AND** on selection, the route SHALL update its local area state with the new ISO 3166-2 code
+- **AND** `ListByLocation` SHALL be called with the new area's centroid coordinates and admin_area
+- **AND** the new area SHALL NOT be saved to the user's account
+
+#### Scenario: Area override is session-scoped
+
+- **WHEN** the user reloads the page or navigates away and returns
+- **THEN** the area selector SHALL reset to the user's persisted home area
+- **AND** any previous session override SHALL be discarded
+
+#### Scenario: Area override for unauthenticated user
+
+- **WHEN** an unauthenticated user opens All Nearby mode
+- **AND** no guest home is stored in localStorage
+- **THEN** the area selector SHALL prompt the user to choose an area
+- **AND** the chosen area SHALL be used for the session without persisting to localStorage
+
+---
+
+### Requirement: All Nearby Concert List
+
+The All Nearby mode SHALL display concerts returned by `ConcertService.ListByLocation` using the existing `ConcertHighway` component with HOME and NEARBY lanes.
+
+#### Scenario: HOME and NEARBY lanes rendered
+
+- **WHEN** `ListByLocation` returns `ProximityGroup[]`
+- **THEN** the `ConcertHighway` SHALL render HOME-tier concerts in the HOME lane and NEARBY-tier concerts in the NEARBY lane
+- **AND** AWAY-tier concerts SHALL NOT be displayed
+
+#### Scenario: Venue name shown for all lanes
+
+- **WHEN** a concert card is rendered in the All Nearby list
+- **THEN** the `listed_venue_name` (or resolved venue name) SHALL be shown regardless of the lane (HOME or NEARBY)
+- **AND** this overrides the current Dashboard behavior where HOME-lane cards suppress the venue label
+
+#### Scenario: Empty state
+
+- **WHEN** `ListByLocation` returns an empty `groups` list
+- **THEN** the Dashboard SHALL display an empty-state message explaining that no concerts were found for the selected area and date range
+- **AND** the empty state SHALL include a link or button navigating to the Discovery tab
+
+---
+
+### Requirement: Follow CTA in Event Detail Sheet for All Nearby
+
+When viewing a concert in All Nearby mode, the `EventDetailSheet` SHALL surface a follow action for artists the user does not yet follow.
+
+#### Scenario: Follow button visible for unfollowed artist
+
+- **WHEN** the user opens the `EventDetailSheet` for a concert in All Nearby mode
+- **AND** the concert's artist is not in the user's followed artists list
+- **THEN** the sheet SHALL display a "Follow this artist" button
+
+#### Scenario: Follow action from detail sheet
+
+- **WHEN** the user taps "Follow this artist" in the `EventDetailSheet`
+- **THEN** `ArtistService.Follow` SHALL be called
+- **AND** the button SHALL change to a "Following" indicator
+- **AND** the DNA Orb absorption animation SHALL NOT play (the sheet is not the Discovery context)
+
+#### Scenario: No follow button for already-followed artist
+
+- **WHEN** the user opens the `EventDetailSheet` for a concert in All Nearby mode
+- **AND** the concert's artist is already followed
+- **THEN** the follow button SHALL NOT be displayed
+
+#### Scenario: Follow button for unauthenticated user
+
+- **WHEN** an unauthenticated user taps "Follow this artist" in the `EventDetailSheet`
+- **THEN** the system SHALL surface the sign-up prompt banner instead of calling `ArtistService.Follow`

--- a/openspec/changes/passive-concert-discovery/specs/user-home/spec.md
+++ b/openspec/changes/passive-concert-discovery/specs/user-home/spec.md
@@ -1,0 +1,62 @@
+## MODIFIED Requirements
+
+### Requirement: Unified Home Area Selector Component
+
+The frontend SHALL provide a single reusable `user-home-selector` component for selecting the user's home area. This component SHALL be used in the onboarding flow (Dashboard BottomSheet), the Settings page, and the Dashboard All Nearby area selector. The component SHALL implement a consistent 2-step selection flow with an optional quick-select shortcut.
+
+The component SHALL be a pure selection UI: it SHALL NOT call `UserService.updateHome()`, write to localStorage, or resolve `IUserStore` / `IAuthService` internally. All persistence decisions are delegated to the caller via the `onHomeSelected` callback.
+
+#### Scenario: Step 1 displays quick-select cities and regions
+
+- **WHEN** the `user-home-selector` component is opened
+- **THEN** Step 1 SHALL display quick-select buttons for major cities (Tokyo, Osaka, Nagoya, Fukuoka, Sapporo, Sendai)
+- **AND** Step 1 SHALL display region buttons (Hokkaido, Tohoku, Kanto, Chubu, Kinki, Chugoku, Shikoku, Kyushu)
+
+#### Scenario: Quick-select city confirms immediately
+
+- **WHEN** a user taps a quick-select city button
+- **THEN** the component SHALL confirm the selection with the city's ISO 3166-2 prefecture code
+- **AND** the component SHALL NOT transition to Step 2
+- **AND** the component SHALL invoke the `onHomeSelected` callback with the code
+
+#### Scenario: Region tap transitions to Step 2
+
+- **WHEN** a user taps a region button
+- **THEN** the component SHALL transition to Step 2 displaying the prefectures within that region
+- **AND** Step 2 SHALL display a back control to return to Step 1
+- **AND** the back control SHALL render BOTH a chevron-back icon AND a visible text label so the affordance is recognizable as a back action without relying on the icon alone
+- **AND** the visible text label SHALL be sourced from a localized i18n key
+- **AND** the back control SHALL NOT carry a separately bound `aria-label`; the visible text label supplies the accessible name directly, and a diverging `aria-label` would violate WCAG 2.5.3 (Label in Name). Use visible text as the sole accessible name to eliminate that risk.
+
+#### Scenario: Prefecture selection in Step 2 confirms
+
+- **WHEN** a user taps a prefecture in Step 2
+- **THEN** the component SHALL confirm the selection with the prefecture's ISO 3166-2 code
+- **AND** the component SHALL invoke the `onHomeSelected` callback with the code
+
+#### Scenario: Caller owns persistence — authenticated home save
+
+- **WHEN** the `user-home-selector` is used on the Settings page or onboarding flow
+- **THEN** the caller (Settings page / onboarding handler) SHALL call `UserService.updateHome()` in its `onHomeSelected` handler
+- **AND** the component itself SHALL NOT call any backend RPC
+
+#### Scenario: Caller owns persistence — guest home save
+
+- **WHEN** the `user-home-selector` is used on the Settings page or onboarding flow for a guest user
+- **THEN** the caller SHALL write the ISO 3166-2 code to localStorage under `guest.home`
+- **AND** the component itself SHALL NOT write to localStorage
+
+#### Scenario: Caller owns persistence — session-only override
+
+- **WHEN** the `user-home-selector` is used as the All Nearby area selector
+- **THEN** the caller SHALL update only the route's local state with the selected code
+- **AND** neither `UserService.updateHome()` nor localStorage SHALL be written
+
+#### Scenario: Current selection highlight via bindable prop
+
+- **WHEN** the `user-home-selector` component is opened
+- **THEN** it SHALL accept a `@bindable currentCode: string | null` prop representing the currently active ISO 3166-2 code
+- **AND** the component SHALL use `currentCode` to highlight the matching prefecture or city button
+- **AND** `currentCode` SHALL replace the former `IUserStore`-derived `currentHomeCode` getter; the component SHALL NOT derive the current code from `IUserStore` internally
+- **WHEN** the caller does not provide `currentCode`
+- **THEN** no prefecture SHALL be highlighted

--- a/openspec/changes/passive-concert-discovery/tasks.md
+++ b/openspec/changes/passive-concert-discovery/tasks.md
@@ -1,0 +1,70 @@
+## 1. Specification — Proto Schema
+
+- [ ] 1.1 Create `proto/liverty_music/entity/v1/geo_location.proto` with `GeoLocation` message (`latitude`, `longitude`, `admin_area`)
+- [ ] 1.2 Add `ListByLocation` RPC to `proto/liverty_music/rpc/concert/v1/concert_service.proto` with `ListByLocationRequest` / `ListByLocationResponse`; add protovalidate constraint `to - from ≤ 30 days`
+- [ ] 1.3 Rename `ListWithProximity` → `ListByArtists` in `concert_service.proto` (update request/response message names to match)
+- [ ] 1.4 Run `buf lint` and `buf format -w`; verify `buf breaking` only flags the intentional rename
+- [ ] 1.5 Open specification PR, add `buf skip breaking` label for the rename, get review
+
+## 2. Specification — Release
+
+- [ ] 2.1 Merge specification PR to main
+- [ ] 2.2 Publish GitHub Release (tag `vX.Y.Z`) to trigger `buf-release.yml` → BSR gen
+- [ ] 2.3 Monitor `gh run list --repo liverty-music/specification --workflow buf-release.yml` until BSR gen succeeds
+
+## 3. Backend — Repository Layer
+
+- [ ] 3.1 Upgrade backend generated package: `go get buf.build/gen/go/liverty-music/schema/...@vX.Y.Z && go mod tidy`
+- [ ] 3.2 Add `ConcertRepository.ListByLocation(ctx, geoLocation, from, to)` method; SQL query: `WHERE e.local_event_date BETWEEN $from AND $to` with bounding-box pre-filter on `v.latitude/longitude` + `v.admin_area = $admin_area` OR clause
+- [ ] 3.3 Apply final Haversine 200 km filter in Go via `Concert.ProximityTo`; since that method takes `*entity.Home`, construct a transient adapter: `entity.Home{Level1: req.AdminArea, Centroid: &entity.Coordinates{Latitude: req.Latitude, Longitude: req.Longitude}}`; pass it to `entity.GroupByDateAndProximity`; strip ProximityGroup entries where `len(g.Home)+len(g.Nearby)==0` (entire empty-lane date rows must be omitted, not returned)
+
+## 4. Backend — Use Case & Handler
+
+- [ ] 4.1 Add `ConcertUseCase.ListByLocation(ctx, geoLocation, from, to)` method; call `ConcertRepository.ListByLocation`; construct transient `*entity.Home` from `geoLocation` fields (per task 3.3); call `entity.GroupByDateAndProximity(concerts, adaptedHome)`; strip ProximityGroup entries where `len(g.Home)+len(g.Nearby)==0` before returning
+- [ ] 4.2 Add `ListByLocation` handler in `internal/adapter/rpc/concert_handler.go`; map `entity.v1.GeoLocation` proto to `entity.GeoLocation` Go struct; no auth required
+- [ ] 4.3 Rename `ListWithProximity` handler to `ListByArtists`; update DI wiring
+- [ ] 4.4 Add unit tests for `ConcertUseCase.ListByLocation` (mock repo; verify AWAY exclusion and correct GroupByDateAndProximity call)
+- [ ] 4.5 Run `make check` — all tests green
+
+## 5. Backend — PR
+
+- [ ] 5.1 Open backend PR; ensure CI passes (govulncheck, schema-lint, tests)
+- [ ] 5.2 Merge backend PR; verify deployment via `gh run list --repo liverty-music/backend --branch main`
+
+## 6. Frontend — Dependency & Centroid Constants
+
+- [ ] 6.1 Upgrade frontend generated package: `npm install @buf/liverty-music_schema.connectrpc_es@latest`
+- [ ] 6.2 Rename `listWithProximity` → `listByArtists` in all frontend call sites: `src/services/concert-store.ts` (public method + all internal usages), `src/adapter/rpc/client/concert-client.ts`, and `src/routes/welcome/welcome-route.ts`
+- [ ] 6.3 Add `JP_PREFECTURE_CENTROIDS` constant map (`Record<string, { lat: number; lng: number }>`) for all 47 JP prefectures to `src/entities/user.ts` alongside `JP_PREFECTURES` (same file, same key space — single source of truth)
+- [ ] 6.4 Add helper `geoLocationFromLevel1(level1: string): GeoLocation` that looks up `JP_PREFECTURE_CENTROIDS` and returns a `GeoLocation` proto object (`{ latitude, longitude, adminArea: level1 }`)
+
+## 7. Frontend — UserHomeSelector Refactor
+
+- [ ] 7.1 Remove `IUserStore` and `IAuthService` injection from `UserHomeSelector`; remove any internal `updateHome()` / localStorage write calls
+- [ ] 7.2 Add `@bindable currentCode: string | null` prop to `UserHomeSelector`; replace the former `currentHomeCode` getter (which derived from `userStore.currentHome`) with this bindable; use `currentCode` to drive the active-highlight state on prefecture / city buttons
+- [ ] 7.3 Ensure `onHomeSelected(code: string)` is the sole output of the component
+- [ ] 7.4 Update Settings page: pass `currentCode.bind="userStore.currentHome"` to `user-home-selector`; in `onHomeSelected` handler call `userStore.updateHome(code)` for authenticated users, write `guest.home` to localStorage for guests
+- [ ] 7.5 Update onboarding flow with same persistence logic and `currentCode` binding
+- [ ] 7.6 Run `make check` — no type errors, existing E2E smoke tests green
+
+## 8. Frontend — Dashboard Toggle & All Nearby Mode
+
+- [ ] 8.1 Add mode toggle ("My Timetable" / "All Nearby") to `dashboard-route.html` / `dashboard-route.ts`; default to My Timetable; session-only state (not persisted)
+- [ ] 8.2 Show date-preset selector and area selector only when All Nearby mode is active
+- [ ] 8.3 Implement date-preset selector component (今週末 / 7日以内 / 30日以内 / カスタム) with `LocalDate` pair output; implement 今週末 date logic (Sat–Sun relative to today)
+- [ ] 8.4 Implement area selector: display current area name; open `user-home-selector` on tap passing `currentCode.bind="selectedAreaCode ?? userStore.currentHome"`; on `onHomeSelected` update route-local `selectedAreaCode` state; do NOT call `userStore.updateHome()`; resolve `GeoLocation` from `selectedAreaCode` via `geoLocationFromLevel1()` (override case) or from `user.home.centroid.latitude/longitude` + `user.home.level_1` (default case)
+- [ ] 8.5 Wire `ConcertStore.listByLocation(geoLocation, from, to)` call triggered by mode switch or filter change; cache result in route-local state separate from My Timetable cache
+
+## 9. Frontend — All Nearby Concert List UI
+
+- [ ] 9.1 Pass All Nearby `ProximityGroup[]` to `ConcertHighway`; set `showVenueAlways: true` (or equivalent prop) so venue name renders in HOME lane as well as NEARBY
+- [ ] 9.2 Add `showVenueAlways` (or `showLocationLabel`) bindable to `ConcertHighway` / `EventCard`; when `true`, render venue label for all lanes; default `false` to preserve My Timetable behavior
+- [ ] 9.3 Implement empty-state UI for All Nearby mode when no concerts returned; include link to Discovery tab
+- [ ] 9.4 Add follow CTA to `EventDetailSheet`: (1) inject `IFollowStore`; (2) add `@bindable isAllNearby: boolean` flag (default `false`) to distinguish All Nearby context from My Timetable — show the follow button only when `isAllNearby` is true and `!followStore.isFollowed(event.artistId)`; (3) add null guard on `event.artist` before calling `followStore.follow(artist)` — if `artist` is `undefined` (unresolved performer), log a warning and do not throw; (4) update button to "Following" state without DNA Orb animation; (5) show sign-up prompt banner for unauthenticated users instead of calling follow
+
+## 10. Frontend — PR & Prod Release
+
+- [ ] 10.1 Run `make check` — type-check, unit tests, E2E smoke green
+- [ ] 10.2 Open frontend PR; ensure CI passes
+- [ ] 10.3 Merge frontend PR
+- [ ] 10.4 Create frontend GitHub Release → prod pin-bump → verify ArgoCD sync

--- a/openspec/changes/restore-journey-status-ui/tasks.md
+++ b/openspec/changes/restore-journey-status-ui/tasks.md
@@ -1,14 +1,14 @@
 ## 1. Restore event-card journey badge
 
-- [ ] 1.1 In `src/components/live-highway/event-card.html`, add back the journey badge `<span>` inside the `<article>` element, after the location-label span: `<span if.bind="journeyConfig" data-journey-status.bind="event.journeyStatus" class="journey-badge" data-testid="journey-badge" role="img" aria-label.bind="journeyConfig.labelKey | t">${journeyConfig.icon}</span>`
+- [x] 1.1 In `src/components/live-highway/event-card.html`, add back the journey badge `<span>` inside the `<article>` element, after the location-label span: `<span if.bind="journeyConfig" data-journey-status.bind="event.journeyStatus" class="journey-badge" data-testid="journey-badge" role="img" aria-label.bind="journeyConfig.labelKey | t">${journeyConfig.icon}</span>`
 
 ## 2. Restore event-detail-sheet journey section
 
-- [ ] 2.1 In `src/components/live-highway/event-detail-sheet.html`, restore the `<section if.bind="isAuthenticated" class="sheet-journey">` block between the closing `</section>` of `.sheet-details` and the opening `<footer class="sheet-actions">`, containing the full journey radiogroup: process phase (tracking → applied) and outcome phase (unpaid → paid | lost), plus the remove button
-- [ ] 2.2 Verify the restored section includes: `data-testid="sheet-journey"` on the section, `data-testid="journey-btn"` on each radiogroup button, and `data-testid="journey-remove-btn"` on the remove button
+- [x] 2.1 In `src/components/live-highway/event-detail-sheet.html`, restore the `<section if.bind="isAuthenticated" class="sheet-journey">` block between the closing `</section>` of `.sheet-details` and the opening `<footer class="sheet-actions">`, containing the full journey radiogroup: process phase (tracking → applied) and outcome phase (unpaid → paid | lost), plus the remove button
+- [x] 2.2 Verify the restored section includes: `data-testid="sheet-journey"` on the section, `data-testid="journey-btn"` on each radiogroup button, and `data-testid="journey-remove-btn"` on the remove button
 
 ## 3. Verify and ship
 
-- [ ] 3.1 Run `make check` in the frontend repo — lint, typecheck, and unit tests must all pass
+- [x] 3.1 Run `make check` in the frontend repo — lint, typecheck, and unit tests must all pass
 - [ ] 3.2 Open a PR against `frontend` main with the two template changes
 - [ ] 3.3 Merge PR and create a patch release to ship to prod


### PR DESCRIPTION
## Summary

- Add `entity.v1.GeoLocation` proto message — a semantically neutral geographic reference point (latitude, longitude, admin_area) distinct from the user-specific `Home` entity
- Add `ConcertService.ListByLocation` RPC — unauthenticated, filters concerts by proximity to a `GeoLocation` within a date range (max 30 days), returns `ProximityGroup[]`
- **BREAKING**: Rename `ConcertService.ListWithProximity` → `ListByArtists` — `artist_ids` is the primary filter; "WithProximity" described the output format, not the filter axis
- Add OpenSpec change artifacts (proposal, design, 6 capability specs, tasks) for `passive-concert-discovery`

## Changes

**New proto entity** (`entity/v1/geo_location.proto`):
- `GeoLocation { latitude, longitude, admin_area }` with protovalidate range constraints (lat ±90, lng ±180, admin_area non-empty)

**Updated RPC** (`rpc/concert/v1/concert_service.proto`):
- `ListByLocation(ListByLocationRequest)` — `GeoLocation location`, `LocalDate from`, `LocalDate to`; cross-field CEL constraint enforces `from ≤ to` and range ≤ 30 days
- `ListByArtists` (renamed from `ListWithProximity`) — identical signature/behavior

**OpenSpec artifacts** (`openspec/changes/passive-concert-discovery/`):
- proposal.md, design.md — 8 key design decisions documented
- specs: `geo-location`, `passive-concert-discovery`, `concert-service`, `dashboard-concert-cache`, `user-home`, `artist-following`
- tasks.md — 10-section implementation checklist covering spec → BSR → backend → frontend → prod

## Testing

- `buf lint` and `buf format -w` must pass on changed proto files
- `buf breaking` will flag the `ListWithProximity` rename — label `buf skip breaking` is applied

## Notes

- Frontend implementation: Dashboard toggle (My Timetable / All Nearby), area selector, date presets, ConcertHighway reuse
- Backend implementation: `ConcertRepository.ListByLocation` with bounding box ±1.8°lat / ±2.6°lng pre-filter, Go Haversine post-filter via `entity.GroupByDateAndProximity`
- `UserHomeSelector` refactor separates selection UI from persistence — covered in `user-home` spec delta

Closes: #733
