### PR TITLE
docs(openspec): propose remove-blockchain-ticket-system

### DIFF
--- a/openspec/changes/remove-blockchain-ticket-system/.openspec.yaml
+++ b/openspec/changes/remove-blockchain-ticket-system/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-06

--- a/openspec/changes/remove-blockchain-ticket-system/design.md
+++ b/openspec/changes/remove-blockchain-ticket-system/design.md
@@ -1,0 +1,77 @@
+## Context
+
+The blockchain ticket system (SBT minting, ERC-4337 Safe address prediction, off-chain ZKP entry) shipped across all four repos via several archived changes (`align-ticket-rpcs-with-auth-scoping`, `refactor-mint-ticket`, `remove-gpl-zk-prover`, and the SBT-CI changes) plus the still-open `implement-ticket-system-mvp` (72/79). The code is **live in `main` but dormant**: the frontend ticket-sales navigation is hidden behind a flag, and the backend handlers are wired into DI but unreachable in production because they depend on dev-only Secret Manager entries (contract key, Base Sepolia RPC, Bundler API key). A fair MVP-and-future assessment concluded the platform is a walled garden (Scenario A), so this change removes the blockchain stack cleanly rather than leaving dead code and a custodial key as standing liabilities.
+
+This is a **cross-repo teardown** touching `specification` (proto/BSR), `backend` (Go + Foundry + migrations + JetStream), `frontend` (circuits/prover/route/PWA), and `cloud-provisioning` (Secret Manager). The ordering matters because the proto services are consumed via BSR by both backend and frontend, and because JetStream streams and an applied DB migration are involved.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Remove all blockchain-specific ticket code, dependencies, contracts, circuits, and secrets.
+- Drop the blockchain DB schema (`tickets`, `merkle_tree`, `nullifiers`, `users.safe_address`, `events.merkle_root`) with a backward-compatible forward migration.
+- Retire the blockchain proto services from BSR without breaking the preserved Web2 ticket services.
+- Preserve the Web2 features `ticket-journey` and `ticket-email-import`, and general Passkey auth, untouched.
+- Leave the codebase in a clean state for a future, separate Web2 ticket change.
+
+**Non-Goals:**
+- Designing or building the Web2 replacement (account-bound tickets + signed rotating QR). That is a separate follow-up change.
+- Un-deploying the Base Sepolia `TicketSBT` contract (it is a testnet artifact; abandoning it is sufficient).
+- Touching `ticket-journey` / `ticket-email-import` behavior or their JetStream streams.
+
+## Decisions
+
+### Decision 1: Remove consumers before the proto contract (dependency-safe ordering)
+
+Delete the backend and frontend code that imports the generated `TicketService` / `EntryService` types **first**, land those, then remove the services from the proto schema and cut a BSR release. This avoids a window where downstream repos reference removed generated types. The proto removal is a **breaking change**, so the `specification` PR carries the `buf skip breaking` label per repo convention.
+
+**Alternative considered**: Remove proto first — rejected; it would red-CI backend/frontend until their removals land, violating the "downstream builds stay green" rule.
+
+### Decision 2: Forward DROP migration, not migration deletion
+
+The five ticket migrations (`20260221…`–`20260223…`) are already applied in environments, so they are immutable history. Removal is a **new forward migration** that `DROP`s the tables and columns. Because nothing outside the removed code reads `tickets` / `merkle_tree` / `nullifiers` / `users.safe_address` / `events.merkle_root` (verified: `ticket-journey` and `ticket-email-import` do not depend on them), the drop is backward-compatible for all preserved readers. Authored in Atlas format with `atlas migrate hash`, following the hand-authored-migration pattern (local canary is known-broken).
+
+**Alternative considered**: Leave tables dormant — rejected; the user chose clean removal, and empty orphan tables plus a `safe_address` column are avoidable schema debt.
+
+### Decision 3: Retire ENTRY stream and the TICKET mint subject; keep TICKET_JOURNEY / TICKET_EMAIL
+
+`messaging/streams.go` defines `ENTRY` (`ENTRY.*`), `TICKET` (`TICKET.*`, carrying `TICKET.mint_completed`), `TICKET_JOURNEY`, and `TICKET_EMAIL`. `ENTRY` is fully removable. For `TICKET`: its only subject is the blockchain `mint_completed` analytics event, so the stream is removed too — but **only after** the emitter is deleted, to avoid a subscriber binding to a subject that no longer publishes. `TICKET_JOURNEY` and `TICKET_EMAIL` are Web2 and stay. Per the stale-durable-wedge lesson, delete the obsolete durables/consumers explicitly and confirm via `nats consumer ls` after rollout; do not rely on passive cleanup.
+
+**Alternative considered**: Keep `TICKET` stream for a future Web2 mint event — rejected; a future event will define its own subject/stream, and keeping an unused stream risks a stale-durable wedge.
+
+### Decision 4: Remove analytics events at the spec + catalogue level
+
+`ticket.mint.completed` and `entry.zk_proof.verified` move from `dormant` to the Removed events section of the `product-analytics` catalogue. This keeps the "no phantom events" invariant intact and documents the deletion. `ticket.email.parsed` stays (Web2, still dormant).
+
+### Decision 5: Supersede the in-flight blockchain proposals
+
+`implement-ticket-system-mvp` (72/79) and `sbt-formal-verification` (0/34, no code) are annotated as superseded by this change under Scenario A. Neither is archived (archive implies shipped-as-designed). `sbt-formal-verification` has no landed code, so its retirement is documentation-only.
+
+## Risks / Trade-offs
+
+| Risk | Mitigation |
+|---|---|
+| BSR breaking removal reddens downstream CI if ordering slips | Land backend+frontend consumer removals first; add `buf skip breaking`; release BSR; then bump downstream deps |
+| Stale JetStream durable for ENTRY/TICKET wedges other consumers | Delete emitters first, then streams; explicitly delete durables; verify `nats consumer ls` + no `<unknown>` in HPA post-rollout |
+| Applied-migration DROP is irreversible in prod | Confirm zero rows / zero readers before drop; ship DOWN migration; drop is backward-compatible (no preserved reader touches the objects) |
+| Hidden coupling from a preserved feature to a dropped symbol | Pre-verified `ticket-journey` / `ticket-email-import` independence; `make check` in backend + frontend must pass after each repo's removal |
+| `go mod tidy` surfaces an unrelated advisory (govulncheck repo-wide reddening) | If it happens, split a dedicated deps-bump PR and rebase, per the known govulncheck gate behavior |
+| Removing `contracts/` also removes Slither/forge CI jobs | Remove the CI job definitions in the same PR so CI config does not reference deleted paths |
+| Frontend visual/pwa baselines reference the tickets route / circuit precache | Delete the `tickets` and `pwa-circuit-precache` E2E/visual specs; refresh visual baselines per the main-branch baseline-artifact process |
+
+## Migration Plan
+
+1. **backend (consumers)**: delete entry/ticket/merkle/nullifier code, `contracts/`, `configs/zkp/`, `blockchain/`/`zkp/`/`merkle/` infra, DI wiring, crypto deps (`go mod tidy`); remove Slither/forge CI jobs; add the forward DROP migration (`atlas migrate hash`); retire `ENTRY` stream + `TICKET.mint_completed` emitter/stream; remove the two analytics events. `make check` green. Open PR (does not yet touch proto-generated types beyond deletion of their callers).
+2. **frontend (consumers)**: delete `circuits/`, `prover/`, `public/circuits/`, `tickets` route, proof worker/service, entry/ticket clients + stores, PWA circuit precache, and the related E2E/visual specs; refresh baselines; `make check` green. Open PR.
+3. **specification (contract)**: remove `TicketService`, `EntryService`, and blockchain-only entity messages from proto; `buf lint`; PR with `buf skip breaking`; merge; GitHub Release → `buf-release.yml` pushes to BSR.
+4. **backend + frontend (dep bump)**: bump the generated BSR package to the post-removal version; confirm `make check` still green with the services gone; merge.
+5. **cloud-provisioning**: remove the contract key / RPC URL / Bundler API key from Pulumi Secret Manager and the corresponding ExternalSecret mappings; `pulumi preview` → apply; drop the recorded Base Sepolia address.
+6. **Ship to prod**: backend release → prod pin bump → confirm migration applied and pods healthy; frontend release → prod pin bump; verify ArgoCD Synced/Healthy.
+7. **openspec**: annotate `implement-ticket-system-mvp` and `sbt-formal-verification` as superseded; archive this change once all PRs are merged and shipped.
+
+**Rollback**: Each repo's removal is an independent revert of a stateless deployment. The DB DROP is the only stateful step; its DOWN migration recreates the empty tables/columns, and no data is lost because the objects hold no production data.
+
+## Open Questions
+
+- Confirm whether the five ticket migrations were applied to **prod** (not just dev) so the DROP migration's environment targeting is correct.
+- Confirm no PostHog dashboard/funnel currently references `ticket.mint.completed` or `entry.zk_proof.verified` before removing them (spec says they are dormant, but verify live).
+- Should the preserved-but-dormant `ticket.email.parsed` event and `ticket-email-import` feature also be reviewed for Scenario A relevance, or left as-is? (Out of scope here; flag for product.)

