### PR TITLE
chore(openspec): normalize main spec structure for 1.8.0 validate

### DIFF
--- a/openspec/specs/admin-area-normalization/spec.md
+++ b/openspec/specs/admin-area-normalization/spec.md
@@ -1,3 +1,11 @@
+# Admin Area Normalization Specification
+
+## Purpose
+
+Defines how administrative area strings are normalized (including country-code extraction) so concert discovery matching and stored data stay consistent.
+
+## Requirements
+
 ### Requirement: Admin Area Normalization Function
 
 The system SHALL provide a normalization function that converts free-text administrative area strings into ISO 3166-2 subdivision codes.

--- a/openspec/specs/app-error-log-alerting/spec.md
+++ b/openspec/specs/app-error-log-alerting/spec.md
@@ -1,5 +1,9 @@
 # App Error Log Alerting
 
+## Purpose
+
+Defines error-log-based alerting across backend workloads and CronJobs, including migration-failure detection, notification routing, and rate limiting.
+
 ## Requirements
 
 ### Requirement: Error log detection per workload

--- a/openspec/specs/artist-image-ui/spec.md
+++ b/openspec/specs/artist-image-ui/spec.md
@@ -1,3 +1,11 @@
+# Artist Image UI Specification
+
+## Purpose
+
+Specifies how artist imagery (logos, hero images, fanart) is surfaced across event cards and detail sheets in the frontend.
+
+## Requirements
+
 ### Requirement: Event Card Logo Display
 The dashboard event card SHALL display the artist's transparent logo image instead of the text artist name when a logo URL is available. The system SHALL use `hd_music_logo` as the primary source and fall back to `music_logo` when `hd_music_logo` is unavailable. When neither logo is available, the card SHALL display the existing text artist name.
 

--- a/openspec/specs/backend-service-exposure/spec.md
+++ b/openspec/specs/backend-service-exposure/spec.md
@@ -1,4 +1,10 @@
-## MODIFIED Requirements
+# Backend Service Exposure Specification
+
+## Purpose
+
+Defines how backend services are exposed and discovered, including backend protocol support and health-check integration.
+
+## Requirements
 
 ### Requirement: Backend Service Discoverability
 The backend Service SHALL be discoverable by external load balancers (Gateway) via explicit cross-namespace references.

--- a/openspec/specs/bubble-replenishment/spec.md
+++ b/openspec/specs/bubble-replenishment/spec.md
@@ -1,3 +1,11 @@
+# Bubble Replenishment Specification
+
+## Purpose
+
+Defines how the discovery canvas replenishes artist bubbles when the pool of similar artists is exhausted.
+
+## Requirements
+
 ### Requirement: Canvas replenishes bubbles when similar artists are exhausted
 When a user follows an artist and the similar-artist API returns no new (unseen) artists, the system SHALL automatically fetch replacement bubbles from the top-artist pool to keep the canvas populated. Replenishment SHALL be coordinated through BubbleManager.
 

--- a/openspec/specs/certificate-manager-integration/spec.md
+++ b/openspec/specs/certificate-manager-integration/spec.md
@@ -1,4 +1,10 @@
-## ADDED Requirements
+# Certificate Manager Integration Specification
+
+## Purpose
+
+Defines Google-managed TLS certificate provisioning, DNS validation, gateway binding, automatic renewal, and status monitoring.
+
+## Requirements
 
 ### Requirement: Google-Managed Certificate Provisioning
 The system SHALL obtain TLS certificates from Google Certificate Manager for the domain `api.liverty-music.app`.

--- a/openspec/specs/concert-search-internals/spec.md
+++ b/openspec/specs/concert-search-internals/spec.md
@@ -4,8 +4,7 @@
 
 Defines internal quality requirements for the concert search usecase implementation. These requirements enforce Clean Architecture boundaries, testability, and code structure. They do not affect any external behavior -- all existing concert search functionality remains identical.
 
