### PR TITLE
docs(openspec): organizer-console + organizer-rpc-server (① 3/4 + 4/4)

### DIFF
--- a/openspec/changes/organizer-console/.openspec.yaml
+++ b/openspec/changes/organizer-console/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-13

--- a/openspec/changes/organizer-console/design.md
+++ b/openspec/changes/organizer-console/design.md
@@ -1,0 +1,57 @@
+## Context
+
+See proposal.md - Why. Mirrors the admin console pattern (bundle-isolated
+entry + dedicated hosting) for the organizer surface. Depends on
+`organizer-tenancy` (the `organizer-console` OIDC app + per-tenant login
+policy with domain discovery). Full design:
+[`docs/organizer-platform-design.md`](../../../docs/organizer-platform-design.md).
+
+## Goals / Non-Goals
+
+**Goals:** a bundle-isolated organizer entry, OIDC login via domain
+discovery, a role-claim route guard, a placeholder, and the dedicated
+hosting.
+
+**Non-Goals:** business screens; the organizer API server
+(`organizer-rpc-server`); per-org branding; a reception PWA.
+
+## Decisions
+
+**D1 — One OIDC client, org resolved by domain discovery.** A single
+`organizer-console` client serves all tenants; the operator's org is resolved
+at login by email domain discovery (enabled on tenant orgs in
+`organizer-tenancy`). This is why the organizer `/config.json` omits a fixed
+`zitadelOrgId` — baking one in would break the multi-tenant single-app model.
+
+**D2 — Role-claim route guard, backend is source of truth.** Unlike the admin
+console (where Google Workspace login *is* the wall), any tenant-org account
+authenticates successfully; the console guard therefore inspects the
+`organizer-console` project roles claim and admits only `master`. Real
+enforcement is at the backend; the guard is UX.
+
+**D3 — Dedicated hosting mirrors admin-console-hosting.** `organizer.{base}`
+host with HTTPRoute + cert + Cloud DNS + per-host `/config.json`; bundle
+isolation is enforced the same way as the admin console (consumer chunk
+graph contains no organizer module).
+
+**D4 — Consumer config contract unchanged.** The organizer entry defines its
+own config shape (this change); the consumer's `frontend-runtime-config`
+requirement governs the consumer SPA only and is not modified.
+
+## Risks / Trade-offs
+
+- **Shared AppConfig type** → if the organizer entry reuses the consumer
+  AppConfig type, `zitadelOrgId` must become optional for the organizer
+  variant; keep the consumer's required-org contract intact (implementation
+  reconciliation, not a consumer spec change).
+- **Bundle-isolation regression** → reuse the admin console's chunk-graph CI
+  assertion.
+
+## Migration Plan
+
+1. frontend: `organizer.html` entry (bundle-isolated), OIDC via domain
+   discovery, role-claim route guard, placeholder; chunk-graph CI assertion.
+2. cloud-provisioning: `organizer.{base}` host (HTTPRoute, cert, Cloud DNS) +
+   per-host ConfigMap; add the host to the `organizer-console` OIDC app
+   redirect URIs.
+- Rollback: additive entry + host; remove with no consumer/admin impact.