--- a/openspec/changes/remove-blockchain-ticket-system/proposal.md
+++ b/openspec/changes/remove-blockchain-ticket-system/proposal.md
@@ -1,0 +1,50 @@
+## Why
+
+A fair, forward-looking assessment (MVP **and** future extensibility) concluded that every blockchain-unique property in the ticket system — SBT non-transferability, on-chain minting, ERC-4337 Smart Accounts, ZKP membership entry — only becomes load-bearing when the platform crosses a trust boundary (an open multi-promoter secondary market, cross-platform composability). None of those are on Liverty's roadmap: the product is a **walled-garden**, single-operator concert platform (Scenario A). Within that boundary a Web2 architecture (account-bound tickets + signed rotating QR + Passkey) meets every functional and regulatory requirement at equal or higher quality, without the blockchain stack's cost and risk surface (heavy crypto dependencies, a `circom2gnark` bridge, a trusted-setup ceremony, testnet instability, a custodial contract private key, and 5–30 MB circuit downloads with 3–30 s mobile proof generation).
+
+This change **removes the shipped-but-dormant blockchain ticket implementation** so the codebase stops carrying dead weight and attack surface. The Web2 replacement is deliberately scoped as a **separate follow-up change** — removal and rebuild are not mixed.
+
+## What Changes
+
+- **BREAKING** Remove the `TicketService` (`MintTicket`, `GetTicket`, `ListTickets`) and `EntryService` (`GetMerklePath`, `VerifyEntry`) from the proto schema and BSR. Requires the `buf skip breaking` label.
+- Remove the backend blockchain stack: `contracts/` (Foundry + `TicketSBT.sol`), `configs/zkp/`, `internal/infrastructure/blockchain/`, `internal/infrastructure/zkp/`, `internal/infrastructure/merkle/`, and the entry/ticket-mint/merkle/nullifier entities, use cases, handlers, repositories, mocks, and DI wiring.
+- Remove the backend crypto dependencies (`consensys/gnark`, `vocdoni/circom2gnark`, `ethereum/go-ethereum`, `gnark-crypto`, `icicle-gnark`) from `go.mod` and run `go mod tidy`.
+- Remove the frontend ZKP stack: `circuits/`, `prover/`, `public/circuits/`, the `tickets` route, `proof.worker.ts`, `proof-service.ts`, `entry-client.ts`, `ticket-client.ts`, `ticket-store.ts`, and the PWA circuit-precache handling.
+- Drop the blockchain schema via a forward migration: `DROP TABLE tickets, merkle_tree, nullifiers`; `ALTER users DROP COLUMN safe_address`; `ALTER events DROP COLUMN merkle_root`.
+- Retire the `ENTRY` and `TICKET` JetStream streams and the `ticket.mint.completed` / `entry.zk_proof.verified` analytics events, taking care not to wedge the preserved `TICKET_JOURNEY` and `TICKET_EMAIL` consumers.
+- Deprovision the Base Sepolia contract deployer key, RPC URL, and Bundler API key from Secret Manager (`cloud-provisioning`).
+- Supersede the in-flight blockchain proposals: mark `implement-ticket-system-mvp` (72/79) and `sbt-formal-verification` (0/34) as withdrawn/obsolete under Scenario A.
+
+**Preserved (NOT touched):** the Web2 ticket features `ticket-journey` (interest-tier funnel / status UI, in production) and `ticket-email-import` (email ingestion), plus general `user-auth`, `authentication`, and PWA capabilities. Passkey auth via Zitadel stays — it was never blockchain-specific.
+
+## Capabilities
+
+### New Capabilities
+
+- _None._ This change is purely a removal. The Web2 ticket system is a separate follow-up change.
+
+### Modified Capabilities
+
+**Removed in full** (each spec is deleted via a REMOVED delta):
+- `ticket-management`: the on-chain `TicketService` (SBT mint/get/list) capability.
+- `ticket-minting-internals`: the `MintTicket` on-chain orchestrator sub-method structure.
+- `zkp-entry`: the `EntryService` ZKP entry capability (`GetMerklePath`, `VerifyEntry`).
+- `client-zk-proving`: the browser-side Groth16 proving runtime capability.
+- `sbt-test-coverage`: the `TicketSBT` Solidity contract test requirements.
+- `sbt-static-analysis`: the Slither / `forge snapshot` contract-CI requirements.
+
+**Partially modified** (blockchain requirements stripped, the rest kept):
+- `database`: remove the `tickets.minted_at` / `nullifiers.used_at` column-naming requirements.
+- `product-analytics`: remove `ticket.mint.completed` and `entry.zk_proof.verified` from the event catalogue (keep the Web2 `ticket.email.parsed`).
+- `entity-domain-logic`: remove the `ParseZKPPublicSignals` / `ZKPPublicSignals` requirement.
+- `frontend-testing`: remove the `proof-service` pure-utility test requirement.
+- `frontend-store-cache`: remove `Entry.getMerklePath` from the network-first resource set.
+- `live-events`: remove `merkle root` from the optional event fields.
+
+## Impact
+
+- **Proto / BSR** (`specification`): breaking removal of two services + blockchain entity messages; new BSR release; downstream Go/TS dependency bumps.
+- **Backend** (`backend`): large deletion across `entity`, `usecase`, `adapter/rpc`, `infrastructure`, `contracts`, `configs`; `go.mod` slimming; one forward DROP migration (backward-compatible — no reader depends on the dropped columns/tables); JetStream stream retirement.
+- **Frontend** (`frontend`): removal of circuits, WASM prover, tickets route, and proof workers; PWA service-worker precache simplification; bundle-size reduction.
+- **Cloud provisioning** (`cloud-provisioning`): Secret Manager entries removed via Pulumi; Base Sepolia deployment abandoned (testnet, no action needed beyond dropping the recorded address).
+- **Risk**: dormant feature (frontend nav already hidden, backend handlers unreachable without dev secrets), so removal is low user-facing risk. Primary care points are JetStream durable/stream retirement ordering and the applied-migration DROP.

