### PR TITLE
docs(openspec): harden-web-push-subscription-lifecycle

### DIFF
--- a/openspec/changes/harden-web-push-subscription-lifecycle/.openspec.yaml
+++ b/openspec/changes/harden-web-push-subscription-lifecycle/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-15

--- a/openspec/changes/harden-web-push-subscription-lifecycle/design.md
+++ b/openspec/changes/harden-web-push-subscription-lifecycle/design.md
@@ -1,0 +1,48 @@
+## Context
+
+See proposal.md — Why. Production forensics confirmed the pipeline is healthy up to the final Web Push send; delivery fails only because recipients have no subscription. Two client defects (no `pushsubscriptionchange` handling, no recovery after a lost/absent subscription) turned a routine subscription loss into a permanent silent outage, and the DB-only failure record made it invisible for ~2 weeks.
+
+Relevant existing constraints:
+- The frontend bundle is env-agnostic; `vapidPublicKey` is fetched from `/config.json` at bootstrap on the main thread (not baked at build). The Service Worker (`src/sw.ts`, `injectManifest`) has no access to `IAppConfig`.
+- The VAPID keypair is unchanged (public key stable since 2026-05-16; backend `VAPID_PRIVATE_KEY` matches). Re-subscribing with the same key is valid.
+- Backend already has OTel instrumentation; the notification service already records `delivered`/`failed` with a failure reason in the DB.
+
+## Goals / Non-Goals
+
+Goals:
+- No permission-granted user stays silently unsubscribed after a browser-side subscription loss.
+- Browser-initiated subscription rotation is renewed automatically, even with the app closed.
+- A systemic push-delivery failure is detectable operationally within minutes.
+
+Non-Goals:
+- Preventing subscription loss from legitimate client actions (PWA uninstall, clearing site data) — that loss is correct Web behavior; only recovery and detection are in scope.
+- Changing the hype/proximity delivery filtering (unchanged; now merely observable).
+- Server-side creation of subscriptions (impossible — a subscription can only originate in the browser).
+
+## Decisions
+
+- **SW obtains the VAPID key by fetching `/config.json` at runtime, not by build-time baking.** The `pushsubscriptionchange` handler needs `applicationServerKey`, but baking it into the SW would break the env-agnostic bundle. The SW fetches same-origin `/config.json` (cache-first) to read `vapidPublicKey`. Alternative considered: main thread posts the key to the SW via `postMessage` and the SW caches it in IndexedDB — rejected as primary because `pushsubscriptionchange` can fire with no client open, so the SW must be able to self-serve the key.
+- **Two complementary recovery paths, not one.** (1) SW `pushsubscriptionchange` renews on browser-initiated rotation (works with app closed). (2) A main-thread "resolve push state" check on app open / settings load re-subscribes when permission is `granted` but `getSubscription()` is `null`. `pushsubscriptionchange` has inconsistent cross-browser firing, so the main-thread path is the safety net that also covers uninstall→reinstall and data-clear cases (which fire no event).
+- **Detect systemic failure via a log-based metric on the WARNING delivery-failure log, not a raw OTel counter.** Prior art in this project shows the OTLP collector drops some server metrics for cost and that missing-metric alert policies can 400 an entire prod apply. A log-based metric derived from the structured WARNING log (with `failure_reason` as a label) is cheaper, guaranteed present, and avoids that failure mode. The backend still emits the WARNING log as the single source; the alert is built on the log-based metric in cloud-provisioning.
+- **Recovery of already-lapsed users is client-driven and automatic.** No server backfill is possible. Existing users with granted permission re-subscribe on next app open via the main-thread path; users whose permission is not granted get the re-enable affordance. This needs no data migration.
+- **Re-registration reuses the existing `Create` RPC and per-browser (user, endpoint) scoping.** A rotated subscription yields a new endpoint → a new row; the old endpoint is reaped by the existing `410 Gone` cleanup on the next send. No new RPC or schema change.
+
+## Risks / Trade-offs
+
+- [`pushsubscriptionchange` is not fired reliably by all browsers] → The main-thread resolve-on-open path is the primary safety net; the SW handler is an optimization for the app-closed case, not the sole mechanism.
+- [SW `/config.json` fetch fails offline] → Best-effort with cache-first; renewal retries on the next event/open. Failure never crashes the event.
+- [Ratio-based alerts are noisy at low pre-launch volume] → Pair the failure-ratio alert with a minimum-volume guard, and add the absolute "active-subscription starvation" signal so a mass loss is caught even at low counts.
+- [Duplicate/aggressive re-subscribe loops] → Gate re-subscribe on a state check (`getSubscription()` null AND permission granted) so it runs once per actual loss, not on every navigation.
+
+## Migration Plan
+
+1. Backend release: WARNING logs + delivery-outcome signal + zero-recipient logs (additive, safe).
+2. cloud-provisioning: add the log-based metric + alert policy (mirrors `app-error-log-alerting`).
+3. Frontend release: SW `pushsubscriptionchange` handler + main-thread recovery + error surfacing (SW update ships via the existing PWA update flow).
+4. Verify: approve a concert for a followed artist and confirm real-device delivery; confirm `push_subscriptions` grows as clients re-subscribe and that a forced failure raises the alert.
+
+Rollback: revert the respective releases; all changes are additive (no schema/proto change), so rollback is clean. A reverted SW still leaves users no worse than today.
+
+## Open Questions
+
+- Exact alert thresholds and evaluation windows (failure ratio %, minimum volume) — tunable operationally after deploy without changing the specs or task breakdown; start conservative.