--- a/openspec/changes/organizer-console/proposal.md
+++ b/openspec/changes/organizer-console/proposal.md
@@ -1,0 +1,60 @@
+## Why
+
+Organizer operators need a place to sign in. This sub-change (3/4 of roadmap
+step ①) adds the **organizer console frontend + its hosting** — a
+bundle-isolated `organizer.html` entry authenticated against the operator's
+own Zitadel tenant org (via domain discovery), served at a dedicated host.
+Business screens land in later changes; this establishes the
+access-controlled shell. Grounded in `docs/organizer-platform-design.md` and
+`docs/zitadel-tenancy-model.md`, tracked by liverty-music/specification#759.
+Depends on `organizer-tenancy` (the `organizer-console` OIDC app).
+
+## What Changes
+
+- Add a third frontend entry point **`organizer.html`** — a Vite/Rollup MPA
+  bundle-isolated from the consumer SPA and the admin console (no organizer
+  code in the consumer chunk graph).
+- Authenticate via Zitadel OIDC using the shared `organizer-console` client;
+  the operator's tenant org is resolved by **email domain discovery** (no
+  fixed org id at build time, no org picker).
+- Add a **route guard** that inspects the token's `organizer-console` project
+  roles and admits only operators holding `master`; unauthenticated visitors
+  are sent to sign-in; authenticated operators land on a post-login welcome
+  placeholder.
+- Add **hosting** for the entry at `organizer.{base-domain}`
+  (`organizer.dev.liverty-music.app` / `organizer.liverty-music.app`):
+  HTTPRoute on the shared gateway, TLS cert (certmap), Cloud DNS record, and
+  a per-host `/config.json`.
+- **Runtime config**: the organizer `/config.json` carries the issuer + the
+  `organizer-console` client id + `apiBaseUrl = api.organizer.{base}`, and
+  deliberately **omits a fixed `zitadelOrgId`** — the org is resolved at
+  login (domain discovery). This organizer config shape is specified in the
+  `organizer-console` capability; the consumer SPA's `frontend-runtime-config`
+  contract is unchanged (it governs the consumer entry only).
+
+Explicit non-goals: business screens (event authoring etc.); the
+organizer-facing API server (`organizer-rpc-server`); per-org branding; a
+reception check-in PWA.
+
+## Capabilities
+
+### New Capabilities
+- `organizer-console`: the `organizer.html` bundle-isolated entry, OIDC
+  login via domain discovery, the role-claim route guard + placeholder, and
+  the organizer runtime-config shape (no fixed org id).
+- `organizer-console-hosting`: the `organizer.{base}` host — HTTPRoute, TLS
+  cert, Cloud DNS, and per-host `/config.json`.
+
+### Modified Capabilities
+<!-- None. The organizer entry defines its own config shape in the
+     organizer-console capability; the consumer's frontend-runtime-config
+     contract (which governs the consumer SPA entry) is unchanged. -->
+
+## Impact
+
+- **frontend**: new `organizer.html` entry (bundle-isolated), OIDC via the
+  shared client with domain discovery, role-claim route guard, placeholder;
+  a CI assertion that the consumer chunk graph contains no organizer module.
+- **cloud-provisioning**: the `organizer.{base}` host (HTTPRoute, cert, Cloud
+  DNS) + per-host ConfigMap; mirrors `admin-console-hosting`. No proto
+  changes.

