### PR TITLE
docs(openspec): propose swappable plain-date library (Date→Temporal seam, +0KB until Baseline)

### DIFF
--- a/openspec/changes/introduce-swappable-plain-date-lib/.openspec.yaml
+++ b/openspec/changes/introduce-swappable-plain-date-lib/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-12

--- a/openspec/changes/introduce-swappable-plain-date-lib/design.md
+++ b/openspec/changes/introduce-swappable-plain-date-lib/design.md
@@ -1,0 +1,98 @@
+## Context
+
+See proposal.md — Why. Today the frontend has no date library and does all civil-date math on native `Date`, scattered across `date-presets.ts`, `date-preset-selector.ts`, and `concert-store.ts`. The domain already carries the right value type: `CalendarDate { year, month, day }` (1-based month/day), defined in the generated RPC client. `Temporal.PlainDate` is a structural match for `CalendarDate`, but Temporal is not yet Baseline (Safari ships it only in Technology Preview as of 2026-08) and `@js-temporal/polyfill` is ~44 KB gzipped — an unacceptable regression for a PWA that ships zero date libraries today.
+
+Relevant environment facts that shape the design:
+- Node 25 (the current dev/test runtime) has **no** `globalThis.Temporal`; Vitest runs under jsdom, so the Temporal engine's tests must supply the polyfill themselves.
+- `vite.config.ts` already uses `loadEnv` / `VITE_*`, so a mode-keyed `resolve.alias` is a natural fit.
+- The `frontend-runtime-config` capability already establishes the precedent of grep/bundle-content CI assertions — the polyfill-purity guard follows the same pattern.
+
+## Goals / Non-Goals
+
+**Goals:**
+- One import seam (`src/lib/plain-date`) for all pure civil-date arithmetic, with `CalendarDate`/primitives as the only boundary types.
+- Two engines (`Date`, `Temporal`) proven equivalent by a single shared differential test suite.
+- Build-time engine selection that tree-shakes the unselected engine; production ships the `Date` engine at +0 KB.
+- A CI guard that fails if the Temporal polyfill ever reaches the production bundle.
+
+**Non-Goals:**
+- Temporal-izing relative-time (`toRelative`) or `Intl` display formatting in `value-converters/date.ts` (Instant/Intl concerns; deferred).
+- Migrating `Concert.date: Date` to `CalendarDate` (wider UI blast radius; deferred to a separate change).
+- Any change to the observable behavior of the All Nearby date presets (owned by `passive-concert-discovery`).
+- Actually switching production to Temporal — this change only builds the seam; the flip happens later, once Temporal is Baseline.
+
+## Decisions
+
+### D1: Interface as a module of pure functions over `CalendarDate`, not a DI service
+
+The seam is a plain ES module (`src/lib/plain-date/index.ts`) re-exporting a fixed set of pure functions. Proposed contract (names owned here, behavior owned by the spec):
+
+```ts
+// Boundary types only — no Date/Temporal ever crosses.
+export interface CalendarDate { year: number; month: number; day: number }
+export interface DateRangeCD { from: CalendarDate; to: CalendarDate }
+
+export function todayCalendarDate(): CalendarDate               // local components
+export function addDays(d: CalendarDate, days: number): CalendarDate
+export function resolveWeekend(base: CalendarDate): DateRangeCD
+export function parseDateInput(value: string): CalendarDate | null
+export function formatDateInput(d: CalendarDate): string        // "YYYY-MM-DD"
+export function inclusiveDaySpan(from: CalendarDate, to: CalendarDate): number
+export function isValidCalendarDate(d: CalendarDate): boolean
+```
+
+- **Why functions over a DI-injected `IPlainDateOps` service?** DI registration keeps both engines reachable at runtime, defeating tree-shaking — the exact opposite of the +0 KB goal. A module seam resolved by the bundler eliminates the dead engine statically. DI would also add observation/injection overhead for what is pure, stateless math.
+- **Why `CalendarDate` at the boundary (not `Date`)?** It is the anti-corruption boundary: with only plain data crossing, the two engines are trivially swappable and the differential test needs no adapter. It also stops raw `Date` from leaking further into the UI (the existing `Concert.date: Date` leak is explicitly left alone but not widened).
+- `resolvePreset` / `DateRange` / `DatePresetId` / `MAX_RANGE_DAYS` / `rangeCacheKey` stay in `date-presets.ts` — they are All-Nearby glue (preset enum, cache key), not pure calendar math. `date-presets.ts` re-exports the calendar primitives from the new lib so its public surface is unchanged for current importers where practical.
+
+### D2: Engine selection via mode-keyed Vite `resolve.alias` (build-time), not a runtime flag
+
+`index.ts` imports from a virtual specifier (e.g. `plain-date-engine`) that `vite.config.ts` aliases to the concrete engine file based on an env flag:
+
+```ts
+// vite.config.ts (sketch)
+const engine = env.VITE_DATE_ENGINE === 'temporal' ? 'temporal-impl' : 'date-impl'
+resolve: { alias: { 'plain-date-engine': `/src/lib/plain-date/${engine}.ts` } }
+```
+
+- **Why alias, not a conditional `import`?** A top-level `import` of both engines with a runtime branch bundles both (and drags in the polyfill if the Temporal engine references it). A `resolve.alias` picks exactly one file at build time; the other is never in the module graph, so it is not merely tree-shaken but never resolved. This is what guarantees +0 KB.
+- **Default = `date-impl`.** `temporal` requires the explicit `VITE_DATE_ENGINE=temporal` opt-in, used only for CI equivalence builds / future validation — never the default.
+
+### D3: Temporal engine references `globalThis.Temporal`; polyfill is test-only
+
+- The Temporal engine (`temporal-impl.ts`) uses `globalThis.Temporal.PlainDate` and never imports the polyfill, so a future native build is 0 KB.
+- Vitest cannot see `globalThis.Temporal` on Node 25, so the differential test's setup imports `@js-temporal/polyfill` and installs it on `globalThis` for the test run only. `@js-temporal/polyfill` is added to **`devDependencies`**.
+
+### D4: Differential test as the executable contract
+
+A single parametrized Vitest suite imports both `date-impl` and `temporal-impl` directly (bypassing the alias) and runs every contract case against both, asserting deep equality. The one genuine semantic divergence and two convergent-by-construction cases are pinned as explicit contract cases:
+
+| Case | `Date` engine | `Temporal` engine | Contract |
+|---|---|---|---|
+| Out-of-domain component (e.g. `month=0`) — **the real divergence** | silent rollover | `PlainDate.from` throws | both return `null` at boundary → Temporal engine catches the throw, Date engine validates before constructing |
+| Day arithmetic (`addDays`) | pure calendar-day math on a date-only value | pure calendar-day math on `PlainDate` | identical `CalendarDate` out. Because the boundary is `CalendarDate`→`CalendarDate` (no wall-clock time), neither engine is DST-sensitive — the current `resolvePreset` midnight-local normalization is no longer needed by *either* engine and is dropped |
+| `formatDateInput` zero-padding | manual `padStart` | `PlainDate.toString()` / `padStart` | identical `"YYYY-MM-DD"` |
+
+The suite doubles as the regression fence for the eventual native-Temporal flip.
+
+### D5: Bundle-purity CI guard
+
+After `npm run build`, a check greps the emitted `dist/` chunks for `@js-temporal` / polyfill identifiers and fails on any hit (mirrors the `frontend-runtime-config` bundle-content assertions). Runs in the default-engine (Date) build. Wired into `make check` / CI so the +0 KB property cannot silently regress.
+
+## Risks / Trade-offs
+
+- **Two implementations to maintain until the flip (~1 year).** → The interface is tiny (7 functions) and frozen by the differential suite; drift is caught by CI. Scope is deliberately limited to pure calendar math to keep the surface minimal.
+- **Temporal engine is written now but never exercised in production until Baseline (rot risk).** → The shared differential suite runs the Temporal engine on every CI run via the polyfill, so it stays honest against the same contract as the shipped engine.
+- **`resolve.alias` virtual specifier could confuse IDE/type resolution.** → Provide a matching `tsconfig` path mapping (and/or a `.d.ts`) for `plain-date-engine` so types resolve to the interface regardless of the built engine.
+- **Polyfill accidentally imported by application code (bundle regression).** → D5's CI guard fails the build; the Temporal engine references `globalThis.Temporal` only, and the spec forbids polyfill imports outside tests.
+- **Node/jsdom polyfill install leaks between tests.** → Install on `globalThis` in a scoped setup file used only by the differential suite; do not install globally for the whole test run.
+
+## Migration Plan
+
+1. Land the lib (interface + both engines + differential suite + alias + CI guard) with production defaulting to the `Date` engine — behavior-neutral, ships immediately.
+2. Repoint `date-presets.ts` / `date-preset-selector.ts` to the interface; keep All-Nearby glue in place. Existing preset tests stay green (behavior unchanged).
+3. **Later, separate change (not this one):** once Temporal is Baseline (Safari stable + widely available), flip the default alias to a native-Temporal build (no polyfill), verify the differential suite + bundle-purity guard, ship. Rollback = revert the one-line alias default.
+
+## Open Questions
+
+- Exact `dist/` scan mechanism for D5 (standalone Vitest test vs. a `make`-level grep step) — either satisfies the spec; pick during implementation.

