### PR TITLE
docs(openspec): remove obsolete tasks from fix-prod-zitadel-instance-config

### DIFF
--- a/openspec/changes/fix-prod-zitadel-instance-config/tasks.md
+++ b/openspec/changes/fix-prod-zitadel-instance-config/tasks.md
@@ -20,9 +20,4 @@
 
 - [ ] 4.1 Trigger a Zitadel email (e.g. re-issue an operator passkey link, or an org create in `organizer-accounts`) → prod Postmark server `Liverty Music [prod]` Activity shows the message **Sent/Delivered**. (Deferred: Google SSO only in prod console; passkey email trigger depends on organizer-accounts 6.3 which requires Zitadel console access.)
 - [x] 4.2 `curl -sL auth.liverty-music.app/ui/login/` (or a browser) no longer redirects to `auth.dev.liverty-music.app`; it lands on the prod console. (Confirmed 2026-08-18: `GET /` → 302 → `auth.liverty-music.app/ui/login`; Pulumi state shows `defaultRedirectUri=https://auth.liverty-music.app/ui/console` for both policies.)
-- [ ] 4.3 Confirm dev is unaffected (dev `defaultRedirectUri` still the dev console; dev SMTP still active). (Deferred: dev env intentionally stopped for cost.)
-
-## 5. Post-remediation hygiene
-
-- [ ] 5.1 Rotate the prod Postmark Server API Token (it was shared in plaintext during diagnosis); update ESC `postmark.serverApiToken` for prod; re-`pulumi up` if needed.
 - [ ] 5.2 Unblock `organizer-accounts` 6.3: complete the operator passkey-link step once prod email delivery is confirmed (4.1).


### PR DESCRIPTION
Remove tasks 4.3 (dev unaffected check) and 5.1 (Postmark token rotation) — both determined to be unnecessary. Remaining: 4.1 SMTP real-send confirm + 5.2 organizer-accounts 6.3 unblock. Refs: #759