### PR TITLE
docs(openspec): propose refactor-discovery-bubble-field-state

### DIFF
--- a/openspec/changes/refactor-discovery-bubble-field-state/.openspec.yaml
+++ b/openspec/changes/refactor-discovery-bubble-field-state/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-07

--- a/openspec/changes/refactor-discovery-bubble-field-state/design.md
+++ b/openspec/changes/refactor-discovery-bubble-field-state/design.md
@@ -1,0 +1,76 @@
+## Context
+
+The Discovery bubble field is represented across independently-mutable stores kept in sync by an imperative reconcile:
+
+- `ArtistStore.lastBubbles` — app-lifetime snapshot for instant re-entry paint
+- `ArtistStore` `CachedResource<listTop>` — separate SWR cache of raw RPC
+- `BubblePool.availableBubbles` — per-route working pool (recreated each re-entry via `new BubbleManager`)
+- `BubblePhysics.bubbleMap` — the actual on-screen bodies (the real "what's visible")
+- `FollowStore.followedIds` — follow state used to filter in 3–4 places
+
+Invariants (exclude-followed, 50-cap, dedup) are re-implemented at multiple sites with different semantics: cap is `evict-oldest` in the pool, `slice` in the manager, and a silent `break` in physics. Because model (pool) and view (bubbleMap) are separate stores synced by a lossy one-way reconcile (`artistsChanged`), they diverge. A prod re-entry with 6 follows reproduces pool=33 but physics=16: the background load replaces the pool wholesale, `artistsChanged` fades ~41 old bodies and calls `addBubbles(newSet)`, but the physics cap counts the still-fading bodies and `break`s, silently dropping ~17 artists that are never retried. Separately, re-entry always re-derives the field (seed-similar when followed), so a full field collapses on return.
+
+This change is frontend-only. No proto/API/backend change.
+
+## Goals / Non-Goals
+
+**Goals:**
+- One authoritative owner of the display field; physics/cache derive from it.
+- Physics becomes a pure projection: `reconcile(target)` with no cap/dedup/followed policy; render parity (bodies == field at rest) guaranteed even across background refresh.
+- Invariants applied exactly once at the field boundary.
+- Re-entry preserves the in-session field (TTL-fresh reuse + non-destructive delta) instead of wholesale replace.
+- Encode the Aurelia observation contract so the fix cannot silently regress.
+
+**Non-Goals:**
+- Web Worker / OffscreenCanvas physics offload (the `reconcile(target)` boundary is designed to enable it later, but it is out of scope here).
+- Redesigning the seed-similar recommendation logic itself (only *when* it runs changes).
+- Changing the 50-bubble cap value or the tap/absorption/search UX.
+- `content-visibility` based pause (current `visibilitychange` pause/resume is retained; CV is a later enhancement needing an IntersectionObserver fallback).
+
+## Decisions
+
+### D1: A single field owner (`DiscoveryFieldStore`), physics is a pure projection
+Introduce one owner of `field: Artist[]`. It applies the invariants (exclude-followed + dedup + cap) in one place when producing/updating the field. `BubblePhysics` gains `reconcile(target: Artist[])` that diffs `bubbleMap` against the target (keep/remove/add) and **removes the MAX-cap `break` and fading-body counting**. `BubblePool` is reduced to a pure dedup/cap helper (or folded into the owner) — it no longer holds a second authoritative copy.
+
+- **Alternative considered:** keep pool+physics separate and just fix the cap counting. Rejected — it patches the symptom (⑤) but leaves the divergence architecture (pool≠physics can still drift on any future path) and the duplicated invariants.
+- **Owner lifetime:** app-lifetime DI singleton (`DI.createInterface(..., x => x.singleton(...))`) so it survives the per-route component churn and can hold the session-preserve state.
+
+### D2: Aurelia observation contract (prevents regression)
+- The field is handed to the canvas as an **immutable snapshot (new array reference)** on every update. Aurelia's `[bindable]Changed` (`artistsChanged`) fires on reference change, not in-place mutation — so a new reference guarantees deterministic propagation. (The "never immutably replace domain state" rule does not apply: this is a derived *view projection*, not the source of truth.)
+- Multi-step field updates use `batch()` so `@observable` sync notifications collapse into one reconcile.
+- The reconcile applies physics changes aligned to the render loop / async flush — heavy work does not run synchronously inside the bindable callback (INP).
+- Separate concerns by lifecycle: router `loading()` only requests a field update on the owner; the canvas initializes from the owner's current snapshot in `attached()` (bottom-up, after the owner is ready) and reacts to subsequent changes. This removes the current `loading()`-before-canvas-attached ordering hazard.
+
+- **Alternative considered:** inject the field store directly into `dna-orb-canvas` and observe via `@watch`/`IObservation` instead of the `artists` bindable. Rejected as the default to keep the canvas presentational/testable; the bindable-snapshot contract achieves the same determinism. (Kept as a fallback if binding timing proves fragile.)
+
+### D3: Re-entry preserves the field via non-destructive delta
+On re-entry, if the cached field is fresh (within TTL) the owner reuses it and applies only: (a) remove newly-followed artists, (b) top-up **only** if below the display floor. No wholesale `replace()`. A stale (TTL-expired) field falls back to a full cold-style reload. TTL reuses the existing SWR staleness concept so there is a single freshness notion.
+
+- **Alternative considered:** keep the wholesale background replace but make it additive/stable. Rejected — replace inherently recomposes (seed-similar vs top) and is the root of the collapse; a delta is the minimal correct behavior.
+
+### D4: Collapse the two caches
+Remove `ArtistStore.lastBubbles`. The single bubble-field cache is owned by `DiscoveryFieldStore` (derived from the SWR `listTop` results after invariants). `ArtistStore` keeps only the raw-RPC SWR cache and is renamed conceptually to a repository role (rename optional/cosmetic, can defer).
+
+## Risks / Trade-offs
+
+- **[Risk] Behavior change: re-entry no longer re-rolls the field** → This is intended (proposal marks it BREAKING-UX). Mitigation: TTL-expiry still gives a fresh field periodically; the display floor keeps it full.
+- **[Risk] Removing the physics cap `break` could exceed 50 bodies if the field owner fails to cap** → Mitigation: cap is enforced at the field boundary (D-invariant), and physics keeps a *logged* hard safety ceiling (never a silent drop) per the spec.
+- **[Risk] Immutable-snapshot reassignment churns GC / re-runs reconcile** → Mitigation: reconcile is a diff (only add/remove deltas touch physics); array allocation of ≤50 refs per update is negligible.
+- **[Risk] Singleton field store leaking subscriptions across route churn** → Mitigation: canvas/route unsubscribe in `detaching`/`unbinding`; do not mutate `@observable` in `unbinding`.
+- **[Risk] Scope creep into seed-similar/worker** → Explicit Non-Goals; the `reconcile(target)` boundary is the only worker-enabling seam introduced.
+
+## Migration Plan
+
+Frontend-only; ships behind normal release. Phased so the visible bug is fixed early and independently:
+
+1. **Phase 0 (stop-the-bleed, independently shippable):** in `BubblePhysics`, make `reconcile(target)` a diff and stop counting fading-out bodies against capacity (remove the silent `break`). Restores render parity (physics == field) without the larger refactor.
+2. **Phase 1 (single source of truth):** introduce `DiscoveryFieldStore`, fold pool/`lastBubbles` into it, apply invariants once, wire the Aurelia snapshot/`batch()` contract.
+3. **Phase 2 (preserve on re-entry):** TTL-fresh reuse + non-destructive delta; remove wholesale replace.
+4. **Phase 3 (cleanup):** collapse caches, remove duplicated dedup/cap/followed sites, optional `ArtistStore`→repository rename.
+
+Rollback: each phase is a separate PR/release; revert the offending phase. No data migration.
+
+## Open Questions
+
+- Display floor value and TTL for re-entry reuse — reuse the existing SWR `staleTime` (24h) or a shorter session-scoped TTL? (Leaning: session-scoped freshness for reuse, SWR TTL for the raw cache.)
+- Should `DiscoveryFieldStore` be a true app singleton or a session-scoped store cleared on sign-out (to avoid cross-user field bleed)? (Leaning: singleton that clears on the same `SignedOut` event `FollowStore` already listens to.)

