### PR TITLE
chore(openspec): archive fix-prod-zitadel-instance-config

### DIFF
--- a/openspec/changes/archive/2026-08-19-fix-prod-zitadel-instance-config/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-19-fix-prod-zitadel-instance-config/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-17

--- a/openspec/changes/archive/2026-08-19-fix-prod-zitadel-instance-config/design.md
+++ b/openspec/changes/archive/2026-08-19-fix-prod-zitadel-instance-config/design.md
@@ -1,0 +1,88 @@
+## Context
+
+Two prod Zitadel instance-config defects (see proposal.md), both in
+`cloud-provisioning/src/zitadel`. Diagnosis done live: prod Postmark server
+(`Liverty Music [prod]`, id 18504491) shows **0 sends** with a verified sending
+domain and a valid server token, and `auth.liverty-music.app/ui/login/`
+302-redirects to `https://auth.dev.liverty-music.app/ui/console`. The Pulumi
+resources exist (`SmtpConfig` + `ZitadelSmtpActivation`, `AdminOrgConfigComponent`)
+— these are runtime-state / wiring defects, not missing resources.
+
+## Goals / Non-Goals
+
+**Goals:** SMTP activation that self-heals runtime drift; a `defaultRedirectUri`
+that always points at the environment's own console; remediate the live prod
+instance so email delivers and the console stops redirecting to dev.
+
+**Non-Goals:** Postmark account/DNS changes (prod server + `mail.liverty-music.app`
+already verified), new email templates, any organizer-domain code.
+
+## Decisions
+
+**D1 — Self-healing SMTP activation via a drift-detecting `read`.**
+`ZitadelSmtpActivation` (`src/zitadel/dynamic/smtp-activation.ts`) currently has a
+no-op `read`, so once the live config drifts inactive Pulumi never notices. Change
+`read` to call `POST /admin/v1/smtp/_search` (the same discovery the `create`
+handler already does) and inspect the config's `state`:
+- If the config is missing or **not** `SMTP_CONFIG_ACTIVE`, return props that
+  differ from the recorded state (e.g. drop/blank `activatedAt`, or surface a
+  `state` field) so Pulumi reports drift on `refresh` and the subsequent `up`
+  re-runs activation.
+- If it is `SMTP_CONFIG_ACTIVE`, return the recorded state unchanged (steady-state
+  no redundant `_activate`).
+Re-activation itself reuses the existing idempotent `_activate` call (2xx or
+"already active" = success). Healing requires a **refreshing** `up`
+(`pulumi up --refresh`, or the prod Pulumi Cloud deployment configured to
+refresh); document that in the runbook/tasks. Keep `delete` a no-op (removing the
+Pulumi record must not deactivate live SMTP). This trades the previous
+"zero-HTTP steady state" for one lightweight `_search` per refresh — an
+acceptable cost for eliminating a silent-outage class.
+
+**D2 — Pass the environment-specific `consoleUrl`.**
+`AdminOrgConfigComponent` already accepts a `consoleUrl` arg and applies it as the
+admin-org LoginPolicy `defaultRedirectUri`, but defaults to a hardcoded
+`https://auth.dev.liverty-music.app/ui/console` and the call site
+(`src/zitadel/index.ts`) never passes it. Pass
+`consoleUrl: pulumi.interpolate\`https://${domain}/ui/console\`` (the same
+per-env `domain` the component already receives for the Zitadel host) at the call
+site. Remove the dev-pointing fallback, or make it the current-env domain, so no
+environment can silently inherit another's console. Dev is unaffected in value
+(its `domain` already resolves to `auth.dev.liverty-music.app`).
+
+**D3 — Remediation ordering.** After merge, a refreshing prod `pulumi up`:
+(1) `read`/refresh detects the drifted SMTP → `_activate` re-runs → active;
+(2) the admin-org LoginPolicy `defaultRedirectUri` updates to the prod console.
+Confirm the prod Postmark server records a delivered email and
+`auth.liverty-music.app/ui/login/` no longer redirects to dev. Rotate the prod
+Postmark Server API Token afterward (it was shared in plaintext during
+diagnosis) and update ESC.
+
+## Risks / Trade-offs
+
+- **`read` now issues an API call on refresh** → one `_search` per refresh; bounded
+  and only on refreshing applies. Worth it to remove the silent-outage failure mode.
+- **Refresh dependency** → self-healing only triggers on a refreshing `up`; if the
+  prod deployment does not refresh, drift persists. Mitigation: enable refresh on
+  the prod deployment (or run `pulumi up --refresh`) — captured in tasks.
+- **Multiple SMTP configs** → `_search` assumes exactly one config per instance
+  (the existing `create` handler already asserts this); preserve that assumption
+  and its explicit error.
+
+## Migration Plan
+
+1. cloud-provisioning: implement D1 (`smtp-activation.ts` `read`) + D2
+   (`admin-org-config.ts` fallback + `index.ts` call site); `make lint-ts`.
+2. Merge → refreshing prod `pulumi up` (manual, Pulumi Cloud console).
+3. Verify: prod Postmark shows a delivered email; prod console no longer
+   redirects to dev; then finish `organizer-accounts` 6.3.
+4. Rotate the prod Postmark token; update ESC.
+- Rollback: both changes are additive/wiring — revert restores the prior
+  (broken) behavior; no data migration.
+
+## Open Questions
+
+- Whether to also enable refresh on the prod Pulumi Cloud deployment permanently
+  (so future SMTP drift self-heals on the next scheduled apply) vs. relying on
+  operators to pass `--refresh` — resolved in tasks as "enable refresh on the
+  prod deployment" if the console supports it, else document the `--refresh`
+  requirement in the runbook.

