### PR TITLE
docs(openspec): revise organizer-tenancy after best-practice review

### DIFF
--- a/docs/organizer-platform-design.md
+++ b/docs/organizer-platform-design.md
@@ -28,17 +28,28 @@ the Organizer domain, its surfaces, and the resolved audit gaps.
   deactivated Organizer frees its artists for re-association).
 - **Tenancy: Zitadel org-per-Organizer** + a shared, actor-named
   `organizer-console` project (owned by the `liverty-music` org),
-  Project-Granted to each Organizer org; `master` role via User Grant.
+  Project-Granted to each Organizer org; `owner` role via User Grant.
   Actor-named so a future `venue-console` never collides. Full model:
   `zitadel-tenancy-model.md`.
 - **Provisioning:** static platform is IaC; per-Organizer org + grant +
   operator is created **at runtime via the Zitadel Management API** in the
   admin vetting flow.
-- **Login (recommended, pending final confirm):** organizer tenant orgs use
-  a **passkey-only** login policy (no Google IdP), explicitly set at
-  provisioning (never inherit the admin default). Operator org is resolved
-  at login via **email domain discovery** — one OIDC app serves all
-  tenants.
+- **Login (confirmed 2026-08 after best-practice review):** organizer tenant
+  orgs use a **passkey-primary** login policy — `passwordlessType=ALLOWED`,
+  `allowUsernamePassword=false` (no passwords), `allowRegister=false`
+  (backend-provisioned only), `allowExternalIDP=true` (federate to a tenant's
+  own workspace IdP when it has one), `ignoreUnknownUsernames=true` —
+  explicitly set at provisioning (never inherit the admin default). A
+  **recovery path is mandatory** (admin re-invite via re-issued passkey init
+  link; optional step-up-protected magic-link/OTP); passkey-only-with-no-
+  recovery is prohibited (synced passkeys reduce but do not remove single-
+  credential risk; Zitadel hard passkey-only lockdown is fragile —
+  #11682/#8996). **Org resolution is org-pinned, not email-domain-based**
+  (org-scoped init link → remembered `org_id` → org-code/slug or app-layer
+  "email me a link" → the `org:id` scope) — one OIDC app serves all tenants,
+  no per-tenant domain verification; email-domain discovery is a future
+  optional enhancement (`allowDomainDiscovery` off in MVP). Full rationale:
+  the `organizer-tenancy` change design.md "Best-practice review".
 - **Fan ⇄ operator same person:** two **independent identities** (separate
   `sub` per org); never linked/merged; no cross-org SSO between the fan app
   and the organizer console.
@@ -88,18 +99,25 @@ timestamps use domain-specific `*_at` names (schema-lint bans
 Ordered, idempotent, compensating — keyed on `OrganizerId`:
 1. Insert `organizers` row `provisioning_state = provisioning`.
 2. Management API: create tenant org (name `org-<uuid-short>`, not the
-   display name, to avoid collisions); **set an explicit passkey-only login
-   policy + `allowDomainDiscovery`**.
+   display name, to avoid collisions); **set the explicit passkey-primary
+   login policy** (shape above: `passwordlessType=ALLOWED`,
+   `allowUsernamePassword=false`, `allowRegister=false`, `allowExternalIDP=
+   true`, `ignoreUnknownUsernames=true`; `allowDomainDiscovery` off in MVP).
 3. Persist `zitadel_org_id` on the row.
-4. Project-Grant `organizer-console` (role subset incl. `master`) to the
+4. Project-Grant `organizer-console` (role subset incl. `owner`) to the
    org.
-5. Create the operator human user (no password) + User Grant `master`;
-   trigger Zitadel **init email** → operator registers a passkey on first
-   sign-in.
+5. Create the operator human user (no password) with
+   `request_passwordless_registration=true` + User Grant `owner`; deliver the
+   returned Zitadel **passkey-registration init link**
+   (`requestPlatformType=platform`) → operator enrolls a passkey on first
+   sign-in. Recovery = admin re-invite (re-issue the init link after
+   out-of-band verification). Author the provisioner root-key **rotation
+   runbook** here (the key created in `organizer-tenancy` is first consumed at
+   this step).
 6. Set `provisioning_state = active`.
 On failure, a reconciler re-enters at the first incomplete step (each
-Zitadel create is existence-checked). The operator is never left without a
-`master` grant.
+Zitadel create is existence-checked). The operator is never left without an
+`owner` grant.
 
 **Machine user:** a dedicated `organizer-provisioner` (NOT the existing
 single-org `backend-app` user) with the narrowest instance role that
