### PR TITLE
docs(openspec): organizer-tenancy — Zitadel tenancy foundation (① 1/4)

### DIFF
--- a/openspec/changes/organizer-tenancy/.openspec.yaml
+++ b/openspec/changes/organizer-tenancy/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-13

--- a/openspec/changes/organizer-tenancy/design.md
+++ b/openspec/changes/organizer-tenancy/design.md
@@ -1,0 +1,96 @@
+## Context
+
+See proposal.md - Why. Grounded in
+[`docs/organizer-platform-design.md`](../../../docs/organizer-platform-design.md)
+(the `organizer-tenancy` row of the four-change decomposition) and
+[`docs/zitadel-tenancy-model.md`](../../../docs/zitadel-tenancy-model.md).
+Today the instance pins exactly two orgs (`admin`, `liverty-music`) with a
+single `admin` role; the `admin` org owns an `admin-console` project and the
+`liverty-music` org owns the consumer `liverty-music` project. There is no
+Organizer tenancy. This change adds the static platform scaffolding for it
+and relaxes the topology pin — nothing per-tenant and no domain entity.
+
+## Goals / Non-Goals
+
+**Goals:**
+- The static Zitadel resources every Organizer sub-change depends on: one
+  shared `organizer-console` project (role + apps) and a provisioner machine
+  user.
+- Relax the topology pin so runtime Organizer tenant orgs are legal (not
+  drift).
+- Fix the required tenant-org login policy shape so later provisioning is
+  unambiguous.
+
+**Non-Goals:**
+- The Organizer domain entity, admin vetting, and the runtime provisioning
+  saga (`organizer-accounts`).
+- `organizer.html` and its hosting (`organizer-console`).
+- The `api.organizer.*` server, `OrganizerService.Get`, and org-scoped authz
+  (`organizer-rpc-server`).
+- Sub-owner roles (only `master` now); per-org branding.
+
+## Decisions
+
+**D1 — The shared project is owned by the `liverty-music` org, not a new
+`platform` org nor the `admin` org.** The organizer console is a
+Liverty-Music product surface, so it belongs with the other product
+projects; a *separate* project (not the fan `liverty-music` project) keeps
+its roles/grants/branding independent; and the `admin` org is hardened as
+internal-only (Google Workspace, default org), so an external-facing app
+must not live there. Owner org is only the project's administrative home —
+operators authenticate in their own tenant org, so the owner org's login
+policy never applies to them. (Full rationale: tenancy-model doc.)
+
+**D2 — Actor-named project (`organizer-console`), not a generic `console`.**
+Every mature platform splits back-office by actor; a generic name would
+collide with a future `venue-console`. RBAC (roles/grants) is project-scoped,
+so a distinct actor gets a distinct project; multiple apps (console web,
+later a reception PWA) can share one project.
+
+**D3 — Dedicated `organizer-provisioner` machine user.** Creating orgs +
+cross-org grants needs instance-level rights far broader than the existing
+single-org `backend-app` user (`ORG_USER_MANAGER` on one org). A dedicated
+user isolates that blast radius; credential in ESC/Secret Manager.
+*Alternative — reuse `backend-app`:* rejected (wrong scope + coupled blast
+radius). Note the `machine-user` "no rotation, expires 2099" caveat applies
+and warrants a rotation runbook given this user's power.
+
+**D4 — Tenant-org login policy is set explicitly, never inherited.** A new
+org inherits the instance `DefaultLoginPolicy` = the admin Google-IdP-only
+policy, which would make external operators unable to sign in. Provisioning
+MUST set a passkey-only policy + `allowDomainDiscovery`. This change defines
+the required shape; `organizer-accounts` applies it per org.
+
+**D5 — No proto in this change.** Organizer tenancy is IaC + spec only; the
+entity/RPC proto lands in `organizer-accounts`. So this change ships without
+BSR generation.
+
+## Risks / Trade-offs
+
+- **Latent verification** → the tenant-org login-policy requirement can only
+  be observed once orgs are created (`organizer-accounts`). It is a forward
+  contract; its acceptance test lives in that change.
+- **Machine-user power** → mitigate with the narrowest instance role that
+  still allows org-create + grants, credential isolation, and a rotation
+  runbook.
+- **Topology drift detection** → Pulumi must be taught that runtime tenant
+  orgs are not drift (the modified `identity-management` "No third org"
+  scenario), else it would try to revert them.
+
+## Migration Plan
+
+1. specification: the `identity-management` topology delta + the new
+   `organizer-tenancy` capability spec → merge (no BSR gen needed).
+2. cloud-provisioning (IaC): add the `organizer-console` project + `master`
+   role + `organizer-console`/`backend-api` apps in the `liverty-music` org,
+   and the `organizer-provisioner` machine user + credential; ensure Pulumi
+   does not treat runtime tenant orgs as drift.
+- Rollback: additive — remove the project, apps, and machine user; no
+  consumer/admin impact (no tenant orgs exist yet at this stage).
+
+## Open Questions
+
+- The exact narrowest Zitadel instance role for `organizer-provisioner`
+  (e.g. an org-manager-class role vs `IAM_OWNER`) is an implementation
+  detail confirmed during the cloud-provisioning task; it does not change
+  the spec or the decomposition.