--- a/openspec/changes/remove-blockchain-ticket-system/specs/client-zk-proving/spec.md
+++ b/openspec/changes/remove-blockchain-ticket-system/specs/client-zk-proving/spec.md
@@ -1,0 +1,25 @@
+## REMOVED Requirements
+
+### Requirement: Distributed bundle contains no copyleft-licensed code
+**Reason**: The browser-side ZK proving runtime and circuit artifacts are removed with the ZKP entry flow under the Scenario A pivot; there is no shipped proving bundle to license-constrain.
+**Migration**: None; the `prover/`, `circuits/`, and `public/circuits/` artifacts are deleted.
+
+### Requirement: Client-generated proofs remain verifiable by the gnark backend
+**Reason**: Both the client prover and the backend `gnark`/`circom2gnark` verifier are removed.
+**Migration**: None; code and dependencies deleted.
+
+### Requirement: Proof generation stays on-device
+**Reason**: No ZK proof is generated anymore.
+**Migration**: None; code deleted.
+
+### Requirement: Offline proof generation is preserved
+**Reason**: No ZK proof is generated anymore; offline entry (if needed) will be handled by an offline-verifiable signed QR in the Web2 design.
+**Migration**: None; code deleted.
+
+### Requirement: Circuit artifact integrity is verified before use
+**Reason**: No circuit artifacts are served.
+**Migration**: None; artifacts deleted.
+
+### Requirement: Cross-origin isolation when multithreaded proving is used
+**Reason**: No multithreaded WASM prover is served, so the COOP/COEP requirement no longer applies.
+**Migration**: None; the proving runtime is deleted.