--- a/openspec/changes/harden-web-push-subscription-lifecycle/proposal.md
+++ b/openspec/changes/harden-web-push-subscription-lifecycle/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+New-concert push notifications silently stopped reaching every follower in production. The pipeline (approve → `CONCERT.created` → consumer → follower/hype match → notification record) is healthy; delivery fails only at the final Web Push send because **no push subscription exists** for the recipients. Forensics on one follower show deliveries succeeded through 2026-07-29, then the first send after that (2026-08-13 09:55:18) returned `410 Gone`, the backend auto-deleted the row, and every later send recorded `no active push subscription`. The trigger was a legitimate client event (a PWA uninstall→reinstall), but two latent product defects turned a routine subscription loss into a permanent, invisible outage:
+
+1. The Service Worker does not handle `pushsubscriptionchange`, so browser-initiated subscription rotation/expiry is never renewed.
+2. After a subscription is lost (410, uninstall, data clear), nothing re-subscribes the user or prompts them — push is lost until they happen to toggle it back on manually.
+
+And it stayed invisible for ~2 weeks because delivery failures are recorded only in the database, never surfaced as logs, metrics, or alerts.
+
+## What Changes
+
+- **Service Worker renews subscriptions automatically**: add a `pushsubscriptionchange` handler that re-subscribes with the configured VAPID key and re-registers the new subscription with the backend `Create` RPC — without any user interaction.
+- **Client recovers from a lost/absent subscription instead of no-op**: when browser notification permission is already granted but the browser has no active subscription (or the backend reports the endpoint gone), the client re-subscribes automatically; if permission is not granted, the user is re-prompted rather than left silently off. This extends today's self-heal, which explicitly does nothing when the browser subscription is missing — the exact gap that caused this outage.
+- **Subscribe/registration failures are surfaced**: `pushManager.subscribe()` / `Create` errors are no longer swallowed; they are logged and reflected in the UI toggle state.
+- **Delivery failures become observable**: the backend emits WARNING logs and a metric for every failed push delivery (including `no active push subscription`), and the notify use case logs its zero-recipient early-returns instead of returning silently.
+- **Alerting on systemic push loss**: a new alert fires when the push delivery failure ratio (or active-subscription starvation) crosses a threshold, so a repeat of this outage is caught in minutes, not weeks.
+- Out of scope (not the cause here): the hype/proximity venue-coordinate filtering. It is left unchanged; the new observability will make any future proximity-driven drops visible.
+
+## Capabilities
+
+### New Capabilities
+- `web-push-delivery-alerting`: detection and alerting when Web Push delivery is systemically failing (high failure ratio, or zero active subscriptions while notifications are being generated), so silent push outages surface operationally.
+
+### Modified Capabilities
+- `push-notification-service`: client subscription lifecycle gains automatic renewal on `pushsubscriptionchange` and automatic recovery when the browser subscription is lost/absent (the current self-heal is a no-op in that case); subscribe/register failures are surfaced rather than swallowed.
+- `notification-lifecycle`: per-notification delivery failures SHALL be surfaced as observable signals (WARNING log + delivery-outcome metric), and the notification-fan-out SHALL log when it skips delivery because there are zero followers or zero eligible recipients, instead of returning silently.
+
+## Impact
+
+- **frontend** (Aurelia 2 PWA): `src/sw.ts` (new `pushsubscriptionchange` handler), `src/services/push-service.ts` (recovery + error surfacing), `src/routes/settings/settings-route.ts` and the notification-prompt flow (recovery/re-prompt). No proto/schema change — reuses the existing `PushNotificationService.Create`/`Get` RPCs and the unchanged VAPID public key.
+- **backend** (Go): `internal/usecase/notification_uc.go` and `internal/usecase/push_notification_uc.go` (WARNING logs + metric on failed delivery and zero-recipient early-returns); a delivery-outcome metric via the existing OTel instrumentation.
+- **cloud-provisioning**: a Cloud Monitoring alert policy for the push delivery failure metric (mirrors existing `app-error-log-alerting` / `argocd-deployment-alerts` patterns).
+- **Recovery**: existing users whose subscriptions already lapsed are re-subscribed automatically on next app open (permission granted) or re-prompted (permission not granted); no manual per-user action required.

