### PR TITLE
docs: Phase 3 ticketing roadmap + organizer platform design (① split into 4)

### DIFF
--- a/docs/organizer-platform-design.md
+++ b/docs/organizer-platform-design.md
@@ -1,0 +1,185 @@
+# Organizer Platform — Design & Change Decomposition
+
+Durable design for the **Organizer** feature cluster (roadmap change ① of
+`ticketing-platform-roadmap.md`, "the vetted seller foundation"). The
+original single `organizer-accounts` change grew too large — a
+spec-completeness audit surfaced ~33 gaps spanning identity, provisioning,
+a dedicated API server, dedicated hosting, and offboarding. To avoid
+losing scope coverage, ① is **decomposed into four changes** (see the last
+section); this document is the source of truth they are authored from.
+
+Related: identity/RBAC mechanics live in
+[`zitadel-tenancy-model.md`](./zitadel-tenancy-model.md); this doc covers
+the Organizer domain, its surfaces, and the resolved audit gaps.
+
+## Confirmed decisions
+
+- **Organizer = the vetted seller entity**, distinct from Artist/Performer
+  (schema.org `organizer`). Exists only via admin creation → existence is
+  the vetting; **no business `verified` flag**.
+- **Entity fields:** `OrganizerId` (UUIDv7), `OrganizerName` (1–200 chars),
+  `zitadel_org_id` (the tenant org, unique, backend-only), and an
+  operational `provisioning_state` (`provisioning` / `active` /
+  `deactivated`) — this is a lifecycle marker, **not** the rejected
+  business `verified` flag.
+- **Organizer↔Artist:** an Organizer represents many Artists; **each Artist
+  is represented by at most one Organizer** via a partial-unique index on
+  `artist_id` (`WHERE provisioning_state != 'deactivated'`, so a
+  deactivated Organizer frees its artists for re-association).
+- **Tenancy: Zitadel org-per-Organizer** + a shared, actor-named
+  `organizer-console` project (owned by the `liverty-music` org),
+  Project-Granted to each Organizer org; `master` role via User Grant.
+  Actor-named so a future `venue-console` never collides. Full model:
+  `zitadel-tenancy-model.md`.
+- **Provisioning:** static platform is IaC; per-Organizer org + grant +
+  operator is created **at runtime via the Zitadel Management API** in the
+  admin vetting flow.
+- **Login (recommended, pending final confirm):** organizer tenant orgs use
+  a **passkey-only** login policy (no Google IdP), explicitly set at
+  provisioning (never inherit the admin default). Operator org is resolved
+  at login via **email domain discovery** — one OIDC app serves all
+  tenants.
+- **Fan ⇄ operator same person:** two **independent identities** (separate
+  `sub` per org); never linked/merged; no cross-org SSO between the fan app
+  and the organizer console.
+- **Offboarding:** a `deactivated` state hook ships now (backend rejects all
+  organizer RPCs for a deactivated Organizer; operators deactivated in
+  Zitadel). Full cascade is Phase 2.
+
+## Domain model
+
+```
+Organizer(id, name, zitadel_org_id UNIQUE, provisioning_state)
+   └──< organizer_artists (organizer_id, artist_id) >── Artist (existing)
+        partial UNIQUE(artist_id) WHERE state != 'deactivated'
+        both FKs ON DELETE CASCADE
+```
+`zitadel_org_id` is the load-bearing link from the token's tenant claim to
+the Organizer PK; **DB is the source of truth**, org metadata mirror is
+deferred. Not exposed on the consumer proto (internal linkage). Audit
+timestamps use domain-specific `*_at` names (schema-lint bans
+`created_at/updated_at`).
+
+## RPC surface
+
+- **Admin** (`rpc.admin.v1.OrganizerService`, admin-role gated, rides the
+  existing admin server): bare-verb `Create`, `AssociateArtist`,
+  `DisassociateArtist`, `List`, `Get`. `Create` takes `operator_email`
+  (+ optional display name); non-idempotent on name but
+  **compensating on the provisioning saga** (a retry completes a
+  half-provisioned Organizer, never duplicates). `List`/`Get` are required
+  for the admin management screen. `AssociateArtist` takes an existing
+  `ArtistId` and **rejects `NOT_FOUND`** for unknown artists (no
+  create-on-demand); rejects `ALREADY_EXISTS` if the artist is already
+  claimed. `DisassociateArtist` is idempotent; reassignment = disassociate
+  + associate.
+- **Organizer** (`rpc.organizer.v1.OrganizerService`, org-scoped, dedicated
+  server): bare-verb `Get` only for MVP (returns the caller's identity +
+  associated artists). Request carries an `OrganizerId` verified to equal
+  the token-derived tenant (rpc-auth-scoping, tenant variant). Update/List
+  deferred.
+- **protovalidate:** `OrganizerId.value = uuid`; wrap name in
+  `OrganizerName` (`min_len=1, max_len=200`) per the `ArtistName`
+  convention. Each RPC documents its error matrix (INVALID_ARGUMENT /
+  NOT_FOUND / ALREADY_EXISTS / PERMISSION_DENIED / UNAUTHENTICATED).
+
+## Provisioning saga (admin Create side effect)
+
+Ordered, idempotent, compensating — keyed on `OrganizerId`:
+1. Insert `organizers` row `provisioning_state = provisioning`.
+2. Management API: create tenant org (name `org-<uuid-short>`, not the
+   display name, to avoid collisions); **set an explicit passkey-only login
+   policy + `allowDomainDiscovery`**.
+3. Persist `zitadel_org_id` on the row.
+4. Project-Grant `organizer-console` (role subset incl. `master`) to the
+   org.
+5. Create the operator human user (no password) + User Grant `master`;
+   trigger Zitadel **init email** → operator registers a passkey on first
+   sign-in.
+6. Set `provisioning_state = active`.
+On failure, a reconciler re-enters at the first incomplete step (each
+Zitadel create is existence-checked). The operator is never left without a
+`master` grant.
+
+**Machine user:** a dedicated `organizer-provisioner` (NOT the existing
+single-org `backend-app` user) with the narrowest instance role that
+permits org-create + cross-org grant; credential in ESC/Secret Manager,
+isolated blast radius, rotation runbook required.
+
+## Authorization (organizer surface)
+
+Backend validates issuer/signature + **`aud` includes the organizer-console
+project id** (console requests the `...:project:id:{id}:aud` scope), then
+reads `urn:zitadel:iam:org:project:{projectId}:roles` = `role → { orgId →
+domain }`; the inner orgId is the tenant. Failure matrix (all
+`PERMISSION_DENIED`, never 500): missing/empty roles claim (require
+`accessTokenRoleAssertion=true`, `projectRoleCheck=false`), `aud` without
+the project id, login-scope org ≠ requested Organizer. A multi-org operator
+is authorized only against the **session's login-scope org**. Zitadel
+supplies identity + tenant + role; **which artists/events an Organizer may
+touch is Liverty's own data** (`organizer_artists`, event ownership),
+enforced in the backend.
+
+## Delivery surfaces (the audit's deepest blind spot)
+
+Mirroring the admin precedent (`admin-rpc-server`, `admin-console-hosting`):
+- **Organizer API server:** serve `rpc.organizer.v1.OrganizerService` on a
+  **dedicated** Connect server at `api.organizer.{base}` with its own CORS
+  allowlist (only the `organizer.{base}` origin), cert, DNS, health, and
+  tenant-scoped authorization. Exclude it from the consumer and admin
+  servers. The **admin** OrganizerService rides the existing admin server.
+- **Organizer console hosting:** serve `organizer.html` at
+  `organizer.{base}` (`organizer.dev.liverty-music.app` /
+  `organizer.liverty-music.app`) with HTTPRoute + certmap + Cloud DNS +
+  per-host `/config.json`.
+- **Runtime config:** the organizer `/config.json` carries the issuer + the
+  `organizer-console` client id + `apiBaseUrl = api.organizer.{base}`, but
+  **NOT a fixed `zitadelOrgId`** — the org is resolved at login (domain
+  discovery). Requires a `frontend-runtime-config` delta (its AppConfig
+  currently assumes one static org).
+
+## Observability
+
+Emit backend analytics events `organizer.created` and
+`organizer.artist.associated` (JetStream → PostHog), modeled as
+admin-actor / group events keyed on `organizer_id` (no fan UserId); add
+them to the event catalog in the same change. Wrap the provisioning call in
+an OTel span + a `organizer_provisioning_failed` metric.
+
+## Non-Goals (Phase 2 — stated so their absence is deliberate)
+
+Slug/handle; contact/billing fields; organizer-side `Update`/`List`; full
+offboarding cascade (org/grant/association teardown beyond the
+`deactivated` hook); per-org branding; sub-owner 4-role RBAC + audit log;
+org-creation rate limiting; the optional stable-`organizer-id` claim
+Action. No data backfill (additive tables only).
+
+## Change decomposition (① → four changes)
+
+Dependency-ordered; each independently reviewable. Owned-gap references are
+to the audit themes.
+
+| Change | Scope | Owns (audit) | Depends on |
+|--------|-------|--------------|------------|
+| **`organizer-tenancy`** | `identity-management` topology delta (allow runtime Organizer tenant orgs); Zitadel platform **IaC**: `organizer-console` project + `master` role + OIDC/API apps + `organizer-provisioner` machine user; per-org passkey-only login policy + domain discovery shape | A (login policy), C (machine user), identity topology | existing admin |
+| **`organizer-accounts`** | Organizer **entity** (`zitadel_org_id`, `provisioning_state`) + Organizer↔Artist (partial-unique); **admin** `OrganizerService` (Create/AssociateArtist/DisassociateArtist/List/Get); **tenant provisioning saga** + operator bootstrap (email + init/passkey); **deactivated** hook; analytics events | A (operator seed/bootstrap), C (saga/linkage/state), D (offboard hook), E (entity/assoc/admin RPCs), G (analytics) | `organizer-tenancy` |
+| **`organizer-console`** | `organizer.html` bundle-isolated entry (OIDC domain discovery, role-claim route guard, placeholder) + **hosting** (`organizer.{base}` DNS/cert/HTTPRoute/config.json) + `frontend-runtime-config` delta | A (route guard), C (login discovery), F (hosting, runtime-config) | `organizer-tenancy` (usable login target after `organizer-accounts`) |
+| **`organizer-rpc-server`** | Dedicated organizer Connect server at `api.organizer.{base}` + CORS/cert/DNS/health; `rpc.organizer.v1.OrganizerService.Get`; **org-scoped role-claim authorization** (the failure matrix) | B (authz matrix), E (Get shape), F (server/CORS) | `organizer-tenancy` + `organizer-accounts` |
+
+```
+organizer-tenancy ──▶ organizer-accounts ──┬──▶ organizer-console
+                                            └──▶ organizer-rpc-server
+```
+
+Downstream roadmap changes (②–⑥) depend on this cluster as a whole. Each
+sub-change is created with `/opsx:propose` when its work starts.
+
+## Open decisions (recommended defaults recorded above; confirm before build)
+
+- Login method: **passkey-only** (recommended) vs password+MFA.
+- Login org discovery: **email domain discovery** (recommended) vs org
+  param/subdomain.
+- Offboarding: **`deactivated` hook + partial-unique now** (recommended) vs
+  fully Phase 2.
+- Fan⇄operator: **two independent identities, no SSO** (recommended,
+  confirm).