-## ADDED Requirements
-
+## Requirements
 ### Requirement: Usecase layer SHALL NOT import infrastructure packages
 
 The concert search usecase (`internal/usecase/`) SHALL NOT directly import any package from `internal/infrastructure/`. All infrastructure dependencies SHALL be accessed through interfaces defined in the usecase or entity layer.

--- a/openspec/specs/connect-rpc-cors/spec.md
+++ b/openspec/specs/connect-rpc-cors/spec.md
@@ -1,4 +1,10 @@
-## ADDED Requirements
+# Connect-RPC CORS Specification
+
+## Purpose
+
+Defines CORS handling for Connect-RPC endpoints: allowed origins, required protocol headers, authorization support, and validation at startup.
+
+## Requirements
 
 ### Requirement: CORS Middleware for Connect-RPC
 The system SHALL implement Cross-Origin Resource Sharing (CORS) middleware in the Connect-RPC server using the `connectrpc.com/cors` package.

--- a/openspec/specs/cube-css-layer-constraints/spec.md
+++ b/openspec/specs/cube-css-layer-constraints/spec.md
@@ -4,8 +4,7 @@
 
 Enforces per-layer content restrictions in the CUBE CSS methodology: exception layer selectors must use `data-*` attributes, composition layer must not contain visual properties, utility selectors are limited in property count, and block layer rules must be wrapped in `@scope`.
 
-## ADDED Requirements
-
+## Requirements
 ### Requirement: `cube/exception-data-attr` requires `data-*` selectors in exception layer
 Selectors inside `@layer exception` SHALL contain at least one `[data-*]` attribute selector. CSS-class-only exceptions are prohibited.
 

--- a/openspec/specs/cube-css-layer-enforcement/spec.md
+++ b/openspec/specs/cube-css-layer-enforcement/spec.md
@@ -4,8 +4,7 @@
 
 Enforces that all CSS rules live inside `@layer` blocks and that layer declarations follow the canonical CUBE CSS order (`reset, tokens, global, composition, utility, block, exception`). Prevents cascade conflicts caused by unlayered styles.
 
-## ADDED Requirements
-
+## Requirements
 ### Requirement: `cube/require-layer` rejects CSS rules outside `@layer` blocks
 All CSS rules SHALL be inside an `@layer` block. Unlayered styles override all layers and break the CUBE CSS cascade.
 

--- a/openspec/specs/cube-css-lint-plugin/spec.md
+++ b/openspec/specs/cube-css-lint-plugin/spec.md
@@ -4,8 +4,7 @@
 
 Defines the Stylelint plugin architecture for CUBE CSS enforcement: plugin registration under the `cube/` namespace, local ESM package structure, shared utilities (`getLayerContext`), and test coverage requirements.
 
-## ADDED Requirements
-
+## Requirements
 ### Requirement: Plugin registers all rules under the `cube/` namespace
 The plugin SHALL export all rules prefixed with `cube/` so they can be configured individually in `stylelint.config.js`.
 

--- a/openspec/specs/cube-css-modern-css-rules/spec.md
+++ b/openspec/specs/cube-css-modern-css-rules/spec.md
@@ -4,8 +4,7 @@
 
 Enforces modern CSS best practices within the CUBE CSS methodology: logical viewport units (`vi` over `vw`), named containers (`container-name` required with `container-type`), and `color-mix()`/relative color syntax for derived color tokens.
 
-## ADDED Requirements
-
+## Requirements
 ### Requirement: `cube/prefer-vi-over-vw` recommends `vi` unit over `vw`
 CSS values SHALL use the `vi` (viewport inline) unit instead of `vw` (viewport width) for logical consistency with writing-mode awareness.
 

--- a/openspec/specs/cube-css-structural-rules/spec.md
+++ b/openspec/specs/cube-css-structural-rules/spec.md
@@ -4,8 +4,7 @@
 
 Enforces structural limits on CUBE CSS block layer: maximum lines per `@scope` block, one block component per file, and `:where()` wrapping in reset/global layers for zero-specificity defaults.
 
