### PR TITLE
docs(openspec): propose unify-workload-naming change

### DIFF
--- a/openspec/changes/unify-workload-naming/.openspec.yaml
+++ b/openspec/changes/unify-workload-naming/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-17

--- a/openspec/changes/unify-workload-naming/design.md
+++ b/openspec/changes/unify-workload-naming/design.md
@@ -1,0 +1,102 @@
+## Context
+
+See proposal.md — Why. Current workloads: backend `server-app` / `consumer-app` /
+`admin-console-api`, frontend `web-app` / `admin-app` / `organizer-app`. The
+`admin-console-api` split + its GCP-identity isolation (dedicated GSA, Cloud SQL IAM
+user, `admin-console-secrets` ExternalSecret, DATABASE_USER override, app-schema grant
+migration) landed in `organizer-accounts` / `organizer-tenancy` and is the working
+template for how one isolated workload's identity + DB access is wired. This change
+generalizes that shape across every workload and unifies the names.
+
+Rename precedent: `zitadel`→`zitadel-api`/`zitadel-web` (`zitadel-self-hosted-deployment`)
+established the create-new → cutover → delete-old discipline and the "renamed canonical
+names must be present in the rendered tree before prod ArgoCD picks them up" rule.
+
+## Goals / Non-Goals
+
+**Goals:** one derivable `<audience>-<tier>` name for every workload + all bound
+Kubernetes, GCP-identity, image, route, and secret resources; a spec that future
+workloads follow; a per-resource migration that tolerates brief interruption but keeps
+external hostnames stable.
+
+**Non-Goals:** splitting `event-consumer` per entity (future); changing any external
+hostname, OIDC app, or API contract; re-architecting the workloads (this is naming +
+identity only); renaming `admin-console-api` (already conforms) or building
+`organizer-console-api` (that is `organizer-rpc-server` ①4/4, which will adopt the name
+natively).
+
+## Decisions
+
+**D1 — Scheme `<audience>-<tier>`.** audience ∈ `fan`/`admin-console`/`organizer-console`
+mirrors the proto RPC audience; tier ∈ `web`/`api`/`event-consumer`. Chosen over
+domain-based names (`organizer-api`) because a workload serves an *audience surface*, not
+one domain (the admin API serves `organizer`, and later other admin domains). Chosen over
+keeping `-app` because `-app` does not distinguish web vs api vs worker.
+
+**D2 — GCP identity keys off the workload name.** GSA account-id = stem, Cloud SQL IAM
+user = `<stem>@<project>.iam`, GSM key = `zitadel-machine-key-for-<stem>`, AR repo =
+`<layer>/<stem>`. This makes the identity self-describing and matches the existing
+`zitadel-machine-key-for-<principal>` convention. Alternative (keep GCP identity names,
+rename only K8s) was rejected by the explicit requirement to unify the identity layer.
+
+**D3 — Create-new → cutover → delete-old per resource.** In-place renames of state-tracked
+(Pulumi GSA/secret/SQL user) or route-bound (HTTPRoute) resources trigger replace
+cascades or routing gaps. Additive migration (stand up the new-named resource, repoint,
+then delete the old) is safe and matches the `admin-console-api` template. Pulumi URN
+renames on lifecycle-sensitive resources use `aliases` where an in-place adopt is
+preferable to a destroy/create (per the platform's URN-rename practice).
+
+**D4 — `event-consumer` stays single.** One cross-domain worker now; the name reserves
+the `-event-consumer` tier so a future per-entity split (`concert-event-consumer`, …) is
+additive. KEDA durables are already behavior-named and are NOT renamed by the workload
+rename (renaming durables would churn JetStream consumers — explicitly avoided).
+
+**D5 — Hostnames are frozen.** `api.liverty-music.app`, `admin.liverty-music.app`,
+`organizer.{base}`, `api.admin.liverty-music.app` etc. stay put; only the internal
+resource names change, so external clients and OIDC redirect URIs are untouched.
+
+**D6 — Spec reconciliation scope.** Only `zitadel-self-hosted-deployment` pins a renamed
+identifier as a normative requirement (the GSM key) → a MODIFIED delta. Other specs'
+name mentions are incidental prose reconciled by a tasks sweep against the new convention
+spec; they carry no behavioral change (hostnames/APIs unchanged).
+
+## Risks / Trade-offs (per-resource)
+
+| Resource class | Blast radius | Risk → Mitigation |
+|---|---|---|
+| **GSA `backend-app`→`fan-api`** | WI binding, per-secret IAM, Cloud SQL IAM user, GSM key, all role grants | Widest. New GSA lacks all bindings until re-granted → **create GSA + replicate every role/binding (cloudsql.client+instanceUser, secret accessors, WI) first, verify, then cutover KSA annotation, then delete old** (the `admin-console-api` incident showed a missing `cloudsql.client`/DB-user/grant crashloops the pod — replicate the *full* set). |
+| **Zitadel MachineKey / GSM `…-for-backend-app`→`…-for-fan-api`** | backend→Zitadel JWT auth | keyId drift breaks bearer auth (§13.15 class) → **re-issue MachineKey under fan-api, write new GSM, cutover fan-api env + ESO ref, confirm `keyId` matches Zitadel AuthNKey, then delete old key/secret.** |
+| **Cloud SQL IAM DB user `backend-app@…`→`fan-api@…`** | fan-api DB access | new user has no app-schema grants → **create CLOUD_IAM_SERVICE_ACCOUNT user + run the grant-loop migration (as in `organizer-accounts` #390) before flipping DATABASE_USER.** |
+| **Backend Deployment/Service/HTTPRoute `server-app`/`server-route`→`fan-api*`** | `api.liverty-music.app` routing | routing gap on repoint → **create fan-api Deployment/Service/route, attach route to the Gateway (hostname unchanged), verify 200, then detach/delete server-route + server-app.** |
+| **AR image repos `backend/server`,`frontend/web-app`,…→`…/fan-api`,`…/fan-web`,…** | CI push, prod pin, immutable-tag retag, bump-prod-pin dispatch list | prod pin/retag reference old repo → **create new repos, update CI push targets + `bump-prod-pin` image list + release retag map, cut a release to populate new repos, then repoint overlays' `images:` block.** |
+| **Frontend Deployments `*-app`→`*-web` + bundle-isolation** | admin/organizer/web bundles | isolation script allowlists old workload/bundle names → **update `verify-bundle-isolation` allowlist in lockstep; create-new deploys, repoint frontend HTTPRoutes, delete old.** |
+| **ExternalSecret `admin-console-secrets`→`admin-console-api-secrets` (+ per-workload)** | ESO sync + mount | mount ref mismatch → **create new ExternalSecret (new target Secret), update deployment mount, Reloader restarts, delete old.** |
+| **`consumer-app`→`event-consumer` + KEDA ScaledObject** | JetStream durables | renaming durables wedges consumers → **rename only the Deployment/Service/ScaledObject/image; keep durable names; verify HPA currentMetrics not `<unknown>`.** |
+| **Monitoring `app.kubernetes.io/name` labels + PodMonitoring/AlertPolicy** | dashboards, alerts, PromQL | queries keyed on old workload name go blind → **update PromQL/dashboards/AlertPolicies referencing old names in the same change; verify metrics still resolve post-cutover.** |
+| **Pulumi logical URNs** | state | logical-name change → destroy/create → **use `aliases` for adopt-in-place where safe; accept destroy/create only for the additively-recreated identities above.** |
+
+## Migration Plan
+
+Per audience, additively and one workload at a time (dev first, then prod), so a failure
+is contained to one surface:
+
+1. **cloud-provisioning (identity + infra)**: add new GSA/DB-user/GSM-key/AR-repo/WI +
+   all bindings for the target name (old kept live). `pulumi up`.
+2. **backend/frontend (images)**: point CI at new AR repos, cut a release to populate
+   them (dual-published), run the Cloud SQL grant migration for the new DB user.
+3. **k8s (create-new)**: add new-named Deployment/Service/SA/HTTPRoute/HealthCheckPolicy/
+   ExternalSecret/configmap/ScaledObject/PodMonitoring alongside the old; ArgoCD sync.
+4. **cutover**: repoint each HTTPRoute (hostname unchanged) + DATABASE_USER + secret refs
+   + monitoring labels to the new workload; verify health (200 + DB connect + auth).
+5. **delete-old**: remove old Deployments/Services/routes/secrets/GSA/DB-user/GSM-key/
+   AR-repo; `pulumi up`; confirm no dangling references.
+6. **spec sweep**: reconcile incidental old-name references in the other specs against the
+   `workload-naming-convention` spec.
+- **Rollback**: until step 5, the old-named resources are still live — repoint routes/
+  env back to them; the new resources are additive and removable.
+
+## Open Questions
+
+- Whether to fold `cloud-sql-proxy` into the convention (it is a shared 3rd-party proxy,
+  not an audience workload) — leaning keep-as-is; resolve during cloud-provisioning tasks
+  without changing the spec.

--- a/openspec/changes/unify-workload-naming/proposal.md
+++ b/openspec/changes/unify-workload-naming/proposal.md
@@ -1,0 +1,90 @@
+## Why
+
+Platform workloads are named on three inconsistent axes — `server-app` / `web-app` /
+`admin-app` / `organizer-app` (`-app`), `admin-console-api` (`-api`), `consumer-app`
+(worker) — so the same logical application has different names in the app layer
+(proto `rpc.admin.organizer.v1`, backend `organizer`) and the infra layer
+(`admin-console-api` backend vs `admin-app` frontend). The mismatch obscures which
+frontend, backend, GCP identity, image, route, and secret belong together, and every
+new workload re-litigates the naming. This change establishes one convention and
+migrates every existing resource to it so a reader can derive all related resource
+names from the audience alone.
+
+## What Changes
+
+- Introduce a platform **workload naming convention**: `<audience-console>-<tier>`,
+  where audience ∈ `fan` / `admin-console` / `organizer-console` and tier ∈ `web`
+  (browser bundle), `api` (Connect-RPC server), `event-consumer` (JetStream worker).
+  Derived resource suffixes stay uniform: Service `-svc`, HealthCheckPolicy
+  `-policy`, HTTPRoute `-route`, ExternalSecret `-secrets`, and the GCP identity /
+  GSM-key naming (`zitadel-machine-key-for-<principal>`) keys off the same principal.
+- **BREAKING (resource identity)** rename every existing workload + its derived
+  resources to the convention (service interruption during cutover is accepted):
+  - `web-app` → `fan-web`, `server-app` → `fan-api`, `consumer-app` → `event-consumer`
+  - `admin-app` → `admin-console-web` (backend `admin-console-api` already conforms)
+  - `organizer-app` → `organizer-console-web` (the organizer backend API is built as
+    `organizer-console-api` from the start by `organizer-rpc-server` ①4/4)
+- **BREAKING (GCP identity)** rename the GCP layer to match the principal: GSA
+  `backend-app` → `fan-api` (and the admin GSA already `admin-console-api`), the
+  Cloud SQL `CLOUD_IAM_SERVICE_ACCOUNT` users, the per-secret IAM bindings, the
+  Workload Identity bindings, and the GSM key `zitadel-machine-key-for-backend-app`
+  → `zitadel-machine-key-for-fan-api` (re-issued Zitadel `backend-app` MachineKey).
+- Rename the derived resources coherently in the same cutover: Deployments,
+  Services, ServiceAccounts, HTTPRoutes (`server-route` → `fan-api-route`, etc.),
+  HealthCheckPolicies, ExternalSecrets (incl. `admin-console-secrets` →
+  `admin-console-api-secrets`), configmaps, Artifact Registry image repositories,
+  prod image pins, `app.kubernetes.io/name` labels + PodMonitoring, KEDA
+  ScaledObject, and the frontend bundle-isolation script's workload allowlist.
+- Adopt a **create-new → cutover → delete-old** migration per resource (mirroring
+  the `zitadel`→`zitadel-api`/`zitadel-web` rename precedent) so state-tracked and
+  route-bound resources move without a stuck/replace cascade.
+- `event-consumer` stays a single worker in this change; future per-entity split
+  (e.g. `concert-event-consumer`) is out of scope but the name anticipates it.
+
+## Capabilities
+
+### New Capabilities
+- `workload-naming-convention`: the canonical `<audience-console>-<tier>` scheme, the
+  derived-resource suffix rules, the GCP identity / GSM-key naming, the full canonical
+  name mapping table, and the migration ordering rule (create-new → cutover →
+  delete-old). Future workloads SHALL derive their names from this spec.
+
+### Modified Capabilities
+- `zitadel-self-hosted-deployment`: the GSM key requirement changes from
+  `zitadel-machine-key-for-backend-app` to `zitadel-machine-key-for-fan-api` (the
+  `backend-app` Zitadel principal is renamed `fan-api`). This is the one existing
+  spec that pins a renamed identifier as a normative requirement.
+
+<!-- Other specs (`identity-management`, `deployment-infrastructure`,
+     `prod-image-pipeline`, `k8s-resource-right-sizing`, `prod-image-tag-immutability`,
+     `argocd-image-automation`, `frontend-hosting`, `apex-frontend-serving`,
+     `prod-environment-bootstrap`, `zitadel-action-webhook`, `secret-management`,
+     `dev-db-access`, `atlas-operator`, `argocd-*`) mention old workload names only
+     incidentally (prose/examples), not as behavioral contracts — external behavior
+     (hostnames, APIs) is unchanged by a rename. Their references are reconciled as an
+     implementation task sweep against the new convention spec, not as behavioral
+     deltas here. -->
+- (documentation reconciliation of incidental name references → tasks.md, not a delta)
+
+## Impact
+
+- **cloud-provisioning**: the bulk — Pulumi (`kubernetes.ts` GSAs + IAM, `postgres.ts`
+  Cloud SQL users, GSM secret names in `identity`/`project`), all `k8s/namespaces/{backend,frontend}`
+  base + overlays (Deployments/Services/SAs/HTTPRoutes/HealthCheckPolicies/ExternalSecrets/
+  configmaps/ScaledObject/PodMonitoring), prod image pins, and the bump-prod-pin workflow's
+  image list.
+- **backend**: Dockerfile/CI image repo targets (`backend/server`→`backend/fan-api`), the
+  Cloud SQL `DATABASE_USER` for fan-api, Atlas grant migration for the renamed IAM DB user,
+  any workload-name references in config/docs.
+- **frontend**: CI image repo targets (`frontend/web-app`→`frontend/fan-web`, `admin-app`→
+  `admin-console-web`, `organizer-app`→`organizer-console-web`), the bundle-isolation script
+  allowlist, release/retag + repository_dispatch pin-bump image names.
+- **specification**: this new capability spec + the modified deltas above; a sweep to
+  reconcile incidental name references in other specs (`k8s-resource-right-sizing`,
+  `prod-image-tag-immutability`, `argocd-image-automation`, `frontend-hosting`,
+  `apex-frontend-serving`, `prod-environment-bootstrap`, `zitadel-action-webhook`,
+  `secret-management`, `dev-db-access`, `atlas-operator`, `argocd-*`).
+- **Zitadel**: re-issue the `backend-app` MachineKey under the `fan-api` principal +
+  its GSM secret; the login/OIDC apps are unaffected (audience hostnames unchanged).
+- Cutover accepts brief per-service interruption; hostnames (`api.liverty-music.app`,
+  `admin.liverty-music.app`, etc.) are unchanged so external URLs are stable.

--- a/openspec/changes/unify-workload-naming/specs/workload-naming-convention/spec.md
+++ b/openspec/changes/unify-workload-naming/specs/workload-naming-convention/spec.md
@@ -1,0 +1,110 @@
+## Purpose
+
+Establish a single, derivable naming convention for platform workloads and every
+resource bound to them (Kubernetes objects, GCP identities, image repositories,
+routes, secrets), so that from an application's audience alone an operator or tool
+can predict all of its related resource names, and so future workloads are named
+without re-litigation.
+
+## ADDED Requirements
+
+### Requirement: Workload names follow the audience-tier scheme
+
+Every deployable workload SHALL be named `<audience>-<tier>`, where `<audience>` is
+one of `fan`, `admin-console`, or `organizer-console`, and `<tier>` is one of `web`
+(browser bundle served to that audience), `api` (Connect-RPC server for that
+audience), or `event-consumer` (JetStream event worker). The audience SHALL match the
+proto RPC audience segment (`rpc.<audience>.*`, where the consumer/fan audience is the
+unprefixed default). No workload SHALL use an ad-hoc suffix such as `-app`.
+
+#### Scenario: Deriving a workload name from its audience and tier
+
+- **WHEN** a reader needs the name of the fan-facing Connect-RPC server
+- **THEN** it SHALL be `fan-api`, the fan browser bundle SHALL be `fan-web`, the admin
+  console API SHALL be `admin-console-api`, the admin console bundle SHALL be
+  `admin-console-web`, and the organizer console API/bundle SHALL be
+  `organizer-console-api` / `organizer-console-web`
+
+#### Scenario: The JetStream worker uses the event-consumer tier
+
+- **WHEN** the platform runs a single cross-domain JetStream event worker
+- **THEN** it SHALL be named `event-consumer` (a future per-entity split MAY prefix the
+  entity, e.g. `concert-event-consumer`, but SHALL keep the `-event-consumer` tier)
+
+#### Scenario: No legacy ad-hoc suffixes remain
+
+- **WHEN** the platform's workloads are enumerated after migration
+- **THEN** none SHALL be named `server-app`, `web-app`, `admin-app`, `organizer-app`,
+  or `consumer-app`
+
+### Requirement: Derived resources share the workload stem with uniform suffixes
+
+Every Kubernetes resource bound to a workload SHALL reuse the workload name as its
+stem with a uniform suffix: Service `<stem>-svc`, HealthCheckPolicy `<stem>-policy`,
+HTTPRoute `<stem>-route`, ExternalSecret `<stem>-secrets`, and configmap `<stem>-config`.
+Env-specific hostnames on HTTPRoutes SHALL remain unchanged by the rename (they are the
+external contract).
+
+#### Scenario: Deriving bound resource names for a workload
+
+- **WHEN** the workload is `fan-api`
+- **THEN** its Service SHALL be `fan-api-svc`, its HTTPRoute `fan-api-route`, its
+  HealthCheckPolicy `fan-api-policy`, and any dedicated ExternalSecret
+  `fan-api-secrets`
+
+#### Scenario: The admin console ExternalSecret conforms
+
+- **WHEN** the admin console API's dedicated secret is rendered after migration
+- **THEN** it SHALL be named `admin-console-api-secrets` (not `admin-console-secrets`)
+
+### Requirement: GCP identities and image repositories key off the same principal
+
+A workload's GCP identity SHALL use the workload name as the principal: the Google
+Service Account account-id SHALL be `<stem>`, its Cloud SQL IAM database user SHALL be
+`<stem>@<project>.iam`, its Zitadel MachineKey GSM secret SHALL be
+`zitadel-machine-key-for-<stem>`, and its Artifact Registry image repository SHALL be
+`<layer>/<stem>` (layer ∈ `backend` / `frontend`). Workload Identity and per-secret IAM
+bindings SHALL reference that principal.
+
+#### Scenario: Deriving GCP identity names for a workload
+
+- **WHEN** the fan-facing API workload `fan-api` is provisioned
+- **THEN** its GSA account-id SHALL be `fan-api`, its Cloud SQL IAM user SHALL be
+  `fan-api@<project>.iam`, its image repo SHALL be `backend/fan-api`, and its Zitadel
+  MachineKey secret SHALL be `zitadel-machine-key-for-fan-api`
+
+### Requirement: A canonical name mapping is the authoritative reference
+
+This capability SHALL maintain a canonical mapping from each current workload to its
+target name so that the migration and all downstream references resolve to a single
+source of truth.
+
+#### Scenario: The mapping enumerates every platform workload
+
+- **WHEN** an operator consults the convention for a workload's canonical name
+- **THEN** the mapping SHALL cover at least: `server-app`→`fan-api`,
+  `web-app`→`fan-web`, `consumer-app`→`event-consumer`, `admin-app`→`admin-console-web`
+  (`admin-console-api` unchanged), and `organizer-app`→`organizer-console-web`
+  (`organizer-console-api` built new), plus each workload's derived Kubernetes, GCP
+  identity, image, and secret names
+
+### Requirement: Renames use an additive create-new then cutover then delete-old migration
+
+Renaming a live workload or a state-tracked / route-bound resource SHALL follow a
+create-new → cutover → delete-old sequence rather than an in-place rename, so that
+Gateway routes, Pulumi/Cloud SQL/IAM state, and ArgoCD-managed resources move without a
+stuck-replace or dependency cascade. A brief per-service interruption during cutover is
+acceptable; external hostnames SHALL NOT change.
+
+#### Scenario: Renaming a route-bound backend workload
+
+- **WHEN** `server-app` is renamed to `fan-api`
+- **THEN** the new `fan-api` Deployment/Service/route SHALL be created and the HTTPRoute
+  hostname (`api.liverty-music.app`) SHALL be repointed to it before the old `server-app`
+  resources are deleted, leaving the external hostname unchanged
+
+#### Scenario: Future workloads are named from the convention at creation
+
+- **WHEN** a new workload is introduced (e.g. the organizer console API)
+- **THEN** it SHALL be created directly under its canonical name (`organizer-console-api`)
+  with no later rename required

--- a/openspec/changes/unify-workload-naming/specs/zitadel-self-hosted-deployment/spec.md
+++ b/openspec/changes/unify-workload-naming/specs/zitadel-self-hosted-deployment/spec.md
@@ -1,0 +1,41 @@
+## MODIFIED Requirements
+
+### Requirement: Backend MachineKey Lifecycle Tied to Zitadel-Side Identity
+
+The fan-facing API's Zitadel MachineKey SHALL be stored in a GSM secret named
+`zitadel-machine-key-for-fan-api`, following the platform-wide convention
+`zitadel-machine-key-for-<principal>` where `<principal>` is the workload name from
+the `workload-naming-convention` capability. The `fan-api` principal is the renamed
+`backend-app` workload (see `workload-naming-convention`); the legacy GSM name
+`zitadel-machine-key-for-backend-app` (itself a prior rename from the ambiguous
+`zitadel-machine-key`) SHALL be migrated to the new principal name via the additive
+create-new → cutover → delete-old sequence, re-issuing the MachineKey so the GSM
+`keyDetails` and the Zitadel AuthNKey stay consistent across the rename.
+
+The name encodes which Zitadel principal owns the key so the platform's multiple
+`MachineKey`s (`pulumi-admin`, `fan-api`) remain distinguishable at a glance — the
+ambiguity of the original `zitadel-machine-key` directly cost triage time in the
+§13.15 incident chain.
+
+#### Scenario: keyId in GSM matches Zitadel DB
+
+- **WHEN** Pulumi state contains a `MachineKey` for a given user
+- **THEN** the `keyId` in the GSM SecretVersion's JSON SHALL match a row in Zitadel's AuthNKey table for that user
+- **AND** the fan-api → Zitadel API JWT bearer auth SHALL succeed
+
+#### Scenario: Force-replace on detected drift
+
+- **WHEN** the operator detects keyId drift (e.g., via `Errors.AuthNKey.NotFound` in fan-api logs)
+- **THEN** the operator SHALL force-replace the Pulumi `MachineKey` resource by changing a non-cosmetic property (e.g., bumping `expirationDate` to a different valid value)
+- **AND** the resulting Pulumi apply SHALL produce a new `keyDetails` value, propagate it through the dependency graph, replace the GSM SecretVersion, sync ESO, and trigger Reloader-driven fan-api Pod restart
+
+#### Scenario: Both dev and prod produce a Backend MachineKey
+
+- **WHEN** `pulumi up` runs for the `dev` stack and again for the `prod` stack
+- **THEN** each stack's resulting Pulumi state SHALL contain exactly one `MachineKey` resource for the `fan-api` machine user
+- **AND** each stack's GSM project (`liverty-music-dev` and `liverty-music-prod` respectively) SHALL contain a Secret named `zitadel-machine-key-for-fan-api` with at least one enabled SecretVersion
+
+#### Scenario: The legacy backend-app key name is retired after migration
+
+- **WHEN** the rename migration has completed in an environment
+- **THEN** no GSM secret named `zitadel-machine-key-for-backend-app` SHALL remain, and the fan-api workload SHALL read only `zitadel-machine-key-for-fan-api`

--- a/openspec/changes/unify-workload-naming/tasks.md
+++ b/openspec/changes/unify-workload-naming/tasks.md
@@ -1,0 +1,52 @@
+## 1. Convention + tooling
+
+- [ ] 1.1 Land the `workload-naming-convention` spec (canonical name mapping table as the source of truth) and the `zitadel-self-hosted-deployment` GSM-key delta via a specification PR → merge (no Release; docs/spec only)
+- [ ] 1.2 Add a rename helper/checklist to cloud-provisioning docs capturing the create-new → cutover → delete-old order per resource class (from design.md)
+
+## 2. fan audience — `web-app`→`fan-web`, `server-app`→`fan-api` (highest blast radius)
+
+### 2a. Identity + infra (cloud-provisioning, additive)
+- [ ] 2.1 Add GSA `fan-api` with the FULL binding set replicated from `backend-app` (cloudsql.client + cloudsql.instanceUser + logging/monitoring/cloudtrace/aiplatform/serviceusage + artifact-registry reader), WI binding, and per-secret SecretAccessor bindings; keep `backend-app` live
+- [ ] 2.2 Add Cloud SQL `CLOUD_IAM_SERVICE_ACCOUNT` user `fan-api@<project>.iam` (postgres.ts); keep `backend-app@…` live
+- [ ] 2.3 Re-issue the Zitadel `backend-app` MachineKey under the `fan-api` principal into GSM `zitadel-machine-key-for-fan-api`; keep the old secret live
+- [ ] 2.4 Create AR image repos `backend/fan-api` and `frontend/fan-web`; keep old repos live. `pulumi up` (dev then prod)
+
+### 2b. Images + DB grants
+- [ ] 2.5 Point backend CI push target to `backend/fan-api` (+ prod retag map) and frontend CI to `frontend/fan-web`; add both to the `bump-prod-pin` image list
+- [ ] 2.6 Backend grant migration: grant app-schema privileges to the `fan-api@…` IAM DB user (grant-loop, as in organizer-accounts #390)
+- [ ] 2.7 Cut backend + frontend releases to populate the new AR repos (dual-published)
+
+### 2c. K8s create-new + cutover + delete-old
+- [ ] 2.8 Add `fan-api` Deployment/Service(`fan-api-svc`)/SA(`fan-api`)/HTTPRoute(`fan-api-route`)/HealthCheckPolicy(`fan-api-policy`)/configmap(`fan-api-config`)/ExternalSecret(`fan-api-secrets`) and `fan-web` Deployment/Service/route, alongside the old; set fan-api `DATABASE_USER=fan-api@…`; ArgoCD sync
+- [ ] 2.9 Cutover: repoint `api.liverty-music.app` → `fan-api-route`/`fan-api-svc` and the fan bundle host → `fan-web`; update the `verify-bundle-isolation` allowlist; verify 200 + DB connect + Zitadel JWT auth + bundle isolation
+- [ ] 2.10 Delete old `server-app`/`server-route`/`server-svc`/`web-app` + their configmaps/secrets; then delete `backend-app` GSA, `backend-app@…` DB user, `zitadel-machine-key-for-backend-app`, and old AR repos. `pulumi up`; confirm no dangling refs
+
+## 3. admin-console — `admin-app`→`admin-console-web` (+ ExternalSecret align)
+
+- [ ] 3.1 Rename ExternalSecret `admin-console-secrets`→`admin-console-api-secrets` (new target Secret + deployment mount), create-new → cutover → delete-old
+- [ ] 3.2 Create AR repo `frontend/admin-console-web`, point frontend CI + pin list, release to populate
+- [ ] 3.3 Add `admin-console-web` Deployment/Service/route alongside `admin-app`; cutover `admin.liverty-music.app` → `admin-console-web`; update bundle-isolation allowlist; verify 200 + isolation; delete `admin-app` + old AR repo
+- [ ] 3.4 Confirm `admin-console-api` (already conforming) is unaffected
+
+## 4. organizer-console — `organizer-app`→`organizer-console-web`
+
+- [ ] 4.1 Create AR repo `frontend/organizer-console-web`, point CI + pin list, release to populate
+- [ ] 4.2 Add `organizer-console-web` Deployment/Service/route alongside `organizer-app`; cutover `organizer.{base}` → `organizer-console-web`; update bundle-isolation allowlist; verify 200 + isolation; delete `organizer-app` + old AR repo
+- [ ] 4.3 Confirm the future organizer backend API is planned as `organizer-console-api` in `organizer-rpc-server` (①4/4) — no rename needed there
+
+## 5. event-consumer — `consumer-app`→`event-consumer`
+
+- [ ] 5.1 Create AR repo `backend/event-consumer` (or reuse the backend image with a renamed Deployment — decide in impl), point CI + pin list
+- [ ] 5.2 Add `event-consumer` Deployment/Service/ScaledObject/configmap/PodMonitoring alongside `consumer-app`, keeping the existing JetStream durable names unchanged; ArgoCD sync; verify HPA currentMetrics not `<unknown>` and events consumed
+- [ ] 5.3 Delete `consumer-app` + old ScaledObject/configmap/AR repo; confirm durables intact and no event backlog
+
+## 6. Monitoring + spec reconciliation
+
+- [ ] 6.1 Update `app.kubernetes.io/name` labels, PodMonitoring, dashboards, and AlertPolicies referencing old workload names; verify metrics/alerts resolve post-cutover
+- [ ] 6.2 Spec sweep: reconcile incidental old-name references against `workload-naming-convention` across `identity-management`, `deployment-infrastructure`, `prod-image-pipeline`, `k8s-resource-right-sizing`, `prod-image-tag-immutability`, `argocd-image-automation`, `frontend-hosting`, `apex-frontend-serving`, `prod-environment-bootstrap`, `zitadel-action-webhook`, `secret-management`, `dev-db-access`, `atlas-operator`, `argocd-*` (specification PR → merge)
+
+## 7. Ship to prod + verify
+
+- [ ] 7.1 Apply each audience's migration to prod (pulumi up prod + releases + prod pin bumps + ArgoCD sync), audience-by-audience with health verification between cutovers
+- [ ] 7.2 Prod verification: all workloads render under the new names (`kubectl get deploy` shows only convention names); `api.liverty-music.app` / `admin.liverty-music.app` / `organizer.{base}` all 200; fan-api DB + Zitadel auth OK; event-consumer draining; ArgoCD apps Synced/Healthy
+- [ ] 7.3 Cleanup: confirm no old-named GSAs, DB users, GSM secrets, AR repos, routes, or Deployments remain in dev or prod; no `<unknown>` HPA metrics; no stale monitoring queries


### PR DESCRIPTION
## Summary

Proposes the OpenSpec change **`unify-workload-naming`** (planning artifacts only — no implementation). It establishes one platform workload naming convention and plans the migration of every existing workload and its bound resources to it.

Same application, one name across layers: today the same surface is `admin-console-api` (backend) but `admin-app` (frontend), and `server-app`/`web-app`/`consumer-app` mix `-app`/`-api`/worker suffixes. This makes the naming derivable from the audience alone.

## Convention

`<audience>-<tier>`:
- audience ∈ `fan` / `admin-console` / `organizer-console` (mirrors the proto RPC audience)
- tier ∈ `web` (browser bundle) / `api` (Connect-RPC server) / `event-consumer` (JetStream worker)
- derived resources reuse the stem: Service `-svc`, HealthCheckPolicy `-policy`, HTTPRoute `-route`, ExternalSecret `-secrets`; GCP identity keys off the same principal (GSA, Cloud SQL IAM user, `zitadel-machine-key-for-<principal>`, AR repo `<layer>/<stem>`)

## Canonical renames

- `web-app`→`fan-web`, `server-app`→`fan-api`, `consumer-app`→`event-consumer`
- `admin-app`→`admin-console-web` (`admin-console-api` already conforms)
- `organizer-app`→`organizer-console-web` (`organizer-console-api` built new by organizer-rpc-server ①4/4)
- GCP identity included: GSA `backend-app`→`fan-api`, its Cloud SQL IAM user, and GSM `zitadel-machine-key-for-backend-app`→`zitadel-machine-key-for-fan-api`

## Artifacts

- `proposal.md` — why + what + capabilities + impact
- `specs/workload-naming-convention/spec.md` — **new capability**: the scheme, suffix rules, GCP-identity/image naming, canonical mapping, and create-new→cutover→delete-old rule
- `specs/zitadel-self-hosted-deployment/spec.md` — **MODIFIED**: GSM key principal rename (the one existing spec that pins a renamed identifier as a requirement)
- `design.md` — decisions + **per-resource risk analysis table** + migration plan + rollback
- `tasks.md` — 7-phase additive migration (convention → fan → admin-console → organizer-console → event-consumer → monitoring/spec sweep → prod ship + verify + cleanup)

Service interruption during cutover is accepted; external hostnames stay stable. `openspec validate --strict` passes.

close: #799