--- a/openspec/changes/organizer-console/specs/organizer-console-hosting/spec.md
+++ b/openspec/changes/organizer-console/specs/organizer-console-hosting/spec.md
@@ -1,0 +1,36 @@
+## Purpose
+
+Hosting for the organizer console entry at a dedicated per-environment host,
+mirroring the admin console hosting: an HTTPRoute on the shared gateway, a
+TLS certificate, a Cloud DNS record, and a per-host `/config.json`.
+
+## ADDED Requirements
+
+### Requirement: Serve the organizer console at a dedicated per-env host
+
+The system SHALL serve `organizer.html` at `organizer.{base-domain}` per
+environment (`organizer.dev.liverty-music.app` in dev,
+`organizer.liverty-music.app` in prod), provisioned via IaC: an HTTPRoute on
+the shared gateway, a TLS certificate (certmap), and a Cloud DNS record. The
+`organizer-console` OIDC app's redirect URIs SHALL include this host.
+
+#### Scenario: Organizer host is reachable over TLS per environment
+
+- **WHEN** the IaC is applied for an environment
+- **THEN** `organizer.{base-domain}` for that environment SHALL resolve via
+  Cloud DNS and terminate TLS via the provisioned certificate
+- **AND** an HTTPRoute SHALL route it to the organizer console
+
+### Requirement: Serve a per-host organizer config
+
+The system SHALL serve a per-host `/config.json` for the organizer host
+carrying the organizer runtime config (issuer, `organizer-console` client
+id, organizer `apiBaseUrl`), with the Service Worker (if any) bypassing cache
+for `/config.json`.
+
+#### Scenario: Organizer host serves its own config
+
+- **WHEN** the organizer console requests `/config.json` at
+  `organizer.{base-domain}`
+- **THEN** it SHALL receive the organizer config for that environment (not
+  the consumer SPA's config)

--- a/openspec/changes/organizer-console/specs/organizer-console/spec.md
+++ b/openspec/changes/organizer-console/specs/organizer-console/spec.md
@@ -1,0 +1,83 @@
+## Purpose
+
+The organizer (seller) frontend shell: a dedicated `organizer.html` entry,
+bundle-isolated from the consumer SPA and admin console, authenticated
+against the operator's own Zitadel tenant org via domain discovery, with a
+role-claim route guard and a post-login placeholder. Business screens land
+in later changes.
+
+## ADDED Requirements
+
+### Requirement: Bundle isolation from the consumer SPA and admin console
+
+The organizer console SHALL be built as a separate Vite/Rollup entry point
+(`organizer.html`) such that no organizer-only code is included in any chunk
+loaded by the consumer SPA or the admin console. Adding it MUST NOT increase
+the consumer SPA's downloaded bundle size or regress its Core Web Vitals.
+
+#### Scenario: Consumer page loads no organizer code
+
+- **WHEN** a fan loads the consumer SPA at the consumer hostname
+- **THEN** the consumer entry's chunk graph SHALL contain no module
+  originating from the organizer source directory
+
+### Requirement: Authenticate operators via domain discovery, one client for all tenants
+
+The organizer console SHALL authenticate operators through Zitadel OIDC
+(PKCE, no client secret) using the shared `organizer-console` client, with
+the operator's tenant org resolved by **email domain discovery** — the
+operator enters their email and is routed to their own org, with no fixed
+org id at build time and no org picker.
+
+#### Scenario: Operator signs in and is routed to their org
+
+- **WHEN** an operator enters their email and completes sign-in
+- **THEN** domain discovery SHALL route them to their own Organizer tenant
+  org and return them authenticated to the console
+
+#### Scenario: One OIDC client serves all tenants
+
+- **WHEN** operators of different Organizer tenant orgs sign in
+- **THEN** the same `organizer-console` OIDC client SHALL serve them all (no
+  per-tenant client, no build-time org id)
+
+### Requirement: Route guard admits only master-role operators
+
+The organizer console SHALL guard its routes: unauthenticated visitors are
+sent to sign-in, and an authenticated user is admitted only if the token's
+`organizer-console` project roles include `master`; otherwise access is
+denied. The backend remains the source of truth for authorization; the guard
+is a UX gate. On success the operator lands on a post-login welcome
+placeholder.
+
+#### Scenario: Unauthenticated visitor is redirected to sign-in
+
+- **WHEN** an unauthenticated visitor navigates to an organizer console route
+- **THEN** the guard SHALL redirect them to Zitadel sign-in
+
+#### Scenario: Authenticated operator with master role sees the placeholder
+
+- **WHEN** an authenticated operator whose token carries the `master` role
+  loads the console
+- **THEN** they SHALL see the post-login welcome placeholder
+
+#### Scenario: Authenticated account without the master role is denied
+
+- **WHEN** an authenticated user whose token lacks the `master` role loads
+  the console
+- **THEN** the guard SHALL deny access to organizer screens
+
+### Requirement: Organizer runtime config resolves the org at login
+
+The organizer console SHALL load its runtime config from `/config.json`
+carrying the Zitadel issuer, the `organizer-console` client id, and
+`apiBaseUrl` pointing at the organizer API host. It SHALL **omit a fixed
+organization id** — the tenant org is resolved at login via domain
+discovery, not baked into config.
+
+#### Scenario: Organizer config omits a fixed org id
+
+- **WHEN** the organizer console loads `/config.json`
+- **THEN** the config SHALL provide the issuer, `organizer-console` client
+  id, and the organizer `apiBaseUrl`
+- **AND** it SHALL NOT require a fixed organization id

--- a/openspec/changes/organizer-console/tasks.md
+++ b/openspec/changes/organizer-console/tasks.md
@@ -1,0 +1,21 @@
+## 1. Frontend
+
+- [ ] 1.1 `organizer.html` Vite/Rollup entry, bundle-isolated (separate chunk graph); reuse shared auth-service + config loader
+- [ ] 1.2 OIDC via the shared `organizer-console` client with email domain discovery (no fixed org id); post-login welcome placeholder
+- [ ] 1.3 Route guard: inspect the `organizer-console` project roles claim, admit only `master`, redirect unauthenticated to sign-in
+- [ ] 1.4 Organizer `/config.json` loader shape (issuer + `organizer-console` client id + `api.organizer` base; no fixed org id)
+- [ ] 1.5 CI assertion: consumer chunk graph contains no organizer module (reuse admin-console bundle-isolation check)
+- [ ] 1.6 `make check` passes
+
+## 2. Cloud-provisioning (hosting)
+
+- [ ] 2.1 `organizer.{base}` host: HTTPRoute on the shared gateway + TLS cert (certmap) + Cloud DNS record (dev + prod)
+- [ ] 2.2 Per-host `/config.json` ConfigMap for the organizer entry; SW bypasses cache for `/config.json`
+- [ ] 2.3 Add the `organizer.{base}` redirect URIs to the `organizer-console` OIDC app (coordinate with organizer-tenancy IaC)
+- [ ] 2.4 `make lint` (kustomize render) passes; `pulumi preview` shows only intended additions
+
+## 3. Ship to prod
+
+- [ ] 3.1 Frontend PR merged → release → organizer.html shipped
+- [ ] 3.2 Cloud-provisioning PR merged → ArgoCD synced (host, cert, DNS, config)
+- [ ] 3.3 Verify in prod: `organizer.liverty-music.app` serves the console over TLS; an operator signs in via email domain discovery and (with `master`) sees the placeholder; a non-master account is denied; the consumer bundle is unaffected

--- a/openspec/changes/organizer-rpc-server/.openspec.yaml
+++ b/openspec/changes/organizer-rpc-server/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-13

--- a/openspec/changes/organizer-rpc-server/design.md
+++ b/openspec/changes/organizer-rpc-server/design.md
@@ -1,0 +1,68 @@
+## Context
+
+See proposal.md - Why. Mirrors `admin-rpc-server` (each audience gets its own
+Connect server + ingress + CORS + cert + DNS + health). Depends on
+`organizer-accounts` (the `Organizer` entity + the `zitadel_org_id`
+tenant→Organizer link) and `organizer-tenancy` (the `organizer-console`
+project id used as the token audience). Full design + authorization matrix:
+[`docs/organizer-platform-design.md`](../../../docs/organizer-platform-design.md);
+Zitadel claim shapes in
+[`docs/zitadel-tenancy-model.md`](../../../docs/zitadel-tenancy-model.md).
+
+## Goals / Non-Goals
+
+**Goals:** a dedicated, isolated organizer API server; `OrganizerService.Get`;
+correct org-scoped authorization with an explicit failure matrix.
+
+**Non-Goals:** organizer-side `Update`/`List` (Phase 2); write/business RPCs;
+the admin surface (`organizer-accounts`).
+
+## Decisions
+
+**D1 — Dedicated server per audience.** The organizer audience is external
+and org-scoped, distinct from consumer (public) and admin (Google-Workspace)
+audiences, so it gets its own Connect server, ingress `api.organizer.{base}`,
+CORS allowlist, cert, DNS, and health — and is excluded from the other
+servers. Mirrors `admin-rpc-server`.
+
+**D2 — Authorization from the org-scoped role claim.** Validate JWT →
+require the organizer-console project id in `aud` (console requests the
+`...:project:id:{id}:aud` scope) → read `role → { orgId → domain }`; the
+inner orgId is the tenant. Authorize `{tenant, role}`; resolve the active
+tenant from the session's login-scope org; a multi-org operator is
+authorized only against that org. Analogous to `rpc-auth-scoping` (body id
+vs token), here target Organizer vs token tenant.
+
+**D3 — Every failure is PERMISSION_DENIED / UNAUTHENTICATED, never 500.**
+Missing/empty roles claim (require `accessTokenRoleAssertion=true` on the
+app), `aud` without the project id, or login-scope↔target mismatch →
+`PERMISSION_DENIED`; absent/invalid token → `UNAUTHENTICATED`.
+
+**D4 — `Get` request shape.** `GetRequest` carries an explicit `OrganizerId`
+verified equal to the token tenant (consistent with `rpc-auth-scoping`),
+rejecting any other value.
+
+## Risks / Trade-offs
+
+- **Assertion/aud misconfig silently denies or over-permits** → assert
+  `accessTokenRoleAssertion` on the app and require the project id in `aud`;
+  cover the no-role / wrong-aud / scope-mismatch paths with tests (the
+  crown-jewel security tests).
+- **Tenant→Organizer resolution** → read the `zitadel_org_id` link from
+  `organizer-accounts` (DB is source of truth); do not depend on a Zitadel
+  round-trip per request.
+
+## Migration Plan
+
+1. specification: `rpc/organizer/v1/organizer_service.proto` → merge →
+   Release → BSR gen.
+2. backend: dedicated organizer Connect server + `Get` handler + org-scoped
+   authorization interceptor; tests for the failure matrix.
+3. cloud-provisioning: `api.organizer.{base}` ingress (HTTPRoute, cert, Cloud
+   DNS), CORS, health; mirror `admin-rpc-server`.
+- Rollback: additive server + host; remove with no consumer/admin impact.
+
+## Open Questions
+
+- None blocking. The exact port/health wiring follows the `admin-rpc-server`
+  precedent and is an implementation detail.

--- a/openspec/changes/organizer-rpc-server/proposal.md
+++ b/openspec/changes/organizer-rpc-server/proposal.md
@@ -1,0 +1,58 @@
+## Why
+
+Organizer operators need an API to read their own Organizer. This sub-change
+(4/4 of roadmap step ①) adds the organizer-facing `OrganizerService.Get` on a
+**dedicated** Connect server at `api.organizer.{base}` with its own CORS,
+cert, DNS, and health, plus **org-scoped role-claim authorization** — every
+prior audience surface on this platform (`admin-rpc-server`) gets its own
+server, and the external organizer audience must too. Grounded in
+`docs/organizer-platform-design.md` and `docs/zitadel-tenancy-model.md`,
+tracked by liverty-music/specification#759. Depends on `organizer-accounts`
+(the Organizer entity) and `organizer-tenancy` (the `organizer-console`
+project + audience).
+
+## What Changes
+
+- Add `rpc/organizer/v1/organizer_service.proto`: bare-verb **`Get`**
+  returning the authenticated Organizer's identity + associated artists. The
+  request carries an `OrganizerId` that MUST equal the token-derived tenant.
+- Serve it on a **dedicated organizer Connect server** at
+  `api.organizer.{base-domain}` with its own CORS allowlist (only the
+  `organizer.{base}` origin), TLS cert, Cloud DNS, and health check. The
+  consumer and admin servers SHALL NOT serve organizer services, and this
+  server SHALL NOT serve consumer/admin services.
+- Add an **org-scoped authorization interceptor**: validate the JWT, require
+  the organizer-console project id in the token `aud`, read the roles claim
+  (`role → { orgId → domain }`), and authorize `{tenant, role}` — the inner
+  orgId is the tenant. Reject with `PERMISSION_DENIED` on a missing/empty
+  roles claim, an `aud` without the project id, or a mismatch between the
+  session's login-scope org and the requested Organizer; `UNAUTHENTICATED`
+  when the token is absent/invalid.
+
+Explicit non-goals: organizer-side `Update`/`List` (Phase 2); any write/
+business RPCs (later changes); the admin surface (in `organizer-accounts`).
+
+## Capabilities
+
+### New Capabilities
+- `organizer-rpc-server`: the dedicated organizer Connect server
+  (`api.organizer.{base}` + CORS + cert + DNS + health), the
+  `OrganizerService.Get` RPC, and the org-scoped role-claim authorization
+  with its failure matrix.
+
+### Modified Capabilities
+<!-- None. The organizer server is a new, isolated surface; existing
+     consumer/admin servers are unchanged (they already exclude services
+     they do not own). -->
+
+## Impact
+
+- **specification**: new `rpc/organizer/v1/organizer_service.proto` (imports
+  the `Organizer` entity from `organizer-accounts`). Ships via the cross-repo
+  release order.
+- **backend**: a dedicated organizer Connect server + `OrganizerService.Get`
+  handler + the org-scoped authorization interceptor (analogous to
+  `rpc-auth-scoping`, tenant variant); reads the tenant→Organizer link
+  (`zitadel_org_id`) from `organizer-accounts`.
+- **cloud-provisioning**: `api.organizer.{base}` ingress host (HTTPRoute,
+  cert, Cloud DNS), CORS config, and health; mirrors `admin-rpc-server`.

--- a/openspec/changes/organizer-rpc-server/specs/organizer-rpc-server/spec.md
+++ b/openspec/changes/organizer-rpc-server/specs/organizer-rpc-server/spec.md
@@ -1,0 +1,82 @@
+## Purpose
+
+The organizer-facing API surface: a dedicated Connect server at
+`api.organizer.{base}` serving `OrganizerService.Get`, isolated from the
+consumer and admin servers, with org-scoped role-claim authorization so an
+operator can read only their own Organizer.
+
+## ADDED Requirements
+
+### Requirement: Dedicated organizer Connect server isolated by audience
+
+The system SHALL serve the organizer-facing `OrganizerService` on a
+dedicated Connect server at `api.organizer.{base-domain}` with its own CORS
+allowlist (only the `organizer.{base-domain}` origin), TLS cert, Cloud DNS,
+and health check. The consumer and admin servers SHALL NOT serve organizer
+services, and this server SHALL NOT serve consumer or admin services.
+
+#### Scenario: Organizer server is reachable and isolated
+
+- **WHEN** the organizer console calls `api.organizer.{base-domain}`
+- **THEN** the request SHALL be served by the dedicated organizer server
+- **AND** the same organizer service SHALL NOT be reachable on the consumer
+  or admin API hosts
+
+#### Scenario: CORS admits only the organizer origin
+
+- **WHEN** a browser request to the organizer API originates from the
+  `organizer.{base-domain}` origin
+- **THEN** CORS SHALL permit it
+- **AND** requests from other origins SHALL be rejected by CORS
+
+### Requirement: OrganizerService.Get returns the caller's own organizer
+
+The system SHALL expose a bare-verb `Get` returning the authenticated
+Organizer's identity (id, name) and associated artists. The request SHALL
+carry an `OrganizerId` that MUST equal the tenant derived from the token; a
+mismatch SHALL be rejected.
+
+#### Scenario: Operator reads their own organizer
+
+- **WHEN** an operator calls `Get` with their own OrganizerId
+- **THEN** the system SHALL return that Organizer's id, name, and associated
+  artists
+
+#### Scenario: Operator cannot read a different organizer
+
+- **WHEN** an operator calls `Get` with an OrganizerId other than their
+  token's tenant
+- **THEN** the system SHALL reject it with a permission-denied error
+
+### Requirement: Org-scoped authorization from the role claim
+
+The system SHALL authorize organizer requests from the token: it SHALL
+validate the JWT, require the organizer-console project id in the token
+`aud`, and read the roles claim (`role → { orgId → domain }`) where the inner
+orgId is the tenant. It SHALL authorize the request against `{tenant, role}`
+and resolve the active tenant from the session's login-scope org. All
+authorization failures SHALL return `PERMISSION_DENIED` (never a server
+error); an absent/invalid token SHALL return `UNAUTHENTICATED`.
+
+#### Scenario: Missing or empty roles claim is denied
+
+- **WHEN** a request's token carries no `organizer-console` role for the
+  target tenant
+- **THEN** the system SHALL reject it with `PERMISSION_DENIED`
+
+#### Scenario: Token audience without the project id is denied
+
+- **WHEN** a request's token `aud` does not include the organizer-console
+  project id
+- **THEN** the system SHALL reject it with `PERMISSION_DENIED`
+
+#### Scenario: Login-scope org and requested organizer must match
+
+- **WHEN** the session's login-scope org does not map to the requested
+  Organizer
+- **THEN** the system SHALL reject it with `PERMISSION_DENIED`
+
+#### Scenario: Unauthenticated request is rejected
+
+- **WHEN** a request has no valid token
+- **THEN** the system SHALL reject it with `UNAUTHENTICATED`

--- a/openspec/changes/organizer-rpc-server/tasks.md
+++ b/openspec/changes/organizer-rpc-server/tasks.md
@@ -1,0 +1,24 @@
+## 1. Specification (proto)
+
+- [ ] 1.1 `rpc/organizer/v1/organizer_service.proto`: bare-verb `Get` (request carries `OrganizerId`) returning the Organizer identity + associated artists; import the `Organizer` entity from `organizer-accounts`; document the error matrix
+- [ ] 1.2 `buf lint`/`format`/`breaking` pass; open specification PR, merge, cut Release, confirm BSR gen succeeds
+
+## 2. Backend — server & authorization
+
+- [ ] 2.1 Dedicated organizer Connect server (own port) serving `rpc.organizer.v1.OrganizerService`; excluded from the consumer and admin servers
+- [ ] 2.2 Org-scoped authorization interceptor: validate JWT, require the organizer-console project id in `aud`, read `role → { orgId }`, authorize `{tenant, role}`, resolve active tenant from login-scope org
+- [ ] 2.3 `Get` handler: verify request `OrganizerId` == token tenant; resolve tenant→Organizer via the `zitadel_org_id` link; return identity + associated artists
+- [ ] 2.4 Tests (crown-jewel security): cross-organizer `Get` → PERMISSION_DENIED; missing role / missing `aud` / login-scope mismatch → PERMISSION_DENIED; no token → UNAUTHENTICATED; happy path returns own organizer
+- [ ] 2.5 `make check` passes with upgraded BSR package
+
+## 3. Cloud-provisioning (ingress)
+
+- [ ] 3.1 `api.organizer.{base}` ingress host: HTTPRoute + TLS cert (certmap) + Cloud DNS (dev + prod); health check
+- [ ] 3.2 CORS allowlist limited to the `organizer.{base}` origin
+- [ ] 3.3 `make lint` (kustomize render) passes; `pulumi preview` shows only intended additions
+
+## 4. Ship to prod
+
+- [ ] 4.1 Backend PR merged → release → prod pin bump; confirm the organizer server pod is running
+- [ ] 4.2 Cloud-provisioning PR merged → ArgoCD synced (host, cert, DNS, CORS)
+- [ ] 4.3 Verify in prod: an operator's console reads their own organizer via `api.organizer.liverty-music.app`; a cross-organizer request is denied; the organizer service is not reachable on the consumer/admin API hosts


### PR DESCRIPTION
## Summary

The final two sub-changes of roadmap step ① (the organizer-facing surfaces),
completing the four-change decomposition. OpenSpec planning artifacts only;
implementation follows under each change's tasks.

## Changes

**`organizer-console` (3/4)** — the seller frontend shell:
- bundle-isolated `organizer.html` entry (no organizer code in the consumer
  chunk graph);
- OIDC login via **email domain discovery** — one `organizer-console` client
  serves all tenants, org resolved at login (no fixed org id, no picker);
- a **role-claim route guard** admitting only `master`, with a post-login
  placeholder;
- dedicated **hosting** at `organizer.{base}` (HTTPRoute + TLS cert + Cloud
  DNS + per-host `/config.json`).
- The consumer `frontend-runtime-config` contract is unchanged; the organizer
  entry defines its own config shape.

**`organizer-rpc-server` (4/4)** — the organizer-facing API:
- `rpc/organizer/v1/OrganizerService.Get` returning the caller's own
  Organizer (request `OrganizerId` verified == token tenant);
- a **dedicated Connect server** at `api.organizer.{base}` with its own
  CORS / cert / DNS / health, isolated from the consumer and admin servers;
- **org-scoped role-claim authorization** with an explicit failure matrix
  (missing/empty roles claim, `aud` without the project id, or
  login-scope↔target mismatch → `PERMISSION_DENIED`; no token →
  `UNAUTHENTICATED`).

## Non-Goals

Business/write RPCs and screens; organizer-side `Update`/`List`; per-org
branding; a reception check-in PWA; sub-owner roles.

## Testing

`openspec validate --strict` passes for both changes. Proto/backend/frontend/
IaC implementation happens under each change's tasks.

## Related

Refs: #759 — Phase 3 umbrella (stays open). Depends on `organizer-tenancy`
(#774) and `organizer-accounts` (#775). Full design + resolved gap-audit:
`docs/organizer-platform-design.md`.
