### PR TITLE
docs(openspec): fix-prod-zitadel-instance-config + organizer-accounts reconcile

### DIFF
--- a/openspec/changes/fix-prod-zitadel-instance-config/.openspec.yaml
+++ b/openspec/changes/fix-prod-zitadel-instance-config/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-17

--- a/openspec/changes/fix-prod-zitadel-instance-config/design.md
+++ b/openspec/changes/fix-prod-zitadel-instance-config/design.md
@@ -1,0 +1,88 @@
+## Context
+
+Two prod Zitadel instance-config defects (see proposal.md), both in
+`cloud-provisioning/src/zitadel`. Diagnosis done live: prod Postmark server
+(`Liverty Music [prod]`, id 18504491) shows **0 sends** with a verified sending
+domain and a valid server token, and `auth.liverty-music.app/ui/login/`
+302-redirects to `https://auth.dev.liverty-music.app/ui/console`. The Pulumi
+resources exist (`SmtpConfig` + `ZitadelSmtpActivation`, `AdminOrgConfigComponent`)
+— these are runtime-state / wiring defects, not missing resources.
+
+## Goals / Non-Goals
+
+**Goals:** SMTP activation that self-heals runtime drift; a `defaultRedirectUri`
+that always points at the environment's own console; remediate the live prod
+instance so email delivers and the console stops redirecting to dev.
+
+**Non-Goals:** Postmark account/DNS changes (prod server + `mail.liverty-music.app`
+already verified), new email templates, any organizer-domain code.
+
+## Decisions
+
+**D1 — Self-healing SMTP activation via a drift-detecting `read`.**
+`ZitadelSmtpActivation` (`src/zitadel/dynamic/smtp-activation.ts`) currently has a
+no-op `read`, so once the live config drifts inactive Pulumi never notices. Change
+`read` to call `POST /admin/v1/smtp/_search` (the same discovery the `create`
+handler already does) and inspect the config's `state`:
+- If the config is missing or **not** `SMTP_CONFIG_ACTIVE`, return props that
+  differ from the recorded state (e.g. drop/blank `activatedAt`, or surface a
+  `state` field) so Pulumi reports drift on `refresh` and the subsequent `up`
+  re-runs activation.
+- If it is `SMTP_CONFIG_ACTIVE`, return the recorded state unchanged (steady-state
+  no redundant `_activate`).
+Re-activation itself reuses the existing idempotent `_activate` call (2xx or
+"already active" = success). Healing requires a **refreshing** `up`
+(`pulumi up --refresh`, or the prod Pulumi Cloud deployment configured to
+refresh); document that in the runbook/tasks. Keep `delete` a no-op (removing the
+Pulumi record must not deactivate live SMTP). This trades the previous
+"zero-HTTP steady state" for one lightweight `_search` per refresh — an
+acceptable cost for eliminating a silent-outage class.
+
+**D2 — Pass the environment-specific `consoleUrl`.**
+`AdminOrgConfigComponent` already accepts a `consoleUrl` arg and applies it as the
+admin-org LoginPolicy `defaultRedirectUri`, but defaults to a hardcoded
+`https://auth.dev.liverty-music.app/ui/console` and the call site
+(`src/zitadel/index.ts`) never passes it. Pass
+`consoleUrl: pulumi.interpolate\`https://${domain}/ui/console\`` (the same
+per-env `domain` the component already receives for the Zitadel host) at the call
+site. Remove the dev-pointing fallback, or make it the current-env domain, so no
+environment can silently inherit another's console. Dev is unaffected in value
+(its `domain` already resolves to `auth.dev.liverty-music.app`).
+
+**D3 — Remediation ordering.** After merge, a refreshing prod `pulumi up`:
+(1) `read`/refresh detects the drifted SMTP → `_activate` re-runs → active;
+(2) the admin-org LoginPolicy `defaultRedirectUri` updates to the prod console.
+Confirm the prod Postmark server records a delivered email and
+`auth.liverty-music.app/ui/login/` no longer redirects to dev. Rotate the prod
+Postmark Server API Token afterward (it was shared in plaintext during
+diagnosis) and update ESC.
+
+## Risks / Trade-offs
+
+- **`read` now issues an API call on refresh** → one `_search` per refresh; bounded
+  and only on refreshing applies. Worth it to remove the silent-outage failure mode.
+- **Refresh dependency** → self-healing only triggers on a refreshing `up`; if the
+  prod deployment does not refresh, drift persists. Mitigation: enable refresh on
+  the prod deployment (or run `pulumi up --refresh`) — captured in tasks.
+- **Multiple SMTP configs** → `_search` assumes exactly one config per instance
+  (the existing `create` handler already asserts this); preserve that assumption
+  and its explicit error.
+
+## Migration Plan
+
+1. cloud-provisioning: implement D1 (`smtp-activation.ts` `read`) + D2
+   (`admin-org-config.ts` fallback + `index.ts` call site); `make lint-ts`.
+2. Merge → refreshing prod `pulumi up` (manual, Pulumi Cloud console).
+3. Verify: prod Postmark shows a delivered email; prod console no longer
+   redirects to dev; then finish `organizer-accounts` 6.3.
+4. Rotate the prod Postmark token; update ESC.
+- Rollback: both changes are additive/wiring — revert restores the prior
+  (broken) behavior; no data migration.
+
+## Open Questions
+
+- Whether to also enable refresh on the prod Pulumi Cloud deployment permanently
+  (so future SMTP drift self-heals on the next scheduled apply) vs. relying on
+  operators to pass `--refresh` — resolved in tasks as "enable refresh on the
+  prod deployment" if the console supports it, else document the `--refresh`
+  requirement in the runbook.