--- a/openspec/changes/remove-blockchain-ticket-system/specs/database/spec.md
+++ b/openspec/changes/remove-blockchain-ticket-system/specs/database/spec.md
@@ -1,0 +1,25 @@
+## MODIFIED Requirements
+
+### Requirement: Database tables SHALL NOT include metadata timestamp columns
+
+Application tables SHALL NOT include `created_at` or `updated_at` columns for audit purposes. Business-meaningful timestamps (e.g., `start_at`, `open_at`, `searched_at`, `scheduled_at`, `sent_at`) SHALL be retained. (The `tickets.minted_at` and `nullifiers.used_at` columns are removed along with the blockchain ticket schema under the Scenario A pivot.)
+
+#### Scenario: Metadata timestamps removed from all tables
+
+- **WHEN** the migration is applied
+- **THEN** the following columns SHALL be dropped:
+  - `users.created_at`, `users.updated_at`
+  - `events.created_at`, `events.updated_at`
+  - `venues.created_at`, `venues.updated_at`
+  - `artist_official_site.created_at`, `artist_official_site.updated_at`
+  - `followed_artists.created_at`
+  - `notifications.created_at`, `notifications.updated_at`
+- **AND** `schema.sql` SHALL NOT contain `created_at` or `updated_at` in any table definition
+
+#### Scenario: Business timestamps are preserved
+
+- **WHEN** the migration is applied
+- **THEN** the following columns SHALL remain unchanged:
+  - `events.start_at`, `events.open_at`
+  - `latest_search_logs.searched_at`
+  - `notifications.scheduled_at`, `notifications.sent_at`

--- a/openspec/changes/remove-blockchain-ticket-system/specs/entity-domain-logic/spec.md
+++ b/openspec/changes/remove-blockchain-ticket-system/specs/entity-domain-logic/spec.md
@@ -1,0 +1,13 @@
+## REMOVED Requirements
+
+### Requirement: ZKP public signal parsing
+**Reason**: `ParseZKPPublicSignals` / `ZKPPublicSignals` exist only to support the removed off-chain ZKP `EntryService` verification path.
+**Migration**: None; the `entity/zkp_signals.go` code is deleted with the ZKP entry flow.
+
+### Requirement: ZKP event ID verification
+**Reason**: `VerifyEventID` operates on the removed `ZKPPublicSignals` type.
+**Migration**: None; code deleted.
+
+### Requirement: ZKP byte conversion helpers
+**Reason**: These helpers exist solely to translate BN254 field elements for ZKP public-signal handling, which is removed.
+**Migration**: None; code deleted.

--- a/openspec/changes/remove-blockchain-ticket-system/specs/frontend-store-cache/spec.md
+++ b/openspec/changes/remove-blockchain-ticket-system/specs/frontend-store-cache/spec.md
@@ -1,0 +1,19 @@
+## MODIFIED Requirements
+
+### Requirement: Caching scope is limited to audited read resources
+The primitive SHALL be applied only to read-only resources whose value derives from cross-route re-entry: `Concert.listByFollower`, `Concert.listWithProximity`, and `Artist.listTop`. Resources that are requested at most once per session, are network-first for freshness, or are client-owned local state SHALL NOT be cached by the primitive. `User.get` SHALL remain out of scope: it keeps its existing idempotent get-or-create recovery (in-memory + localStorage) and SHALL NOT be migrated onto the primitive. (`Ticket.listTickets` and `Entry.getMerklePath` are removed together with the blockchain ticket system under the Scenario A pivot and are therefore no longer in scope.)
+
+#### Scenario: One-shot per-artist reads are not cached
+- **WHEN** `Concert.listConcerts(artistId)` or `Artist.listSimilar(artistId)` is requested
+- **THEN** it SHALL be issued as a direct pass-through
+- **AND** it SHALL NOT be stored in the primitive
+
+#### Scenario: Network-first resources are not cached
+- **WHEN** a network-first resource (`Push.*`, `Artist.search`) is requested
+- **THEN** it SHALL be issued fresh
+- **AND** it SHALL NOT be served from the primitive
+
+#### Scenario: User.get is not migrated onto the primitive
+- **WHEN** the current user entity is read via `User.get`
+- **THEN** it SHALL be served by its existing idempotent get-or-create recovery (in-memory + localStorage)
+- **AND** it SHALL NOT be routed through the shared primitive

