### PR TITLE
feat(concert): add GeoLocation + ListByLocation RPC; rename ListWithProximity → ListByArtists

### DIFF
--- a/openspec/changes/passive-concert-discovery/tasks.md
+++ b/openspec/changes/passive-concert-discovery/tasks.md
@@ -4,7 +4,7 @@
 - [x] 1.2 Add `ListByLocation` RPC to `proto/liverty_music/rpc/concert/v1/concert_service.proto` with `ListByLocationRequest` / `ListByLocationResponse`; add protovalidate constraint `to - from ≤ 30 days`
 - [x] 1.3 Rename `ListWithProximity` → `ListByArtists` in `concert_service.proto` (update request/response message names to match)
 - [x] 1.4 Run `buf lint` and `buf format -w`; verify `buf breaking` only flags the intentional rename
-- [ ] 1.5 Open specification PR, add `buf skip breaking` label for the rename, get review
+- [x] 1.5 Open specification PR, add `buf skip breaking` label for the rename, get review
 
 ## 2. Specification — Release
 

--- a/openspec/changes/passive-concert-discovery/tasks.md
+++ b/openspec/changes/passive-concert-discovery/tasks.md
@@ -1,9 +1,9 @@
 ## 1. Specification — Proto Schema
 
-- [ ] 1.1 Create `proto/liverty_music/entity/v1/geo_location.proto` with `GeoLocation` message (`latitude`, `longitude`, `admin_area`)
-- [ ] 1.2 Add `ListByLocation` RPC to `proto/liverty_music/rpc/concert/v1/concert_service.proto` with `ListByLocationRequest` / `ListByLocationResponse`; add protovalidate constraint `to - from ≤ 30 days`
-- [ ] 1.3 Rename `ListWithProximity` → `ListByArtists` in `concert_service.proto` (update request/response message names to match)
-- [ ] 1.4 Run `buf lint` and `buf format -w`; verify `buf breaking` only flags the intentional rename
+- [x] 1.1 Create `proto/liverty_music/entity/v1/geo_location.proto` with `GeoLocation` message (`latitude`, `longitude`, `admin_area`)
+- [x] 1.2 Add `ListByLocation` RPC to `proto/liverty_music/rpc/concert/v1/concert_service.proto` with `ListByLocationRequest` / `ListByLocationResponse`; add protovalidate constraint `to - from ≤ 30 days`
+- [x] 1.3 Rename `ListWithProximity` → `ListByArtists` in `concert_service.proto` (update request/response message names to match)
+- [x] 1.4 Run `buf lint` and `buf format -w`; verify `buf breaking` only flags the intentional rename
 - [ ] 1.5 Open specification PR, add `buf skip breaking` label for the rename, get review
 
 ## 2. Specification — Release

--- a/proto/liverty_music/entity/v1/geo_location.proto
+++ b/proto/liverty_music/entity/v1/geo_location.proto
@@ -1,0 +1,31 @@
+syntax = "proto3";
+
+package liverty_music.entity.v1;
+
+import "buf/validate/validate.proto";
+
+// GeoLocation is a reusable geographic reference point for proximity-based queries.
+//
+// It is semantically neutral: unlike Home, it carries no assumption about whether the
+// coordinates represent a user's home, current GPS position, or any other concept. Any
+// caller may construct a GeoLocation from any source. Servers use latitude/longitude for
+// Haversine distance (NEARBY tier: <= 200 km) and admin_area for exact venue.admin_area
+// matching (HOME tier).
+message GeoLocation {
+  // The WGS 84 latitude in decimal degrees of the reference point.
+  double latitude = 1 [(buf.validate.field).double = {
+    gte: -90.0
+    lte: 90.0
+  }];
+
+  // The WGS 84 longitude in decimal degrees of the reference point.
+  double longitude = 2 [(buf.validate.field).double = {
+    gte: -180.0
+    lte: 180.0
+  }];
+
+  // The ISO 3166-2 subdivision code used for HOME-tier classification (e.g., "JP-13").
+  // An exact match against a venue's admin_area classifies that venue as HOME regardless
+  // of Haversine distance.
+  string admin_area = 3 [(buf.validate.field).string.min_len = 1];
+}

--- a/proto/liverty_music/rpc/concert/v1/concert_service.proto
+++ b/proto/liverty_music/rpc/concert/v1/concert_service.proto
@@ -6,6 +6,7 @@ import "buf/validate/validate.proto";
 import "liverty_music/entity/v1/artist.proto";
 import "liverty_music/entity/v1/concert.proto";
 import "liverty_music/entity/v1/entity.proto";
+import "liverty_music/entity/v1/geo_location.proto";
 import "liverty_music/entity/v1/user.proto";
 
 // ConcertService provides operations for managing the catalog of musical concerts.
