### PR TITLE
docs(payments): JP regulatory compliance obligations + commerce gaps

### DIFF
--- a/docs/payments-design.md
+++ b/docs/payments-design.md
@@ -115,6 +115,51 @@ provider switch (KOMOJU) or added methods.
 - MoR designation + 特商法 seller wording; fee rate; hold-duration N;
   refund/cancellation policy; 適格請求書発行事業者 registration.
 
+## Regulatory compliance obligations (JP) — beyond the 収納代行 scheme
+
+Additional obligations surfaced by the 2026-08 legal sweep (issue #778).
+Not legal advice — confirm the flagged items with counsel. **Owner** = who
+implements/holds the duty.
+
+| # | Obligation | Blocking | Owner | What to build / disclose |
+|---|-----------|----------|-------|--------------------------|
+| 1 | **総額表示義務** (消費税法 §63, since 2021-04) | **Yes** | Platform | Render every consumer-facing price **tax-inclusive** (ticket AND system/payment fee, each as its own 税込 line) + a clear grand total on listing/cart/confirmation. |
+| 2 | **特商法 通信販売: 最終確認画面 + 返品特約 + no cooling-off** (§11, §12-6 2022) | **Yes** | Platform (screen) / Organizer (事業者情報) | Confirmation screen showing 分量・価格(税込)・**支払時期方法**・**引渡時期**・**返品特約**・per-Organizer **事業者情報**; make the **charge-on-lottery-win timing/amount unambiguous**; state "通信販売 = クーリングオフ無し". **Omitting 返品特約 triggers an 8-day statutory return right** — so spell out "no returns except event cancellation/postponement". |
+| 3 | **割賦販売法 (2018): card-data 非保持化 / PCI** | **Yes (precondition)** | Platform (加盟店) / Stripe | Stripe Elements so **no PAN touches our systems** (store only Stripe tokens/customer ids — incl. the saved-card-at-draw flow); keep **PCI SAQ A** + EMV 3DS on file. |
+| 4 | **個人情報保護法 (2022): 越境移転 to Stripe (US)** | **Yes** | Platform | Privacy policy: personal/card data is **entrusted (委託) to an overseas processor (Stripe, USA)** + **外的環境の把握** (US regime + Stripe safeguards); hold a **Stripe DPA** as 委託先監督 evidence. |
+| 5 | **犯収法 / AML-KYC** | Confirm | Stripe (card-level) | A pure 収納代行 that does **not** perform 為替取引 is generally **not** a 犯収法 特定事業者. Document why the flow is 収納代行, not remittance. **Same determination as the 資金決済法 boundary** — close it once. |
+| 6 | **反社会的勢力排除 (暴排条例)** | **Yes** | Platform | Organizer onboarding contract with a **暴排条項** (表明保証 + immediate termination) + a **反社チェック** step in vetting. *(Belongs to the organizer-accounts vetting flow — cross-reference.)* |
+| 7 | **電子帳簿保存法 (2024 電子取引 mandatory)** | From day one | Platform | Retain fee invoices/receipts/transaction records electronically with **真実性 + 可視性** (searchable by date/amount/counterparty). |
+| 8 | **領収書 + 印紙税 / 適格請求書** | Low | Organizer (ticket) / Platform (fee) | Receipts must **print "クレジットカード決済"** → 印紙-free at any amount. 適格請求書: Organizer 登録番号 on the ticket, platform 登録番号 on the fee (代理交付/媒介者交付特例). |
+
+**Highest-leverage counsel question (closes #5 + reinforces 資金決済法):**
+confirm our payout timing/holding keeps 収納代行 **out of 為替取引 /
+資金移動業** — this single determination decides both the license question and
+whether 犯収法 KYC applies to the platform.
+
+## Commerce spec still to define (in ⑤ `ticket-purchase-and-issuance`)
+
+Non-regulatory gaps to specify when ⑤ is authored:
+
+- **Pricing model:** Organizer-set price, JPY, tax-inclusive, ticket tiers
+  (adult/child sharing the capacity pool), any price cap.
+- **Order ↔ Ticket ↔ Payment linkage:** one Order = N tickets (companion,
+  ≤ `max_tickets_per_application`); a successful charge issues N tickets.
+- **Refund taxonomy:** **postponement (延期, event still happens) vs
+  cancellation (中止)**, partial refunds, and the "no returns except
+  cancellation" 返品特約 wording (ties to §2 above).
+- **Payout mechanics:** payout schedule, per-Organizer **settlement
+  statement (支払明細)**, failed-payout + negative-balance handling, Stripe
+  KYC bank onboarding.
+- **Dispute/chargeback ops:** evidence/representment, Organizer↔platform
+  liability split via `transfer_reversal`, reserve past the dispute window.
+- **Platform-fee 適格請求書** to the Organizer + Stripe-balance
+  reconciliation.
+- **Webhook security** (signature verification) + idempotency keys; a
+  **test/sandbox** strategy for the lottery charge flow.
+- **Purchase limits** (1 account / 1 application) enforced at the
+  payment/order layer (anti-scalp).
+
 ## References
 
 - Tracking + research log: issue liverty-music/specification#778.


### PR DESCRIPTION
## Summary

Fold the JP **regulatory compliance obligations** surfaced by a legal sweep
into `docs/payments-design.md`, and enumerate the remaining **commerce spec
gaps** for ⑤. This is the session's purpose — defining the payment spec
against the legal framework — completing the picture beyond the already-
captured 資金決済法/収納代行/特商法-seller/景表法/未成年 items. Docs-only.
Not legal advice.

## Added regulatory obligations (each: blocking / owner / what-to-build)

1. **総額表示義務** (tax-inclusive price display) — blocking.
2. **特商法 最終確認画面 + 返品特約 + no cooling-off** — blocking (omitting
   返品特約 triggers an 8-day statutory return right).
3. **割賦販売法 非保持化 / PCI SAQ A** — satisfied by Stripe Elements.
4. **個人情報保護法 cross-border transfer to Stripe (US)** — 委託 +
   外的環境の把握 + DPA.
5. **犯収法 / AML** — confirm 収納代行 ≠ 為替取引 (same call as 資金決済法).
6. **反社排除条項 + 反社チェック** — Organizer vetting (cross-refs
   organizer-accounts).
7. **電子帳簿保存法** e-retention (2024 mandatory).
8. **領収書 印紙-free ("クレジットカード決済") + 適格請求書 attribution**.

## Added commerce gaps for ⑤

Pricing model; Order↔Ticket↔Payment linkage; refund taxonomy (延期 vs 中止);
payout mechanics + settlement statement; dispute/chargeback ops; fee
適格請求書 + reconciliation; webhook security + idempotency + test strategy;
purchase limits.

## Testing

Documentation only.

## Related

Refs: #778 (payments track). Note: item #6 (反社チェック) also belongs to the
organizer-accounts vetting flow.
