### PR TITLE
docs(openspec): add filter-timetable-by-date change

### DIFF
--- a/openspec/changes/filter-timetable-by-date/.openspec.yaml
+++ b/openspec/changes/filter-timetable-by-date/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-15

--- a/openspec/changes/filter-timetable-by-date/design.md
+++ b/openspec/changes/filter-timetable-by-date/design.md
@@ -1,0 +1,56 @@
+## Context
+
+See proposal.md — Why. Current state, verified in code:
+
+- `ListByFollowerRequest` is an empty message; `listConcertsByFollowerQuery` has no date predicate, so past concerts are returned and rendered at the top of the chronological highway.
+- `ListByLocation` already models a date window with `from`/`to` of `entity.v1.LocalDate` (wrapping `google.type.Date`), and the frontend already sends client-supplied `CalendarDate`s for the "All Nearby" mode. This is the precedent to follow.
+- The dashboard filter bottom sheet already hosts artist and journey facets that narrow the **already-loaded** set purely client-side, with URL sync via `history.replaceState` (`artists`, `journey` params).
+- `ConcertStore.listByFollower` caches under a single key with 24h stale-while-revalidate.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Default the timetable to today-onward with a client-anchored "today".
+- Let the user widen the range into the past from a chosen date via a collapsible date facet, with URL persistence.
+- Reuse existing proto/UI conventions (LocalDate VO, bottom-sheet facet, URL sync).
+
+**Non-Goals:**
+- No `to`/upper-bound for the timetable — the date facet is open-ended (`>= from`); only a lower bound is added.
+- No change to "All Nearby" mode (already has its own from/to range).
+- No change to the artist/journey facets' semantics beyond the fact that their chip counts now compute over a possibly past-inclusive loaded set.
+- No DB migration (query predicate only).
+
+## Decisions
+
+### D1: Add `from` to `ListByFollowerRequest` rather than a new RPC
+Add `entity.v1.LocalDate from = 1;` (optional). Mirrors `ListByLocationRequest.from` and the "Proto Value Object Consistency" requirement. Additive field = wire-compatible; the behavioral default (future-only) is the only breaking aspect and it is the desired behavior.
+- *Alternative rejected*: a separate `ListPastByFollower` RPC — duplicates grouping/proximity logic and the caching path for no benefit.
+
+### D2: Client owns "today"; backend defaults to `CURRENT_DATE` when `from` is unset
+The frontend always sends `from = client local today` for the default view. Backend query becomes `AND e.local_event_date >= COALESCE($2, CURRENT_DATE)`. This keeps the date boundary correct across timezones (server is UTC; a user just after local midnight would otherwise see yesterday's shows drop or persist a day early). The `COALESCE` default protects any non-dashboard caller that omits `from`.
+- *Alternative rejected*: backend always uses `CURRENT_DATE` and ignores client date — simpler but reintroduces the UTC boundary skew the client-anchored approach avoids.
+
+### D3: Date facet triggers an RPC round-trip, not a client-side narrow
+Unlike artist/journey facets, changing `from` changes what the server returns, so it re-fetches `ListByFollower(from)`. The store cache key MUST incorporate `from` so switching between today-onward and a past date does not serve a stale set. Expanding into the past is the only case that fetches more data; the common default path is unchanged in cost.
+- *Consequence*: the artist/journey chip counts (spec'd as "over the loaded set") naturally recompute over the past-inclusive set once past concerts are loaded — this is acceptable and documented in the `dashboard-date-filter` spec.
+
+### D4: URL param + collapsible facet UI
+Add a single date query param (e.g. `from=YYYY-MM-DD`) synced via `replaceState`, matching `artists`/`journey`. In the sheet, the date facet is collapsed behind "過去のコンサートも表示" and expands to one date field ("この日付以降を表示"), committed by the shared confirm button. Clearing it back to today removes the param.
+
+## Risks / Trade-offs
+
+- **[Behavioral break for any consumer expecting past concerts from `ListByFollower`]** → The only current consumer is the dashboard, which is updated in the same coordinated release. The `COALESCE` default is explicit and documented; `from` remains optional on the wire.
+- **[Unbounded payload when a very old `from` is chosen]** → Acceptable: past widening is user-initiated and rare; the default path stays future-only and bounded. If it becomes a problem later, add pagination or a floor date — out of scope here.
+- **[Cache key regression]** → If `from` is omitted from the cache key, users would see a stale today-onward set after choosing a past date (or vice versa). Explicit task + test to key the cache on `from`.
+- **[Timezone correctness depends on client sending the right local date]** → Reuse the same client date source already used by "All Nearby" (frontend-plain-date-lib) to avoid a second date-source discrepancy.
+
+## Migration Plan
+
+Standard cross-repo proto coordination (see global protocol):
+1. specification: add `from` to `ListByFollowerRequest`, open PR (CI/lint/breaking).
+2. In parallel, prepare backend (query predicate + handler/use-case threading) and frontend (store/client `from` arg, cache key, date facet, URL sync) against the planned shape with TODO markers for generated types.
+3. Merge spec PR → publish Release tag → monitor `buf-release.yml` BSR gen.
+4. Upgrade generated packages (backend `go get`, frontend `npm install`), swap TODO placeholders for generated types, run `make check`.
+5. Open backend/frontend PRs once green locally; ship to prod.
+
+Rollback: revert the backend query predicate (returns to all-concerts) and/or frontend to not send `from`; the additive proto field can remain unused. No data migration to reverse.

--- a/openspec/changes/filter-timetable-by-date/proposal.md
+++ b/openspec/changes/filter-timetable-by-date/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+The dashboard "My Timetable" currently loads **all** concerts of followed artists, including past ones, because `ListByFollower` applies no date filter. Past concerts pile up at the top of the chronological list, pushing upcoming shows down and making the timetable harder to act on. Fans want the timetable to default to "from today onward", while still being able to look back at past concerts on demand (e.g. to revisit a show they attended).
+
+## What Changes
+
+- **BREAKING (behavioral, not wire)**: `ListByFollower` SHALL default to returning only concerts on/after the current date instead of all concerts. Existing callers that relied on receiving past concerts will now receive future-only results unless they opt in via the new parameter.
+- Add an optional `from` date parameter to `ListByFollowerRequest` (`entity.v1.LocalDate`, matching `ListByLocationRequest.from`). When provided, the service returns concerts on/after `from`; when omitted, it defaults to the current date.
+- The frontend dashboard SHALL always send `from` so the "today" boundary is anchored to the **client's** local date (avoids server-UTC vs client timezone off-by-one at date boundaries).
+- Add a **date facet** to the existing dashboard filter bottom sheet: a collapsed "過去のコンサートも表示" affordance that expands a single date field ("この日付以降を表示"). Selecting an earlier date re-fetches the timetable including past concerts from that date.
+- Persist the selected `from` in the dashboard URL (query param) so it survives reload and is shareable, consistent with the existing `artists` / `journey` filters.
+
+## Capabilities
+
+### New Capabilities
+- `dashboard-date-filter`: The dashboard timetable's date-based filtering — the URL-synced date query parameter, the collapsible date facet in the filter bottom sheet, its default (today onward) and past-inclusive states, and the RPC round-trip re-fetch it triggers (distinct from the client-side artist/journey facets).
+
+### Modified Capabilities
+- `live-events`: The `ListByFollower` RPC contract (Live Schedule Access → "List Concerts by Follower") changes to default to future-only results and to accept an optional `from` date that widens the range into the past.
+
+## Impact
+
+- **specification**: `ListByFollowerRequest` gains a `from` field (`entity.v1.LocalDate`). Additive proto change (non-breaking on the wire); triggers BSR regeneration and a new schema version.
+- **backend**: `listConcertsByFollowerQuery` gains a `local_event_date >= $2` predicate; handler/use case thread the `from` value (defaulting to `CURRENT_DATE` when unset). No DB migration.
+- **frontend**: `ConcertClient.listByFollower` / `ConcertStore` gain a `from` argument; the store cache key incorporates `from`; the dashboard filter bottom sheet gains the date facet and URL sync. The per-artist / journey chip counts recompute over the newly loaded (possibly past-inclusive) set.
+- **cross-repo**: Standard proto → BSR → backend/frontend release coordination applies (spec PR → merge → Release → BSR gen → consumer upgrade → type swap).

--- a/openspec/changes/filter-timetable-by-date/specs/dashboard-date-filter/spec.md
+++ b/openspec/changes/filter-timetable-by-date/specs/dashboard-date-filter/spec.md
@@ -1,0 +1,81 @@
+## Purpose
+
+Defines the dashboard timetable's date-based filtering: a URL-synchronised date query parameter, the collapsible date facet in the filter bottom sheet ("過去のコンサートも表示" → "この日付以降を表示"), the default today-onward view, and the past-inclusive re-fetch it triggers. Unlike the artist and journey facets, which narrow the already-loaded set client-side, the date facet changes what the server returns via a `ListByFollower` round-trip.
+
+## ADDED Requirements
+
+### Requirement: Default today-onward timetable
+
+The dashboard "My Timetable" SHALL, by default, display only concerts whose date is on or after the current local date. The "today" boundary SHALL be anchored to the client's local date, and the dashboard SHALL request the timetable by passing that date as the `from` argument to `ListByFollower`.
+
+#### Scenario: Fresh load defaults to today onward
+
+- **WHEN** the user opens `/dashboard` with no date query parameter
+- **THEN** the timetable SHALL request `ListByFollower` with `from` set to the client's current local date
+- **AND** only concerts on or after today SHALL be displayed
+- **AND** past concerts of followed artists SHALL NOT be displayed
+
+#### Scenario: Empty upcoming timetable
+
+- **WHEN** the default (today-onward) timetable contains no upcoming concerts for the user's followed artists
+- **THEN** the empty-state placeholder SHALL be displayed
+- **AND** the "過去のコンサートも表示" affordance SHALL remain available so the user can look back
+
+### Requirement: URL-driven date filter
+
+The dashboard SHALL accept a date query parameter (e.g. `from`) containing a single calendar date. When present, the timetable SHALL display concerts on or after that date, including past concerts when the date precedes today. When absent, the timetable SHALL behave as the default today-onward view.
+
+#### Scenario: Past date from URL
+
+- **WHEN** the user navigates to `/dashboard?from=<pastDate>`
+- **THEN** the timetable SHALL request `ListByFollower` with `from = <pastDate>`
+- **AND** concerts on or after `<pastDate>` (including past ones) SHALL be displayed
+
+#### Scenario: Invalid or malformed date value
+
+- **WHEN** the date query parameter is missing, empty, or not a valid calendar date
+- **THEN** it SHALL be ignored and the default today-onward view SHALL be shown
+
+#### Scenario: Future date from URL
+
+- **WHEN** the date query parameter is a date after today
+- **THEN** the timetable SHALL display only concerts on or after that future date
+
+### Requirement: Date facet in the filter bottom sheet
+
+The filter bottom sheet SHALL include a date facet presented as a collapsed affordance labelled "過去のコンサートも表示". Expanding it SHALL reveal a single date field labelled "この日付以降を表示" for choosing the earliest date to display. The facet SHALL coexist with the existing artist and journey facets in the same sheet and be committed by the same confirm action.
+
+#### Scenario: Expanding the date facet
+
+- **WHEN** the user taps "過去のコンサートも表示" in the filter bottom sheet
+- **THEN** a single date field ("この日付以降を表示") SHALL be revealed
+- **AND** the field SHALL default to the currently active `from` date (today when the default view is active)
+
+#### Scenario: Choosing a past date and confirming
+
+- **WHEN** the user picks a date earlier than today in the date field and taps confirm
+- **THEN** the bottom sheet SHALL close
+- **AND** the dashboard URL SHALL update to carry the chosen date without a full page reload
+- **AND** the timetable SHALL re-fetch via `ListByFollower` with `from` set to the chosen date and display the past-inclusive result
+
+#### Scenario: Collapsing back to today onward
+
+- **WHEN** a past date is active and the user clears the date facet (returns it to the default) and confirms
+- **THEN** the date query parameter SHALL be removed from the URL
+- **AND** the timetable SHALL revert to the default today-onward view
+
+#### Scenario: Date facet combines with artist and journey facets
+
+- **WHEN** a past `from` date is active together with an artist and/or journey filter
+- **THEN** the timetable SHALL first load all followed-artist concerts on or after `from`, then narrow that set by the active artist and journey facets
+- **AND** the per-artist and journey chip counts SHALL be computed over the loaded (past-inclusive) set
+
+### Requirement: Date filter state persistence
+
+The active date filter SHALL survive a page reload and be shareable via the URL, consistent with the existing artist and journey filters.
+
+#### Scenario: Reload preserves the date filter
+
+- **WHEN** the user reloads the page while a past `from` date is active
+- **THEN** the date query parameter SHALL be re-parsed from the URL
+- **AND** the same past-inclusive timetable SHALL be restored

--- a/openspec/changes/filter-timetable-by-date/specs/live-events/spec.md
+++ b/openspec/changes/filter-timetable-by-date/specs/live-events/spec.md
@@ -1,0 +1,31 @@
+## MODIFIED Requirements
+
+### Requirement: Live Schedule Access
+
+The system MUST provide access to the collected schedule of concerts.
+
+#### Scenario: List Concerts
+
+- **WHEN** `ListConcerts` is called for a valid artist ID
+- **THEN** the system MUST return a chronologically sorted list of future concerts for that artist.
+
+#### Scenario: List Concerts by Follower
+
+- **WHEN** `ListByFollower` is called by an authenticated user
+- **THEN** the system MUST return concerts for all artists followed by that user, grouped by date and classified into home/nearby/away lanes
+- **AND** by default (no `from` provided) the result SHALL include only concerts whose local event date is on or after the current date
+- **AND** each group SHALL contain a calendar date and three concert lists (home, nearby, away)
+- **AND** groups SHALL be ordered by date ascending
+- **AND** lane classification SHALL be performed by the backend using the proximity classification model
+- **AND** the result SHALL be retrieved in a single RPC call
+
+#### Scenario: List Concerts by Follower from a given date
+
+- **WHEN** `ListByFollower` is called with a `from` date
+- **THEN** the system SHALL return concerts for the user's followed artists whose local event date is on or after `from`, including dates in the past when `from` is before the current date
+- **AND** the grouping, lane classification, and date-ascending ordering SHALL be identical to the default call
+
+#### Scenario: List Concerts by Follower with no matching concerts
+
+- **WHEN** `ListByFollower` is called and no followed-artist concert falls on or after the effective start date
+- **THEN** the system SHALL return an empty list of groups (not an error)

--- a/openspec/changes/filter-timetable-by-date/tasks.md
+++ b/openspec/changes/filter-timetable-by-date/tasks.md
@@ -1,0 +1,31 @@
+## 1. Specification (proto)
+
+- [ ] 1.1 Add optional `from` field (`entity.v1.LocalDate from = 1;`) to `ListByFollowerRequest` in `concert_service.proto`, with a doc comment describing the today-onward default when omitted
+- [ ] 1.2 Run buf lint/format/breaking locally-equivalent checks; open the specification PR
+- [ ] 1.3 After review + CI pass, merge and publish a Release tag; monitor `buf-release.yml` BSR generation to success
+
+## 2. Backend implementation (prepare in parallel with §1)
+
+- [ ] 2.1 Thread a `from` (nullable date) argument through the concert handler → use case → repository for `ListByFollower`
+- [ ] 2.2 Add `AND e.local_event_date >= COALESCE($2, CURRENT_DATE)` to `listConcertsByFollowerQuery`, binding `from` (or nil) as `$2`
+- [ ] 2.3 Map the request `from` LocalDate to the repository argument in the handler (TODO marker until generated types land)
+- [ ] 2.4 Unit tests: default (nil) returns future-only; explicit past `from` returns past-inclusive; empty result returns empty groups, not error
+- [ ] 2.5 After BSR gen: `go get` the new schema version, `go mod tidy`, swap TODO placeholders for generated types, `make check`
+
+## 3. Frontend implementation (prepare in parallel with §1)
+
+- [ ] 3.1 Add a `from` argument to `ConcertClient.listByFollower` (wrap in `LocalDate`) and to `ConcertStore.listByFollower`; incorporate `from` into the store cache key
+- [ ] 3.2 Dashboard: on default load, pass the client's current local date as `from` (reuse the existing plain-date lib / All-Nearby date source)
+- [ ] 3.3 Parse and validate the `from` query param from the URL; ignore missing/malformed values (fall back to today-onward)
+- [ ] 3.4 Add the collapsible date facet to the filter bottom sheet: "過去のコンサートも表示" affordance → single "この日付以降を表示" date field, committed by the shared confirm button
+- [ ] 3.5 On confirm, sync the chosen date to the URL via `replaceState`; clearing back to today removes the param and reverts to today-onward
+- [ ] 3.6 Re-fetch `ListByFollower(from)` on date change; ensure artist/journey chip counts recompute over the loaded (past-inclusive) set
+- [ ] 3.7 Empty-state: when the default view has no upcoming concerts, keep the "過去のコンサートも表示" affordance available
+- [ ] 3.8 Tests: URL round-trip (reload preserves `from`), default today-onward request, past-date re-fetch, combined artist+journey+date facets
+- [ ] 3.9 After BSR gen: `npm install` the new schema package, swap TODO placeholders for generated types, `make check`
+
+## 4. Ship & verify
+
+- [ ] 4.1 Open backend and frontend PRs once green locally; merge after CI + review
+- [ ] 4.2 Cut backend and frontend releases; confirm prod rollout (ArgoCD sync / pin bump)
+- [ ] 4.3 Prod verify: dashboard defaults to today-onward; expanding "過去も表示" with a past date shows past concerts; reload preserves the filter


### PR DESCRIPTION
## 🔗 Related Issue

Closes #785

## 📝 Summary of Changes

Adds the OpenSpec change **`filter-timetable-by-date`** (planning artifacts only — no proto/code yet).

**Motivation:** The dashboard "My Timetable" loads *all* concerts of followed artists, including past ones, because `ListByFollower` applies no date filter. Past shows pile up at the top of the chronological highway and push upcoming concerts down.

**What this change specifies:**
- **`live-events` (MODIFIED):** `ListByFollower` defaults to returning only concerts on/after the current date, and accepts an optional `from` date that widens the range into the past.
- **`dashboard-date-filter` (NEW):** URL-synced date query param, a collapsible date facet in the filter bottom sheet ("過去のコンサートも表示" → "この日付以降を表示"), the default today-onward view, and the RPC round-trip re-fetch it triggers (distinct from the client-side artist/journey facets).

**Technical approach (see `design.md`):**
- Add `entity.v1.LocalDate from = 1;` to `ListByFollowerRequest`, mirroring `ListByLocationRequest.from` (additive, wire-compatible).
- Backend query gains `AND e.local_event_date >= COALESCE($2, CURRENT_DATE)`; no DB migration.
- The frontend always sends the client's local "today" as `from` so the date boundary stays correct across timezones.
- The store cache key incorporates `from`.

This PR contains only the specification (`proposal` / `specs` / `design` / `tasks`). `openspec validate --strict` passes. Backend/frontend implementation follows the standard proto → BSR → consumer coordination once merged and released.

## ✅ Self-Checklist

- [x] I have linked the related issue.
- [x] I have updated the relevant documentation (OpenSpec artifacts under `openspec/changes/`).
- [ ] I have run `buf lint` and `buf format` locally and all checks have passed. — *N/A: no `.proto` changes in this PR (spec/docs only).*
- [x] My proto definitions follow the project's style guidelines and validation rules. — *proposed shape follows the `LocalDate` VO convention.*
- [ ] Breaking changes have been justified and documented if applicable. — *N/A on the wire; the behavioral default change (future-only) is documented in `proposal.md` / `design.md`.*
