### PR TITLE
docs(openspec): reconcile organizer-accounts with shipped organizer-tenancy

### DIFF
--- a/openspec/changes/organizer-accounts/design.md
+++ b/openspec/changes/organizer-accounts/design.md
@@ -1,7 +1,7 @@
 ## Context
 
 See proposal.md - Why. Builds on `organizer-tenancy` (the shared
-`organizer-console` project, `master` role, apps, and `organizer-provisioner`
+`organizer-console` project, `owner` role, apps, and `organizer-provisioner`
 machine user, plus the relaxed topology). Full design, resolved gap-audit,
 and the four-change decomposition are in
 [`docs/organizer-platform-design.md`](../../../docs/organizer-platform-design.md);
@@ -46,18 +46,35 @@ authorization in this change (that is the organizer-facing server, 4/4).
 **D4 — Provisioning saga (idempotent, compensating), keyed on OrganizerId.**
 Order: (1) insert `organizers` row `provisioning_state=provisioning`; (2)
 Management API create tenant org (name `org-<uuid-short>`, explicit
-passkey-only + domain-discovery login policy); (3) persist `zitadel_org_id`;
-(4) Project-Grant `organizer-console` (role subset incl. `master`); (5)
-create operator human user (no password, init email) + `master` User Grant;
-(6) set `provisioning_state=active`. A reconciler re-enters at the first
-incomplete step (each Zitadel create existence-checked). Uses the
-`organizer-provisioner` credential from ESC/Secret Manager. Wrap the call in
-an OTel span + an `organizer_provisioning_failed` metric.
+**passkey-primary** login policy per `organizer-tenancy`:
+`passwordlessType=ALLOWED`, `allowUsernamePassword=false`,
+`allowRegister=false`, `allowExternalIDP=true`, `ignoreUnknownUsernames=true`;
+NOT domain-discovery); (3) persist `zitadel_org_id`; (4) Project-Grant
+`organizer-console` (role subset incl. `owner`); (5) create operator human
+user (no password, `request_passwordless_registration` → passkey init link) +
+`owner` User Grant; (6) set `provisioning_state=active`. A reconciler re-enters
+at the first incomplete step (each Zitadel create existence-checked). Uses the
+`organizer-provisioner` credential from ESC/Secret Manager (JWT-profile →
+short-lived tokens). Wrap the call in an OTel span + an
+`organizer_provisioning_failed` metric.
+
+*Provisioner hardening (carried over from the `organizer-tenancy` code-review,
+recorded in its design "deferred" list):* isolate GCP-layer read access to the
+provisioner key with a **dedicated provisioner workload + GCP SA** (so the
+`backend-app` SA no longer reads the `IAM_ORG_MANAGER` key — an IaC /
+cloud-provisioning change alongside this backend work), and add a **key-expiry
+monitoring alert** for the finite provisioner key (expires 2027-08-13) plus the
+rotation runbook.
 
 **D5 — Operator bootstrap.** The operator is created without a password;
-Zitadel's init-email flow lets them register a passkey on first sign-in; the
-tenant org's login policy (set in step 2) is passkey-only with domain
-discovery, so no org picker is needed.
+Zitadel delivers a **passkey-registration init link** so they register a
+passkey on first sign-in. The tenant org's login policy (set in step 2) is
+**passkey-primary** with a mandatory recovery path (admin re-invite via
+re-issued init link; optional step-up magic-link/OTP) and permits workspace-IdP
+federation. **Org resolution is org-pinned** (org-scoped init link → remembered
+`org_id` → org code / "email me a link" → the `org:id` scope), NOT email-domain
+discovery — so no per-tenant domain verification and gmail operators work. (The
+console URL/config carrier is `organizer-console`.)
 
 **D6 — Deactivation hook.** `provisioning_state=deactivated` gates the
 backend (reject all organizer ops) and deactivates the Zitadel operators;
