### PR TITLE
docs: payments design + market notes + roadmap calibrations

### DIFF
--- a/docs/market-design-notes.md
+++ b/docs/market-design-notes.md
@@ -1,0 +1,67 @@
+# Market & Competitor Design Notes (JP ticketing, 2025-2026)
+
+Durable record of the competitor / market research behind the Phase 3
+ticketing roadmap, so the design rationale and the two roadmap calibrations
+below are not lost. Sources: LivePocket, tiget, ZAIKO, teket (DNP),
+チケプラ, ぴあ/e+, チケミー; デジタル庁 マイナンバー実証 2025;
+チケトレ shutdown 2025-06; LINEチケット exit 2022.
+
+## Verdict
+
+Our direction **aligns strongly** with where the JP market is heading, and
+our sharpest differentiator — **proactive fan auto-notification/discovery** —
+is a **white space** among the "後発" (later-generation) pure-plays
+(teket / ZAIKO / Peatix don't do it; only legacy ぴあ does a weaker version).
+Two calibrations are warranted (below). Web2 (no blockchain) is validated —
+NFT ticketing retreated to a theater niche (チケミー); the mainstream is
+Web2 + face-auth.
+
+## Dominant 後発 patterns (adopt)
+
+- Zero-fixed-cost, revenue-share-only; **buyer-shiftable flat %** fee (a flat
+  % reads cleaner than tiget's stacked ¥220+¥99, which draws complaints).
+- **Organizer self-serve is table-stakes** (teket/ZAIKO), not a
+  differentiator. (We deliberately chose **vetted partners** for MVP — a
+  conscious divergence; our moat is fan-notification + curation, and
+  self-serve can open later.)
+- **In-platform official face-value resale** is now the market default
+  (after the industry チケトレ shut down 2025-06 and resale moved inside
+  チケプラTrade / e+ / ぴあ).
+- Companion **分配URL (organizer-toggle, returnable)** is standard; plus
+  multi-ticket single-buyer group entry (teket/スマチケ).
+- Rotating QR + server-side one-time validation is **baseline** (not novel).
+
+## Trend: identity at entry (the moving competitive bar)
+
+- **Hardware-free, on-device face-auth entry** shipped (チケプラ, 2025-12) —
+  removes the operator-tablet barrier and is becoming the anti-scalp bar for
+  high-demand tours. Photo-bound tickets are now the floor at the leaders.
+- **マイナンバーカード linkage** (デジタル庁 2025 実証): zero fraud on linked
+  tickets, but low linkage (13-28%) + install friction → treat as an
+  **opt-in high-assurance tier**, not mandatory.
+
+## Roadmap calibrations (folded into ticketing-platform-roadmap.md)
+
+- **#2 Pull `official-resale` earlier.** It is both the cannot-attend valve
+  and now a market default. Promote from deep Phase 2 to **immediately after
+  the lottery/ticketing MVP** (tie it to the lottery loser pool).
+- **#3 Add a face-auth anti-scalp tier.** Our ⑥ rotating-QR + Passkey is the
+  floor; add **photo-bound → live-face-match-to-open** as a Phase-2 tier, and
+  **マイナンバー** as an opt-in high-assurance option. Without it we look a
+  generation behind the leaders.
+
+## Watch (not yet calibrations)
+
+- **#4 分配 reconsideration:** the market norm is organizer-toggle,
+  returnable, name-bound 分配URL. Our "same-time entry only, no distribution
+  URL" is more restrictive; with name-binding/face-auth a returnable,
+  account-bound 分配 is scalp-safe and more convenient. Revisit at ⑥.
+- **#1 vetted-only vs zero-gate self-serve:** conscious divergence; keep for
+  MVP, keep open-self-serve as a future option.
+- **#5 fee model:** flat %, buyer-shiftable → see `payments-design.md`.
+
+## The moat, in one line
+
+No 後発 competitor bundles **fan auto-notification × lottery × in-platform
+official resale × hardware-free face-auth** in one app. Our existing
+fan-notification product is that core.

--- a/docs/payments-design.md
+++ b/docs/payments-design.md
@@ -1,0 +1,121 @@
+# Payments Design (Phase 3 ⑤)
+
+Durable design for the ticket **payment** track — the input to the roadmap
+change `ticket-purchase-and-issuance` (⑤). Consolidates the research and
+decisions tracked in issue liverty-music/specification#778 so they are not
+lost in ephemeral notes. Not legal advice — the counsel flags below must be
+confirmed before launch.
+
+Grounded in `ticketing-platform-roadmap.md` (Deferred Payment Details) and
+the competitor/market research in `market-design-notes.md`.
+
+## Decisions (settled)
+
+- **Provider: Stripe Connect.** Chosen for breadth + DX. Money is
+  **platform-intermediated** (Liverty collects, takes a fee, pays out the
+  Organizer). *Challenger to PoC:* **KOMOJU (Degica)** is arguably a better
+  fit for a JP lottery (authorize→split-at-capture, deepest JP methods) —
+  run a serious PoC before locking in. Adyen for Platforms is the
+  enterprise-scale "graduation" target.
+- **Connect charge model:** **destination charges + `on_behalf_of=<organizer>`
+  + `application_fee_amount`.** The Organizer is the settlement merchant on
+  the buyer's statement (matches "Organizer = seller-of-record", below).
+- **Methods: card-only for MVP** (incl. **debit / prepaid** cards — the
+  cardless-fan substitute — and Apple Pay / Google Pay, which are just
+  `card` wallets). **Konbini / PayPay are out of scope** for MVP (async
+  settlement, ¥300k caps, PayPay's Connect incompatibility). The domain
+  entity is provider- and method-agnostic, so they can be added later
+  without a proto break. Trade-off: card-only excludes some cardless
+  students/minors — accepted for a vetted-partner MVP, revisit on demand.
+- **Lottery charge mechanism: `SetupIntent`-primary, NOT auth-hold.** This
+  is the load-bearing correction (see Why below). At application, save the
+  card via a `SetupIntent` (`usage=off_session`) — **no hold on the buyer's
+  credit**. At the draw, charge **only winners** via an off-session
+  `PaymentIntent` (MIT). A full-amount authorization hold is a narrow
+  exception (high-value / extreme-scarcity where a funds guarantee matters).
+- **Winner-charge-failure flow (required):** a saved card can fail at draw
+  (expiry / insufficient funds / authentication_required). Grace + a
+  re-auth link with a deadline → else **当選無効 → 繰上げ (waitlist)** — the
+  JP "unpaid-by-deadline → void" convention. Do not collect CVC at draw
+  (would reclassify as CIT).
+- **Payout: hold to event + dispute window.** Organizer accounts on
+  **manual payout**; release via Payouts API **after the event AND a
+  dispute-safety buffer** (chargebacks arrive days-to-weeks later — "after
+  event" alone is too early). Refunds via `Refund` (platform balance) +
+  `transfer_reversal` to claw the Organizer's share.
+- **Webhooks are the source of truth** for capture / refund / dispute — never
+  issue tickets on the client confirm alone. Idempotent handlers.
+- **Fee model: a flat percentage, buyer-shiftable.** A single clean % (like
+  LivePocket's flat 5%) reads better than a stacked per-ticket fee (tiget's
+  ¥220+¥99 draws complaints). Buyer-pass-through toggle → organizer cost can
+  be ¥0. Exact rate is a business decision (#778).
+
+### Why SetupIntent, not an authorization hold (the correction)
+
+JP competitors (ぴあ / ローチケ / LivePocket / 楽天チケット) do **not** hold the
+full amount at application — only a ¥1 validity check; the full 与信枠 hold
+lands at **draw** time, and winners' cards are **auto-charged** after
+results. Holding the full amount at application:
+- ties up credit across the **many** lotteries a fan applies to (they win
+  1–2), the exact 与信枠圧迫 JP platforms avoid; and
+- **breaks on prepaid/debit** (the cardless-fan substitute), which release
+  holds in 1–8 days — the reservation silently vanishes before the draw.
+
+`SetupIntent` (save at apply, charge winners) matches the JP norm, avoids
+credit lock-up, works with prepaid/debit, and does 3DS once at setup (JP
+EMV-3DS mandate) with MIT-exempt winner charges.
+
+## Legal / money scheme (収納代行) — not legal advice
+
+- **収納代行 (collection agent) + intermediary marketplace; Organizer =
+  seller-of-record.** Avoid MoR, 資金移動業, 前払式支払手段.
+- Buyer ToS: the buyer's obligation is **discharged on paying the platform**.
+  Organizer contract: grants the platform **代理受領権限**.
+- **前払式 avoidance:** charge a **specific-event ticket at win, deliver
+  promptly** — no wallet / points / stored balance.
+- **特商法:** Organizer is the **販売業者** (own 特商法 表記 / group page). The
+  **final-confirmation screen (2022)** must state total (tax+fees) and the
+  **charge timing** — for lottery: "charged only if you win, at the draw;
+  card saved for that later charge." Log consent + timestamp (also MIT /
+  dispute evidence).
+- **未成年:** DOB + parental-consent notice (an "18+" button is legally
+  insufficient); own-name card implies consent.
+- **Refund norm:** on cancellation refund face value + system/発券 fee, but
+  **keep the payment-processor fee** (JP standard).
+- **景品表示法 / 賭博: fine as designed** — paid 抽選販売 is allocation of the
+  purchased ticket, not a 懸賞/景品, and not 賭博 since **losers pay ¥0**.
+  Guardrails: losers pay nothing; no purchase-scaled free bonus; wording
+  "抽選販売", not "prize".
+
+## Counsel flags (confirm before launch)
+
+1. **⚠️ Consumer-payer 収納代行 carve-out** — the buyer is a consumer; FSA
+   2020-2025 rulemaking scrutinizes consumer-facing collection. This most
+   directly determines whether we avoid a 資金移動業 license.
+2. **⚠️ Hold-duration line** — the max defensible "after event, within N
+   business days" before held funds are 預り金 → 資金移動業; plus disclosure.
+3. Charge-after-win card-on-file + MIT — confirm no 割賦販売法 / 前払式 issue.
+4. MoR / 特商法 seller-of-record + domestic-fee 課税 (10%) → register as
+   適格請求書発行事業者; 媒介者交付特例 only if organizers are registered.
+5. 消費者契約法 enforceability of refund/cancellation clauses.
+
+## Domain entity (provider-agnostic)
+
+Order/Payment carries only: `provider` (stripe), opaque `payment_intent_id`
+(`pi_…`) + `payment_method_id` (`pm_…`), `payment_method_type` (card now;
+konbini/paypay later), own `status` (`pending`/`paid`/`failed`/`refunded` —
+no `awaiting_payment` now that konbini is out), `amount`+`currency`,
+`paid_at`, optional display facets (`card_brand`/`card_last4`). Never store
+PAN/CVC/expiry or Stripe's raw status. This keeps ⑤'s proto stable across a
+provider switch (KOMOJU) or added methods.
+
+## Open decisions (business / counsel, long lead — start now)
+
+- KOMOJU-vs-Stripe PoC outcome; Stripe Connect account type + KYC/審査 apply.
+- MoR designation + 特商法 seller wording; fee rate; hold-duration N;
+  refund/cancellation policy; 適格請求書発行事業者 registration.
+
+## References
+
+- Tracking + research log: issue liverty-music/specification#778.
+- Market/competitor design: `market-design-notes.md`.

--- a/docs/ticketing-platform-roadmap.md
+++ b/docs/ticketing-platform-roadmap.md
@@ -16,6 +16,11 @@ Primary source for the ticketing technical direction (Web2, no
 blockchain) is the decision record in `product-design.md` and
 `openspec/changes/archive/2026-08-09-remove-blockchain-ticket-system/`.
 
+Companion durable docs: [`payments-design.md`](./payments-design.md)
+(the ⑤ payment design + legal scheme) and
+[`market-design-notes.md`](./market-design-notes.md) (2025-2026
+competitor/market check + the roadmap calibrations it drove).
+
 ## Guiding Decisions (settled)
 
 These answers scope the entire roadmap and must be carried into each
@@ -107,12 +112,16 @@ change's `design.md`:
   Organizer (which exists only via admin vetting), that artist is simply
   **excluded from concert-search scraping** (first-party is authoritative;
   saves cost).
-- **Payments: Stripe, and the platform intermediates.** Liverty receives
-  the buyer's payment, takes a fee, and pays out the organizer (required
-  to monetize and to control cancellation refunds). Charges happen
-  **after winning** (D1). The domain Order/Payment entity is
-  **provider- and method-agnostic** (see D2); Apple Pay / Google Pay are
-  just wallet presentations of a `card` and need no dedicated fields.
+- **Payments: Stripe Connect, platform-intermediated, card-only MVP.**
+  Liverty collects, takes a fee, pays out the organizer. **Card-only** for
+  MVP (incl. debit/prepaid + Apple/Google Pay; konbini/PayPay deferred).
+  The lottery charges **only winners** — via **`SetupIntent` (save card at
+  application, charge winners at the draw), NOT an authorization hold**
+  (holds tie up credit across parallel applications and break on
+  prepaid/debit; this matches the JP norm). The domain Order/Payment entity
+  is **provider- and method-agnostic** (see D2). Full design + legal scheme
+  (収納代行, Organizer = seller-of-record) + counsel flags:
+  [`payments-design.md`](./payments-design.md) (issue #778).
 - **Web First, No Native App** (product constraint): the check-in tool is
   a PWA using the web camera, not a native scanner app.
 - **Organizer identity & RBAC: Zitadel B2B org-per-tenant.** Each Organizer
@@ -167,7 +176,15 @@ change when picked up:
 
 - `official-resale` — anonymous face-value resale pool (the sanctioned
   cannot-attend / anti-scalp path; reuses lottery losers as the demand
-  pool). **May be pulled earlier — see Open Decisions.**
+  pool). **Calibration (market-design-notes #2): PULL EARLY — now a market
+  default** (post-チケトレ, resale moved in-platform) and the cannot-attend
+  valve → plan it **immediately after the lottery/ticketing MVP (⑥)**, not
+  deep in Phase 2.
+- `face-auth-entry` — anti-scalp **identity tier** on top of ⑥'s rotating-QR
+  + Passkey floor: **photo-bound tickets → live-face-match-to-open**
+  (hardware-free, on-device), with **マイナンバーカード** as an opt-in
+  high-assurance option. Calibration (market-design-notes #3): the leaders'
+  bar moved here (チケプラ 2025-12); without it we look a generation behind.
 - `organizer-rbac-subowners` — full 4-role model (editor / viewer /
   reception staff), sub-owner invites, **audit log** (add audit subjects
   to the existing JetStream analytics pipeline).
@@ -235,11 +252,11 @@ the relevant change's `design.md`.
 
 ## Open Decisions (still to make)
 
-- **Official-resale timing.** MVP minimal return-to-pool/resale vs Phase
-  2. Argument for MVP: the cannot-attend case is a day-one fan need and a
-  legal best-practice, and the lottery losers already form the demand
-  pool, so a minimal version reuses lottery infrastructure. Argument for
-  Phase 2: keeps the MVP small.
+- **Official-resale timing.** ~~MVP vs Phase 2~~ **Leaning EARLY** after the
+  2025-2026 market check: official resale is now a JP market default (post-
+  チケトレ) and the cannot-attend valve, reusing the lottery loser pool →
+  plan it right after the ticketing MVP (⑥), not deep in Phase 2. See
+  `market-design-notes.md` #2. Final MVP-vs-immediately-after sizing TBD.
 - **Separate-time companion entry.** Whether to add pre-registered named
   companions (individual QR bound to a specific account, no open URL) for
   groups who cannot enter together. Deferred by default; revisit if


### PR DESCRIPTION
## Summary

Persist the Phase 3 **payment** design and the **2025-2026 competitor/market
check** into durable `docs/` (previously only in issue #778 comments and
ephemeral report files), and fold two roadmap calibrations in. Docs-only.

## Changes

- **`docs/payments-design.md`** — the input to change ⑤
  (`ticket-purchase-and-issuance`): Stripe Connect (destination charges +
  `on_behalf_of` + `application_fee`), **card-only MVP** (incl.
  debit/prepaid; konbini/PayPay deferred), and the load-bearing correction:
  **`SetupIntent`-primary (save card at application, charge only winners at
  the draw), NOT an authorization hold** — holds tie up credit across the
  many parallel lotteries a fan enters and break on prepaid/debit; this
  matches the JP norm. Plus the 収納代行 legal scheme (Organizer =
  seller-of-record), payout hold to event + dispute window,
  fee/dispute/reserve, 特商法/未成年/景表法, provider-agnostic entity, and
  the counsel flags. Tracks issue #778.
- **`docs/market-design-notes.md`** — competitor design (LivePocket, tiget,
  ZAIKO, teket, チケプラ) + 2024-2026 trends. Verdict: our direction aligns;
  **fan auto-notification is a white-space moat** among 後発 pure-plays;
  Web2 (no blockchain) validated.
- **`docs/ticketing-platform-roadmap.md`** — payments bullet → card-only +
  SetupIntent + pointer; **pull `official-resale` early** (now a JP market
  default post-チケトレ + the cannot-attend valve); add a **`face-auth-entry`**
  anti-scalp tier (hardware-free live-face-match — the new competitive bar,
  チケプラ 2025-12); link both new docs.

## Testing

Documentation only. No proto/code changes.

## Related

Refs: #759 (Phase 3 umbrella) · #778 (payments track). Both stay open.