--- a/openspec/changes/refactor-discovery-bubble-field-state/proposal.md
+++ b/openspec/changes/refactor-discovery-bubble-field-state/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+The Discovery bubble field is represented in several independently-mutable stores (`ArtistStore.lastBubbles` cache, a per-route `BubblePool`, the `BubblePhysics.bubbleMap`, plus the `listTop` SWR cache), synchronized only by a lossy imperative reconcile. There is no enforced single source of truth, and the same invariants (exclude-followed, 50-cap, dedup) are re-implemented in 3–4 places with different semantics. As a result the rendered field can silently diverge from the data pool — a prod re-entry reproduces pool=33 but only 16 bubbles rendered — and the field the user was looking at is discarded and re-derived on every re-entry, so navigating away and back collapses a full field to a few bubbles. The existing `bubble-state-management` spec already asserts "pool count and physics body count SHALL be equal", but the implementation does not satisfy it.
+
+## What Changes
+
+- Establish a single owner of "the current display field" (`Artist[]`); the pool cache, physics bodies, and SWR cache all derive from it. Remove the duplicate `ArtistStore.lastBubbles` snapshot in favor of one cache.
+- Make the physics/canvas layer a **pure projection** of the field: it reconciles its bodies to a target list and MUST NOT own the capacity cap, dedup, or followed-exclusion. Guarantee rendered-body count equals the field count at rest, including across background-refresh transitions (fixes the fading-body cap contention that silently drops bubbles).
+- Apply the invariants (exclude-followed, 50-cap, dedup) exactly once, at the field-update boundary — not at each call site (`loading()`, `loadInitialArtists`, `genre`, `onArtistSelected`).
+- Re-entry within a session preserves the field the user was viewing: reuse the existing field when fresh (within TTL) and apply a **non-destructive delta** (drop newly-followed, top-up only if below the floor) instead of a wholesale `pool.replace()` that shrinks and re-composes the field. **BREAKING (UX)**: returning to Discovery no longer re-rolls the bubble field.
+- Encode the Aurelia observation contract so the fix does not regress: the display field propagates to the canvas as an immutable snapshot (reference change) so the change callback fires deterministically; multi-step updates use `batch()`; data fetch (router `loading`) is separated from view init (`attached`).
+
+## Capabilities
+
+### New Capabilities
+
+_None._
+
+### Modified Capabilities
+
+- `bubble-state-management`: enforce a real single source of truth — physics becomes a pure projection that reconciles to the field with no independent cap/dedup; rendered count equals field count at rest even during refresh; capacity/dedup/followed-exclusion applied once at the field boundary.
+- `discovery-bubble-cache`: re-entry preserves the prior in-session field (TTL-fresh) and applies a non-destructive delta (remove followed, top-up below floor) rather than a full replace; collapse the two overlapping caches (`lastBubbles` + `listTop` SWR) into one.
+
+## Impact
+
+- Frontend only — no proto/API/backend change.
+- `frontend/src/routes/discovery/` — `discovery-route.ts` (loading/loadInitialBubbles/onReset/onArtistSelected/onFollowFromSearch), `bubble-manager.ts`, `genre-filter-controller.ts`.
+- `frontend/src/services/` — `artist-store.ts` (remove `lastBubbles`, keep single SWR cache), `bubble-pool.ts` (reduced to pure dedup/cap helper or folded into the field owner).
+- `frontend/src/components/dna-orb/` — `dna-orb-canvas.ts` (`artistsChanged` → declarative reconcile), `bubble-physics.ts` (`reconcile(target)`; drop the MAX-cap `break` and fading-body counting).
+- Related specs touched at the edges: `bubble-pool-lifecycle` (cap/dedup ownership), `artist-discovery-dna-orb-ui` (physics render parity). Unblocks a future Web-Worker/OffscreenCanvas split (the `reconcile(target)` boundary is serializable).

