### PR TITLE
docs(openspec): organizer-accounts — Organizer domain (① 2/4)

### DIFF
--- a/openspec/changes/organizer-accounts/.openspec.yaml
+++ b/openspec/changes/organizer-accounts/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-13

--- a/openspec/changes/organizer-accounts/design.md
+++ b/openspec/changes/organizer-accounts/design.md
@@ -1,0 +1,100 @@
+## Context
+
+See proposal.md - Why. Builds on `organizer-tenancy` (the shared
+`organizer-console` project, `master` role, apps, and `organizer-provisioner`
+machine user, plus the relaxed topology). Full design, resolved gap-audit,
+and the four-change decomposition are in
+[`docs/organizer-platform-design.md`](../../../docs/organizer-platform-design.md);
+Zitadel mechanics in
+[`docs/zitadel-tenancy-model.md`](../../../docs/zitadel-tenancy-model.md).
+This design references them rather than restating.
+
+## Goals / Non-Goals
+
+**Goals:** the Organizer entity + association, the admin management surface,
+robust runtime tenant provisioning, operator first-sign-in bootstrap, a
+minimal off-switch, and lifecycle analytics.
+
+**Non-Goals:** the organizer-facing `Get` + `api.organizer.*` server +
+org-scoped authz (`organizer-rpc-server`); `organizer.html` + hosting
+(`organizer-console`); sub-owner roles; organizer-side Update/List; full
+offboarding cascade; slug / contact fields.
+
+## Decisions
+
+**D1 — Data model.** `organizers(id UUIDv7, name, zitadel_org_id UNIQUE,
+provisioning_state)` + `organizer_artists(organizer_id, artist_id)` with a
+**partial UNIQUE(artist_id) WHERE provisioning_state != 'deactivated'** so a
+deactivated Organizer frees its artists. Both FKs `ON DELETE CASCADE`.
+`zitadel_org_id` is the token-tenant→Organizer link (DB is source of truth;
+backend-only, not on the consumer proto). `provisioning_state` is an
+operational lifecycle flag (`provisioning`/`active`/`deactivated`) — NOT the
+business `verified` flag the design rejected. `*_at` names per schema-lint.
+
+**D2 — Proto.** `entity/v1/organizer.proto` (Organizer, OrganizerId=uuid,
+OrganizerName min_len=1/max_len=200, matching the `ArtistName` convention);
+`rpc/admin/v1/organizer_service.proto` with **bare-verb** methods
+`Create`, `AssociateArtist`, `DisassociateArtist`, `List`, `Get`. Each RPC
+documents its error matrix (INVALID_ARGUMENT / NOT_FOUND / ALREADY_EXISTS /
+PERMISSION_DENIED). The organizer-facing `Get` service is defined and served
+in `organizer-rpc-server` (4/4), not here.
+
+**D3 — Admin-gated only.** All RPCs ride the existing admin Connect server
+behind `RequireRoleInterceptor(admin)`. There is no organizer-scoped
+authorization in this change (that is the organizer-facing server, 4/4).
+
+**D4 — Provisioning saga (idempotent, compensating), keyed on OrganizerId.**
+Order: (1) insert `organizers` row `provisioning_state=provisioning`; (2)
+Management API create tenant org (name `org-<uuid-short>`, explicit
+passkey-only + domain-discovery login policy); (3) persist `zitadel_org_id`;
+(4) Project-Grant `organizer-console` (role subset incl. `master`); (5)
+create operator human user (no password, init email) + `master` User Grant;
+(6) set `provisioning_state=active`. A reconciler re-enters at the first
+incomplete step (each Zitadel create existence-checked). Uses the
+`organizer-provisioner` credential from ESC/Secret Manager. Wrap the call in
+an OTel span + an `organizer_provisioning_failed` metric.
+
+**D5 — Operator bootstrap.** The operator is created without a password;
+Zitadel's init-email flow lets them register a passkey on first sign-in; the
+tenant org's login policy (set in step 2) is passkey-only with domain
+discovery, so no org picker is needed.
+
+**D6 — Deactivation hook.** `provisioning_state=deactivated` gates the
+backend (reject all organizer ops) and deactivates the Zitadel operators;
+the partial-unique index frees the artists. Full teardown (org/grant
+removal) is Phase 2 — the hook ships now so it is not a later migration.
+
+**D7 — Analytics.** Emit `organizer.created` / `organizer.artist.associated`
+via the existing JetStream→PostHog path, keyed on `organizer_id` (admin-actor
+/ group events, no fan UserId); add them to the event catalog in this change.
+
+## Risks / Trade-offs
+
+- **Two-system saga without 2PC** → the DB-row-first + existence-checked,
+  reconciler-retried design (D4) makes a partial failure recoverable without
+  duplicates; the operator is never left without a `master` grant.
+- **`provisioning_state` looks like reversing "no status column"** → it is an
+  *operational* lifecycle flag, explicitly distinct from the rejected
+  business `verified` flag; called out so review does not read it as a
+  reversal.
+- **Analytics events without a fan UserId** → model as admin-actor / group
+  events keyed on `organizer_id`; confirm they are forwarded despite lacking
+  a person `distinct_id`.
+
+## Migration Plan
+
+1. specification: additive proto → merge → Release → BSR gen.
+2. backend: Atlas migration (`organizers` + `organizer_artists`, partial
+   unique, `zitadel_org_id`, `provisioning_state`); entity/repo/usecases;
+   admin handler; provisioning client + reconciler; analytics; tests
+   (incl. the compensating-retry and double-claim paths).
+3. frontend: admin console organizer-management screen.
+- Rollback: additive tables + additive proto; remove the screen and tables
+  (no tenant orgs exist until Create is used).
+
+## Open Questions
+
+- Whether the initial operator is seeded in the same `Create` call or invited
+  immediately after — resolved as **same call** here (so the E2E "a master
+  signs in" is verifiable); revisit only if invite-later UX is needed (Phase
+  2), which would not change these specs.