--- a/docs/product-design.md
+++ b/docs/product-design.md
@@ -116,6 +116,10 @@ graph TD
 - アーティスト向け機能（チケット販売・管理システム）
 - チケット販売によるマネタイズ
 
+> Phase 3 の詳細な分割ロードマップ（審査済み Organizer / Stripe 決済 /
+> 抽選のみ MVP を、独立してリリース可能な複数の OpenSpec change へ分割）は
+> [Ticketing Platform Roadmap](./ticketing-platform-roadmap.md) を参照。
+
 > **チケットシステムの技術方針（決定記録・2026-08）**
 >
 > チケット販売・入場システムを将来構築する場合、**Web2 アーキテクチャ**

--- a/docs/ticketing-platform-roadmap.md
+++ b/docs/ticketing-platform-roadmap.md
@@ -35,7 +35,7 @@ change's `design.md`:
 
   ```
   Organizer (1) ──publishes──▶ (N) Event ──features──▶ (N) Artist   (existing event_performers)
-       └──────── mandate ──────────────▶ (N) Artist                 (label/mgmt case, N:M)
+       └──────── represents ──────────▶ (N) Artist                 (each artist ≤1 organizer)
   ```
 
   In MVP the Organizer role is filled by a vetted party: an **artist**
@@ -47,12 +47,14 @@ change's `design.md`:
   treated as interchangeable; a company owning multiple label brands is
   still one Organizer (label brand is a later display attribute). An
   artist who self-publishes is modeled as an Organizer account associated