--- a/openspec/changes/refactor-discovery-bubble-field-state/specs/bubble-state-management/spec.md
+++ b/openspec/changes/refactor-discovery-bubble-field-state/specs/bubble-state-management/spec.md
@@ -1,0 +1,59 @@
+## MODIFIED Requirements
+
+### Requirement: BubbleManager provides single source of truth for bubble lifecycle
+The system SHALL manage the current display field (`Artist[]`) through a single owner (the BubbleManager / field state), and every other representation — the physics bodies, any cache — SHALL be a derived projection of that field. Pool state and physics state SHALL be synchronized such that the rendered physics-body count equals the field count at rest, including after a background refresh replaces the field. No representation other than the field owner SHALL hold authoritative membership.
+
+#### Scenario: Adding bubbles synchronizes pool and physics
+- **WHEN** new artist bubbles are added to the field
+- **THEN** the BubbleManager SHALL update the field AND the physics projection SHALL reconcile to it
+- **AND** the field count and physics body count SHALL be equal after the operation
+
+#### Scenario: Removing a bubble synchronizes pool and physics
+- **WHEN** an artist bubble is removed from the field (e.g., followed)
+- **THEN** the BubbleManager SHALL remove it from the field AND the physics projection SHALL remove the body
+- **AND** no orphaned physics bodies SHALL remain
+
+#### Scenario: Eviction synchronizes pool and physics
+- **WHEN** the field owner evicts oldest bubbles to make room for new ones
+- **THEN** the evicted physics bodies SHALL fade out
+- **AND** the evicted artists SHALL be removed from the field
+- **AND** the field and physics counts SHALL remain equal after eviction completes
+
+#### Scenario: Background refresh preserves render parity
+- **WHEN** a background load produces a new field that differs from the currently rendered set
+- **THEN** the physics projection SHALL converge to exactly the new field
+- **AND** the rendered body count SHALL equal the new field count at rest
+- **AND** no field member SHALL be dropped from rendering because fading-out bodies temporarily occupied capacity
+
+## ADDED Requirements
+
+### Requirement: Physics layer is a pure projection of the field
+The physics/canvas layer SHALL render the field it is given and SHALL NOT own bubble policy. It SHALL NOT apply the capacity cap, deduplication, or followed-artist exclusion; those are guaranteed upstream by the field owner. The physics layer SHALL expose a reconcile operation that diffs its current bodies against a target `Artist[]` and applies only the additions and removals needed to match it.
+
+#### Scenario: Reconcile to a target list
+- **WHEN** the physics layer is asked to reconcile to a target field
+- **THEN** it SHALL keep bodies whose artist is still in the target, remove bodies no longer in the target, and add bodies for new artists in the target
+- **AND** the resulting body set SHALL equal the target
+
+#### Scenario: Fading-out bodies do not block replacements
+- **WHEN** bodies are fading out while new artists are being added in the same reconcile
+- **THEN** the fading-out bodies SHALL NOT count against capacity such that new artists are dropped
+- **AND** every artist in the target SHALL receive a body
+
+#### Scenario: Physics never silently drops a target member
+- **WHEN** a reconcile target is applied
+- **THEN** the physics layer SHALL NOT silently discard any target artist due to a capacity check
+- **AND** if a hard safety cap is ever hit, it SHALL be logged rather than dropped silently
+
+### Requirement: Bubble invariants are applied once at the field boundary
+The invariants — exclude followed artists, deduplicate by name/id/mbid, and enforce the 50-bubble capacity — SHALL be applied exactly once, when the field owner produces or updates the field. Downstream consumers (router hooks, genre/reset/search flows, the physics layer) SHALL NOT re-apply these invariants independently.
+
+#### Scenario: Followed exclusion happens once
+- **WHEN** the field is produced or updated from any source (initial load, cache re-entry, genre, reset, similar top-up)
+- **THEN** followed-artist exclusion SHALL be applied by the field owner as part of producing the field
+- **AND** no consumer SHALL re-filter followed artists after the field is produced
+
+#### Scenario: Capacity enforced once
+- **WHEN** the field is produced or updated
+- **THEN** the 50-bubble capacity SHALL be enforced by the field owner
+- **AND** the physics layer SHALL receive a field already within capacity and SHALL NOT re-cap it