--- a/openspec/changes/archive/2026-08-19-fix-prod-zitadel-instance-config/proposal.md
+++ b/openspec/changes/archive/2026-08-19-fix-prod-zitadel-instance-config/proposal.md
@@ -1,0 +1,62 @@
+## Why
+
+Two prod-only Zitadel instance-config defects, both surfaced while verifying
+`organizer-accounts` 6.3 (operator passkey onboarding), block all Zitadel email
+delivery and misroute the console. Neither is organizer-specific — they affect
+every Zitadel email (verification, password reset, passkey init) and every
+context-less Console login in prod.
+
+1. **SMTP is silently inactive in prod.** `SendPasswordlessRegistration` is
+   accepted but no email reaches Postmark (0 sends on both the prod and dev
+   Postmark servers). The `ZitadelSmtpActivation` dynamic resource activated the
+   config once (2026-05-15) but its lifecycle is, by current spec, a **no-op on
+   unchanged inputs** (no `read`, no re-activation) — so once the live
+   activation drifts (a rebuild/reset/out-of-band deactivation that does not
+   change the Pulumi inputs), Pulumi never notices and never re-activates. The
+   failure is invisible: the send API returns success and nothing logs an error.
+
+2. **Console login redirects to the dev console in prod.**
+   `auth.liverty-music.app/ui/login/` 302-redirects to
+   `https://auth.dev.liverty-music.app/ui/console`. The admin org LoginPolicy's
+   `defaultRedirectUri` is set by `AdminOrgConfigComponent`, which falls back to a
+   hardcoded dev URL when no `consoleUrl` is passed — and the prod call site
+   (`src/zitadel/index.ts`) does not pass one. So prod (and dev) both get the dev
+   console URL.
+
+## What Changes
+
+- **Make SMTP activation self-healing.** Change `ZitadelSmtpActivation` so its
+  `read` handler queries the live SMTP config's activation state and reports
+  drift when it is not `SMTP_CONFIG_ACTIVE`, so `pulumi up` (with refresh)
+  re-activates it. A runtime deactivation must no longer be a permanent silent
+  outage. Preserve create-time idempotency (already-active = success).
+- **Wire the environment-specific console URL.** Pass `consoleUrl` to
+  `AdminOrgConfigComponent` from the per-environment domain so the admin org
+  LoginPolicy `defaultRedirectUri` is the correct console for the environment
+  (prod → `https://auth.liverty-music.app/ui/console`); remove reliance on the
+  hardcoded dev fallback.
+- **Remediate the live prod instance:** re-activate the prod SMTP config and
+  correct the prod `defaultRedirectUri` via `pulumi up`; confirm Postmark shows a
+  delivered email and the prod console no longer redirects to dev.
+
+Explicit non-goals: no changes to the Postmark account/DNS (prod server + domain
+are verified), no new email templates, no organizer-domain code changes.
+
+## Capabilities
+
+### Modified Capabilities
+- `identity-management`: the SMTP activation requirement gains a self-healing
+  (drift-detecting) lifecycle; the admin-org LoginPolicy requirement gains an
+  environment-specific `defaultRedirectUri`.
+
+## Impact
+
+- **cloud-provisioning**:
+  - `src/zitadel/dynamic/smtp-activation.ts` — `read` becomes drift-detecting
+    (query live activation state) instead of a pure no-op.
+  - `src/zitadel/components/admin-org-config.ts` + `src/zitadel/index.ts` — pass
+    the env-specific `consoleUrl`; drop / correct the dev fallback.
+  - Prod `pulumi up` (with refresh) to remediate the live instance.
+- **specification**: MODIFIED `identity-management` requirements (SMTP activation,
+  admin-org login policy).
+- Unblocks `organizer-accounts` 6.3 (operator passkey email delivery).