@@ -115,7 +133,8 @@ domain }`; the inner orgId is the tenant. Failure matrix (all
 `PERMISSION_DENIED`, never 500): missing/empty roles claim (require
 `accessTokenRoleAssertion=true`, `projectRoleCheck=false`), `aud` without
 the project id, login-scope org ≠ requested Organizer. A multi-org operator
-is authorized only against the **session's login-scope org**. Zitadel
+is authorized only against the **session's login-scope org**. (The top role
+in the roles claim is `owner`, not `admin`.) Zitadel
 supplies identity + tenant + role; **which artists/events an Organizer may
 touch is Liverty's own data** (`organizer_artists`, event ownership),
 enforced in the backend.
@@ -134,9 +153,18 @@ Mirroring the admin precedent (`admin-rpc-server`, `admin-console-hosting`):
   per-host `/config.json`.
 - **Runtime config:** the organizer `/config.json` carries the issuer + the
   `organizer-console` client id + `apiBaseUrl = api.organizer.{base}`, but
-  **NOT a fixed `zitadelOrgId`** — the org is resolved at login (domain
-  discovery). Requires a `frontend-runtime-config` delta (its AppConfig
-  currently assumes one static org).
+  **NOT a fixed `zitadelOrgId`** (one app serves all tenants). The org is
+  resolved per session by an **org-pinned entry**, not the email domain: the
+  org-scoped passkey init link on first login, then an org handle
+  (org code/slug in the URL or a remembered `org_id`), and on a fresh device an
+  org-code entry or an app-layer "email me a sign-in link" (backend org lookup,
+  works for gmail) — all turned into the Zitadel
+  `urn:zitadel:iam:org:id:<orgId>` scope. **Email-domain discovery is NOT used
+  in the MVP** (a future optional enhancement for verified-custom-domain +
+  enterprise-SSO tenants); **consumer/free-mail domains (gmail) never drive
+  routing** (the common indie-artist case).
+  Requires a `frontend-runtime-config` delta (its AppConfig currently assumes
+  one static org) to carry the org handle.
 
 ## Observability
 
@@ -161,9 +189,9 @@ to the audit themes.
 
 | Change | Scope | Owns (audit) | Depends on |
 |--------|-------|--------------|------------|
-| **`organizer-tenancy`** | `identity-management` topology delta (allow runtime Organizer tenant orgs); Zitadel platform **IaC**: `organizer-console` project + `master` role + OIDC/API apps + `organizer-provisioner` machine user; per-org passkey-only login policy + domain discovery shape | A (login policy), C (machine user), identity topology | existing admin |
+| **`organizer-tenancy`** | `identity-management` topology delta (allow runtime Organizer tenant orgs); Zitadel platform **IaC**: `organizer-console` project + `owner` role + OIDC/API apps + `organizer-provisioner` machine user; per-org passkey-primary + recovery + federation + org-pinned-resolution login policy shape | A (login policy), C (machine user), identity topology | existing admin |
 | **`organizer-accounts`** | Organizer **entity** (`zitadel_org_id`, `provisioning_state`) + Organizer↔Artist (partial-unique); **admin** `OrganizerService` (Create/AssociateArtist/DisassociateArtist/List/Get); **tenant provisioning saga** + operator bootstrap (email + init/passkey); **deactivated** hook; analytics events | A (operator seed/bootstrap), C (saga/linkage/state), D (offboard hook), E (entity/assoc/admin RPCs), G (analytics) | `organizer-tenancy` |
-| **`organizer-console`** | `organizer.html` bundle-isolated entry (OIDC domain discovery, role-claim route guard, placeholder) + **hosting** (`organizer.{base}` DNS/cert/HTTPRoute/config.json) + `frontend-runtime-config` delta | A (route guard), C (login discovery), F (hosting, runtime-config) | `organizer-tenancy` (usable login target after `organizer-accounts`) |
+| **`organizer-console`** | `organizer.html` bundle-isolated entry (org-pinned login: org handle/slug + remembered `org_id` + "email me a link" → `org:id` scope; role-claim route guard; placeholder) + **hosting** (`organizer.{base}` DNS/cert/HTTPRoute/config.json) + `frontend-runtime-config` delta | A (route guard), C (login org-pinned), F (hosting, runtime-config) | `organizer-tenancy` (usable login target after `organizer-accounts`) |
 | **`organizer-rpc-server`** | Dedicated organizer Connect server at `api.organizer.{base}` + CORS/cert/DNS/health; `rpc.organizer.v1.OrganizerService.Get`; **org-scoped role-claim authorization** (the failure matrix) | B (authz matrix), E (Get shape), F (server/CORS) | `organizer-tenancy` + `organizer-accounts` |
 
 ```
@@ -176,9 +204,13 @@ sub-change is created with `/opsx:propose` when its work starts.
 
 ## Open decisions (recommended defaults recorded above; confirm before build)
 
