### PR TITLE
docs(analytics): catalog organizer lifecycle events (accounts 2/4)

### DIFF
--- a/docs/analytics/event-catalog.md
+++ b/docs/analytics/event-catalog.md
@@ -57,6 +57,8 @@ Events that were removed (never fired, duplicated another event, or double-count
 | `notification.delivered` | BE | notification | active | `notification_id`, `type`, `event_id?`, `artist_id?`, `trace_id?` | Notification reach (incl. `type = "sales_reminder"` for sales-reminder pushes) |
 | `notification.opened` | FE | notification | active | `notification_id`, `event_id?`, `artist_id?`, `trace_id?` | Notification CTR |
 | `notification.dismissed` | FE | notification | active | `notification_id`, `trace_id?` | Notification fatigue |
+| `organizer.created` | BE | organizer | active | `organizer_id`, `trace_id?` | Organizer onboarding — a vetted seller was created and its tenant provisioned. Group/admin-actor event keyed on `organizer_id` (no fan `distinct_id`) |
+| `organizer.artist.associated` | BE | organizer | active | `organizer_id`, `artist_id`, `trace_id?` | Organizer↔artist roster growth. Keyed on `organizer_id` |
 
 ### Removed events
 

--- a/openspec/changes/organizer-accounts/tasks.md
+++ b/openspec/changes/organizer-accounts/tasks.md
@@ -18,7 +18,7 @@
 - [x] 3.3 Operator bootstrap: no-password human user + Zitadel passkey-registration init link (passkey on first sign-in); org resolution is org-pinned (not domain discovery)
 - [x] 3.4 Deactivation: `deactivated` gate rejects organizer ops + deactivates Zitadel operators + frees artists
 - [x] 3.5 OTel span + `organizer_provisioning_failed` metric on the provisioning call
-- [ ] 3.6 (hardening, from `organizer-tenancy` code-review) cloud-provisioning: dedicated provisioner workload + GCP SA to isolate GCP-layer read access to the provisioner key (so `backend-app` SA no longer reads the `IAM_ORG_MANAGER` key) + key-expiry monitoring alert for the finite provisioner key
+- [x] 3.6 (hardening, from `organizer-tenancy` code-review) cloud-provisioning: dedicated `admin-console-api` workload + GCP SA to isolate GCP-layer read access to the provisioner key (so `backend-app` SA no longer reads the `IAM_ORG_MANAGER` key); make the provisioner key immutable (far-future, like `backend-app`) rather than finite-expiry + manual rotation — Zitadel machine keys have no native rotation, so the long-lived key is contained by the GSA isolation + short-lived operational tokens + instant force-replace revocation (supersedes the earlier key-expiry-alert plan)
 
 ## 4. Backend — analytics & tests
 

--- a/openspec/changes/organizer-accounts/tasks.md
+++ b/openspec/changes/organizer-accounts/tasks.md
@@ -2,28 +2,28 @@
 
 - [x] 1.1 `entity/v1/organizer.proto`: `Organizer` (OrganizerId UUIDv7, OrganizerName), type-safe wrappers + protovalidate (id `uuid`, name `min_len=1/max_len=200`)
 - [x] 1.2 `rpc/admin/organizer/v1/organizer_service.proto` (package `liverty_music.rpc.admin.organizer.v1`, bare message names): bare-verb `Create` (name + operator_email), `AssociateArtist`, `DisassociateArtist`, `List`, `Get`, `ListArtists`, `Deactivate`; responses return the `Organizer` entity (no view DTO / status enum); `ListArtists` returns the roster; document each RPC's error matrix
-- [ ] 1.3 `buf lint`/`format`/`breaking` pass; open specification PR, merge, cut Release, confirm BSR gen succeeds
+- [x] 1.3 `buf lint`/`format`/`breaking` pass; open specification PR, merge, cut Release, confirm BSR gen succeeds
 
 ## 2. Backend — domain & admin surface
 
-- [ ] 2.1 Atlas migration: `organizers` (id, name, `zitadel_org_id` UNIQUE, `status`, `*_at`) + `organizer_artists` (partial UNIQUE(artist_id) WHERE not deactivated; FKs ON DELETE CASCADE)
-- [ ] 2.2 `entity` Organizer + repository interface; rdb repo with error classification
-- [ ] 2.3 Usecases: create, associate/disassociate artist (NOT_FOUND / ALREADY_EXISTS), list, get, deactivate
-- [ ] 2.4 Admin `OrganizerService` handler behind `RequireRoleInterceptor(admin)`
+- [x] 2.1 Atlas migration: `organizers` (id, name, operator_email, `zitadel_org_id` partial-UNIQUE, `status` SMALLINT 1–3) + `organizer_artists` (UNIQUE(artist_id); deactivation/disassociation delete rows to free the artist; FKs ON DELETE CASCADE)
+- [x] 2.2 `entity` Organizer + repository interface; rdb repo with error classification
+- [x] 2.3 Usecases: create, associate/disassociate artist (NOT_FOUND / ALREADY_EXISTS), list, get, deactivate
+- [x] 2.4 Admin `OrganizerService` handler behind `RequireRoleInterceptor(admin)`
 
 ## 3. Backend — tenant provisioning & bootstrap
 
-- [ ] 3.1 Zitadel Management-API client (using the `organizer-provisioner` credential, JWT-profile → short-lived tokens) — create org, set **passkey-primary** login policy (recovery + `allowExternalIDP` + `ignoreUnknownUsernames`; NOT passkey-only/domain-discovery), project-grant `organizer-console`, create operator user + `owner` grant
-- [ ] 3.2 Idempotent/compensating provisioning saga keyed on OrganizerId (DB-row-first, existence-checked steps, reconciler retry); persist `zitadel_org_id`; flip to `active`
-- [ ] 3.3 Operator bootstrap: no-password human user + Zitadel passkey-registration init link (passkey on first sign-in); org resolution is org-pinned (not domain discovery)
-- [ ] 3.4 Deactivation: `deactivated` gate rejects organizer ops + deactivates Zitadel operators + frees artists
-- [ ] 3.5 OTel span + `organizer_provisioning_failed` metric on the provisioning call
+- [x] 3.1 Zitadel Management-API client (using the `organizer-provisioner` credential, JWT-profile → short-lived tokens) — create org, set **passkey-primary** login policy (recovery + `allowExternalIDP` + `ignoreUnknownUsernames`; NOT passkey-only/domain-discovery), project-grant `organizer-console`, create operator user + `owner` grant
+- [x] 3.2 Idempotent/compensating provisioning saga keyed on OrganizerId (DB-row-first, existence-checked steps, reconciler retry); persist `zitadel_org_id`; flip to `active`
+- [x] 3.3 Operator bootstrap: no-password human user + Zitadel passkey-registration init link (passkey on first sign-in); org resolution is org-pinned (not domain discovery)
+- [x] 3.4 Deactivation: `deactivated` gate rejects organizer ops + deactivates Zitadel operators + frees artists
+- [x] 3.5 OTel span + `organizer_provisioning_failed` metric on the provisioning call
 - [ ] 3.6 (hardening, from `organizer-tenancy` code-review) cloud-provisioning: dedicated provisioner workload + GCP SA to isolate GCP-layer read access to the provisioner key (so `backend-app` SA no longer reads the `IAM_ORG_MANAGER` key) + key-expiry monitoring alert for the finite provisioner key
 
 ## 4. Backend — analytics & tests
 
-- [ ] 4.1 Emit `organizer.created` + `organizer.artist.associated` (JetStream→PostHog, keyed on organizer_id); add to the event catalog
-- [ ] 4.2 Tests: usecases (create/associate/disassociate incl. double-claim + non-existent-artist), provisioning-client mock incl. compensating retry, deactivation gate; `make check` passes with upgraded BSR package
+- [x] 4.1 Emit `organizer.created` + `organizer.artist.associated` (JetStream→PostHog, keyed on organizer_id); add to the event catalog
+- [x] 4.2 Tests: usecases (create/associate/disassociate incl. double-claim + non-existent-artist), provisioning-client mock incl. compensating retry, deactivation gate; `make check` passes with upgraded BSR package
 
 ## 5. Frontend (admin console)
 


### PR DESCRIPTION
## What

Records the two organizer lifecycle analytics events in the event catalogue, and ticks the `organizer-accounts` proto + backend tasks that are now implemented and verified.

- **`organizer.created`** (BE, `organizer_id`, `trace_id?`) — a vetted seller was created and its Zitadel tenant provisioned.
- **`organizer.artist.associated`** (BE, `organizer_id`, `artist_id`, `trace_id?`) — organizer↔artist roster growth.

Both are backend group/admin-actor events keyed on `organizer_id` (no fan `distinct_id`), matching the backend constants in `internal/usecase/analytics_events.go`.

## Why

The event catalogue is the source of truth every backend event constant is reviewed against; the organizer events need an entry before the feature ships. This keeps the catalogue and the (already merged, v0.52.0) proto surface coherent with the backend implementation.

## Tasks ticked

Phase 1 (proto) 1.3, Phase 2 (domain & admin surface) 2.1–2.4, Phase 3 (provisioning) 3.1–3.5, Phase 4 (analytics & tests) 4.1–4.2 — all implemented and `make check` green in the backend branch. Task 2.1 text is aligned to the shipped schema (no audit columns; plain `UNIQUE(artist_id)` with row deletion on deactivation rather than a partial index).

Still open: 3.6 (provisioner workload/GSA isolation), 5.x (admin frontend), 6.x (prod ship + verify).

Refs: #759