-## ADDED Requirements
-
+## Requirements
 ### Requirement: `cube/block-max-lines` limits block size
 Each `@scope` block inside `@layer block` SHALL contain at most the configured number of lines (default: 80).
 

--- a/openspec/specs/cube-css-token-enforcement/spec.md
+++ b/openspec/specs/cube-css-token-enforcement/spec.md
@@ -4,8 +4,7 @@
 
 Enforces design token usage via `var()` references for spacing, color, typography, and animation properties in consumption layers (composition, utility, block, exception). Token definition layers (reset, tokens, global) are excluded.
 
-## ADDED Requirements
-
+## Requirements
 ### Requirement: `cube/require-token-variables` enforces `var()` for design token properties
 Configured properties in consumption layers (composition, utility, block, exception) SHALL use `var()` references instead of raw literal values.
 

--- a/openspec/specs/dna-orb-color-injection/spec.md
+++ b/openspec/specs/dna-orb-color-injection/spec.md
@@ -1,4 +1,10 @@
-## ADDED Requirements
+# DNA Orb Color Injection Specification
+
+## Purpose
+
+Defines how followed-artist bubble hues are injected into discovery orb particles, including the swirl animation triggered on follow.
+
+## Requirements
 
 ### Requirement: Bubble Hue Injection into Orb Particles
 

--- a/openspec/specs/entity-test-coverage/spec.md
+++ b/openspec/specs/entity-test-coverage/spec.md
@@ -1,4 +1,10 @@
-## ADDED Requirements
+# Entity Test Coverage Specification
+
+## Purpose
+
+Defines the required unit-test coverage for frontend entity mapping and helper functions.
+
+## Requirements
 
 ### Requirement: isHypeMatched exhaustive coverage
 `isHypeMatched(hype, lane)` SHALL be tested for all 12 combinations of HypeLevel x LaneType using table-driven tests.

--- a/openspec/specs/festival-orb-effects/spec.md
+++ b/openspec/specs/festival-orb-effects/spec.md
@@ -1,5 +1,9 @@
 # Festival Orb Effects
 
+## Purpose
+
+Defines the festival-stage visual escalation effects applied to discovery orbs as users follow more artists.
+
 ## Requirements
 
 ### Requirement: Stage-level escalation system

--- a/openspec/specs/frontend-entity-layer/spec.md
+++ b/openspec/specs/frontend-entity-layer/spec.md
@@ -1,3 +1,11 @@
+# Frontend Entity Layer Specification
+
+## Purpose
+
+Defines the frontend entity layer that maps backend proto types (Artist, FollowedArtist, Concert) to a single canonical representation.
+
+## Requirements
+
 ### Requirement: Artist entity
 The frontend SHALL use the BSR-generated proto `Artist` class from `@buf/liverty-music_schema.bufbuild_es/liverty_music/entity/v1/artist_pb.js` as the canonical artist representation across all layers (services, state, components). Custom interfaces (`ArtistBubble`, `GuestFollow`) that duplicate Artist fields SHALL be removed. The `src/entities/artist.ts` file SHALL re-export the proto `Artist` type and provide helper functions for common field access patterns (e.g., best logo URL extraction).
 

--- a/openspec/specs/gke-gateway-infrastructure/spec.md
+++ b/openspec/specs/gke-gateway-infrastructure/spec.md
@@ -1,4 +1,10 @@
-## ADDED Requirements
+# GKE Gateway Infrastructure Specification
+
+## Purpose
+
+Defines the GKE Gateway API resources: HTTPRoute routing, GatewayClass selection, cross-namespace routing, and certificate/policy attachment.
+
+## Requirements
 
 ### Requirement: Gateway API Resource Creation
 The system SHALL provide a GKE Gateway API resource that listens on HTTPS (443) and HTTP (80) ports, deployed in the `gateway` namespace.