--- a/openspec/changes/introduce-swappable-plain-date-lib/proposal.md
+++ b/openspec/changes/introduce-swappable-plain-date-lib/proposal.md
@@ -1,0 +1,36 @@
+## Why
+
+The frontend's calendar arithmetic — weekend/range preset resolution, `<input type="date">` parse/format, inclusive day spans, `CalendarDate` conversions — is scattered across `date-presets.ts`, `date-preset-selector.ts`, and `concert-store.ts` and built entirely on the native `Date` object. `Date` forces us to hand-guard footguns it creates across all of these: silent month rollover (the `new Date(2026, -1, 15)` → 2025-12-15 pattern that already required an explicit null-guard in `concert-store.ts` to avoid misbucketing a concert), midnight-local normalization to avoid DST drift, and `Date.UTC` hacks for day-span math. TC39 `Temporal` (ES2026, Stage 4 since 2026-03) eliminates this whole class of bugs and its `Temporal.PlainDate` maps 1:1 onto our existing `CalendarDate` value type — but it is **not yet Baseline** (Chrome 144 / Firefox 139 ship it; Safari only in Technology Preview) and its `@js-temporal/polyfill` is ~44 KB gzipped. We ship **zero** date libraries today, so adopting Temporal natively now would be a pure +44 KB bundle regression for a mobile PWA that tracks INP/LCP.
+
+This change builds the seam now — while the analysis is fresh — so that the eventual switch to native `Temporal` is a one-line, already-proven change once it reaches Baseline, without paying any bundle cost in the meantime.
+
+## What Changes
+
+- Introduce a new frontend library `src/lib/plain-date/` that exposes calendar arithmetic through an **implementation-agnostic interface** whose boundary values are always the plain `CalendarDate` data type (no `Date` or `Temporal` object crosses the boundary).
+- Move the existing pure calendar primitives (`addDays`, `resolveWeekend`, `parseDateInput`, `formatDateInput`, `inclusiveDaySpan`, and a Date-less `todayCalendarDate` replacing the current `toCalendarDate(d: Date)`) out of `date-presets.ts` into a **`Date`-backed implementation** behind that interface. Call sites import the interface entry point, not a concrete implementation. The All-Nearby glue that is not pure calendar math — `resolvePreset`, `DateRange`, `DatePresetId`, `MAX_RANGE_DAYS`, `rangeCacheKey` — stays in `date-presets.ts` and re-points onto the new primitives.
+- Add a **second `Temporal`-backed implementation** of the same interface (referencing `globalThis.Temporal`, never importing the polyfill in application code).
+- Add `@js-temporal/polyfill` as a **`devDependencies`-only** package, used solely to run the `Temporal` implementation under Vitest/jsdom (where `globalThis.Temporal` is absent on Node 25).
+- Add a **shared differential test suite** run against BOTH implementations that fixes the behavioral contract (including the semantic decision points: invalid-component handling, weekend rules, span clamping) so the two engines are proven equivalent.
+- Select the active implementation at **build time via Vite `resolve.alias`** keyed on mode/env (a build-time flag, NOT a runtime flag): production builds resolve to the `Date` implementation only; the `Temporal` implementation is tree-shaken out. This keeps the production bundle at **+0 KB**.
+- Add a **CI guard** asserting the production bundle contains no `@js-temporal` / Temporal-polyfill code, so the +0 KB property cannot silently regress.
+
+Out of scope (explicitly deferred): the `Temporal`-ization of relative-time formatting (`toRelative`) and `Intl` display formatting in `value-converters/date.ts` (Instant/Intl concerns, little Temporal upside); and migrating `concert-store.ts`'s own date construction (`concertFrom`, `timestampToTimeString`) and the `Concert.date: Date` UI entity field to the new library / `CalendarDate` (wider UI blast radius — tracked separately). Those keep their existing inline guards for now; this change establishes the reusable seam they will later adopt.
+
+## Capabilities
+
+### New Capabilities
+
+- `frontend-plain-date-lib`: An implementation-agnostic calendar-arithmetic library for the SPA. Defines the `CalendarDate`-boundary interface, its behavioral contract (weekend/range preset resolution, date-input parse/format, inclusive day span, invalid-component handling), the requirement that two interchangeable engines (`Date` and `Temporal`) satisfy that contract identically under a shared test suite, build-time engine selection, and the production-bundle purity guarantee (no Temporal polyfill shipped).
+
+### Modified Capabilities
+
+<!-- None. The observable behavior of the All Nearby date presets (specced in passive-concert-discovery) is intentionally unchanged; this change relocates the implementation behind a seam without altering any user-facing behavior. -->
+
+## Impact
+
+- **New code**: `frontend/src/lib/plain-date/` (interface + `Date` impl + `Temporal` impl + shared differential tests).
+- **Modified code**: `frontend/src/components/all-nearby/date-presets.ts` and `date-preset-selector.ts` re-point to the new interface; `date-presets.ts` retains only the `all-nearby`-specific glue (`DateRange`, `DatePresetId`, `MAX_RANGE_DAYS`, `rangeCacheKey`) that is not pure calendar arithmetic.
+- **Build config**: `frontend/vite.config.ts` gains a mode-keyed `resolve.alias` for the plain-date engine.
+- **Dependencies**: `@js-temporal/polyfill` added to `devDependencies` only.
+- **CI**: a new bundle-purity assertion (test or build-step grep) in the frontend pipeline.
+- **No backend, proto, or infra impact.** No user-facing behavior change.