--- a/openspec/changes/organizer-tenancy/proposal.md
+++ b/openspec/changes/organizer-tenancy/proposal.md
@@ -1,0 +1,60 @@
+## Why
+
+Phase 3 needs a vetted-seller (Organizer) **tenancy foundation** before any
+Organizer entity, console, or API can exist. Following Zitadel's official
+B2B guidance (an Organization *is* the tenant), this change lays the static
+Zitadel platform scaffolding and relaxes the pinned two-org topology so that
+one Organization per Organizer can be provisioned at runtime later. This is
+the first of four sub-changes decomposing roadmap step ①; grounded in
+`docs/organizer-platform-design.md` and `docs/zitadel-tenancy-model.md`,
+tracked by liverty-music/specification#759.
+
+## What Changes
+
+- Relax the Zitadel org topology so the instance may contain, besides the
+  two IaC-managed platform orgs (`admin`, `liverty-music`), **runtime-
+  provisioned Organizer tenant orgs** (one per Organizer) that are NOT
+  IaC-managed and NOT treated as drift.
+- Add a shared, **actor-named `organizer-console` Zitadel Project** owned by
+  the `liverty-music` org, with the `master` ProjectRole and access-token
+  role assertion enabled. Actor-named so a future `venue-console` never
+  collides.
+- Register the **`organizer-console` OIDC app** and a **`backend-api` app**
+  on that project (the app audience the organizer API server will validate).
+- Provision a dedicated **`organizer-provisioner` machine user** with
+  instance-level org-create + cross-org grant rights (credential in
+  ESC/Secret Manager), isolated from the existing single-org `backend-app`
+  machine user.
+- Define the **required login policy for Organizer tenant orgs**:
+  passkey-only (`passwordlessType=ALLOWED`, `userLogin=false`,
+  `allowRegister=false`, no Google IdP) with `allowDomainDiscovery=true`,
+  set explicitly at provisioning — tenant orgs MUST NOT inherit the admin
+  default (Google-IdP-only) policy.
+
+Explicit non-goals (later sub-changes): the Organizer domain entity + admin
+vetting + the runtime provisioning saga (`organizer-accounts`),
+`organizer.html` + hosting (`organizer-console`), and the `api.organizer.*`
+server + `OrganizerService.Get` + org-scoped authz (`organizer-rpc-server`).
+
+## Capabilities
+
+### New Capabilities
+- `organizer-tenancy`: the shared `organizer-console` Zitadel project (its
+  `master` role and apps), the `organizer-provisioner` machine user, and the
+  required passkey-only + domain-discovery login policy that Organizer
+  tenant orgs are provisioned with.
+
+### Modified Capabilities
+- `identity-management`: relax the "exactly two top-level orgs" topology to
+  allow runtime-provisioned Organizer tenant orgs (one per Organizer).
+
+## Impact
+
+- **specification**: the `identity-management` topology delta + the new
+  `organizer-tenancy` capability spec. **No proto/entity changes** (those
+  land in `organizer-accounts`), so this change needs no BSR generation.
+- **cloud-provisioning (IaC / Pulumi)**: the `organizer-console` project +
+  `master` role + `organizer-console`/`backend-api` apps in the
+  `liverty-music` org, and the `organizer-provisioner` machine user +
+  credential.
+- **backend / frontend**: none in this change.

