### PR TITLE
docs(openspec): mark refactor-discovery-bubble-field-state Phase 0 complete

### DIFF
--- a/openspec/changes/refactor-discovery-bubble-field-state/tasks.md
+++ b/openspec/changes/refactor-discovery-bubble-field-state/tasks.md
@@ -1,11 +1,11 @@
 ## 1. Phase 0 — Stop-the-bleed: physics render parity (independently shippable)
 
-- [ ] 1.1 `bubble-physics.ts`: add `reconcile(target: Artist[])` that diffs `bubbleMap` vs target (keep matching ids, fade/remove ids not in target, add ids not present)
-- [ ] 1.2 `bubble-physics.ts`: stop counting fading-out bodies against capacity when adding; remove the silent `break` in `addBubbles` cap path (replace with a logged hard safety ceiling that never silently drops a target member)
-- [ ] 1.3 `dna-orb-canvas.ts`: route `artistsChanged` through `physics.reconcile(newVal)` instead of the fade-out + `revealGhostBubbles` + `addBubbles` sequence for the real-artist path
-- [ ] 1.4 Unit tests: reconcile converges body set to target; background-refresh transition ends with body count == field count (covers `bubble-state-management` "Background refresh preserves render parity" + "Physics never silently drops a target member")
-- [ ] 1.5 `make check` green
-- [ ] 1.6 Frontend PR → CI green → merge → Release → prod roll; verify re-entry render parity in prod (pool count == rendered bubble count)
+- [x] 1.1 `bubble-physics.ts`: add `reconcile(target: Artist[])` that diffs `bubbleMap` vs target (keep matching ids, fade/remove ids not in target, add ids not present)
+- [x] 1.2 `bubble-physics.ts`: stop counting fading-out bodies against capacity when adding; remove the silent `break` in `addBubbles` cap path (replace with a logged hard safety ceiling that never silently drops a target member)
+- [x] 1.3 `dna-orb-canvas.ts`: route `artistsChanged` through `physics.reconcile(newVal)` instead of the fade-out + `revealGhostBubbles` + `addBubbles` sequence for the real-artist path
+- [x] 1.4 Unit tests: reconcile converges body set to target; background-refresh transition ends with body count == field count (covers `bubble-state-management` "Background refresh preserves render parity" + "Physics never silently drops a target member"). Also added a revive-on-re-add regression test (mid-fade target member re-added within the fade window) per #514 review.
+- [x] 1.5 `make check` green
+- [x] 1.6 Frontend PR (#514) → CI green → merge → Release (v1.39.2) → prod roll (CP pin 850104b). Prod-verified via the live Aurelia VM: rendered physics bodies == UNIQUE pool artists, `inPoolButNotRendered=0`, no collapse. NOTE: raw `pool.length` > rendered because the pool still holds duplicates (seed-similar top-up dedup gap) — physics dedupes by id so the field is visually correct; the pool-level dedup is fixed by Phase 1 task 2.2 (invariants applied once). Also shipped deps PR #516 (dompurify ^3.4.13 override) to clear the repo-wide Security Audit gate.
 
 ## 2. Phase 1 — Single source of truth (DiscoveryFieldStore)
 


### PR DESCRIPTION
## Summary

Marks **Phase 0** of `refactor-discovery-bubble-field-state` complete in the change's `tasks.md`. Docs-only.

Phase 0 (physics render parity — the stop-the-bleed) shipped and was verified in production:

- **frontend PR #514** — `BubblePhysics.reconcile(target)`; `addBubbles` caps against live (non-fading) bodies + returns a dropped-count instead of a silent `break`; revive a mid-fade target member re-added within the fade window (from #514 review).
- **deps PR #516** — `dompurify ^3.4.13` override to clear the repo-wide Security Audit gate.
- **Release v1.39.2** → CP prod pin `850104b` (web-app) → ArgoCD.
- **Prod verification** (live Aurelia VM): rendered physics bodies == unique pool artists, `inPoolButNotRendered=0`, no field collapse (was pool=33/rendered=16 before the fix).

## Changes

- `openspec/changes/refactor-discovery-bubble-field-state/tasks.md`: tick 1.1–1.6, with a note that raw `pool.length` exceeds the rendered count because the pool still holds duplicates (seed-similar top-up dedup gap) — a pool-level issue Phase 1 (task 2.2, invariants applied once) resolves, not a Phase 0 regression.

## Related

Refs: #737 — Phases 1–3 remain.
