### PR TITLE
chore(openspec): rewrite state-transition-diagram into requirement/scenario format

### DIFF
--- a/openspec/specs/state-transition-diagram/spec.md
+++ b/openspec/specs/state-transition-diagram/spec.md
@@ -1,84 +1,116 @@
 # State Transition Diagram Specification
 
-## 1. Onboarding State
+## Purpose
 
-### 1.1 Overview
+Defines the client-side state machines that govern the first-run experience: the one-way onboarding latch, the independent coach-mark hint, and the ephemeral guest-data state accumulated before account creation. It captures each machine's states, transitions, triggers, persistence, and invariants so the frontend behaves consistently across routes.
 
-Onboarding is a single latched boolean, not an ordered step machine. A brand-new user
-starts in the `onboarding` state and transitions once, irreversibly, to `completed`. There
-is no forced navigation ordering: the dashboard and every route are reachable at any time
-(soft gate), and a guest with no follows is guided by an in-page empty-state CTA rather than
-a guard redirect. The flag is exposed as `OnboardingService.isOnboarding`
-(`isCompleted === !isOnboarding`) and persisted as `onboardingComplete` (absent key =
-still onboarding).
+## Requirements
 
-### 1.2 States
+### Requirement: Onboarding is a one-way latched boolean
 
-| State        | Description                                                |
-|--------------|------------------------------------------------------------|
-| `onboarding` | First-run experience (default for a new user)              |
-| `completed`  | Onboarding finished (terminal; one-way)                    |
+Onboarding SHALL be modeled as a single latched boolean, not an ordered step machine. A brand-new user starts in the `onboarding` state and transitions exactly once, irreversibly, to `completed`. There SHALL be no forced navigation ordering — every route is reachable at any time (soft gate); a guest with no follows is guided by an in-page empty-state CTA, not a guard redirect. The flag is exposed as `OnboardingService.isOnboarding` (`isCompleted === !isOnboarding`) and persisted as `onboardingComplete` (absent key = still onboarding).
 
-### 1.3 Transitions
-
-| Trigger                              | From         | To          | Where                          |
-|--------------------------------------|--------------|-------------|--------------------------------|
-| Meaningful first dashboard arrival ¹ | `onboarding` | `completed` | dashboard-route (`finish()`)   |
-| Sign-up (idempotent backstop)        | `onboarding` | `completed` | auth-callback-route (`finish()`)|
-
-¹ "Meaningful" = the timetable is real (region set + concert data loaded) **and** the guest
-has at least one followed artist (`followedCount >= 1`). The latch is evaluated after the
-light-celebration decision but is driven by the data-ready + engaged condition, not by whether
-the celebration overlay rendered. A zero-follow dashboard arrival does NOT latch. Completion is
-one-way; it never returns to `onboarding` except via an explicit fresh-onboarding reset. The
-legacy `onboardingStep` value is migrated once on load (`'completed'`/`'7'` → completed).
-
-### 1.4 Coach Mark (independent)
-
-The coach mark is a single, transient, non-blocking hint owned by `CoachMarkService` — not part
-of the onboarding state. It is activated from `DiscoveryRoute` when `isOnboarding` and the live
-follow/concert counts cross the threshold (`followedCount >= 5` OR `artistsWithConcertsCount >= 3`),
-and dismissed on target tap or route detach. It does not lock scroll or block off-target
-interaction, and tapping it navigates only (no state mutation).
-
-| Action                       | From       | To         |
-|------------------------------|------------|------------|
-| `CoachMarkService.activate`  | `inactive` | `active`   |
-| `CoachMarkService.deactivate`| `active`   | `inactive` |
-
-### 1.5 State Diagram
+| State        | Description                                   |
+|--------------|-----------------------------------------------|
+| `onboarding` | First-run experience (default for a new user) |
+| `completed`  | Onboarding finished (terminal; one-way)       |
 
 ```mermaid
 stateDiagram-v2
     [*] --> onboarding
     onboarding --> completed : finish() — meaningful dashboard arrival OR sign-up
     completed --> [*]
-
-    state "Coach mark (independent)" as coachmark {
-        [*] --> inactive
-        inactive --> active : activate (isOnboarding & counts threshold)
-        active --> inactive : deactivate (tap / route detach)
-    }
 ```
 
----
+#### Scenario: New user defaults to onboarding
 
-## 2. Guest Data
+- **WHEN** a brand-new user with no persisted `onboardingComplete` key loads the app
+- **THEN** `OnboardingService.isOnboarding` SHALL be `true`
 
-### 2.1 Overview
+#### Scenario: Meaningful dashboard arrival latches completion
 
-The guest state machine tracks ephemeral data accumulated before the user creates an account:
-followed artists and home location. This data is merged into the backend on signup,
-then cleared.
+- **WHEN** the user arrives at the dashboard AND the timetable is real (region set and concert data loaded) AND `followedCount >= 1`
+- **THEN** `dashboard-route` `finish()` SHALL latch the state to `completed`
+- **AND** the latch SHALL be driven by the data-ready + engaged condition, not by whether the celebration overlay rendered
 
-### 2.2 Transitions
+#### Scenario: Zero-follow dashboard arrival does not latch
 
-Guest state is a simple data bag — there are no discrete named states, only data mutations.
-The key invariant is: `guest/follow` is idempotent (duplicate artistId is a no-op).
+- **WHEN** the user arrives at the dashboard with `followedCount === 0`
+- **THEN** the state SHALL remain `onboarding`
 
