### PR TITLE
docs(openspec): propose fix-brand-label-consistency

### DIFF
--- a/openspec/changes/fix-brand-label-consistency/.openspec.yaml
+++ b/openspec/changes/fix-brand-label-consistency/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-09

--- a/openspec/changes/fix-brand-label-consistency/design.md
+++ b/openspec/changes/fix-brand-label-consistency/design.md
@@ -1,0 +1,56 @@
+## Context
+
+Two small, related frontend presentation bugs concern how the product's own name and navigation labels are shown to users.
+
+1. **PWA home-screen label.** `frontend/public/manifest.webmanifest` declares `name: "Liverty Music"` and `short_name: "Liverty"`. Per the Web App Manifest spec, launchers prefer `short_name` for the space-constrained home-screen icon label; on Android it is the primary label and on iOS/iPadOS (16.4+) the manifest `short_name` takes precedence over the legacy `apple-mobile-web-app-title` meta tag (which this app does not set). So the installed icon reads "Liverty" — an abbreviation, not the service name.
+
+2. **Settings header locale inconsistency.** Every main tab route binds its `page-header` to a `nav.*` key, and `nav.*` labels are catalogued as invariant-English Layer B brand expressions (they read "Timetable" / "Discovery" / "My Artists" / "Tickets" in both JA and EN). The Settings route alone binds `title-key="settings.title"`, which is a Layer-A-style localized string ("設定" in JA). On a Japanese-locale device, the Settings header is therefore the only tab header rendered in Japanese, breaking the visual consistency of the tab set.
+
+The `page-header` custom element resolves any `title-key` via the i18n `t` binding; the behavior difference is entirely in which key each route chooses. `nav.settings` already exists and is `"Settings"` in both locales. `settings.title` is referenced only by the Settings header.
+
+## Goals / Non-Goals
+
+**Goals:**
+- The installed PWA home-screen icon presents the real service name, not the "Liverty" abbreviation.
+- The Settings page header is invariant English "Settings", consistent with sibling tab headers.
+- The product name's canonical brand forms are recorded authoritatively so they cannot drift silently.
+
+**Non-Goals:**
+- No change to the manifest `name` field (stays "Liverty Music"), icons, theme color, or any other manifest member.
+- No change to the `page-header` custom element contract.
+- No cleanup of the unrelated `import-ticket-email` route, whose header is a hard-coded Japanese `title="チケットメール取り込み"` (a separate, out-of-scope inconsistency).
+- No attempt to re-label already-installed home-screen icons; the OS controls that and only refreshes on re-install.
+
+## Decisions
+
+### Decision 1: `short_name` = "LivertyMusic" (single word, no space)
+
+Set `short_name` to `"LivertyMusic"` rather than `"Liverty Music"`.
+
+- **Why:** Home-screen label truncation is launcher- and glyph-width-dependent (~12–15 chars typical: ~15 on Pixel/stock, ~14 Samsung One UI, ~12 on budget devices, ~16 Nova), not a fixed OS limit. `"LivertyMusic"` is 12 characters and avoids the space that could trigger wrapping or an earlier cut; it also matches `short_name`'s intended role as the space-constrained short form. `"Liverty Music"` (13 chars incl. space) risks "Liverty Musi…" on the narrowest launchers.
+- **Alternative considered — keep `name` and `short_name` identical ("Liverty Music"):** rejected for the truncation risk above and because it defeats the purpose of `short_name`.
+- **Alternative considered — leave `short_name` "Liverty":** rejected; that is the bug being fixed.
+
+### Decision 2: Settings header switches to `nav.settings`, not a JA→EN edit of `settings.title`
+
+Change the Settings route to `<page-header title-key="nav.settings">`.
+
+- **Why:** `nav.settings` is already the invariant-English Layer B label used by the bottom navigation, so the page header and the nav tab share one source of truth and Settings joins the exact pattern its siblings use. One HTML line changes.
+- **Alternative considered — rewrite `settings.title` in the JA locale from "設定" to "Settings":** rejected; it injects an English literal into the localized (Layer A-style) namespace, contradicting the two-layer brand-vocabulary model, and leaves two keys that must be kept in sync.
+- **Follow-through:** `settings.title` becomes unreferenced; remove it from both `ja` and `en` translation JSON to avoid a dead key. The `brand-vocabulary` lint enforces `entity.*` parity only, so removing a `settings.*` key is safe.
+
+### Decision 3: Record the product name in the `brand-vocabulary` Layer B catalogue
+
+Add the product name to the Layer B brand-expression catalogue: full form "Liverty Music" (manifest `name`, `<title>`, prose) and EN home-screen short form "LivertyMusic" (manifest `short_name`).
+
+- **Why:** The product name has no protobuf entity backing, so by the two-layer model it is a Layer B brand expression whose canonical forms belong in this spec. Recording it makes "LivertyMusic" the authoritative short form and prevents future re-abbreviation to "Liverty".
+
+## Risks / Trade-offs
+
+- **Already-installed icons keep the old "Liverty" label** → Mitigation: expected OS behavior; the corrected label appears on re-install / new installs. No action available or needed.
+- **"LivertyMusic" (12 chars, wide "M") could still truncate on the very narrowest launchers** → Mitigation: accepted; it is materially better than "Liverty Music" and the exact cut point is device-controlled. Correct branding outweighs a marginal truncation edge case.
+- **Removing `settings.title` could orphan an external reference** → Mitigation: repo grep confirms the key is used only by the Settings header before removal; the change is verified by `make check` (typecheck + lint) and the Settings header E2E/test.
+
+## Migration Plan
+
+Standard frontend change → PR → merge → GitHub Release → automated prod pin-bump → ArgoCD sync. No data migration. Rollback is a normal revert; the manifest and header changes are stateless. Verify the installed-PWA label and the Settings header render post-release.

