### PR TITLE
docs(openspec): rework unify-workload-naming for prod-direct cutover

### DIFF
--- a/openspec/changes/unify-workload-naming/design.md
+++ b/openspec/changes/unify-workload-naming/design.md
@@ -77,23 +77,38 @@ spec; they carry no behavioral change (hostnames/APIs unchanged).
 
 ## Migration Plan
 
-Per audience, additively and one workload at a time (dev first, then prod), so a failure
-is contained to one surface:
+**D7 — Prod-direct cutover (no dev-first).** The dev environment is intentionally
+stopped for cost, so the "dev first, then prod" rehearsal is not available. Instead the
+migration runs **directly in prod**, made safe by the additive create-new → cutover →
+delete-old discipline itself: the new-named resources stand up **alongside** the live
+old ones and carry no traffic/identity until the explicit cutover step, and every step
+before delete-old is reversible by repointing back to the old resources. This trades the
+dev rehearsal for a strictly additive prod rollout with a per-resource rollback at each
+gate. The delete-old step is deferred until the new workload is verified healthy in prod.
+
+Per audience, additively and one workload at a time (prod-direct), so a failure is
+contained to one surface:
 
 1. **cloud-provisioning (identity + infra)**: add new GSA/DB-user/GSM-key/AR-repo/WI +
-   all bindings for the target name (old kept live). `pulumi up`.
+   all bindings for the target name (old kept live). `pulumi up` (prod).
 2. **backend/frontend (images)**: point CI at new AR repos, cut a release to populate
    them (dual-published), run the Cloud SQL grant migration for the new DB user.
 3. **k8s (create-new)**: add new-named Deployment/Service/SA/HTTPRoute/HealthCheckPolicy/
    ExternalSecret/configmap/ScaledObject/PodMonitoring alongside the old; ArgoCD sync.
+   The new workload is running and self-verifiable (health probe, DB connect, auth) while
+   still detached from the external hostname.
 4. **cutover**: repoint each HTTPRoute (hostname unchanged) + DATABASE_USER + secret refs
-   + monitoring labels to the new workload; verify health (200 + DB connect + auth).
-5. **delete-old**: remove old Deployments/Services/routes/secrets/GSA/DB-user/GSM-key/
-   AR-repo; `pulumi up`; confirm no dangling references.
+   + monitoring labels to the new workload; verify health (200 on the live hostname + DB
+   connect + auth). This is the only step with a brief interruption window.
+5. **delete-old**: only after the new workload is confirmed healthy in prod, remove old
+   Deployments/Services/routes/secrets/GSA/DB-user/GSM-key/AR-repo; `pulumi up`; confirm
+   no dangling references.
 6. **spec sweep**: reconcile incidental old-name references in the other specs against the
    `workload-naming-convention` spec.
 - **Rollback**: until step 5, the old-named resources are still live — repoint routes/
-  env back to them; the new resources are additive and removable.
+  env back to them; the new resources are additive and removable. Because there is no dev
+  rehearsal, the new workload's self-verification in step 3 (before cutover) is the
+  primary safety gate: do not proceed to cutover until it passes detached.
 
 ## Open Questions
 

--- a/openspec/changes/unify-workload-naming/tasks.md
+++ b/openspec/changes/unify-workload-naming/tasks.md
@@ -1,7 +1,11 @@
+> Migration runs **prod-direct** (dev is intentionally stopped for cost). Safety comes
+> from the additive create-new → cutover → delete-old discipline, with the new workload
+> self-verified in prod while detached before cutover. See design.md D7.
+
 ## 1. Convention + tooling
 
-- [ ] 1.1 Land the `workload-naming-convention` spec (canonical name mapping table as the source of truth) and the `zitadel-self-hosted-deployment` GSM-key delta via a specification PR → merge (no Release; docs/spec only)
-- [ ] 1.2 Add a rename helper/checklist to cloud-provisioning docs capturing the create-new → cutover → delete-old order per resource class (from design.md)
+- [x] 1.1 Land the `workload-naming-convention` spec (canonical name mapping table as the source of truth) and the `zitadel-self-hosted-deployment` GSM-key delta via a specification PR → merge (no Release; docs/spec only) — landed on main via merged PR #800; prod-direct design refinement (D7) follows in a small docs PR
+- [x] 1.2 Add a rename helper/checklist to cloud-provisioning docs capturing the create-new → cutover → delete-old order per resource class (from design.md)
 
 ## 2. fan audience — `web-app`→`fan-web`, `server-app`→`fan-api` (highest blast radius)
 
@@ -9,7 +13,7 @@
 - [ ] 2.1 Add GSA `fan-api` with the FULL binding set replicated from `backend-app` (cloudsql.client + cloudsql.instanceUser + logging/monitoring/cloudtrace/aiplatform/serviceusage + artifact-registry reader), WI binding, and per-secret SecretAccessor bindings; keep `backend-app` live
 - [ ] 2.2 Add Cloud SQL `CLOUD_IAM_SERVICE_ACCOUNT` user `fan-api@<project>.iam` (postgres.ts); keep `backend-app@…` live
 - [ ] 2.3 Re-issue the Zitadel `backend-app` MachineKey under the `fan-api` principal into GSM `zitadel-machine-key-for-fan-api`; keep the old secret live
-- [ ] 2.4 Create AR image repos `backend/fan-api` and `frontend/fan-web`; keep old repos live. `pulumi up` (dev then prod)
+- [ ] 2.4 Create AR image repos `backend/fan-api` and `frontend/fan-web`; keep old repos live. `pulumi up` (prod-direct — dev is stopped; see design.md D7)
 
 ### 2b. Images + DB grants
 - [ ] 2.5 Point backend CI push target to `backend/fan-api` (+ prod retag map) and frontend CI to `frontend/fan-web`; add both to the `bump-prod-pin` image list
@@ -49,4 +53,4 @@
 
 - [ ] 7.1 Apply each audience's migration to prod (pulumi up prod + releases + prod pin bumps + ArgoCD sync), audience-by-audience with health verification between cutovers
 - [ ] 7.2 Prod verification: all workloads render under the new names (`kubectl get deploy` shows only convention names); `api.liverty-music.app` / `admin.liverty-music.app` / `organizer.{base}` all 200; fan-api DB + Zitadel auth OK; event-consumer draining; ArgoCD apps Synced/Healthy
-- [ ] 7.3 Cleanup: confirm no old-named GSAs, DB users, GSM secrets, AR repos, routes, or Deployments remain in dev or prod; no `<unknown>` HPA metrics; no stale monitoring queries
+- [ ] 7.3 Cleanup: confirm no old-named GSAs, DB users, GSM secrets, AR repos, routes, or Deployments remain in prod; no `<unknown>` HPA metrics; no stale monitoring queries


### PR DESCRIPTION
## Summary

Refines the already-merged `unify-workload-naming` plan (#800) to run **prod-direct**, because the dev environment is intentionally stopped for cost and the specced "dev first, then prod" cutover rehearsal is unavailable.

- **design.md**: adds decision **D7 — Prod-direct cutover (no dev-first)**. Safety is preserved by the additive create-new → cutover → delete-old discipline: new-named resources stand up alongside the live old ones and carry no traffic/identity until the explicit cutover, with pre-cutover detached self-verification in prod as the primary safety gate. Delete-old is deferred until the new workload is verified healthy in prod.
- **tasks.md**: drops dev-first ordering (preamble note + task edits pointing at D7).

Docs/spec only — no Release, no code, no infra change.

## Test plan

- `openspec validate unify-workload-naming --strict` → valid.

Refs: #799