### PR TITLE
docs(openspec): update watchdog change for per-pod sidecar liveness probe plan

### DIFF
--- a/openspec/changes/fix-zitadel-watchdog-slow-wedge-detection/proposal.md
+++ b/openspec/changes/fix-zitadel-watchdog-slow-wedge-detection/proposal.md
@@ -1,4 +1,4 @@
-# Fix the Zitadel wedge watchdog to detect the slow-5xx wedge variant
+# Fix the Zitadel wedge watchdog: time-based detection + per-pod liveness probe sidecar
 
 ## Why
 
@@ -8,44 +8,58 @@ to auto-restart a `zitadel-api` pod caught in the projection-trigger wedge
 It detects the wedge by probing `ProjectService/ListProjectRoles` and treating
 a probe that "hangs past the gateway timeout" as the wedge signal.
 
-The prod manifest implemented "hang" **too narrowly**: it counted a probe as
-hung **only when `curl` returned `http_code=000`** (a full client-side timeout
-at `--max-time 10`). But the wedge does not always time the client out. When
-the projection trigger blocks, Zitadel's own internal ~10s deadline frequently
-fires **first**, returning a **slow HTTP 500 at ~9.9s** — just under the old
-`--max-time 10`. That is a real wedge, yet `http_code=000` never matched, so
-`hangs` stayed at 0 and the watchdog **never restarted the pod**.
+**Problem 1 — detection gap:** The prod manifest implemented "hang" too narrowly:
+it counted a probe as hung **only when `curl` returned `http_code=000`** (a full
+client-side timeout at `--max-time 10`). But the wedge does not always time the
+client out. When the projection trigger blocks, Zitadel's own internal ~10s
+deadline frequently fires **first**, returning a **slow HTTP 500 at ~9.9s** —
+just under the old `--max-time 10`. That is a real wedge, yet `http_code=000`
+never matched, so `hangs` stayed at 0 and the watchdog **never restarted the
+pod**. This was observed directly (test-organizer Deactivate; RemoveUser wedged;
+ListProjectRoles returned slow 500s; healthz stayed 200; watchdog took no action).
 
-This was observed directly while trying to deactivate a test organizer: the
-`RemoveUser` path wedged, `ListProjectRoles` returned slow 500s, `/debug/healthz`
-stayed 200, and the watchdog took no action — the exact failure the watchdog was
-built to prevent. The narrow `000`-only check made the safeguard effectively
-inert against the most common manifestation of the wedge.
+**Problem 2 — structural availability gap:** The CronJob-based watchdog issues
+`kubectl rollout restart`, which replaces **both replicas simultaneously**. The
+~90s rollout window leaves the service fully unavailable. Worse, because both
+replicas restart in lockstep they also re-wedge in lockstep (~3 min after each
+restart), causing repeated complete outages. Post-deployment observation confirmed
+this: Cloud Logging showed `http_code=000` at 180/180 probes per hour (100% wedge)
+from 2026-08-17T13:00 through 2026-08-18T05:00 with **zero restarts** (old 000-only
+check never fired), then ~20 CronJob-triggered restarts/hour after the detection
+fix — improving availability from 0% to ~50%, but still with periodic full-outage
+windows from the synchronised restart pattern.
+
+A per-pod liveness probe restarts each replica **independently**, naturally
+desynchronising them so at least one replica is always in its healthy post-startup
+window while the other restarts.
 
 ## What Changes
 