@@ -72,7 +89,7 @@ via the existing JetStream→PostHog path, keyed on `organizer_id` (admin-actor
 
 - **Two-system saga without 2PC** → the DB-row-first + existence-checked,
   reconciler-retried design (D4) makes a partial failure recoverable without
-  duplicates; the operator is never left without a `master` grant.
+  duplicates; the operator is never left without an `owner` grant.
 - **`provisioning_state` looks like reversing "no status column"** → it is an
   *operational* lifecycle flag, explicitly distinct from the rejected
   business `verified` flag; called out so review does not read it as a
@@ -89,12 +106,15 @@ via the existing JetStream→PostHog path, keyed on `organizer_id` (admin-actor
    admin handler; provisioning client + reconciler; analytics; tests
    (incl. the compensating-retry and double-claim paths).
 3. frontend: admin console organizer-management screen.
+4. cloud-provisioning (hardening, from the `organizer-tenancy` code-review):
+   a dedicated provisioner workload + GCP SA for GCP-layer key-access isolation,
+   and a key-expiry monitoring alert for the provisioner key.
 - Rollback: additive tables + additive proto; remove the screen and tables
   (no tenant orgs exist until Create is used).
 
 ## Open Questions
 
 - Whether the initial operator is seeded in the same `Create` call or invited
-  immediately after — resolved as **same call** here (so the E2E "a master
+  immediately after — resolved as **same call** here (so the E2E "an owner
   signs in" is verifiable); revisit only if invite-later UX is needed (Phase
   2), which would not change these specs.

--- a/openspec/changes/organizer-accounts/proposal.md
+++ b/openspec/changes/organizer-accounts/proposal.md
@@ -27,14 +27,17 @@ and the console frontend are separate sub-changes (3/4, 4/4).
   already-claimed artists; reassignment = disassociate + associate.
 - Add **runtime tenant provisioning**: on `Create`, the backend calls the
   Zitadel Management API (via the `organizer-provisioner` machine user) to
-  create the Organizer's tenant org, set its passkey-only + domain-discovery
-  login policy, Project-Grant `organizer-console`, and seed the initial
-  operator as `master` — **idempotent/compensating** so a retry never
+  create the Organizer's tenant org, set its **passkey-primary** login policy
+  (mandatory recovery + workspace-IdP federation; NOT passkey-only, NOT
+  domain-discovery), Project-Grant `organizer-console`, and seed the initial
+  operator as `owner` — **idempotent/compensating** so a retry never
   duplicates the org and never leaves the operator without a grant.
 - Add the **operator first-sign-in bootstrap**: the initial operator is a
-  tenant human user with no password; Zitadel sends an init email; the
-  operator registers a **passkey** and signs into their org (resolved by
-  email domain discovery).
+  tenant human user with no password; Zitadel delivers a passkey-registration
+  init link; the operator registers a **passkey** and signs into their org
+  (org resolved by **org-pinned entry** — init link / remembered `org_id` /
+  org code / "email me a link" → the Zitadel `org:id` scope — not email
+  domain).
 - Add a **`deactivated` off-switch hook**: the backend rejects all organizer
   operations for a deactivated Organizer and its operators are deactivated
   in Zitadel; freed artists become re-associable. Full teardown cascade is

--- a/openspec/changes/organizer-accounts/specs/organizer-accounts/spec.md
+++ b/openspec/changes/organizer-accounts/specs/organizer-accounts/spec.md
@@ -14,13 +14,13 @@ Organizer with a name and an initial operator email. Creation is the vetting
 — there is no separate `verified` flag and no self-serve registration. An
 Organizer is distinct from an Artist and has its own OrganizerId. On success
 the Organizer is provisioned an isolated Zitadel tenant (see idempotent
-provisioning) with the initial operator seeded as its `master`.
+provisioning) with the initial operator seeded as its `owner`.
 
 #### Scenario: Admin creates an organizer
 
 - **WHEN** an operator with the `admin` role creates an Organizer with a name
   and an initial operator email
-- **THEN** the Organizer SHALL exist with an isolated tenant and a `master`
+- **THEN** the Organizer SHALL exist with an isolated tenant and a `owner`
   operator, and SHALL become an active organizer
 
 #### Scenario: Non-admin cannot create an organizer
@@ -38,23 +38,33 @@ provisioning) with the initial operator seeded as its `master`.
 ### Requirement: Initial operator bootstraps credentials on first sign-in
 
 The system SHALL create the initial operator as a human user in the
-Organizer's tenant org with no password, and trigger a Zitadel
-initialization email. The operator SHALL complete first sign-in by
-registering a passkey, and SHALL be routed to their own tenant org by email
-domain discovery (no org picker).
+Organizer's tenant org with no password (`request_passwordless_registration`),
+and deliver the Zitadel passkey-registration init link. The operator SHALL
+complete first sign-in by registering a passkey. The tenant org's login policy
+is **passkey-primary** with a mandatory recovery path (admin re-invite via
+re-issued init link) and permits workspace-IdP federation — NOT passkey-only,
+and NOT email-domain discovery. Org resolution is **org-pinned**: the operator
+is returned to their own tenant org via the org-scoped init link on first
+sign-in, and thereafter via an org handle (remembered `org_id`, or an org
+code / "email me a sign-in link") that the console turns into the Zitadel
+`urn:zitadel:iam:org:id:<orgId>` scope. (The login-policy shape + the
+`organizer-console` project/role are provided by `organizer-tenancy`; this
+change applies the policy per org and seeds the operator.)
 
-#### Scenario: Operator completes first sign-in via init email and passkey
+#### Scenario: Operator completes first sign-in via init link and passkey
 
-- **WHEN** an initial operator opens their initialization email and starts
-  first sign-in
+- **WHEN** an initial operator opens their passkey-registration init link and
+  starts first sign-in
 - **THEN** they SHALL register a passkey and be returned authenticated to
   their Organizer tenant org
 
-#### Scenario: Operator is routed to their org by email domain
+#### Scenario: Operator is routed to their org by org-pinned entry
 
-- **WHEN** the operator enters their email at login
-- **THEN** domain discovery SHALL route them to their Organizer tenant org
-  without an org picker
+- **WHEN** the operator returns to sign in
+- **THEN** the org SHALL be resolved by an org-pinned entry (org-scoped init
+  link, remembered `org_id`, or org code / "email me a link") and pinned via
+  the Zitadel `org:id` scope — never by raw email domain
+- **AND** a mismatched org entry SHALL simply fail auth (no cross-org access)
 
 ### Requirement: An artist is represented by at most one organizer
 
@@ -108,9 +118,9 @@ organizer-management screen.
 
 Creating an Organizer SHALL be idempotent and compensating across the
 tenant-provisioning steps (tenant org, login policy, project grant, operator
-+ master grant, and the persisted `zitadel_org_id`). A retry after a partial
++ owner grant, and the persisted `zitadel_org_id`). A retry after a partial
 failure SHALL complete provisioning without creating a duplicate Organizer or