--- a/openspec/changes/organizer-accounts/proposal.md
+++ b/openspec/changes/organizer-accounts/proposal.md
@@ -1,0 +1,75 @@
+## Why
+
+With the Zitadel tenancy foundation in place (`organizer-tenancy`), this
+change adds the **Organizer domain** — the vetted seller an admin creates,
+its link to the artists it represents, and the runtime provisioning that
+gives each Organizer an isolated Zitadel tenant its operator can sign into.
+This is sub-change 2/4 of roadmap step ①; grounded in
+`docs/organizer-platform-design.md` and `docs/zitadel-tenancy-model.md`,
+tracked by liverty-music/specification#759. The organizer-facing API server
+and the console frontend are separate sub-changes (3/4, 4/4).
+
+## What Changes
+
+- Introduce the **Organizer** entity (`OrganizerId` UUIDv7, `OrganizerName`),
+  distinct from Artist/Performer. It exists only via admin creation →
+  existence is the vetting (no `verified` flag). It carries an internal
+  `zitadel_org_id` (the tenant org link, backend-only) and an operational
+  `provisioning_state` (`provisioning`/`active`/`deactivated`).
+- Add the **Organizer↔Artist association**: an Organizer represents many
+  Artists, and **each Artist is represented by at most one Organizer**
+  (partial-unique on `artist_id`, excluding deactivated organizers so
+  their artists are re-associable).
+- Add an **admin `OrganizerService`** (bare-verb `Create`, `AssociateArtist`,
+  `DisassociateArtist`, `List`, `Get`) behind the existing admin-role gate.
+  `Create` takes an `operator_email`; `AssociateArtist` rejects `NOT_FOUND`
+  for unknown artists (no create-on-demand) and `ALREADY_EXISTS` for
+  already-claimed artists; reassignment = disassociate + associate.
+- Add **runtime tenant provisioning**: on `Create`, the backend calls the
+  Zitadel Management API (via the `organizer-provisioner` machine user) to
+  create the Organizer's tenant org, set its passkey-only + domain-discovery
+  login policy, Project-Grant `organizer-console`, and seed the initial
+  operator as `master` — **idempotent/compensating** so a retry never
+  duplicates the org and never leaves the operator without a grant.
+- Add the **operator first-sign-in bootstrap**: the initial operator is a
+  tenant human user with no password; Zitadel sends an init email; the
+  operator registers a **passkey** and signs into their org (resolved by
+  email domain discovery).
+- Add a **`deactivated` off-switch hook**: the backend rejects all organizer
+  operations for a deactivated Organizer and its operators are deactivated
+  in Zitadel; freed artists become re-associable. Full teardown cascade is
+  Phase 2.
+- Emit backend **analytics events** `organizer.created` and
+  `organizer.artist.associated`.
+
+Explicit non-goals: the organizer-facing `OrganizerService.Get` + its
+dedicated `api.organizer.*` server + org-scoped authz (`organizer-rpc-server`,
+4/4); `organizer.html` + hosting (`organizer-console`, 3/4); sub-owner roles;
+organizer-side Update/List; full offboarding cascade; slug/contact fields.
+
+## Capabilities
+
+### New Capabilities
+- `organizer-accounts`: the Organizer entity + Organizer↔Artist association,
+  the admin `OrganizerService`, runtime tenant provisioning + operator
+  bootstrap, the `deactivated` hook, and organizer lifecycle analytics.
+
+### Modified Capabilities
+<!-- None. Topology was relaxed in organizer-tenancy; this change consumes
+     that foundation without further requirement changes to it. -->
+
+## Impact
+
+- **specification**: new `entity/v1/organizer.proto` (Organizer, OrganizerId,
+  OrganizerName; protovalidate: id uuid, name 1–200) and
+  `rpc/admin/v1/organizer_service.proto` (admin service). Ships via the
+  cross-repo release order (spec merge → Release → BSR gen).
+- **backend**: Organizer entity + repository + usecases; admin handler behind
+  `RequireRoleInterceptor(admin)`; the Zitadel Management-API provisioning
+  client (using the `organizer-provisioner` credential); `organizers` +
+  `organizer_artists` Atlas migration (partial-unique on `artist_id`,
+  `zitadel_org_id` unique, `provisioning_state`); analytics emission.
+- **frontend**: admin console gains an organizer-management screen (create /
+  associate / disassociate / list) reusing the existing artist search.
+- **cloud-provisioning**: none new (the project/role/apps/machine user were
+  provisioned in `organizer-tenancy`).

