### PR TITLE
docs(openspec): propose auto-publish-new-concerts

### DIFF
--- a/openspec/changes/auto-publish-new-concerts/.openspec.yaml
+++ b/openspec/changes/auto-publish-new-concerts/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-17

--- a/openspec/changes/auto-publish-new-concerts/design.md
+++ b/openspec/changes/auto-publish-new-concerts/design.md
@@ -1,0 +1,103 @@
+## Context
+
+See proposal.md — Why. Today every discovered concert is staged and manually approved.
+The new-vs-conflict decision (`detectDuplicateEvent`) currently runs at **approval time**,
+inside `concertUseCase.Approve` (`internal/usecase/concert_admin_uc.go`), because it needs a
+resolved `venue_id` (get-or-create), and venue rows are only created on approval. The
+`CONCERT.discovered` consumer (`internal/usecase/concert_creation_uc.go`) only resolves the
+venue via Google Places and denormalizes preview fields onto a `staged_concert` row.
+
+Key existing pieces this change reuses unchanged:
+- `resolveOrCreateVenue`, `detectDuplicateEvent`, `buildAndInsertConcerts`, and the
+  `resolveExistingEvent` fill logic in the admin usecase.
+- The two-source discovery dedup `FilterNew` in `internal/usecase/concert_uc.go`.
+- The unchanged `Approve` reconciliation (`KeepExisting` / `AdoptStaged`) for staged conflicts.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Move the new-vs-conflict branch from approval time into the `CONCERT.discovered` consumer.
+- Auto-publish new concerts (insert + `CONCERT.created`) without a staged row.
+- Keep staged rows + `Approve` reconciliation for same-slot conflicts only.
+- Mark published events with origin + auto-publish time; expose on admin `List`.
+- Add a suppression concept keyed by natural key; consult it in `FilterNew`; write it on `Delete`.
+
+**Non-Goals:**
+- Changing the conflict definition (still same-slot `(venue_id, local_event_date, start_at)`).
+- Changing `Approve` reconciliation semantics.
+- A per-concert Gemini confidence gate (grounding confidence is unreliable per prior findings).
+- An un-suppress UI beyond a minimal operator escape hatch (can be a follow-up).
+
+## Decisions
+
+**1. Branch point lives in the discovery consumer, reusing the admin usecase helpers.**
+The consumer calls `resolveOrCreateVenue` → `detectDuplicateEvent`. `nil` → `buildAndInsertConcerts`
++ publish `CONCERT.created`; conflict → upsert `staged_concert` (today's staging path). This keeps
+one canonical duplicate-detection implementation and avoids drift between discovery and approval.
+*Alternative considered:* keep the branch at approval and add an "auto-approve" flag — rejected;
+it still forces every concert through the queue table and a second processing hop.
+
+**2. Venue row is created only on the auto-publish path.** A conflict resolves to the existing
+event's venue, so `resolveOrCreateVenue` returns an existing row (no insert) whenever a conflict is
+detected; a brand-new venue implies no existing event there, i.e. the new/publish path. This
+preserves the "no orphan venues for never-published concerts" guarantee without extra bookkeeping.
+
+**3. Origin is a column on the published event.** Add `origin` (enum: `auto_published` /
+`admin_approved`) and `auto_published_at` (nullable `TIMESTAMPTZ`) to `events`. Approval sets
+`admin_approved`; the consumer's auto-publish sets `auto_published` + `auto_published_at`. The admin
+`List` response gains additive fields. The "recently auto-published" view is a client-side filter on
+`origin = auto_published AND auto_published_at >= now - window`; the 7-day window is presentation-only
+(no server state), so aging needs no background job. *Naming:* per backend schema-lint, avoid a bare
+`created_at`; `auto_published_at` is domain-specific and allowed.
+
+**4. Suppression is its own table, not the rejection log.** New `suppressed_concerts` keyed by the
+**event** natural key `(venue_id, local_event_date, start_at)` with `NULLS NOT DISTINCT` on
+`start_at` to mirror the `events` unique key exactly. `FilterNew` gains a third exclusion source
+alongside published events and pending staged rows. `Delete` writes a suppression row inside the same
+transaction as the cascade delete. The `rejected_concerts_log` stays analysis-only. *Alternative:*
+reuse the rejection log with a "suppress" flag — rejected; the spec explicitly keeps that log
+non-suppressing and analysis-only, and conflating the two invites accidental suppression.
+*Un-suppress:* delete the `suppressed_concerts` row (minimal operator path; UI optional follow-up).
+
+**5. Suppression key granularity matches the event-level deletion, and applies regardless of origin.**
+`Delete` removes an entire event `(venue_id, local_event_date, start_at)` by cascade, independent of
+performing artist, so the suppression key is the same triple — no `artist_id`. This prevents a
+co-headliner's per-artist discovery from resurrecting a physical slot the operator deleted. Keying is
+origin-agnostic: deleting a `admin_approved` concert must also suppress, because after auto-publish a
+deleted-then-rediscovered concert would otherwise return as `auto_published` with no review. The
+deleted event already carries `venue_id`/`local_event_date`/`start_at`, so the suppression row is
+derived directly from it — no Google Places call at delete. *Alternative considered:* key by
+`(artist_id, venue_id, local_event_date, start_at)` to match the per-artist discovery model — rejected
+as weaker than the deletion granularity (a different performer could resurrect the slot).
+
+## Risks / Trade-offs
+
+- **Auto-publishing the least-anchored data** → New concerts have no existing counterpart to
+  validate against, yet they now publish and notify without review. Mitigation: the recently-
+  auto-published review view + one-click delete-with-suppression is the safety net; immediate
+  notification is an accepted product decision.
+- **Immediate push for a hallucinated concert cannot be recalled** → Accepted. Mitigation: keep the
+  review window tight enough that operators catch bad rows soon; deleting suppresses re-creation.
+- **Dead deep-link after deletion** → A push already delivered may deep-link to a deleted event.
+  Mitigation: the concert-detail deep-link path degrades gracefully to a "no longer available" state
+  (existing deeplink-push handling).
+- **Suppression breaks the "re-discovery is idempotent / non-permanent" philosophy** → Intentional and
+  scoped: suppression is a deliberate operator signal, reversible only via the un-suppress path,
+  and kept separate from the non-suppressing rejection log.
+- **Co-headliner / different-performer-same-slot** → If artist A auto-publishes an event and artist B
+  is later discovered at the same `(venue, date, start)`, B is detected as a conflict and staged;
+  today's `AdoptStaged` does not add B as a performer. This is a pre-existing reconciliation gap that
+  auto-publish may surface more often; out of scope here, noted for a follow-up.
+- **Heavier consumer** → The consumer now does venue get-or-create + an event lookup per discovered
+  concert (previously only Places resolution). Acceptable: discovery is a batched CronJob, not a hot
+  path.
+
+## Migration Plan
+
+1. Atlas migration: add `events.origin` (default `admin_approved` for existing rows) + nullable
+   `events.auto_published_at`; create `suppressed_concerts`.
+2. Backend: move the branch into the consumer; `Delete` writes suppression; `FilterNew` consults it.
+   Ship behind the discovery consumer so behavior only changes on the next discovery run.
+3. Proto (BSR): additive `origin` + `auto_published_at` on the admin `List` concert message.
+4. Frontend admin console: recently-auto-published review view + delete action.
+5. Rollback: revert the consumer branch to always-stage; the new columns/table are inert if unused.

--- a/openspec/changes/auto-publish-new-concerts/proposal.md
+++ b/openspec/changes/auto-publish-new-concerts/proposal.md
@@ -1,0 +1,70 @@
+## Why
+
+Every concert the search pipeline discovers is currently staged as `pending` and
+requires a developer to approve it one by one — including brand-new concerts that
+have no existing counterpart to reconcile against. In practice the vast majority
+of the queue is brand-new concerts, so approval is mostly rubber-stamping. Now
+that Gemini search quality has improved, the manual gate on brand-new concerts
+buys little and costs a lot of reviewer time.
+
+The remaining hard cases are the *conflicts*: a discovered concert that collides
+with an already-published event at the same `(venue, date, start)` and where a
+human must decide which record to keep. Those still need judgment.
+
+This change moves the new-vs-conflict decision earlier so that new concerts
+publish automatically while conflicts keep the human reconciliation gate, and adds
+a lightweight post-hoc safety net so an operator can retract a bad auto-published
+concert.
+
+## What Changes
+
+- **Auto-publish brand-new concerts.** The `CONCERT.discovered` consumer resolves
+  the venue and runs duplicate detection up front. When the discovered concert is
+  genuinely new (no existing event at the resolved `(venue_id, local_date,
+  start_at)`), it publishes the concert directly — inserting the
+  `series`/`events`/`event_performers` rows and emitting `CONCERT.created` (so
+  follower push notifications fire immediately) — instead of writing a `pending`
+  staged row.
+- **Conflicts still go to the queue.** When duplicate detection finds a collision,
+  the concert is staged as `pending` exactly as today, and the developer resolves
+  it via the existing `Approve` reconciliation (`KeepExisting` / `AdoptStaged`).
+  The conflict definition is unchanged (same-slot collision at the resolved
+  `(venue_id, local_date, start_at)`; the known-start "fill" case is not a
+  conflict).
+- **Origin marking.** Published events record whether they were auto-published or
+  approved by a developer, and when they were auto-published, so a review view can
+  surface recently auto-published concerts.
+- **Post-hoc moderation with suppression.** Deleting an auto-published concert
+  records a suppression entry keyed by the concert's natural key; re-discovery
+  SHALL NOT auto-publish or re-stage a suppressed natural key. This breaks the
+  "delete → Gemini re-discovers → auto-publishes again" loop. Suppression is a new
+  concept, distinct from the analysis-only `rejected_concerts_log` (which remains
+  non-suppressing).
+- **BREAKING (operational, not API):** the approval queue's meaning narrows —
+  `pending` staged rows now represent only conflicts, not all discovered concerts.
+
+## Capabilities
+
+### New Capabilities
+<!-- none -->
+
+### Modified Capabilities
+- `concert-approval-queue`: discovery no longer stages every concert — new
+  concerts are auto-published, only conflicts are staged; the `Approve` path is
+  now reconciliation-only; re-discovery dedup additionally consults a suppression
+  set; a new suppression requirement covers deletion of auto-published concerts.
+- `admin-concert-management`: published concerts carry an origin (auto-published
+  vs developer-approved) and auto-publish timestamp exposed on the admin `List`
+  surface so the console can present a recently-auto-published review view;
+  `Delete` of an auto-published concert additionally records a suppression entry.
+
+## Impact
+
+- **Backend (Go):**
+  - `internal/adapter/event/concert_consumer.go` + `internal/usecase/concert_creation_uc.go`: move venue get-or-create + `detectDuplicateEvent` into the discovery consumer; branch auto-publish vs stage.
+  - `internal/usecase/concert_admin_uc.go`: `Approve` becomes reconciliation-only; `Delete` records suppression.
+  - Discovery `FilterNew` dedup (`internal/usecase/concert_uc.go`) additionally consults the suppression set.
+  - DB migration (Atlas): `events` gains an origin + auto-published-at column; a new suppression table keyed by concert natural key.
+- **Proto/BSR:** admin `ConcertService.List` response gains origin + auto-published-at fields (additive). No breaking proto change expected.
+- **Frontend (admin console):** new "recently auto-published" review view (time-based aging, default 7-day window) with a delete action wired to the existing `Delete` RPC.
+- **Notifications:** auto-published new concerts emit `CONCERT.created` immediately, so followers are notified without a review step. A push whose concert is later deleted may deep-link to a removed event; the concert-detail deep-link path should degrade gracefully.

--- a/openspec/changes/auto-publish-new-concerts/specs/admin-concert-management/spec.md
+++ b/openspec/changes/auto-publish-new-concerts/specs/admin-concert-management/spec.md
@@ -1,0 +1,108 @@
+## ADDED Requirements
+
+### Requirement: Admin console recently-auto-published review view
+
+The admin console SHALL provide a review view that surfaces concerts that were
+auto-published by the discovery pipeline, so an operator can retract a bad one after the
+fact. The view SHALL present only auto-published concerts (origin = auto-published) within a
+recency window (default 7 days from the auto-publish timestamp; configurable). Items SHALL
+age out of the view automatically once they fall outside the window — no explicit
+acknowledgement is required, so a correct auto-published concert costs the operator zero
+clicks. Each row SHALL expose a delete action that invokes the admin `Delete` operation.
+
+#### Scenario: View lists recently auto-published concerts
+
+- **WHEN** an operator opens the recently-auto-published review view
+- **THEN** it SHALL list concerts whose origin is auto-published and whose auto-publish
+  timestamp is within the recency window
+- **AND** it SHALL NOT list developer-approved concerts
+
+#### Scenario: Items age out without acknowledgement
+
+- **WHEN** an auto-published concert's auto-publish timestamp falls outside the recency window
+- **THEN** it SHALL no longer appear in the review view
+- **AND** no operator action SHALL have been required to clear it
+
+#### Scenario: Operator deletes a bad auto-published concert
+
+- **WHEN** an operator triggers delete on a row in the review view
+- **THEN** the console SHALL call the admin `Delete` operation for that concert's event id
+
+## MODIFIED Requirements
+
+### Requirement: Admin lists every published concert
+
+The admin `ConcertService` SHALL provide a `List` operation that returns every
+published concert, with no follower, proximity, or personalization filtering, so an
+operator can review the full published catalog. Each returned concert SHALL carry
+the identifiers required for follow-up actions (the published event id, the
+performing artist, and human-readable date/venue/title fields). Each returned concert
+SHALL additionally carry its origin (auto-published vs developer-approved) and, when
+auto-published, the auto-publish timestamp, so the console can present the
+recently-auto-published review view. `List` SHALL NOT return concerts that are still
+pending review (those are returned by `ListPending`).
+
+#### Scenario: List returns all published concerts
+
+- **WHEN** an admin calls `List`
+- **THEN** every published concert SHALL be returned regardless of any follow or
+  proximity relationship
+- **AND** each entry SHALL include its published event id and performing artist
+
+#### Scenario: List entries carry origin and auto-publish time
+
+- **WHEN** an admin calls `List`
+- **THEN** each returned concert SHALL indicate whether it was auto-published or
+  developer-approved
+- **AND** an auto-published concert SHALL carry its auto-publish timestamp
+
+#### Scenario: Pending concerts are excluded from List
+
+- **WHEN** concerts exist in both the published catalog and the pending review queue
+- **THEN** `List` SHALL return only the published concerts
+- **AND** the pending concerts SHALL be returned only by `ListPending`
+
+### Requirement: Admin hard-deletes a published concert
+
+The admin `ConcertService` SHALL provide a `Delete` operation that permanently
+removes a published concert identified by its event id. The deletion SHALL cascade
+through the database's referential integrity to every row that references the
+event (performers, tickets, ticket journeys, ticket emails, merkle tree nodes, and
+the series' sales phases). The operation SHALL be unconditional: it SHALL NOT be
+blocked by the presence of dependent rows such as minted tickets or fan ticket
+journeys. This is an operator correction tool; the absence of a guard is
+intentional for the pre-launch internal surface. On deletion the system SHALL record
+a suppression entry for the deleted event's natural key (`venue_id`, local event date,
+`start_at` — independent of performing artist), regardless of the concert's origin, so
+that a later discovery run does not re-create it (see the re-discovery suppression
+requirement in `concert-approval-queue`).
+
+#### Scenario: Delete removes the concert and cascades
+
+- **WHEN** an admin calls `Delete` with a published concert's event id
+- **THEN** the event and its concert record SHALL be removed
+- **AND** all rows referencing that event SHALL be removed by database cascade
+
+#### Scenario: Delete records a suppression entry
+
+- **WHEN** an admin calls `Delete` with a published concert's event id
+- **THEN** the system SHALL record a suppression entry for that concert's natural key
+- **AND** a later discovery run producing that natural key SHALL NOT re-create the concert
+
+#### Scenario: Delete is unconditional
+
+- **WHEN** an admin calls `Delete` on a concert that has dependent rows
+  (e.g. ticket journeys or minted tickets)
+- **THEN** the deletion SHALL proceed and remove those dependent rows
+- **AND** the operation SHALL NOT be rejected on account of the dependents
+
+#### Scenario: Delete is idempotent
+
+- **WHEN** a `Delete` targets an event id that no longer exists
+- **THEN** the operation SHALL succeed without error
+
+#### Scenario: Malformed event id is rejected
+
+- **WHEN** a `Delete` is called with a missing or malformed event id
+- **THEN** it SHALL be rejected with `INVALID_ARGUMENT`
+- **AND** no concert SHALL be deleted

--- a/openspec/changes/auto-publish-new-concerts/specs/concert-approval-queue/spec.md
+++ b/openspec/changes/auto-publish-new-concerts/specs/concert-approval-queue/spec.md
@@ -1,0 +1,127 @@
+## ADDED Requirements
+
+### Requirement: Discovery auto-publishes new concerts and stages only conflicts
+
+The `CONCERT.discovered` consumer SHALL resolve the venue and evaluate the discovered
+concert for a same-slot conflict against the published catalog BEFORE deciding how to
+persist it. When the discovered concert is genuinely new — no existing published event at
+the resolved `(venue_id, local_event_date, start_at)` (the known-start "fill" of an
+existing unknown-start row counts as new, not a conflict) — the consumer SHALL publish it
+directly: create or reuse the `venues` row, insert the published
+`series`/`events`/`event_performers` rows (reusing the existing bulk-insert and natural-key
+UPSERT behavior), and publish `CONCERT.created` so follower notifications fire immediately.
+It SHALL NOT write a `pending` staged row for a new concert. When a same-slot conflict IS
+detected, the consumer SHALL instead persist a `pending` `staged_concert` row (carrying the
+scraped fields and the resolved-venue preview) and SHALL NOT insert any published row or
+publish `CONCERT.created`; that staged row is resolved later through the existing approval
+reconciliation. Each auto-published event SHALL record its origin as auto-published and the
+timestamp at which it was auto-published.
+
+A `venues` row SHALL be created only on the auto-publish path. The conflict-staging path
+SHALL NOT create a new `venues` row, because a same-slot conflict necessarily resolves to
+the venue of the already-published event; thus rejected or never-approved concerts SHALL
+NOT create orphan `venues` rows.
+
+#### Scenario: New concert is auto-published without staging
+
+- **WHEN** the `CONCERT.discovered` consumer processes a discovered concert whose resolved
+  `(venue_id, local_event_date, start_at)` has no existing published event
+- **THEN** it SHALL create or reuse the `venues` row and insert the published event (with its
+  series and performers)
+- **AND** it SHALL publish `CONCERT.created`
+- **AND** it SHALL NOT write a `pending` staged row
+- **AND** it SHALL record the event's origin as auto-published with the auto-publish timestamp
+
+#### Scenario: Conflicting concert is staged for reconciliation
+
+- **WHEN** the `CONCERT.discovered` consumer processes a discovered concert that maps onto an
+  existing published event at the resolved `(venue_id, local_event_date, start_at)`
+- **THEN** it SHALL persist a `pending` `staged_concert` row carrying the scraped fields and
+  resolved-venue preview
+- **AND** it SHALL NOT insert any published row and SHALL NOT publish `CONCERT.created`
+
+#### Scenario: Known-start fill is treated as new, not a conflict
+
+- **WHEN** a discovered concert has a known start time and the only existing published event at
+  that venue and date has an unknown (NULL) start time
+- **THEN** the consumer SHALL treat it as the new/publish path (filling the existing row per the
+  established fill behavior) rather than staging it as a conflict
+
+#### Scenario: Pending concerts are not fan-visible
+
+- **WHEN** a concert is in `pending` state in the approval queue
+- **THEN** it SHALL NOT be returned by any consumer-facing read RPC (`List`, `ListByFollower`,
+  `ListWithProximity`)
+
+### Requirement: Deleting a published concert suppresses re-discovery
+
+Deleting a published concert (via the admin `Delete` operation) SHALL record a suppression
+entry keyed by the deleted event's natural key (resolved venue, local event date, and start
+time) — the same `(venue_id, local_event_date, start_at)` identity the event is stored under,
+independent of performing artist, so the suppression granularity matches the event-level
+deletion. Suppression applies regardless of the deleted concert's origin (auto-published or
+developer-approved): a deleted concert SHALL NOT silently return via auto-publish. Suppression
+is a distinct, persistent concept from the analysis-only `rejected_concerts_log`: it exists
+specifically to stop a concert an operator judged wrong from being auto-published or re-staged
+again by a later discovery run. Suppression SHALL be reversible only through a deliberate
+un-suppress path, not by ordinary re-discovery.
+
+#### Scenario: Delete records a suppression entry
+
+- **WHEN** an operator deletes a published concert
+- **THEN** the system SHALL record a suppression entry for that concert's natural key
+
+#### Scenario: Suppression is separate from the rejection log
+
+- **WHEN** a suppression entry is recorded
+- **THEN** it SHALL NOT be written to or read from the `rejected_concerts_log`
+- **AND** the `rejected_concerts_log` SHALL remain analysis-only and non-suppressing
+
+### Requirement: Re-discovery skips suppressed concerts
+
+When the search pipeline filters newly discovered concerts, it SHALL exclude any concert
+whose natural key matches a suppression entry, in addition to the existing exclusions for
+published events and `pending` staged rows. A suppressed natural key SHALL NOT be
+auto-published and SHALL NOT be re-staged as `pending`, so an operator's deletion of a bad
+auto-published concert is not undone by the next discovery run.
+
+#### Scenario: Suppressed concert is not re-created
+
+- **WHEN** a discovered concert's natural key matches a suppression entry
+- **THEN** the concert SHALL NOT be auto-published
+- **AND** SHALL NOT be staged as `pending`
+
+#### Scenario: Un-suppressed concert can be discovered again
+
+- **WHEN** a suppression entry for a natural key has been removed through the deliberate
+  un-suppress path
+- **AND** a later discovery run produces that natural key
+- **AND** that natural key is absent from `events` and `pending` staging
+- **THEN** the concert SHALL be eligible for auto-publish or conflict staging as normal
+
+## REMOVED Requirements
+
+### Requirement: Discovered concerts are staged, not published
+
+**Reason**: The blanket "every discovered concert is staged for human approval" gate is
+replaced. Now that search quality is sufficient, genuinely new concerts are auto-published on
+discovery and only same-slot conflicts are staged. The staging queue no longer represents all
+discovered concerts — only the conflict subset that needs human reconciliation.
+
+**Migration**: Superseded by "Discovery auto-publishes new concerts and stages only conflicts".
+The venue orphan-free guarantee is preserved by that requirement (a new `venues` row is created
+only on the auto-publish path; a conflict resolves to the existing event's venue). No data
+migration of existing `staged_concert` rows is required — remaining pending rows are still
+resolved through the unchanged approval reconciliation.
+
+### Requirement: Venue resolved at staging time, persisted at approval
+
+**Reason**: Venue persistence timing changes. A `venues` row is now created on the auto-publish
+path at discovery time (not at approval), and the conflict-staging path never creates a new
+`venues` row because a same-slot conflict resolves to the already-published event's venue.
+
+**Migration**: Superseded by "Discovery auto-publishes new concerts and stages only conflicts",
+which owns the venue behavior: resolved-venue fields are denormalized onto the auto-published
+event (publish path) or onto the `staged_concert` row for reviewer preview (conflict path), a
+`venues` row is created only on the auto-publish path, and never-published concerts leave no
+orphan `venues` rows.

--- a/openspec/changes/auto-publish-new-concerts/tasks.md
+++ b/openspec/changes/auto-publish-new-concerts/tasks.md
@@ -1,0 +1,45 @@
+## 1. Specification (proto / BSR)
+
+- [ ] 1.1 Add `origin` (enum: `auto_published` / `admin_approved`) and `auto_published_at` fields to the admin `ConcertService.List` concert message in `rpc/admin/v1`
+- [ ] 1.2 `buf lint` + `buf format -w` + `buf breaking` pass (fields are additive; no breaking label expected)
+- [ ] 1.3 Open specification PR, merge, publish GitHub Release (vX.Y.Z), confirm `buf-release.yml` pushes to BSR
+
+## 2. Backend — data model
+
+- [ ] 2.1 Atlas migration: add `events.origin` (NOT NULL, default `admin_approved` for existing rows) and nullable `events.auto_published_at` (`TIMESTAMPTZ`)
+- [ ] 2.2 Atlas migration: create `suppressed_concerts` keyed by the event triple `(venue_id, local_event_date, start_at)` with `NULLS NOT DISTINCT` on `start_at` (mirrors the `events` unique key; no `artist_id`)
+- [ ] 2.3 Register both migration files in `k8s/atlas/base/kustomization.yaml`; `atlas migrate apply --env local` + `validate` pass
+- [ ] 2.4 Add repository methods: insert/exists on `suppressed_concerts`; set `origin`/`auto_published_at` on event insert
+
+## 3. Backend — auto-publish branch in the discovery consumer
+
+- [ ] 3.1 In `concert_creation_uc.go`, resolve/create venue and run `detectDuplicateEvent` before persisting
+- [ ] 3.2 New concert (no conflict) → `buildAndInsertConcerts` with `origin=auto_published` + `auto_published_at`, then publish `CONCERT.created`
+- [ ] 3.3 Conflict detected → upsert `staged_concert` (existing staging path), no publish
+- [ ] 3.4 Preserve the known-start "fill" path as new/publish, not a conflict
+- [ ] 3.5 Set `origin=admin_approved` on the approval insert path in `concert_admin_uc.go`
+- [ ] 3.6 Unit tests: new→auto-publish+event emitted; conflict→staged+no event; fill→publish; no orphan venue for staged-only
+
+## 4. Backend — suppression + dedup + delete
+
+- [ ] 4.1 Extend `FilterNew` (`concert_uc.go`) to exclude natural keys present in `suppressed_concerts` (third source alongside published + pending)
+- [ ] 4.2 In admin `Delete`, write a `suppressed_concerts` row (derived from the event's `venue_id`/`local_event_date`/`start_at`, origin-agnostic) in the same transaction as the cascade delete
+- [ ] 4.3 Add a minimal un-suppress path (remove a `suppressed_concerts` row) for operator recovery
+- [ ] 4.4 Map `origin` + `auto_published_at` into the admin `List` RPC response
+- [ ] 4.5 Unit tests: suppressed key not re-created (auto nor staged); delete writes suppression; un-suppress re-enables discovery; `List` carries origin/time
+- [ ] 4.6 `make check` passes; open backend PR after BSR gen; merge
+
+## 5. Frontend — admin console review view
+
+- [ ] 5.1 Upgrade the generated schema package to the released version; swap to generated `origin`/`auto_published_at` types
+- [ ] 5.2 Add a "recently auto-published" review view: client-side filter `origin=auto_published AND auto_published_at >= now - window` (default 7 days, configurable)
+- [ ] 5.3 Items age out of the view automatically (no acknowledgement); each row has a delete action calling admin `Delete`
+- [ ] 5.4 Ensure the concert-detail deep-link degrades gracefully when the target event was deleted
+- [ ] 5.5 `make check` passes; open frontend PR after BSR gen; merge
+
+## 6. Ship to production & verify
+
+- [ ] 6.1 Release backend (tag) → ArgoCD rollout; confirm migration applied and new consumer running
+- [ ] 6.2 Release frontend (GH Release → pin-bump) → confirm review view live in admin console
+- [ ] 6.3 Verify on next discovery run: a genuinely new concert auto-publishes + push fires; a same-slot conflict still lands in the approval queue
+- [ ] 6.4 Verify delete-with-suppression: delete an auto-published concert, confirm it is not re-created on the following discovery run


### PR DESCRIPTION
## Summary

Relax the concert approval gate now that Gemini search quality is sufficient. Today the discovery pipeline stages **every** discovered concert for manual approval, but the queue is dominated by brand-new concerts that only get rubber-stamped. This OpenSpec change (`auto-publish-new-concerts`) moves the new-vs-conflict decision into the discovery consumer:

- **New concerts auto-publish** on discovery — insert the published event and emit `CONCERT.created` (follower push fires immediately). No staging.
- **Same-slot conflicts** (a collision at the resolved `(venue_id, local_event_date, start_at)`) still route to the admin approval queue for the existing `KeepExisting` / `AdoptStaged` reconciliation.

Result: approval workload drops from "all discovered concerts" to "only same-slot conflicts".

## Safety net (post-hoc moderation)

- Published events record their **origin** (`auto_published` / `admin_approved`) + auto-publish timestamp.
- Admin console gains a **recently-auto-published review view** — time-based aging (default 7-day window), no acknowledgement clicks, so a correct auto-published concert costs the operator zero clicks.
- Deleting a published concert records a **suppression** entry keyed by the event triple `(venue_id, local_event_date, start_at)`, **origin-agnostic**, so a deleted concert is not silently re-created by the next discovery run. Suppression is a distinct concept from the analysis-only `rejected_concerts_log`; reversible via a deliberate un-suppress path.

## Changes (planning artifacts only)

- `proposal.md` — why + what + capability deltas.
- `specs/concert-approval-queue/spec.md` — ADDED auto-publish/suppression requirements; REMOVED the blanket "staged, not published" and "venue persisted at approval" requirements (behavior inverts/moves; Reason + Migration included).
- `specs/admin-concert-management/spec.md` — `List` surfaces origin + auto-publish time; `Delete` records suppression; new recently-auto-published review view.
- `design.md` — branch moved into the discovery consumer (reusing `detectDuplicateEvent` / `resolveOrCreateVenue` / `buildAndInsertConcerts`); `events.origin` + `auto_published_at`; `suppressed_concerts` table (event-triple key); risks (auto-publishing the least-anchored data, dead deep-link, co-headliner reconciliation gap).
- `tasks.md` — spec → BSR → backend (migration / consumer branch / suppression / dedup) → frontend review view → prod release & verify.

`openspec validate --strict` passes. No proto changes in this PR — additive `List` fields land with the backend/frontend follow-up after BSR gen.

## Testing

- `openspec validate auto-publish-new-concerts --strict` → valid.

close: #797