--- a/openspec/changes/remove-blockchain-ticket-system/specs/frontend-testing/spec.md
+++ b/openspec/changes/remove-blockchain-ticket-system/specs/frontend-testing/spec.md
@@ -1,0 +1,13 @@
+## REMOVED Requirements
+
+### Requirement: Proof service utility functions perform correct byte-to-field conversions
+**Reason**: `proof-service` and its byte-to-field helpers exist only for client-side ZK proof generation, which is removed under the Scenario A pivot.
+**Migration**: None; `src/services/proof-service.ts` and its tests are deleted.
+
+### Requirement: Proof service verifies circuit file integrity
+**Reason**: No circuit files are served, so integrity verification has no target.
+**Migration**: None; code and tests deleted.
+
+### Requirement: Tickets page generates ZK proof entry QR codes
+**Reason**: The blockchain tickets route and its ZK proof QR flow are removed.
+**Migration**: None; `src/routes/tickets/` and its tests are deleted. A Web2 tickets route will be specified by the follow-up Web2 ticket change.

--- a/openspec/changes/remove-blockchain-ticket-system/specs/live-events/spec.md
+++ b/openspec/changes/remove-blockchain-ticket-system/specs/live-events/spec.md
@@ -1,0 +1,44 @@
+## MODIFIED Requirements
+
+### Requirement: Concert Schedue Data Model
+
+The system MUST define standard data structures for core concert entities to ensure consistency across services.
+
+#### Scenario: Artist Definition
+
+- **WHEN** an artist is represented
+- **THEN** it MUST include a unique ID, name, and a list of official media channels.
+
+#### Scenario: Venue Definition
+
+- **WHEN** a venue is represented
+- **THEN** it MUST include a unique ID and name.
+- **AND** it MAY include an administrative area (`admin_area`) as an ISO 3166-2 subdivision code representing the venue's geographic administrative division (e.g., `JP-13` for Tokyo, `JP-40` for Fukuoka).
+
+#### Scenario: Concert Definition
+
+- **WHEN** a concert is represented
+- **THEN** it MUST include the artist ID, venue ID, local date (`local_date`), title, and start time.
+- **AND** it MAY include open time, source URL, listed venue name, and an embedded `Venue` object.
+- **AND** all primitive scalar fields (date, time, title, URL, venue name) SHALL be represented as VO wrapper messages.
+
+#### Scenario: Event Definition
+
+- **WHEN** an event is represented
+- **THEN** it MUST include a unique ID, an embedded `Venue` object, title, and local date.
+- **AND** it MAY include start time and open time.
+- **AND** all primitive scalar fields SHALL be represented as VO wrapper messages.
+- **AND** it SHALL NOT include `create_time` or `update_time` fields.
+- **AND** it SHALL NOT include a `merkle_root` field (removed with the blockchain ticket system under the Scenario A pivot).
+
+#### Scenario: Concert card displays ticket journey badge
+
+- **WHEN** a concert is rendered on the dashboard
+- **AND** the user has a ticket journey for that concert's event
+- **THEN** the concert card SHALL display a badge indicating the current `TicketJourneyStatus`
+
+#### Scenario: Concert card without ticket journey
+
+- **WHEN** a concert is rendered on the dashboard
+- **AND** the user has no ticket journey for that concert's event
+- **THEN** the concert card SHALL NOT display a journey status badge

--- a/openspec/changes/remove-blockchain-ticket-system/specs/product-analytics/spec.md
+++ b/openspec/changes/remove-blockchain-ticket-system/specs/product-analytics/spec.md
@@ -1,0 +1,24 @@
+## MODIFIED Requirements
+
+### Requirement: The event catalogue records a per-event collection status
+The event catalogue SHALL record, for every listed event, a collection status of `active` (currently emitted and consumed) or `dormant` (has a real emitter but is not currently emitting, pending a deferred feature or an external fix). A removed event SHALL NOT remain in the live catalogue table; it SHALL instead be recorded in a dedicated Removed events section together with the reason for removal, so the deletion is documented without reopening the phantom pattern. Dashboards and funnels SHALL be built only on `active` events. The primary conversion funnel SHALL terminate at the last observable step given the current active set — `concert.detail.viewed` — rather than at a `dormant` ticketing event.
+
+#### Scenario: Dashboard is built only on active events
+- **WHEN** a dashboard or funnel is defined in PostHog
+- **THEN** every step SHALL reference an event catalogued as `active`
+- **AND** a step SHALL NOT reference a `dormant` event such as `ticket.email.parsed`
+
+#### Scenario: Deferred ticketing events are dormant, not deleted
+- **WHEN** the catalogue lists an implemented-but-inactive event such as `ticket.email.parsed`
+- **THEN** the event SHALL be catalogued with status `dormant` and an activation note
+- **AND** the event SHALL NOT be counted toward active event volume or listed on any live dashboard
+
+#### Scenario: A removed event is recorded, not silently dropped
+- **WHEN** an event is removed from active collection (phantom, redundant, double-counting, firehose, wrong-altitude, or a removed capability such as the blockchain ticket flow)
+- **THEN** its row SHALL be removed from the live catalogue table
+- **AND** the event SHALL be listed in the Removed events section with the reason for its removal
+
+#### Scenario: Blockchain ticket analytics events are removed
+- **WHEN** the blockchain ticket system is removed under the Scenario A pivot
+- **THEN** `ticket.mint.completed` and `entry.zk_proof.verified` SHALL be moved from `dormant` to the Removed events section with the reason "blockchain ticket capability removed"
+- **AND** neither event SHALL appear in the live catalogue table