--- a/openspec/changes/fix-brand-label-consistency/proposal.md
+++ b/openspec/changes/fix-brand-label-consistency/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+The PWA install on Android (and iOS) shows the home-screen label "Liverty" because the web app manifest's `short_name` is set to the abbreviated word "Liverty" instead of the real service name. Separately, the Settings page header is the only main tab whose header switches by locale (renders "設定" in Japanese) while every sibling tab page (Timetable, Discovery, My Artists, Tickets) renders an invariant English brand label. Both are user-visible inconsistencies in how the product's own name and navigation labels are presented.
+
+## What Changes
+
+- Change the PWA manifest `short_name` from `"Liverty"` to `"LivertyMusic"` so the home-screen icon label reads the correct service name. The `name` field stays `"Liverty Music"`. `"LivertyMusic"` (12 chars, no space) is chosen to minimize home-screen label truncation, which is launcher/width dependent (~12–15 chars) rather than a fixed OS limit.
+- Change the Settings route header to render the invariant English brand label "Settings" (via the existing `nav.settings` key, which is already `"Settings"` in both JA and EN locales) instead of the locale-switched `settings.title`. This aligns Settings with its sibling tab pages, which all bind `title-key="nav.*"`.
+- Catalogue the product name as a Layer B brand expression in `brand-vocabulary` so the canonical home-screen (`LivertyMusic`) and full (`Liverty Music`) forms are authoritative and cannot drift silently.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `app-shell-layout`: the web app manifest requirement gains explicit canonical values — `name` = "Liverty Music" and `short_name` = "LivertyMusic" — so the installed home-screen label presents the correct service name.
+- `settings`: the fixed Settings page header SHALL render the invariant English brand label "Settings" (the Layer B navigation label), consistent with sibling tab pages, rather than a locale-switched title string.
+- `brand-vocabulary`: the Layer B brand-expression catalogue gains the product name (full form "Liverty Music" / EN home-screen short form "LivertyMusic") and affirms the bottom-navigation / page-header tab labels as invariant-English Layer B expressions.
+
+## Impact
+
+- Frontend only. No backend, proto, or infrastructure changes.
+- `frontend/public/manifest.webmanifest` — `short_name` value.
+- `frontend/src/routes/settings/settings-route.html` — `page-header` `title-key`.
+- `frontend/src/locales/{ja,en}/translation.json` — `settings.title` becomes unreferenced and MAY be removed.
+- Ships via the standard frontend release → prod pin-bump path. The manifest change takes effect on next PWA install / manifest re-fetch; already-installed home-screen icons keep their old label until re-installed (OS-controlled).