-duplicate tenant org, and SHALL never leave the Organizer without a `master`
+duplicate tenant org, and SHALL never leave the Organizer without a `owner`
 operator.
 
 #### Scenario: Retry after mid-provisioning failure does not duplicate
@@ -119,11 +129,11 @@ operator.
 - **THEN** the system SHALL complete the remaining steps without creating a
   second Organizer or a second tenant org
 
-#### Scenario: Operator is never left without a master grant
+#### Scenario: Operator is never left without an owner grant
 
 - **WHEN** provisioning completes for an Organizer
 - **THEN** the Organizer SHALL have at least one operator holding the
-  `master` role
+  `owner` role
 
 ### Requirement: An organizer can be deactivated
 

--- a/openspec/changes/organizer-accounts/tasks.md
+++ b/openspec/changes/organizer-accounts/tasks.md
@@ -13,11 +13,12 @@
 
 ## 3. Backend — tenant provisioning & bootstrap
 
-- [ ] 3.1 Zitadel Management-API client (using the `organizer-provisioner` credential) — create org, set passkey-only + domain-discovery login policy, project-grant `organizer-console`, create operator user + `master` grant
+- [ ] 3.1 Zitadel Management-API client (using the `organizer-provisioner` credential, JWT-profile → short-lived tokens) — create org, set **passkey-primary** login policy (recovery + `allowExternalIDP` + `ignoreUnknownUsernames`; NOT passkey-only/domain-discovery), project-grant `organizer-console`, create operator user + `owner` grant
 - [ ] 3.2 Idempotent/compensating provisioning saga keyed on OrganizerId (DB-row-first, existence-checked steps, reconciler retry); persist `zitadel_org_id`; flip to `active`