--- a/openspec/changes/remove-blockchain-ticket-system/specs/sbt-static-analysis/spec.md
+++ b/openspec/changes/remove-blockchain-ticket-system/specs/sbt-static-analysis/spec.md
@@ -1,0 +1,13 @@
+## REMOVED Requirements
+
+### Requirement: Slither static analysis in CI
+**Reason**: The `contracts/` directory and all Solidity sources are removed under the Scenario A pivot, so the contract-CI gate has nothing to analyze.
+**Migration**: None; remove the `slither` CI job together with `contracts/`.
+
+### Requirement: Gas regression detection
+**Reason**: No Solidity contracts remain, so `forge snapshot` has no target.
+**Migration**: None; remove the `forge snapshot --check` step and `.gas-snapshot`.
+
+### Requirement: Increased fuzz depth in CI
+**Reason**: No Foundry tests remain.
+**Migration**: None; remove the `forge-test` CI job.

--- a/openspec/changes/remove-blockchain-ticket-system/specs/sbt-test-coverage/spec.md
+++ b/openspec/changes/remove-blockchain-ticket-system/specs/sbt-test-coverage/spec.md
@@ -1,0 +1,33 @@
+## REMOVED Requirements
+
+### Requirement: approve and setApprovalForAll MUST revert
+**Reason**: The `TicketSBT` Solidity contract and its Foundry test suite are removed under the Scenario A pivot; there is no on-chain token.
+**Migration**: None; `contracts/` is deleted.
+
+### Requirement: All transfer paths MUST revert
+**Reason**: `TicketSBT` contract removed.
+**Migration**: None; `contracts/` is deleted.
+
+### Requirement: Duplicate mint MUST revert
+**Reason**: `TicketSBT` contract removed.
+**Migration**: None; `contracts/` is deleted.
+
+### Requirement: Mint to zero address MUST revert
+**Reason**: `TicketSBT` contract removed.
+**Migration**: None; `contracts/` is deleted.
+
+### Requirement: ERC-165 supportsInterface correctness
+**Reason**: `TicketSBT` contract removed.
+**Migration**: None; `contracts/` is deleted.
+
+### Requirement: AccessControl role management
+**Reason**: `TicketSBT` contract removed (no `MINTER_ROLE`).
+**Migration**: None; `contracts/` is deleted.
+
+### Requirement: Constructor initializes correct state
+**Reason**: `TicketSBT` contract removed.
+**Migration**: None; `contracts/` is deleted.
+
+### Requirement: Fuzz testing for mint and access control
+**Reason**: `TicketSBT` contract removed.
+**Migration**: None; `contracts/` is deleted.

--- a/openspec/changes/remove-blockchain-ticket-system/specs/ticket-management/spec.md
+++ b/openspec/changes/remove-blockchain-ticket-system/specs/ticket-management/spec.md
@@ -1,0 +1,13 @@
+## REMOVED Requirements
+
+### Requirement: MintTicket request carries explicit user_id
+**Reason**: The on-chain `TicketService` (soulbound minting) is removed under the Scenario A (walled-garden) pivot; blockchain minting provides no load-bearing value for a single-operator platform.
+**Migration**: No consumer path is live (frontend ticket nav is hidden; handlers are unreachable without dev-only secrets). A future Web2 ticket capability will define account-bound issuance in a separate change.
+
+### Requirement: ListTickets request carries explicit user_id
+**Reason**: Part of the removed on-chain `TicketService`.
+**Migration**: Web2 ticket listing will be redefined by the follow-up Web2 ticket change.
+
+### Requirement: GetTicket remains identifier-scoped
+**Reason**: Part of the removed on-chain `TicketService`.
+**Migration**: Web2 ticket retrieval will be redefined by the follow-up Web2 ticket change.

--- a/openspec/changes/remove-blockchain-ticket-system/specs/ticket-minting-internals/spec.md
+++ b/openspec/changes/remove-blockchain-ticket-system/specs/ticket-minting-internals/spec.md
@@ -1,0 +1,25 @@
+## REMOVED Requirements
+
+### Requirement: MintTicket orchestrator conciseness
+**Reason**: The `MintTicket` on-chain operation is removed with the blockchain ticket stack under the Scenario A pivot.
+**Migration**: No live consumer. Web2 issuance internals, if needed, will be specified by the follow-up Web2 ticket change.
+
+### Requirement: Input validation isolation
+**Reason**: Sub-method of the removed on-chain `MintTicket` operation.
+**Migration**: None; code deleted.
+
+### Requirement: Idempotency check isolation
+**Reason**: Sub-method of the removed on-chain `MintTicket` operation.
+**Migration**: None; code deleted.
+
+### Requirement: Mint-or-reconcile isolation
+**Reason**: Sub-method of the removed on-chain `MintTicket` operation (on-chain reconciliation is gone).
+**Migration**: None; code deleted.
+
+### Requirement: Persistence isolation
+**Reason**: Sub-method of the removed on-chain `MintTicket` operation.
+**Migration**: None; code deleted.
+
+### Requirement: No multi-value return anti-pattern
+**Reason**: Structural rule scoped to the removed `MintTicket` sub-methods.
+**Migration**: None; code deleted.