-| Action              | Effect                                                  | Where                  |
-|---------------------|---------------------------------------------------------|------------------------|
-| `guest/follow`      | Append `{ artistId, name }` to follows (skip if exists) | discovery-route        |
-| `guest/unfollow`    | Remove entry by artistId                                | my-artists-route       |
-| `guest/setUserHome` | Set home ISO-3166-2 code                                | area-selector (modal)  |
-| `guest/clearAll`    | Reset follows to `[]` and home to `null`                | welcome-route, merge   |
+#### Scenario: Sign-up is an idempotent completion backstop
+
+- **WHEN** the user completes sign-up via `auth-callback-route`
+- **THEN** `finish()` SHALL latch the state to `completed`
+- **AND** invoking it when the state is already `completed` SHALL be a no-op
+
+#### Scenario: Completion is one-way
+
+- **WHEN** the state is `completed`
+- **THEN** it SHALL NOT return to `onboarding` except via an explicit fresh-onboarding reset
+
+#### Scenario: Legacy onboardingStep is migrated on load
+
+- **WHEN** the app loads with a legacy `onboardingStep` value of `'completed'` or `'7'`
+- **THEN** the state SHALL be migrated once to `completed`
+
+### Requirement: Coach mark is an independent, non-blocking hint
+
+The coach mark SHALL be a single, transient, non-blocking hint owned by `CoachMarkService`, separate from onboarding state. It is activated from `DiscoveryRoute` when `isOnboarding` is true and the live counts cross the threshold (`followedCount >= 5` OR `artistsWithConcertsCount >= 3`), and dismissed on target tap or route detach. It SHALL NOT lock scroll or block off-target interaction, and tapping it SHALL navigate only (no state mutation).
+
+| Action                        | From       | To         |
+|-------------------------------|------------|------------|
+| `CoachMarkService.activate`   | `inactive` | `active`   |
+| `CoachMarkService.deactivate` | `active`   | `inactive` |
+
+#### Scenario: Coach mark activates when thresholds cross
+
+- **WHEN** `isOnboarding` is true AND (`followedCount >= 5` OR `artistsWithConcertsCount >= 3`)
+- **THEN** `CoachMarkService.activate` SHALL move the coach mark from `inactive` to `active`
+
+#### Scenario: Coach mark deactivates on tap or route detach
+
+- **WHEN** the coach-mark target is tapped OR the route detaches
+- **THEN** `CoachMarkService.deactivate` SHALL move it from `active` to `inactive`
+
+#### Scenario: Coach mark does not block interaction
+
+- **WHEN** the coach mark is `active`
+- **THEN** it SHALL NOT lock scroll or block off-target interaction
+- **AND** tapping it SHALL navigate only, with no onboarding-state mutation
+
+### Requirement: Guest data accumulates before signup and clears after merge
+
+Guest state SHALL be a simple data bag tracking ephemeral data accumulated before the user creates an account (followed artists and home location). On signup the data is merged into the backend, then cleared. There are no discrete named states, only data mutations. The key invariant is that `guest/follow` is idempotent — a duplicate `artistId` is a no-op.
+
+| Action              | Effect                                                  | Where                 |
+|---------------------|---------------------------------------------------------|-----------------------|
+| `guest/follow`      | Append `{ artistId, name }` to follows (skip if exists) | discovery-route       |
+| `guest/unfollow`    | Remove entry by artistId                                | my-artists-route      |
+| `guest/setUserHome` | Set home ISO-3166-2 code                                | area-selector (modal) |
+| `guest/clearAll`    | Reset follows to `[]` and home to `null`                | welcome-route, merge  |
+
+#### Scenario: guest/follow is idempotent
+
+- **WHEN** `guest/follow` is dispatched with an `artistId` already present in the follows list
+- **THEN** the list SHALL be unchanged (no duplicate entry)
+
+#### Scenario: guest/follow appends a new artist
+
+- **WHEN** `guest/follow` is dispatched from `discovery-route` with a new `artistId`
+- **THEN** `{ artistId, name }` SHALL be appended to the follows list
+
+#### Scenario: guest/unfollow removes an entry
+
+- **WHEN** `guest/unfollow` is dispatched with an `artistId` present in the list
+- **THEN** the matching entry SHALL be removed by `artistId`
+
+#### Scenario: guest/setUserHome sets the home code
+
+- **WHEN** `guest/setUserHome` is dispatched from the area selector
+- **THEN** the guest home SHALL be set to the given ISO-3166-2 code
+
+#### Scenario: guest/clearAll resets on merge or welcome
+
+- **WHEN** `guest/clearAll` is dispatched (from `welcome-route` or after a signup merge)
+- **THEN** follows SHALL be reset to `[]` and home to `null`


### PR DESCRIPTION
## Summary

The last **structural** OpenSpec 1.8.0 `validate` failure. `state-transition-diagram` used a non-standard numbered-section format (`## 1. Onboarding State`, `### 1.2 States`, `### 1.3 Transitions` …) with no `### Requirement:` / `#### Scenario:` blocks, so it could not parse.

Rewritten into the canonical `## Purpose` / `## Requirements` structure, **preserving all domain content** — state tables, transition tables, the mermaid diagram, thresholds, persistence keys, and invariants:

- **Onboarding is a one-way latched boolean** — 6 scenarios (default onboarding, meaningful dashboard latch, zero-follow no-latch, sign-up idempotent backstop, one-way completion, legacy `onboardingStep` migration).
- **Coach mark is an independent, non-blocking hint** — 3 scenarios.
- **Guest data accumulates before signup and clears after merge** — 5 scenarios.

Passes `validate` in **both normal and `--strict`** mode.

## Impact

`openspec validate --all`: **4 → 3 failures** — and 3 is the floor: the 2 intentionally-parked proposal-only changes (`login-register-error-classification`, `manage-analytics-data-rights`) and the active `refactor-discovery-bubble-field-state` WIP. Content/structure only; no behavior change.

Refs: #770