--- a/openspec/changes/harden-web-push-subscription-lifecycle/specs/notification-lifecycle/spec.md
+++ b/openspec/changes/harden-web-push-subscription-lifecycle/specs/notification-lifecycle/spec.md
@@ -1,0 +1,33 @@
+## MODIFIED Requirements
+
+### Requirement: Per-notification delivery outcome is recorded
+The service SHALL record the delivery outcome of each notification's channel send: `queued` on creation, then `delivered` once the channel accepts the send, or `failed` (with a failure reason) on error, so that "did this notification reach the user?" is answerable from stored state. (Web push provides no separate sent-vs-delivered receipt, so `delivered` denotes acceptance by the push service; a distinct `sent` state is not modelled for this channel.)
+
+In addition to persisting the outcome, a `failed` delivery SHALL be surfaced as an operational signal — logged at WARNING with the failure reason, and emitted as a delivery-outcome metric labelled by outcome and failure reason — so that a systemic delivery failure is observable without querying the database. A `failed` outcome SHALL NOT be observable only from stored state.
+
+#### Scenario: Successful web-push send is recorded as delivered
+- **WHEN** the web-push channel send for a notification succeeds
+- **THEN** the notification's delivery status SHALL be recorded as `delivered` with a delivery timestamp
+
+#### Scenario: Failed send is recorded as failed, not dropped
+- **WHEN** the web-push channel send fails (e.g. the push service rejects it)
+- **THEN** the notification's delivery status SHALL be recorded as `failed` with a failure reason
+- **AND** the notification record SHALL remain so the failure is auditable and the send is re-dispatchable
+
+#### Scenario: Failed send is surfaced as an operational signal
+- **WHEN** a notification's delivery is recorded as `failed`
+- **THEN** the service SHALL log the failure at WARNING including the failure reason
+- **AND** SHALL emit a delivery-outcome metric labelled by outcome and failure reason
+- **AND** the failure SHALL therefore be detectable without reading the notifications table
+
+## ADDED Requirements
+
+### Requirement: Notification fan-out logs zero-recipient skips
+When the new-concert notification fan-out completes without dispatching any notification — because the artist has no followers, or because no follower is eligible after hype filtering, or because there are no deliverable concerts — the system SHALL log that outcome with the reason and the relevant identifiers (e.g., artist), instead of returning silently. This ensures "processed the event but sent nothing" is diagnosable from logs alone.
+
+#### Scenario: Event processed but no eligible recipients
+- **WHEN** a `CONCERT.created` event is processed
+- **AND** the fan-out dispatches zero notifications
+- **THEN** the system SHALL log the zero-dispatch outcome with its reason (no followers, no eligible recipients, or no deliverable concerts)
+- **AND** the log SHALL include the artist identifier
+- **AND** the processing SHALL still complete successfully (the empty outcome is not an error)