--- a/openspec/changes/refactor-discovery-bubble-field-state/specs/discovery-bubble-cache/spec.md
+++ b/openspec/changes/refactor-discovery-bubble-field-state/specs/discovery-bubble-cache/spec.md
@@ -1,0 +1,52 @@
+## MODIFIED Requirements
+
+### Requirement: Discovery bubble pool is cached in ArtistStore singleton
+The system SHALL cache the last successfully generated bubble field (`Artist[]`) in a single app-lifetime store so that `DiscoveryRoute` re-entries can paint real artists immediately without waiting on network RPCs. There SHALL be exactly one authoritative bubble-field cache; the raw `listTop` SWR cache and the display-field cache SHALL NOT be maintained as two independent snapshots of the same field.
+
+#### Scenario: Re-entry paints cached artists instantly
+- **WHEN** the user navigates to Discovery after a prior visit
+- **AND** at least one cached artist is not yet followed
+- **THEN** the bubble field SHALL be initialized from the cached field synchronously during `loading()`
+- **AND** followed artists SHALL be excluded as part of producing the field
+- **AND** no ghost bubbles SHALL be shown
+- **AND** any background refresh SHALL reconcile the field via a non-destructive delta (see "Re-entry preserves the in-session bubble field"), NOT a wholesale replacement that recomposes or shrinks the visible field
+
+#### Scenario: Cache excludes followed artists on re-entry
+- **WHEN** the cached bubble field contains artists that the user has since followed
+- **THEN** those artists SHALL be excluded when the field is produced
+- **AND** the followed artists SHALL NOT appear as bubbles in the physics engine
+
+#### Scenario: Cold visit uses ghost bubbles
+- **WHEN** no cached field exists (first visit or cache cleared)
+- **THEN** the route SHALL initialize with ghost placeholder bubbles as the current behavior
+- **AND** switch to real artists when the initial load completes
+
+#### Scenario: Cache is updated after each successful load
+- **WHEN** an initial load or refresh completes successfully
+- **THEN** the resulting field SHALL be persisted to the single bubble-field cache
+- **AND** the next re-entry SHALL use the updated field
+
+## ADDED Requirements
+
+### Requirement: Re-entry preserves the in-session bubble field
+Within a session, navigating away from Discovery and back SHALL preserve the field the user was viewing rather than re-deriving it. When the cached field is fresh (within its TTL), the system SHALL reuse it and apply only a non-destructive delta; it SHALL NOT issue a wholesale `replace()` that recomposes the field or reduces it below the display floor.
+
+#### Scenario: Fresh field is reused on re-entry
+- **WHEN** the user returns to Discovery within the cache TTL
+- **THEN** the previously displayed field SHALL be reused as the starting field
+- **AND** the rendered bubble count SHALL NOT drop below the count shown before leaving, except for artists the user followed while away
+
+#### Scenario: Non-destructive delta on refresh
+- **WHEN** a background refresh runs on re-entry
+- **THEN** it SHALL remove only newly-followed artists and top up only if the field is below the display floor
+- **AND** it SHALL NOT replace the entire field with a freshly-fetched set that changes composition or shrinks the field
+
+#### Scenario: Follow while away is reconciled without collapsing the field
+- **WHEN** the user followed one or more artists on another route and returns to Discovery
+- **THEN** only the newly-followed artists SHALL be removed from the field
+- **AND** the remaining bubbles SHALL stay, with top-up applied only to restore the display floor
+
+#### Scenario: Stale field triggers a full reload
+- **WHEN** the user returns to Discovery after the cache TTL has expired
+- **THEN** the system MAY perform a full reload as on a cold visit
+- **AND** the reload SHALL still converge to a field within capacity with render parity

