### PR TITLE
docs(openspec): propose deeplink-push-to-concert-detail

### DIFF
--- a/openspec/changes/deeplink-push-to-concert-detail/.openspec.yaml
+++ b/openspec/changes/deeplink-push-to-concert-detail/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-10

--- a/openspec/changes/deeplink-push-to-concert-detail/design.md
+++ b/openspec/changes/deeplink-push-to-concert-detail/design.md
@@ -1,0 +1,69 @@
+## Context
+
+A new-concert push notification is produced by `NotifyNewConcerts` in the backend for one artist and a batch of newly created concerts. Followers carry a hype level (`watch` / `home` / `nearby` / `away`≡`anywhere`) that gates delivery. Today the per-follower gate is a boolean (`f.Hype.ShouldNotify(home, venueAreas, concerts)`), the body count is `len(concerts)` over the whole batch, and the payload `data.url` is a hardcoded `"/dashboard"`.
+
+On the frontend, `concerts/:id` already routes to `DashboardRoute`, and the detail sheet already owns the `/concerts/:id` URL: `open()` does `history.pushState(..., '/concerts/:id')` and `close()` does `history.replaceState(..., '/dashboard')`. `DashboardRoute.loading()` currently ignores the `:id` route param and only reads `?artists=` / `?journey=` query params. The dashboard's `listByFollower` result groups concerts into `home` / `nearby` / `away` lanes, and the `away` lane captures far / unknown-location concerts — so any followed-artist concert is present in the list regardless of geography.
+
+This change wires the notification to the concert that actually triggered each recipient's hype match, and makes the deep-link land on that concert's detail sheet.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Tapping a new-concert notification opens the earliest hype-matched concert's detail sheet, dashboard filtered to that artist.
+- The deep-link target and the body count are computed from the per-recipient hype-matched subset (case A), fixing the pre-existing `home`-hype over-count.
+- Reuse existing surfaces: the `/concerts/:id` URL, the `listByFollower` fetch, the detail sheet's open/close. No new URL form, no new RPC.
+
+**Non-Goals:**
+- No new `GetConcert(id)` single-resource RPC (the `away` lane guarantees list presence; hype-match range ⊆ dashboard range).
+- No change to the detail sheet component's own open/close/URL behavior.
+- No `nearby` productization beyond its current phase-1 semantics.
+- No proto/schema change (the payload already carries `data.url`; count is a formatting concern).
+
+## Decisions
+
+### Decision 1: Deep-link URL is `/concerts/<concertId>`, artist filter derived (not `?artists=`)
+
+Reuse the URL the detail sheet already writes, so a push-tap and a manual card-tap converge on identical URL + state. The artist is redundant with the concert, so it is derived on open (`filteredArtistIds = [concert.artistId]`) rather than duplicated in a query param.
+
+- **Alternative — `/dashboard?artists=<id>&concert=<id>`**: introduces a second representation of "concert open" (the sheet still writes `/concerts/:id`), forcing either two URL forms or a larger refactor of the sheet. Rejected for maintainability.
+- **Alternative — keep the shipped `/dashboard?artists=<id>`**: only filters; never opens the concert. Fails the intended experience.
+
+Rationale over "REST purity": the decisive factor is that `/concerts/:id` already exists end-to-end. This is a consistency/least-surface choice, not a claim that path-over-query is universally correct for overlays.
+
+### Decision 2: Case A — per-recipient hype-matched subset drives both count and deep-link
+
+Refactor the per-follower boolean `ShouldNotify(...) bool` into a subset selector (e.g. `MatchingConcerts(home, concerts) []Concert`). The delivery gate becomes `len(subset) > 0`; the body count becomes `len(subset)`; the deep-link concert is the earliest of `subset` (local date asc, tie-break start time asc).
+
+- **Alternative — case B (global earliest)**: keep the boolean gate and deep-link everyone to the batch's globally earliest concert. Simpler backend, but a `home`-hype recipient could be deep-linked to an out-of-area concert that never matched their hype — reintroducing the "notification says X, tapping shows Y" mismatch this change exists to remove. Rejected.
+
+Case A also fixes the pre-existing over-count for free (the `home`-hype user's count reflects only their in-area matches).
+
+### Decision 3: Frontend resolves the pending open against the authoritative fetch, not the cache paint
+
+`loading()` records `pendingConcertId` from the `:id` param. `loadData()` already fetches `listByFollower` (fast-path paints from cache first, then background-refreshes; cold boot awaits the full fetch). The auto-open resolves the concert **when the authoritative fetch promise settles**, then calls `detailSheet.open(concert)` and derives the filter. No optimistic cache-open, no timer, no reconciliation pass.
+
+- **Alternative — open from cache paint then reconcile**: adds machinery for a warm-focus edge case; the cold-boot case (the common notification-tap path) has no cache anyway. Rejected as unnecessary complexity.
+
+### Decision 4: Absent-concert path degrades to filter-only
+
+If the resolved list has no matching concert (unfollow-after-send, zero-date, or unresolved-performer anomaly), apply the artist filter if still derivable and leave the sheet closed — no error surfaced. Because geography never drops a concert (away lane) and the notification implies a followed artist, this path is rare.
+
+## Risks / Trade-offs
+
+- **Behavioral change to `home`-hype counts** → intended and spec'd; call it out in the release notes since the visible count shrinks for those users.
+- **Warm-focus timing (existing window focused, stale cache)** → mitigated by resolving the open on the authoritative fetch promise rather than the cache paint; the concert appears once the refresh lands.
+- **Concert genuinely missing (rare edge)** → mitigated by the filter-only graceful degrade; no error, dashboard still narrows to the artist.
+- **Two URL writers on the dashboard (sheet open/close vs the `syncFilterUrl` `@watch`)** → the deep-link path sets `filteredArtistIds` which would trigger `syncFilterUrl`; sequence the sheet `pushState('/concerts/:id')` so it wins while the sheet is open, and let the filter URL apply after close. Verify no double-write drops a state during apply.
+
+## Migration Plan
+
+1. specification: land the delta specs (no proto change expected). If review concludes a proto/schema touch is needed, follow the cross-repo BSR release flow; otherwise skip BSR.
+2. backend: refactor hype to subset selection + earliest-concert deep-link + subset-aligned count; unit-test the `home`/`away` subset and earliest tie-break; `make check`.
+3. frontend: wire `loading()` `:id` → pending open resolved on the authoritative fetch + derived filter + graceful degrade; unit/e2e for open, filter-derive, close-no-reload, and absent-concert; `make check`.
+4. Release backend, then frontend; bump prod pins; verify a real notification tap in prod opens the correct concert's sheet filtered to its artist.
+5. Rollback: revert the backend `data.url`/count change and the frontend `loading()` wiring independently; the deep-link URL reverting to `/dashboard` is the prior (buggy but safe) behavior.
+
+## Open Questions
+
+- Does the current hype entity expose a clean seam to return the matched subset, or does `MatchingConcerts` need a small new method alongside `ShouldNotify` (kept for any other caller)? Confirm during backend implementation.
+- Confirm no other caller depends on the body count meaning "all new concerts" before narrowing it to the subset.

--- a/openspec/changes/deeplink-push-to-concert-detail/proposal.md
+++ b/openspec/changes/deeplink-push-to-concert-detail/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+Tapping a new-concert push notification currently lands the fan on an unfiltered `/dashboard`, forcing them to hunt for the concert they were just told about. Two defects compound: the backend sends a bare `/dashboard` URL (dropping the artist filter that the `dashboard-artist-filter` spec already requires — regressed when a prior `/concerts?artist=<id>` 404 was "fixed"), and the intended experience — land the fan directly on the concert that triggered their hype match — was never specified or built. The notification promises a specific concert for a specific artist; the destination should honor that promise.
+
+## What Changes
+
+- The new-concert push notification deep-link SHALL target the **earliest concert that matched the recipient's own hype level** (`/concerts/<concertId>`), not a bare dashboard.
+- Tapping the notification SHALL **auto-open that concert's detail sheet** on the dashboard, with the dashboard **filtered to the concert's artist** behind it.
+- The notification body count and the deep-link target SHALL both be computed from the **per-recipient hype-matched subset** of the newly created concerts. This fixes a pre-existing over-count where a `home`-hype fan saw the count of *all* new concerts rather than only those in their home area. **BREAKING** (behavioral): `home`-hype recipients now see a smaller, area-accurate count.
+- The deep-link **reuses the existing `/concerts/:id` detail-sheet URL** (the sheet already writes it on open and reverts to `/dashboard` on close; `concerts/:id` already routes to the dashboard). No new URL surface, no redundant `?artists=` query param (the artist is derived from the opened concert), no new get-by-id RPC (the concert is guaranteed present in the dashboard's existing `listByFollower` result).
+- When the target concert is genuinely absent from the fan's list (rare: unfollowed after send, or a zero-date / unresolved-performer data anomaly), the dashboard SHALL **degrade gracefully to the artist-filtered view** without opening a sheet.
+
+## Capabilities
+
+### New Capabilities
+<!-- No new capabilities; all behavior extends existing specs. -->
+
+### Modified Capabilities
+- `push-notification-service`: the deep-link URL and the notification count SHALL be computed from the per-recipient hype-matched concert subset, and the deep-link SHALL point to the earliest concert in that subset (tie-broken by start time).
+- `dashboard-artist-filter`: the push-notification deep-link requirement changes — the notification URL is now `/concerts/<concertId>` (not `/dashboard?artists=<id>`), and the artist filter is derived from the opened concert rather than carried in the URL.
+- `concert-detail`: add a deep-link auto-open requirement — navigating to `/concerts/:id` (e.g. from a push notification) SHALL open that concert's detail sheet after the authoritative concert fetch resolves, filtered to the concert's artist, degrading to filter-only when the concert is absent.
+
+## Impact
+
+- **specification**: delta specs for the three capabilities above. No proto change expected — the Web Push payload already carries `data.url`, and the count is a formatting concern, not a schema field.
+- **backend**: `internal/usecase/push_notification_uc.go` and the hype entity types — refactor the per-follower `ShouldNotify(...) bool` gate into a matched-subset selector, choose the earliest matched concert per recipient for `data.url`, and align the body count to that subset.
+- **frontend**: `src/routes/dashboard/dashboard-route.ts` — read the `:id` route param in `loading()`, and after the existing `listByFollower` fetch resolves, open the detail sheet for that concert and derive the artist filter. No changes to the RPC layer or the detail-sheet component's own open/close.
+- **Shipping goal**: land in prod — specification Release → BSR (only if a proto change proves necessary) → backend release → frontend release → prod pin bump → verify a real notification tap opens the correct concert sheet.

--- a/openspec/changes/deeplink-push-to-concert-detail/specs/concert-detail/spec.md
+++ b/openspec/changes/deeplink-push-to-concert-detail/specs/concert-detail/spec.md
@@ -1,0 +1,31 @@
+## ADDED Requirements
+
+### Requirement: Deep-link auto-open of a concert detail sheet
+
+When the dashboard loads at the `/concerts/:id` route (for example, from a tapped push notification), it SHALL automatically open the detail sheet for concert `:id` once the authoritative concert list has resolved, and SHALL derive the dashboard's artist filter from that concert. This reuses the existing `/concerts/:id` URL that the detail sheet already writes on manual open, so a deep-link and a manual card tap converge on the same URL and the same state.
+
+The auto-open SHALL resolve the concert against the authoritative `listByFollower` fetch that the dashboard already performs — NOT against a cache first-paint, and without any additional get-by-id RPC, timer, or optimistic pre-open. When the concert is absent from the resolved list (for example, the recipient unfollowed the artist after the notification was sent, or the concert carries an invalid date / unresolved performer), the dashboard SHALL degrade gracefully: apply the artist filter if derivable and leave the sheet closed, never surfacing an error.
+
+#### Scenario: Deep-link opens the concert after the authoritative fetch resolves
+
+- **WHEN** the dashboard loads at `/concerts/<concertId>` and the `listByFollower` fetch resolves with a concert whose id is `<concertId>`
+- **THEN** the system SHALL open that concert's detail sheet
+- **AND** the sheet SHALL NOT be opened from a stale cache first-paint before the authoritative fetch resolves
+
+#### Scenario: Deep-link derives the artist filter from the opened concert
+
+- **WHEN** a concert detail sheet is auto-opened from a `/concerts/:id` deep-link
+- **THEN** the dashboard's `filteredArtistIds` SHALL be set to `[concert.artistId]` so only that artist's concerts remain behind the sheet
+
+#### Scenario: Closing the deep-linked sheet does not reload the dashboard
+
+- **WHEN** the fan closes a detail sheet that was auto-opened from a `/concerts/:id` deep-link
+- **THEN** the URL SHALL revert via `history.replaceState` without triggering router navigation
+- **AND** the dashboard already mounted behind the sheet SHALL be revealed without a re-fetch
+
+#### Scenario: Target concert absent degrades to filter-only
+
+- **WHEN** the dashboard loads at `/concerts/<concertId>` but the resolved `listByFollower` result contains no concert with id `<concertId>`
+- **THEN** the system SHALL NOT open a detail sheet
+- **AND** SHALL NOT surface an error
+- **AND** SHALL apply the artist filter only when the artist is still derivable

--- a/openspec/changes/deeplink-push-to-concert-detail/specs/dashboard-artist-filter/spec.md
+++ b/openspec/changes/deeplink-push-to-concert-detail/specs/dashboard-artist-filter/spec.md
@@ -1,0 +1,17 @@
+## MODIFIED Requirements
+
+### Requirement: Push notification deep-link to filtered dashboard
+
+Tapping a new-concert push notification SHALL open the deep-linked concert's detail sheet on the dashboard, with the dashboard filtered to that concert's artist. The notification carries a `/concerts/<concertId>` URL (see the `concert-detail` deep-link auto-open requirement). The artist filter SHALL be **derived from the opened concert** (`filteredArtistIds = [concert.artistId]`), not carried as a `?artists=` query parameter in the notification URL.
+
+#### Scenario: Notification tap opens the concert filtered to its artist
+
+- **WHEN** a push notification with `data.url = "/concerts/<concertId>"` is tapped
+- **THEN** the browser SHALL navigate to `/concerts/<concertId>`
+- **AND** the dashboard SHALL derive the artist filter from the opened concert so only that artist's concerts remain behind the sheet
+
+#### Scenario: Deep-link auto-open suppressed during onboarding
+
+- **WHEN** the user is in the onboarding flow (`isOnboarding` is true)
+- **THEN** the deep-link SHALL NOT auto-open a detail sheet and SHALL NOT derive an artist filter
+- **AND** the manual filter trigger button SHALL remain hidden (via `if.bind="!isOnboarding"`) and any `artists` query param SHALL be ignored until onboarding is complete

--- a/openspec/changes/deeplink-push-to-concert-detail/specs/push-notification-service/spec.md
+++ b/openspec/changes/deeplink-push-to-concert-detail/specs/push-notification-service/spec.md
@@ -1,0 +1,67 @@
+## MODIFIED Requirements
+
+### Requirement: Delivery scope limited to newly created concerts
+
+When notifying followers about newly created concerts for an artist, the system SHALL use only the set of concerts that were just created in the triggering operation — not the artist's full upcoming schedule. Hype-level filtering, notification payload content, and delivery decisions SHALL all be computed against this new-concert set.
+
+Furthermore, for each individual recipient the system SHALL narrow the new-concert set to the recipient's **hype-matched subset** — the new concerts that satisfy that recipient's hype-level predicate (`away`/`anywhere` → all; `home` → new concerts in the recipient's home area; `nearby` → new concerts within range of the recipient's home centroid). The notification body count and the deep-link target concert SHALL both be computed from this per-recipient matched subset, never from the unfiltered new-concert set.
+
+#### Scenario: Home filter evaluated against new concerts only
+
+- **WHEN** a new concert is created for an artist in admin area `JP-40`
+- **AND** the artist also has pre-existing upcoming concerts in admin area `JP-13`
+- **AND** a follower with `hype = home` whose home area is `JP-13` exists
+- **THEN** the follower SHALL NOT receive a push notification
+- **AND** filtering SHALL be computed from the set `{JP-40}`, never `{JP-40, JP-13}`
+
+#### Scenario: Nearby filter evaluated against new concerts only
+
+- **WHEN** a new concert is created for an artist at a venue 300 km from a follower's home centroid
+- **AND** the artist also has pre-existing upcoming concerts within 200 km of that follower's home centroid
+- **AND** the follower's hype level is `nearby`
+- **THEN** the follower SHALL NOT receive a push notification
+- **AND** proximity SHALL be computed from only the new concerts
+
+#### Scenario: Notification count reflects the recipient's matched subset
+
+- **WHEN** 2 new concerts are created for an artist that already has 10 upcoming concerts
+- **AND** a follower with `hype = away` exists
+- **THEN** the notification payload SHALL report the count as `2`
+- **AND** the count SHALL NOT include the pre-existing upcoming concerts
+
+#### Scenario: Home-hype count excludes out-of-area new concerts
+
+- **WHEN** 3 new concerts are created for an artist — 1 in admin area `JP-13` and 2 in admin area `JP-40`
+- **AND** a follower with `hype = home` whose home area is `JP-13` exists
+- **THEN** the follower SHALL receive a push notification
+- **AND** the notification payload SHALL report the count as `1`
+- **AND** the count SHALL NOT include the 2 `JP-40` concerts that did not match the recipient's home area
+
+#### Scenario: No delivery when zero concerts are newly created
+
+- **WHEN** the concert creation operation completes with zero newly created concerts for an artist
+- **THEN** the system SHALL NOT trigger the notification pipeline for that artist
+- **AND** SHALL NOT publish a `CONCERT.created` event
+
+## ADDED Requirements
+
+### Requirement: New-concert notification deep-links to the earliest matched concert
+
+The new-concert push notification payload SHALL carry a `data.url` that deep-links to a specific concert: the **earliest concert in the recipient's hype-matched subset**. "Earliest" SHALL be determined by concert local date ascending, tie-broken by start time ascending. The URL SHALL take the form `/concerts/<concertId>`, reusing the frontend's canonical concert-detail URL, and SHALL NOT carry a redundant artist filter query parameter (the artist is derivable from the concert).
+
+#### Scenario: Deep-link targets the earliest matched concert
+
+- **WHEN** a recipient's hype-matched subset for an artist contains concerts on 2026-09-10 and 2026-09-03
+- **THEN** the notification payload `data.url` SHALL be `/concerts/<id-of-2026-09-03-concert>`
+
+#### Scenario: Same-day matched concerts tie-broken by start time
+
+- **WHEN** a recipient's hype-matched subset contains two concerts both dated 2026-09-03, starting at 18:00 and 19:30
+- **THEN** the notification payload `data.url` SHALL point to the 18:00 concert
+
+#### Scenario: Home recipient deep-links to their in-area concert, not the globally earliest
+
+- **WHEN** new concerts are created for an artist — one in `JP-40` on 2026-09-01 and one in `JP-13` on 2026-09-05
+- **AND** a follower with `hype = home` whose home area is `JP-13` exists
+- **THEN** that follower's notification `data.url` SHALL point to the `JP-13` 2026-09-05 concert
+- **AND** SHALL NOT point to the earlier `JP-40` concert that did not match the recipient's home area

--- a/openspec/changes/deeplink-push-to-concert-detail/tasks.md
+++ b/openspec/changes/deeplink-push-to-concert-detail/tasks.md
@@ -1,0 +1,29 @@
+## 1. Specification
+
+- [ ] 1.1 Land the delta specs for `push-notification-service`, `dashboard-artist-filter`, and `concert-detail`; run `openspec validate --strict`
+- [ ] 1.2 Confirm no proto/schema change is required (payload already carries `data.url`; count is a formatting concern). Only if review concludes otherwise, follow the cross-repo BSR release flow
+- [ ] 1.3 Open the specification PR; merge after review + CI
+
+## 2. Backend — hype matched-subset + deep-link
+
+- [ ] 2.1 Add a matched-subset selector to the hype types (e.g. `MatchingConcerts(home, concerts) []Concert`) covering `watch` (empty), `home` (in-area), `nearby` (in-range), `away`/`anywhere` (all); keep or delegate `ShouldNotify` as `len(subset) > 0`
+- [ ] 2.2 Unit-test the subset selector: home in/out-of-area, nearby in/out-of-range, away-all, watch-empty
+- [ ] 2.3 In `push_notification_uc.go`, compute the per-recipient subset once; gate delivery on non-empty subset; set the body count to `len(subset)`
+- [ ] 2.4 Select the earliest concert of the subset (local date asc, tie-break start time asc) and set `data.url = "/concerts/<concertId>"`
+- [ ] 2.5 Unit-test earliest selection (date ordering + same-day start-time tie-break) and the home-recipient "in-area, not globally-earliest" case
+- [ ] 2.6 `make check`; open backend PR; merge after review + CI
+
+## 3. Frontend — deep-link auto-open
+
+- [ ] 3.1 In `DashboardRoute.loading()`, read the `:id` route param into a `pendingConcertId` field (suppressed during onboarding)
+- [ ] 3.2 After the authoritative `listByFollower` fetch resolves in `loadData()`, resolve `pendingConcertId` against the result — NOT on the cache first-paint; no timer, no optimistic pre-open, no extra RPC
+- [ ] 3.3 On match, call `detailSheet.open(concert)` and derive the filter (`filteredArtistIds = [concert.artistId]`); reconcile with the `syncFilterUrl` `@watch` so the sheet's `/concerts/:id` URL wins while open
+- [ ] 3.4 On no-match (unfollow / zero-date / unresolved-performer), degrade to filter-only: apply the artist filter if derivable, leave the sheet closed, surface no error
+- [ ] 3.5 Unit/e2e tests: auto-open after fetch, filter derived from concert, close reverts via `replaceState` with no dashboard reload, and absent-concert filter-only path
+- [ ] 3.6 `make check`; open frontend PR; merge after review + CI
+
+## 4. Release & prod verification
+
+- [ ] 4.1 Release backend (tag) and bump prod pin; confirm rollout
+- [ ] 4.2 Release frontend (GH Release → automated prod pin bump); confirm ArgoCD sync
+- [ ] 4.3 Verify in prod: tap a real new-concert notification opens the earliest matched concert's detail sheet, dashboard filtered to its artist; confirm `home`-hype count reflects the in-area subset


### PR DESCRIPTION
## 🔗 Related Issue

Closes #753

## 📝 Summary of Changes

Adds the OpenSpec change `deeplink-push-to-concert-detail`, which specifies how tapping a new-concert push notification should behave.

**Problem:** The notification currently deep-links to a bare, unfiltered `/dashboard` — dropping the artist filter the `dashboard-artist-filter` spec already requires (regressed by `336566e`), and never opening the concert the fan was told about. `home`-hype recipients also see an over-count (all new concerts, not just their in-area matches).

**Approach (decision: case A):**
- The notification deep-links to `/concerts/<concertId>` — the **earliest concert in the recipient's hype-matched subset** (local date asc, tie-break start time). Reuses the frontend's existing detail-sheet URL; no new URL surface, no `?artists=` redundancy.
- The dashboard auto-opens that concert's detail sheet after the authoritative `listByFollower` fetch resolves and **derives** the artist filter from the opened concert. Degrades to filter-only when the concert is genuinely absent (unfollow / data anomaly).
- The notification body count is aligned to the per-recipient matched subset, fixing the pre-existing `home`-hype over-count.
- No new get-by-id RPC (the dashboard's `away` lane guarantees the concert is present in `listByFollower`).

**Artifacts:** `proposal.md`, `design.md` (4 decisions + rejected alternatives), `tasks.md` (spec → backend → frontend → prod verify), and delta specs for `push-notification-service`, `dashboard-artist-filter`, and `concert-detail`. `openspec validate --strict` passes.

Cross-repo implementation (backend `push_notification_uc.go` + hype types, frontend `DashboardRoute`) follows after this spec merges.

## ✅ Self-Checklist

- [x] I have linked the related issue.
- [x] I have updated the relevant documentation (OpenSpec artifacts).
- [ ] I have run `buf lint` and `buf format` locally and all checks have passed. — N/A, no proto changes (docs-only)
- [x] My proto definitions follow the project's style guidelines and validation rules. — N/A, no proto changes
- [ ] Breaking changes have been justified and documented if applicable. — behavioral only (home-hype count shrinks), documented in proposal/design