-- **MODIFIED** `zitadel-self-hosted-deployment` — redefine the watchdog's "hang"
-  detection as **time-based**, not HTTP-code-based. A probe counts as a hang
-  when its **total time crosses a slow-response threshold** (whole seconds,
-  `WATCHDOG_SLOW_SEC`, default 8s) **OR** it times out entirely (`http_code=000`).
-  A **fast** response — a healthy sub-second `200`, or a fast transient error —
-  is NOT a hang (preserving the conservative-against-false-restarts guarantee).
-  The client `--max-time` is set above the server's internal deadline so a slow
-  error is captured **with its timing** instead of racing to a bare `000`.
-- Add a scenario asserting a **slow 5xx returned just under the client timeout**
-  is detected as a wedge (the previously-missed case).
-- Add a scenario asserting a **fast transient error** is NOT treated as a wedge.
+**Phase 1 (shipped 2026-08-18):** Time-based hang detection in the existing CronJob.
+- **MODIFIED** `zitadel-self-hosted-deployment` — redefine "hang" as time-based:
+  a probe counts as hung when its total time crosses `WATCHDOG_SLOW_SEC` (8s) OR
+  it times out entirely (`http_code=000`). Client `--max-time` raised to 12s (above
+  the server's ~10s internal deadline) so a slow error is captured with its timing.
+  Fast responses are still NOT hangs (conservative-against-false-restarts preserved).
 
-No credential, RBAC, probe-target, read-only, or healthz-precondition behavior
-changes — only the hang classifier is refined.
+**Phase 2 (planned):** Replace the CronJob watchdog with a per-pod liveness probe sidecar.
+- A `curl`-capable sidecar container is added to the `zitadel-api` pod spec. A K8s
+  `exec` liveness probe on that sidecar runs the same time-based `ListProjectRoles`
+  check (same WATCHDOG_SLOW_SEC threshold, same PAT credential). Each pod restarts
+  **independently** on wedge detection, eliminating the synchronised restart window
+  and keeping at least one replica healthy at all times.
+- The CronJob, its ServiceAccount, RoleBinding, Role, and standalone ExternalSecret
+  are removed. The PAT secret is retargeted to the `zitadel-api` pod itself.
 
 ## Impact
 
 - Affected capability: `zitadel-self-hosted-deployment` (watchdog requirement).
-- Affected code: `cloud-provisioning/k8s/namespaces/zitadel/overlays/prod/cronjob-watchdog-zitadel.yaml`
-  (probe loop reads `%{time_total}`; `--max-time 10 → 12`; inter-probe `sleep 5 → 3`
-  to keep the worst-case run under 60s; new `WATCHDOG_SLOW_SEC` env).
-- Prod-only; the wedge and the watchdog are prod concerns. Rolling restart stays
-  non-disruptive behind the 2-replica posture.
-- Temporary: still annotated `until-upstream-zitadel-10103-fix`; removed when the
-  upstream fix ships and is pinned.
+- Affected code (Phase 1, complete):
+  - `cloud-provisioning/k8s/namespaces/zitadel/overlays/prod/cronjob-watchdog-zitadel.yaml`
+    (probe loop reads `%{time_total}`; `--max-time 10 → 12`; `sleep 5 → 3`;
+    new `WATCHDOG_SLOW_SEC` env).
+- Affected code (Phase 2, planned):
+  - Add liveness probe sidecar to `zitadel-api` Deployment (Helm values / overlay patch).
+  - Remove `cronjob-watchdog-zitadel.yaml` and standalone `external-secret-watchdog-probe-pat.yaml`.
+- Prod-only; the wedge and the watchdog are prod concerns.
+- Temporary: removed entirely when upstream zitadel/zitadel#10103 ships and is pinned.

--- a/openspec/changes/fix-zitadel-watchdog-slow-wedge-detection/specs/zitadel-self-hosted-deployment/spec.md
+++ b/openspec/changes/fix-zitadel-watchdog-slow-wedge-detection/specs/zitadel-self-hosted-deployment/spec.md
@@ -2,59 +2,109 @@
 
 ### Requirement: Self-healing watchdog auto-restarts a wedged Zitadel API
 
-The prod environment SHALL run an in-cluster watchdog that detects the Zitadel projection-trigger wedge (zitadel/zitadel#10103) and automatically restarts the `zitadel-api` Deployment without operator action. The watchdog SHALL be a Kubernetes `CronJob` modeled on the existing dev restart CronJob pattern (a container image carrying `curl` and `kubectl`, plus a dedicated ServiceAccount and a `Role`/`RoleBinding` scoped to `get`/`patch` on the `zitadel-api` Deployment in the `zitadel` namespace only) — NOT a compiled application.
+The prod environment SHALL detect the Zitadel projection-trigger wedge
+(zitadel/zitadel#10103) and automatically restart affected `zitadel-api` pods
+without operator action.
 
-The watchdog SHALL detect the wedge using a **read-only call that exercises the wedged trigger-on-read path**, NOT a `/debug/healthz` or `/debug/ready` check (both return 200 during the wedge). The reference signal is the Connect/gRPC `zitadel.project.v2.ProjectService/ListProjectRoles` method (HTTP+JSON `POST`) against a static project id, which calls `SearchProjectRoles(…, shouldTriggerBulk=true, …)` and so triggers `ProjectRoleProjection.Trigger(WithAwaitRunning())` — the projection observed wedging on 2026-06-23 — as a pure read (no eventstore write). The call returns quickly (well under a second) when healthy. When wedged the trigger-on-read blocks, and the probe surfaces this in one of two ways depending on the race with the server's own internal request deadline (~10s): either the client times out first (`http_code=000`), or the server returns a **slow error (typically 5xx) — or occasionally a slow 2xx — right at its deadline** (~9–10s). Both are the wedge. The probe MUST present a valid credential: unauthenticated calls return `401` before the trigger runs and cannot detect the wedge. The probe SHALL NOT use a write endpoint (e.g. `/oauth/v2/authorize`) and SHALL NOT hardcode a product/consumer OIDC client id.
+**Detection mechanism:** The watchdog SHALL use a **read-only call that exercises
+the wedged trigger-on-read path**, NOT `/debug/healthz` or `/debug/ready` (both
+return 200 during the wedge). The reference signal is the Connect/gRPC
+`zitadel.project.v2.ProjectService/ListProjectRoles` method (HTTP+JSON `POST`)
+against a static project id, which calls
+`SearchProjectRoles(…, shouldTriggerBulk=true, …)` and triggers
+`ProjectRoleProjection.Trigger(WithAwaitRunning())` — the projection observed
+wedging on 2026-06-23 — as a pure read (no eventstore write). The call returns
+quickly (well under a second) when healthy. When wedged the trigger-on-read
+blocks and surfaces as either a full client timeout (`http_code=000`) or a slow
+error/response at the server's internal ~10s deadline. The probe MUST present a
+valid credential (unauthenticated calls return `401` before the trigger runs and
+cannot detect the wedge). The probe SHALL NOT use a write endpoint and SHALL NOT
+hardcode a product/consumer OIDC client id.
 
-The probe credential SHALL be a **dedicated, least-privilege machine-user Personal Access Token** (scoped only to the project-role read needed by `ListProjectRoles`, never a shared admin identity), provisioned out of band, stored in Google Secret Manager, synced into the `zitadel` namespace via External Secrets, and mounted into the CronJob as a bearer token. The credential failure mode SHALL be fail-safe: an invalid/expired PAT returns a fast `401` that the watchdog treats as "responded" (no false restart); to avoid silently losing detection, the PAT SHALL be long-lived and its expiry tracked, and a `401`/`403` from the probe SHALL be logged distinctly.
+**Hang classification:** Detection SHALL be **time-based**, not HTTP-code-based.
+A probe counts as a hang when its total time crosses a configured slow-response
+threshold (whole seconds, default 8s) **OR** it times out entirely
+(`http_code=000`). This captures both wedge manifestations. The client request
+timeout SHALL be set above the server's internal deadline (e.g. 12s vs ~10s) so
+a slow error is captured with its timing. A fast response — healthy sub-second
+`2xx`, or a fast transient error below the threshold — SHALL NOT be counted as a
+hang.
 
-The watchdog SHALL classify a probe as a **hang using response TIME, not the final HTTP status code**. A probe counts as a hang when its total time crosses a configured slow-response threshold (whole seconds, default 8s) **OR** it times out entirely (`http_code=000`). This deliberately captures both wedge manifestations — the full client timeout AND the slow error/response returned just under the server deadline. The client request timeout SHALL be set **above** the server's internal deadline (e.g. 12s vs ~10s) so that a slow error is captured together with its timing rather than being truncated to a bare `000`. A `401`/`403` is exempt (credential fail-safe, above) and SHALL NOT be counted as a hang.
+**Implementation:** The watchdog SHALL be implemented as a **per-pod `exec`
+liveness probe on a `curl`-capable sidecar container** added to the `zitadel-api`
+pod spec — NOT a cluster-wide CronJob. The sidecar approach ensures each pod
+restarts **independently** based on its own probe result, naturally
+desynchronising the two replicas so at least one is always healthy while the
+other recovers. A CronJob issuing `rollout restart` restarts both replicas
+simultaneously, creating a full outage window on every wedge detection cycle.
+
+The probe credential SHALL be a **dedicated, least-privilege machine-user Personal
+Access Token** (scoped only to the project-role read needed by `ListProjectRoles`,
+never a shared admin identity), stored in Google Secret Manager, synced into the
+`zitadel` namespace via External Secrets, and mounted into the `zitadel-api` pod
+as a bearer token. The credential failure mode SHALL be fail-safe: a fast `401`
+is treated as "not wedged" (no restart), and `401`/`403` SHALL be logged
+distinctly.
 
 The watchdog SHALL be **conservative against false restarts**:
-- It SHALL restart only after **N consecutive hanging probes within a single run** (no single transient blip triggers a restart).
-- A **fast** response — a healthy sub-second `2xx`, or a fast transient error whose total time is below the slow threshold — SHALL NOT be counted as a hang, so unrelated momentary errors do not trigger a restart.
-- It SHALL restart only when `/debug/healthz` returns `200` at probe time (the wedge signature is "core healthy AND the read-only trigger path hung"); if core health is also failing it SHALL NOT restart, since the fault is not the wedge.
-- It SHALL use `concurrencyPolicy: Forbid` so runs never overlap.
+- It SHALL restart only after **N consecutive hanging probes** (`failureThreshold`).
+- A **fast** response SHALL NOT be counted as a hang.
+- It SHALL use K8s-native `initialDelaySeconds` to avoid restarting during pod
+  startup/warmup before the projection is ready.
 
 #### Scenario: Wedged pod is auto-restarted
 
-- **WHEN** the authenticated `ListProjectRoles` probe hangs (times out, or returns at/after the slow threshold) for N consecutive probes in one run while `/debug/healthz` returns 200
-- **THEN** the watchdog SHALL run the equivalent of `kubectl rollout restart deploy/zitadel-api` in the `zitadel` namespace
-- **AND** a fresh `ListProjectRoles` probe SHALL return a normal response within normal latency after the new pod becomes Ready
+- **WHEN** the authenticated `ListProjectRoles` probe hangs (times out, or returns
+  at/after the slow threshold) for N consecutive probes
+- **THEN** the K8s liveness probe fails and the kubelet restarts that pod
+- **AND** a fresh `ListProjectRoles` probe SHALL return a normal response within
+  normal latency after the new pod becomes Ready
 
 #### Scenario: Slow 5xx just under the client timeout is detected as a wedge
 
-- **WHEN** the `ListProjectRoles` probe returns a slow error (e.g. HTTP 500) whose total time is at or above the slow-response threshold but below the client request timeout — i.e. the server's internal deadline fired before the client timed out — for N consecutive probes in one run while `/debug/healthz` returns 200
-- **THEN** the watchdog SHALL treat each such probe as a hang and SHALL restart the Deployment
-- **AND** it SHALL NOT rely on the probe having produced `http_code=000` to make that decision
+- **WHEN** the `ListProjectRoles` probe returns a slow error whose total time is
+  at or above the slow threshold but below the client timeout (server's internal
+  deadline fired before the client timed out) for N consecutive probes
+- **THEN** the watchdog SHALL treat each such probe as a hang and SHALL restart
+  the pod
+- **AND** it SHALL NOT rely on `http_code=000` to make that decision
+
+#### Scenario: Replicas restart independently — no full-outage window
+
+- **WHEN** one `zitadel-api` pod is wedged and its liveness probe fails
+- **THEN** only that pod is restarted by the kubelet; the other pod continues
+  serving traffic
+- **AND** the PDB (`minAvailable: 1`) enforces that at least one replica remains
+  Ready throughout
 
 #### Scenario: Probe is read-only (no auth-request writes)
 
 - **WHEN** the watchdog runs its healthy probes over time
-- **THEN** it SHALL create no OIDC auth requests or other eventstore writes (the probe is a read query)
+- **THEN** it SHALL create no OIDC auth requests or other eventstore writes
 
 #### Scenario: Transient blip does not trigger a restart
 
-- **WHEN** a single probe in a run hangs but the remaining probes in the same run return normally
-- **THEN** the watchdog SHALL NOT restart the Deployment
+- **WHEN** a single probe in a series hangs but the remaining probes return normally
+- **THEN** the watchdog SHALL NOT restart the pod (`failureThreshold` not reached)
 
 #### Scenario: Fast transient error does not trigger a restart
 
-- **WHEN** a probe returns an error status (e.g. HTTP 500 or 502) but its total time is below the slow-response threshold (a fast failure, not a wedge)
-- **THEN** the watchdog SHALL NOT count that probe as a hang and SHALL NOT restart the Deployment on its account
-
-#### Scenario: Full outage (core health down) does not trigger a restart
-
-- **WHEN** the probe fails AND `/debug/healthz` does not return 200 (e.g. gateway/DNS outage, pod not running)
-- **THEN** the watchdog SHALL NOT restart the Deployment, because the fault is not the in-process wedge
+- **WHEN** a probe returns an error status whose total time is below the slow
+  threshold
+- **THEN** the watchdog SHALL NOT count that probe as a hang
 
 #### Scenario: Invalid credential is fail-safe (no false restart)
 
-- **WHEN** the watchdog's PAT is missing, expired, or unauthorized so the probe returns `401`/`403` quickly
-- **THEN** the watchdog SHALL treat the fast response as "not wedged" and SHALL NOT restart the Deployment
-- **AND** it SHALL log the credential failure distinctly so the loss of detection is discoverable
+- **WHEN** the watchdog's PAT is missing, expired, or unauthorized (`401`/`403`)
+- **THEN** the watchdog SHALL treat the fast response as "not wedged", SHALL NOT
+  restart the pod, and SHALL log the credential failure distinctly
+
+#### Scenario: Full outage (core health down) does not trigger a restart
+
+- **WHEN** the probe fails AND core health is also down (e.g. gateway/DNS outage, pod not running, init failure) — not the in-process wedge signature
+- **THEN** the liveness probe exec script's healthz-precondition guard (checking `/debug/healthz` before counting hangs) ensures a gateway-level failure is not mistaken for the wedge; non-wedge failures are handled by existing readiness/startup probe lifecycle, not this liveness probe
 
 #### Scenario: Healthy steady state issues no restart
 
-- **WHEN** the `ListProjectRoles` probe returns normally within normal latency on every probe
+- **WHEN** the `ListProjectRoles` probe returns normally within normal latency
 - **THEN** the watchdog SHALL take no action

--- a/openspec/changes/fix-zitadel-watchdog-slow-wedge-detection/tasks.md
+++ b/openspec/changes/fix-zitadel-watchdog-slow-wedge-detection/tasks.md
@@ -17,6 +17,15 @@
 - [x] 3.2 Trigger prod ArgoCD sync (automatic on merge) and confirm the updated CronJob is applied. (ArgoCD synced `f7422bc`, Healthy; live CronJob shows `WATCHDOG_SLOW_SEC=8` + `--max-time 12` + `time_total`)
 - [x] 3.3 Confirm the next natural wedge (or a controlled reproduction) now triggers an auto-restart. (Observed live minutes after sync: `zitadel-wedge-watchdog-29783839` logged 3/3 `→ hang` while healthz=200 and ran `rollout restart deployment/zitadel-api`; rollout succeeded to 2/2 fresh pods; next cycle healthy `200 @0.36s`, and a fast `503 @0.97s` was correctly NOT counted as a hang)
 
-## 4. Follow-up
+## 5. Replace CronJob watchdog with per-pod liveness probe sidecar (cloud-provisioning)
 
-- [ ] 4.1 Once upstream zitadel/zitadel#10103 ships a fix and prod is pinned to it, remove the watchdog CronJob and its RBAC/ExternalSecret (all carry `liverty-music.app/temporary: until-upstream-zitadel-10103-fix`).
+- [ ] 5.1 Add `curl`-capable sidecar container to `zitadel-api` Helm values / overlay patch (`image: alpine/curl` or equivalent; `command: ["sleep","infinity"]`; hardened `securityContext`; resource requests/limits).
+- [ ] 5.2 Add `exec` liveness probe on the sidecar: same `ListProjectRoles` check with `WATCHDOG_SLOW_SEC=8`, `--max-time 12`, `failureThreshold=3`, `periodSeconds=20`, `initialDelaySeconds=60`.
+- [ ] 5.3 Mount the watchdog PAT secret into the sidecar (retarget the existing GSM secret + ExternalSecret to the `zitadel-api` pod instead of the CronJob pod).
+- [ ] 5.4 Remove `cronjob-watchdog-zitadel.yaml` (CronJob + ServiceAccount + Role + RoleBinding) from the prod overlay; remove standalone `external-secret-watchdog-probe-pat.yaml` if it is no longer needed separately.
+- [ ] 5.5 Kustomize dry-run clean; kube-linter no new findings; open cloud-provisioning PR; CI green; merge; ArgoCD sync confirmed.
+- [ ] 5.6 Verify: observe two `zitadel-api` pod restarts triggered by liveness probe failures on different schedules (not simultaneous); confirm no full-outage window during the wedge cycle.
+
+## 6. Follow-up
+
+- [ ] 6.1 Once upstream zitadel/zitadel#10103 ships a fix and prod is pinned to it, remove the liveness probe sidecar, the PAT secret mount, and the GSM secret / ExternalSecret entirely (all carry `liverty-music.app/temporary: until-upstream-zitadel-10103-fix`).


### PR DESCRIPTION
Updates `fix-zitadel-watchdog-slow-wedge-detection` planning artifacts to reflect the Phase 2 plan: replace the CronJob watchdog with a per-pod `exec` liveness probe sidecar.

## Root cause of full-outage windows (newly documented)
Cloud Logging confirmed: `http_code=000` appeared **180/180 probes/hour for ~16h** before the Phase 1 detection fix (old watchdog never fired). After Phase 1, ~20 CronJob-triggered restarts/hour improved availability 0%→~50%, but **both replicas restart in lockstep** (CronJob issues `rollout restart`) → periodic full-outage windows persist.

## Phase 2 plan
Per-pod `exec` liveness probe on a `curl`-capable sidecar → each pod restarts independently → at least one replica always healthy during the wedge cycle.

## Artifact changes
- **proposal.md**: Phase 1 (shipped) + Phase 2 (planned) rationale; structural availability gap documented
- **specs delta**: requirement rewritten from "SHALL be a CronJob" → "SHALL be a per-pod exec liveness probe sidecar"; adds "Replicas restart independently" scenario; all existing scenarios preserved
- **tasks.md**: section 5 (sidecar impl tasks 5.1–5.6) + section 6 (upstream cleanup 6.1); old task 4.1 retired into 6.1 with updated scope

`openspec validate --strict` → valid. 10/17 tasks complete (Phase 1 done; Phase 2 pending).

Implementation PR will follow in cloud-provisioning.

Refs: #804