--- a/openspec/changes/organizer-accounts/specs/organizer-accounts/spec.md
+++ b/openspec/changes/organizer-accounts/specs/organizer-accounts/spec.md
@@ -1,0 +1,163 @@
+## Purpose
+
+The Organizer domain: the vetted seller an admin creates, its link to the
+artists it represents, the runtime provisioning that gives each Organizer an
+isolated Zitadel tenant its operator can sign into, and the admin surface to
+manage them. The organizer-facing API and console are separate capabilities.
+
+## ADDED Requirements
+
+### Requirement: Admin creates an organizer with an initial operator
+
+The system SHALL let an operator holding the platform `admin` role create an
+Organizer with a name and an initial operator email. Creation is the vetting
+— there is no separate `verified` flag and no self-serve registration. An
+Organizer is distinct from an Artist and has its own OrganizerId. On success
+the Organizer is provisioned an isolated Zitadel tenant (see idempotent
+provisioning) with the initial operator seeded as its `master`.
+
+#### Scenario: Admin creates an organizer
+
+- **WHEN** an operator with the `admin` role creates an Organizer with a name
+  and an initial operator email
+- **THEN** the Organizer SHALL exist with an isolated tenant and a `master`
+  operator, and SHALL become an active organizer
+
+#### Scenario: Non-admin cannot create an organizer
+
+- **WHEN** a create request is made without the `admin` role
+- **THEN** the system SHALL reject it with a permission-denied error
+
+#### Scenario: Organizer identity is separate from artist identity
+
+- **WHEN** an artist self-publishes and an Organizer account is created for
+  them
+- **THEN** the Organizer SHALL have its own OrganizerId distinct from the
+  Artist's ArtistId
+
+### Requirement: Initial operator bootstraps credentials on first sign-in
+
+The system SHALL create the initial operator as a human user in the
+Organizer's tenant org with no password, and trigger a Zitadel
+initialization email. The operator SHALL complete first sign-in by
+registering a passkey, and SHALL be routed to their own tenant org by email
+domain discovery (no org picker).
+
+#### Scenario: Operator completes first sign-in via init email and passkey
+
+- **WHEN** an initial operator opens their initialization email and starts
+  first sign-in
+- **THEN** they SHALL register a passkey and be returned authenticated to
+  their Organizer tenant org
+
+#### Scenario: Operator is routed to their org by email domain
+
+- **WHEN** the operator enters their email at login
+- **THEN** domain discovery SHALL route them to their Organizer tenant org
+  without an org picker
+
+### Requirement: An artist is represented by at most one organizer
+
+The system SHALL associate an Organizer with zero or more Artists, and each
+Artist SHALL be represented by **at most one** Organizer. Associating an
+Artist that does not exist SHALL be rejected (no create-on-demand);
+associating an Artist already represented SHALL be rejected. An admin SHALL
+be able to disassociate an Artist; reassignment is disassociate followed by
+associate.
+
+#### Scenario: A label organizer represents multiple artists
+
+- **WHEN** an Organizer is associated with several existing Artists
+- **THEN** all associated Artists SHALL be retrievable for that Organizer
+
+#### Scenario: Associating a non-existent artist is rejected
+
+- **WHEN** an admin associates an ArtistId that does not exist
+- **THEN** the system SHALL reject it with a not-found error and SHALL NOT
+  create the artist
+
+#### Scenario: An artist cannot be claimed by a second organizer
+
+- **WHEN** an Artist already represented by one Organizer is associated with
+  a different Organizer
+- **THEN** the system SHALL reject it with an already-exists error
+
+#### Scenario: Disassociate frees the artist
+
+- **WHEN** an admin disassociates an Artist from its Organizer
+- **THEN** the association SHALL be removed and the Artist SHALL be
+  associable to another Organizer
+
+### Requirement: Admin can list and inspect organizers
+
+The system SHALL provide admin-gated `List` and `Get` returning Organizers
+with their associated artists, so the admin console can render the
+organizer-management screen.
+
+#### Scenario: Admin lists organizers with their artists
+
+- **WHEN** an operator with the `admin` role lists organizers
+- **THEN** the system SHALL return each Organizer with its associated artists
+
+#### Scenario: Non-admin cannot list organizers
+
+- **WHEN** a list/get request is made without the `admin` role
+- **THEN** the system SHALL reject it with a permission-denied error
+
+### Requirement: Organizer provisioning is idempotent and compensating
+
+Creating an Organizer SHALL be idempotent and compensating across the
+tenant-provisioning steps (tenant org, login policy, project grant, operator
++ master grant, and the persisted `zitadel_org_id`). A retry after a partial
+failure SHALL complete provisioning without creating a duplicate Organizer or
+duplicate tenant org, and SHALL never leave the Organizer without a `master`
+operator.
+
+#### Scenario: Retry after mid-provisioning failure does not duplicate
+
+- **WHEN** a `Create` is retried after failing partway through provisioning
+- **THEN** the system SHALL complete the remaining steps without creating a
+  second Organizer or a second tenant org
+
+#### Scenario: Operator is never left without a master grant
+
+- **WHEN** provisioning completes for an Organizer
+- **THEN** the Organizer SHALL have at least one operator holding the
+  `master` role
+
+### Requirement: An organizer can be deactivated
+
+The system SHALL support deactivating an Organizer. For a deactivated
+Organizer, the backend SHALL reject all organizer operations, its operators
+SHALL be deactivated in Zitadel, and its artist associations SHALL be freed
+so the artists can be re-associated. Full teardown of the tenant org and
+grants is out of scope for this change.
+
+#### Scenario: Deactivated organizer's operations are rejected
+
+- **WHEN** an Organizer is deactivated and a request targets it
+- **THEN** the system SHALL reject the request and the Organizer's operators
+  SHALL no longer be able to act
+
+#### Scenario: Deactivation frees the organizer's artists
+
+- **WHEN** an Organizer with associated artists is deactivated
+- **THEN** those artists SHALL become associable to another Organizer
+
+### Requirement: Organizer lifecycle emits analytics events
+
+The system SHALL emit backend analytics events `organizer.created` and
+`organizer.artist.associated`, keyed on `organizer_id` (admin-actor / group
+events, not fan-user events), forwarded to the analytics pipeline.
+
+#### Scenario: Creating an organizer emits an event
+
+- **WHEN** an Organizer is created
+- **THEN** the system SHALL emit an `organizer.created` analytics event with
+  the `organizer_id`
+
+#### Scenario: Associating an artist emits an event
+
+- **WHEN** an Artist is associated with an Organizer
+- **THEN** the system SHALL emit an `organizer.artist.associated` event with
+  the `organizer_id` and `artist_id`