--- a/openspec/changes/fix-prod-zitadel-instance-config/proposal.md
+++ b/openspec/changes/fix-prod-zitadel-instance-config/proposal.md
@@ -1,0 +1,62 @@
+## Why
+
+Two prod-only Zitadel instance-config defects, both surfaced while verifying
+`organizer-accounts` 6.3 (operator passkey onboarding), block all Zitadel email
+delivery and misroute the console. Neither is organizer-specific — they affect
+every Zitadel email (verification, password reset, passkey init) and every
+context-less Console login in prod.
+
+1. **SMTP is silently inactive in prod.** `SendPasswordlessRegistration` is
+   accepted but no email reaches Postmark (0 sends on both the prod and dev
+   Postmark servers). The `ZitadelSmtpActivation` dynamic resource activated the
+   config once (2026-05-15) but its lifecycle is, by current spec, a **no-op on
+   unchanged inputs** (no `read`, no re-activation) — so once the live
+   activation drifts (a rebuild/reset/out-of-band deactivation that does not
+   change the Pulumi inputs), Pulumi never notices and never re-activates. The
+   failure is invisible: the send API returns success and nothing logs an error.
+
+2. **Console login redirects to the dev console in prod.**
+   `auth.liverty-music.app/ui/login/` 302-redirects to
+   `https://auth.dev.liverty-music.app/ui/console`. The admin org LoginPolicy's
+   `defaultRedirectUri` is set by `AdminOrgConfigComponent`, which falls back to a
+   hardcoded dev URL when no `consoleUrl` is passed — and the prod call site
+   (`src/zitadel/index.ts`) does not pass one. So prod (and dev) both get the dev
+   console URL.
+
+## What Changes
+
+- **Make SMTP activation self-healing.** Change `ZitadelSmtpActivation` so its
+  `read` handler queries the live SMTP config's activation state and reports
+  drift when it is not `SMTP_CONFIG_ACTIVE`, so `pulumi up` (with refresh)
+  re-activates it. A runtime deactivation must no longer be a permanent silent
+  outage. Preserve create-time idempotency (already-active = success).
+- **Wire the environment-specific console URL.** Pass `consoleUrl` to
+  `AdminOrgConfigComponent` from the per-environment domain so the admin org
+  LoginPolicy `defaultRedirectUri` is the correct console for the environment
+  (prod → `https://auth.liverty-music.app/ui/console`); remove reliance on the
+  hardcoded dev fallback.
+- **Remediate the live prod instance:** re-activate the prod SMTP config and
+  correct the prod `defaultRedirectUri` via `pulumi up`; confirm Postmark shows a
+  delivered email and the prod console no longer redirects to dev.
+
+Explicit non-goals: no changes to the Postmark account/DNS (prod server + domain
+are verified), no new email templates, no organizer-domain code changes.
+
+## Capabilities
+
+### Modified Capabilities
+- `identity-management`: the SMTP activation requirement gains a self-healing
+  (drift-detecting) lifecycle; the admin-org LoginPolicy requirement gains an
+  environment-specific `defaultRedirectUri`.
+
+## Impact
+
+- **cloud-provisioning**:
+  - `src/zitadel/dynamic/smtp-activation.ts` — `read` becomes drift-detecting
+    (query live activation state) instead of a pure no-op.
+  - `src/zitadel/components/admin-org-config.ts` + `src/zitadel/index.ts` — pass
+    the env-specific `consoleUrl`; drop / correct the dev fallback.
+  - Prod `pulumi up` (with refresh) to remediate the live instance.
+- **specification**: MODIFIED `identity-management` requirements (SMTP activation,
+  admin-org login policy).
+- Unblocks `organizer-accounts` 6.3 (operator passkey email delivery).

