### PR TITLE
docs(openspec): propose fix-zitadel-watchdog-slow-wedge-detection

### DIFF
--- a/openspec/changes/fix-zitadel-watchdog-slow-wedge-detection/proposal.md
+++ b/openspec/changes/fix-zitadel-watchdog-slow-wedge-detection/proposal.md
@@ -1,0 +1,51 @@
+# Fix the Zitadel wedge watchdog to detect the slow-5xx wedge variant
+
+## Why
+
+The self-healing watchdog (`zitadel-self-hosted-deployment` capability) exists
+to auto-restart a `zitadel-api` pod caught in the projection-trigger wedge
+(zitadel/zitadel#10103, still OPEN upstream as of v4.17.x — no fix shipped).
+It detects the wedge by probing `ProjectService/ListProjectRoles` and treating
+a probe that "hangs past the gateway timeout" as the wedge signal.
+
+The prod manifest implemented "hang" **too narrowly**: it counted a probe as
+hung **only when `curl` returned `http_code=000`** (a full client-side timeout
+at `--max-time 10`). But the wedge does not always time the client out. When
+the projection trigger blocks, Zitadel's own internal ~10s deadline frequently
+fires **first**, returning a **slow HTTP 500 at ~9.9s** — just under the old
+`--max-time 10`. That is a real wedge, yet `http_code=000` never matched, so
+`hangs` stayed at 0 and the watchdog **never restarted the pod**.
+
+This was observed directly while trying to deactivate a test organizer: the
+`RemoveUser` path wedged, `ListProjectRoles` returned slow 500s, `/debug/healthz`
+stayed 200, and the watchdog took no action — the exact failure the watchdog was
+built to prevent. The narrow `000`-only check made the safeguard effectively
+inert against the most common manifestation of the wedge.
+
+## What Changes
+
+- **MODIFIED** `zitadel-self-hosted-deployment` — redefine the watchdog's "hang"
+  detection as **time-based**, not HTTP-code-based. A probe counts as a hang
+  when its **total time crosses a slow-response threshold** (whole seconds,
+  `WATCHDOG_SLOW_SEC`, default 8s) **OR** it times out entirely (`http_code=000`).
+  A **fast** response — a healthy sub-second `200`, or a fast transient error —
+  is NOT a hang (preserving the conservative-against-false-restarts guarantee).
+  The client `--max-time` is set above the server's internal deadline so a slow
+  error is captured **with its timing** instead of racing to a bare `000`.
+- Add a scenario asserting a **slow 5xx returned just under the client timeout**
+  is detected as a wedge (the previously-missed case).
+- Add a scenario asserting a **fast transient error** is NOT treated as a wedge.
+
+No credential, RBAC, probe-target, read-only, or healthz-precondition behavior
+changes — only the hang classifier is refined.
+
+## Impact
+
+- Affected capability: `zitadel-self-hosted-deployment` (watchdog requirement).
+- Affected code: `cloud-provisioning/k8s/namespaces/zitadel/overlays/prod/cronjob-watchdog-zitadel.yaml`
+  (probe loop reads `%{time_total}`; `--max-time 10 → 12`; inter-probe `sleep 5 → 3`
+  to keep the worst-case run under 60s; new `WATCHDOG_SLOW_SEC` env).
+- Prod-only; the wedge and the watchdog are prod concerns. Rolling restart stays
+  non-disruptive behind the 2-replica posture.
+- Temporary: still annotated `until-upstream-zitadel-10103-fix`; removed when the
+  upstream fix ships and is pinned.

--- a/openspec/changes/fix-zitadel-watchdog-slow-wedge-detection/specs/zitadel-self-hosted-deployment/spec.md
+++ b/openspec/changes/fix-zitadel-watchdog-slow-wedge-detection/specs/zitadel-self-hosted-deployment/spec.md
@@ -1,0 +1,60 @@
+## MODIFIED Requirements
+
+### Requirement: Self-healing watchdog auto-restarts a wedged Zitadel API
+
+The prod environment SHALL run an in-cluster watchdog that detects the Zitadel projection-trigger wedge (zitadel/zitadel#10103) and automatically restarts the `zitadel-api` Deployment without operator action. The watchdog SHALL be a Kubernetes `CronJob` modeled on the existing dev restart CronJob pattern (a container image carrying `curl` and `kubectl`, plus a dedicated ServiceAccount and a `Role`/`RoleBinding` scoped to `get`/`patch` on the `zitadel-api` Deployment in the `zitadel` namespace only) — NOT a compiled application.
+
+The watchdog SHALL detect the wedge using a **read-only call that exercises the wedged trigger-on-read path**, NOT a `/debug/healthz` or `/debug/ready` check (both return 200 during the wedge). The reference signal is the Connect/gRPC `zitadel.project.v2.ProjectService/ListProjectRoles` method (HTTP+JSON `POST`) against a static project id, which calls `SearchProjectRoles(…, shouldTriggerBulk=true, …)` and so triggers `ProjectRoleProjection.Trigger(WithAwaitRunning())` — the projection observed wedging on 2026-06-23 — as a pure read (no eventstore write). The call returns quickly (well under a second) when healthy. When wedged the trigger-on-read blocks, and the probe surfaces this in one of two ways depending on the race with the server's own internal request deadline (~10s): either the client times out first (`http_code=000`), or the server returns a **slow error (typically 5xx) — or occasionally a slow 2xx — right at its deadline** (~9–10s). Both are the wedge. The probe MUST present a valid credential: unauthenticated calls return `401` before the trigger runs and cannot detect the wedge. The probe SHALL NOT use a write endpoint (e.g. `/oauth/v2/authorize`) and SHALL NOT hardcode a product/consumer OIDC client id.
+
+The probe credential SHALL be a **dedicated, least-privilege machine-user Personal Access Token** (scoped only to the project-role read needed by `ListProjectRoles`, never a shared admin identity), provisioned out of band, stored in Google Secret Manager, synced into the `zitadel` namespace via External Secrets, and mounted into the CronJob as a bearer token. The credential failure mode SHALL be fail-safe: an invalid/expired PAT returns a fast `401` that the watchdog treats as "responded" (no false restart); to avoid silently losing detection, the PAT SHALL be long-lived and its expiry tracked, and a `401`/`403` from the probe SHALL be logged distinctly.
+
+The watchdog SHALL classify a probe as a **hang using response TIME, not the final HTTP status code**. A probe counts as a hang when its total time crosses a configured slow-response threshold (whole seconds, default 8s) **OR** it times out entirely (`http_code=000`). This deliberately captures both wedge manifestations — the full client timeout AND the slow error/response returned just under the server deadline. The client request timeout SHALL be set **above** the server's internal deadline (e.g. 12s vs ~10s) so that a slow error is captured together with its timing rather than being truncated to a bare `000`. A `401`/`403` is exempt (credential fail-safe, above) and SHALL NOT be counted as a hang.
+
+The watchdog SHALL be **conservative against false restarts**:
+- It SHALL restart only after **N consecutive hanging probes within a single run** (no single transient blip triggers a restart).
+- A **fast** response — a healthy sub-second `2xx`, or a fast transient error whose total time is below the slow threshold — SHALL NOT be counted as a hang, so unrelated momentary errors do not trigger a restart.
+- It SHALL restart only when `/debug/healthz` returns `200` at probe time (the wedge signature is "core healthy AND the read-only trigger path hung"); if core health is also failing it SHALL NOT restart, since the fault is not the wedge.
+- It SHALL use `concurrencyPolicy: Forbid` so runs never overlap.
+
+#### Scenario: Wedged pod is auto-restarted
+
+- **WHEN** the authenticated `ListProjectRoles` probe hangs (times out, or returns at/after the slow threshold) for N consecutive probes in one run while `/debug/healthz` returns 200
+- **THEN** the watchdog SHALL run the equivalent of `kubectl rollout restart deploy/zitadel-api` in the `zitadel` namespace
+- **AND** a fresh `ListProjectRoles` probe SHALL return a normal response within normal latency after the new pod becomes Ready
+
+#### Scenario: Slow 5xx just under the client timeout is detected as a wedge
+
+- **WHEN** the `ListProjectRoles` probe returns a slow error (e.g. HTTP 500) whose total time is at or above the slow-response threshold but below the client request timeout — i.e. the server's internal deadline fired before the client timed out — for N consecutive probes in one run while `/debug/healthz` returns 200
+- **THEN** the watchdog SHALL treat each such probe as a hang and SHALL restart the Deployment
+- **AND** it SHALL NOT rely on the probe having produced `http_code=000` to make that decision
+
+#### Scenario: Probe is read-only (no auth-request writes)
+
+- **WHEN** the watchdog runs its healthy probes over time
+- **THEN** it SHALL create no OIDC auth requests or other eventstore writes (the probe is a read query)
+
+#### Scenario: Transient blip does not trigger a restart
+
+- **WHEN** a single probe in a run hangs but the remaining probes in the same run return normally
+- **THEN** the watchdog SHALL NOT restart the Deployment
+
+#### Scenario: Fast transient error does not trigger a restart
+
+- **WHEN** a probe returns an error status (e.g. HTTP 500 or 502) but its total time is below the slow-response threshold (a fast failure, not a wedge)
+- **THEN** the watchdog SHALL NOT count that probe as a hang and SHALL NOT restart the Deployment on its account
+
+#### Scenario: Full outage (core health down) does not trigger a restart
+
+- **WHEN** the probe fails AND `/debug/healthz` does not return 200 (e.g. gateway/DNS outage, pod not running)
+- **THEN** the watchdog SHALL NOT restart the Deployment, because the fault is not the in-process wedge
+
+#### Scenario: Invalid credential is fail-safe (no false restart)
+
+- **WHEN** the watchdog's PAT is missing, expired, or unauthorized so the probe returns `401`/`403` quickly
+- **THEN** the watchdog SHALL treat the fast response as "not wedged" and SHALL NOT restart the Deployment
+- **AND** it SHALL log the credential failure distinctly so the loss of detection is discoverable
+
+#### Scenario: Healthy steady state issues no restart
+
+- **WHEN** the `ListProjectRoles` probe returns normally within normal latency on every probe
+- **THEN** the watchdog SHALL take no action

--- a/openspec/changes/fix-zitadel-watchdog-slow-wedge-detection/tasks.md
+++ b/openspec/changes/fix-zitadel-watchdog-slow-wedge-detection/tasks.md
@@ -1,0 +1,22 @@
+## 1. Refine the watchdog hang classifier (cloud-provisioning)
+
+- [x] 1.1 `k8s/namespaces/zitadel/overlays/prod/cronjob-watchdog-zitadel.yaml`: capture `%{time_total}` alongside `%{http_code}` in the probe `curl`; count a hang when `http_code=000` OR whole-seconds(`time_total`) `>= WATCHDOG_SLOW_SEC`.
+- [x] 1.2 Add `WATCHDOG_SLOW_SEC` env (default `"8"`); bump probe `--max-time 10 → 12` (above the ~10s server deadline); reduce inter-probe `sleep 5 → 3` to keep the worst-case run < 60s under `concurrencyPolicy: Forbid`.
+- [x] 1.3 Keep `401`/`403` credential fail-safe, the `/debug/healthz=200` precondition, N-consecutive-hangs rule, and read-only probe target unchanged.
+- [x] 1.4 Update the manifest header/comments to document time-based detection and why 000-only missed the slow-5xx variant.
+
+## 2. Verify
+
+- [x] 2.1 `kubectl kustomize --enable-helm --load-restrictor LoadRestrictionsNone k8s/namespaces/zitadel/overlays/prod` renders without error and the CronJob shows the new probe logic.
+- [x] 2.2 Unit-check the shell classifier against representative cases: healthy fast 200, slow 5xx (~9.9s), curl timeout 000, slow 503 at threshold, fast transient 500, 401, slow 200, empty output. All classify correctly.
+- [x] 2.3 kube-linter introduces no new findings on the watchdog CronJob (pre-existing chart-Job findings unaffected).
+
+## 3. Ship + remediate the live prod instance
+
+- [ ] 3.1 Open cloud-provisioning PR; CI green; merge to main.
+- [ ] 3.2 Trigger prod ArgoCD sync (automatic on merge) and confirm the updated CronJob is applied (`kubectl get cronjob zitadel-wedge-watchdog -o yaml` shows `WATCHDOG_SLOW_SEC` + `--max-time 12`).
+- [ ] 3.3 Confirm the next natural wedge (or a controlled reproduction) now triggers an auto-restart: watchdog Job logs show `→ hang` on slow-5xx probes and `restarting deployment/zitadel-api`.
+
+## 4. Follow-up
+
+- [ ] 4.1 Once upstream zitadel/zitadel#10103 ships a fix and prod is pinned to it, remove the watchdog CronJob and its RBAC/ExternalSecret (all carry `liverty-music.app/temporary: until-upstream-zitadel-10103-fix`).


### PR DESCRIPTION
## Why

The self-healing wedge watchdog (`zitadel-self-hosted-deployment`) detects the projection-trigger wedge (zitadel/zitadel#10103, **still OPEN upstream**) by probing `ListProjectRoles` and treating a probe that "hangs past the gateway timeout" as the signal. The prod manifest implemented "hang" too narrowly — **only `curl http_code=000`** — so the common **slow-5xx** manifestation (a 500 returned at ~9.9s, just under the client timeout) was never counted, and the watchdog never restarted genuinely wedged pods.

## What

MODIFIES `zitadel-self-hosted-deployment` → **Self-healing watchdog auto-restarts a wedged Zitadel API**:

- Redefine "hang" as **time-based**: `http_code=000` **OR** `time_total >= slow threshold` (default 8s), with the client timeout set above the server's internal deadline so a slow error is captured with its timing.
- New scenario: **slow 5xx just under the client timeout is detected as a wedge** (the previously-missed case).
- New scenario: **fast transient error does NOT trigger a restart** (preserves conservative-against-false-restarts).
- No change to credential, RBAC, probe target, read-only, or healthz-precondition behavior — only the hang classifier.

Implementation PR: liverty-music/cloud-provisioning#415.

`openspec validate fix-zitadel-watchdog-slow-wedge-detection --strict` → valid.

Refs: #804