--- a/openspec/changes/organizer-tenancy/specs/identity-management/spec.md
+++ b/openspec/changes/organizer-tenancy/specs/identity-management/spec.md
@@ -1,0 +1,94 @@
+## MODIFIED Requirements
+
+### Requirement: Manage Zitadel Organization
+
+The system SHALL manage Zitadel organization topology so that the instance
+always exposes a clear separation between operator (admin), product, and
+Organizer-tenant identities. The instance SHALL contain **two IaC-managed
+platform organizations**, plus **one runtime-provisioned Organizer tenant
+organization per vetted Organizer**:
+
+- An **`admin`** role org, created by Zitadel at first-instance bootstrap
+  via the configmap setting `ZITADEL_FIRSTINSTANCE_ORG_NAME=admin`,
+  brought into Pulumi state via a one-time `pulumi import
+  zitadel:index/org:Org admin <admin-org-id>` (see Migration Plan in
+  design.md), and pinned with `protect: true`. This org holds operator
+  identities only (machine users used by IaC and the Login V2 service,
+  plus human admins who manage the instance) and is the **Zitadel
+  default org** so that the Console (which omits `org_id` in its OIDC
+  AuthN) routes to its `LoginPolicy`.
+
+- A **`liverty-music`** product org, created by Pulumi as a `zitadel.Org`
+  resource with `isDefault: false`. This org holds the product Project,
+  applications, end-user login policy, and end-user accounts. The
+  frontend SPA's `ApplicationOidc` carries an explicit `client_id`
+  whose owning org Zitadel resolves to `liverty-music`, so the
+  default-org choice does not affect end-user OIDC routing. This org also
+  owns the actor-named **`organizer-console`** Project (its roles and
+  apps), which is Project-Granted to each Organizer tenant org.
+
+- **Organizer tenant orgs** — one per vetted Organizer, **provisioned at
+  runtime via the Zitadel Management API** when an admin vets an Organizer
+  (from the admin console → backend, using a machine-user credential), NOT
+  IaC-managed. Each isolates one Organizer's operator identities and
+  receives a Project Grant to the `liverty-music` org's `organizer-console`
+  project. See `docs/zitadel-tenancy-model.md`.
+
+#### Scenario: Provision admin role org via bootstrap + import
+
+- **WHEN** the Zitadel instance bootstraps for the first time in any
+  environment
+- **THEN** the configmap SHALL set `ZITADEL_FIRSTINSTANCE_ORG_NAME=admin`
+- **AND** Zitadel SHALL create an organization named `admin` containing
+  the `pulumi-admin` machine user
+- **AND** an operator SHALL run `pulumi import zitadel:index/org:Org
+  admin <admin-org-id>` (with `--provider liverty-music-provider=...`)
+  to bring the admin org into Pulumi state
+- **AND** the Pulumi declaration SHALL set `isDefault: true` and
+  `{ protect: true }` on the admin org
+- **AND** no Pulumi rename step SHALL be required to reach the intended
+  name
+
+#### Scenario: Provision product org via Pulumi
+
+- **WHEN** Pulumi stack is applied
+- **THEN** a `zitadel.Org` resource named `liverty-music` SHALL exist
+  with `isDefault: false`
+- **AND** all product resources (Project, ApplicationOidc, end-user
+  LoginPolicy, end-user HumanUsers) SHALL live in this org
+- **AND** the `organizer-console` Project (its roles and apps) SHALL also
+  live in this org
+
+#### Scenario: Console login routes to the admin org's policy
+
+- **WHEN** an operator opens
+  `https://auth.dev.liverty-music.app/ui/console`
+- **THEN** the Zitadel Console's OIDC AuthN SHALL hit Login V2 without
+  an explicit `org_id`
+- **AND** Login V2 SHALL render the **default org's `LoginPolicy`**,
+  which is the admin org's policy (Google IdP enabled,
+  `userLogin = false`)
+- **AND** the operator SHALL see a "Sign in with Google" button
+  immediately, without needing to type a username first
+
+#### Scenario: No third org
+
+- **WHEN** the instance is fully provisioned
+- **THEN** exactly two IaC-managed platform orgs SHALL exist (`admin` and
+  `liverty-music`) — no third *IaC-managed* org
+- **AND** any additional organization SHALL exist only as a
+  runtime-provisioned Organizer tenant org (one per vetted Organizer),
+  created via the Zitadel Management API
+- **AND** such runtime-provisioned Organizer tenant orgs SHALL NOT be
+  treated as Pulumi drift or reverted on apply
+
+#### Scenario: Admin org cannot be accidentally destroyed
+
+- **WHEN** any operator runs `pulumi destroy` against the dev stack
+- **THEN** Pulumi SHALL refuse to remove the `admin` org because of
+  `protect: true`
+- **AND** removing the protection SHALL require a code change in a
+  reviewable PR
+- **AND** this protection SHALL prevent the cascading loss of the
+  `pulumi-admin` machine user, which would lock the
+  `@pulumiverse/zitadel` provider out of the instance

