### PR TITLE
docs(openspec): reconcile organizer-console with shipped organizer-tenancy

### DIFF
--- a/openspec/changes/organizer-console/design.md
+++ b/openspec/changes/organizer-console/design.md
@@ -2,14 +2,14 @@
 
 See proposal.md - Why. Mirrors the admin console pattern (bundle-isolated
 entry + dedicated hosting) for the organizer surface. Depends on
-`organizer-tenancy` (the `organizer-console` OIDC app + per-tenant login
-policy with domain discovery). Full design:
+`organizer-tenancy` (the `organizer-console` OIDC app + per-tenant
+passkey-primary login policy). Full design:
 [`docs/organizer-platform-design.md`](../../../docs/organizer-platform-design.md).
 
 ## Goals / Non-Goals
 
-**Goals:** a bundle-isolated organizer entry, OIDC login via domain
-discovery, a role-claim route guard, a placeholder, and the dedicated
+**Goals:** a bundle-isolated organizer entry, OIDC login via org-pinned
+entry, a role-claim route guard, a placeholder, and the dedicated
 hosting.
 
 **Non-Goals:** business screens; the organizer API server
@@ -17,16 +17,22 @@ hosting.
 
 ## Decisions
 
-**D1 — One OIDC client, org resolved by domain discovery.** A single
-`organizer-console` client serves all tenants; the operator's org is resolved
-at login by email domain discovery (enabled on tenant orgs in
-`organizer-tenancy`). This is why the organizer `/config.json` omits a fixed
-`zitadelOrgId` — baking one in would break the multi-tenant single-app model.
+**D1 — One OIDC client, org resolved by org-pinned entry (not domain
+discovery).** A single `organizer-console` client serves all tenants; the
+operator's org is resolved at login by an **org handle** (org code/slug in the
+URL, a remembered `org_id`, or an app-level "email me a sign-in link"), which
+the console turns into the Zitadel `urn:zitadel:iam:org:id:<orgId>` scope. This
+is why the organizer `/config.json` omits a fixed `zitadelOrgId` — baking one
+in would break the multi-tenant single-app model. Email-domain discovery was
+dropped from the MVP in `organizer-tenancy` (redundant, and useless for
+consumer/gmail operators); this console implements the org-pinned path instead.
+A fresh device with no remembered `org_id` uses the org-code entry or the
+"email me a link" flow.
 
 **D2 — Role-claim route guard, backend is source of truth.** Unlike the admin
 console (where Google Workspace login *is* the wall), any tenant-org account
 authenticates successfully; the console guard therefore inspects the
-`organizer-console` project roles claim and admits only `master`. Real
+`organizer-console` project roles claim and admits only `owner`. Real
 enforcement is at the backend; the guard is UX.
 
 **D3 — Dedicated hosting mirrors admin-console-hosting.** `organizer.{base}`

--- a/openspec/changes/organizer-console/proposal.md
+++ b/openspec/changes/organizer-console/proposal.md
@@ -3,7 +3,7 @@
 Organizer operators need a place to sign in. This sub-change (3/4 of roadmap
 step ①) adds the **organizer console frontend + its hosting** — a
 bundle-isolated `organizer.html` entry authenticated against the operator's
-own Zitadel tenant org (via domain discovery), served at a dedicated host.
+own Zitadel tenant org (via org-pinned entry), served at a dedicated host.
 Business screens land in later changes; this establishes the
 access-controlled shell. Grounded in `docs/organizer-platform-design.md` and
 `docs/zitadel-tenancy-model.md`, tracked by liverty-music/specification#759.
@@ -15,10 +15,12 @@ Depends on `organizer-tenancy` (the `organizer-console` OIDC app).
   bundle-isolated from the consumer SPA and the admin console (no organizer
   code in the consumer chunk graph).
 - Authenticate via Zitadel OIDC using the shared `organizer-console` client;