@@ -25,14 +26,26 @@ service ConcertService {
   // - UNAUTHENTICATED: The user identity could not be verified.
   rpc ListByFollower(ListByFollowerRequest) returns (ListByFollowerResponse);
 
-  // ListWithProximity retrieves concerts for the specified artists, grouped by date
+  // ListByArtists retrieves concerts for the specified artists, grouped by date
   // and classified by geographic proximity to the caller's home area.
   // Authentication is not required; the caller provides artist IDs and home explicitly.
+  // The primary filter axis is artist_ids; proximity grouping is a property of the
+  // response format, not the filter.
   //
   // Possible errors:
   // - INVALID_ARGUMENT: The request is missing required fields, contains invalid data,
   //   or exceeds the maximum number of artist IDs (50).
-  rpc ListWithProximity(ListWithProximityRequest) returns (ListWithProximityResponse);
+  rpc ListByArtists(ListByArtistsRequest) returns (ListByArtistsResponse);
+
+  // ListByLocation retrieves all concerts in the catalog whose venues are HOME or NEARBY
+  // relative to a geographic reference point, within a date range, grouped by date and
+  // proximity. Authentication is not required. AWAY-tier concerts (beyond 200 km with a
+  // different admin_area) are excluded from the response.
+  //
+  // Possible errors:
+  // - INVALID_ARGUMENT: The request is missing required fields, the location is invalid,
+  //   from is after to, or the date range exceeds 30 days.
+  rpc ListByLocation(ListByLocationRequest) returns (ListByLocationResponse);
 
   // SearchNewConcerts discovers new concerts for a given artist using generative AI.
   // The call blocks until the search completes (up to 60 seconds) and returns any
@@ -93,9 +106,9 @@ message ProximityGroup {
   repeated entity.v1.Concert away = 4;
 }
 
-// ListWithProximityRequest specifies the artists and home area for proximity-grouped
+// ListByArtistsRequest specifies the artists and home area for proximity-grouped
 // concert retrieval. Used during onboarding when the caller is not yet authenticated.
-message ListWithProximityRequest {
+message ListByArtistsRequest {
   // Required. The artists whose concerts are to be listed.
   // Maximum 50 artist IDs per request.
   repeated entity.v1.ArtistId artist_ids = 1 [
@@ -107,12 +120,54 @@ message ListWithProximityRequest {
   entity.v1.Home home = 2 [(buf.validate.field).required = true];
 }
 
-// ListWithProximityResponse contains concerts for the specified artists,
+// ListByArtistsResponse contains concerts for the specified artists,
 // grouped by date and classified by geographic proximity.
-message ListWithProximityResponse {
+message ListByArtistsResponse {
   // Concert groups ordered by date ascending. Each group contains concerts
   // for a single date, classified into home/nearby/away buckets based on
   // the geographic proximity between the provided home area and each venue.
+  repeated ProximityGroup groups = 1;
+}
+
+// ListByLocationRequest specifies a geographic reference point and a date range for
+// discovering all concerts in the catalog near that point. Used by the Dashboard
+// "All Nearby" mode; no authentication is required.
+//
+// The from <= to ordering is enforced here via a message-level CEL constraint. The
+// "to - from <= 30 days" maximum is enforced in the server use-case layer because
+// protovalidate CEL has no calendar-day arithmetic for google.type.Date, and switching
+// the fields to google.protobuf.Timestamp would reintroduce the timezone ambiguity that
+// LocalDate deliberately avoids.
+message ListByLocationRequest {
+  option (buf.validate.message).cel = {
+    id: "list_by_location.from_before_to"
+    message: "from must not be later than to"
+    expression:
+      "this.from.value.year < this.to.value.year"
+      "|| (this.from.value.year == this.to.value.year"
+      "    && (this.from.value.month < this.to.value.month"
+      "        || (this.from.value.month == this.to.value.month"
+      "            && this.from.value.day <= this.to.value.day)))"
+  };
+
+  // Required. The geographic reference point for proximity classification.
+  entity.v1.GeoLocation location = 1 [(buf.validate.field).required = true];
+
+  // Required. The inclusive start of the date range (venue-local calendar date).
+  entity.v1.LocalDate from = 2 [(buf.validate.field).required = true];
+
+  // Required. The inclusive end of the date range (venue-local calendar date).
+  // Must not be earlier than from, and the span must not exceed 30 days.
+  entity.v1.LocalDate to = 3 [(buf.validate.field).required = true];
+}
+
+// ListByLocationResponse contains all concerts near the reference point in the given
+// date range, grouped by date and classified by proximity. The away field of every
+// group is always empty — AWAY-tier concerts are excluded from this response.
+message ListByLocationResponse {
+  // Concert groups ordered by date ascending. Each group contains concerts for a single
+  // date, classified into home/nearby buckets based on the geographic proximity between
+  // the reference point and each venue. Groups with no HOME or NEARBY concerts are omitted.
   repeated ProximityGroup groups = 1;
 }
 


### PR DESCRIPTION
## Summary

Part of the `passive-concert-discovery` OpenSpec change — adds location-and-date-driven concert browsing ("All Nearby" Dashboard mode).

- **New** `entity.v1.GeoLocation` (`latitude`, `longitude`, `admin_area`) — a semantically neutral geographic reference point, distinct from the user-specific `Home` entity.
- **New** RPC `ConcertService.ListByLocation` — returns catalog concerts HOME/NEARBY relative to a `GeoLocation` within a date range, grouped by proximity, unauthenticated. AWAY tier is excluded. `from <= to` enforced via message-level CEL.
- **BREAKING** rename `ConcertService.ListWithProximity` → `ListByArtists` (primary filter axis is `artist_ids`; proximity is a response-format property). Guarded by `buf skip breaking`.

## Validation

- `buf lint` clean
- `buf format -w` applied
- `buf breaking` flags **only** the intentional `ListWithProximity` rename

## Notes

The `to - from ≤ 30 days` cap is enforced in the backend use-case layer rather than CEL: protovalidate CEL has no calendar-day arithmetic over `google.type.Date`, and switching `from`/`to` to `Timestamp` would reintroduce the timezone ambiguity `LocalDate` exists to avoid.

Refs: #739