### PR TITLE
feat(openspec): fix-discovery-followed-bubble-stale-cache

### DIFF
--- a/openspec/changes/fix-discovery-followed-bubble-stale-cache/.openspec.yaml
+++ b/openspec/changes/fix-discovery-followed-bubble-stale-cache/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-28

--- a/openspec/changes/fix-discovery-followed-bubble-stale-cache/design.md
+++ b/openspec/changes/fix-discovery-followed-bubble-stale-cache/design.md
@@ -42,10 +42,13 @@ this.bubbles.pool.replace(filteredCache)
 ### D2: `renderBubble()` の `isFollowed` 分岐を削除する
 
 `isFollowed ? opacity * 0.4` は、本来現れないはずのフォロー済みバブルへのフォールバック描画だった。
-D1 の修正後は到達不能になるため、削除してコードをシンプルにする。
+
+**適用前提**: 実装時に `onFollowFromSearch` がフォロー済みバブルを物理エンジンから除去していることを確認すること（`pool.remove()` 等）。タップによるフォロー（`onArtistSelected`）はバブル吸収アニメーションで除去されるが、検索フォローは別コードパスである。除去できていない場合、この分岐を削除すると該当バブルが dimmed → full opacity になり regression となるため、D2 は適用せず分岐を残すこと。
+
+除去が確認できた場合、D1 の修正後は到達不能になるため削除してコードをシンプルにする。
 `showFollowedIndicator` バインダブルと `followedIds` バインダブルも、他に利用箇所がなくなれば削除対象とする。
 
 ## Risks / Trade-offs
 
 - **[リスク] フィルタ後プールが空になる** → `loadInitialBubbles()` がバックグラウンドで即座に走り新アーティストをロードするため、ゴーストバブル UX で空にならない（`loading()` 内の ghost artist パスが引き続き機能する）
-- **[リスク] `followedIds` が `loading()` 時点で未ロード** → `IFollowStore` は DI シングルトンであり `loading()` より前に初期化されるため問題ない
+- **[リスク] `followedIds` が `loading()` 時点で未ロード** → `FollowStore` は Dashboard 起動時に `loadFollowed()` を完了させており、Discovery の `loading()` が呼ばれる時点では `followedIds` が populated されている。この前提が実装上崩れる場合（初回起動直後に Discovery へ直接遷移するケースなど）は、`loading()` 内で follow データのロード完了を `await` してからフィルタを適用すること

--- a/openspec/changes/fix-discovery-followed-bubble-stale-cache/design.md
+++ b/openspec/changes/fix-discovery-followed-bubble-stale-cache/design.md
@@ -1,0 +1,51 @@
+## Context
+
+`ArtistStore` はシングルトンとして `lastBubbles` に最後に生成されたバブルプールをキャッシュし、
+`DiscoveryRoute` の re-entry 時に `peekBubbles()` で即時描画を実現する。
+
+問題は `setBubbles()` が `loadInitialBubbles()` 完了時にのみ呼ばれる点にある。
+セッション中にバブルをタップしてフォローしても、キャッシュは更新されない。
+次の re-entry で `peekBubbles()` が返すプールにはフォロー済みアーティストが残っており、
+`pool.replace()` → `artistsChanged()` → `physics.addBubbles()` の経路でバブルが物理エンジンに追加され、
+`renderBubble()` の `isFollowed ? opacity * 0.4` でバブルが薄く表示される。
+
+## Goals / Non-Goals
+
+**Goals:**
+- re-entry 時にフォロー済みアーティストのバブルが表示されなくなる
+- `renderBubble()` の `isFollowed` 条件分岐（opacity 0.4）を削除してコードをシンプルにする
+
+**Non-Goals:**
+- セッション中のフォロー発生時にキャッシュをリアルタイム更新すること（タップ後即座にバブルは物理的に消えているため不要）
+- 50バブル上限修正（別 change `discovery-perf-instrumentation-and-bubble-cap` で対応）
+
+## Decisions
+
+### D1: フィルタはキャッシュ「読み込み時」に行う
+
+**選択**: `loading()` で `peekBubbles()` した直後に `followedIds` でフィルタする。
+
+```typescript
+// Before
+this.bubbles.pool.replace(cachedBubbles)
+
+// After
+const filteredCache = cachedBubbles.filter(a => !this.followStore.followedIds.has(a.id))
+this.bubbles.pool.replace(filteredCache)
+```
+
+**理由**: フォロー時にキャッシュを更新する方式（書き込み側フィルタ）だと、
+`onArtistSelected` / `onFollowFromSearch` の 2 箇所にキャッシュ更新コードが必要になり、
+将来のフォロー経路が増えたときに漏れる。読み込み側で一元的にフィルタする方が、
+「キャッシュは生プールを保持し、消費時に除外する」という責務分離が明確で保守しやすい。
+
+### D2: `renderBubble()` の `isFollowed` 分岐を削除する
+
+`isFollowed ? opacity * 0.4` は、本来現れないはずのフォロー済みバブルへのフォールバック描画だった。
+D1 の修正後は到達不能になるため、削除してコードをシンプルにする。
+`showFollowedIndicator` バインダブルと `followedIds` バインダブルも、他に利用箇所がなくなれば削除対象とする。
+
+## Risks / Trade-offs
+
+- **[リスク] フィルタ後プールが空になる** → `loadInitialBubbles()` がバックグラウンドで即座に走り新アーティストをロードするため、ゴーストバブル UX で空にならない（`loading()` 内の ghost artist パスが引き続き機能する）
+- **[リスク] `followedIds` が `loading()` 時点で未ロード** → `IFollowStore` は DI シングルトンであり `loading()` より前に初期化されるため問題ない