-  the operator's tenant org is resolved by **email domain discovery** (no
-  fixed org id at build time, no org picker).
+  the operator's tenant org is resolved by **org-pinned entry** (an org
+  handle — org code/slug, remembered `org_id`, or re-issued sign-in link →
+  the `org:id` scope), NOT email domain (no fixed org id at build time, no
+  org picker).
 - Add a **route guard** that inspects the token's `organizer-console` project
-  roles and admits only operators holding `master`; unauthenticated visitors
+  roles and admits only operators holding `owner`; unauthenticated visitors
   are sent to sign-in; authenticated operators land on a post-login welcome
   placeholder.
 - Add **hosting** for the entry at `organizer.{base-domain}`
@@ -28,7 +30,7 @@ Depends on `organizer-tenancy` (the `organizer-console` OIDC app).
 - **Runtime config**: the organizer `/config.json` carries the issuer + the
   `organizer-console` client id + `apiBaseUrl = api.organizer.{base}`, and
   deliberately **omits a fixed `zitadelOrgId`** — the org is resolved at
-  login (domain discovery). This organizer config shape is specified in the
+  login by org-pinned entry (org handle). This organizer config shape is specified in the
   `organizer-console` capability; the consumer SPA's `frontend-runtime-config`
   contract is unchanged (it governs the consumer entry only).
 
@@ -40,7 +42,7 @@ reception check-in PWA.
 
 ### New Capabilities
 - `organizer-console`: the `organizer.html` bundle-isolated entry, OIDC
-  login via domain discovery, the role-claim route guard + placeholder, and
+  login via org-pinned entry, the role-claim route guard + placeholder, and
   the organizer runtime-config shape (no fixed org id).
 - `organizer-console-hosting`: the `organizer.{base}` host — HTTPRoute, TLS
   cert, Cloud DNS, and per-host `/config.json`.
@@ -53,7 +55,7 @@ reception check-in PWA.
 ## Impact
 
 - **frontend**: new `organizer.html` entry (bundle-isolated), OIDC via the
-  shared client with domain discovery, role-claim route guard, placeholder;
+  shared client with org-pinned entry, role-claim route guard, placeholder;
   a CI assertion that the consumer chunk graph contains no organizer module.
 - **cloud-provisioning**: the `organizer.{base}` host (HTTPRoute, cert, Cloud
   DNS) + per-host ConfigMap; mirrors `admin-console-hosting`. No proto

--- a/openspec/changes/organizer-console/specs/organizer-console/spec.md
+++ b/openspec/changes/organizer-console/specs/organizer-console/spec.md
@@ -2,7 +2,7 @@
 
 The organizer (seller) frontend shell: a dedicated `organizer.html` entry,
 bundle-isolated from the consumer SPA and admin console, authenticated
-against the operator's own Zitadel tenant org via domain discovery, with a
+against the operator's own Zitadel tenant org via org-pinned entry, with a
 role-claim route guard and a post-login placeholder. Business screens land
 in later changes.
 
@@ -21,19 +21,28 @@ the consumer SPA's downloaded bundle size or regress its Core Web Vitals.
 - **THEN** the consumer entry's chunk graph SHALL contain no module
   originating from the organizer source directory
 
-### Requirement: Authenticate operators via domain discovery, one client for all tenants
+### Requirement: Authenticate operators via org-pinned entry, one client for all tenants
 
 The organizer console SHALL authenticate operators through Zitadel OIDC
 (PKCE, no client secret) using the shared `organizer-console` client, with