-- Login method: **passkey-only** (recommended) vs password+MFA.
-- Login org discovery: **email domain discovery** (recommended) vs org
-  param/subdomain.
+- ~~Login method~~ **Resolved (2026-08):** passkey-primary + mandatory
+  recovery + optional workspace-IdP federation (not passkey-only, not
+  password+MFA). See the Login bullet above.
+- ~~Login org discovery~~ **Resolved (2026-08):** org-pinned entry (org
+  handle/slug + remembered `org_id` + app-layer "email me a link" → `org:id`
+  scope). Email-domain discovery dropped from MVP → future optional
+  enhancement. See the Login bullet + `organizer-tenancy` design D6.
 - Offboarding: **`deactivated` hook + partial-unique now** (recommended) vs
   fully Phase 2.
 - Fan⇄operator: **two independent identities, no SSO** (recommended,

--- a/docs/zitadel-tenancy-model.md
+++ b/docs/zitadel-tenancy-model.md
@@ -39,9 +39,9 @@ Zitadel Instance
 │           ├── App(OIDC): organizer-console    web console
 │           ├── App(PWA):  reception            check-in (later, ⑥) — same roles
 │           ├── App(API):  backend-api          audience
-│           └── Roles: master [→ editor, viewer, reception (Phase 2)]
+│           └── Roles: owner [→ editor, viewer, reception (Phase 2)]
 │     └── (future) Project: venue-console        venue seat maps / calendar / door lists
-├── Org: organizer-<A>  (runtime)  ── ProjectGrant(organizer-console, roles⊆) + UserGrant(staff→master)
+├── Org: organizer-<A>  (runtime)  ── ProjectGrant(organizer-console, roles⊆) + UserGrant(staff→owner)
 ├── Org: organizer-<B>  (runtime)  ── ProjectGrant(organizer-console, roles⊆) + UserGrant(staff→viewer)
 └── … one org per vetted Organizer
 ```
@@ -60,7 +60,7 @@ own** org, so the owning org's login policy never applies to them.
 
 1. Admin vets Organizer A → runtime provisioning (below) creates Org A, a
    Project Grant of `organizer-console` (role subset), and a User Grant
-   (`master`) for the first operator.
+   (`owner`) for the first operator.
 2. Operator signs into the `organizer-console` OIDC app with the org-scope
    `urn:zitadel:iam:org:id:<A>` (pins login to their org).
 3. Token carries roles as a nested map

--- a/openspec/changes/organizer-tenancy/design.md
+++ b/openspec/changes/organizer-tenancy/design.md
@@ -27,7 +27,9 @@ and relaxes the topology pin — nothing per-tenant and no domain entity.
 - `organizer.html` and its hosting (`organizer-console`).
 - The `api.organizer.*` server, `OrganizerService.Get`, and org-scoped authz
   (`organizer-rpc-server`).
-- Sub-owner roles (only `master` now); per-org branding.
+- Sub-owner roles (only `owner` now — named `owner` not `admin` to avoid
+  collision with the internal `admin-console` role; editor/viewer/reception
+  deferred); per-org branding.
 
 ## Decisions
 
@@ -52,27 +54,91 @@ cross-org grants needs instance-level rights far broader than the existing
 single-org `backend-app` user (`ORG_USER_MANAGER` on one org). A dedicated
 user isolates that blast radius; credential in ESC/Secret Manager.
 *Alternative — reuse `backend-app`:* rejected (wrong scope + coupled blast
-radius). Note the `machine-user` "no rotation, expires 2099" caveat applies
-and warrants a rotation runbook given this user's power.
+radius).
 
-**D4 — Tenant-org login policy is set explicitly, never inherited.** A new
-org inherits the instance `DefaultLoginPolicy` = the admin Google-IdP-only
-policy, which would make external operators unable to sign in. Provisioning
-MUST set a passkey-only policy + `allowDomainDiscovery`. This change defines
-the required shape; `organizer-accounts` applies it per org.
+*Credential lifecycle (revised after best-practice review):* the security
+delta over the existing `backend-app` "expires 2099, no rotation" pattern is
+the **root key's own lifecycle**, not the operational tokens. Any machine user
+authenticating with a JWT-profile key already gets **short-lived access
+tokens** from the standard `jwt-bearer` OAuth flow (Zitadel default — no
+long-lived bearer / PAT is stored, and nothing bespoke to build). What this
+high-privilege identity MUST additionally satisfy is a **finite root-key
+expiry + rotation runbook** — a year-2099 non-expiring key is prohibited.
+Automated rotation / workload-identity federation is the target end-state
+(future hardening); the rotation runbook is authored in `organizer-accounts`,
+where the key is first consumed.
+
+**D4 — Tenant-org login policy is set explicitly, never inherited, and is
+passkey-primary with a designed recovery path (not passkey-only).** A new org
+inherits the instance `DefaultLoginPolicy` = the admin Google-IdP-only policy
+(confirmed in Zitadel source `getOrgLoginPolicy`: an org with no active custom
+policy falls back to the instance default), which would make external
+operators unable to sign in. Provisioning MUST set an explicit policy.
+
+The 2025-2026 state-of-the-art for a B2B operator console invite→first-login
+flow is **passkey-primary with a passwordless fallback**, not passkey-only:
+synced passkeys (iCloud/Google) survive single-device loss, so passkeys are
+the right primary, but a recovery lane is non-negotiable (whole-account loss,
+offboarding, and unfinished FIDO cross-ecosystem migration are residual gaps).
+Zitadel-specific: a hard passkey-only lockdown is currently fragile
+(`allowLocalAuthentication=false` bugs — zitadel#11682/#8996), reinforcing
+"keep a fallback". So the required shape is: `passwordlessType=ALLOWED`
+(primary) + `allowUsernamePassword=false` (no passwords) + `allowRegister=
+false` (backend-provisioned only) + `allowExternalIDP=true` (federate to a
+tenant's workspace IdP when it has one) + `ignoreUnknownUsernames=true` (no
+enumeration), plus a mandatory recovery path (admin re-invite via re-issued
+passkey init link; optional step-up-protected magic-link/OTP). A second
+**hardware** authenticator is NOT mandated for this operator persona (reserve
+for regulated / super-admin). **Org resolution is org-pinned, not
+email-domain-based** — see D6 — so `allowDomainDiscovery` is NOT in the MVP
+shape. This change defines the required shape; `organizer-accounts` applies it per org
+(exact values, per-tenant IdP wiring, init-link channel/TTL). Full rationale +
+sources: "Best-practice review" below.
 
 **D5 — No proto in this change.** Organizer tenancy is IaC + spec only; the
 entity/RPC proto lands in `organizer-accounts`. So this change ships without
 BSR generation.
+
+**D6 — Org resolution is org-pinned, not email-domain discovery (MVP).**
+Because first login already persists `org_id` (the console remembers it) and
+the console can always pin the org via the `urn:zitadel:iam:org:id:<orgId>`
+scope, a *single* org-pinned path serves everyone: org-scoped init link →
+remembered `org_id` → on a fresh device an org code/slug or an app-layer
+"email me a sign-in link" (backend org lookup, works for gmail). Email-domain
+discovery would only add value in one narrow spot — a custom-domain operator
+on a fresh device typing their email instead of an org code — at the cost of
+per-tenant DNS-TXT domain verification, enumeration hardening, and a console
+branch, and it does not help the consumer-domain (gmail) majority at all. The
+app-layer "email me a link" flow delivers the same "just type your email" UX
+uniformly without domain verification, so it strictly dominates. Domain
+discovery is therefore **dropped from the MVP** and recorded as a future
+optional enhancement (verified custom domain + enterprise SSO). *Alternative —
+require domain discovery as a second path:* rejected (redundant branch + real
+per-tenant verification burden for a minor, minority-only convenience).
 
 ## Risks / Trade-offs
 
 - **Latent verification** → the tenant-org login-policy requirement can only
   be observed once orgs are created (`organizer-accounts`). It is a forward
   contract; its acceptance test lives in that change.
-- **Machine-user power** → mitigate with the narrowest instance role that
-  still allows org-create + grants, credential isolation, and a rotation
-  runbook.
+- **Machine-user power** → mitigate with the narrowest built-in instance role
+  (`IAM_ORG_MANAGER`, not `IAM_OWNER`), credential isolation, **short-lived
+  operational tokens** (JWT-profile mint), and a rotation runbook. `IAM_ORG_
+  MANAGER` still manages all orgs; a custom minimal `defaults.yaml` role is a
+  recorded future hardening.
+- **Passkey recovery** → passkey-primary is correct, but the recovery lane
+  (admin re-invite; optional step-up magic-link/OTP) is mandatory — a
+  passkey-only-no-recovery org would lock operators out. Zitadel's hard
+  passkey-only lockdown is fragile (zitadel#11682/#8996), so the policy
+  expresses "no passwords" via `allowUsernamePassword=false`, not a full
+  `allowLocalAuthentication=false` lockdown.
+- **Org resolution** → **org-pinned for everyone** (D6): org-scoped init link
+  → remembered `org_id` → org code/slug or app-layer "email me a link" → the
+  Zitadel `urn:zitadel:iam:org:id:<orgId>` scope. Keep `ignoreUnknownUsernames=
+  true` so the login endpoint is not a tenant-enumeration oracle. No
+  email-domain discovery and no per-tenant domain verification in the MVP; a
+  mismatched org-pinned entry just fails auth. (Console URL/config carrier:
+  `organizer-console` / `frontend-runtime-config`.)
 - **Topology drift detection** → Pulumi must be taught that runtime tenant
   orgs are not drift (the modified `identity-management` "No third org"
   scenario), else it would try to revert them.
@@ -81,7 +147,7 @@ BSR generation.
 
 1. specification: the `identity-management` topology delta + the new
    `organizer-tenancy` capability spec → merge (no BSR gen needed).
-2. cloud-provisioning (IaC): add the `organizer-console` project + `master`
+2. cloud-provisioning (IaC): add the `organizer-console` project + `owner`
    role + `organizer-console`/`backend-api` apps in the `liverty-music` org,
    and the `organizer-provisioner` machine user + credential; ensure Pulumi
    does not treat runtime tenant orgs as drift.
@@ -90,7 +156,85 @@ BSR generation.
 
 ## Open Questions
 
-- The exact narrowest Zitadel instance role for `organizer-provisioner`
-  (e.g. an org-manager-class role vs `IAM_OWNER`) is an implementation
-  detail confirmed during the cloud-provisioning task; it does not change
-  the spec or the decomposition.
+*(none open — the former role question is resolved below.)*
+
+- ~~The exact narrowest Zitadel instance role for `organizer-provisioner`.~~
+  **Resolved:** `IAM_ORG_MANAGER` — the narrowest **built-in** instance role
+  that permits `org.create` + cross-org Project/User grants (verified against
+  Zitadel's role model; strictly less than `IAM_OWNER`). A still-narrower
+  custom `defaults.yaml` `InternalAuthZ.RolePermissionMappings` role is
+  possible but edits the Zitadel deployment config → deferred as future
+  hardening.
+
+## Best-practice review (2026-08)
+
+This change was reviewed against current Zitadel docs (context7) and IDaaS
+industry guidance (NIST SP 800-63B-4, FIDO Alliance 2024-25, Okta/Auth0/Clerk/
+WorkOS/Corbado, Google Cloud workload-identity). Verdicts:
+
+- **Org = tenant, project-per-actor, Project Grant, roles claim** → sound,
+  matches Zitadel's recommended B2B model. Unchanged.
+- **Explicit per-org login policy (no inherit)** → correct and necessary
+  (confirmed `getOrgLoginPolicy` falls back to the admin default otherwise).
+- **Login method** → passkey-primary is state-of-the-art; **passkey-only with
+  no recovery** was flagged as an anti-pattern and softened to **passkey-
+  primary + designed recovery + optional federation** (synced passkeys reduce,
+  but don't remove, the single-credential risk). See D4.
+- **Org resolution** → email-domain discovery was initially specced, then
+  dropped: since first login persists `org_id` and the console pins the org
+  via the `org:id` scope, one org-pinned path serves everyone; domain
+  discovery is a redundant branch with a real per-tenant DNS-verification cost
+  that helps only a custom-domain minority on fresh devices, and an app-layer
+  "email me a link" flow beats it uniformly. MVP = org-pinned only; domain
+  discovery deferred as a future optional enhancement. See D6.
+- **Provisioner credential** → an indefinite year-2099 static key on a
+  high-privilege identity is an anti-pattern; revised to a finite root-key
+  expiry + rotation runbook (operational access tokens are already short-lived
+  via the standard `jwt-bearer` flow). See D3.
+- **Provisioner role** → `IAM_ORG_MANAGER` is broad (all-org management); kept
+  as the narrowest built-in, with a custom minimal role recorded as future
+  hardening.
+
+Deferred to `organizer-accounts` (runtime): exact per-org login-policy values,
+per-tenant IdP federation wiring, init-link channel/TTL, and the provisioner
+credential-minting + rotation implementation.
+
+## Zitadel built-in surface (used vs custom)
+
+Grounds the downstream cluster (`organizer-accounts`, `organizer-console`):
+the login / passkey / token / role-grant machinery is Zitadel-native (this
+instance already self-hosts Login v2), so only a thin app layer is custom.
+
+**Used as-is (Zitadel built-in):**
+- Hosted **Login v2 UI** (already self-hosted) — sign-in, passkey (WebAuthn)
+  prompt, IdP/SSO redirect, MFA/step-up. No custom login screens.
+- **Passkey registration link API** (`POST /v2/users/{id}/passkeys/
+  registration_link`) — `sendLink` (Zitadel emails via urlTemplate) or
+  `returnCode` (self-distribute). First-login enrollment on the hosted page.
+- **Management API** — create org, create human user, set org login policy,
+  Project Grant, User Grant, IdP config (the `organizer-accounts` saga).
+- **OIDC/OAuth2 + PKCE**, JWT/JWKS, token lifetimes (`DefaultOidcSettings`),
+  refresh tokens.
+- **Roles claim assertion** (`accessTokenRoleAssertion`) + Project/User Grant
+  → tenant-scoped `owner` role in the token.
+- **Reserved scopes**: `urn:zitadel:iam:org:id:<orgId>` (org-pin) and
+  `...:project:id:<id>:aud` (audience).
+- **Login-policy flags**: `passwordlessType`, `allowUsernamePassword`,
+  `allowRegister`, `allowExternalIDP`, `ignoreUnknownUsernames`.
+- **External IdP federation** templates (Google Workspace / Entra OIDC) —
+  future per-tenant.
+- **SMTP notifications** (Postmark wired) — can send the passkey init link.
+- **Actions v2** — optional stable `organizer-id` custom claim (future).
+
+**Custom (this cluster builds):**
+- organizer console SPA (post-auth console + OIDC client via `oidc-client-ts`
+  PKCE; login redirects to hosted Login v2).
+- Org-pinned resolution glue (slug→`org_id`, remembered `org_id`, app-layer
+  "email me a sign-in link" backend lookup) — the org pre-step, since domain
+  discovery is dropped (D6). Credential screens stay Zitadel's.
+- Provisioning saga orchestration (backend Go) + Organizer DB row.
+- Backend authz (`aud` + tenant-scoped roles claim validation).
+- Hosting (`organizer.{base}` DNS/cert/HTTPRoute/`config.json`).
+
+Boundary: **identity / passkey / token / role-grant = Zitadel built-in;
+org pre-step + console + provisioning + hosting = custom.**

--- a/openspec/changes/organizer-tenancy/proposal.md
+++ b/openspec/changes/organizer-tenancy/proposal.md
@@ -16,20 +16,31 @@ tracked by liverty-music/specification#759.
   provisioned Organizer tenant orgs** (one per Organizer) that are NOT
   IaC-managed and NOT treated as drift.
 - Add a shared, **actor-named `organizer-console` Zitadel Project** owned by
-  the `liverty-music` org, with the `master` ProjectRole and access-token
+  the `liverty-music` org, with the `owner` ProjectRole and access-token
   role assertion enabled. Actor-named so a future `venue-console` never
   collides.
 - Register the **`organizer-console` OIDC app** and a **`backend-api` app**
   on that project (the app audience the organizer API server will validate).
-- Provision a dedicated **`organizer-provisioner` machine user** with
-  instance-level org-create + cross-org grant rights (credential in
-  ESC/Secret Manager), isolated from the existing single-org `backend-app`
-  machine user.
+- Provision a dedicated **`organizer-provisioner` machine user** with the
+  `IAM_ORG_MANAGER` instance role (org-create + cross-org grants; narrowest
+  built-in role, less than `IAM_OWNER`), isolated from the existing
+  single-org `backend-app` machine user. Its **root** JWT-profile key lives in
+  ESC/Secret Manager with a **finite expiry + rotation runbook** (no year-2099
+  non-expiring key for this high-privilege identity); operational access
+  tokens are short-lived by default via the standard `jwt-bearer` OAuth flow.
 - Define the **required login policy for Organizer tenant orgs**:
-  passkey-only (`passwordlessType=ALLOWED`, `userLogin=false`,
-  `allowRegister=false`, no Google IdP) with `allowDomainDiscovery=true`,
-  set explicitly at provisioning — tenant orgs MUST NOT inherit the admin
-  default (Google-IdP-only) policy.
+  **passkey-primary** (`passwordlessType=PASSWORDLESS_TYPE_ALLOWED`,
+  `allowUsernamePassword=false`, `allowRegister=false`) with a **designed
+  recovery path** (admin re-invite via re-issued passkey init link; optional
+  magic-link/OTP fallback, step-up protected) — passkey-only-with-no-recovery
+  is prohibited. `allowExternalIDP=true` permits OIDC federation to a
+  tenant's own workspace IdP; `ignoreUnknownUsernames=true` prevents
+  enumeration. **Org resolution is org-pinned** (org-scoped init link →
+  remembered `org_id` → org-code / app-layer "email me a link" → the Zitadel
+  `org:id` scope), NOT email-domain-based, so no per-tenant domain
+  verification is needed; email-domain discovery is a future optional
+  enhancement. Set explicitly at provisioning — tenant orgs MUST NOT inherit
+  the admin default (Google-IdP-only) policy.
 
 Explicit non-goals (later sub-changes): the Organizer domain entity + admin
 vetting + the runtime provisioning saga (`organizer-accounts`),
@@ -40,9 +51,9 @@ server + `OrganizerService.Get` + org-scoped authz (`organizer-rpc-server`).
 
 ### New Capabilities
 - `organizer-tenancy`: the shared `organizer-console` Zitadel project (its
-  `master` role and apps), the `organizer-provisioner` machine user, and the
-  required passkey-only + domain-discovery login policy that Organizer
-  tenant orgs are provisioned with.
+  `owner` role and apps), the `organizer-provisioner` machine user, and the
+  required passkey-primary + recovery + federation + org-pinned-resolution
+  login policy that Organizer tenant orgs are provisioned with.
 
 ### Modified Capabilities
 - `identity-management`: relax the "exactly two top-level orgs" topology to
@@ -54,7 +65,7 @@ server + `OrganizerService.Get` + org-scoped authz (`organizer-rpc-server`).
   `organizer-tenancy` capability spec. **No proto/entity changes** (those
   land in `organizer-accounts`), so this change needs no BSR generation.
 - **cloud-provisioning (IaC / Pulumi)**: the `organizer-console` project +
-  `master` role + `organizer-console`/`backend-api` apps in the
+  `owner` role + `organizer-console`/`backend-api` apps in the
   `liverty-music` org, and the `organizer-provisioner` machine user +
   credential.
 - **backend / frontend**: none in this change.

--- a/openspec/changes/organizer-tenancy/specs/organizer-tenancy/spec.md
+++ b/openspec/changes/organizer-tenancy/specs/organizer-tenancy/spec.md
@@ -12,20 +12,27 @@ the domain entity, the console, and the API server are separate changes.
 
 The system SHALL provision, via IaC, a single actor-named
 **`organizer-console`** Zitadel Project owned by the `liverty-music` product
-org, defining a **`master`** ProjectRole and enabling access-token role
+org, defining an **`owner`** ProjectRole and enabling access-token role
 assertion so operator tokens carry the `organizer-console` project roles.
 The project SHALL be shared to Organizer tenant orgs via Project Grant (the
-grant itself is created at runtime, not by IaC). Roles for a future
-sub-owner model are out of scope; only `master` is defined now. The project
-name is actor-qualified so a future `venue-console` project does not
-collide.
+grant itself is created at runtime, not by IaC). The sub-owner roles
+(`editor`, `viewer`, `reception`) are out of scope; only `owner` is defined
+now. The project name is actor-qualified so a future `venue-console` project
+does not collide.
+
+The top role is named **`owner`**, NOT `admin`: `admin` already denotes the
+Liverty-internal operator role on the separate `admin-console` project, so
+reusing it would overload the roles claim and collide with Zitadel's own
+admin concepts. The Organizer's principal operator owns their own tenant —
+they are the tenant **owner**, not a platform administrator — so `owner` is
+the accurate, industry-standard term (cf. Zitadel `ORG_OWNER`).
 
 #### Scenario: Organizer-console project exists in the product org
 
 - **WHEN** the Pulumi stack is applied
 - **THEN** an `organizer-console` Zitadel Project SHALL exist owned by the
   `liverty-music` org
-- **AND** it SHALL define a `master` ProjectRole
+- **AND** it SHALL define an `owner` ProjectRole (not `admin` — see rationale)
 - **AND** access-token role assertion SHALL be enabled so operator tokens
   carry the project roles claim
 
@@ -68,41 +75,166 @@ The system SHALL provision, via IaC, a dedicated **`organizer-provisioner`**
 machine user holding the narrowest instance-level role that permits creating
 organizations and cross-org Project Grants and User Grants, separate from
 the existing single-org `backend-app` machine user, with its credential
-stored in ESC / Secret Manager. This user is the credential the backend uses
-at runtime to provision Organizer tenant orgs.
+stored in ESC / Secret Manager. This user is the identity the backend uses
+at runtime to provision Organizer tenant orgs. On the self-hosted Zitadel
+instance the narrowest **built-in** instance role that satisfies these needs
+is **`IAM_ORG_MANAGER`** (org lifecycle + cross-org grants across all orgs;
+strictly less than `IAM_OWNER`, which additionally holds instance/system
+settings). A still-narrower custom instance role (a `defaults.yaml`
+`InternalAuthZ.RolePermissionMappings` entry scoped to `org.create` + initial
+grants only) is possible but out of scope for this change (it edits the
+Zitadel deployment config); it is recorded as a future hardening.
 
 #### Scenario: Provisioner machine user exists with org-create rights
 
 - **WHEN** the Pulumi stack is applied
-- **THEN** an `organizer-provisioner` machine user SHALL exist with
-  instance-level rights to create organizations and cross-org grants
+- **THEN** an `organizer-provisioner` machine user SHALL exist with the
+  `IAM_ORG_MANAGER` instance role (create organizations + cross-org grants)
 - **AND** it SHALL be distinct from the `backend-app` machine user (blast
   radius isolation)
 - **AND** its credential SHALL be stored in ESC / Secret Manager, not in
   source
 
-### Requirement: Organizer tenant orgs use a passkey-only login policy with domain discovery
+### Requirement: Organizer-provisioner root key has a finite lifecycle
+
+The `organizer-provisioner` is a high-privilege identity (it can create orgs
+and issue cross-org grants), so it MUST NOT hold an effectively indefinite
+static key. Its root JWT-profile signing key SHALL be stored only in
+ESC / Secret Manager and SHALL carry a **finite expiry** with a **documented
+rotation runbook** — a year-2099 non-expiring key is prohibited for this
+identity. The backend authenticates as the provisioner with this key via the
+standard JWT-profile (`jwt-bearer`) grant, through which Zitadel issues
+**short-lived access tokens** by the normal OAuth flow (inherent to machine
+users — no long-lived opaque bearer / PAT is stored). Automated rotation /
+workload-identity federation is the target end-state (future hardening); the
+rotation runbook is authored in `organizer-accounts`, where the credential is
+first consumed.
+
+#### Scenario: Provisioner key is finite, not indefinite
+
+- **WHEN** the Pulumi stack provisions the `organizer-provisioner`
+- **THEN** its root JWT-profile key SHALL have a finite expiry (not a
+  year-2099 non-expiring key)
+- **AND** the backend SHALL authenticate via the JWT-profile grant, which
+  yields short-lived access tokens by the standard OAuth flow
+- **AND** no long-lived opaque bearer token (PAT) SHALL be stored for this
+  identity
+
+### Requirement: Organizer tenant orgs use a passkey-primary login policy with a designed recovery path
 
 Every runtime-provisioned Organizer tenant org SHALL be given an **explicit**
 login policy — it SHALL NOT inherit the instance default (admin
-Google-IdP-only) policy. The policy SHALL be **passkey-only**
-(`passwordlessType=ALLOWED`, `userLogin=false`, `allowRegister=false`, no
-external/Google IdP) with **`allowDomainDiscovery=true`** so an operator is
-routed to their own org by their email domain at login. (Applying this
-policy to each org happens in the runtime provisioning flow of
-`organizer-accounts`; this requirement defines the required shape.)
+Google-IdP-only) policy. The policy SHALL make **passkeys the primary
+credential** and SHALL have this shape:
 
-#### Scenario: A provisioned tenant org has the passkey-only policy
+- `passwordlessType = PASSWORDLESS_TYPE_ALLOWED` — passkeys enabled and
+  primary; operators enroll a passkey on first login (the backend creates the
+  operator with `request_passwordless_registration=true` and delivers the
+  Zitadel passkey-registration init link).
+- `allowUsernamePassword = false` — no passwords for Organizer operators.
+- `allowRegister = false` — no open self-registration; operator accounts are
+  backend-provisioned for vetted Organizers only.
+- `allowExternalIDP = true` — permit OIDC federation so an Organizer that
+  already has a workspace IdP (Google Workspace / Microsoft Entra) can
+  federate; wiring a *specific* tenant IdP is a per-tenant runtime concern.
+- `ignoreUnknownUsernames = true` — the login flow SHALL NOT disclose whether
+  a given account or org exists (anti-enumeration).
+- `allowDomainDiscovery` — **NOT required (MVP defaults it off)**. Org
+  resolution is org-pinned (below), not email-domain-based, so no per-tenant
+  domain verification is needed. Email-domain discovery is a **future optional
+  enhancement** for a tenant that verifies a custom domain and wants
+  type-email-only routing (typically alongside enterprise SSO).
+
+A **recovery path MUST exist** — passkey-only with **no** recovery is
+prohibited. Recovery SHALL be an **admin-initiated re-invite** (Zitadel
+re-issues the operator's passkey-registration link after out-of-band
+verification), optionally with an email magic-link/OTP self-serve fallback;
+any non-passkey fallback lane SHALL be step-up protected so it is not a weaker
+bypass. The policy SHALL NOT rely on a hard `allowLocalAuthentication=false`
+lockdown (Zitadel #11682 / #8996 make full passkey-only lockdown fragile);
+`allowUsernamePassword=false` expresses the "no passwords" intent while the
+init-link/recovery lane stays available.
+
+Synced passkeys (iCloud Keychain / Google Password Manager) survive
+single-device loss, so a second **hardware** authenticator is NOT mandated for
+this operator persona (reserve that for regulated / super-admin accounts).
+
+**Org resolution SHALL be org-pinned, not email-domain-based.** The single
+OIDC app serves all tenants; the caller's org is fixed by *where they enter*,
+and the console pins it via the Zitadel `urn:zitadel:iam:org:id:<orgId>`
+scope: (a) first login uses the org-scoped passkey init link; (b) a returning
+operator on the same device uses the `org_id` the console remembered at first
+login; (c) a fresh device / cleared storage resolves the org via an org handle
+(org code/slug in the URL) **or** an app-layer "email me a sign-in link" flow
+(the backend looks up the operator's org(s) and emails an org-pinned link —
+this works for consumer/free-mail addresses and never discloses org existence).
+An operator SHALL NOT be routed to a different org by supplying a different
+email; a mismatched org-pinned entry simply fails auth (no cross-org access).
+This uniform path covers consumer-domain operators (the common indie-artist /
+gmail case) without any per-tenant domain verification.
+
+Applying this policy per org, the exact field values, per-tenant IdP wiring,
+and the init-link channel/TTL are runtime concerns of `organizer-accounts`;
+the org-handle carrier (console URL / `/config.json`) is delivered by
+`organizer-console` / `frontend-runtime-config`. This requirement defines the
+required shape. (Best-practice basis recorded in design.md "Best-practice
+review".)
+
+#### Scenario: A provisioned tenant org has the passkey-primary policy
 
 - **WHEN** an Organizer tenant org is provisioned
 - **THEN** it SHALL have an explicitly set login policy, not the inherited
   admin default
-- **AND** the policy SHALL be passkey-only (`passwordlessType=ALLOWED`,
-  `userLogin=false`, `allowRegister=false`, no Google IdP)
-- **AND** `allowDomainDiscovery` SHALL be enabled
+- **AND** the policy SHALL be passkey-primary
+  (`passwordlessType=PASSWORDLESS_TYPE_ALLOWED`, `allowUsernamePassword=false`,
+  `allowRegister=false`)
+- **AND** `allowExternalIDP` and `ignoreUnknownUsernames` SHALL be enabled
+- **AND** `allowDomainDiscovery` SHALL NOT be required (MVP defaults it off;
+  org resolution is org-pinned)
 
-#### Scenario: Operator is routed to their org by email domain
+#### Scenario: Operator completes first login by enrolling a passkey
 
-- **WHEN** an operator enters their email on the organizer console login
-- **THEN** domain discovery SHALL route them to their own Organizer tenant
-  org's login policy without an org picker
+- **WHEN** the backend creates a no-password operator with
+  `request_passwordless_registration=true` and delivers the returned
+  passkey-registration init link
+- **THEN** the operator SHALL complete first login by enrolling a passkey via
+  that link
+- **AND** passkeys SHALL be the credential used on subsequent logins
+
+#### Scenario: A recovery path exists for a lost passkey
+
+- **WHEN** an operator loses access to their passkey(s)
+- **THEN** an admin SHALL be able to re-invite them (re-issue the
+  passkey-registration link) after out-of-band verification
+- **AND** a policy with no recovery path (passkey-only, no re-invite / no
+  fallback) SHALL be rejected
+- **AND** any non-passkey fallback lane SHALL be step-up protected
+
+#### Scenario: Org is resolved by org-pinned entry for every operator
+
+- **WHEN** any operator (consumer / free-mail such as `gmail.com`, or a custom
+  domain) signs in
+- **THEN** the org SHALL be resolved by an **org-pinned entry**, never by the
+  email domain: the org-scoped passkey init link on first login; a remembered
+  `org_id` on the same device thereafter; and on a fresh device an org handle
+  (org code/slug in the URL) or an app-layer "email me a sign-in link" flow
+  (backend resolves the operator's org(s) and emails an org-pinned link)
+- **AND** the console SHALL pin the org via the Zitadel
+  `urn:zitadel:iam:org:id:<orgId>` scope
+- **AND** an operator SHALL NOT be routed into a different org by supplying a
+  different address (a mismatched org-pinned entry simply fails auth — no
+  cross-org access; `ignoreUnknownUsernames` keeps org existence undisclosed)
+- **AND** no per-tenant domain verification SHALL be required for this path
+- **AND** the concrete console URL / runtime-config carrier for the org handle
+  is delivered by `organizer-console` / `frontend-runtime-config`
+
+#### Scenario: Email-domain discovery is a future optional enhancement
+
+- **WHEN** a later change enables type-email-only routing for an Organizer that
+  has a **verified** custom domain (typically alongside enterprise SSO)
+- **THEN** that enhancement MAY set `allowDomainDiscovery=true` for that org,
+  gated on domain ownership verification (DNS-TXT) and excluding consumer /
+  free-mail domains
+- **AND** it SHALL remain additive — the org-pinned path above stays the
+  baseline and is never removed
+- **AND** this MVP change neither requires nor implements domain discovery

--- a/openspec/changes/organizer-tenancy/tasks.md
+++ b/openspec/changes/organizer-tenancy/tasks.md
@@ -1,19 +1,19 @@
 ## 1. Specification
 
-- [ ] 1.1 `identity-management` MODIFIED delta: relax the org topology to allow runtime-provisioned Organizer tenant orgs (not IaC-managed, not drift)
-- [ ] 1.2 New `organizer-tenancy` capability spec: shared `organizer-console` project + `master` role + apps, `organizer-provisioner` machine user, required passkey-only + domain-discovery tenant-org login policy
+- [x] 1.1 `identity-management` MODIFIED delta: relax the org topology to allow runtime-provisioned Organizer tenant orgs (not IaC-managed, not drift)
+- [x] 1.2 New `organizer-tenancy` capability spec: shared `organizer-console` project + `owner` role (named `owner`, not `admin`) + apps, `organizer-provisioner` machine user (IAM_ORG_MANAGER + short-lived credential), required passkey-primary + recovery + federation + org-pinned-resolution tenant-org login policy
 - [ ] 1.3 `openspec validate --strict organizer-tenancy` passes; open specification PR and merge (no BSR gen — no proto changes)
 
 ## 2. Cloud-provisioning (IaC / Pulumi)
 
-- [ ] 2.1 `organizer-console` Zitadel Project in the `liverty-music` org with the `master` ProjectRole and access-token role assertion enabled (`projectRoleCheck` off)
-- [ ] 2.2 `organizer-console` OIDC app (PKCE, no secret) + per-env redirect URIs for the organizer console host; `backend-api` app on the same project (audience)
-- [ ] 2.3 `organizer-provisioner` machine user with the narrowest instance role that permits org-create + cross-org Project Grant + User Grant; credential in ESC/Secret Manager; separate from `backend-app`
-- [ ] 2.4 Ensure Pulumi does not treat runtime-provisioned Organizer tenant orgs as drift
+- [x] 2.1 `organizer-console` Zitadel Project in the `liverty-music` org with the `owner` ProjectRole and access-token role assertion enabled (`projectRoleCheck` off)
+- [x] 2.2 `organizer-console` OIDC app (PKCE, no secret) + per-env redirect URIs for the organizer console host; `backend-api` app on the same project (audience)
+- [x] 2.3 `organizer-provisioner` machine user with `IAM_ORG_MANAGER` (narrowest built-in instance role for org-create + cross-org Project/User Grants); credential in ESC/Secret Manager; separate from `backend-app`; root JWT-profile key has a **finite expiry** (not year-2099), short-lived access tokens come from the standard jwt-bearer flow. (Rotation runbook is authored in `organizer-accounts`, where the key is first consumed.)
+- [x] 2.4 Ensure Pulumi does not treat runtime-provisioned Organizer tenant orgs as drift
 - [ ] 2.5 `make lint` (biome + tsc + kustomize render) passes; `pulumi preview` shows only the intended additions
 
 ## 3. Ship to prod
 
 - [ ] 3.1 cloud-provisioning PR merged → dev Pulumi up (automated) applies the project/role/apps + machine user; confirm via `pulumi stack`
 - [ ] 3.2 Prod Pulumi up (manual from console) applies the same; confirm the `organizer-console` project, apps, and `organizer-provisioner` machine user exist in prod
-- [ ] 3.3 Verify: the `organizer-console` project + `master` role + both apps + the provisioner machine user are present in each env; no other org was created (topology still two IaC-managed orgs)
+- [ ] 3.3 Verify: the `organizer-console` project + `owner` role + both apps + the provisioner machine user are present in each env; no other org was created (topology still two IaC-managed orgs)


### PR DESCRIPTION
## 🔗 Related Issue

Refs #759

<!-- #759 is the umbrella Phase-3 roadmap / decomposition issue spanning all
four Organizer sub-changes; this PR is a planning-artifact revision of the
`organizer-tenancy` sub-change, so it references (does not close) #759. -->

## 📝 Summary of Changes

Revises the **`organizer-tenancy`** OpenSpec planning artifacts (and the shared
`docs/` design references the whole Organizer cluster is authored from) to fold
in the outcome of a best-practice review against current Zitadel docs and IDaaS
guidance (NIST SP 800-63B-4, FIDO Alliance, Okta/Auth0/Clerk/WorkOS). No code,
no proto, no BSR generation.

**Design decisions changed:**

- **Login policy — passkey-primary with a mandatory recovery path** (was
  "passkey-only"). Shape: `passwordlessType=ALLOWED` + `allowUsernamePassword=
  false` + `allowRegister=false` + `allowExternalIDP=true` (workspace-IdP
  federation) + `ignoreUnknownUsernames=true`. Recovery (admin re-invite via
  re-issued passkey init link; optional step-up-protected magic-link/OTP) is
  mandatory — passkey-only-with-no-recovery is prohibited. No hard
  `allowLocalAuthentication=false` lockdown (zitadel#11682/#8996). Synced
  passkeys mean a second **hardware** authenticator is not required for this
  persona.
- **Org resolution — org-pinned, domain discovery dropped from MVP** (design
  D6). Since first login persists `org_id` and the console pins the org via the
  `urn:zitadel:iam:org:id:<orgId>` scope, one org-pinned path serves everyone
  (init link → remembered `org_id` → org code/slug or an app-layer "email me a
  sign-in link" backend lookup that works for gmail). Email-domain discovery
  was a redundant branch with per-tenant DNS-verification cost that does not
  help the consumer-domain majority; it is deferred as a future optional
  enhancement.
- **Top role renamed `master` → `owner`.** `owner` is accurate (the tenant's
  owner, not a platform admin) and avoids collision with the internal
  `admin-console` `admin` role and Zitadel's own admin concepts (cf.
  `ORG_OWNER`).
- **Provisioner** — `IAM_ORG_MANAGER` recorded as the narrowest **built-in**
  instance role (< `IAM_OWNER`); the root key must have a **finite expiry +
  rotation runbook** (no year-2099 static key). Operational tokens are already
  short-lived via the standard `jwt-bearer` flow.
- **New "Zitadel built-in surface (used vs custom)"** section in design.md so
  downstream changes know login / passkey / token / role-grant are
  Zitadel-native (hosted Login v2 is already self-hosted) and only a thin app
  layer (console, org pre-step, provisioning saga, hosting) is custom.

**Files:** `openspec/changes/organizer-tenancy/{proposal,design,tasks,specs/organizer-tenancy/spec}.md`,
`docs/organizer-platform-design.md`, `docs/zitadel-tenancy-model.md`.

`openspec validate --strict organizer-tenancy` passes.

## ✅ Self-Checklist

- [x] I have linked the related issue (Refs #759 — umbrella issue, intentionally not auto-closed).
- [x] I have updated the relevant documentation (shared `docs/` design references synced with the change).
- [ ] I have run `buf lint` and `buf format` locally — N/A (no proto changes in this PR).
- [ ] My proto definitions follow the project's style guidelines — N/A (no proto).
- [ ] Breaking changes — N/A (docs/spec only).
