### PR TITLE
docs(openspec): archive redesign-all-nearby-filters

### DIFF
--- a/openspec/changes/archive/2026-08-10-redesign-all-nearby-filters/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-10-redesign-all-nearby-filters/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-10

--- a/openspec/changes/archive/2026-08-10-redesign-all-nearby-filters/design.md
+++ b/openspec/changes/archive/2026-08-10-redesign-all-nearby-filters/design.md
@@ -1,0 +1,49 @@
+## Context
+
+The All Nearby mode (shipped in passive-concert-discovery) renders a filter area above the `ConcertHighway` timetable. Today it stacks: an area-selector button on its own row, a four-chip date-preset group, and — when カスタム is selected — two labeled native date inputs that expand inline. The inline expansion and the full-width area row consume vertical/horizontal space that belongs to the timetable, and the native inputs are unlocalized.
+
+The design was prototyped and reviewed interactively; the chosen direction is "compact chips in the bar, complex input in a bottom sheet". The `bottom-sheet` primitive and `user-home-selector` already exist and are reused. The date sheet emits the same `{ from, to }` `CalendarDate` pair the route already consumes, so no data-layer change is needed.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Keep the filter bar to a single, fixed-height row so the timetable is never squeezed.
+- Reduce the date filter to a single chip that surfaces the current selection, with all options (presets + custom range) reachable in one tap.
+- Make custom-range adjustment a short path: chip → edit dates → apply (no dropdown drill-down).
+- Localize every date display to Japanese (`Intl.DateTimeFormat('ja-JP')`).
+- Replace unnatural All Nearby Japanese copy with natural, native phrasing.
+
+**Non-Goals:**
+- No change to `ConcertService.ListByLocation`, the `CalendarDate` contract, or any backend/proto.
+- No calendar/grid date-range picker widget (native `<input type="date">` inside the sheet is sufficient for MVP).
+- No change to the mode toggle (My Timetable / All Nearby) shipped earlier.
+- No new date presets beyond the existing three + custom.
+
+## Decisions
+
+### D1 — Filter bar = single row of two chips (area + date)
+The bar always renders `[📍 <area> ▾]` and `[📅 <date> ▾]` on one line. The area chip opens the existing `user-home-selector`; the date chip opens the date-range sheet. No control expands the bar, so the timetable's height is constant across all filter states.
+
+### D2 — One date-range bottom sheet holding presets AND editable dates
+Tapping the date chip opens a single bottom sheet (shared `bottom-sheet`) containing: a quick-preset chip row (今週末 / 7日以内 / 30日以内) and directly-editable 開始 / 終了 `<input type="date">` fields plus an apply action. There is no intermediate dropdown/menu — presets and manual dates live together, so custom adjustment is chip → edit → apply.
+
+**Rationale:** an earlier dropdown-menu variant put custom behind two taps (open menu → tap カスタム → then a picker). Co-locating presets and fields removes the drill-down while keeping the bar to one chip.
+
+### D3 — Preset = apply-and-close; custom = edit-then-apply
+Tapping a quick preset resolves the range, applies it, and closes the sheet in one tap (the common path). Editing a date field keeps the sheet open for adjustment; a primary "apply" action confirms the custom range. This matches the tap-economy the product owner asked for.
+
+### D4 — Localize all date display via Intl.DateTimeFormat('ja-JP')
+The chip label and any range text render through `Intl.DateTimeFormat('ja-JP', { month, day })` → `8/12〜8/20` (or a single day when from === to), and preset selections show their preset name. The unlocalized native input format is no longer the primary display; the native inputs remain only as the in-sheet editing control.
+
+### D5 — Client-side range validation mirrors the server cap
+The sheet validates live: `to` may not precede `from`, and the inclusive span may not exceed 30 days (matching the server's use-case cap). Invalid states show an inline hint and block apply; the `to` field's `min`/`max` also constrain the native picker.
+
+### D6 — Natural Japanese copy pass
+Audit and rewrite `allNearby.*` strings (mode title/toggle, area prompt, empty state, preset labels, range hint) into natural Japanese, keeping ja/en key parity.
+
+## Risks / Trade-offs
+
+- **[Bottom sheet vs inline for a quick date tweak]** A sheet is one extra surface vs inline fields. Mitigation: presets apply in a single tap; the sheet is the standard mobile pattern for multi-field input and preserves the timetable's space — a net win at mobile width.
+- **[Native date input inside the sheet]** The native picker's own chrome is still OS-localized, but the always-visible chip and range text are guaranteed Japanese via Intl, so the user-facing summary is correct regardless of OS locale.
+- **[Visual-regression baselines]** The dashboard snapshot changes intentionally; baselines must be regenerated on merge.
+- **[Copy changes ripple to any tests asserting the old strings]** Update affected unit/E2E assertions in the same change.

--- a/openspec/changes/archive/2026-08-10-redesign-all-nearby-filters/proposal.md
+++ b/openspec/changes/archive/2026-08-10-redesign-all-nearby-filters/proposal.md
@@ -1,0 +1,38 @@
+## Why
+
+The Dashboard "All Nearby" filter UI shipped functional but space-inefficient, and prod use surfaced concrete UX problems:
+
+- Choosing the **カスタム** date preset expands two stacked, labeled `<input type="date">` fields inline, growing the filter area and **squeezing the concert timetable** — the screen's primary content.
+- The native date inputs render an **unlocalized US `MM/DD/YYYY`** format for Japanese users.
+- The **area selector occupies its own full row**, wasting horizontal space.
+- The **four date presets are four separate chips**, consuming horizontal width for a single-select choice.
+- Several **All Nearby Japanese strings read unnaturally** (machine-translation feel).
+
+The feature is otherwise complete and in production; this change is a frontend-only UX refinement (no proto or backend change).
+
+## What Changes
+
+- The All Nearby filter bar becomes a **single row of two chips**: an **area chip** and a **single date chip** — no inline expansion, so the timetable height is never reduced.
+- The date chip opens **one date-range bottom sheet** (reusing the shared bottom-sheet primitive) that holds BOTH quick presets (今週末 / 7日以内 / 30日以内) AND directly-editable start/end date fields with live validation (`from ≤ to`, span ≤ 30 days). Adjusting a custom range is chip → edit → apply — no drill-down.
+- Quick presets apply immediately and close the sheet; custom edits confirm via an apply action.
+- The date chip label and every range display are **localized with `Intl.DateTimeFormat('ja-JP')`** (e.g. `8/12〜8/20`), replacing the unlocalized native format.
+- The **All Nearby Japanese i18n copy is audited and rewritten** into natural, native Japanese (mode titles/toggle, area prompt, empty state, date-preset labels, range hints).
+
+Grounded in mobile UI best practice (Material 3 date-pickers & chips, Apple HIG segmented/date controls, NNG/UXPin filter guidance): present filters as compact chips and move complex/multi-field input into a bottom sheet rather than expanding it inline. Validated with an interactive prototype and the direction confirmed with the product owner.
+
+## Capabilities
+
+### New Capabilities
+
+<!-- none — this refines existing All Nearby behavior -->
+
+### Modified Capabilities
+
+- `passive-concert-discovery`: Replaces the inline "Date Preset Selector" and standalone "Area Selector" requirements with a compact single-row filter (area chip + single date chip → date-range bottom sheet with presets + editable, validated, localized range); adds a localized-date-formatting requirement; requires natural Japanese copy for the All Nearby surface.
+
+## Impact
+
+- **Frontend only** (`liverty-music/frontend`); no proto, backend, or BSR change.
+- Components: `date-preset-selector` (replaced by a date chip + date-range bottom sheet built on the shared `bottom-sheet` primitive), `dashboard-route` (filter bar wiring), the area chip, and the `allNearby.*` i18n keys (ja + en).
+- No change to `ConcertService.ListByLocation` or the `CalendarDate` contract — the sheet still emits a `{ from, to }` `CalendarDate` pair.
+- Visual-regression baselines for the dashboard will need regeneration (intentional UI change).

--- a/openspec/changes/archive/2026-08-10-redesign-all-nearby-filters/specs/passive-concert-discovery/spec.md
+++ b/openspec/changes/archive/2026-08-10-redesign-all-nearby-filters/specs/passive-concert-discovery/spec.md
@@ -1,0 +1,137 @@
+## ADDED Requirements
+
+### Requirement: Compact All Nearby Filter Bar
+
+The All Nearby mode SHALL present its filters as a single, fixed-height row of two chips — an area chip and a date chip — such that selecting or adjusting any filter never changes the height of the filter area and therefore never reduces the concert timetable's height.
+
+#### Scenario: Filter bar is a single row of two chips
+
+- **WHEN** All Nearby mode is active
+- **THEN** the filter area SHALL render exactly two controls on one row: an area chip and a date chip
+- **AND** neither chip SHALL expand the filter area inline when tapped
+
+#### Scenario: Timetable height is unaffected by filter interaction
+
+- **WHEN** the user opens the area sheet, opens the date sheet, or changes any filter
+- **THEN** the height of the `ConcertHighway` timetable SHALL NOT decrease as a result
+- **AND** all complex input SHALL occur in a bottom sheet overlay rather than inline expansion
+
+### Requirement: Localized All Nearby Date Display
+
+Every user-facing date and date-range in the All Nearby filter SHALL be formatted for the Japanese locale via `Intl.DateTimeFormat('ja-JP')`; the browser's native `MM/DD/YYYY` input rendering SHALL NOT be the primary display of the selected range.
+
+#### Scenario: Date chip shows a localized range
+
+- **WHEN** a custom range from 2026-08-12 to 2026-08-20 is applied
+- **THEN** the date chip SHALL display the localized range `8/12〜8/20`
+
+#### Scenario: Single-day range
+
+- **WHEN** the applied range has `from` equal to `to`
+- **THEN** the date chip SHALL display that single localized date (e.g. `8/10`) rather than a `〜`-joined pair
+
+#### Scenario: Preset shows its name
+
+- **WHEN** a quick preset (今週末 / 7日以内 / 30日以内) is applied
+- **THEN** the date chip SHALL display that preset's name rather than a raw date range
+
+### Requirement: Natural Japanese Copy for All Nearby
+
+All user-facing Japanese strings on the All Nearby surface SHALL read as natural, native Japanese; machine-translated or awkward phrasing SHALL be corrected. Japanese and English i18n keys SHALL remain at parity.
+
+#### Scenario: All Nearby strings are natural Japanese
+
+- **WHEN** the All Nearby mode title, mode toggle labels, area prompt, empty-state text, date-preset labels, and range hint are displayed in Japanese
+- **THEN** each SHALL be phrased in natural Japanese
+- **AND** every `allNearby.*` key present in the Japanese bundle SHALL also exist in the English bundle (and vice versa)
+
+## MODIFIED Requirements
+
+### Requirement: Date Preset Selector
+
+The All Nearby mode SHALL expose its date filter as a single date chip that opens one date-range bottom sheet. The sheet SHALL offer three quick presets (今週末, 7日以内, 30日以内) and a directly-editable custom range (start/end date fields), so a custom range is adjusted without any intermediate menu or drill-down. There is no standalone "カスタム" preset chip; custom selection is simply editing the date fields.
+
+#### Scenario: Date chip opens the range sheet in one tap
+
+- **WHEN** the user taps the date chip
+- **THEN** a date-range bottom sheet SHALL open containing both the quick presets and editable start/end date fields
+
+#### Scenario: Available quick presets
+
+- **WHEN** the date-range sheet is displayed
+- **THEN** it SHALL offer exactly three quick presets: 今週末, 7日以内, 30日以内
+- **AND** it SHALL provide directly-editable start (開始) and end (終了) date fields for a custom range
+
+#### Scenario: 今週末 preset date range
+
+- **WHEN** the user selects 今週末
+- **AND** today is Monday through Friday
+- **THEN** `from` SHALL be set to the next Saturday and `to` to the next Sunday
+
+#### Scenario: 今週末 when today is Saturday or Sunday
+
+- **WHEN** the user selects 今週末
+- **AND** today is Saturday
+- **THEN** `from` SHALL be today and `to` SHALL be the next day (Sunday)
+- **WHEN** the user selects 今週末
+- **AND** today is Sunday
+- **THEN** `from` and `to` SHALL both be today
+
+#### Scenario: 7日以内 preset date range
+
+- **WHEN** the user selects 7日以内
+- **THEN** `from` SHALL be today and `to` SHALL be today + 6 days (inclusive 7-day window)
+
+#### Scenario: 30日以内 preset date range
+
+- **WHEN** the user selects 30日以内
+- **THEN** `from` SHALL be today and `to` SHALL be today + 29 days (inclusive 30-day window)
+
+#### Scenario: Quick preset applies and closes in one tap
+
+- **WHEN** the user taps a quick preset in the sheet
+- **THEN** the corresponding range SHALL be applied and the sheet SHALL close without a further confirmation tap
+
+#### Scenario: Custom range is edited then applied
+
+- **WHEN** the user edits the start and/or end date fields in the sheet
+- **THEN** the sheet SHALL remain open for adjustment
+- **AND** an apply action SHALL confirm the edited range and close the sheet
+
+#### Scenario: Custom range validation
+
+- **WHEN** the user edits the custom date fields
+- **THEN** the UI SHALL prevent `to` from being earlier than `from`
+- **AND** the UI SHALL prevent the inclusive range from exceeding 30 days
+- **AND** an inline hint SHALL communicate an invalid range and block applying it
+
+### Requirement: Area Selector in All Nearby Mode
+
+The All Nearby mode SHALL present the current reference area as an **area chip** in the single-row filter bar, and allow the user to override it for the duration of the session by opening the shared `user-home-selector` from that chip.
+
+#### Scenario: Default area is user home
+
+- **WHEN** All Nearby mode activates for an authenticated user who has set a home area
+- **THEN** the area chip SHALL display the user's home area name (prefecture display name)
+- **AND** the `GeoLocation` passed to `ListByLocation` SHALL use `user.home.centroid.latitude`, `user.home.centroid.longitude`, and `user.home.level_1` as `admin_area` (`centroid` is the nested `Coordinates` sub-message on the `Home` proto; `centroid_latitude`/`centroid_longitude` are reserved field names)
+
+#### Scenario: Area override via UserHomeSelector
+
+- **WHEN** the user taps the area chip
+- **THEN** the `user-home-selector` component SHALL open
+- **AND** on selection, the route SHALL update its local area state with the new ISO 3166-2 code
+- **AND** `ListByLocation` SHALL be called with the new area's centroid coordinates and admin_area
+- **AND** the new area SHALL NOT be saved to the user's account
+
+#### Scenario: Area override is session-scoped
+
+- **WHEN** the user reloads the page or navigates away and returns
+- **THEN** the area chip SHALL reset to the user's persisted home area
+- **AND** any previous session override SHALL be discarded
+
+#### Scenario: Area override for unauthenticated user
+
+- **WHEN** an unauthenticated user opens All Nearby mode
+- **AND** no guest home is stored in localStorage
+- **THEN** the area chip SHALL prompt the user to choose an area
+- **AND** the chosen area SHALL be used for the session without persisting to localStorage

--- a/openspec/changes/archive/2026-08-10-redesign-all-nearby-filters/tasks.md
+++ b/openspec/changes/archive/2026-08-10-redesign-all-nearby-filters/tasks.md
@@ -1,0 +1,33 @@
+## 1. Date-range bottom sheet component
+
+- [x] 1.1 Create a `date-range-sheet` component built on the shared `bottom-sheet` primitive: quick-preset chips (今週末 / 7日以内 / 30日以内) + editable 開始/終了 `<input type="date">` fields + a range hint + an apply action
+- [x] 1.2 Move the preset date math (weekend / 7-day / 30-day resolution) into the sheet, reusing `date-presets.ts`; a quick preset applies its `{ from, to }` and closes the sheet in one tap
+- [x] 1.3 Custom path: editing a field keeps the sheet open; apply confirms and closes. Live-validate `from ≤ to` and inclusive span ≤ 30 days, show an inline hint, and block apply on invalid; set the `to` input `min`/`max` too
+- [x] 1.4 Emit the existing `range-changed` `{ from, to }` `CalendarDate` pair (unchanged contract) on apply / preset selection
+
+## 2. Compact filter bar (chips)
+
+- [x] 2.1 Replace the inline date-preset group + standalone area row in `dashboard-route.html` with a single-row filter bar: an area chip and a date chip
+- [x] 2.2 Date chip: label shows the current selection (preset name, or localized range via `Intl.DateTimeFormat('ja-JP')` e.g. `8/12〜8/20`, single day when `from === to`); tap opens the `date-range-sheet`
+- [x] 2.3 Area chip: shows the current area name; tap opens the existing `user-home-selector` (session-only override, unchanged persistence semantics)
+- [x] 2.4 Remove all inline-expansion markup/CSS so the filter area is a fixed-height single row and the timetable height is never reduced
+- [x] 2.5 Retire the old `date-preset-selector` component (and its inline custom-range block) once the chip + sheet replace it
+
+## 3. Localized Japanese copy
+
+- [x] 3.1 Audit `allNearby.*` i18n keys (ja + en) — mode title/toggle, area prompt, empty state, preset labels, range hint — and rewrite the Japanese into natural, native phrasing
+- [x] 3.2 Ensure ja/en key parity (every `allNearby.*` key exists in both bundles); add any keys the new sheet/chip need
+- [x] 3.3 Confirm all date/range display uses `Intl.DateTimeFormat('ja-JP')`, not the native input format
+
+## 4. Verification & tests
+
+- [x] 4.1 Update/add unit tests: preset date math, range validation (inverted + >30 days), localized label formatting; update any tests asserting old strings/markup
+- [x] 4.2 Run `make check` (biome, stylelint, template tsc, no-inline-style guard, i18n parity, vitest, build) — all green
+- [x] 4.3 Verify on the dev server (headless browser): one-tap sheet open, preset apply+close, custom edit+apply, localized chip label, 30-day guard, timetable height unchanged across all states
+
+## 5. PR, release & prod verification
+
+- [x] 5.1 Open the frontend PR (#520); Visual Regression passed as-is (no baseline conflict), all CI green
+- [x] 5.2 Merge the PR (#520 → main a39ee7e)
+- [x] 5.3 GH Release v1.40.0 → dispatch-prod-pin (CP 8a0d01e) → ArgoCD synced web-app to v1.40.0
+- [x] 5.4 Prod (liverty-music.app v1.40.0) verified: 2-chip bar (東京都 + 7日以内), one-tap sheet (今週末/7日以内/30日以内 + 開始日/終了日), custom 8/15〜8/22 localized, natural JA copy, 0 console errors

--- a/openspec/specs/passive-concert-discovery/spec.md
+++ b/openspec/specs/passive-concert-discovery/spec.md
@@ -32,12 +32,18 @@ The Dashboard SHALL provide a segment toggle control that switches between "My T
 
 ### Requirement: Date Preset Selector
 
-The All Nearby mode SHALL provide four date presets for filtering the concert date range.
+The All Nearby mode SHALL expose its date filter as a single date chip that opens one date-range bottom sheet. The sheet SHALL offer three quick presets (今週末, 7日以内, 30日以内) and a directly-editable custom range (start/end date fields), so a custom range is adjusted without any intermediate menu or drill-down. There is no standalone "カスタム" preset chip; custom selection is simply editing the date fields.
 
-#### Scenario: Available presets
+#### Scenario: Date chip opens the range sheet in one tap
 
-- **WHEN** the date-preset selector is displayed
-- **THEN** it SHALL offer exactly four options: 今週末, 7日以内, 30日以内, カスタム
+- **WHEN** the user taps the date chip
+- **THEN** a date-range bottom sheet SHALL open containing both the quick presets and editable start/end date fields
+
+#### Scenario: Available quick presets
+
+- **WHEN** the date-range sheet is displayed
+- **THEN** it SHALL offer exactly three quick presets: 今週末, 7日以内, 30日以内
+- **AND** it SHALL provide directly-editable start (開始) and end (終了) date fields for a custom range
 
 #### Scenario: 今週末 preset date range
 
@@ -64,28 +70,37 @@ The All Nearby mode SHALL provide four date presets for filtering the concert da
 - **WHEN** the user selects 30日以内
 - **THEN** `from` SHALL be today and `to` SHALL be today + 29 days (inclusive 30-day window)
 
-#### Scenario: カスタム preset shows date inputs
+#### Scenario: Quick preset applies and closes in one tap
 
-- **WHEN** the user selects カスタム
-- **THEN** two date input fields SHALL appear for explicit `from` and `to` selection
-- **AND** the UI SHALL prevent `to` from being set earlier than `from`
-- **AND** the UI SHALL prevent the range from exceeding 30 days
+- **WHEN** the user taps a quick preset in the sheet
+- **THEN** the corresponding range SHALL be applied and the sheet SHALL close without a further confirmation tap
 
----
+#### Scenario: Custom range is edited then applied
+
+- **WHEN** the user edits the start and/or end date fields in the sheet
+- **THEN** the sheet SHALL remain open for adjustment
+- **AND** an apply action SHALL confirm the edited range and close the sheet
+
+#### Scenario: Custom range validation
+
+- **WHEN** the user edits the custom date fields
+- **THEN** the UI SHALL prevent `to` from being earlier than `from`
+- **AND** the UI SHALL prevent the inclusive range from exceeding 30 days
+- **AND** an inline hint SHALL communicate an invalid range and block applying it
 
 ### Requirement: Area Selector in All Nearby Mode
 
-The All Nearby mode SHALL display the current reference area and allow the user to override it for the duration of the session.
+The All Nearby mode SHALL present the current reference area as an **area chip** in the single-row filter bar, and allow the user to override it for the duration of the session by opening the shared `user-home-selector` from that chip.
 
 #### Scenario: Default area is user home
 
 - **WHEN** All Nearby mode activates for an authenticated user who has set a home area
-- **THEN** the area selector SHALL display the user's home area name (prefecture display name)
+- **THEN** the area chip SHALL display the user's home area name (prefecture display name)
 - **AND** the `GeoLocation` passed to `ListByLocation` SHALL use `user.home.centroid.latitude`, `user.home.centroid.longitude`, and `user.home.level_1` as `admin_area` (`centroid` is the nested `Coordinates` sub-message on the `Home` proto; `centroid_latitude`/`centroid_longitude` are reserved field names)
 
 #### Scenario: Area override via UserHomeSelector
 
-- **WHEN** the user taps the area selector
+- **WHEN** the user taps the area chip
 - **THEN** the `user-home-selector` component SHALL open
 - **AND** on selection, the route SHALL update its local area state with the new ISO 3166-2 code
 - **AND** `ListByLocation` SHALL be called with the new area's centroid coordinates and admin_area
@@ -94,17 +109,15 @@ The All Nearby mode SHALL display the current reference area and allow the user 
 #### Scenario: Area override is session-scoped
 
 - **WHEN** the user reloads the page or navigates away and returns
-- **THEN** the area selector SHALL reset to the user's persisted home area
+- **THEN** the area chip SHALL reset to the user's persisted home area
 - **AND** any previous session override SHALL be discarded
 
 #### Scenario: Area override for unauthenticated user
 
 - **WHEN** an unauthenticated user opens All Nearby mode
 - **AND** no guest home is stored in localStorage
-- **THEN** the area selector SHALL prompt the user to choose an area
+- **THEN** the area chip SHALL prompt the user to choose an area
 - **AND** the chosen area SHALL be used for the session without persisting to localStorage
-
----
 
 ### Requirement: All Nearby Concert List
 
@@ -157,4 +170,49 @@ When viewing a concert in All Nearby mode, the `EventDetailSheet` SHALL surface 
 
 - **WHEN** an unauthenticated user taps "Follow this artist" in the `EventDetailSheet`
 - **THEN** the system SHALL surface the sign-up prompt banner instead of calling `ArtistService.Follow`
+
+### Requirement: Compact All Nearby Filter Bar
+
+The All Nearby mode SHALL present its filters as a single, fixed-height row of two chips — an area chip and a date chip — such that selecting or adjusting any filter never changes the height of the filter area and therefore never reduces the concert timetable's height.
+
+#### Scenario: Filter bar is a single row of two chips
+
+- **WHEN** All Nearby mode is active
+- **THEN** the filter area SHALL render exactly two controls on one row: an area chip and a date chip
+- **AND** neither chip SHALL expand the filter area inline when tapped
+
+#### Scenario: Timetable height is unaffected by filter interaction
+
+- **WHEN** the user opens the area sheet, opens the date sheet, or changes any filter
+- **THEN** the height of the `ConcertHighway` timetable SHALL NOT decrease as a result
+- **AND** all complex input SHALL occur in a bottom sheet overlay rather than inline expansion
+
+### Requirement: Localized All Nearby Date Display
+
+Every user-facing date and date-range in the All Nearby filter SHALL be formatted for the Japanese locale via `Intl.DateTimeFormat('ja-JP')`; the browser's native `MM/DD/YYYY` input rendering SHALL NOT be the primary display of the selected range.
+
+#### Scenario: Date chip shows a localized range
+
+- **WHEN** a custom range from 2026-08-12 to 2026-08-20 is applied
+- **THEN** the date chip SHALL display the localized range `8/12〜8/20`
+
+#### Scenario: Single-day range
+
+- **WHEN** the applied range has `from` equal to `to`
+- **THEN** the date chip SHALL display that single localized date (e.g. `8/10`) rather than a `〜`-joined pair
+
+#### Scenario: Preset shows its name
+
+- **WHEN** a quick preset (今週末 / 7日以内 / 30日以内) is applied
+- **THEN** the date chip SHALL display that preset's name rather than a raw date range
+
+### Requirement: Natural Japanese Copy for All Nearby
+
+All user-facing Japanese strings on the All Nearby surface SHALL read as natural, native Japanese; machine-translated or awkward phrasing SHALL be corrected. Japanese and English i18n keys SHALL remain at parity.
+
+#### Scenario: All Nearby strings are natural Japanese
+
+- **WHEN** the All Nearby mode title, mode toggle labels, area prompt, empty-state text, date-preset labels, and range hint are displayed in Japanese
+- **THEN** each SHALL be phrased in natural Japanese
+- **AND** every `allNearby.*` key present in the Japanese bundle SHALL also exist in the English bundle (and vice versa)
 


### PR DESCRIPTION
Archives the `redesign-all-nearby-filters` OpenSpec change now that it has shipped and been verified in production.

## Spec sync into `passive-concert-discovery`
- **+3 ADDED**: Compact All Nearby Filter Bar; Localized All Nearby Date Display; Natural Japanese Copy for All Nearby
- **~2 MODIFIED**: Date Preset Selector (single date chip → one range sheet, 3 presets + editable custom, no カスタム chip); Area Selector in All Nearby Mode (area chip)

## Shipping evidence
- frontend PR liverty-music/frontend#520 → merged to main (`a39ee7e`)
- GitHub Release **v1.40.0**
- cloud-provisioning prod pin `8a0d01e` (frontend overlay → v1.40.0), ArgoCD synced
- Verified live on liverty-music.app: fixed two-chip filter bar (東京都 + 7日以内), one-tap date-range sheet (今週末 / 7日以内 / 30日以内 + 開始日/終了日), custom range localized as `8/15〜8/22`, natural Japanese copy, 0 console errors, timetable height unaffected

Frontend-only change — no proto/BSR impact.

Refs #519