--- a/openspec/specs/http-retry/spec.md
+++ b/openspec/specs/http-retry/spec.md
@@ -1,4 +1,10 @@
-## ADDED Requirements
+# HTTP Retry Specification
+
+## Purpose
+
+Defines HTTP client retry behavior for transient errors: Retry-After handling, context cancellation, request-body replay, and backoff limits.
+
+## Requirements
 
 ### Requirement: HTTP retry on transient errors
 The system SHALL automatically retry HTTP requests that fail with transient status codes (408 Request Timeout, 429 Too Many Requests, 500 Internal Server Error, 502 Bad Gateway, 503 Service Unavailable, 504 Gateway Timeout) using exponential backoff with jitter.

--- a/openspec/specs/infra/spec.md
+++ b/openspec/specs/infra/spec.md
@@ -1,3 +1,11 @@
+# Infrastructure Specification
+
+## Purpose
+
+Defines infrastructure invariants for KEDA-managed Deployments and how ArgoCD reconciles their replica counts.
+
+## Requirements
+
 ### Requirement: KEDA-managed Deployments SHALL NOT declare replicas
 
 Deployments targeted by a KEDA ScaledObject SHALL omit `spec.replicas` from their Kustomize base manifest, delegating replica count management entirely to KEDA.

--- a/openspec/specs/k8s-service-cross-namespace-routing/spec.md
+++ b/openspec/specs/k8s-service-cross-namespace-routing/spec.md
@@ -1,4 +1,10 @@
-## ADDED Requirements
+# K8s Service Cross-Namespace Routing Specification
+
+## Purpose
+
+Defines Kubernetes Service configuration that enables cross-namespace routing from an external Gateway while maintaining namespace isolation.
+
+## Requirements
 
 ### Requirement: Backend Service Accessibility from External Gateway
 The system SHALL make the `server` Service (backend namespace) accessible to HTTPRoute resources in the `gateway` namespace.

--- a/openspec/specs/landing-page/spec.md
+++ b/openspec/specs/landing-page/spec.md
@@ -1,3 +1,9 @@
+# Landing Page Specification
+
+## Purpose
+
+Defines the guest-facing landing page: passkey authentication CTA, welcome copy, language switching, and authenticated-user redirect.
+
 ## Requirements
 
 ### Requirement: Passkey Authentication CTA