--- a/openspec/changes/fix-brand-label-consistency/specs/app-shell-layout/spec.md
+++ b/openspec/changes/fix-brand-label-consistency/specs/app-shell-layout/spec.md
@@ -1,0 +1,27 @@
+## MODIFIED Requirements
+
+### Requirement: Brand Identity Elements
+The system SHALL display proper brand identity elements across the application.
+
+#### Scenario: Page title displays service name
+- **WHEN** any page is loaded
+- **THEN** the HTML `<title>` SHALL include "Liverty Music" (e.g., "Liverty Music" or "Liverty Music - [Page Name]")
+- **AND** the system SHALL NOT display default scaffold or template names (e.g., "Aurelia", "Vite", "React App")
+
+#### Scenario: Favicon and PWA icons
+- **WHEN** the application is loaded
+- **THEN** the system SHALL display a brand favicon in the browser tab, served as PNG and ICO assets (no SVG favicon is required)
+- **AND** the system SHALL provide an `apple-touch-icon` PNG for the iOS home screen
+- **AND** the system SHALL provide a web app manifest with themed PNG icons (including a maskable variant) for Android and other PWA-compliant platforms
+- **AND** the web app manifest SHALL NOT reference SVG icon assets
+
+#### Scenario: Web app manifest declares the service name
+- **WHEN** the web app manifest is served
+- **THEN** the manifest `name` member SHALL be "Liverty Music"
+- **AND** the manifest `short_name` member SHALL be "LivertyMusic"
+- **AND** the `short_name` SHALL NOT be an abbreviation that omits part of the service name (e.g. "Liverty")
+- **AND** consequently the installed PWA home-screen icon label SHALL present the service name rather than an abbreviation
+
+#### Scenario: Theme color is consistent across HTML and manifest
+- **WHEN** the application is loaded
+- **THEN** the `theme-color` declared in the HTML `<head>` meta tag SHALL equal the `theme_color` declared in the web app manifest