--- a/openspec/changes/fix-prod-zitadel-instance-config/specs/identity-management/spec.md
+++ b/openspec/changes/fix-prod-zitadel-instance-config/specs/identity-management/spec.md
@@ -1,0 +1,101 @@
+## MODIFIED Requirements
+
+### Requirement: SMTP Configuration Must Be Activated After Creation
+
+The system SHALL invoke the Zitadel admin API `POST /admin/v1/smtp/{id}/_activate` after creating a `SmtpConfig` resource via a **Pulumi Dynamic Resource (`ZitadelSmtpActivation`)** that fires as a declarative dependency of the `SmtpConfig` resource, because Zitadel v4 ships new SMTP configurations in `SMTP_CONFIG_INACTIVE` state and the `@pulumiverse/zitadel.SmtpConfig` resource does not flip the activation flag. The activation SHALL additionally be **self-healing**: the resource's `read` handler SHALL query the live SMTP config's activation state, so that a runtime loss of activation (an instance rebuild/reset, or an out-of-band deactivation, that does not change the resource's Pulumi inputs) is surfaced as drift and re-activated on the next refreshing `pulumi up`, without an input change or a manual step.
+
+**Rationale**: An inactive SMTP config silently swallows all outbound notification events. Verification emails, password-reset emails, passkey-registration links, and admin notifications are queued but never delivered to the SMTP provider. The failure mode is invisible — the send API returns success, the notification worker logs nothing, and the user-facing UX is "no email arrived." The original implementation activated once at create time but treated every later reconcile as a no-op (no `read`, no re-check), so once the live activation drifted the outage was permanent and undetectable. This was observed in prod: `SendPasswordlessRegistration` succeeded yet Postmark received zero sends. The contract is therefore strengthened from "activate once" to "activate and keep active."
+
+#### Scenario: Newly provisioned SMTP config is activated automatically
+
+- **WHEN** Pulumi provisions a `SmtpConfig` resource on a fresh Zitadel instance
+- **THEN** the `ZitadelSmtpActivation` Dynamic Resource SHALL call `POST /admin/v1/smtp/{id}/_activate` as part of the same `pulumi up`
+- **AND** the resulting state SHALL be `SMTP_CONFIG_ACTIVE`
+- **AND** subsequent verification emails SHALL be queued AND delivered to the SMTP provider
+
+#### Scenario: First apply against an already-active SMTP succeeds (create-time idempotency)
+
+- **WHEN** Pulumi runs `create()` for `ZitadelSmtpActivation` against an SMTP config that is already in `SMTP_CONFIG_ACTIVE` state (e.g., activated out-of-band prior to this resource being added to the stack)
+- **THEN** the `_activate` POST SHALL return Zitadel's "already active" response shape
+- **AND** `create()` SHALL treat that response as success
+- **AND** the resource SHALL be recorded in Pulumi state with a fresh `activatedAt` timestamp
+
+#### Scenario: Refresh detects a drifted (inactive) SMTP and re-activation heals it
+
+- **WHEN** the live SMTP config has drifted to a non-active state (e.g., after an instance rebuild/reset or an out-of-band deactivation) while the `ZitadelSmtpActivation` resource's Pulumi inputs are unchanged
+- **AND** an operator runs a refreshing `pulumi up` (`pulumi up --refresh`, or a stack whose deployment refreshes)
+- **THEN** the `read` handler SHALL query the live activation state and report the resource as out-of-date (drifted)
+- **AND** the ensuing `pulumi up` SHALL re-invoke `_activate` so the config returns to `SMTP_CONFIG_ACTIVE`
+- **AND** no manual `curl`/`gcloud` step and no input change SHALL be required to heal it
+
+#### Scenario: Re-apply with unchanged inputs is a Pulumi-graph no-op
+
+- **WHEN** Pulumi re-applies the stack **without a refresh** and the `ZitadelSmtpActivation` resource's inputs (`smtpConfigId`, `domain`, `jwtProfileJson`) are unchanged from the previous apply
+- **THEN** Pulumi's input diff SHALL be empty
+- **AND** no lifecycle handler (`create` / `update` / `delete` / `read`) on `ZitadelSmtpActivation` SHALL be invoked (drift detection is the refreshing-apply path above)
+- **AND** zero HTTP traffic SHALL be generated against the Zitadel admin API
+- **AND** the Pulumi state graph SHALL continue to record the resource as up-to-date
+
+#### Scenario: Activation runs on a fresh Zitadel rebuild without operator intervention
+
+- **WHEN** the dev (or staging / prod) Zitadel instance is destroyed and recreated from scratch
+- **AND** Pulumi runs `pulumi up` against the recreated instance
+- **THEN** the `SmtpConfig` resource SHALL be recreated
+- **AND** the `ZitadelSmtpActivation` resource SHALL fire `_activate` automatically as the next step in the dependency graph
+- **AND** the operator SHALL NOT need to run any manual `curl` or `gcloud` step
+- **AND** the first user sign-up after the rebuild SHALL receive a verification email
+
+### Requirement: Configure Admin Org Login Policy
+
+The system SHALL configure a `LoginPolicy` on the `admin` role org that
+permits external IdP sign-in via the admin Google IdP, disables
+username + password sign-in (so the random initial password set on the
+human admin is unreachable), and disallows self-registration. IdP-level
+linking settings (configured on the Google IdP itself, see "Provision
+Google IdP for Admin Sign-in") govern the actual auto-link-by-email
+behaviour. The system SHALL also configure the `DefaultLoginPolicy`
+(instance-level) consistently so that Console login behaviour does not
+depend on Login V2's choice of routing path. The policy's
+`defaultRedirectUri` (where a context-less login lands) SHALL be the
+**environment-specific** Console URL derived from that environment's Zitadel
+domain — prod → `https://auth.liverty-music.app/ui/console`, dev →
+`https://auth.dev.liverty-music.app/ui/console` — and SHALL NOT rely on a
+hardcoded default that points at another environment.
+
+#### Scenario: Apply admin org login policy
+
+- **WHEN** Pulumi stack is applied
+- **THEN** the `admin` role org SHALL have a `LoginPolicy` with
+  `allowExternalIdp = true`
+- **AND** the policy `idps` array SHALL include the id of the admin Google
+  IdP
+- **AND** the policy `userLogin` SHALL be `false` (disables
+  username + password sign-in form)
+- **AND** the policy SHALL NOT enable self-registration
+  (`allowRegister = false`) so that no anonymous Google identity becomes
+  a Zitadel user without explicit Pulumi provisioning
+
+#### Scenario: defaultRedirectUri matches the environment's own console
+
+- **WHEN** Pulumi applies the admin-org and default login policies in a given environment
+- **THEN** the policy `defaultRedirectUri` SHALL be that environment's own Console URL (prod → `https://auth.liverty-music.app/ui/console`)
+- **AND** a context-less login at `https://auth.<env-domain>/ui/login/` SHALL land on that same-environment Console
+- **AND** prod SHALL NOT redirect to `auth.dev.liverty-music.app`
+
+#### Scenario: DefaultLoginPolicy mirrors admin org policy for Console fallback
+
+- **WHEN** Pulumi stack is applied
+- **THEN** the IAM-level `DefaultLoginPolicy` SHALL also enable external
+  IdP with the admin Google IdP and disallow self-registration
+- **AND** the product org's explicit `LoginPolicy` override SHALL take
+  precedence for product-org login flows, leaving end-user passkey-only
+  behaviour intact
+
+#### Scenario: Admin org enables domain discovery routing
+
+- **WHEN** Pulumi stack is applied
+- **THEN** the `admin` role org's `LoginPolicy` SHALL set
+  `allowDomainDiscovery = true`
+- **AND** when a user types an email address whose domain matches an
+  organisation domain registered against the `admin` org, Login V2 SHALL
+  resolve to the `admin` org's policy

--- a/openspec/changes/fix-prod-zitadel-instance-config/tasks.md
+++ b/openspec/changes/fix-prod-zitadel-instance-config/tasks.md
@@ -1,0 +1,28 @@
+## 1. SMTP activation self-healing (cloud-provisioning)
+
+- [ ] 1.1 `src/zitadel/dynamic/smtp-activation.ts`: change `read` from no-op to drift-detecting — `POST /admin/v1/smtp/_search`, inspect `state`; return props that differ from recorded state when the config is missing or not `SMTP_CONFIG_ACTIVE` (so refresh reports drift), unchanged when already active. Keep `create`/`update`/`delete` semantics (idempotent `_activate`, no-op delete).
+- [ ] 1.2 Preserve the single-config assumption + explicit error (>1 config) already in `create`.
+- [ ] 1.3 `make lint-ts` passes (biome + tsc).
+
+## 2. Environment-specific console redirect (cloud-provisioning)
+
+- [ ] 2.1 `src/zitadel/index.ts`: pass `consoleUrl: pulumi.interpolate` `https://${domain}/ui/console` to `new AdminOrgConfigComponent(...)`.
+- [ ] 2.2 `src/zitadel/components/admin-org-config.ts`: remove the hardcoded dev fallback (or make it the current-env domain) so no env inherits another's console.
+- [ ] 2.3 `make lint-ts` passes.
+
+## 3. Ship + remediate the live prod instance
+
+- [ ] 3.1 Open cloud-provisioning PR; CI green; merge to main.
+- [ ] 3.2 Run a **refreshing** prod `pulumi up` (Pulumi Cloud console, `--refresh` enabled): SMTP `read`/refresh detects drift → `_activate` re-runs → `SMTP_CONFIG_ACTIVE`; admin-org LoginPolicy `defaultRedirectUri` updates to the prod console.
+- [ ] 3.3 Enable refresh on the prod deployment (if the console supports it) OR document the `pulumi up --refresh` requirement in the runbook so future SMTP drift self-heals.
+
+## 4. Verify in prod
+
+- [ ] 4.1 Trigger a Zitadel email (e.g. re-issue an operator passkey link, or an org create in `organizer-accounts`) → prod Postmark server `Liverty Music [prod]` Activity shows the message **Sent/Delivered**.
+- [ ] 4.2 `curl -sL auth.liverty-music.app/ui/login/` (or a browser) no longer redirects to `auth.dev.liverty-music.app`; it lands on the prod console.
+- [ ] 4.3 Confirm dev is unaffected (dev `defaultRedirectUri` still the dev console; dev SMTP still active).
+
+## 5. Post-remediation hygiene
+
+- [ ] 5.1 Rotate the prod Postmark Server API Token (it was shared in plaintext during diagnosis); update ESC `postmark.serverApiToken` for prod; re-`pulumi up` if needed.
+- [ ] 5.2 Unblock `organizer-accounts` 6.3: complete the operator passkey-link step now that prod email delivers.

--- a/openspec/changes/organizer-accounts/design.md
+++ b/openspec/changes/organizer-accounts/design.md
@@ -64,14 +64,21 @@ authorization in this change (that is the organizer-facing server, 4/4).
 
 **D4 — Provisioning saga (idempotent, compensating), keyed on OrganizerId.**
 Order: (1) insert `organizers` row `status=provisioning`; (2)
-Management API create tenant org (name `org-<uuid-short>`, explicit
+Management API create tenant org (name `org-<full-uuid>` — the full OrganizerId,
+NOT a short prefix: the first 8 hex of a UUIDv7 are its millisecond timestamp, so
+a prefix collides for any two organizers created within the same ~65s window,
+which would resolve the second into the first's tenant [cross-tenant `owner`
+grant]; explicit
 **passkey-primary** login policy per `organizer-tenancy`:
 `passwordlessType=ALLOWED`, `allowUsernamePassword=false`,
 `allowRegister=false`, `allowExternalIDP=true`, `ignoreUnknownUsernames=true`;
 NOT domain-discovery); (3) persist `zitadel_org_id`; (4) Project-Grant
 `organizer-console` (role subset incl. `owner`); (5) create operator human
 user (no password, `request_passwordless_registration` → passkey init link) +
-`owner` User Grant; (6) set `status=active`. A reconciler re-enters
+`owner` User Grant; (6) compare-and-set `status` `provisioning`→`active` (a
+conditional update, NOT an unconditional set: a concurrent `Deactivate` during
+the multi-second saga must not be clobbered by a trailing activation — a
+superseded CAS is a no-op and deactivation wins). A reconciler re-enters
 at the first incomplete step (each Zitadel create existence-checked). Uses the
 `organizer-provisioner` credential from ESC/Secret Manager (JWT-profile →
 short-lived tokens). Wrap the call in an OTel span + an
@@ -79,11 +86,27 @@ short-lived tokens). Wrap the call in an OTel span + an
 
 *Provisioner hardening (carried over from the `organizer-tenancy` code-review,
 recorded in its design "deferred" list):* isolate GCP-layer read access to the
-provisioner key with a **dedicated provisioner workload + GCP SA** (so the
+provisioner key with a **dedicated `admin-console-api` workload + GCP SA** (so the
 `backend-app` SA no longer reads the `IAM_ORG_MANAGER` key — an IaC /
-cloud-provisioning change alongside this backend work), and add a **key-expiry
-monitoring alert** for the finite provisioner key (expires 2027-08-13) plus the
-rotation runbook.
+cloud-provisioning change alongside this backend work), and make the provisioner
+key **immutable (far-future expiry)** rather than finite-expiry + manual rotation:
+Zitadel machine keys have no native rotation, so a finite expiry is a silent
+day-N outage; the long-lived key is instead contained by the GSA isolation +
+short-lived operational tokens + instant force-replace revocation (this
+**supersedes** the earlier key-expiry-alert plan).
+
+*Isolated-workload data access (gap found in prod — the isolated workload runs
+the same backend binary and must reach Postgres):* the `admin-console-api` GSA
+needs its **own** Cloud SQL identity, not `backend-app`'s. It connects via the
+in-process Cloud SQL Go connector under Workload Identity, so grant it BOTH
+`roles/cloudsql.client` (`instances.connect`) **and** `roles/cloudsql.instanceUser`
+(`instances.get`/login), create a dedicated `CLOUD_IAM_SERVICE_ACCOUNT` Postgres
+user (`admin-console-api@<project>.iam`), override `DATABASE_USER` on the
+Deployment to that user (an explicit container `env` wins over the shared
+`server-config` `envFrom`), and grant that IAM user `app`-schema privileges via a
+migration. Cloud SQL IAM auth ties the DB user to the connecting GSA, so the
+isolated workload cannot reuse `backend-app`'s DB user; without this it
+CrashLoopBackOffs. (Shipped as cloud-provisioning #405/#406 + backend #390.)
 
 **D5 — Operator bootstrap.** The operator is created without a password;
 Zitadel delivers a **passkey-registration init link** so they register a

--- a/openspec/changes/organizer-accounts/tasks.md
+++ b/openspec/changes/organizer-accounts/tasks.md
@@ -19,6 +19,7 @@
 - [x] 3.4 Deactivation: `deactivated` gate rejects organizer ops + deactivates Zitadel operators + frees artists
 - [x] 3.5 OTel span + `organizer_provisioning_failed` metric on the provisioning call
 - [x] 3.6 (hardening, from `organizer-tenancy` code-review) cloud-provisioning: dedicated `admin-console-api` workload + GCP SA to isolate GCP-layer read access to the provisioner key (so `backend-app` SA no longer reads the `IAM_ORG_MANAGER` key); make the provisioner key immutable (far-future, like `backend-app`) rather than finite-expiry + manual rotation — Zitadel machine keys have no native rotation, so the long-lived key is contained by the GSA isolation + short-lived operational tokens + instant force-replace revocation (supersedes the earlier key-expiry-alert plan)
+- [x] 3.7 (gap found in prod) admin-console-api Cloud SQL access: the isolated GSA needs its OWN DB identity — grant `roles/cloudsql.client` + `roles/cloudsql.instanceUser`, create a dedicated `CLOUD_IAM_SERVICE_ACCOUNT` Postgres user (`admin-console-api@<project>.iam`), override `DATABASE_USER` on the Deployment (explicit env over shared `server-config` envFrom), and grant `app`-schema privileges via migration (cloud-provisioning #405/#406 + backend #390); without it the workload CrashLoopBackOffs
 
 ## 4. Backend — analytics & tests
 
@@ -27,11 +28,13 @@
 
 ## 5. Frontend (admin console)
 
-- [ ] 5.1 Organizer-management screen: create (name + operator email), list with associated artists, associate/disassociate (reuse existing artist search), deactivate
-- [ ] 5.2 `make check` passes with upgraded BSR package
+- [x] 5.1 Organizer-management screen: create (name + operator email), list with associated artists, associate/disassociate (reuse existing artist search), deactivate
+- [x] 5.2 `make check` passes with upgraded BSR package
 
 ## 6. Release & ship to prod
 
-- [ ] 6.1 Backend PR merged → release → prod pin bump; confirm rollout (depends on `organizer-tenancy` IaC applied in the env first)
-- [ ] 6.2 Frontend PR merged → release
+- [x] 6.1 Backend PR merged → release → prod pin bump; confirm rollout (depends on `organizer-tenancy` IaC applied in the env first)
+- [x] 6.2 Frontend PR merged → release
 - [ ] 6.3 Verify in prod: an admin creates an Organizer (name + operator email) → tenant org + project grant + `owner` operator provisioned; the operator completes the passkey init link + passkey and signs into their org (org-pinned); associate/disassociate + deactivate behave per spec; analytics events land
+  - Provisioning + associate/disassociate + deactivate + analytics: VERIFIED in prod (admin-console-api logs + JetStream `ORGANIZER` stream delivery confirmed).
+  - **Blocked**: the operator passkey-link step depends on prod Zitadel actually delivering email. Prod Zitadel currently has no active SMTP provider (0 sends on Postmark; `SendPasswordlessRegistration` is accepted but not delivered), and the bare-login redirect points at the dev console — both are prod Zitadel instance-config issues tracked separately in `fix-prod-zitadel-instance-config` (SMTP `smtp-activation` self-heal + `AdminOrgConfigComponent` `consoleUrl` wiring). Complete 6.3's passkey step after that ships.


### PR DESCRIPTION
## Summary

OpenSpec planning-only change. Two concerns, no proto/code touched:

1. **New change `fix-prod-zitadel-instance-config`** — proposes fixing two prod-only Zitadel instance-config defects found while verifying `organizer-accounts` 6.3. Both affect **all** Zitadel email + console login, not just organizer:
   - **SMTP silently inactive in prod** — 0 Postmark sends despite a verified sending domain + valid prod server token; `SendPasswordlessRegistration` is accepted but nothing is delivered. Root cause: `ZitadelSmtpActivation` is a no-op on unchanged inputs, so a runtime loss of activation is never healed (the existing spec even *mandates* that no-op). Delta makes activation **self-healing** (drift-detecting `read` → re-activate on a refreshing `pulumi up`).
   - **Console login redirects to the dev console in prod** — `auth.liverty-music.app/ui/login/` 302s to `auth.dev.liverty-music.app/ui/console`. Root cause: `AdminOrgConfigComponent` falls back to a hardcoded dev `defaultRedirectUri` and the prod call site never passes `consoleUrl`. Delta mandates an **environment-specific** `defaultRedirectUri`.

2. **`organizer-accounts` reconcile** — fold prod-surfaced implementation refinements back into its design/tasks so the change stays archive-ready (full-UUID org name, compare-and-set status flip, immutable provisioner key, and the admin-console-api Cloud SQL identity requirement + task 3.7). 6.3 is annotated as blocked on the Zitadel SMTP fix above.

## Changes

- `openspec/changes/fix-prod-zitadel-instance-config/` — new proposal / specs (MODIFIED `identity-management`) / design / tasks.
- `openspec/changes/organizer-accounts/{design,tasks}.md` — coherence updates.

## Testing

- `openspec validate fix-prod-zitadel-instance-config --strict` ✅
- `openspec validate organizer-accounts --strict` ✅

Refs: #759