--- a/openspec/changes/refactor-discovery-bubble-field-state/tasks.md
+++ b/openspec/changes/refactor-discovery-bubble-field-state/tasks.md
@@ -1,0 +1,41 @@
+## 1. Phase 0 — Stop-the-bleed: physics render parity (independently shippable)
+
+- [ ] 1.1 `bubble-physics.ts`: add `reconcile(target: Artist[])` that diffs `bubbleMap` vs target (keep matching ids, fade/remove ids not in target, add ids not present)
+- [ ] 1.2 `bubble-physics.ts`: stop counting fading-out bodies against capacity when adding; remove the silent `break` in `addBubbles` cap path (replace with a logged hard safety ceiling that never silently drops a target member)
+- [ ] 1.3 `dna-orb-canvas.ts`: route `artistsChanged` through `physics.reconcile(newVal)` instead of the fade-out + `revealGhostBubbles` + `addBubbles` sequence for the real-artist path
+- [ ] 1.4 Unit tests: reconcile converges body set to target; background-refresh transition ends with body count == field count (covers `bubble-state-management` "Background refresh preserves render parity" + "Physics never silently drops a target member")
+- [ ] 1.5 `make check` green
+- [ ] 1.6 Frontend PR → CI green → merge → Release → prod roll; verify re-entry render parity in prod (pool count == rendered bubble count)
+
+## 2. Phase 1 — Single source of truth (DiscoveryFieldStore)
+
+- [ ] 2.1 Add `DiscoveryFieldStore` (DI app-singleton) owning `field: Artist[]`, with a single `setField`/`update` path that applies invariants (exclude-followed + dedup + 50-cap) exactly once
+- [ ] 2.2 Move follow-exclusion, dedup, and cap out of `discovery-route.ts` `loading()`, `bubble-manager.ts`, and `genre-filter-controller.ts` into the field store's single boundary (covers `bubble-state-management` "Bubble invariants are applied once at the field boundary")
+- [ ] 2.3 Reduce `BubblePool` to a pure dedup/cap helper (or fold into the field store); remove its role as a second authoritative membership store
+- [ ] 2.4 Aurelia observation contract: field store emits an immutable snapshot (new array reference) on each update; wire the canvas to consume it so `artistsChanged` fires deterministically; wrap multi-step updates in `batch()`
+- [ ] 2.5 Separate lifecycle: `loading()` only requests a field update; canvas initializes from the store snapshot in `attached()` and reconciles on change; unsubscribe in `detaching`/`unbinding`
+- [ ] 2.6 Unit tests: invariants applied once (no double-filter downstream); field↔physics parity on add/remove/evict (covers `bubble-state-management` SSoT scenarios)
+- [ ] 2.7 `make check` green
+- [ ] 2.8 Frontend PR → CI green → merge → Release → prod roll
+
+## 3. Phase 2 — Preserve the in-session field on re-entry
+
+- [ ] 3.1 Field store: on re-entry, if the cached field is fresh (within TTL) reuse it and apply a non-destructive delta (remove newly-followed, top-up only below the display floor); no wholesale `replace()`
+- [ ] 3.2 Field store: stale (TTL-expired) re-entry falls back to a full cold-style reload that still converges within capacity with render parity
+- [ ] 3.3 Remove the unconditional wholesale background `pool.replace()` on re-entry from `discovery-route.ts` / `bubble-manager.ts`
+- [ ] 3.4 Unit tests: fresh re-entry reuses field and does not shrink below prior count (minus follows); follow-while-away removes only the followed and tops up to floor (covers `discovery-bubble-cache` re-entry-preservation scenarios)
+- [ ] 3.5 `make check` green
+- [ ] 3.6 Frontend PR → CI green → merge → Release → prod roll; verify in prod: navigate away and back keeps the field (no collapse to a few bubbles), following an artist then re-entering removes only that artist
+
+## 4. Phase 3 — Cleanup: collapse caches and duplicated logic
+
+- [ ] 4.1 Remove `ArtistStore.lastBubbles` (`peekBubbles`/`setBubbles`); the single bubble-field cache lives in `DiscoveryFieldStore` derived from the SWR `listTop` results (covers `discovery-bubble-cache` single-cache requirement)
+- [ ] 4.2 Remove any remaining duplicated dedup/cap/followed-filter call sites; confirm the physics layer applies no policy
+- [ ] 4.3 (Optional) Rename `ArtistStore` to a repository role to reflect raw-RPC-cache-only responsibility
+- [ ] 4.4 `make check` green
+- [ ] 4.5 Frontend PR → CI green → merge → Release → prod roll
+
+## 5. Close-out
+
+- [ ] 5.1 Verify all delta spec scenarios are satisfied by the shipped implementation (render parity, invariants-once, re-entry preservation, single cache)
+- [ ] 5.2 Archive the change (sync deltas into `bubble-state-management` and `discovery-bubble-cache` canonical specs)


