### PR TITLE
feat(concert): add optional `from` date to ListByFollowerRequest

### DIFF
--- a/proto/liverty_music/rpc/concert/v1/concert_service.proto
+++ b/proto/liverty_music/rpc/concert/v1/concert_service.proto
@@ -72,9 +72,17 @@ message ListResponse {
 }
 
 // ListByFollowerRequest is the request for retrieving concerts for all artists
-// followed by the authenticated user. No fields are required; the user identity
-// is determined from the authentication context.
-message ListByFollowerRequest {}
+// followed by the authenticated user. The user identity is determined from the
+// authentication context.
+message ListByFollowerRequest {
+  // Optional. The inclusive start of the date range (venue-local calendar date).
+  // When provided, only concerts whose local event date is on or after this date
+  // are returned, including dates in the past when it precedes the current date.
+  // When omitted, the result defaults to concerts on or after the current date
+  // (today onward). Dashboard callers should send the client's local date to
+  // anchor the "today" boundary to the caller's timezone.
+  entity.v1.LocalDate from = 1;
+}
 
 // ListByFollowerResponse contains concerts for all artists followed by the caller,
 // grouped by date and classified by geographic proximity.


### PR DESCRIPTION
## Summary
Adds an optional `entity.v1.LocalDate from` field to `ListByFollowerRequest` so the dashboard "My Timetable" can default to **today-onward** and widen into the past on demand.

- Mirrors `ListByLocationRequest.from` (same `LocalDate` VO / from-convention).
- Additive, wire-compatible field. The behavioral default (future-only when omitted) is the intended change; the backend `COALESCE($2, CURRENT_DATE)` predicate applies it.
- The frontend always sends the client's local "today" so the boundary is timezone-correct.

## Checks
- `buf format -w` / `buf lint` / `buf breaking` (against `main`) all pass locally.

## Downstream (coordinated release)
After merge → Release `vX.Y.Z` → `buf-release.yml` BSR gen → backend & frontend consume the new schema and swap their TODO placeholders. Backend & frontend implementations are already prepared locally against this shape.

OpenSpec change: `filter-timetable-by-date` (docs merged in #786).

Refs: #785