--- a/openspec/changes/harden-web-push-subscription-lifecycle/specs/push-notification-service/spec.md
+++ b/openspec/changes/harden-web-push-subscription-lifecycle/specs/push-notification-service/spec.md
@@ -1,0 +1,78 @@
+## MODIFIED Requirements
+
+### Requirement: Stale subscription self-healing on the client
+
+The system SHALL keep the browser's push subscription and the backend's stored subscription convergent automatically, without requiring user interaction, whenever the user has already granted browser notification permission. Recovery SHALL cover both divergence directions:
+
+- **Backend missing the browser's subscription** — the browser has an active subscription the backend does not know about.
+- **Browser missing a subscription entirely** — the browser has no active subscription (e.g., after the push service invalidated it, a `410 Gone` cleanup on the backend, a PWA reinstall, or site-data clearing), even though permission is still granted.
+
+In the second case, when permission is granted, the system SHALL create a fresh browser subscription with the configured VAPID application server key and register it via `PushNotificationService.Create`. The system SHALL NOT leave a permission-granted user silently unsubscribed. When permission is NOT granted, the system SHALL surface an OFF/re-enable affordance rather than silently doing nothing.
+
+#### Scenario: Self-heal on settings page load
+
+- **WHEN** the settings page loads
+- **AND** `PushManager.getSubscription()` returns a non-null subscription
+- **AND** `PushNotificationService.Get` returns `NOT_FOUND` for that endpoint
+- **THEN** the system SHALL call `PushNotificationService.Create` with the browser's existing subscription material
+- **AND** on success, the UI toggle SHALL reflect the ON state
+- **AND** the user SHALL NOT be prompted to re-grant notification permission
+
+#### Scenario: No self-heal when browser has no subscription
+
+- **WHEN** the settings page loads
+- **AND** `PushManager.getSubscription()` returns `null`
+- **AND** browser notification permission is NOT `granted`
+- **THEN** the UI toggle SHALL reflect the OFF state
+- **AND** the system SHALL NOT call `Create` or `Get`
+- **AND** the system SHALL offer the user an affordance to enable notifications
+
+#### Scenario: Auto re-subscribe when browser has no subscription but permission is granted
+
+- **WHEN** the app resolves push state (e.g., on settings page load or app startup)
+- **AND** browser notification permission is `granted`
+- **AND** `PushManager.getSubscription()` returns `null`
+- **THEN** the system SHALL call `PushManager.subscribe()` with the configured VAPID application server key
+- **AND** SHALL register the resulting subscription via `PushNotificationService.Create`
+- **AND** on success the UI toggle SHALL reflect the ON state
+- **AND** the user SHALL NOT be prompted to re-grant notification permission
+
+#### Scenario: Self-heal failure degrades to OFF
+
+- **WHEN** the self-heal `subscribe()` or `Create` call fails
+- **THEN** the UI toggle SHALL reflect the OFF state
+- **AND** the system SHALL surface the error via standard frontend error handling
+- **AND** SHALL NOT swallow the failure silently
+
+## ADDED Requirements
+
+### Requirement: Service Worker renews the subscription on pushsubscriptionchange
+
+The Service Worker SHALL handle the `pushsubscriptionchange` event. When the push service rotates or expires the subscription, the Service Worker SHALL obtain a new subscription using the configured VAPID application server key and re-register it with the backend via `PushNotificationService.Create`, so that browser-initiated subscription churn does not silently end delivery. Renewal SHALL run without any user interaction and SHALL NOT require the app UI to be open.
+
+#### Scenario: Browser rotates the subscription
+
+- **WHEN** the browser fires `pushsubscriptionchange` in the Service Worker
+- **AND** a new subscription can be obtained with the configured VAPID application server key
+- **THEN** the Service Worker SHALL subscribe to the push service for the new subscription
+- **AND** SHALL register the new subscription with the backend via `PushNotificationService.Create`
+- **AND** the user SHALL continue to receive push notifications without re-enabling them
+
+#### Scenario: Renewal cannot obtain a new subscription
+
+- **WHEN** the Service Worker handles `pushsubscriptionchange`
+- **AND** a new subscription cannot be obtained (e.g., permission was revoked)
+- **THEN** the Service Worker SHALL NOT crash the event
+- **AND** the stale endpoint SHALL NOT remain registered as if active
+
+### Requirement: Subscription registration failures are observable on the client
+
+Push subscription registration (`PushManager.subscribe()` and the `PushNotificationService.Create` RPC) SHALL NOT fail silently. Failures SHALL be logged on the client and reflected in the notification toggle state, so a user who believes they enabled notifications is not left silently unsubscribed.
+
+#### Scenario: subscribe() throws during enable
+
+- **WHEN** the user enables notifications
+- **AND** `PushManager.subscribe()` throws
+- **THEN** the failure SHALL be logged on the client
+- **AND** the UI toggle SHALL reflect the OFF (not-enabled) state
+- **AND** the user SHALL NOT be shown a success state