-  with that Artist, not a second entity type. "Vetted" is a **`verified`
-  status** on the Organizer. An Organizer is simply associated with the
-  artists it represents (no full/partial mandate concept — keep it
-  simple).
+  with that Artist, not a second entity type. An Organizer **exists only
+  via admin vetting** (existence = vetted); there is no separate `verified`
+  flag (a lifecycle/status can be added later if suspension is ever needed).
+  An Organizer is simply associated with the artists it represents (no
+  full/partial mandate concept — keep it simple), and **each artist is
+  represented by at most one Organizer**.
 
-- **Sellers: vetted organizers only.** Reuse the existing admin approval
+- **Organizers: vetted only.** Reuse the existing admin approval
   pattern to onboard them. Open self-serve submission is out of scope,
   which also removes the fake-event risk.
 - **Sales method: lottery only for MVP.** FCFS, common inventory pool,
@@ -96,14 +98,15 @@ change's `design.md`:
   without consent is prohibited, (2) specify date/venue and
   seat-or-eligible-person, (3) capture **本人確認** (purchaser name +
   contact). Ties to the ④ identity requirement and ⑥ ticket rendering.
-- **First-party data supersedes; verified-organizer artists are excluded
+- **First-party data supersedes; organizer-represented artists are excluded
   from scraping.** When an organizer-published event or issued ticket
   exists it supersedes the inferred/self-reported data for the same
   subject (a published event overrides the scraped
   `staged_concert`/`sales_phase`; issuing a ticket syncs the user's
-  `ticket-journey` to `PAID`). Once an artist is represented by a
-  `verified` Organizer, that artist is simply **excluded from
-  concert-search scraping** (first-party is authoritative; saves cost).
+  `ticket-journey` to `PAID`). Once an artist is represented by an
+  Organizer (which exists only via admin vetting), that artist is simply
+  **excluded from concert-search scraping** (first-party is authoritative;
+  saves cost).
 - **Payments: Stripe, and the platform intermediates.** Liverty receives
   the buyer's payment, takes a fee, and pays out the organizer (required
   to monetize and to control cancellation refunds). Charges happen
@@ -112,14 +115,23 @@ change's `design.md`:
   just wallet presentations of a `card` and need no dedicated fields.
 - **Web First, No Native App** (product constraint): the check-in tool is
   a PWA using the web camera, not a native scanner app.
+- **Organizer identity & RBAC: Zitadel B2B org-per-tenant.** Each Organizer
+  is its own Zitadel Organization; a shared, actor-named `organizer-console`
+  project (owned by the `liverty-music` org) is Project-Granted to each; the
+  backend authorizes from the org-scoped role claim; per-tenant orgs are
+  created at runtime via the Management API from admin vetting. Full model
+  and rationale: [`zitadel-tenancy-model.md`](./zitadel-tenancy-model.md).
 
 ## MVP Decomposition
 