--- a/openspec/changes/fix-discovery-followed-bubble-stale-cache/proposal.md
+++ b/openspec/changes/fix-discovery-followed-bubble-stale-cache/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+`ArtistStore.lastBubbles` キャッシュはセッション中にフォローが発生しても更新されないため、
+re-entry 時に `peekBubbles()` がフォロー済みアーティストを含む古いプールを返し、そのアーティストのバブルが薄く（opacity 0.4）表示され続ける。
+フォロー済みアーティストはバブルフィールドに表示しないというシステム全体の設計方針（`dedup()` による除外）と矛盾する。
+
+## What Changes
+
+- `DiscoveryRoute.loading()` でキャッシュ読み込み時に `followedIds` を使って followed artist をフィルタする（1行追加）
+- `DnaOrbCanvas.renderBubble()` の `isFollowed ? opacity * 0.4` 描画パスを削除（上記修正で到達不能になる）
+- `discovery-bubble-cache` spec に「キャッシュ再読み込み時は followed artist を除外する」要件を追記
+
+## Capabilities
+
+### New Capabilities
+
+_なし_
+
+### Modified Capabilities
+
+- `discovery-bubble-cache`: re-entry 時のキャッシュ読み込みで followed artist を除外する要件を追加
+
+## Impact
+
+- `frontend/src/routes/discovery/discovery-route.ts` — `loading()` に 1 行フィルタ追加
+- `frontend/src/components/dna-orb/dna-orb-canvas.ts` — `renderBubble()` の `isFollowed` opacity 分岐を削除
+- 仕様: `openspec/specs/discovery-bubble-cache/spec.md` に要件追記

--- a/openspec/changes/fix-discovery-followed-bubble-stale-cache/specs/discovery-bubble-cache/spec.md
+++ b/openspec/changes/fix-discovery-followed-bubble-stale-cache/specs/discovery-bubble-cache/spec.md
@@ -5,10 +5,18 @@
 
 #### Scenario: Re-entry paints cached artists instantly
 - **WHEN** the user navigates to Discovery after a prior visit
-- **THEN** the bubble pool SHALL be initialized from the cached artists synchronously during `loading()`
+- **AND** at least one cached artist is not yet followed
+- **THEN** the bubble pool SHALL be initialized from the filtered cached artists synchronously during `loading()`
 - **AND** followed artists SHALL be excluded from the cached pool before it is applied
 - **AND** no ghost bubbles SHALL be shown
 - **AND** `loadInitialBubbles()` SHALL run in the background to refresh the pool