--- a/openspec/changes/harden-web-push-subscription-lifecycle/specs/web-push-delivery-alerting/spec.md
+++ b/openspec/changes/harden-web-push-subscription-lifecycle/specs/web-push-delivery-alerting/spec.md
@@ -1,0 +1,26 @@
+## Purpose
+
+Detect and alert on systemic Web Push delivery failure — a high delivery failure ratio, or notifications being generated while no active subscriptions can receive them — so that a push outage surfaces operationally within minutes instead of going unnoticed for weeks.
+
+## ADDED Requirements
+
+### Requirement: Alert on sustained push delivery failure
+The system SHALL raise an operational alert when the Web Push delivery failure ratio stays above a defined threshold over a sustained window, so that a systemic inability to deliver notifications is detected without manual inspection. The alert SHALL be derived from the delivery-outcome signal emitted by the notification service and SHALL identify that push delivery is failing.
+
+#### Scenario: Delivery failure ratio breaches threshold
+- **WHEN** the ratio of `failed` to total notification deliveries stays above the configured threshold over the configured evaluation window
+- **THEN** an alert SHALL fire to the operational notification channel
+- **AND** the alert SHALL indicate that Web Push delivery is failing
+
+#### Scenario: Healthy delivery does not alert
+- **WHEN** notification deliveries are predominantly `delivered` over the evaluation window
+- **THEN** no delivery-failure alert SHALL fire
+
+### Requirement: Alert on active-subscription starvation
+The system SHALL raise an operational alert when notifications are being generated but essentially no active push subscriptions exist to receive them (e.g., failures dominated by `no active push subscription`), so that a mass subscription loss is caught even though each individual send "completes". 
+
+#### Scenario: Notifications generated with no deliverable subscriptions
+- **WHEN** notifications are being created over the evaluation window
+- **AND** deliveries fail predominantly with `no active push subscription`
+- **THEN** an alert SHALL fire to the operational notification channel
+- **AND** the alert SHALL indicate that push subscriptions are absent for the targeted recipients

--- a/openspec/changes/harden-web-push-subscription-lifecycle/tasks.md
+++ b/openspec/changes/harden-web-push-subscription-lifecycle/tasks.md
@@ -1,0 +1,42 @@
+# Tasks
+
+No proto/schema change — this change reuses the existing `PushNotificationService.Create`/`Get` RPCs and the unchanged VAPID keypair, so no BSR/specification-release coordination is required.
+
+## 1. Backend — delivery observability
+
+- [ ] 1.1 Emit a WARNING log on every `failed` notification delivery in `notification_uc.go`, including the failure reason and user/notification identifiers
+- [ ] 1.2 Emit a delivery-outcome metric (counter) labelled by outcome and failure reason via the existing OTel instrumentation, keeping labels to the bounded failure-reason set (no high cardinality)
+- [ ] 1.3 Log zero-recipient early-returns in `push_notification_uc.go` (`NotifyNewConcerts`) with the reason (no followers / no eligible recipients / no deliverable concerts) and the artist id, instead of returning silently
+- [ ] 1.4 Unit tests: failed delivery produces the WARNING log + metric; each zero-recipient path produces its log; success path stays quiet
+- [ ] 1.5 `make check` passes
+
+## 2. cloud-provisioning — alerting
+
+- [ ] 2.1 Add a log-based metric derived from the backend delivery-failure WARNING log (label by failure reason)
+- [ ] 2.2 Add a Cloud Monitoring alert policy for sustained delivery-failure ratio, paired with a minimum-volume guard (mirror the existing `app-error-log-alerting` pattern)
+- [ ] 2.3 Add an alert for active-subscription starvation (failures dominated by `no active push subscription` while notifications are being generated)
+- [ ] 2.4 Validate the policy applies cleanly in prod (avoid the known missing-metric 400-on-apply failure mode; use the log-based metric, not a raw OTLP metric)
+
+## 3. Frontend — Service Worker renewal
+
+- [ ] 3.1 Add a `pushsubscriptionchange` handler in `src/sw.ts` that re-subscribes with the VAPID key and re-registers via `PushNotificationService.Create`, without requiring an open client
+- [ ] 3.2 Make the VAPID public key available to the SW by fetching same-origin `/config.json` (cache-first) at renewal time, preserving the env-agnostic bundle
+- [ ] 3.3 Ensure the handler never crashes the event when a new subscription cannot be obtained (permission revoked / offline); best-effort with retry on next event
+- [ ] 3.4 Tests for the renewal handler (success re-registers; failure is non-fatal)
+
+## 4. Frontend — client recovery and error surfacing
+
+- [ ] 4.1 In `push-service.ts`, add an auto re-subscribe path: when permission is `granted` and `PushManager.getSubscription()` is `null`, subscribe with the VAPID key and call `Create`; gate it on a state check so it runs once per actual loss
+- [ ] 4.2 Update the settings/notification-prompt flow so that permission-granted-but-no-subscription resolves to auto re-subscribe, and permission-not-granted surfaces a re-enable affordance (no silent OFF)
+- [ ] 4.3 Surface `subscribe()` / `Create` failures: log on the client and reflect OFF in the toggle; never show a success state on failure
+- [ ] 4.4 Component/unit tests for the recovery matrix (granted+null → re-subscribe; not-granted+null → affordance; subscribe/Create error → OFF + surfaced)
+- [ ] 4.5 `make check` passes (including visual/baseline updates if the affordance changes UI)
+
+## 5. Verification and prod rollout
+
+- [ ] 5.1 Ship backend release to prod; confirm the WARNING log + metric appear on a forced/failed delivery
+- [ ] 5.2 Merge cloud-provisioning; confirm ArgoCD syncs the alert policy and it is active
+- [ ] 5.3 Ship frontend release to prod; confirm the SW update rolls out
+- [ ] 5.4 On a real device: let a lapsed (permission-granted) client auto re-subscribe on app open; confirm a new `push_subscriptions` row is created
+- [ ] 5.5 Approve a concert for a followed artist and confirm real-device push receipt and a `delivered` notification record (closes the original report)
+- [ ] 5.6 Confirm `push_subscriptions` count recovers as clients re-subscribe, and that a forced failure raises the alert