-Six changes, dependency-ordered. Each is independently reviewable and
-releasable.
+Six numbered steps, dependency-ordered — each independently reviewable and
+releasable. Step ① (organizer platform) is itself decomposed into four
+sub-changes (see its row and `organizer-platform-design.md`).
 
 ```
-① organizer-accounts   (organizer identity, vetting, seller entry point)
+① organizer platform  (decomposed into 4 sub-changes — see organizer-platform-design.md)
+     organizer-tenancy ─▶ organizer-accounts ─┬─▶ organizer-console
+                                               └─▶ organizer-rpc-server
      │
      ├──▶ ② organizer-event-authoring   (event page create / publish / private URL)
      │         │
@@ -134,8 +146,8 @@ releasable.
 
 | # | Change | Adds (capabilities / entities) | Depends on | Boundary rationale |
 |---|--------|--------------------------------|------------|--------------------|
-| ① | `organizer-accounts` | Organizer entity (distinct from Artist, `verified` status), Organizer↔Artist association, vetting via admin console, `seller.html` third entry point, `master` role via Zitadel org scope | existing admin only | Every seller-facing feature needs an organizer identity first. Vetting extends the existing admin approval pattern. |
-| ② | `organizer-event-authoring` | Organizer-authored Event/Series/Venue, publish flow, **private visibility via signed tokenized URL**, first-party supersedes scraped concerts, **verified-organizer artists excluded from scraping** | ① | Turns the existing `Series/Event/Venue/event_performers` model from a scrape-reconstruction target into a first-party authoring target. |
+| ① | **organizer platform** (4 sub-changes) | The vetted-seller foundation, split to keep each change reviewable: **`organizer-tenancy`** (identity-management topology delta + Zitadel platform IaC: `organizer-console` project/roles/apps + provisioner machine user + per-org passkey login), **`organizer-accounts`** (Organizer entity + admin vetting RPCs + runtime tenant-provisioning saga + operator bootstrap + `deactivated` hook + analytics), **`organizer-console`** (`organizer.html` entry + hosting `organizer.{base}` + runtime-config delta), **`organizer-rpc-server`** (dedicated `api.organizer.{base}` server + CORS + `OrganizerService.Get` + org-scoped authz). Full design + resolved gap-audit: [`organizer-platform-design.md`](./organizer-platform-design.md). | existing admin only | A completeness audit showed a single change hid ~33 gaps (a dedicated API server, dedicated hosting, provisioning saga, offboarding). Splitting by surface (identity/accounts/console/rpc-server) mirrors the admin precedent and keeps each spec complete. |
+| ② | `organizer-event-authoring` | Organizer-authored Event/Series/Venue, publish flow, **private visibility via signed tokenized URL**, first-party supersedes scraped concerts, **organizer-represented artists excluded from scraping** | ① | Turns the existing `Series/Event/Venue/event_performers` model from a scrape-reconstruction target into a first-party authoring target. |
 | ③ | `follower-event-publish-notification` | Publish trigger → existing `follow` + `Hype.ShouldNotify` + `push` | ② | Ships with zero ticketing code and rides entirely on existing assets. Immediate differentiator: an organizer's event reaches existing followers on publish. |
 | ④ | `lottery-application` | LotterySalesPhase (extends `sales_phase`), `max_tickets_per_application`, TicketApplication, automatic draw, win/loss, payment deadline, **本人確認 identity + 1 account / 1 application** | ② | Draw logic is substantial and stands alone. Couples to payment only through "winning = right to purchase". 本人確認 also makes tickets legally "covered". |
 | ⑤ | `ticket-purchase-and-issuance` | Order (provider/method-agnostic, opaque payment refs), platform-intermediated Stripe payment (card/wallet/**konbini async**), **Web2 account-bound Ticket issuance** (N per order), event-cancellation refund, `ticket-journey` sync to PAID | ④ | Stripe integration is heavy on its own: post-win payment → order → issuance is a single pipeline. |
@@ -218,7 +230,7 @@ the relevant change's `design.md`.
   with a non-camera "tap stamp" fallback (⑥).
 - **D5 — Organizer vetting reuses the existing admin console** (admin
   approves/creates organizer accounts + sets mandate); organizers use
-  `seller.html` (a third entry point, following the proven consumer/admin
+  `organizer.html` (a third entry point, following the proven consumer/admin
   dual-entry pattern) (①).
 
 ## Open Decisions (still to make)

--- a/docs/ticketing-platform-roadmap.md
+++ b/docs/ticketing-platform-roadmap.md
@@ -1,0 +1,267 @@
+# Ticketing Platform Roadmap
+
+This document decomposes **Phase 3 (Platform Expansion)** of
+[`product-design.md`](./product-design.md) — the organizer-facing ticket
+sales & management system — into a sequence of independently shippable
+OpenSpec changes.
+
+It exists because Phase 3 is large enough that a single OpenSpec change
+cannot hold it, and a roadmap spanning many future changes belongs in
+`docs/` (project strategy), not in `openspec/` (which tracks the current
+capability truth and individual deltas). Each change listed here is
+created with `/opsx:propose` **when work on it actually starts** — do not
+pre-create empty change stubs.
+
+Primary source for the ticketing technical direction (Web2, no
+blockchain) is the decision record in `product-design.md` and
+`openspec/changes/archive/2026-08-09-remove-blockchain-ticket-system/`.
+
+## Guiding Decisions (settled)
+
+These answers scope the entire roadmap and must be carried into each
+change's `design.md`:
+
+- **Issuance/entry architecture: Web2.** Account-bound tickets +
+  server-signed rotating QR + Passkey identity. No blockchain. (Already
+  recorded in `product-design.md`.)
+- **Seller entity: `Organizer` — a role, not a company category** (name
+  chosen over "Partner", which in platform contexts usually means an
+  integration/affiliate partner). The Organizer is the account authorized
+  to publish an artist's events and sell their tickets. It is the
+  `schema.org/Event` `organizer` property, used by Eventbrite / Peatix /
+  ZAIKO, and is a **distinct entity from Artist/Performer** (Ticketmaster
+  splits Promoter↔Attraction; schema.org splits
+  `organizer`/`performer`/`seller`). Relationship:
+
+  ```
+  Organizer (1) ──publishes──▶ (N) Event ──features──▶ (N) Artist   (existing event_performers)
+       └──────── mandate ──────────────▶ (N) Artist                 (label/mgmt case, N:M)
+  ```
+
+  In MVP the Organizer role is filled by a vetted party: an **artist**
+  self-publishing, or an **organization authorized to represent the
+  artist — a record label, management/agency, or promoter**. Industry
+  note: concerts are frequently organized by the promoter/management, not
+  the record label per se, so the entity is defined by *authority over an
+  artist's events*, not company type. "レコード会社" and "レーベル" are
+  treated as interchangeable; a company owning multiple label brands is
+  still one Organizer (label brand is a later display attribute). An
+  artist who self-publishes is modeled as an Organizer account associated
+  with that Artist, not a second entity type. "Vetted" is a **`verified`
+  status** on the Organizer. An Organizer is simply associated with the
+  artists it represents (no full/partial mandate concept — keep it
+  simple).
+
+- **Sellers: vetted organizers only.** Reuse the existing admin approval
+  pattern to onboard them. Open self-serve submission is out of scope,
+  which also removes the fake-event risk.
+- **Sales method: lottery only for MVP.** FCFS, common inventory pool,
+  seat maps, manual draw, and preference ordering are all deferred until
+  demand is proven. Lottery draws against a fixed capacity *after*
+  applications close, which removes the hardest correctness problem
+  (real-time oversell prevention) from the MVP.
+- **Tickets per application: variable, per-event.** The organizer sets a
+  `max_tickets_per_application` on each lottery phase (sized to venue
+  capacity). Capacity is accounted in **tickets**, not applications.
+- **Companion group entry = same-time entry (in MVP); NO open
+  distribution URL.** Group attendance is handled by the lead buyer
+  holding all won tickets on their own device, with the lead and
+  companions entering the gate **together** (plan-1.md's "一括表示・同時
+  入場", ZAIKO-style). We deliberately **reject the open 分配URL pattern**
+  (each companion gets an individually shareable QR): though framed as
+  free distribution, it is a scalping loophole — a scalper can win, send
+  the share URL, and collect a high price **off-platform** while the
+  system only sees a free hand-off. Same-time entry defeats this because a
+  stranger cannot enter without the lead physically present, which does
+  not scale. Backstops: rotating QR + login (a sold screenshot is
+  useless) and covered-ticket legality (off-platform purchases are
+  invalid at entry). Residual risk (small-scale physical escort) is
+  accepted. Separate-time companion entry, if ever needed, is solved later
+  by **pre-registered** named companions (not an open URL) — see Open
+  Decisions. The cannot-attend case is handled by official resale, not by
+  companion hand-off.
+- **Cannot-attend → official face-value resale, not ad-hoc refunds.** The
+  buyer's own seat is account/identity-bound and cannot be handed to a
+  named person; the sanctioned path is an **anonymous face-value resale
+  pool** that refunds the original buyer when it sells. General refunds
+  are reserved for **event cancellation**. In a lottery, the **losers
+  form the natural demand pool** that absorbs returned tickets (DICE
+  waitlist model). This is the anti-scalp gold standard (ローチケ/ぴあ)
+  and the legally favored path. **Open timing decision:** official resale
+  is listed in Phase 2, but "the buyer got sick" is a real day-one need —
+  decide whether a minimal return-to-pool/resale ships in MVP or
+  immediately after (see Open Decisions).
+- **Legal "covered ticket" (チケット不正転売禁止法).** To make anti-scalp
+  actually enforceable, tickets must (1) state on their face that resale
+  without consent is prohibited, (2) specify date/venue and
+  seat-or-eligible-person, (3) capture **本人確認** (purchaser name +
+  contact). Ties to the ④ identity requirement and ⑥ ticket rendering.
+- **First-party data supersedes; verified-organizer artists are excluded
+  from scraping.** When an organizer-published event or issued ticket
+  exists it supersedes the inferred/self-reported data for the same
+  subject (a published event overrides the scraped
+  `staged_concert`/`sales_phase`; issuing a ticket syncs the user's
+  `ticket-journey` to `PAID`). Once an artist is represented by a
+  `verified` Organizer, that artist is simply **excluded from
+  concert-search scraping** (first-party is authoritative; saves cost).
+- **Payments: Stripe, and the platform intermediates.** Liverty receives
+  the buyer's payment, takes a fee, and pays out the organizer (required
+  to monetize and to control cancellation refunds). Charges happen
+  **after winning** (D1). The domain Order/Payment entity is
+  **provider- and method-agnostic** (see D2); Apple Pay / Google Pay are
+  just wallet presentations of a `card` and need no dedicated fields.
+- **Web First, No Native App** (product constraint): the check-in tool is
+  a PWA using the web camera, not a native scanner app.
+
+## MVP Decomposition
+
+Six changes, dependency-ordered. Each is independently reviewable and
+releasable.
+
+```
+① organizer-accounts   (organizer identity, vetting, seller entry point)
+     │
+     ├──▶ ② organizer-event-authoring   (event page create / publish / private URL)
+     │         │
+     │         ├──▶ ③ follower-event-publish-notification   ★ ships early, no ticketing needed
+     │         │
+     │         └──▶ ④ lottery-application   (lottery phase, apply, auto draw, win/loss, 本人確認)
+     │                    │
+     │                    └──▶ ⑤ ticket-purchase-and-issuance   (Stripe → order → issued ticket)
+     │                                 │
+     │                                 └──▶ ⑥ ticket-wallet-and-checkin   (wallet + same-time entry + rotating QR + check-in PWA)
+```
+
+| # | Change | Adds (capabilities / entities) | Depends on | Boundary rationale |
+|---|--------|--------------------------------|------------|--------------------|
+| ① | `organizer-accounts` | Organizer entity (distinct from Artist, `verified` status), Organizer↔Artist association, vetting via admin console, `seller.html` third entry point, `master` role via Zitadel org scope | existing admin only | Every seller-facing feature needs an organizer identity first. Vetting extends the existing admin approval pattern. |
+| ② | `organizer-event-authoring` | Organizer-authored Event/Series/Venue, publish flow, **private visibility via signed tokenized URL**, first-party supersedes scraped concerts, **verified-organizer artists excluded from scraping** | ① | Turns the existing `Series/Event/Venue/event_performers` model from a scrape-reconstruction target into a first-party authoring target. |
+| ③ | `follower-event-publish-notification` | Publish trigger → existing `follow` + `Hype.ShouldNotify` + `push` | ② | Ships with zero ticketing code and rides entirely on existing assets. Immediate differentiator: an organizer's event reaches existing followers on publish. |
+| ④ | `lottery-application` | LotterySalesPhase (extends `sales_phase`), `max_tickets_per_application`, TicketApplication, automatic draw, win/loss, payment deadline, **本人確認 identity + 1 account / 1 application** | ② | Draw logic is substantial and stands alone. Couples to payment only through "winning = right to purchase". 本人確認 also makes tickets legally "covered". |
+| ⑤ | `ticket-purchase-and-issuance` | Order (provider/method-agnostic, opaque payment refs), platform-intermediated Stripe payment (card/wallet/**konbini async**), **Web2 account-bound Ticket issuance** (N per order), event-cancellation refund, `ticket-journey` sync to PAID | ④ | Stripe integration is heavy on its own: post-win payment → order → issuance is a single pipeline. |
+| ⑥ | `ticket-wallet-and-checkin` | Ticket wallet UI, **same-time group entry (all tickets on lead's device)**, **server-signed rotating QR + Passkey re-auth**, **reception PWA (web-camera QR via getUserMedia)**, real-time entry status | ⑤ | Requires an issued ticket. Same-time entry is how a multi-ticket win is used (no distribution); check-in as a PWA honors No-Native-App. |
+
+### Recommended sequencing note
+
+①② introduce most of the new proto entities — land them first to
+stabilize the schema. ④⑤ then finalize LotterySalesPhase/Order/Ticket. ③
+carries minimal proto change (reuses existing notification), so it can
+start right after ② merges and delivers value fastest.
+
+## Phase 2+ Backlog
+
+Deferred until demand is proven. Each becomes its own `/opsx:propose`
+change when picked up:
+
+- `official-resale` — anonymous face-value resale pool (the sanctioned
+  cannot-attend / anti-scalp path; reuses lottery losers as the demand
+  pool). **May be pulled earlier — see Open Decisions.**
+- `organizer-rbac-subowners` — full 4-role model (editor / viewer /
+  reception staff), sub-owner invites, **audit log** (add audit subjects
+  to the existing JetStream analytics pipeline).
+- `first-come-inventory-pool` — FCFS + common inventory pool with
+  oversell prevention (row locks / reservation TTL). Only after lottery
+  validates demand.
+- `seat-map-assignment` — seat map upload, block/individual seat
+  assignment.
+- `manual-lottery-and-preferences` — manual win/loss, 1st–3rd preference,
+  supply-demand adjustment rules.
+- `companion-pre-registration` — separate-time companion entry via
+  pre-registered named accounts (not an open URL), if convenience demands
+  it.
+- `cross-sell-merch-cart` — merch cross-sell cart + venue-pickup
+  fulfillment.
+- `digital-content-delivery` — paid digital content delivery (signed
+  URLs, entitlement control).
+- `organizer-crm-segment-messaging` — segmented messaging with
+  attachments.
+- `organizer-realtime-dashboard` — sales visualization, demographic
+  dashboard.
+
+## Cross-cutting Design Decisions (provisional)
+
+Recorded here so they are not lost; each is formalized (or superseded) in
+the relevant change's `design.md`.
+
+- **D1 — Lottery charges after winning.** No charge at application.
+  Stripe authorization holds are too short-lived for lottery windows;
+  present winners a payment deadline instead (matches the existing
+  `payment_deadline_at` model and Japanese lottery UX).
+- **D2 — Payment entity is provider- and method-agnostic.** Stripe
+  intermediates (platform collects, takes a fee, pays out organizers).
+  Apple Pay / Google Pay are **not** distinct methods — they settle as
+  `card` with a `card.wallet.type` facet, so they need no dedicated
+  fields. Store the stable set and nothing card/wallet-shaped as identity:
+
+  - **Store:** `provider` (stripe), `payment_intent_id` (`pi_…`),
+    `payment_method_id` (`pm_…`), `payment_method_type`
+    (card/konbini/paypay/bank_transfer), own `status` enum
+    (pending/awaiting_payment/paid/failed/refunded), `amount`+`currency`,
+    `paid_at`. Optional nullable display facets: `wallet_type`,
+    `card_brand`, `card_last4`.
+  - **Do not store:** PAN/CVC/expiry/`dynamic_last4`/`fingerprint`,
+    Stripe's raw status (map into our enum), or `apple_pay`/`google_pay`
+    as a top-level type (would force a proto-breaking change later).
+  - **Architecture (not just config):** **konbini is asynchronous** —
+    the Order needs an `awaiting_payment` state and must treat
+    `payment_intent.succeeded` **webhooks** (idempotent) as the source of
+    truth, not the client confirm. **Apple Pay needs per-domain
+    verification** (`/.well-known/apple-developer-merchantid-domain-association`)
+    — the PWA service worker must not intercept `/.well-known/`. Audit
+    timestamps use domain-specific `*_at` names (repo schema-lint bans
+    generic `created_at/updated_at`).
+
+- **D3 — Private events use signed tokenized URLs, not referrer control.**
+  Referrer restriction is fragile (browsers strip referrers; asking
+  external sites to add `<meta name="referrer">` is unrealistic) (②).
+- **D4 — Check-in is a PWA + web-camera QR** (No-Native-App constraint),
+  with a non-camera "tap stamp" fallback (⑥).
+- **D5 — Organizer vetting reuses the existing admin console** (admin
+  approves/creates organizer accounts + sets mandate); organizers use
+  `seller.html` (a third entry point, following the proven consumer/admin
+  dual-entry pattern) (①).
+
+## Open Decisions (still to make)
+
+- **Official-resale timing.** MVP minimal return-to-pool/resale vs Phase
+  2. Argument for MVP: the cannot-attend case is a day-one fan need and a
+  legal best-practice, and the lottery losers already form the demand
+  pool, so a minimal version reuses lottery infrastructure. Argument for
+  Phase 2: keeps the MVP small.
+- **Separate-time companion entry.** Whether to add pre-registered named
+  companions (individual QR bound to a specific account, no open URL) for
+  groups who cannot enter together. Deferred by default; revisit if
+  same-time entry proves too restrictive.
+
+## Deferred Payment Details (decide later, no proto impact)
+
+Behind the opaque payment reference; changeable without schema breaks:
+Stripe charge model (destination vs separate charges & transfers) and
+merchant-of-record; payout timing (immediate vs held past the event for
+refunds); platform fee rate; tax/currency (JPY tax-inclusive, インボイス);
+特定商取引法 seller-of-record disclosure and refund-policy wording;
+official-resale price cap.
+
+Note: merchant-of-record / 特商法 / refund policy, Stripe Connect account
+type & onboarding, and the fee rate are business/legal decisions with
+long lead times — start them on a separate track before ⑤ begins.
+
+## Existing-asset Reuse Map
+
+- **Rides on existing assets:** follow + push + notification pipeline
+  (③), `Series/Event/Venue/event_performers` model (②), Zitadel org
+  scoping and admin approval queue (①), JetStream analytics pipeline
+  (audit log, Phase 2), `sales_phase` and `ticket-journey` models (④⑤),
+  PWA infrastructure (⑥).
+- **Net new:** organizer accounts, tokenized private URLs,
+  lottery application/draw, Stripe integration, Order, account-bound
+  ticket issuance, same-time group entry, rotating-QR signing, reception
+  check-in PWA.
+
+## Operating Notes
+
+- Every change flows through the cross-repo release order: specification
+  PR merge → GitHub Release → BSR gen → backend/frontend consume the new
+  types.
+- Create each change only when its work starts; keep this document as the
+  single map of intended sequencing.

--- a/docs/zitadel-tenancy-model.md
+++ b/docs/zitadel-tenancy-model.md
@@ -1,0 +1,110 @@
+# Zitadel Tenancy & RBAC Model
+
+Durable reference for how Liverty Music maps its actors onto Zitadel
+resources. Encoded normatively in the `identity-management` capability
+spec; this document holds the rationale and the layout so it is
+discoverable when reading the specs. Grounded in Zitadel's official B2B
+guidance (see References).
+
+## The rule in one line
+
+> **Org = tenant. Project = actor + its RBAC. App = a frontend (auth).**
+
+- **Organization = a tenant.** Zitadel defines an Organization as "a tenant
+  in a SaaS system". Each external tenant (Organizer, later Venue) gets its
+  own Organization; internal operators stay in the `admin` org; fans stay
+  in the `liverty-music` org.
+- **Project = one actor's back-office + its RBAC.** Roles, User Grants, and
+  Project Grants are all **project-scoped**, so each distinct actor console
+  is its own Project, **named by actor** (`organizer-console`, later
+  `venue-console`), never a generic `console`. Every mature platform splits
+  back-office by actor (Shopify: merchant/POS/partner/org; Ticketmaster:
+  promoter/venue/box-office/fan) — a single `console` always has to be
+  split later.
+- **App = a frontend/entry.** OIDC client config (client_id, redirect URIs,
+  token settings) is **per-app**, so a Project can hold several apps sharing
+  its role space — e.g. the `organizer-console` web app and a lightweight
+  `reception` check-in PWA both live in the `organizer-console` project and
+  use its roles.
+
+## Resource layout
+
+```
+Zitadel Instance
+├── Org: admin  (IaC, isDefault, protect)      internal operators — Google Workspace login
+│     └── Project: admin-console               internal vetting / moderation (existing)
+├── Org: liverty-music  (IaC)                   fans + product surfaces
+│     ├── Project: liverty-music               consumer SPA (existing)
+│     └── Project: organizer-console  ★ new     organizer back-office
+│           ├── App(OIDC): organizer-console    web console
+│           ├── App(PWA):  reception            check-in (later, ⑥) — same roles
+│           ├── App(API):  backend-api          audience
+│           └── Roles: master [→ editor, viewer, reception (Phase 2)]
+│     └── (future) Project: venue-console        venue seat maps / calendar / door lists
+├── Org: organizer-<A>  (runtime)  ── ProjectGrant(organizer-console, roles⊆) + UserGrant(staff→master)
+├── Org: organizer-<B>  (runtime)  ── ProjectGrant(organizer-console, roles⊆) + UserGrant(staff→viewer)
+└── … one org per vetted Organizer
+```
+
+Why the `organizer-console` project is **owned by the `liverty-music` org**
+(not a new `platform` org, not the `admin` org): the organizer console is a
+Liverty-Music product surface, so it belongs with the other product
+projects; a separate project (not the fan `liverty-music` project) keeps its
+roles, Project Grants, and branding independent; and the `admin` org is
+hardened as internal-only (Google Workspace, default org) so an
+external-facing app should not live there. The owning org is just the
+project's administrative home — Organizer operators authenticate in **their
+own** org, so the owning org's login policy never applies to them.
+
+## RBAC flow (how a request is authorized)
+
+1. Admin vets Organizer A → runtime provisioning (below) creates Org A, a
+   Project Grant of `organizer-console` (role subset), and a User Grant
+   (`master`) for the first operator.
+2. Operator signs into the `organizer-console` OIDC app with the org-scope
+   `urn:zitadel:iam:org:id:<A>` (pins login to their org).
+3. Token carries roles as a nested map
+   `urn:zitadel:iam:org:project:{projectId}:roles` =
+   `role → { orgId → primaryDomain }`. **The inner orgId is the tenant
+   (Organizer) id.** The `aud` includes the backend project id (request the
+   `...:project:id:{projectId}:aud` scope).
+4. Backend (Go) validates issuer/signature + asserts its project id is in
+   `aud`, then reads `{tenant, role}` from the roles claim and authorizes
+   the RPC — rejecting any request whose target Organizer the caller has no
+   role for. Zitadel holds identity + tenant + role; **which artists/events
+   an Organizer may touch is Liverty's own data** (`organizer_artists`,
+   event ownership), enforced in the backend.
+5. (Optional) A stable business `organizer-id` (Liverty's own PK) can be
+   stamped into the token via org metadata + an Action, if keying off the
+   Zitadel org id is undesirable.
+
+## Provisioning: IaC vs runtime
+
+| Layer | Managed by | Resources |
+|-------|-----------|-----------|
+| **Static platform** | IaC (Pulumi) | `admin` + `liverty-music` orgs; the `organizer-console` project, its roles, its apps; the machine user with org-creation rights |
+| **Per-tenant (dynamic)** | Runtime — Zitadel **Management API** | one Organizer org + Project Grant + initial User Grant, created **when an admin vets an Organizer** (from the admin console → backend, using the machine-user credential) |
+
+Per-Organizer Terraform would be overkill; tenant orgs are created in the
+approval flow via the Management API (Zitadel offers a single
+"setup organization" call that creates the org + initial admin). The
+backend writes the Organizer row in Postgres in the same operation.
+
+## Caveats
+
+- Many orgs is a supported Zitadel shape (no hard cap); at high density
+  enable Instance/Organization caching to avoid an N-over-N read cost.
+- The backend MUST validate `aud` **and** authorize off the tenant-scoped
+  roles map — never trust a flat role list.
+- Custom claims (the optional stable `organizer-id`) require an Action
+  (v1 Complement-Token or v2 execution target).
+
+## References (Zitadel official, 2026-08)
+
+- B2B multi-tenant scenario — https://zitadel.com/docs/guides/solution-scenarios/b2b
+- Onboard B2B customers using organizations — https://zitadel.com/docs/guides/integrate/onboarding/b2b
+- Granted projects (Project Grant) — https://zitadel.com/docs/concepts/structure/granted_projects
+- Retrieve user roles (role claim shape) — https://zitadel.com/docs/guides/integrate/retrieve-user-roles
+- Reserved scopes (aud / org-id / roles) — https://zitadel.com/docs/apis/openidoauth/scopes
+- Actions / custom claims — https://zitadel.com/docs/apis/actions/complement-token
+- Terraform provider — https://zitadel.com/docs/guides/manage/terraform-provider


### PR DESCRIPTION
## Summary

Planning + design artifacts for **Phase 3 (Platform Expansion)** of the
ticketing platform. Docs-only — no proto/schema changes.

Two things land here:
1. The Phase 3 roadmap that decomposes the organizer-facing ticket-selling
   system into six dependency-ordered MVP steps.
2. A rescope of step ① (the vetted-seller foundation): an independent
   spec-completeness audit surfaced ~33 gaps that a single change was
   hiding (a dedicated organizer API server, dedicated console hosting, the
   runtime provisioning saga, offboarding). To keep each change reviewable,
   ① is split into four sub-changes and the full design is captured durably
   so nothing is lost.

## Changes

- **`docs/ticketing-platform-roadmap.md`** — the six-step MVP roadmap with
  settled decisions (Organizer entity, lottery-only MVP, Stripe
  platform-intermediated payments, Web2 tickets, same-time companion entry,
  official face-value resale, verified-organizer scraping exclusion) and the
  decomposition of ① into four sub-changes.
- **`docs/organizer-platform-design.md`** — durable design for the Organizer
  feature cluster: domain model (`zitadel_org_id`, `provisioning_state`,
  partial-unique association), admin + organizer RPC surfaces, the runtime
  provisioning saga, the authorization failure matrix, delivery surfaces
  (dedicated API server + hosting + runtime-config), analytics, Non-Goals,
  the resolved gap-audit, and the four-change split
  (`organizer-tenancy` → `organizer-accounts` → `organizer-console` /
  `organizer-rpc-server`).
- **`docs/zitadel-tenancy-model.md`** — Zitadel B2B tenancy & RBAC model
  (org = tenant, actor-named shared `organizer-console` project, Project
  Grant, backend authorization from the org-scoped role claim, IaC vs
  runtime Management-API provisioning), grounded in Zitadel's official B2B
  guidance.

## Testing

Documentation only. No code, proto, or schema changes; nothing to build or
test. Individual sub-changes are authored (and CI-validated) with
`/opsx:propose` when their implementation starts.

## Related

Refs: #759 — this is a planning increment for the Phase 3 umbrella; the
issue stays open to track the four sub-changes and downstream steps ②–⑥.