+
+#### Scenario: Re-entry with all cached artists already followed
+- **WHEN** the user navigates to Discovery after a prior visit
+- **AND** every artist in the cached pool has since been followed
+- **THEN** `pool.replace([])` SHALL be called with an empty array (no stale bubbles rendered)
+- **AND** `loadInitialBubbles()` SHALL run immediately in the background and replace the empty pool with fresh artists
+- **AND** ghost placeholder bubbles SHALL be shown during the background load (same as cold visit behavior)
 
 #### Scenario: Cache excludes followed artists on re-entry
 - **WHEN** the cached bubble pool contains artists that the user has since followed

--- a/openspec/changes/fix-discovery-followed-bubble-stale-cache/specs/discovery-bubble-cache/spec.md
+++ b/openspec/changes/fix-discovery-followed-bubble-stale-cache/specs/discovery-bubble-cache/spec.md
@@ -1,0 +1,26 @@
+## MODIFIED Requirements
+
+### Requirement: Discovery bubble pool is cached in ArtistStore singleton
+`ArtistStore` SHALL cache the last successfully generated bubble pool (`Artist[]`) so that `DiscoveryRoute` re-entries can paint real artists immediately without waiting on network RPCs.
+
+#### Scenario: Re-entry paints cached artists instantly
+- **WHEN** the user navigates to Discovery after a prior visit
+- **THEN** the bubble pool SHALL be initialized from the cached artists synchronously during `loading()`
+- **AND** followed artists SHALL be excluded from the cached pool before it is applied
+- **AND** no ghost bubbles SHALL be shown
+- **AND** `loadInitialBubbles()` SHALL run in the background to refresh the pool
+
+#### Scenario: Cache excludes followed artists on re-entry
+- **WHEN** the cached bubble pool contains artists that the user has since followed
+- **THEN** those artists SHALL be filtered out before `pool.replace()` is called
+- **AND** the followed artists SHALL NOT appear as bubbles in the physics engine
+
+#### Scenario: Cold visit uses ghost bubbles
+- **WHEN** no cached artists exist (first visit or cache cleared)
+- **THEN** the route SHALL initialize with ghost placeholder bubbles as the current behavior
+- **AND** switch to real artists when `loadInitialBubbles()` completes
+
+#### Scenario: Cache is updated after each successful load
+- **WHEN** `loadInitialBubbles()` completes successfully
+- **THEN** `ArtistStore.setBubbles(pool.availableBubbles)` SHALL be called to persist the pool
+- **AND** the next re-entry SHALL use the updated pool

--- a/openspec/changes/fix-discovery-followed-bubble-stale-cache/tasks.md
+++ b/openspec/changes/fix-discovery-followed-bubble-stale-cache/tasks.md
@@ -1,0 +1,9 @@
+## 1. フロントエンド実装
+
+- [ ] 1.1 `discovery-route.ts` の `loading()` で `peekBubbles()` 後に `followedIds` フィルタを追加する: `cachedBubbles.filter(a => !this.followStore.followedIds.has(a.id))`
+- [ ] 1.2 `dna-orb-canvas.ts` の `renderBubble()` で `isFollowed` による `opacity * 0.4` の描画分岐を削除する（`showFollowedIndicator` / `followedIds` バインダブルが他に利用箇所がなければ合わせて削除）
+
+## 2. 検証
+
+- [ ] 2.1 `make check` グリーン確認
+- [ ] 2.2 frontend PR → CI グリーン → マージ → Release → prod ロール確認


### PR DESCRIPTION
## Summary

Adds OpenSpec change artifacts for `fix-discovery-followed-bubble-stale-cache` — a frontend-only bug fix where followed artists remain visible as dimmed bubbles on Discovery re-entry due to a stale `ArtistStore.lastBubbles` cache.

## Changes

- `openspec/changes/fix-discovery-followed-bubble-stale-cache/` — new change with proposal, design, delta spec, and tasks
- `specs/discovery-bubble-cache/spec.md` (delta) — adds requirement: cache reload on re-entry must exclude followed artists

## Implementation scope (frontend only)

- `discovery-route.ts` — filter `peekBubbles()` result by `followedIds` in `loading()`
- `dna-orb-canvas.ts` — remove unreachable `isFollowed ? opacity * 0.4` branch in `renderBubble()`

No proto changes. No backend changes. No BSR release required.

close: #737