--- a/openspec/changes/fix-brand-label-consistency/specs/brand-vocabulary/spec.md
+++ b/openspec/changes/fix-brand-label-consistency/specs/brand-vocabulary/spec.md
@@ -1,0 +1,49 @@
+## MODIFIED Requirements
+
+### Requirement: Brand Expression Registry
+The system SHALL maintain a single registry table in this spec listing every Layer B brand expression with its canonical JA and EN forms.
+
+#### Scenario: Initial registry contents
+- **WHEN** this spec is interpreted at the current revision
+- **THEN** the registry SHALL include the following Layer B expressions, each with identical JA and EN surface forms unless otherwise noted:
+  - `Product name — full form` — JA: `Liverty Music` / EN: `Liverty Music` (used in the HTML `<title>`, the web app manifest `name` member, and prose)
+  - `Product name — home-screen short form` — JA: `LivertyMusic` / EN: `LivertyMusic` (the web app manifest `short_name` member, chosen without a space to minimize home-screen label truncation)
+  - `Navigation tab — Timetable` — JA: `Timetable` / EN: `Timetable`
+  - `Navigation tab — Discovery` — JA: `Discovery` / EN: `Discovery`
+  - `Navigation tab — My Artists` — JA: `My Artists` / EN: `My Artists`
+  - `Navigation tab — Tickets` — JA: `Tickets` / EN: `Tickets`
+  - `Navigation tab — Settings` — JA: `Settings` / EN: `Settings`
+  - `Personal timetable promise` — JA: `あなただけのタイムテーブル` / EN: `your personal timetable`
+  - `HOME STAGE lane` — JA: `HOME STAGE` / EN: `HOME STAGE`
+  - `NEAR STAGE lane` — JA: `NEAR STAGE` / EN: `NEAR STAGE`
+  - `AWAY STAGE lane` — JA: `AWAY STAGE` / EN: `AWAY STAGE`
+  - `Hype concept label` — JA: `Hype` / EN: `Hype`
+  - `Hype tier — Watch` — JA: `Watch` / EN: `Watch`
+  - `Hype tier — Home` — JA: `Home` / EN: `Home`
+  - `Hype tier — Nearby` — JA: `Nearby` / EN: `Nearby`
+  - `Hype tier — Away` — JA: `Away` / EN: `Away`
+
+#### Scenario: Navigation tab labels are invariant across locales
+- **WHEN** a navigation tab label is rendered in any UI surface (bottom navigation bar or a route's page header)
+- **THEN** the label SHALL be the invariant English form from the registry, identical in JA and EN locales
+- **AND** a route's page header SHALL bind the shared `nav.*` label rather than a separate localized title key
+
+#### Scenario: Adding a new brand expression
+- **WHEN** a new coined phrase is introduced into user-facing copy
+- **AND** the phrase has no corresponding protobuf entity
+- **THEN** a row SHALL be added to this spec's registry table before or alongside the change that introduces the phrase
+
+#### Scenario: Removing a graduated expression
+- **WHEN** a Layer B expression becomes entity-modeled and is migrated to Layer A
+- **THEN** its row SHALL be removed from this spec's registry table in the same change that performs the migration
+
+#### Scenario: Japanese gloss is prose, not label
+- **WHEN** a Japanese-locale help or descriptive sentence introduces a Layer B brand expression that may be unfamiliar to first-time JA readers (e.g. `Hype`)
+- **THEN** the sentence MAY include a parenthetical gloss (e.g. `Hype（熱量）`) inline within the prose
+- **AND** the gloss SHALL NOT be promoted to the canonical surface label or stored as a separate i18n key
+
+#### Scenario: Registry SHALL NOT include deprecated colloquial terms
+
+- **WHEN** a colloquial JA term (such as `推し`) is identified as deprecated per the Deprecated Colloquial Terms requirement
+- **THEN** the term SHALL NOT be listed in the Layer B brand expression registry
+- **AND** the term SHALL instead be tracked in the deprecated-terms registry with its canonical entity-grounded replacement

--- a/openspec/changes/fix-brand-label-consistency/specs/settings/spec.md
+++ b/openspec/changes/fix-brand-label-consistency/specs/settings/spec.md
@@ -1,0 +1,14 @@
+## ADDED Requirements
+
+### Requirement: Settings Page Header Label
+The Settings page header SHALL render the invariant English brand label "Settings" — the Layer B navigation tab label — rather than a locale-switched title string, so that the Settings header is consistent with its sibling tab pages whose headers all bind an invariant `nav.*` label.
+
+#### Scenario: Header reads "Settings" regardless of active locale
+- **WHEN** the Settings page is loaded with the active locale set to Japanese
+- **THEN** the page header SHALL display "Settings"
+- **AND** it SHALL NOT display a Japanese translation of the header (e.g. "設定")
+
+#### Scenario: Header shares the navigation tab label source
+- **WHEN** the Settings route renders its `page-header`
+- **THEN** the header title SHALL resolve from the same invariant navigation label used by the bottom-navigation Settings tab (the `nav.settings` key, "Settings" in both JA and EN locales)
+- **AND** the header SHALL NOT depend on a separate localized `settings.title` string

--- a/openspec/changes/fix-brand-label-consistency/tasks.md
+++ b/openspec/changes/fix-brand-label-consistency/tasks.md
@@ -1,0 +1,19 @@
+## 1. PWA manifest short_name
+
+- [ ] 1.1 In `frontend/public/manifest.webmanifest`, change `short_name` from `"Liverty"` to `"LivertyMusic"` (leave `name` as `"Liverty Music"` and all other members unchanged)
+
+## 2. Settings header invariant label
+
+- [ ] 2.1 In `frontend/src/routes/settings/settings-route.html`, change the header binding from `title-key="settings.title"` to `title-key="nav.settings"` (keep the `data-testid="settings-header"` attribute)
+- [ ] 2.2 Remove the now-unreferenced `settings.title` key from both `frontend/src/locales/ja/translation.json` and `frontend/src/locales/en/translation.json` (grep-confirm no other reference before removing)
+
+## 3. Local verification
+
+- [ ] 3.1 Run `make check` in `frontend` (Biome lint + format + stylelint + typecheck + brand-vocabulary + tests) and confirm it passes
+- [ ] 3.2 Confirm the Settings header renders "Settings" under both `ja` and `en` locales, and that no existing Settings test/E2E asserts the old "設定" header (update assertions if any reference `settings.title`)
+
+## 4. Ship to production
+
+- [ ] 4.1 Open the frontend PR (Conventional Commits, mandatory body + `Refs: #<issue>` footer), wait for all CI checks to pass, address review, and merge
+- [ ] 4.2 Cut the frontend GitHub Release so the automated prod pin-bump lands the new tag and ArgoCD syncs prod
+- [ ] 4.3 Verify in production: the served `manifest.webmanifest` reports `short_name: "LivertyMusic"`, a fresh PWA install shows the correct home-screen label, and the Settings header renders "Settings"


### PR DESCRIPTION
## Summary

Proposes the OpenSpec change `fix-brand-label-consistency` to correct two user-visible brand-label inconsistencies in the frontend. Proposal-only PR (documents + spec deltas); implementation lands in a follow-up frontend PR via `/opsx:apply`.

## Why

1. **PWA home-screen label reads "Liverty".** The web app manifest sets `short_name: "Liverty"`, an abbreviation. Launchers prefer `short_name` for the home-screen icon label — on Android as the primary label, and on iOS/iPadOS 16.4+ the manifest `short_name` takes precedence over the legacy `apple-mobile-web-app-title` meta tag (unset here). So the installed icon shows "Liverty" instead of the service name.
2. **Settings header switches by locale.** Every main tab route binds its `page-header` to an invariant-English `nav.*` label (Timetable / Discovery / My Artists / Tickets). The Settings route alone binds `title-key="settings.title"`, a localized string ("設定" in JA), making it the only tab header rendered in Japanese on a JA-locale device.

## Changes (proposed)

- **Manifest**: `short_name` `"Liverty"` → `"LivertyMusic"` (12 chars, no space to minimize home-screen truncation, which is launcher/glyph-width dependent ~12–15 chars; `name` stays `"Liverty Music"`).
- **Settings header**: `title-key="settings.title"` → `"nav.settings"` (already `"Settings"` in both locales); remove the now-unreferenced `settings.title` key.
- **Spec deltas**:
  - `app-shell-layout` — manifest `name`/`short_name` canonical values.
  - `settings` — header renders the invariant English brand label.
  - `brand-vocabulary` — product name + navigation tab labels catalogued as Layer B brand expressions.

## Scope note

The `import-ticket-email` route's hard-coded Japanese header (`title="チケットメール取り込み"`) is a separate inconsistency, intentionally out of scope.

## Testing

- `openspec validate fix-brand-label-consistency --strict` passes.

close: #748