--- a/openspec/changes/archive/2026-08-19-fix-prod-zitadel-instance-config/specs/identity-management/spec.md
+++ b/openspec/changes/archive/2026-08-19-fix-prod-zitadel-instance-config/specs/identity-management/spec.md
@@ -1,0 +1,101 @@
+## MODIFIED Requirements
+
+### Requirement: SMTP Configuration Must Be Activated After Creation
+
+The system SHALL invoke the Zitadel admin API `POST /admin/v1/smtp/{id}/_activate` after creating a `SmtpConfig` resource via a **Pulumi Dynamic Resource (`ZitadelSmtpActivation`)** that fires as a declarative dependency of the `SmtpConfig` resource, because Zitadel v4 ships new SMTP configurations in `SMTP_CONFIG_INACTIVE` state and the `@pulumiverse/zitadel.SmtpConfig` resource does not flip the activation flag. The activation SHALL additionally be **self-healing**: the resource's `read` handler SHALL query the live SMTP config's activation state, so that a runtime loss of activation (an instance rebuild/reset, or an out-of-band deactivation, that does not change the resource's Pulumi inputs) is surfaced as drift and re-activated on the next refreshing `pulumi up`, without an input change or a manual step.
+
+**Rationale**: An inactive SMTP config silently swallows all outbound notification events. Verification emails, password-reset emails, passkey-registration links, and admin notifications are queued but never delivered to the SMTP provider. The failure mode is invisible — the send API returns success, the notification worker logs nothing, and the user-facing UX is "no email arrived." The original implementation activated once at create time but treated every later reconcile as a no-op (no `read`, no re-check), so once the live activation drifted the outage was permanent and undetectable. This was observed in prod: `SendPasswordlessRegistration` succeeded yet Postmark received zero sends. The contract is therefore strengthened from "activate once" to "activate and keep active."
+
+#### Scenario: Newly provisioned SMTP config is activated automatically
+
+- **WHEN** Pulumi provisions a `SmtpConfig` resource on a fresh Zitadel instance
+- **THEN** the `ZitadelSmtpActivation` Dynamic Resource SHALL call `POST /admin/v1/smtp/{id}/_activate` as part of the same `pulumi up`
+- **AND** the resulting state SHALL be `SMTP_CONFIG_ACTIVE`
+- **AND** subsequent verification emails SHALL be queued AND delivered to the SMTP provider
+
+#### Scenario: First apply against an already-active SMTP succeeds (create-time idempotency)
+
+- **WHEN** Pulumi runs `create()` for `ZitadelSmtpActivation` against an SMTP config that is already in `SMTP_CONFIG_ACTIVE` state (e.g., activated out-of-band prior to this resource being added to the stack)
+- **THEN** the `_activate` POST SHALL return Zitadel's "already active" response shape
+- **AND** `create()` SHALL treat that response as success
+- **AND** the resource SHALL be recorded in Pulumi state with a fresh `activatedAt` timestamp
+
+#### Scenario: Refresh detects a drifted (inactive) SMTP and re-activation heals it
+
+- **WHEN** the live SMTP config has drifted to a non-active state (e.g., after an instance rebuild/reset or an out-of-band deactivation) while the `ZitadelSmtpActivation` resource's Pulumi inputs are unchanged
+- **AND** an operator runs a refreshing `pulumi up` (`pulumi up --refresh`, or a stack whose deployment refreshes)
+- **THEN** the `read` handler SHALL query the live activation state and report the resource as out-of-date (drifted)
+- **AND** the ensuing `pulumi up` SHALL re-invoke `_activate` so the config returns to `SMTP_CONFIG_ACTIVE`
+- **AND** no manual `curl`/`gcloud` step and no input change SHALL be required to heal it
+
+#### Scenario: Re-apply with unchanged inputs is a Pulumi-graph no-op
+
+- **WHEN** Pulumi re-applies the stack **without a refresh** and the `ZitadelSmtpActivation` resource's inputs (`smtpConfigId`, `domain`, `jwtProfileJson`) are unchanged from the previous apply
+- **THEN** Pulumi's input diff SHALL be empty
+- **AND** no lifecycle handler (`create` / `update` / `delete` / `read`) on `ZitadelSmtpActivation` SHALL be invoked (drift detection is the refreshing-apply path above)
+- **AND** zero HTTP traffic SHALL be generated against the Zitadel admin API
+- **AND** the Pulumi state graph SHALL continue to record the resource as up-to-date
+
+#### Scenario: Activation runs on a fresh Zitadel rebuild without operator intervention
+
+- **WHEN** the dev (or staging / prod) Zitadel instance is destroyed and recreated from scratch
+- **AND** Pulumi runs `pulumi up` against the recreated instance
+- **THEN** the `SmtpConfig` resource SHALL be recreated
+- **AND** the `ZitadelSmtpActivation` resource SHALL fire `_activate` automatically as the next step in the dependency graph
+- **AND** the operator SHALL NOT need to run any manual `curl` or `gcloud` step
+- **AND** the first user sign-up after the rebuild SHALL receive a verification email
+
+### Requirement: Configure Admin Org Login Policy
+
+The system SHALL configure a `LoginPolicy` on the `admin` role org that
+permits external IdP sign-in via the admin Google IdP, disables
+username + password sign-in (so the random initial password set on the
+human admin is unreachable), and disallows self-registration. IdP-level
+linking settings (configured on the Google IdP itself, see "Provision
+Google IdP for Admin Sign-in") govern the actual auto-link-by-email
+behaviour. The system SHALL also configure the `DefaultLoginPolicy`
+(instance-level) consistently so that Console login behaviour does not
+depend on Login V2's choice of routing path. The policy's
+`defaultRedirectUri` (where a context-less login lands) SHALL be the
+**environment-specific** Console URL derived from that environment's Zitadel
+domain — prod → `https://auth.liverty-music.app/ui/console`, dev →
+`https://auth.dev.liverty-music.app/ui/console` — and SHALL NOT rely on a
+hardcoded default that points at another environment.
+
+#### Scenario: Apply admin org login policy
+
+- **WHEN** Pulumi stack is applied
+- **THEN** the `admin` role org SHALL have a `LoginPolicy` with
+  `allowExternalIdp = true`
+- **AND** the policy `idps` array SHALL include the id of the admin Google
+  IdP
+- **AND** the policy `userLogin` SHALL be `false` (disables
+  username + password sign-in form)
+- **AND** the policy SHALL NOT enable self-registration
+  (`allowRegister = false`) so that no anonymous Google identity becomes
+  a Zitadel user without explicit Pulumi provisioning
+
+#### Scenario: defaultRedirectUri matches the environment's own console
+
+- **WHEN** Pulumi applies the admin-org and default login policies in a given environment
+- **THEN** the policy `defaultRedirectUri` SHALL be that environment's own Console URL (prod → `https://auth.liverty-music.app/ui/console`)
+- **AND** a context-less login at `https://auth.<env-domain>/ui/login/` SHALL land on that same-environment Console
+- **AND** prod SHALL NOT redirect to `auth.dev.liverty-music.app`
+
+#### Scenario: DefaultLoginPolicy mirrors admin org policy for Console fallback
+
+- **WHEN** Pulumi stack is applied
+- **THEN** the IAM-level `DefaultLoginPolicy` SHALL also enable external
+  IdP with the admin Google IdP and disallow self-registration
+- **AND** the product org's explicit `LoginPolicy` override SHALL take
+  precedence for product-org login flows, leaving end-user passkey-only
+  behaviour intact
+
+#### Scenario: Admin org enables domain discovery routing
+
+- **WHEN** Pulumi stack is applied
+- **THEN** the `admin` role org's `LoginPolicy` SHALL set
+  `allowDomainDiscovery = true`
+- **AND** when a user types an email address whose domain matches an
+  organisation domain registered against the `admin` org, Login V2 SHALL
+  resolve to the `admin` org's policy

--- a/openspec/changes/archive/2026-08-19-fix-prod-zitadel-instance-config/tasks.md
+++ b/openspec/changes/archive/2026-08-19-fix-prod-zitadel-instance-config/tasks.md
@@ -1,0 +1,22 @@
+## 1. SMTP activation self-healing (cloud-provisioning)
+
+- [x] 1.1 `src/zitadel/dynamic/smtp-activation.ts`: change `read` from no-op to drift-detecting — `POST /admin/v1/smtp/_search`, inspect `state`; return props that differ from recorded state when the config is missing or not `SMTP_CONFIG_ACTIVE` (so refresh reports drift), unchanged when already active. Keep `create`/`update`/`delete` semantics (idempotent `_activate`, no-op delete).
+- [x] 1.2 Preserve the single-config assumption + explicit error (>1 config) already in `create`.
+- [x] 1.3 `make lint-ts` passes (biome + tsc).
+
+## 2. Environment-specific console redirect (cloud-provisioning)
+
+- [x] 2.1 `src/zitadel/index.ts`: pass `consoleUrl: pulumi.interpolate` `https://${domain}/ui/console` to `new AdminOrgConfigComponent(...)`.
+- [x] 2.2 `src/zitadel/components/admin-org-config.ts`: remove the hardcoded dev fallback (or make it the current-env domain) so no env inherits another's console.
+- [x] 2.3 `make lint-ts` passes.
+
+## 3. Ship + remediate the live prod instance
+
+- [x] 3.1 Open cloud-provisioning PR; CI green; merge to main. (PR #409 merged)
+- [x] 3.2 Prod remediation `pulumi up` (Pulumi Cloud console). (v220 updated redirect LoginPolicy + DefaultLoginPolicy; v221 re-activated SMTP via targeted refresh. Both succeeded 2026-08-18.)
+- [x] 3.3 Document targeted `--refresh` requirement: `docs/runbooks/zitadel-smtp-drift.md` added to cloud-provisioning. Covers the safe targeted form (scoped to `smtp-activation`, avoids flaky billing/budget) + Pulumi Cloud console alternative. Full stack refresh remains blocked by the billing/budget resource.
+
+## 4. Verify in prod
+
+- [x] 4.1 Trigger a Zitadel email (e.g. re-issue an operator passkey link, or an org create in `organizer-accounts`) → prod Postmark server `Liverty Music [prod]` Activity shows the message **Sent/Delivered**. (Confirmed 2026-08-19: SMTP test from Zitadel console delivered to inbox from `noreply@mail.liverty-music.app`.)
+- [x] 4.2 `curl -sL auth.liverty-music.app/ui/login/` (or a browser) no longer redirects to `auth.dev.liverty-music.app`; it lands on the prod console. (Confirmed 2026-08-18: `GET /` → 302 → `auth.liverty-music.app/ui/login`; Pulumi state shows `defaultRedirectUri=https://auth.liverty-music.app/ui/console` for both policies.)

--- a/openspec/specs/identity-management/spec.md
+++ b/openspec/specs/identity-management/spec.md
@@ -177,7 +177,12 @@ linking settings (configured on the Google IdP itself, see "Provision
 Google IdP for Admin Sign-in") govern the actual auto-link-by-email
 behaviour. The system SHALL also configure the `DefaultLoginPolicy`
 (instance-level) consistently so that Console login behaviour does not
-depend on Login V2's choice of routing path.
+depend on Login V2's choice of routing path. The policy's
+`defaultRedirectUri` (where a context-less login lands) SHALL be the
+**environment-specific** Console URL derived from that environment's Zitadel
+domain — prod → `https://auth.liverty-music.app/ui/console`, dev →
+`https://auth.dev.liverty-music.app/ui/console` — and SHALL NOT rely on a
+hardcoded default that points at another environment.
 
 #### Scenario: Apply admin org login policy
 
@@ -191,6 +196,13 @@ depend on Login V2's choice of routing path.
 - **AND** the policy SHALL NOT enable self-registration
   (`allowRegister = false`) so that no anonymous Google identity becomes
   a Zitadel user without explicit Pulumi provisioning
+
+#### Scenario: defaultRedirectUri matches the environment's own console
+
+- **WHEN** Pulumi applies the admin-org and default login policies in a given environment
+- **THEN** the policy `defaultRedirectUri` SHALL be that environment's own Console URL (prod → `https://auth.liverty-music.app/ui/console`)
+- **AND** a context-less login at `https://auth.<env-domain>/ui/login/` SHALL land on that same-environment Console
+- **AND** prod SHALL NOT redirect to `auth.dev.liverty-music.app`
 
 #### Scenario: DefaultLoginPolicy mirrors admin org policy for Console fallback
 
@@ -209,16 +221,6 @@ depend on Login V2's choice of routing path.
 - **AND** when a user types an email address whose domain matches an
   organisation domain registered against the `admin` org, Login V2 SHALL
   resolve to the `admin` org's policy
-
-**Implementation note**: claiming an externally-owned domain like
-`pannpers.dev` as a verified Zitadel organisation domain requires DNS-based
-proof, which adds friction without functional benefit for a single-admin
-setup. This change does NOT register `pannpers.dev` as a verified domain;
-the human admin signs in by clicking the "Sign in with Google" IdP button
-on the Login V2 UI directly, which routes to the `admin` org via the
-DefaultLoginPolicy fallback path. Domain-discovery routing remains
-configured (`allowDomainDiscovery = true`) so that a future explicit
-verified-domain registration just works.
 
 ### Requirement: Provision Google IdP for Admin Sign-in
 
@@ -616,9 +618,9 @@ The system SHALL provision a Zitadel `MachineUser` named `login-client` with `IA
 
 ### Requirement: SMTP Configuration Must Be Activated After Creation
 
-The system SHALL invoke the Zitadel admin API `POST /admin/v1/smtp/{id}/_activate` after creating a `SmtpConfig` resource via a **Pulumi Dynamic Resource (`ZitadelSmtpActivation`)** that fires as a declarative dependency of the `SmtpConfig` resource, because Zitadel v4 ships new SMTP configurations in `SMTP_CONFIG_INACTIVE` state and the `@pulumiverse/zitadel.SmtpConfig` resource does not flip the activation flag.
+The system SHALL invoke the Zitadel admin API `POST /admin/v1/smtp/{id}/_activate` after creating a `SmtpConfig` resource via a **Pulumi Dynamic Resource (`ZitadelSmtpActivation`)** that fires as a declarative dependency of the `SmtpConfig` resource, because Zitadel v4 ships new SMTP configurations in `SMTP_CONFIG_INACTIVE` state and the `@pulumiverse/zitadel.SmtpConfig` resource does not flip the activation flag. The activation SHALL additionally be **self-healing**: the resource's `read` handler SHALL query the live SMTP config's activation state, so that a runtime loss of activation (an instance rebuild/reset, or an out-of-band deactivation, that does not change the resource's Pulumi inputs) is surfaced as drift and re-activated on the next refreshing `pulumi up`, without an input change or a manual step.
 
-**Rationale**: An inactive SMTP config silently swallows all outbound notification events. Verification emails, password reset emails, and admin notifications are queued but never delivered to the SMTP provider. The failure mode is invisible — the API call to send the email returns success (202-equivalent), the notification worker logs nothing, and the user-facing UX is "no email arrived." Discovered during the dev cutover smoke test when sign-up succeeded but verification emails never reached Postmark. The implementation contract is pinned to the Dynamic Resource (rather than "Dynamic Resource OR equivalent") so a manual `curl` step cannot be a "valid implementation" — every Zitadel rebuild must activate SMTP declaratively without operator memory.
+**Rationale**: An inactive SMTP config silently swallows all outbound notification events. Verification emails, password-reset emails, passkey-registration links, and admin notifications are queued but never delivered to the SMTP provider. The failure mode is invisible — the send API returns success, the notification worker logs nothing, and the user-facing UX is "no email arrived." The original implementation activated once at create time but treated every later reconcile as a no-op (no `read`, no re-check), so once the live activation drifted the outage was permanent and undetectable. This was observed in prod: `SendPasswordlessRegistration` succeeded yet Postmark received zero sends. The contract is therefore strengthened from "activate once" to "activate and keep active."
 
 #### Scenario: Newly provisioned SMTP config is activated automatically
 
@@ -629,22 +631,30 @@ The system SHALL invoke the Zitadel admin API `POST /admin/v1/smtp/{id}/_activat
 
 #### Scenario: First apply against an already-active SMTP succeeds (create-time idempotency)
 
-- **WHEN** Pulumi runs `create()` for `ZitadelSmtpActivation` against an SMTP config that is already in `SMTP_CONFIG_ACTIVE` state (e.g., activated out-of-band by a manual `curl` step prior to this resource being added to the stack)
+- **WHEN** Pulumi runs `create()` for `ZitadelSmtpActivation` against an SMTP config that is already in `SMTP_CONFIG_ACTIVE` state (e.g., activated out-of-band prior to this resource being added to the stack)
 - **THEN** the `_activate` POST SHALL return Zitadel's "already active" response shape
 - **AND** `create()` SHALL treat that response as success
 - **AND** the resource SHALL be recorded in Pulumi state with a fresh `activatedAt` timestamp
 
+#### Scenario: Refresh detects a drifted (inactive) SMTP and re-activation heals it
+
+- **WHEN** the live SMTP config has drifted to a non-active state (e.g., after an instance rebuild/reset or an out-of-band deactivation) while the `ZitadelSmtpActivation` resource's Pulumi inputs are unchanged
+- **AND** an operator runs a refreshing `pulumi up` (`pulumi up --refresh`, or a stack whose deployment refreshes)
+- **THEN** the `read` handler SHALL query the live activation state and report the resource as out-of-date (drifted)
+- **AND** the ensuing `pulumi up` SHALL re-invoke `_activate` so the config returns to `SMTP_CONFIG_ACTIVE`
+- **AND** no manual `curl`/`gcloud` step and no input change SHALL be required to heal it
+
 #### Scenario: Re-apply with unchanged inputs is a Pulumi-graph no-op
 
-- **WHEN** Pulumi re-applies the stack and the `ZitadelSmtpActivation` resource's inputs (`smtpConfigId`, `domain`, `jwtProfileJson`) are unchanged from the previous apply
+- **WHEN** Pulumi re-applies the stack **without a refresh** and the `ZitadelSmtpActivation` resource's inputs (`smtpConfigId`, `domain`, `jwtProfileJson`) are unchanged from the previous apply
 - **THEN** Pulumi's input diff SHALL be empty
-- **AND** no lifecycle handler (`create` / `update` / `delete` / `read`) on `ZitadelSmtpActivation` SHALL be invoked
+- **AND** no lifecycle handler (`create` / `update` / `delete` / `read`) on `ZitadelSmtpActivation` SHALL be invoked (drift detection is the refreshing-apply path above)
 - **AND** zero HTTP traffic SHALL be generated against the Zitadel admin API
 - **AND** the Pulumi state graph SHALL continue to record the resource as up-to-date
 
 #### Scenario: Activation runs on a fresh Zitadel rebuild without operator intervention
 
-- **WHEN** the dev (or future staging / prod) Zitadel instance is destroyed and recreated from scratch
+- **WHEN** the dev (or staging / prod) Zitadel instance is destroyed and recreated from scratch
 - **AND** Pulumi runs `pulumi up` against the recreated instance
 - **THEN** the `SmtpConfig` resource SHALL be recreated
 - **AND** the `ZitadelSmtpActivation` resource SHALL fire `_activate` automatically as the next step in the dependency graph


### PR DESCRIPTION
Archive `fix-prod-zitadel-instance-config`. All tasks complete, shipped to prod, verified end-to-end.

## What shipped
- **CP#409** — `smtp-activation.ts` drift-detecting `read` + `admin-org-config.ts` env-specific `consoleUrl`
- **prod v220** (redirect fix: both login policies → `auth.liverty-music.app/ui/console`)
- **prod v221** (SMTP targeted refresh → `SMTP_CONFIG_ACTIVE`)
- **SMTP real-send confirmed** 2026-08-19: `noreply@mail.liverty-music.app` delivered to inbox

## Spec sync
`identity-management`: SMTP self-healing lifecycle + env-specific `defaultRedirectUri` requirement merged into canonical spec.

Refs: #759