### PR TITLE
feat(organizer): add Organizer entity and admin OrganizerService proto

### DIFF
--- a/openspec/changes/organizer-accounts/design.md
+++ b/openspec/changes/organizer-accounts/design.md
@@ -23,28 +23,47 @@ offboarding cascade; slug / contact fields.
 ## Decisions
 
 **D1 — Data model.** `organizers(id UUIDv7, name, zitadel_org_id UNIQUE,
-provisioning_state)` + `organizer_artists(organizer_id, artist_id)` with a
-**partial UNIQUE(artist_id) WHERE provisioning_state != 'deactivated'** so a
+status)` + `organizer_artists(organizer_id, artist_id)` with a
+**partial UNIQUE(artist_id) WHERE status != 'deactivated'** so a
 deactivated Organizer frees its artists. Both FKs `ON DELETE CASCADE`.
 `zitadel_org_id` is the token-tenant→Organizer link (DB is source of truth;
-backend-only, not on the consumer proto). `provisioning_state` is an
+backend-only, not on the consumer proto). `status` is an
 operational lifecycle flag (`provisioning`/`active`/`deactivated`) — NOT the
 business `verified` flag the design rejected. `*_at` names per schema-lint.
 
 **D2 — Proto.** `entity/v1/organizer.proto` (Organizer, OrganizerId=uuid,
-OrganizerName min_len=1/max_len=200, matching the `ArtistName` convention);
-`rpc/admin/v1/organizer_service.proto` with **bare-verb** methods
-`Create`, `AssociateArtist`, `DisassociateArtist`, `List`, `Get`. Each RPC
-documents its error matrix (INVALID_ARGUMENT / NOT_FOUND / ALREADY_EXISTS /
-PERMISSION_DENIED). The organizer-facing `Get` service is defined and served
-in `organizer-rpc-server` (4/4), not here.
+OrganizerName min_len=1/max_len=200, matching the `ArtistName` convention).
+The admin service is `rpc/admin/organizer/v1/organizer_service.proto`, package
+`liverty_music.rpc.admin.organizer.v1`, with **bare-verb** methods `Create`,
+`AssociateArtist`, `DisassociateArtist`, `List`, `Get`, `ListArtists`, and
+`Deactivate` (the last is the admin-surface trigger for the D6 off-switch — the
+earlier 5-method list under-enumerated it). Each RPC documents its error matrix
+(INVALID_ARGUMENT / NOT_FOUND / ALREADY_EXISTS / PERMISSION_DENIED). `Create`/
+`Get` return the `Organizer` entity and `List` returns `repeated Organizer` —
+**no response-DTO wrapper and no status enum** (existence is the vetting; the
+operational lifecycle stays a backend-only `status` column). The artists an
+Organizer represents are returned by `ListArtists(organizer_id)`, kept in this
+organizer package rather than bundled into the organizer responses or added to
+the consumer `rpc.artist.v1` ArtistService (resource-oriented; no organizer
+coupling leaks into the consumer API).
+
+**Package convention.** Services are laid out uniformly as
+`liverty_music.rpc.<audience>.<domain>.v1` (audience ∈ consumer/admin/organizer;
+one service per package → **bare message names**, no `OrganizerService`-prefix).
+Services are never shared across packages; only the higher-privilege **admin**
+server may additionally mount consumer/organizer handlers as needed (a
+server-wiring concern, not a package one). The organizer-facing `Get` is a
+separate service under `rpc.organizer.organizer.v1`, defined and served in
+`organizer-rpc-server` (4/4), not here. Migrating the existing
+`rpc.admin.v1.ConcertService` and the consumer `rpc.<domain>.v1` packages onto
+this convention is **out of scope** for this change.
 
 **D3 — Admin-gated only.** All RPCs ride the existing admin Connect server
 behind `RequireRoleInterceptor(admin)`. There is no organizer-scoped
 authorization in this change (that is the organizer-facing server, 4/4).
 
 **D4 — Provisioning saga (idempotent, compensating), keyed on OrganizerId.**
-Order: (1) insert `organizers` row `provisioning_state=provisioning`; (2)
+Order: (1) insert `organizers` row `status=provisioning`; (2)
 Management API create tenant org (name `org-<uuid-short>`, explicit
 **passkey-primary** login policy per `organizer-tenancy`:
 `passwordlessType=ALLOWED`, `allowUsernamePassword=false`,
@@ -52,7 +71,7 @@ Management API create tenant org (name `org-<uuid-short>`, explicit
 NOT domain-discovery); (3) persist `zitadel_org_id`; (4) Project-Grant
 `organizer-console` (role subset incl. `owner`); (5) create operator human
 user (no password, `request_passwordless_registration` → passkey init link) +
-`owner` User Grant; (6) set `provisioning_state=active`. A reconciler re-enters
+`owner` User Grant; (6) set `status=active`. A reconciler re-enters
 at the first incomplete step (each Zitadel create existence-checked). Uses the
 `organizer-provisioner` credential from ESC/Secret Manager (JWT-profile →
 short-lived tokens). Wrap the call in an OTel span + an
@@ -76,7 +95,7 @@ federation. **Org resolution is org-pinned** (org-scoped init link → remembere
 discovery — so no per-tenant domain verification and gmail operators work. (The
 console URL/config carrier is `organizer-console`.)
 
-**D6 — Deactivation hook.** `provisioning_state=deactivated` gates the
+**D6 — Deactivation hook.** `status=deactivated` gates the
 backend (reject all organizer ops) and deactivates the Zitadel operators;
 the partial-unique index frees the artists. Full teardown (org/grant
 removal) is Phase 2 — the hook ships now so it is not a later migration.
@@ -90,7 +109,7 @@ via the existing JetStream→PostHog path, keyed on `organizer_id` (admin-actor
 - **Two-system saga without 2PC** → the DB-row-first + existence-checked,
   reconciler-retried design (D4) makes a partial failure recoverable without
   duplicates; the operator is never left without an `owner` grant.
-- **`provisioning_state` looks like reversing "no status column"** → it is an
+- **`status` looks like reversing "no status column"** → it is an
   *operational* lifecycle flag, explicitly distinct from the rejected
   business `verified` flag; called out so review does not read it as a
   reversal.
@@ -102,7 +121,7 @@ via the existing JetStream→PostHog path, keyed on `organizer_id` (admin-actor
 
 1. specification: additive proto → merge → Release → BSR gen.
 2. backend: Atlas migration (`organizers` + `organizer_artists`, partial
-   unique, `zitadel_org_id`, `provisioning_state`); entity/repo/usecases;
+   unique, `zitadel_org_id`, `status`); entity/repo/usecases;
    admin handler; provisioning client + reconciler; analytics; tests
    (incl. the compensating-retry and double-claim paths).
 3. frontend: admin console organizer-management screen.

--- a/openspec/changes/organizer-accounts/proposal.md
+++ b/openspec/changes/organizer-accounts/proposal.md
@@ -15,13 +15,15 @@ and the console frontend are separate sub-changes (3/4, 4/4).
   distinct from Artist/Performer. It exists only via admin creation →
   existence is the vetting (no `verified` flag). It carries an internal
   `zitadel_org_id` (the tenant org link, backend-only) and an operational
-  `provisioning_state` (`provisioning`/`active`/`deactivated`).
+  `status` (`provisioning`/`active`/`deactivated`).
 - Add the **Organizer↔Artist association**: an Organizer represents many
   Artists, and **each Artist is represented by at most one Organizer**
   (partial-unique on `artist_id`, excluding deactivated organizers so
   their artists are re-associable).
 - Add an **admin `OrganizerService`** (bare-verb `Create`, `AssociateArtist`,
-  `DisassociateArtist`, `List`, `Get`) behind the existing admin-role gate.
+  `DisassociateArtist`, `List`, `Get`, `ListArtists`, `Deactivate`) behind the
+  existing admin-role gate. Responses return the `Organizer` entity (no view
+  DTO / status enum); an organizer's roster is returned by `ListArtists`.
   `Create` takes an `operator_email`; `AssociateArtist` rejects `NOT_FOUND`
   for unknown artists (no create-on-demand) and `ALREADY_EXISTS` for
   already-claimed artists; reassignment = disassociate + associate.
@@ -65,13 +67,13 @@ organizer-side Update/List; full offboarding cascade; slug/contact fields.
 
 - **specification**: new `entity/v1/organizer.proto` (Organizer, OrganizerId,
   OrganizerName; protovalidate: id uuid, name 1–200) and
-  `rpc/admin/v1/organizer_service.proto` (admin service). Ships via the
+  `rpc/admin/organizer/v1/organizer_service.proto` (admin service). Ships via the
   cross-repo release order (spec merge → Release → BSR gen).
 - **backend**: Organizer entity + repository + usecases; admin handler behind
   `RequireRoleInterceptor(admin)`; the Zitadel Management-API provisioning
   client (using the `organizer-provisioner` credential); `organizers` +
   `organizer_artists` Atlas migration (partial-unique on `artist_id`,
-  `zitadel_org_id` unique, `provisioning_state`); analytics emission.
+  `zitadel_org_id` unique, `status`); analytics emission.
 - **frontend**: admin console gains an organizer-management screen (create /
   associate / disassociate / list) reusing the existing artist search.
 - **cloud-provisioning**: none new (the project/role/apps/machine user were

--- a/openspec/changes/organizer-accounts/specs/organizer-accounts/spec.md
+++ b/openspec/changes/organizer-accounts/specs/organizer-accounts/spec.md
@@ -100,14 +100,16 @@ associate.
 
 ### Requirement: Admin can list and inspect organizers
 
-The system SHALL provide admin-gated `List` and `Get` returning Organizers
-with their associated artists, so the admin console can render the
-organizer-management screen.
+The system SHALL provide admin-gated `List` and `Get` returning Organizers, and
+`ListArtists` returning the artists an Organizer represents, so the admin
+console can render the organizer-management screen.
 
-#### Scenario: Admin lists organizers with their artists
+#### Scenario: Admin lists organizers and inspects an organizer's artists
 
-- **WHEN** an operator with the `admin` role lists organizers
-- **THEN** the system SHALL return each Organizer with its associated artists
+- **WHEN** an operator with the `admin` role lists organizers and then requests
+  a given Organizer's artists
+- **THEN** the system SHALL return the Organizers, and SHALL return the artists
+  that Organizer represents
 
 #### Scenario: Non-admin cannot list organizers
 

--- a/openspec/changes/organizer-accounts/tasks.md
+++ b/openspec/changes/organizer-accounts/tasks.md
@@ -1,12 +1,12 @@
 ## 1. Specification (proto)
 
-- [ ] 1.1 `entity/v1/organizer.proto`: `Organizer` (OrganizerId UUIDv7, OrganizerName), type-safe wrappers + protovalidate (id `uuid`, name `min_len=1/max_len=200`)
-- [ ] 1.2 `rpc/admin/v1/organizer_service.proto`: bare-verb `Create` (name + operator_email), `AssociateArtist`, `DisassociateArtist`, `List`, `Get`; document each RPC's error matrix
+- [x] 1.1 `entity/v1/organizer.proto`: `Organizer` (OrganizerId UUIDv7, OrganizerName), type-safe wrappers + protovalidate (id `uuid`, name `min_len=1/max_len=200`)
+- [x] 1.2 `rpc/admin/organizer/v1/organizer_service.proto` (package `liverty_music.rpc.admin.organizer.v1`, bare message names): bare-verb `Create` (name + operator_email), `AssociateArtist`, `DisassociateArtist`, `List`, `Get`, `ListArtists`, `Deactivate`; responses return the `Organizer` entity (no view DTO / status enum); `ListArtists` returns the roster; document each RPC's error matrix
 - [ ] 1.3 `buf lint`/`format`/`breaking` pass; open specification PR, merge, cut Release, confirm BSR gen succeeds
 
 ## 2. Backend — domain & admin surface
 
-- [ ] 2.1 Atlas migration: `organizers` (id, name, `zitadel_org_id` UNIQUE, `provisioning_state`, `*_at`) + `organizer_artists` (partial UNIQUE(artist_id) WHERE not deactivated; FKs ON DELETE CASCADE)
+- [ ] 2.1 Atlas migration: `organizers` (id, name, `zitadel_org_id` UNIQUE, `status`, `*_at`) + `organizer_artists` (partial UNIQUE(artist_id) WHERE not deactivated; FKs ON DELETE CASCADE)
 - [ ] 2.2 `entity` Organizer + repository interface; rdb repo with error classification
 - [ ] 2.3 Usecases: create, associate/disassociate artist (NOT_FOUND / ALREADY_EXISTS), list, get, deactivate
 - [ ] 2.4 Admin `OrganizerService` handler behind `RequireRoleInterceptor(admin)`

--- a/proto/liverty_music/entity/v1/organizer.proto
+++ b/proto/liverty_music/entity/v1/organizer.proto
@@ -1,0 +1,38 @@
+syntax = "proto3";
+
+package liverty_music.entity.v1;
+
+import "buf/validate/validate.proto";
+
+// Organizer represents a vetted seller that an admin creates to manage the
+// artists it represents. Existence is the vetting: an Organizer exists only
+// because an admin created it, so there is no separate `verified` flag and no
+// self-serve registration. An Organizer is distinct from an Artist — an artist
+// self-publishing gets its own Organizer with a distinct OrganizerId — and it
+// runs against its own isolated Zitadel tenant its operators sign into.
+//
+// The internal tenant link (`zitadel_org_id`) and the operational
+// provisioning lifecycle are backend-only concerns and are intentionally not
+// part of this consumer entity.
+message Organizer {
+  // The unique identifier for the organizer.
+  OrganizerId id = 1 [(buf.validate.field).required = true];
+
+  // The display name of the organizer (e.g., the label or promoter name).
+  OrganizerName name = 2 [(buf.validate.field).required = true];
+}
+
+// OrganizerId is a globally unique identifier for an organizer.
+message OrganizerId {
+  // A UUID string mapping to the organizer's unique identity.
+  string value = 1 [(buf.validate.field).string.uuid = true];
+}
+
+// OrganizerName represents the public display name of an organizer.
+message OrganizerName {
+  // The name string, required to be between 1 and 200 characters.
+  string value = 1 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 200
+  }];
+}

--- a/proto/liverty_music/rpc/admin/organizer/v1/organizer_service.proto
+++ b/proto/liverty_music/rpc/admin/organizer/v1/organizer_service.proto
@@ -1,0 +1,186 @@
+syntax = "proto3";
+
+// Package liverty_music.rpc.admin.organizer.v1 provides the admin-only
+// OrganizerService for managing Organizers from the developer admin console.
+// It is served by the admin Connect server behind the admin-role gate; the
+// organizer-facing surface lives separately in liverty_music.rpc.organizer.v1.
+package liverty_music.rpc.admin.organizer.v1;
+
+import "buf/validate/validate.proto";
+import "liverty_music/entity/v1/artist.proto";
+import "liverty_music/entity/v1/organizer.proto";
+import "liverty_music/entity/v1/user.proto";
+
+// OrganizerService is the admin surface for managing Organizers — the vetted
+// sellers that represent artists. It creates an Organizer (provisioning an
+// isolated Zitadel tenant with an initial `owner` operator), manages the
+// Organizer↔Artist association (each artist is represented by at most one
+// Organizer), lists organizers and the artists an organizer represents for the
+// admin console, and deactivates an Organizer as a minimal off-switch.
+//
+// All RPCs are authorized only for the admin organization; callers outside it
+// are rejected with PERMISSION_DENIED at the admin server boundary.
+service OrganizerService {
+  // Create registers a new Organizer with a display name and an initial
+  // operator email, then provisions its isolated Zitadel tenant (org,
+  // passkey-primary login policy, organizer-console project grant) and seeds
+  // the initial operator as its `owner`. Provisioning is idempotent and
+  // compensating: retrying a Create that failed partway never creates a
+  // duplicate Organizer or tenant org and never leaves the Organizer without an
+  // `owner` operator. The initial operator is created without a password and
+  // receives a Zitadel passkey-registration init link to register a passkey on
+  // first sign-in.
+  //
+  // Possible errors:
+  // - PERMISSION_DENIED: The caller is not a member of the admin organization.
+  // - INVALID_ARGUMENT: The name is empty/too long or the operator email is malformed.
+  rpc Create(CreateRequest) returns (CreateResponse);
+
+  // AssociateArtist links an existing Artist to an Organizer. There is no
+  // create-on-demand: an unknown ArtistId is rejected. Each Artist is
+  // represented by at most one Organizer, so an already-claimed Artist is
+  // rejected; reassignment is DisassociateArtist followed by AssociateArtist.
+  //
+  // Possible errors:
+  // - PERMISSION_DENIED: The caller is not a member of the admin organization.
+  // - INVALID_ARGUMENT: The organizer id or artist id is missing or malformed.
+  // - NOT_FOUND: The organizer or the artist does not exist.
+  // - ALREADY_EXISTS: The artist is already represented by an organizer.
+  rpc AssociateArtist(AssociateArtistRequest) returns (AssociateArtistResponse);
+
+  // DisassociateArtist removes the link between an Artist and its Organizer,
+  // freeing the Artist to be associated with another Organizer. It is
+  // idempotent: disassociating an artist that is not associated succeeds.
+  //
+  // Possible errors:
+  // - PERMISSION_DENIED: The caller is not a member of the admin organization.
+  // - INVALID_ARGUMENT: The organizer id or artist id is missing or malformed.
+  // - NOT_FOUND: The organizer does not exist.
+  rpc DisassociateArtist(DisassociateArtistRequest) returns (DisassociateArtistResponse);
+
+  // List returns every Organizer so the admin console can render the
+  // organizer-management screen. The artists an Organizer represents are
+  // retrieved separately via ListArtists.
+  //
+  // Possible errors:
+  // - PERMISSION_DENIED: The caller is not a member of the admin organization.
+  rpc List(ListRequest) returns (ListResponse);
+
+  // Get returns a single Organizer by id.
+  //
+  // Possible errors:
+  // - PERMISSION_DENIED: The caller is not a member of the admin organization.
+  // - INVALID_ARGUMENT: The organizer id is missing or malformed.
+  // - NOT_FOUND: The organizer does not exist.
+  rpc Get(GetRequest) returns (GetResponse);
+
+  // ListArtists returns the artists an Organizer currently represents, so the
+  // admin console can inspect an organizer's roster. Empty when it represents
+  // none (or its associations were freed by deactivation).
+  //
+  // Possible errors:
+  // - PERMISSION_DENIED: The caller is not a member of the admin organization.
+  // - INVALID_ARGUMENT: The organizer id is missing or malformed.
+  // - NOT_FOUND: The organizer does not exist.
+  rpc ListArtists(ListArtistsRequest) returns (ListArtistsResponse);
+
+  // Deactivate turns an Organizer off: the backend thereafter rejects all
+  // operations targeting it, its operators are deactivated in Zitadel, and its
+  // artist associations are freed so the artists can be re-associated. Full
+  // teardown of the tenant org and grants is out of scope. It is idempotent:
+  // deactivating an already-deactivated Organizer succeeds.
+  //
+  // Possible errors:
+  // - PERMISSION_DENIED: The caller is not a member of the admin organization.
+  // - INVALID_ARGUMENT: The organizer id is missing or malformed.
+  // - NOT_FOUND: The organizer does not exist.
+  rpc Deactivate(DeactivateRequest) returns (DeactivateResponse);
+}
+
+// CreateRequest carries the new Organizer's name and its initial operator's
+// email.
+message CreateRequest {
+  // Required. The display name of the organizer to create.
+  entity.v1.OrganizerName name = 1 [(buf.validate.field).required = true];
+
+  // Required. The email of the initial operator, seeded as the organizer's
+  // `owner` and sent a Zitadel passkey-registration init link.
+  entity.v1.UserEmail operator_email = 2 [(buf.validate.field).required = true];
+}
+
+// CreateResponse returns the newly created Organizer.
+message CreateResponse {
+  // The created organizer.
+  entity.v1.Organizer organizer = 1 [(buf.validate.field).required = true];
+}
+
+// AssociateArtistRequest identifies the Organizer and the existing Artist to
+// link.
+message AssociateArtistRequest {
+  // Required. The organizer that will represent the artist.
+  entity.v1.OrganizerId organizer_id = 1 [(buf.validate.field).required = true];
+
+  // Required. The existing artist to associate. Unknown ids are rejected with
+  // NOT_FOUND (no create-on-demand).
+  entity.v1.ArtistId artist_id = 2 [(buf.validate.field).required = true];
+}
+
+// AssociateArtistResponse is returned upon a successful association.
+message AssociateArtistResponse {}
+
+// DisassociateArtistRequest identifies the Organizer and the Artist to unlink.
+message DisassociateArtistRequest {
+  // Required. The organizer to unlink the artist from.
+  entity.v1.OrganizerId organizer_id = 1 [(buf.validate.field).required = true];
+
+  // Required. The artist to disassociate.
+  entity.v1.ArtistId artist_id = 2 [(buf.validate.field).required = true];
+}
+
+// DisassociateArtistResponse is returned upon a successful disassociation
+// (including the idempotent case where the artist was not associated).
+message DisassociateArtistResponse {}
+
+// ListRequest retrieves every Organizer. It takes no parameters.
+message ListRequest {}
+
+// ListResponse contains every Organizer.
+message ListResponse {
+  // The organizers, in catalog order.
+  repeated entity.v1.Organizer organizers = 1;
+}
+
+// GetRequest identifies the Organizer to retrieve.
+message GetRequest {
+  // Required. The unique identifier of the organizer to retrieve.
+  entity.v1.OrganizerId organizer_id = 1 [(buf.validate.field).required = true];
+}
+
+// GetResponse returns the requested Organizer.
+message GetResponse {
+  // The requested organizer.
+  entity.v1.Organizer organizer = 1 [(buf.validate.field).required = true];
+}
+
+// ListArtistsRequest identifies the Organizer whose represented artists to
+// list.
+message ListArtistsRequest {
+  // Required. The organizer whose represented artists to return.
+  entity.v1.OrganizerId organizer_id = 1 [(buf.validate.field).required = true];
+}
+
+// ListArtistsResponse contains the artists the Organizer currently represents.
+message ListArtistsResponse {
+  // The artists represented by the organizer. Empty when it represents none.
+  repeated entity.v1.Artist artists = 1;
+}
+
+// DeactivateRequest identifies the Organizer to deactivate.
+message DeactivateRequest {
+  // Required. The unique identifier of the organizer to deactivate.
+  entity.v1.OrganizerId organizer_id = 1 [(buf.validate.field).required = true];
+}
+
+// DeactivateResponse is returned upon a successful deactivation (including the
+// idempotent case where the organizer was already deactivated).
+message DeactivateResponse {}


### PR DESCRIPTION
## 🔗 Related Issue

Refs: #759

<!-- Umbrella decomposition issue (spans all 4 sub-changes). This PR is Phase 1
(proto) of sub-change 2/4, so it refs — not closes — #759. -->

## 📝 Summary of Changes

Adds the **Organizer** proto surface — the vetted seller an admin creates to
represent artists (`schema.org` organizer; a *role*, not a company category,
spanning label / agency / promoter / self-publishing artist) — as
**sub-change 2/4** of roadmap step ①. API contract only; no implementation.

**`entity/v1/organizer.proto`** — `Organizer` with type-safe `OrganizerId`
(uuid) and `OrganizerName` (1–200) wrappers (matching `ArtistId`/`ArtistName`).
The internal `zitadel_org_id` tenant link and the operational lifecycle are kept
**off** the consumer entity (backend-only).

**`rpc/admin/organizer/v1/organizer_service.proto`** — package
**`liverty_music.rpc.admin.organizer.v1`**, admin-gated `OrganizerService`:

| RPC | Response |
|-----|----------|
| `Create(name, operator_email)` | `Organizer` |
| `AssociateArtist(organizer_id, artist_id)` | `{}` (NOT_FOUND / ALREADY_EXISTS) |
| `DisassociateArtist(organizer_id, artist_id)` | `{}` (idempotent) |
| `List()` | `repeated Organizer` |
| `Get(organizer_id)` | `Organizer` |
| `ListArtists(organizer_id)` | `repeated Artist` |
| `Deactivate(organizer_id)` | `{}` (idempotent) |

Design notes:

- **No response-DTO wrapper and no status enum.** `Create`/`Get` return the
  `Organizer` entity; `List` returns `repeated Organizer`. Existence is the
  vetting; the operational lifecycle stays a **backend-only `status` column**.
- An Organizer's represented artists are returned by **`ListArtists`**, kept in
  this organizer package — **not** bundled into the organizer responses and
  **not** added as a filter on the consumer `rpc.artist.v1` ArtistService, so no
  organizer coupling leaks into the consumer API (resource-oriented).
- Package layout follows the uniform **`rpc.<audience>.<domain>.v1`** convention
  (one service per package → **bare message names**); the admin audience stays
  isolated from the organizer-facing surface (`rpc.organizer.*`, sub-change 4/4).
  Migrating `rpc.admin.v1.ConcertService` + consumer packages onto this
  convention is **out of scope** here.
- Provisioning docs align with the **shipped `organizer-tenancy`**:
  passkey-primary login, `owner` role, passkey-registration init link.
- `Deactivate` is the admin-surface trigger for the D6 off-switch; `design.md` /
  `spec.md` / `tasks.md` / `proposal.md` updated to match (rebased onto the
  merged `organizer-tenancy` reconciliation).

**Cross-repo release train:** **additive and non-breaking** (`buf breaking`
passes). Merge → cut **Release `vX.Y.Z`** → `buf-release.yml` pushes to BSR →
backend and frontend consume the generated types.

## ✅ Self-Checklist

- [x] I have linked the related issue.
- [x] I have updated the relevant documentation (openspec `design.md`/`spec.md`/`tasks.md`/`proposal.md`).
- [x] I have run `buf lint` and `buf format` locally and all checks have passed.
- [x] My proto definitions follow the project's style guidelines and validation rules.
- [x] Breaking changes have been justified and documented if applicable. (None — additive; `buf breaking` passes.)