--- a/openspec/specs/layout-assertions/spec.md
+++ b/openspec/specs/layout-assertions/spec.md
@@ -1,3 +1,11 @@
+# Layout Assertions Specification
+
+## Purpose
+
+Defines the structural and selector conventions that frontend layout E2E tests assert against.
+
+## Requirements
+
 ### Requirement: E2E selectors use data-testid for stability
 All E2E test selectors for elements that are subject to refactoring SHALL use `data-testid` attributes instead of CSS class selectors, per [Playwright locator best practices](https://playwright.dev/docs/locators#locate-by-test-id).
 

--- a/openspec/specs/localstorage-naming/spec.md
+++ b/openspec/specs/localstorage-naming/spec.md
@@ -1,3 +1,9 @@
+# LocalStorage Naming Specification
+
+## Purpose
+
+Defines the unified naming convention and centralized registry for localStorage keys.
+
 ## Requirements
 
 ### Requirement: Unified key naming convention

--- a/openspec/specs/onboarding-guidance/spec.md
+++ b/openspec/specs/onboarding-guidance/spec.md
@@ -1,3 +1,11 @@
+# Onboarding Guidance Specification
+
+## Purpose
+
+Specifies the onboarding guidance experience rendered within the unified DiscoverPage for new and guest users.
+
+## Requirements
+
 ### Requirement: Onboarding guidance rendered within unified DiscoverPage
 The onboarding guidance SHALL be rendered as a Popover API element within `DiscoverPage` at `/discover`, instead of as an inline grid row.
 

--- a/openspec/specs/schema-lint/spec.md
+++ b/openspec/specs/schema-lint/spec.md
@@ -1,3 +1,11 @@
+# Schema Lint Specification
+
+## Purpose
+
+Defines the database schema lint rules (banned column types, audit columns, comment coverage) enforced during checks.
+
+## Requirements
+
 ### Requirement: SERIAL and BIGSERIAL detection
 The schema linter SHALL detect usage of `SERIAL` or `BIGSERIAL` types in `schema.sql` and report an error.
 

--- a/openspec/specs/state-management/spec.md
+++ b/openspec/specs/state-management/spec.md
@@ -1,3 +1,11 @@
+# State Management Specification
+
+## Purpose
+
+Defines the singleton service state owners (Onboarding, Guest) and how their state is persisted to and hydrated from localStorage.
+
+## Requirements
+
 ### Requirement: OnboardingService as singleton state owner
 
 The system SHALL provide an `OnboardingService` registered as `@singleton` via `DI.createInterface<IOnboardingService>()` that owns all onboarding state. Only properties requiring persistence side-effects (`step`) SHALL use `@observable`. Spotlight properties (`spotlightTarget`, `spotlightMessage`, `spotlightRadius`, `spotlightActive`) SHALL be plain class properties — Aurelia's template binding observes them automatically without `@observable`.

--- a/openspec/specs/user-auth/spec.md
+++ b/openspec/specs/user-auth/spec.md
@@ -1,3 +1,11 @@
+# User Authentication Specification
+
+## Purpose
+
+Defines user authentication behavior: sign up / sign in, session restoration on cold start, and the server-side session monitoring policy.
+
+## Requirements
+
 ### Requirement: Sign Up / Sign In
 
 The system SHALL provide Passkey authentication via Zitadel. For new users, authentication is triggered at the end of the onboarding tutorial (Step 6) via a non-dismissible modal. For returning users, authentication is available via a [Login] link on the landing page.

--- a/openspec/specs/watermill-structured-logging/spec.md
+++ b/openspec/specs/watermill-structured-logging/spec.md
@@ -1,3 +1,11 @@
+# Watermill Structured Logging Specification
+
+## Purpose
+
+Defines that Watermill emits structured JSON logs through the shared slog handler so its output is classified consistently with application logs in GCP.
+
+## Requirements
+
 ### Requirement: Watermill logs use structured JSON output
 The backend SHALL output Watermill logs as structured JSON using Watermill's official slog adapter (`watermill.NewSlogLogger`). All Watermill log entries MUST include a `severity` field that GCP Cloud Logging can parse from `jsonPayload`.
 


### PR DESCRIPTION
## Summary

After the OpenSpec 1.8.0 upgrade (#758), `openspec validate --all` surfaced ~40 pre-existing failures. 1.8.0 enforces the canonical spec structure (`## Purpose` + `## Requirements`) more strictly. Many main specs under `openspec/specs/` had been populated by copying change deltas, so they kept delta headers (`## ADDED Requirements`) and/or lacked the `## Purpose` / title scaffold.

This normalizes **30 main specs** — **structure only, no requirement or scenario content changed**:

- **B (rename)** — leftover `## ADDED` / `## MODIFIED Requirements` headers → `## Requirements`.
- **A (scaffold)** — add missing `# <Title> Specification` + `## Purpose`, plus `## Requirements` for fully headerless specs.

### Impact

`openspec validate --all`: **40 failures → 10**.

Remaining 10 are intentionally **out of scope** and tracked as follow-ups:
- 5 specs with per-requirement `#### Scenario:` gaps (authentication, my-artists, onboarding-page-help, passion-level, typography-focused-dashboard) — need real scenario content.
- `state-transition-diagram` — non-standard numbered-section format; needs a rewrite into requirements/scenarios.
- 4 changes (2 with no deltas, 2 with MODIFIED dropping scenarios; one of those, `refactor-discovery-bubble-field-state`, is an **active WIP** and deliberately untouched).

Refs: #760