--- a/openspec/changes/organizer-accounts/tasks.md
+++ b/openspec/changes/organizer-accounts/tasks.md
@@ -1,0 +1,36 @@
+## 1. Specification (proto)
+
+- [ ] 1.1 `entity/v1/organizer.proto`: `Organizer` (OrganizerId UUIDv7, OrganizerName), type-safe wrappers + protovalidate (id `uuid`, name `min_len=1/max_len=200`)
+- [ ] 1.2 `rpc/admin/v1/organizer_service.proto`: bare-verb `Create` (name + operator_email), `AssociateArtist`, `DisassociateArtist`, `List`, `Get`; document each RPC's error matrix
+- [ ] 1.3 `buf lint`/`format`/`breaking` pass; open specification PR, merge, cut Release, confirm BSR gen succeeds
+
+## 2. Backend — domain & admin surface
+
+- [ ] 2.1 Atlas migration: `organizers` (id, name, `zitadel_org_id` UNIQUE, `provisioning_state`, `*_at`) + `organizer_artists` (partial UNIQUE(artist_id) WHERE not deactivated; FKs ON DELETE CASCADE)
+- [ ] 2.2 `entity` Organizer + repository interface; rdb repo with error classification
+- [ ] 2.3 Usecases: create, associate/disassociate artist (NOT_FOUND / ALREADY_EXISTS), list, get, deactivate
+- [ ] 2.4 Admin `OrganizerService` handler behind `RequireRoleInterceptor(admin)`
+
+## 3. Backend — tenant provisioning & bootstrap
+
+- [ ] 3.1 Zitadel Management-API client (using the `organizer-provisioner` credential) — create org, set passkey-only + domain-discovery login policy, project-grant `organizer-console`, create operator user + `master` grant
+- [ ] 3.2 Idempotent/compensating provisioning saga keyed on OrganizerId (DB-row-first, existence-checked steps, reconciler retry); persist `zitadel_org_id`; flip to `active`
+- [ ] 3.3 Operator bootstrap: no-password human user + Zitadel init email (passkey on first sign-in)
+- [ ] 3.4 Deactivation: `deactivated` gate rejects organizer ops + deactivates Zitadel operators + frees artists
+- [ ] 3.5 OTel span + `organizer_provisioning_failed` metric on the provisioning call
+
+## 4. Backend — analytics & tests
+
+- [ ] 4.1 Emit `organizer.created` + `organizer.artist.associated` (JetStream→PostHog, keyed on organizer_id); add to the event catalog
+- [ ] 4.2 Tests: usecases (create/associate/disassociate incl. double-claim + non-existent-artist), provisioning-client mock incl. compensating retry, deactivation gate; `make check` passes with upgraded BSR package
+
+## 5. Frontend (admin console)
+
+- [ ] 5.1 Organizer-management screen: create (name + operator email), list with associated artists, associate/disassociate (reuse existing artist search), deactivate
+- [ ] 5.2 `make check` passes with upgraded BSR package
+
+## 6. Release & ship to prod
+
+- [ ] 6.1 Backend PR merged → release → prod pin bump; confirm rollout (depends on `organizer-tenancy` IaC applied in the env first)
+- [ ] 6.2 Frontend PR merged → release
+- [ ] 6.3 Verify in prod: an admin creates an Organizer (name + operator email) → tenant org + project grant + master operator provisioned; the operator completes init-email + passkey and signs into their org; associate/disassociate + deactivate behave per spec; analytics events land