--- a/openspec/changes/remove-blockchain-ticket-system/specs/zkp-entry/spec.md
+++ b/openspec/changes/remove-blockchain-ticket-system/specs/zkp-entry/spec.md
@@ -1,0 +1,9 @@
+## REMOVED Requirements
+
+### Requirement: GetMerklePath request carries explicit user_id
+**Reason**: The `EntryService` ZKP entry flow is removed under the Scenario A pivot. In a single-operator (verifier == issuer == DB owner) architecture the ZKP privacy guarantee is vacuous, and a signed rotating-QR scheme meets the entry requirement with instant generation and full offline verification.
+**Migration**: No live consumer. Web2 entry verification will be defined by the follow-up Web2 ticket change.
+
+### Requirement: VerifyEntry remains unauthenticated
+**Reason**: Part of the removed `EntryService` ZKP entry flow.
+**Migration**: Web2 entry verification (signed QR + nullifier as a DB uniqueness guard) will be defined by the follow-up Web2 ticket change.

--- a/openspec/changes/remove-blockchain-ticket-system/tasks.md
+++ b/openspec/changes/remove-blockchain-ticket-system/tasks.md
@@ -1,0 +1,71 @@
+## 1. Backend — remove blockchain code & dependencies
+
+- [ ] 1.1 Delete `contracts/` (Foundry project, `TicketSBT.sol`, interfaces, tests, deploy script, faucet tool, `.gas-snapshot`, `slither.config.json`, `foundry.toml`)
+- [ ] 1.2 Delete `configs/zkp/` (verification key + testdata)
+- [ ] 1.3 Delete `internal/infrastructure/blockchain/` (safe + ticketsbt), `internal/infrastructure/zkp/`, `internal/infrastructure/merkle/`
+- [ ] 1.4 Delete entry/ticket-mint/merkle/nullifier entities (`internal/entity/entry.go`, `merkle.go`, `safe_predictor.go`, `ticket.go`, `zkp_signals.go`) and their tests + mocks
+- [ ] 1.5 Delete ticket/entry repositories (`internal/infrastructure/database/rdb/{ticket,merkle,nullifier}_repo.go`) and tests
+- [ ] 1.6 Delete ticket/entry use cases (`internal/usecase/{ticket_uc,ticket_mint_uc,entry_uc,entry_integration}*`) and mocks
+- [ ] 1.7 Delete ticket/entry RPC handlers + mappers (`internal/adapter/rpc/{entry_handler,ticket_handler,mapper/ticket}*`)
+- [ ] 1.8 Remove ticket/entry provider wiring from `internal/di/provider.go`
+- [ ] 1.9 Remove `gnark`, `vocdoni/circom2gnark`, `go-ethereum`, `gnark-crypto`, `icicle-gnark` from `go.mod`; run `go mod tidy`
+- [ ] 1.10 Run backend `make check`; confirm build + lint + tests green with blockchain code gone
+
+## 2. Backend — database migration
+
+- [ ] 2.1 Confirm whether the five `20260221…`–`20260223…` ticket migrations were applied in prod (not just dev)
+- [ ] 2.2 Author forward migration: `DROP TABLE nullifiers, merkle_tree, tickets`; `ALTER TABLE users DROP COLUMN safe_address`; `ALTER TABLE events DROP COLUMN merkle_root` (Atlas format)
+- [ ] 2.3 Run `atlas migrate hash`; verify apply on local PostgreSQL; author the DOWN migration
+- [ ] 2.4 Confirm no preserved reader (`ticket-journey`, `ticket-email-import`) references the dropped tables/columns
+
+## 3. Backend — messaging & analytics
+
+- [ ] 3.1 Remove the `ticket.mint.completed` and `entry.zk_proof.verified` emitters from the analytics code
+- [ ] 3.2 Remove the `ENTRY` stream and the `TICKET` stream (mint subject) from `messaging/streams.go`; keep `TICKET_JOURNEY` and `TICKET_EMAIL`
+- [ ] 3.3 Remove any KEDA scaledobject triggers for the retired entry/ticket subjects in `cloud-provisioning`
+- [ ] 3.4 Move `ticket.mint.completed` + `entry.zk_proof.verified` to the Removed events section of the analytics catalogue doc
+
+## 4. Backend — CI
+
+- [ ] 4.1 Remove the `slither`, `forge-test`, and gas-snapshot CI jobs (they reference the deleted `contracts/`)
+- [ ] 4.2 Confirm remaining backend CI (`go test ./...` + `golangci-lint`) passes without contract paths
+
+## 5. Frontend — remove ZKP/ticket code
+
+- [ ] 5.1 Delete `circuits/`, `prover/`, `public/circuits/`, `dist/circuits/` artifacts
+- [ ] 5.2 Delete `src/routes/tickets/` (route, html, css, tests)
+- [ ] 5.3 Delete `src/services/proof-service.ts`, `src/workers/proof.worker.ts`, `src/services/ticket-store.ts`
+- [ ] 5.4 Delete `src/adapter/rpc/client/{entry-client,ticket-client}.ts`, `mapper/ticket-mapper.ts`, `src/entities/{entry,ticket}.ts` and tests
+- [ ] 5.5 Remove PWA circuit-precache handling from `sw.ts`; lower `maximumFileSizeToCacheInBytes` back to default
+- [ ] 5.6 Delete `e2e/pwa/pwa-circuit-precache.spec.ts` and the tickets-route E2E/visual specs; refresh visual baselines
+- [ ] 5.7 Remove `Ticket.listTickets` from the store-cache primitive scope; remove any tickets nav flag/entry
+- [ ] 5.8 Run frontend `make check`; confirm build + tests + lint green
+
+## 6. Specification — proto / BSR
+
+- [ ] 6.1 Remove `rpc/ticket/v1/ticket_service.proto` and `rpc/entry/v1/entry_service.proto`
+- [ ] 6.2 Remove blockchain-only fields/messages from entity protos (e.g., merkle root on event, ticket SBT fields) while preserving `ticket_journey` / `ticket_email` entities
+- [ ] 6.3 Run `buf lint` and `buf format -w`; open PR with the `buf skip breaking` label
+- [ ] 6.4 Merge PR; create GitHub Release (tag) → confirm `buf-release.yml` pushes to BSR
+- [ ] 6.5 Monitor BSR gen completion via `gh run watch`
+
+## 7. Downstream dependency bump
+
+- [ ] 7.1 Backend: bump `buf.build/gen/go/liverty-music/schema` to the post-removal version; `go mod tidy`; `make check`
+- [ ] 7.2 Frontend: bump `@buf/liverty-music_schema.*` to the post-removal version; `make check`
+
+## 8. Cloud provisioning — secrets
+
+- [ ] 8.1 Remove contract deployer key, Base Sepolia RPC URL, and Bundler API key from Pulumi Secret Manager
+- [ ] 8.2 Remove the corresponding ExternalSecret mappings from k8s manifests
+- [ ] 8.3 `pulumi preview` → get approval → apply to dev; drop the recorded Base Sepolia contract address
+
+## 9. Ship to prod & finalize
+
+- [ ] 9.1 Open backend PR (after BSR gen + dep bump), pass CI, merge
+- [ ] 9.2 Open frontend PR (after BSR gen + dep bump), pass CI, merge
+- [ ] 9.3 Release backend → prod pin bump → verify migration applied and pods healthy (ArgoCD Synced/Healthy)
+- [ ] 9.4 Release frontend → prod pin bump → verify ArgoCD Synced/Healthy
+- [ ] 9.5 Verify preserved features (`ticket-journey`, `ticket-email-import`) still work in prod
+- [ ] 9.6 Annotate `implement-ticket-system-mvp` and `sbt-formal-verification` as superseded by this change
+- [ ] 9.7 Archive `remove-blockchain-ticket-system` once all PRs are merged and shipped