--- a/openspec/changes/introduce-swappable-plain-date-lib/specs/frontend-plain-date-lib/spec.md
+++ b/openspec/changes/introduce-swappable-plain-date-lib/specs/frontend-plain-date-lib/spec.md
@@ -1,0 +1,115 @@
+## Purpose
+
+This capability defines the SPA's implementation-agnostic calendar-arithmetic library: a single seam through which all pure "civil date" math (weekend/range preset resolution, `<input type="date">` parse/format, inclusive day-span, `CalendarDate` conversions) flows. It fixes one behavioral contract that two interchangeable engines — a native `Date` engine (shipped today) and a `Temporal` engine (shipped when Baseline) — SHALL satisfy identically, so the frontend can migrate from `Date` to `Temporal` at build time without any behavior change and without a production bundle-size regression.
+
+## ADDED Requirements
+
+### Requirement: Calendar arithmetic SHALL be exposed through an implementation-agnostic interface with `CalendarDate` boundary values
+
+The SPA SHALL provide its pure calendar arithmetic through a single library entry point (`src/lib/plain-date`) that exposes a fixed interface. Every value that crosses the interface boundary — as an argument or a return value — SHALL be either a primitive (`number`, `string`) or the plain `CalendarDate` data type (`{ year: number; month: number; day: number }`, all 1-based for month/day). No engine-specific temporal object (a native `Date` instance or a `Temporal.PlainDate` instance) SHALL appear in any interface signature. Call sites SHALL import the interface entry point and SHALL NOT import a concrete engine implementation directly.
+
+#### Scenario: Boundary exposes only plain data
+
+- **WHEN** any function of the plain-date library entry point is called from application code
+- **THEN** its parameters and return value SHALL be primitives or `CalendarDate` objects only
+- **AND** no native `Date` or `Temporal` object SHALL be passed across or returned from the boundary
+
+#### Scenario: Call sites depend on the interface, not an engine
+
+- **WHEN** searching `frontend/src` (excluding `src/lib/plain-date/`) for imports of a concrete engine module (e.g. a `*-impl` path or `@js-temporal/polyfill`)
+- **THEN** zero occurrences SHALL be found
+- **AND** every consumer SHALL import from the `src/lib/plain-date` entry point instead
+
+### Requirement: The library SHALL implement a fixed calendar-arithmetic contract
+
+The library SHALL provide, at minimum, the following operations with the specified behavior, independent of the active engine:
+
+- Convert a "today" reference into a `CalendarDate` using local (never UTC) components.
+- Add a whole number of days to a `CalendarDate`, returning a new `CalendarDate` (pure, no mutation).
+- Resolve the weekend range relative to a reference date: Monday–Friday SHALL yield the coming Saturday..Sunday; Saturday SHALL yield today (Sat)..tomorrow (Sun); Sunday SHALL yield today..today.
+- Parse an `<input type="date">` value (`"YYYY-MM-DD"`) into a `CalendarDate`, returning a sentinel "no value" result for empty or malformed input, and rejecting out-of-domain month (`< 1` or `> 12`) or day (`< 1` or `> 31`) components.
+- Serialize a `CalendarDate` into a zero-padded `"YYYY-MM-DD"` string.
+- Compute the inclusive whole-day span between two `CalendarDate`s (`1` when the two are equal).
+
+These behaviors are the contract; the exact function names are an implementation detail owned by design.md.
+
+#### Scenario: Weekend resolution follows the day-of-week rule
+
+- **WHEN** the weekend range is resolved for a reference date that is a Wednesday
+- **THEN** the resulting range SHALL start on the coming Saturday and end on the following Sunday
+- **AND** WHEN the reference date is a Saturday, the range SHALL start that Saturday and end the next day (Sunday)
+- **AND** WHEN the reference date is a Sunday, the range SHALL start and end on that same Sunday
+
+#### Scenario: Inclusive day span counts both endpoints
+
+- **WHEN** the inclusive day span is computed between two equal `CalendarDate`s
+- **THEN** the result SHALL be `1`
+- **AND** WHEN computed between a date and the date 29 days later, the result SHALL be `30`
+
+#### Scenario: Malformed date-input value yields no `CalendarDate`
+
+- **WHEN** an empty string or a value not matching `"YYYY-MM-DD"`, or a value whose month or day component is out of domain, is parsed
+- **THEN** the library SHALL return its "no value" sentinel result and SHALL NOT return a `CalendarDate`
+
+### Requirement: Invalid calendar components SHALL NOT silently roll over
+
+When the library is asked to interpret a `CalendarDate` (or produce one from arithmetic) whose components do not denote a real calendar day (for example a zero or negative month, or a month/day outside its valid domain), it SHALL surface the invalidity as a rejection (a "no value" / null-equivalent result at the boundary) rather than silently normalizing it to a different real date. This closes the native-`Date` footgun where `new Date(2026, -1, 15)` rolls to 2025-12-15.
+
+#### Scenario: Zero-month input does not roll into the previous year
+
+- **WHEN** the library is asked to interpret a `CalendarDate` with `month = 0` (or any out-of-domain component)
+- **THEN** it SHALL reject the value at the boundary (a "no value" / null-equivalent result)
+- **AND** it SHALL NOT return a `CalendarDate` denoting a rolled-over date in an adjacent month or year
+
+### Requirement: Two interchangeable engines SHALL satisfy the contract identically
+
+The library SHALL ship with two engine implementations of the interface — one backed by the native `Date` object and one backed by `Temporal` (referencing `globalThis.Temporal`). A single shared differential test suite SHALL exercise BOTH engines against the same inputs and SHALL assert identical observable results for every operation in the contract, including the weekend rules, span math, parse/format round-trips, and the invalid-component rejection behavior. The `Temporal` engine SHALL NOT import a polyfill in its own module; the polyfill is a test-only dependency.
+
+#### Scenario: Differential suite runs both engines and requires equivalence
+
+- **WHEN** the shared plain-date test suite runs
+- **THEN** every contract operation SHALL be executed against both the `Date` engine and the `Temporal` engine with the same inputs
+- **AND** the two engines SHALL produce equal results for every case
+- **AND** the suite SHALL fail if any input produces divergent results between the engines
+
+#### Scenario: Temporal engine references the global, not a bundled polyfill
+
+- **WHEN** the `Temporal` engine module source is inspected
+- **THEN** it SHALL reference `globalThis.Temporal`
+- **AND** it SHALL NOT import `@js-temporal/polyfill` (the polyfill is provided only by the test environment)
+
+### Requirement: The active engine SHALL be selected at build time, defaulting to the `Date` engine
+
+The library entry point SHALL resolve to exactly one engine per build via a build-time configuration (a Vite `resolve.alias` keyed on build mode/env), not a runtime branch. The default for development and production builds SHALL be the `Date` engine. Selecting the `Temporal` engine SHALL require an explicit build-time opt-in. Because selection is resolved at build time, the unselected engine SHALL be eliminated from the output by tree-shaking rather than shipped and branched at runtime.
+
+#### Scenario: Default build resolves to the Date engine
+
+- **WHEN** a production build is produced with no engine opt-in
+- **THEN** the plain-date entry point SHALL resolve to the `Date` engine
+- **AND** the `Temporal` engine module SHALL NOT be present in the emitted chunks
+
+#### Scenario: Explicit opt-in resolves to the Temporal engine
+
+- **WHEN** a build is produced with the documented `Temporal` engine opt-in set
+- **THEN** the plain-date entry point SHALL resolve to the `Temporal` engine
+- **AND** the `Date` engine module SHALL NOT be present in the emitted chunks
+
+### Requirement: The production bundle SHALL contain no Temporal polyfill
+
+The shipped production build SHALL NOT include any `@js-temporal/polyfill` / Temporal-polyfill code, keeping the change's bundle-size impact at zero relative to the pre-change baseline. The polyfill SHALL be declared as a `devDependencies`-only package. A CI check SHALL enforce this and fail the pipeline on regression.
+
+#### Scenario: Built chunks are free of polyfill code
+
+- **WHEN** the emitted production `dist/` chunks are scanned for `@js-temporal` / Temporal-polyfill identifiers
+- **THEN** zero occurrences SHALL be found
+
+#### Scenario: Polyfill is a dev-only dependency
+
+- **WHEN** `frontend/package.json` is inspected
+- **THEN** `@js-temporal/polyfill` SHALL appear under `devDependencies`
+- **AND** SHALL NOT appear under `dependencies`
+
+#### Scenario: CI guards the bundle-purity property
+
+- **WHEN** a change causes the production bundle to include Temporal-polyfill code
+- **THEN** the dedicated CI bundle-purity check SHALL fail

