### PR TITLE
docs(openspec): mark watchdog-slow-wedge ship tasks 3.1-3.3 done

### DIFF
--- a/openspec/changes/fix-zitadel-watchdog-slow-wedge-detection/tasks.md
+++ b/openspec/changes/fix-zitadel-watchdog-slow-wedge-detection/tasks.md
@@ -13,9 +13,9 @@
 
 ## 3. Ship + remediate the live prod instance
 
-- [ ] 3.1 Open cloud-provisioning PR; CI green; merge to main.
-- [ ] 3.2 Trigger prod ArgoCD sync (automatic on merge) and confirm the updated CronJob is applied (`kubectl get cronjob zitadel-wedge-watchdog -o yaml` shows `WATCHDOG_SLOW_SEC` + `--max-time 12`).
-- [ ] 3.3 Confirm the next natural wedge (or a controlled reproduction) now triggers an auto-restart: watchdog Job logs show `→ hang` on slow-5xx probes and `restarting deployment/zitadel-api`.
+- [x] 3.1 Open cloud-provisioning PR; CI green; merge to main. (PR #415 merged 2026-08-18; spec delta #805 merged)
+- [x] 3.2 Trigger prod ArgoCD sync (automatic on merge) and confirm the updated CronJob is applied. (ArgoCD synced `f7422bc`, Healthy; live CronJob shows `WATCHDOG_SLOW_SEC=8` + `--max-time 12` + `time_total`)
+- [x] 3.3 Confirm the next natural wedge (or a controlled reproduction) now triggers an auto-restart. (Observed live minutes after sync: `zitadel-wedge-watchdog-29783839` logged 3/3 `→ hang` while healthz=200 and ran `rollout restart deployment/zitadel-api`; rollout succeeded to 2/2 fresh pods; next cycle healthy `200 @0.36s`, and a fast `503 @0.97s` was correctly NOT counted as a hang)
 
 ## 4. Follow-up
 


### PR DESCRIPTION
Bookkeeping for `fix-zitadel-watchdog-slow-wedge-detection` (via `/opsx:apply`).

Tasks **3.1–3.3** are complete and marked `[x]`:
- **3.1** cloud-provisioning#415 + spec#805 merged.
- **3.2** ArgoCD synced `f7422bc` (Healthy); live CronJob shows `WATCHDOG_SLOW_SEC=8` + `--max-time 12` + `time_total`.
- **3.3** Watchdog observed firing on a **live wedge** minutes after sync: 3/3 `→ hang` while healthz=200 → `rollout restart deployment/zitadel-api` → 2/2 fresh pods; next cycle healthy (`200 @0.36s`), and a fast `503 @0.97s` correctly NOT counted as a hang.

**4.1 remains an intentional park** — remove the watchdog only once upstream zitadel/zitadel#10103 ships and prod is pinned. The change is therefore **not archivable** yet (10/11 tasks; the last is upstream-blocked by design).

Refs: #804