### PR DESCRIPTION
## Summary

Adds the OpenSpec change `remove-blockchain-ticket-system`, which proposes the clean removal of the shipped-but-dormant blockchain ticket implementation across all four repos, pivoting the ticket system to a Web2 (walled-garden / Scenario A) architecture.

A fair assessment — covering both the MVP and future extensibility — concluded that every blockchain-unique property (SBT non-transferability, on-chain minting, ERC-4337 Smart Accounts, ZKP membership entry) only becomes load-bearing when the platform crosses a trust boundary (an open multi-promoter secondary market, cross-platform composability). None of those are on the roadmap. Within a single operator, a Web2 architecture meets every functional and regulatory requirement at equal or higher quality, so the blockchain stack is dead weight and a custodial-key liability. Japan's チケット不正転売禁止法 compliance and entry privacy are delivered by identity binding and VC/ZKP respectively — both independent of the chain — so neither justifies it.

This PR is **documentation only** (OpenSpec artifacts). No proto, code, or infrastructure is changed here; implementation is tracked by follow-up PRs per the change's task list.

## Changes

- `proposal.md` — why (Scenario A pivot) and what (cross-repo removal; preserved Web2 features).
- `design.md` — dependency-safe removal ordering (consumers → proto/BSR), forward DROP migration, JetStream `ENTRY`/`TICKET` stream retirement, analytics event removal, superseding the in-flight blockchain proposals, risks, and prod migration plan.
- `specs/` (12 delta specs):
  - **REMOVED (whole capability):** `ticket-management`, `ticket-minting-internals`, `zkp-entry`, `client-zk-proving`, `sbt-test-coverage`, `sbt-static-analysis`.
  - **REMOVED (blockchain-only requirements):** `entity-domain-logic` (ZKP signal parsing), `frontend-testing` (proof-service + tickets QR).
  - **MODIFIED (strip blockchain requirements, keep the rest):** `database`, `product-analytics`, `frontend-store-cache`, `live-events`.
- `tasks.md` — 9 task groups across backend → frontend → spec/BSR → dep bump → cloud-provisioning → prod ship → archive.

**Preserved (not touched):** `ticket-journey` and `ticket-email-import` (Web2, in production), general Passkey auth via Zitadel. Supersedes the in-flight blockchain proposals `implement-ticket-system-mvp` (72/79) and `sbt-formal-verification` (0/34).

## Testing

- `openspec validate remove-blockchain-ticket-system --strict` — passes.
- All delta specs cross-checked against the current canonical specs in `openspec/specs/`.
- Verified the preserved features (`ticket-journey`, `ticket-email-import`) have no dependency on the dropped ticket entities/tables.

Refs: #741
close: #741