--- a/openspec/changes/introduce-swappable-plain-date-lib/tasks.md
+++ b/openspec/changes/introduce-swappable-plain-date-lib/tasks.md
@@ -1,0 +1,43 @@
+## 1. Library scaffold & interface
+
+- [ ] 1.1 Create `frontend/src/lib/plain-date/` with `index.ts` re-exporting the fixed contract (`CalendarDate`, `DateRangeCD`, `todayCalendarDate`, `addDays`, `resolveWeekend`, `parseDateInput`, `formatDateInput`, `inclusiveDaySpan`, `isValidCalendarDate`) from a virtual engine specifier (`plain-date-engine`).
+- [ ] 1.2 Define the boundary types so no `Date`/`Temporal` object appears in any signature; source `CalendarDate` from the existing RPC client type where possible to avoid a duplicate shape.
+- [ ] 1.3 Add a `tsconfig` path mapping (and/or `.d.ts`) for `plain-date-engine` so IDE/type resolution points at the interface regardless of the built engine.
+
+## 2. Date engine (ships to prod)
+
+- [ ] 2.1 Implement `date-impl.ts` by moving the pure calendar functions out of `date-presets.ts` (`addDays`, `resolveWeekend`, `parseDateInput`, `formatDateInput`, `inclusiveDaySpan`), preserving current local-component behavior. Replace the current `toCalendarDate(d: Date)` — whose `Date` parameter would violate the no-`Date`-at-the-boundary requirement — with a Date-less `todayCalendarDate(): CalendarDate` (grep confirms `toCalendarDate` has no external callers, so this is a safe internal rename).
+- [ ] 2.2 Implement `isValidCalendarDate` and make `parseDateInput`/interpretation reject out-of-domain components (no silent rollover) — matching the current null-guard behavior in `concert-store.ts` / `date-presets.ts`.
+
+## 3. Temporal engine (built now, shipped later)
+
+- [ ] 3.1 Implement `temporal-impl.ts` against `globalThis.Temporal.PlainDate`; do NOT import the polyfill in this module.
+- [ ] 3.2 Map the semantic divergence points to the contract: catch `PlainDate.from` throws on invalid components and return `null`; drop DST normalization (unnecessary with `PlainDate`); match `"YYYY-MM-DD"` formatting.
+
+## 4. Build-time engine selection
+
+- [ ] 4.1 Add `@js-temporal/polyfill` to `frontend/package.json` `devDependencies` only.
+- [ ] 4.2 Add a mode-keyed `resolve.alias` in `vite.config.ts` mapping `plain-date-engine` → `date-impl` by default, → `temporal-impl` when `VITE_DATE_ENGINE=temporal`.
+- [ ] 4.3 Verify the default build resolves to the Date engine and the Temporal engine module is absent from emitted chunks (and vice-versa under the opt-in).
+
+## 5. Differential test suite
+
+- [ ] 5.1 Add a scoped Vitest setup that installs `@js-temporal/polyfill` on `globalThis` for the differential suite only (no leak into the wider test run).
+- [ ] 5.2 Write the parametrized suite importing both engines directly, asserting deep equality across all contract operations, with explicit cases for weekend rules (Mon–Fri / Sat / Sun), inclusive span (equal → 1, +29 → 30), parse/format round-trips, and `month=0` / out-of-domain rejection.
+
+## 6. Migrate call sites
+
+- [ ] 6.1 Repoint `date-presets.ts` and `date-preset-selector.ts` to import the calendar primitives from `src/lib/plain-date`; keep All-Nearby glue (`DateRange`, `DatePresetId`, `MAX_RANGE_DAYS`, `resolvePreset`, `rangeCacheKey`) in `date-presets.ts`.
+- [ ] 6.2 Grep `frontend/src` (excluding `src/lib/plain-date/`) to confirm no consumer imports a concrete engine or `@js-temporal/polyfill`.
+- [ ] 6.3 Confirm existing All-Nearby preset tests remain green (behavior unchanged).
+
+## 7. CI bundle-purity guard
+
+- [ ] 7.1 Add a check that scans production `dist/` chunks for `@js-temporal` / polyfill identifiers and fails on any hit; assert `@js-temporal/polyfill` is not in `dependencies`.
+- [ ] 7.2 Wire the guard into `make check` / the frontend CI pipeline.
+
+## 8. Verify & ship to prod
+
+- [ ] 8.1 Run `make check` (lint + typecheck + tests incl. differential suite) and `npm run build`; confirm the bundle-purity guard passes and bundle size is unchanged vs. baseline.
+- [ ] 8.2 Open the frontend PR, pass CI, and merge.
+- [ ] 8.3 Cut the frontend GitHub Release (SemVer minor) → automated prod pin-bump → confirm ArgoCD sync so the change reaches prod (Date engine, +0 KB). No behavior change to verify at runtime.