-the operator's tenant org resolved by **email domain discovery** — the
-operator enters their email and is routed to their own org, with no fixed
-org id at build time and no org picker.
+the operator's tenant org resolved by **org-pinned entry** — NOT by email
+domain. The org is fixed by *where the operator enters*: the org-scoped
+passkey init link on first sign-in, then an **org handle** (an org code/slug
+in the URL, or a remembered `org_id`, or an app-level "email me a sign-in
+link"), which the console turns into the Zitadel
+`urn:zitadel:iam:org:id:<orgId>` scope on the OIDC request. There is no fixed
+org id at build time and no org picker. (Email-domain discovery is a future
+optional enhancement per `organizer-tenancy`, not used here — so consumer /
+free-mail operators work without per-tenant domain verification.)
 
-#### Scenario: Operator signs in and is routed to their org
+#### Scenario: Operator signs in and is routed to their org by org-pinned entry
 
-- **WHEN** an operator enters their email and completes sign-in
-- **THEN** domain discovery SHALL route them to their own Organizer tenant
-  org and return them authenticated to the console
+- **WHEN** an operator opens the console with an org handle (org code/slug or
+  a remembered `org_id`) and completes sign-in
+- **THEN** the console SHALL pin the org via the `org:id` scope and return
+  them authenticated to their own Organizer tenant org — never routing by raw
+  email domain
+- **AND** a mismatched org handle SHALL simply fail auth (no cross-org access)
 
 #### Scenario: One OIDC client serves all tenants
 
@@ -41,11 +50,11 @@ org id at build time and no org picker.
 - **THEN** the same `organizer-console` OIDC client SHALL serve them all (no
   per-tenant client, no build-time org id)
 
-### Requirement: Route guard admits only master-role operators
+### Requirement: Route guard admits only owner-role operators
 
 The organizer console SHALL guard its routes: unauthenticated visitors are
 sent to sign-in, and an authenticated user is admitted only if the token's
-`organizer-console` project roles include `master`; otherwise access is
+`organizer-console` project roles include `owner`; otherwise access is
 denied. The backend remains the source of truth for authorization; the guard
 is a UX gate. On success the operator lands on a post-login welcome
 placeholder.
@@ -55,15 +64,15 @@ placeholder.
 - **WHEN** an unauthenticated visitor navigates to an organizer console route
 - **THEN** the guard SHALL redirect them to Zitadel sign-in
 
-#### Scenario: Authenticated operator with master role sees the placeholder
+#### Scenario: Authenticated operator with owner role sees the placeholder
 
-- **WHEN** an authenticated operator whose token carries the `master` role
+- **WHEN** an authenticated operator whose token carries the `owner` role
   loads the console
 - **THEN** they SHALL see the post-login welcome placeholder
 
-#### Scenario: Authenticated account without the master role is denied
+#### Scenario: Authenticated account without the owner role is denied
 
-- **WHEN** an authenticated user whose token lacks the `master` role loads
+- **WHEN** an authenticated user whose token lacks the `owner` role loads
   the console
 - **THEN** the guard SHALL deny access to organizer screens
 
@@ -72,12 +81,15 @@ placeholder.
 The organizer console SHALL load its runtime config from `/config.json`
 carrying the Zitadel issuer, the `organizer-console` client id, and
 `apiBaseUrl` pointing at the organizer API host. It SHALL **omit a fixed
-organization id** — the tenant org is resolved at login via domain
-discovery, not baked into config.
+organization id** — one client serves all tenants and the tenant org is
+resolved at login by **org-pinned entry** (an org handle carried in the URL /
+remembered / re-issued sign-in link), not baked into config nor resolved by
+email domain.
 
 #### Scenario: Organizer config omits a fixed org id
 
 - **WHEN** the organizer console loads `/config.json`
 - **THEN** the config SHALL provide the issuer, `organizer-console` client
   id, and the organizer `apiBaseUrl`
-- **AND** it SHALL NOT require a fixed organization id
+- **AND** it SHALL NOT require a fixed organization id (the org is resolved
+  per session by org-pinned entry)

--- a/openspec/changes/organizer-console/tasks.md
+++ b/openspec/changes/organizer-console/tasks.md
@@ -1,8 +1,8 @@
 ## 1. Frontend
 
 - [ ] 1.1 `organizer.html` Vite/Rollup entry, bundle-isolated (separate chunk graph); reuse shared auth-service + config loader
-- [ ] 1.2 OIDC via the shared `organizer-console` client with email domain discovery (no fixed org id); post-login welcome placeholder
-- [ ] 1.3 Route guard: inspect the `organizer-console` project roles claim, admit only `master`, redirect unauthenticated to sign-in
+- [ ] 1.2 OIDC via the shared `organizer-console` client with org-pinned entry (org handle → `org:id` scope; org code / remembered `org_id` / "email me a link"; no fixed org id, NOT domain discovery); post-login welcome placeholder
+- [ ] 1.3 Route guard: inspect the `organizer-console` project roles claim, admit only `owner`, redirect unauthenticated to sign-in
 - [ ] 1.4 Organizer `/config.json` loader shape (issuer + `organizer-console` client id + `api.organizer` base; no fixed org id)
 - [ ] 1.5 CI assertion: consumer chunk graph contains no organizer module (reuse admin-console bundle-isolation check)
 - [ ] 1.6 `make check` passes
@@ -18,4 +18,4 @@
 
 - [ ] 3.1 Frontend PR merged → release → organizer.html shipped
 - [ ] 3.2 Cloud-provisioning PR merged → ArgoCD synced (host, cert, DNS, config)
-- [ ] 3.3 Verify in prod: `organizer.liverty-music.app` serves the console over TLS; an operator signs in via email domain discovery and (with `master`) sees the placeholder; a non-master account is denied; the consumer bundle is unaffected
+- [ ] 3.3 Verify in prod: `organizer.liverty-music.app` serves the console over TLS; an operator signs in via org-pinned entry and (with `owner`) sees the placeholder; a non-`owner` account is denied; the consumer bundle is unaffected


### PR DESCRIPTION
## 🔗 Related Issue

Refs #759

<!-- Umbrella Phase-3 issue; planning reconciliation for the `organizer-console`
sub-change. References (does not close) #759. -->

## 📝 Summary of Changes

Reconcile the **`organizer-console`** OpenSpec planning artifacts with the
decisions `organizer-tenancy` shipped to prod. Without this, the console would
be built against the pre-revision auth model. Planning-only; no code, no proto.

- **`master` → `owner`** — the route guard admits `owner`, matching the shipped
  `organizer-console` `owner` ProjectRole.
- **Auth: email domain discovery → org-pinned entry.** The org is resolved by
  an **org handle** (org code/slug in the URL, a remembered `org_id`, or an
  app-level "email me a sign-in link") turned into the Zitadel
  `urn:zitadel:iam:org:id:<orgId>` scope — not by email domain. This is
  **substantive**, not just wording: implementing org-pinned entry (incl. the
  fresh-device org-code / "email me a link" path) is the console's job, and it
  makes consumer/gmail operators work without per-tenant domain verification.
- **`/config.json`** still omits a fixed org id, but carries/derives an org
  handle instead of relying on domain discovery.

## 🔎 Triage — "all stale docs" swept

A repo-wide scan was done; only `organizer-console` was genuinely stale:
- **organizer-accounts** — already reconciled (#783, merged).
- **organizer-rpc-server** — already coherent (authz reads the roles claim
  generically; no hardcoded role).
- **organizer-tenancy main spec / `docs/organizer-platform-design.md`** — the
  remaining "domain discovery" / "passkey-only" mentions are **intentional**
  ("dropped from MVP / future optional enhancement" and "passkey-only-no-recovery
  prohibited").
- **identity-management** — fan (product-org) passkey-only + admin-org domain
  discovery, unrelated to organizer operators.
- **discovery-tap-sonic-feedback** — "master **output**" (audio), false positive.

`openspec validate --strict organizer-console` passes.

## ✅ Self-Checklist

- [x] Linked the related issue (Refs #759 — umbrella, intentionally not closed).
- [x] Planning artifacts reconciled with shipped `organizer-tenancy` reality.
- [ ] `buf lint` / `buf format` — N/A (no proto).
- [ ] Breaking changes — N/A (docs/spec only).