--- a/openspec/changes/organizer-tenancy/specs/organizer-tenancy/spec.md
+++ b/openspec/changes/organizer-tenancy/specs/organizer-tenancy/spec.md
@@ -1,0 +1,108 @@
+## Purpose
+
+The static Zitadel platform scaffolding for the Organizer B2B tenancy model:
+a shared, actor-named `organizer-console` project (roles + apps) owned by the
+product org, a dedicated provisioner machine user, and the login policy that
+runtime-provisioned Organizer tenant orgs must receive. Per-Organizer orgs,
+the domain entity, the console, and the API server are separate changes.
+
+## ADDED Requirements
+
+### Requirement: Shared organizer-console project in the product org
+
+The system SHALL provision, via IaC, a single actor-named
+**`organizer-console`** Zitadel Project owned by the `liverty-music` product
+org, defining a **`master`** ProjectRole and enabling access-token role
+assertion so operator tokens carry the `organizer-console` project roles.
+The project SHALL be shared to Organizer tenant orgs via Project Grant (the
+grant itself is created at runtime, not by IaC). Roles for a future
+sub-owner model are out of scope; only `master` is defined now. The project
+name is actor-qualified so a future `venue-console` project does not
+collide.
+
+#### Scenario: Organizer-console project exists in the product org
+
+- **WHEN** the Pulumi stack is applied
+- **THEN** an `organizer-console` Zitadel Project SHALL exist owned by the
+  `liverty-music` org
+- **AND** it SHALL define a `master` ProjectRole
+- **AND** access-token role assertion SHALL be enabled so operator tokens
+  carry the project roles claim
+
+#### Scenario: Role check does not block sign-in
+
+- **WHEN** an operator without a granted role signs in
+- **THEN** the project SHALL NOT block the login on a missing grant
+  (authorization is enforced at the backend), keeping the login flow
+  resilient
+
+### Requirement: Organizer console OIDC app and backend API app
+
+The system SHALL register, via IaC, an **`organizer-console` OIDC
+application** (PKCE, no client secret) and a **`backend-api` application**
+on the `organizer-console` project. The OIDC app is the single client that
+serves all Organizer tenants; the API app is the audience the organizer API
+server validates. The OIDC app SHALL carry the organizer console redirect
+URIs for each environment.
+
+#### Scenario: OIDC app serves all tenants with per-env redirect URIs
+
+- **WHEN** the Pulumi stack is applied for an environment
+- **THEN** an `organizer-console` OIDC application SHALL exist on the
+  project with PKCE and no client secret
+- **AND** its redirect URIs SHALL include the organizer console host for
+  that environment
+- **AND** a single OIDC app SHALL serve operators of any Organizer tenant
+  org (no per-tenant app)
+
+#### Scenario: Backend API app provides the audience
+
+- **WHEN** the Pulumi stack is applied
+- **THEN** a `backend-api` application SHALL exist on the
+  `organizer-console` project so its project id can be requested into the
+  access-token audience by the organizer console
+
+### Requirement: Dedicated organizer-provisioner machine user
+
+The system SHALL provision, via IaC, a dedicated **`organizer-provisioner`**
+machine user holding the narrowest instance-level role that permits creating
+organizations and cross-org Project Grants and User Grants, separate from
+the existing single-org `backend-app` machine user, with its credential
+stored in ESC / Secret Manager. This user is the credential the backend uses
+at runtime to provision Organizer tenant orgs.
+
+#### Scenario: Provisioner machine user exists with org-create rights
+
+- **WHEN** the Pulumi stack is applied
+- **THEN** an `organizer-provisioner` machine user SHALL exist with
+  instance-level rights to create organizations and cross-org grants
+- **AND** it SHALL be distinct from the `backend-app` machine user (blast
+  radius isolation)
+- **AND** its credential SHALL be stored in ESC / Secret Manager, not in
+  source
+
+### Requirement: Organizer tenant orgs use a passkey-only login policy with domain discovery
+
+Every runtime-provisioned Organizer tenant org SHALL be given an **explicit**
+login policy — it SHALL NOT inherit the instance default (admin
+Google-IdP-only) policy. The policy SHALL be **passkey-only**
+(`passwordlessType=ALLOWED`, `userLogin=false`, `allowRegister=false`, no
+external/Google IdP) with **`allowDomainDiscovery=true`** so an operator is
+routed to their own org by their email domain at login. (Applying this
+policy to each org happens in the runtime provisioning flow of
+`organizer-accounts`; this requirement defines the required shape.)
+
+#### Scenario: A provisioned tenant org has the passkey-only policy
+
+- **WHEN** an Organizer tenant org is provisioned
+- **THEN** it SHALL have an explicitly set login policy, not the inherited
+  admin default
+- **AND** the policy SHALL be passkey-only (`passwordlessType=ALLOWED`,
+  `userLogin=false`, `allowRegister=false`, no Google IdP)
+- **AND** `allowDomainDiscovery` SHALL be enabled
+
+#### Scenario: Operator is routed to their org by email domain
+
+- **WHEN** an operator enters their email on the organizer console login
+- **THEN** domain discovery SHALL route them to their own Organizer tenant
+  org's login policy without an org picker