### PR DESCRIPTION
## Summary

Adds the OpenSpec change `introduce-swappable-plain-date-lib` — planning artifacts only (proposal, design, `frontend-plain-date-lib` spec, tasks). No proto or code changes.

It specs a swappable, implementation-agnostic calendar-arithmetic library (`frontend/src/lib/plain-date`) so the eventual migration from native `Date` to TC39 `Temporal` becomes a one-line, already-proven, **build-time** switch — at **+0 KB** production bundle cost until `Temporal` reaches Baseline.

## Why

- The frontend ships **no** date library today; all civil-date math runs on native `Date`, scattered across `date-presets.ts`, `date-preset-selector.ts`, and `concert-store.ts`, with hand-rolled guards for `Date`'s footguns (silent month rollover, midnight-local DST normalization, `Date.UTC` day-span hacks).
- `Temporal` (ES2026, Stage 4 since 2026-03) maps 1:1 onto our existing `CalendarDate` type and removes that whole class of bugs — but it is **not yet Baseline** (Safari only in Technology Preview) and its polyfill is ~44 KB gzipped, a pure regression if adopted natively now.
- Applying the "three-question test" from the Smashing Magazine article *How Baseline Can Help You Ship Less JavaScript*: adopt the seam now, flip to native `Temporal` when Baseline.

## What this specs (approach B-1)

- **One interface** over `CalendarDate` boundary values — no `Date`/`Temporal` object crosses the boundary.
- **Two interchangeable engines** (`Date` ships now, `Temporal` built now / shipped later) proven equivalent by a single **shared differential test suite** that pins the one real semantic divergence (`month=0`: `Date` rolls over vs `Temporal` throws → both return `null`).
- **Build-time engine selection** via mode-keyed Vite `resolve.alias` (NOT a runtime flag); production defaults to the `Date` engine and tree-shakes the other out.
- `@js-temporal/polyfill` is a **`devDependencies`-only** test dependency; a **CI guard** asserts the production bundle contains no polyfill code (+0 KB).

## Out of scope (deferred)

- `Temporal`-izing relative-time (`toRelative`) and `Intl` display formatting in `value-converters/date.ts`.
- Migrating `concert-store.ts`'s own date construction and the `Concert.date: Date` UI entity field to `CalendarDate` (they keep their existing inline guards for now).
- The actual production flip to `Temporal` — a later change, once Baseline.

## Validation

- `openspec validate --strict introduce-swappable-plain-date-lib` → valid.
- Planning-only; implementation happens in the frontend repo after this merges.

close: #762
