### PR TITLE
docs(openspec): organizer-antisocial-vetting (反社 exclusion in onboarding)

### DIFF
--- a/openspec/changes/organizer-antisocial-vetting/.openspec.yaml
+++ b/openspec/changes/organizer-antisocial-vetting/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-15

--- a/openspec/changes/organizer-antisocial-vetting/design.md
+++ b/openspec/changes/organizer-antisocial-vetting/design.md
@@ -1,0 +1,64 @@
+## Context
+
+See proposal.md - Why. Legal basis + owner in `docs/payments-design.md`
+(Regulatory compliance #6) and issue #778. This layers a vetting precondition
+onto the already-shipping `organizer-accounts` Create / `deactivated` flow;
+that change's capability spec is still in-flight, so this expresses the gate
+in its own capability and integrates at archive time. **Do not edit the
+`organizer-accounts` change dir** (near-complete, owned by another workstream).
+
+## Goals / Non-Goals
+
+**Goals:** an onboarding 暴排条項, an admin 反社チェック gate before activation,
+and deactivation on later discovery — the minimum to exclude 反社会的勢力.
+
+**Non-Goals:** automated third-party screening integration (manual/risk-based
+for MVP); the payment 収納代行 scheme; self-serve onboarding.
+
+## Decisions
+
+**D1 — Manual, risk-based check for MVP.** An admin records a name-screening
+outcome; no third-party screening API integration yet (a future hardening).
+The exemption from liability comes from the 暴排条項 + a documented check, not
+from a specific vendor.
+
+**D2 — Additive data, no change to the shipped organizer proto/service.**
+Record the check as **additive** fields on the Organizer (e.g.
+`antisocial_check_status` / `reviewer` / `checked_at`) via an **ALTER**
+migration on the `organizers` table (shipped by `organizer-accounts`), plus a
+small admin action to record the result. Do **not** alter the shipped
+`rpc/admin/organizer/v1` messages; add a new admin RPC (e.g.
+`RecordAntisocialCheck`) or a Create precondition — a follow-up wiring detail,
+kept additive so it never conflicts with the in-flight change.
+
+**D3 — Gate at activation, reuse the deactivation hook.** A passing check is a
+**precondition** to create/activate; a hit blocks. Post-onboarding discovery
+reuses `organizer-accounts`' `deactivated` state (no new teardown path).
+
+## Risks / Trade-offs
+
+- **Manual check is only as good as the operator** → mitigate with the
+  documented 暴排条項 (contractual R&W + termination right) so a later-
+  discovered tie is a clean termination ground; upgrade to an automated
+  screening service later.
+- **Ordering vs `organizer-accounts`** → this change must land after
+  `organizer-accounts` (it ALTERs its table and gates its Create). Sequence
+  accordingly.
+
+## Migration Plan
+
+1. specification: the new capability spec (+ any additive admin RPC) → merge →
+   Release → BSR gen (only if a proto is added).
+2. backend: additive migration (antisocial-check fields on `organizers`);
+   record-check action; make a passing check a create/activation precondition;
+   deactivation reason.
+3. frontend: a 反社チェック step in the organizer-management screen.
+4. legal/docs: 暴排条項 text in the onboarding agreement.
+- Rollback: additive columns + additive RPC; drop with no impact on the
+  shipped organizer flow.
+
+## Open Questions
+
+- Whether to record the check via a dedicated `RecordAntisocialCheck` admin
+  RPC or as a required attestation field on Create — a wiring detail decided at
+  implementation; does not change the spec.

--- a/openspec/changes/organizer-antisocial-vetting/proposal.md
+++ b/openspec/changes/organizer-antisocial-vetting/proposal.md
@@ -1,0 +1,56 @@
+## Why
+
+A ticketing marketplace that collects money and onboards sellers is expected
+(暴力団排除条例, all 47 prefectures; card acquirers demand it) to **exclude
+反社会的勢力 (antisocial forces)** from its Organizer relationships. Our
+current organizer onboarding (`organizer-accounts`) vets and provisions an
+Organizer but has **no 反社 exclusion** — a launch-blocking gap surfaced by
+this session's legal sweep (see `docs/payments-design.md` → Regulatory
+compliance #6, and issue #778). This change adds that exclusion: a 暴排条項 in
+the onboarding agreement and a 反社チェック gate in admin vetting.
+
+## What Changes
+
+- **暴排条項 in the Organizer onboarding agreement** — a representation &
+  warranty that the Organizer and its principals are **not** 反社会的勢力 and
+  have no such relationships, plus the platform's right to **terminate /
+  deactivate immediately** on breach.
+- **反社チェック gate in admin vetting** — before an Organizer is
+  provisioned/activated, an admin performs a name-screening 反社チェック and
+  records the outcome (reviewer, timestamp, result). A **positive hit blocks**
+  creation/activation. The record is retained for audit.
+- **Post-onboarding discovery → deactivation** — if a 反社 relationship is
+  discovered later, an admin deactivates the Organizer, **reusing the existing
+  `deactivated` hook** from `organizer-accounts`.
+
+Non-goals: automated/third-party screening-service integration (manual/risk-
+based check for MVP); the payment-side 収納代行/legal scheme (payments-design);
+self-serve organizer onboarding.
+
+## Capabilities
+
+### New Capabilities
+- `organizer-antisocial-exclusion`: the 暴排条項 onboarding clause, the admin
+  反社チェック gate on Organizer activation, and post-onboarding deactivation
+  on discovery.
+
+### Modified Capabilities
+<!-- None edited directly. This layers a vetting precondition onto the
+     `organizer-accounts` Create/deactivate flow; that capability's spec is
+     still in-flight in its own change, so the gate is expressed here and
+     integrates when both archive. Cross-reference, do not edit that change. -->
+
+## Impact
+
+- **specification**: a new `organizer-antisocial-exclusion` capability spec.
+  Any proto is **additive** (e.g. an admin RPC to record the check result, or
+  a check-status field) and does not alter the shipped
+  `rpc/admin/organizer/v1` service.
+- **backend**: an **additive** migration adding antisocial-check fields to
+  `organizers` (status / reviewer / checked_at); a create/activation
+  precondition that a passing check exists; deactivation reason.
+- **frontend (admin console)**: a 反社チェック step in the organizer-management
+  screen (record result before create; block on hit).
+- **legal/docs**: the 暴排条項 text in the Organizer onboarding agreement.
+- Depends on `organizer-accounts` (the Create / vetting / `deactivated` flow
+  this gates).

--- a/openspec/changes/organizer-antisocial-vetting/specs/organizer-antisocial-exclusion/spec.md
+++ b/openspec/changes/organizer-antisocial-vetting/specs/organizer-antisocial-exclusion/spec.md
@@ -1,0 +1,63 @@
+## Purpose
+
+Excludes 反社会的勢力 (antisocial forces) from the platform's Organizer
+relationships, as expected of a money-handling marketplace under the 暴力団
+排除条例: an onboarding exclusion clause, an admin 反社チェック gate before an
+Organizer is activated, and deactivation on later discovery.
+
+## ADDED Requirements
+
+### Requirement: Organizer onboarding agreement includes an antisocial-forces exclusion clause
+
+The onboarding agreement each Organizer accepts SHALL include a 暴排条項:
+(a) a **representation and warranty** that the Organizer and its principals
+are **not** 反社会的勢力 (暴力団・暴力団員・準構成員・関係企業・総会屋・
+社会運動標ぼうゴロ・特殊知能暴力集団 等) and have no relationship providing
+them funds or convenience; and (b) the platform's right to **terminate the
+relationship and deactivate the Organizer immediately, without liability**, on
+breach.
+
+#### Scenario: Onboarding requires accepting the 暴排条項
+
+- **WHEN** an Organizer is onboarded
+- **THEN** acceptance of the 暴排条項 (antisocial-forces exclusion clause)
+  SHALL be a condition of the onboarding agreement
+
+### Requirement: Admin antisocial-forces check gates Organizer activation
+
+Before an Organizer is provisioned/activated, an operator holding the platform
+`admin` role SHALL perform a **反社チェック** (name screening of the Organizer
+and its principals) and record the outcome — **reviewer, timestamp, and result
+(pass / hit)**. A **positive hit SHALL block** the Organizer's creation /
+activation. The check record SHALL be retained for audit.
+
+#### Scenario: A passing check allows activation
+
+- **WHEN** an admin records a **passing** 反社チェック for an Organizer
+- **THEN** the Organizer MAY be created / activated
+- **AND** the check result, reviewer, and timestamp SHALL be recorded
+
+#### Scenario: A hit blocks activation
+
+- **WHEN** the 反社チェック returns a **hit** (or no passing check has been
+  recorded)
+- **THEN** the system SHALL block the Organizer's creation / activation
+
+#### Scenario: The check record is retained for audit
+
+- **WHEN** a 反社チェック outcome is recorded
+- **THEN** it SHALL be retained (reviewer, timestamp, result) for later audit
+
+### Requirement: Post-onboarding antisocial discovery triggers deactivation
+
+If a 反社 relationship is discovered **after** onboarding, an operator holding
+the platform `admin` role SHALL **deactivate** the Organizer (reusing the
+existing deactivation hook), and the breach of the 暴排条項 SHALL be a
+documented ground for termination.
+
+#### Scenario: Later discovery deactivates the organizer
+
+- **WHEN** a 反社 relationship is discovered for an already-onboarded Organizer
+- **THEN** an admin SHALL deactivate the Organizer
+- **AND** the deactivation SHALL reject the Organizer's subsequent operations
+  (per the existing deactivation behavior)

--- a/openspec/changes/organizer-antisocial-vetting/tasks.md
+++ b/openspec/changes/organizer-antisocial-vetting/tasks.md
@@ -1,0 +1,27 @@
+## 1. Legal / docs
+
+- [ ] 1.1 Draft the **暴排条項** (antisocial-forces exclusion clause: R&W + immediate termination) for the Organizer onboarding agreement
+- [ ] 1.2 Make acceptance of the clause a condition of onboarding
+
+## 2. Specification (only if a proto is added)
+
+- [ ] 2.1 (if used) additive admin RPC to record the check (e.g. `RecordAntisocialCheck`) in `rpc/admin/organizer/v1` — do NOT alter shipped messages; `buf lint/format/breaking` pass; merge → Release → BSR gen
+
+## 3. Backend
+
+- [ ] 3.1 Additive Atlas migration: antisocial-check fields on `organizers` (`antisocial_check_status`, `reviewer`, `checked_at`) — ALTER the shipped table
+- [ ] 3.2 Record-check usecase + admin handler (admin-role gated); persist reviewer/timestamp/result
+- [ ] 3.3 Gate: a **passing** check is a precondition to create/activate an Organizer; a hit (or no check) blocks
+- [ ] 3.4 Deactivation-on-discovery reuses the existing `deactivated` hook; record the reason
+- [ ] 3.5 Tests: pass→allow, hit→block, no-check→block, record retained; `make check` passes
+
+## 4. Frontend (admin console)
+
+- [ ] 4.1 反社チェック step in the organizer-management screen: record result before create; block on hit; show the retained record
+- [ ] 4.2 `make check` passes
+
+## 5. Release & ship to prod
+
+- [ ] 5.1 Land AFTER `organizer-accounts` (this ALTERs its table + gates its Create)
+- [ ] 5.2 Backend + frontend PRs merged → release → prod
+- [ ] 5.3 Verify in prod: an admin records a passing 反社チェック → Organizer can be created; a hit blocks; later discovery deactivates; records retained for audit


### PR DESCRIPTION
## Summary

Capture a **launch-blocking legal gap** surfaced by this session's legal
sweep: a money-handling ticketing marketplace must **exclude 反社会的勢力**
(antisocial forces) from its Organizer relationships (暴力団排除条例; card
acquirers require it). The shipped organizer onboarding (`organizer-accounts`)
vets/provisions an Organizer but has **no 反社 exclusion**. OpenSpec planning
artifacts only.

## Changes — new capability `organizer-antisocial-exclusion`

- **暴排条項** in the Organizer onboarding agreement (R&W that the Organizer/
  principals are not 反社会的勢力 + platform's immediate-termination right).
- **反社チェック gate** in admin vetting before an Organizer is activated — a
  hit blocks creation/activation; reviewer/timestamp/result retained for audit.
- **Deactivation on later discovery**, reusing `organizer-accounts`' existing
  `deactivated` hook.

**Additive only** (an `ALTER organizers` migration + an optional additive admin
RPC) — it does not touch the near-complete `organizer-accounts` change dir and
lands after it.

## Testing

OpenSpec planning artifacts; `openspec validate --strict` passes.

## Related

Refs: #759 (Phase 3 umbrella) · #778 (payments/legal; see payments-design.md
Regulatory compliance #6). Depends on / lands after `organizer-accounts`.