### PR DESCRIPTION
## Summary

OpenSpec proposal (spec artifacts only — no implementation) for redesigning Discovery bubble state management around a single source of truth.

The current field is spread across independently-mutable stores — `ArtistStore.lastBubbles`, a per-route `BubblePool`, `BubblePhysics.bubbleMap`, and the `listTop` SWR cache — synchronized by a lossy imperative reconcile, with the exclude-followed / 50-cap / dedup invariants re-implemented in 3–4 places with different semantics. Consequences confirmed in prod:

- The rendered field diverges from the data pool: a re-entry with 6 follows reproduces **pool = 33 but only 16 bubbles rendered** (physics cap counts still-fading bodies and silently `break`s, dropping ~17 artists that are never retried).
- Every re-entry re-derives the field, so navigating away and back **collapses a full field to a few bubbles**.

The existing `bubble-state-management` spec already asserts "pool count and physics body count SHALL be equal" — which the implementation does not satisfy.

## Changes

Spec-driven change `refactor-discovery-bubble-field-state`:

- **proposal.md** — problem, scope (frontend-only, no proto/API), modified capabilities.
- **design.md** — decisions D1–D4: one field owner applies invariants once; physics becomes a pure projection (`reconcile(target)`, no independent cap/dedup); re-entry preserves the in-session field via a non-destructive delta; two caches collapsed to one. Encodes the Aurelia observation contract (immutable snapshot → deterministic `artistsChanged`, `batch()`, `loading`/`attached` separation) and notes the INP/Web-Worker seam. Reviewed against the aurelia-specialist and modern-web-guidance skills.
- **specs/bubble-state-management/spec.md** — MODIFIED (real single source of truth + render parity across background refresh) + ADDED (physics as pure projection; invariants applied once at the field boundary).
- **specs/discovery-bubble-cache/spec.md** — MODIFIED (single cache, non-destructive delta) + ADDED (re-entry preserves the in-session field).
- **tasks.md** — phased plan: Phase 0 (stop-the-bleed render parity, independently shippable) → Phase 1 (single source of truth) → Phase 2 (preserve on re-entry) → Phase 3 (cleanup); each phase ships to prod.

`openspec validate --strict` passes.

## Testing

- `openspec validate refactor-discovery-bubble-field-state --strict` → valid.
- No code changes in this PR; implementation follows via `/opsx:apply` per phase, each with its own tests and prod verification.

## Related

Refs: #737 — this refactor is the follow-up from the #737 investigation (the dimmed-bubble fix shipped and archived; this addresses the underlying state-management design surfaced during that verification). Not a close: implementation lands across subsequent phase PRs.