--- a/openspec/changes/organizer-tenancy/tasks.md
+++ b/openspec/changes/organizer-tenancy/tasks.md
@@ -1,0 +1,19 @@
+## 1. Specification
+
+- [ ] 1.1 `identity-management` MODIFIED delta: relax the org topology to allow runtime-provisioned Organizer tenant orgs (not IaC-managed, not drift)
+- [ ] 1.2 New `organizer-tenancy` capability spec: shared `organizer-console` project + `master` role + apps, `organizer-provisioner` machine user, required passkey-only + domain-discovery tenant-org login policy
+- [ ] 1.3 `openspec validate --strict organizer-tenancy` passes; open specification PR and merge (no BSR gen — no proto changes)
+
+## 2. Cloud-provisioning (IaC / Pulumi)
+
+- [ ] 2.1 `organizer-console` Zitadel Project in the `liverty-music` org with the `master` ProjectRole and access-token role assertion enabled (`projectRoleCheck` off)
+- [ ] 2.2 `organizer-console` OIDC app (PKCE, no secret) + per-env redirect URIs for the organizer console host; `backend-api` app on the same project (audience)
+- [ ] 2.3 `organizer-provisioner` machine user with the narrowest instance role that permits org-create + cross-org Project Grant + User Grant; credential in ESC/Secret Manager; separate from `backend-app`
+- [ ] 2.4 Ensure Pulumi does not treat runtime-provisioned Organizer tenant orgs as drift
+- [ ] 2.5 `make lint` (biome + tsc + kustomize render) passes; `pulumi preview` shows only the intended additions
+
+## 3. Ship to prod
+
+- [ ] 3.1 cloud-provisioning PR merged → dev Pulumi up (automated) applies the project/role/apps + machine user; confirm via `pulumi stack`
+- [ ] 3.2 Prod Pulumi up (manual from console) applies the same; confirm the `organizer-console` project, apps, and `organizer-provisioner` machine user exist in prod
+- [ ] 3.3 Verify: the `organizer-console` project + `master` role + both apps + the provisioner machine user are present in each env; no other org was created (topology still two IaC-managed orgs)


### PR DESCRIPTION
## Summary

First of four sub-changes decomposing roadmap step ① (the vetted-seller
foundation): the **Organizer tenancy foundation**. Following Zitadel's B2B
guidance (an Organization *is* the tenant), this lays the static Zitadel
platform scaffolding and relaxes the pinned two-org topology so one
Organization per Organizer can be provisioned at runtime later.

OpenSpec planning artifacts only — no proto/entity changes, so no BSR
generation is triggered by this change.

## Changes

- **`identity-management` (MODIFIED)** — relax the "exactly two top-level
  orgs" topology: besides the IaC-managed `admin` + `liverty-music` orgs, the
  instance may contain runtime-provisioned Organizer tenant orgs (one per
  Organizer, created later via the Management API), which are not IaC-managed
  and not treated as Pulumi drift.
- **`organizer-tenancy` (NEW capability)** —
  - a shared, actor-named `organizer-console` Zitadel Project owned by the
    `liverty-music` org, with the `master` ProjectRole and access-token role
    assertion;
  - the `organizer-console` OIDC app (one client for all tenants) + a
    `backend-api` app (audience);
  - a dedicated `organizer-provisioner` machine user with org-create rights
    (credential in ESC/Secret Manager), isolated from `backend-app`;
  - the required login policy for Organizer tenant orgs — passkey-only + 
    `allowDomainDiscovery`, set explicitly (never inherit the admin default).

## Non-Goals (later sub-changes)

Organizer domain entity + admin vetting + runtime provisioning saga
(`organizer-accounts`); `organizer.html` + hosting (`organizer-console`);
the `api.organizer.*` server + `OrganizerService.Get` + org-scoped authz
(`organizer-rpc-server`).

## Testing

Documentation / OpenSpec planning artifacts only; `openspec validate
--strict organizer-tenancy` passes. Implementation (cloud-provisioning IaC)
happens under this change's tasks and is validated then.

## Related

Refs: #759 — planning increment for the Phase 3 umbrella; the issue stays
open. Full design: `docs/organizer-platform-design.md`,
`docs/zitadel-tenancy-model.md`.