### PR DESCRIPTION
## 🔗 Related Issue

Closes #789

## 📝 Summary of Changes

Adds the OpenSpec change **`harden-web-push-subscription-lifecycle`** (planning artifacts only — proposal / specs / design / tasks). No proto or code changes.

**Motivation / problem.** New-concert push notifications silently stopped reaching every follower in production. Prod logs + DB + code confirm the pipeline (approve → `CONCERT.created` → consumer → follower/hype match → notification record) is healthy; delivery fails only at the final Web Push send because recipients have **no push subscription**. Forensics on one follower: deliveries succeeded through 2026-07-29, then the first send after that (2026-08-13 09:55:18) returned `410 Gone`, the backend auto-deleted the row, and every later send failed with `no active push subscription`. The trigger was a legitimate PWA uninstall→reinstall, but two latent defects turned a routine loss into a permanent, invisible outage — and it stayed invisible ~2 weeks because failures were recorded only in the DB.

**Technical approach (captured in the artifacts).**
- **Modified `push-notification-service`**: Service Worker handles `pushsubscriptionchange` to auto-renew; the client recovers when permission is granted but the browser subscription is absent (today it no-ops); subscribe/register failures are surfaced instead of swallowed.
- **Modified `notification-lifecycle`**: failed deliveries emit a WARNING log + delivery-outcome metric; zero-recipient fan-out early-returns are logged.
- **New `web-push-delivery-alerting`**: alert on sustained delivery-failure ratio and active-subscription starvation.
- Out of scope: hype/proximity venue-coordinate filtering (unchanged; now observable).

Design records the key decisions (SW reads the VAPID key via runtime `/config.json` to keep the env-agnostic bundle; two complementary recovery paths; log-based metric to avoid the known OTel-drop / missing-metric-400 failure mode). Cross-repo implementation (frontend + backend + cloud-provisioning) is broken down in `tasks.md` and ships to prod with end-to-end verification.

## ✅ Self-Checklist

- [x] I have linked the related issue.
- [x] I have updated the relevant documentation (OpenSpec change artifacts).
- [ ] I have run `buf lint` and `buf format` locally and all checks have passed. — N/A (no proto changes)
- [ ] My proto definitions follow the project's style guidelines and validation rules. — N/A (no proto changes)
- [ ] Breaking changes have been justified and documented if applicable. — N/A (planning docs only)