### PR DESCRIPTION
## Summary

Sub-change 2/4 of roadmap step ① — the **Organizer domain**, on top of the
`organizer-tenancy` foundation. OpenSpec planning artifacts (spec deltas +
proto plan); implementation follows under the change's tasks.

## Changes

New capability **`organizer-accounts`**:
- **Entity** — `Organizer` (`OrganizerId` UUIDv7, `OrganizerName`), distinct
  from Artist; internal `zitadel_org_id` (tenant link, backend-only) and an
  operational `provisioning_state` (`provisioning`/`active`/`deactivated`).
  Existence via admin creation = vetting; no `verified` flag.
- **Association** — an Organizer represents many Artists; **each Artist has at
  most one Organizer** (partial-unique on `artist_id`, freed on
  deactivation). Associate rejects `NOT_FOUND` (no create-on-demand) /
  `ALREADY_EXISTS`; reassignment = disassociate + associate.
- **Admin `OrganizerService`** — bare-verb `Create` (name + operator email),
  `AssociateArtist`, `DisassociateArtist`, `List`, `Get`, behind the admin
  role gate.
- **Runtime tenant provisioning** — on `Create`, provision the Organizer's
  Zitadel tenant (org + passkey-only/domain-discovery login policy +
  `organizer-console` project grant + `master` operator) via the Management
  API, **idempotent/compensating** keyed on OrganizerId.
- **Operator bootstrap** — initial operator seeded with no password; Zitadel
  init email → passkey on first sign-in; org resolved by domain discovery.
- **`deactivated` off-switch hook** — backend rejects a deactivated
  Organizer's operations; operators deactivated in Zitadel; artists freed.
- **Analytics** — `organizer.created` / `organizer.artist.associated`.

## Non-Goals (later sub-changes)

Organizer-facing `Get` + `api.organizer.*` server + org-scoped authz
(`organizer-rpc-server`, 4/4); `organizer.html` + hosting
(`organizer-console`, 3/4); sub-owner roles; organizer-side Update/List; full
offboarding cascade; slug/contact fields.

## Testing

OpenSpec planning artifacts; `openspec validate --strict organizer-accounts`
passes. Proto/backend/frontend implementation happens under this change's
tasks and is validated then.

## Related

Refs: #759 — Phase 3 umbrella (stays open). Full design + resolved gap-audit:
`docs/organizer-platform-design.md`. Depends on `organizer-tenancy` (#774).