-- [ ] 3.3 Operator bootstrap: no-password human user + Zitadel init email (passkey on first sign-in)
+- [ ] 3.3 Operator bootstrap: no-password human user + Zitadel passkey-registration init link (passkey on first sign-in); org resolution is org-pinned (not domain discovery)
 - [ ] 3.4 Deactivation: `deactivated` gate rejects organizer ops + deactivates Zitadel operators + frees artists
 - [ ] 3.5 OTel span + `organizer_provisioning_failed` metric on the provisioning call
+- [ ] 3.6 (hardening, from `organizer-tenancy` code-review) cloud-provisioning: dedicated provisioner workload + GCP SA to isolate GCP-layer read access to the provisioner key (so `backend-app` SA no longer reads the `IAM_ORG_MANAGER` key) + key-expiry monitoring alert for the finite provisioner key
 
 ## 4. Backend — analytics & tests
 
@@ -33,4 +34,4 @@
 
 - [ ] 6.1 Backend PR merged → release → prod pin bump; confirm rollout (depends on `organizer-tenancy` IaC applied in the env first)
 - [ ] 6.2 Frontend PR merged → release
-- [ ] 6.3 Verify in prod: an admin creates an Organizer (name + operator email) → tenant org + project grant + master operator provisioned; the operator completes init-email + passkey and signs into their org; associate/disassociate + deactivate behave per spec; analytics events land
+- [ ] 6.3 Verify in prod: an admin creates an Organizer (name + operator email) → tenant org + project grant + `owner` operator provisioned; the operator completes the passkey init link + passkey and signs into their org (org-pinned); associate/disassociate + deactivate behave per spec; analytics events land


### PR DESCRIPTION
## 🔗 Related Issue

Refs #759

<!-- Umbrella Phase-3 issue; planning reconciliation for the `organizer-accounts`
sub-change. References (does not close) #759. -->

## 📝 Summary of Changes

Reconcile the **`organizer-accounts`** OpenSpec planning artifacts with the
decisions that `organizer-tenancy` actually **shipped to prod** (after its
best-practice review). Without this, applying `organizer-accounts` would bake
the pre-revision design into code. Planning-only; no code, no proto.

- **`master` → `owner`** — the role/grant seeded for the initial operator now
  matches the shipped `organizer-console` `owner` role.
- **Login policy: passkey-only + domain-discovery → passkey-primary** with a
  mandatory recovery path (admin re-invite) + workspace-IdP federation
  (`allowExternalIDP`, `ignoreUnknownUsernames`).
- **Org resolution: domain-discovery → org-pinned** (org-scoped init link →
  remembered `org_id` → org code / "email me a link" → the `org:id` scope) —
  works for consumer/gmail operators, no per-tenant domain verification.
- **Operator bootstrap:** Zitadel **passkey-registration init link** (not a
  generic init email); no-password user via `request_passwordless_registration`.
- **Folded in the hardenings** the `organizer-tenancy` code-review deferred to
  this change: a **dedicated provisioner workload + GCP SA** (GCP-layer
  key-access isolation) and a **key-expiry monitoring alert** — new task **3.6**,
  design **D4** note, migration step **4**.

Files: `openspec/changes/organizer-accounts/{proposal,design,tasks,specs/organizer-accounts/spec}.md`.
`openspec validate --strict organizer-accounts` passes.

## ✅ Self-Checklist

- [x] Linked the related issue (Refs #759 — umbrella, intentionally not closed).
- [x] Planning artifacts reconciled with the shipped `organizer-tenancy` reality.
- [ ] `buf lint` / `buf format` — N/A (no proto).
- [ ] Breaking changes — N/A (docs/spec only).
