### PR TITLE
docs(openspec): reconcile watchdog change — REMOVED requirement, root cause resolved

### DIFF
--- a/openspec/changes/fix-zitadel-watchdog-slow-wedge-detection/proposal.md
+++ b/openspec/changes/fix-zitadel-watchdog-slow-wedge-detection/proposal.md
@@ -1,65 +1,59 @@
-# Fix the Zitadel wedge watchdog: time-based detection + per-pod liveness probe sidecar
+# Fix Zitadel wedge: time-based detection, watchdog removal, root cause resolved
 
 ## Why
 
-The self-healing watchdog (`zitadel-self-hosted-deployment` capability) exists
-to auto-restart a `zitadel-api` pod caught in the projection-trigger wedge
-(zitadel/zitadel#10103, still OPEN upstream as of v4.17.x — no fix shipped).
-It detects the wedge by probing `ProjectService/ListProjectRoles` and treating
-a probe that "hangs past the gateway timeout" as the wedge signal.
+The prod `zitadel-api` deployment periodically entered a projection-trigger wedge
+(zitadel/zitadel#10103): `Trigger(WithAwaitRunning())` blocked on a projection
+handler that was occupied, causing logins to hang and return HTTP 500. The
+`/debug/healthz` and `/debug/ready` endpoints kept returning 200 throughout, so
+neither the kubelet nor the existing watchdog CronJob detected the wedge.
 
-**Problem 1 — detection gap:** The prod manifest implemented "hang" too narrowly:
-it counted a probe as hung **only when `curl` returned `http_code=000`** (a full
-client-side timeout at `--max-time 10`). But the wedge does not always time the
-client out. When the projection trigger blocks, Zitadel's own internal ~10s
-deadline frequently fires **first**, returning a **slow HTTP 500 at ~9.9s** —
-just under the old `--max-time 10`. That is a real wedge, yet `http_code=000`
-never matched, so `hangs` stayed at 0 and the watchdog **never restarted the
-pod**. This was observed directly (test-organizer Deactivate; RemoveUser wedged;
-ListProjectRoles returned slow 500s; healthz stayed 200; watchdog took no action).
+Investigation revealed the immediate cause was compounded:
+1. **SMTP was INACTIVE for an extended period** → notification events accumulated
+   as failures in the `projections.notifications` handler retry queue.
+2. **A DB position rollback** (`current_states.position` for
+   `projections.notifications` was set to a past value) caused the handler to
+   re-scan ~5,994 eventstore events, monopolising `MaxOpenConns: 3` for
+   extended periods.
+3. **Login triggers (`Trigger(WithAwaitRunning())`)** needed a DB connection, but
+   the pool was exhausted by the notifications handler → connection timeout →
+   QUERY-5Ngd9 → HTTP 500 → wedge.
 
-**Problem 2 — structural availability gap:** The CronJob-based watchdog issues
-`kubectl rollout restart`, which replaces **both replicas simultaneously**. The
-~90s rollout window leaves the service fully unavailable. Worse, because both
-replicas restart in lockstep they also re-wedge in lockstep (~3 min after each
-restart), causing repeated complete outages. Post-deployment observation confirmed
-this: Cloud Logging showed `http_code=000` at 180/180 probes per hour (100% wedge)
-from 2026-08-17T13:00 through 2026-08-18T05:00 with **zero restarts** (old 000-only
-check never fired), then ~20 CronJob-triggered restarts/hour after the detection
-fix — improving availability from 0% to ~50%, but still with periodic full-outage
-windows from the synchronised restart pattern.
+## What Changed
 
-A per-pod liveness probe restarts each replica **independently**, naturally
-desynchronising them so at least one replica is always in its healthy post-startup
-window while the other restarts.
+**Phase 1 — time-based hang detection (shipped then superseded):**
+The CronJob watchdog's hang classifier was widened from `http_code=000`-only to
+time-based (`000` OR `time_total >= WATCHDOG_SLOW_SEC` (8s)). This correctly
+detected the wedge but the CronJob still issued `rollout restart` on both
+replicas simultaneously, producing full-outage windows every restart cycle.
 
-## What Changes
+**Phase 2 — per-pod liveness probe sidecar (attempted, then reverted):**
+The CronJob was replaced with a `watchdog-probe` sidecar container carrying an
+exec liveness probe using the same time-based check. Discovered in prod that a
+K8s exec liveness probe failure restarts **only the container that owns the
+probe**, not the other containers in the pod — so `watchdog-probe` entered
+CrashLoopBackOff while the wedged `zitadel` container ran on unaffected. The
+sidecar was reverted (cp#429). Both the CronJob and sidecar are removed.
 
-**Phase 1 (shipped 2026-08-18):** Time-based hang detection in the existing CronJob.
-- **MODIFIED** `zitadel-self-hosted-deployment` — redefine "hang" as time-based:
-  a probe counts as hung when its total time crosses `WATCHDOG_SLOW_SEC` (8s) OR
-  it times out entirely (`http_code=000`). Client `--max-time` raised to 12s (above
-  the server's ~10s internal deadline) so a slow error is captured with its timing.
-  Fast responses are still NOT hangs (conservative-against-false-restarts preserved).
-
-**Phase 2 (planned):** Replace the CronJob watchdog with a per-pod liveness probe sidecar.
-- A `curl`-capable sidecar container is added to the `zitadel-api` pod spec. A K8s
-  `exec` liveness probe on that sidecar runs the same time-based `ListProjectRoles`
-  check (same WATCHDOG_SLOW_SEC threshold, same PAT credential). Each pod restarts
-  **independently** on wedge detection, eliminating the synchronised restart window
-  and keeping at least one replica healthy at all times.
-- The CronJob, its ServiceAccount, RoleBinding, Role, and standalone ExternalSecret
-  are removed. The PAT secret is retargeted to the `zitadel-api` pod itself.
+**Phase 3 — root cause resolved (final state):**
+- SMTP was reactivated (cloud-provisioning pulumi up v221), stopping the
+  accumulation of failed notification events.
+- The `projections.notifications` position was advanced to the current eventstore
+  head (`position = 1787110216`), releasing the handler from its backlog and
+  freeing the DB connection pool.
+- Wedge stopped immediately and did not recur (5-minute clean window confirmed).
+- No automated watchdog is needed: under normal operation (SMTP active, no
+  projection position rollback) the wedge does not occur.
 
 ## Impact
 
-- Affected capability: `zitadel-self-hosted-deployment` (watchdog requirement).
-- Affected code (Phase 1, complete):
-  - `cloud-provisioning/k8s/namespaces/zitadel/overlays/prod/cronjob-watchdog-zitadel.yaml`
-    (probe loop reads `%{time_total}`; `--max-time 10 → 12`; `sleep 5 → 3`;
-    new `WATCHDOG_SLOW_SEC` env).
-- Affected code (Phase 2, planned):
-  - Add liveness probe sidecar to `zitadel-api` Deployment (Helm values / overlay patch).
-  - Remove `cronjob-watchdog-zitadel.yaml` and standalone `external-secret-watchdog-probe-pat.yaml`.
-- Prod-only; the wedge and the watchdog are prod concerns.
-- Temporary: removed entirely when upstream zitadel/zitadel#10103 ships and is pinned.
+- **REMOVED** from `zitadel-self-hosted-deployment`: "Self-healing watchdog
+  auto-restarts a wedged Zitadel API" — the requirement is removed because
+  (a) no watchdog implementation was viable within K8s constraints, and
+  (b) the root cause is resolved.
+- **cloud-provisioning**: `cronjob-watchdog-zitadel.yaml`,
+  `external-secret-watchdog-probe-pat.yaml`, `zitadel-api-liveness-sidecar-patch.yaml`
+  all removed (cp#415 → cp#425 → cp#429).
+- Recovery if wedge ever recurs: `kubectl -n zitadel rollout restart deploy/zitadel-api`.
+  Check `projections.notifications` position vs latest eventstore position; if far
+  behind, advance position rather than rolling back.

--- a/openspec/changes/fix-zitadel-watchdog-slow-wedge-detection/specs/zitadel-self-hosted-deployment/spec.md
+++ b/openspec/changes/fix-zitadel-watchdog-slow-wedge-detection/specs/zitadel-self-hosted-deployment/spec.md
@@ -1,110 +1,25 @@
-## MODIFIED Requirements
+## REMOVED Requirements
 
 ### Requirement: Self-healing watchdog auto-restarts a wedged Zitadel API
 
-The prod environment SHALL detect the Zitadel projection-trigger wedge
-(zitadel/zitadel#10103) and automatically restart affected `zitadel-api` pods
-without operator action.
+**Reason**: No watchdog implementation proved viable within Kubernetes constraints,
+and the root cause of the wedge was resolved, making an automated watchdog
+unnecessary.
 
-**Detection mechanism:** The watchdog SHALL use a **read-only call that exercises
-the wedged trigger-on-read path**, NOT `/debug/healthz` or `/debug/ready` (both
-return 200 during the wedge). The reference signal is the Connect/gRPC
-`zitadel.project.v2.ProjectService/ListProjectRoles` method (HTTP+JSON `POST`)
-against a static project id, which calls
-`SearchProjectRoles(…, shouldTriggerBulk=true, …)` and triggers
-`ProjectRoleProjection.Trigger(WithAwaitRunning())` — the projection observed
-wedging on 2026-06-23 — as a pure read (no eventstore write). The call returns
-quickly (well under a second) when healthy. When wedged the trigger-on-read
-blocks and surfaces as either a full client timeout (`http_code=000`) or a slow
-error/response at the server's internal ~10s deadline. The probe MUST present a
-valid credential (unauthenticated calls return `401` before the trigger runs and
-cannot detect the wedge). The probe SHALL NOT use a write endpoint and SHALL NOT
-hardcode a product/consumer OIDC client id.
+Two approaches were attempted and removed:
+1. **CronJob watchdog** (`kubectl rollout restart`) restarted both replicas
+   simultaneously, causing full-outage windows on every detection cycle.
+2. **Per-pod liveness probe sidecar** — a K8s exec liveness probe failure restarts
+   only the container that owns the probe, not other containers in the pod. The
+   `watchdog-probe` sidecar entered CrashLoopBackOff while the wedged `zitadel`
+   container ran on unaffected.
 
-**Hang classification:** Detection SHALL be **time-based**, not HTTP-code-based.
-A probe counts as a hang when its total time crosses a configured slow-response
-threshold (whole seconds, default 8s) **OR** it times out entirely
-(`http_code=000`). This captures both wedge manifestations. The client request
-timeout SHALL be set above the server's internal deadline (e.g. 12s vs ~10s) so
-a slow error is captured with its timing. A fast response — healthy sub-second
-`2xx`, or a fast transient error below the threshold — SHALL NOT be counted as a
-hang.
+The actual wedge (projection-trigger deadlock from an exhausted DB connection pool
+driven by a `projections.notifications` handler stuck in a backlog) was resolved
+by fixing the root cause: SMTP reactivated (no new notification failures) and the
+`projections.notifications` position advanced to the current eventstore head
+(freeing the connection pool). The wedge has not recurred.
 
-**Implementation:** The watchdog SHALL be implemented as a **per-pod `exec`
-liveness probe on a `curl`-capable sidecar container** added to the `zitadel-api`
-pod spec — NOT a cluster-wide CronJob. The sidecar approach ensures each pod
-restarts **independently** based on its own probe result, naturally
-desynchronising the two replicas so at least one is always healthy while the
-other recovers. A CronJob issuing `rollout restart` restarts both replicas
-simultaneously, creating a full outage window on every wedge detection cycle.
-
-The probe credential SHALL be a **dedicated, least-privilege machine-user Personal
-Access Token** (scoped only to the project-role read needed by `ListProjectRoles`,
-never a shared admin identity), stored in Google Secret Manager, synced into the
-`zitadel` namespace via External Secrets, and mounted into the `zitadel-api` pod
-as a bearer token. The credential failure mode SHALL be fail-safe: a fast `401`
-is treated as "not wedged" (no restart), and `401`/`403` SHALL be logged
-distinctly.
-
-The watchdog SHALL be **conservative against false restarts**:
-- It SHALL restart only after **N consecutive hanging probes** (`failureThreshold`).
-- A **fast** response SHALL NOT be counted as a hang.
-- It SHALL use K8s-native `initialDelaySeconds` to avoid restarting during pod
-  startup/warmup before the projection is ready.
-
-#### Scenario: Wedged pod is auto-restarted
-
-- **WHEN** the authenticated `ListProjectRoles` probe hangs (times out, or returns
-  at/after the slow threshold) for N consecutive probes
-- **THEN** the K8s liveness probe fails and the kubelet restarts that pod
-- **AND** a fresh `ListProjectRoles` probe SHALL return a normal response within
-  normal latency after the new pod becomes Ready
-
-#### Scenario: Slow 5xx just under the client timeout is detected as a wedge
-
-- **WHEN** the `ListProjectRoles` probe returns a slow error whose total time is
-  at or above the slow threshold but below the client timeout (server's internal
-  deadline fired before the client timed out) for N consecutive probes
-- **THEN** the watchdog SHALL treat each such probe as a hang and SHALL restart
-  the pod
-- **AND** it SHALL NOT rely on `http_code=000` to make that decision
-
-#### Scenario: Replicas restart independently — no full-outage window
-
-- **WHEN** one `zitadel-api` pod is wedged and its liveness probe fails
-- **THEN** only that pod is restarted by the kubelet; the other pod continues
-  serving traffic
-- **AND** the PDB (`minAvailable: 1`) enforces that at least one replica remains
-  Ready throughout
-
-#### Scenario: Probe is read-only (no auth-request writes)
-
-- **WHEN** the watchdog runs its healthy probes over time
-- **THEN** it SHALL create no OIDC auth requests or other eventstore writes
-
-#### Scenario: Transient blip does not trigger a restart
-
-- **WHEN** a single probe in a series hangs but the remaining probes return normally
-- **THEN** the watchdog SHALL NOT restart the pod (`failureThreshold` not reached)
-
-#### Scenario: Fast transient error does not trigger a restart
-
-- **WHEN** a probe returns an error status whose total time is below the slow
-  threshold
-- **THEN** the watchdog SHALL NOT count that probe as a hang
-
-#### Scenario: Invalid credential is fail-safe (no false restart)
-
-- **WHEN** the watchdog's PAT is missing, expired, or unauthorized (`401`/`403`)
-- **THEN** the watchdog SHALL treat the fast response as "not wedged", SHALL NOT
-  restart the pod, and SHALL log the credential failure distinctly
-
-#### Scenario: Full outage (core health down) does not trigger a restart
-
-- **WHEN** the probe fails AND core health is also down (e.g. gateway/DNS outage, pod not running, init failure) — not the in-process wedge signature
-- **THEN** the liveness probe exec script's healthz-precondition guard (checking `/debug/healthz` before counting hangs) ensures a gateway-level failure is not mistaken for the wedge; non-wedge failures are handled by existing readiness/startup probe lifecycle, not this liveness probe
-
-#### Scenario: Healthy steady state issues no restart
-
-- **WHEN** the `ListProjectRoles` probe returns normally within normal latency
-- **THEN** the watchdog SHALL take no action
+Recovery if the wedge ever occurs: `kubectl -n zitadel rollout restart deploy/zitadel-api`.
+Investigate `projections.notifications` position vs latest eventstore position; if
+far behind, advance position forward rather than rolling back.

--- a/openspec/changes/fix-zitadel-watchdog-slow-wedge-detection/tasks.md
+++ b/openspec/changes/fix-zitadel-watchdog-slow-wedge-detection/tasks.md
@@ -11,21 +11,23 @@
 - [x] 2.2 Unit-check the shell classifier against representative cases: healthy fast 200, slow 5xx (~9.9s), curl timeout 000, slow 503 at threshold, fast transient 500, 401, slow 200, empty output. All classify correctly.
 - [x] 2.3 kube-linter introduces no new findings on the watchdog CronJob (pre-existing chart-Job findings unaffected).
 
-## 3. Ship + remediate the live prod instance
+## 3. Ship time-based detection
 
 - [x] 3.1 Open cloud-provisioning PR; CI green; merge to main. (PR #415 merged 2026-08-18; spec delta #805 merged)
-- [x] 3.2 Trigger prod ArgoCD sync (automatic on merge) and confirm the updated CronJob is applied. (ArgoCD synced `f7422bc`, Healthy; live CronJob shows `WATCHDOG_SLOW_SEC=8` + `--max-time 12` + `time_total`)
-- [x] 3.3 Confirm the next natural wedge (or a controlled reproduction) now triggers an auto-restart. (Observed live minutes after sync: `zitadel-wedge-watchdog-29783839` logged 3/3 `→ hang` while healthz=200 and ran `rollout restart deployment/zitadel-api`; rollout succeeded to 2/2 fresh pods; next cycle healthy `200 @0.36s`, and a fast `503 @0.97s` was correctly NOT counted as a hang)
+- [x] 3.2 Trigger prod ArgoCD sync and confirm the updated CronJob is applied. (ArgoCD synced `f7422bc`; live CronJob shows `WATCHDOG_SLOW_SEC=8` + `--max-time 12` + `time_total`)
+- [x] 3.3 Confirm the next natural wedge triggers an auto-restart. (Watchdog fired on a live wedge; rollout succeeded 2/2 fresh pods; next cycle healthy `200 @0.36s`)
 
-## 5. Replace CronJob watchdog with per-pod liveness probe sidecar (cloud-provisioning)
+## 4. Attempt per-pod liveness probe sidecar — reverted
 
-- [x] 5.1 Add `curl`-capable sidecar container to `zitadel-api` Helm values / overlay patch (`image: alpine/curl:8.21.0`; `command: ["sleep","infinity"]`; hardened `securityContext`; resource requests/limits). Implemented via Kustomize strategic-merge patch `zitadel-api-liveness-sidecar-patch.yaml`.
-- [x] 5.2 Add `exec` liveness probe on the sidecar: same `ListProjectRoles` check with `WATCHDOG_SLOW_SEC=8`, `--max-time 12`, `failureThreshold=3`, `periodSeconds=20`, `initialDelaySeconds=60`.
-- [x] 5.3 Mount the watchdog PAT secret into the sidecar (ExternalSecret `zitadel-watchdog-probe-pat` retained; Secret mounted into `zitadel-api` pod at `/var/run/watchdog/token`).
-- [x] 5.4 Remove `cronjob-watchdog-zitadel.yaml` from `kustomization.yaml` resources; ExternalSecret retained (Secret now used by sidecar).
-- [ ] 5.5 Kustomize dry-run clean ✓; kube-linter no new findings ✓; open cloud-provisioning PR; CI green; merge; ArgoCD sync confirmed.
-- [ ] 5.6 Verify: observe two `zitadel-api` pod restarts triggered by liveness probe failures on different schedules (not simultaneous); confirm no full-outage window during the wedge cycle.
+- [x] 4.1 Implement `zitadel-api-liveness-sidecar-patch.yaml` with `watchdog-probe` sidecar and exec liveness probe (PR #425 merged 2026-08-19).
+- [x] 4.2 Discover K8s design constraint: exec liveness probe failure restarts only the container owning the probe, not other pod containers. `watchdog-probe` entered CrashLoopBackOff (restart count 12); `zitadel` container restart count remained 0. Wedge continued unabated.
+- [x] 4.3 Revert: remove CronJob, sidecar, and ExternalSecret from prod overlay (PR #429 merged 2026-08-19). Recovery is manual `kubectl -n zitadel rollout restart deploy/zitadel-api`.
 
-## 6. Follow-up
+## 5. Investigate and resolve root cause
 
-- [ ] 6.1 Once upstream zitadel/zitadel#10103 ships a fix and prod is pinned to it, remove the liveness probe sidecar, the PAT secret mount, and the GSM secret / ExternalSecret entirely (all carry `liverty-music.app/temporary: until-upstream-zitadel-10103-fix`).
+- [x] 5.1 Identify wedge pattern: `projections.notifications` handler occupied DB connections continuously; `MaxOpenConns: 3` left zero connections for login `Trigger(WithAwaitRunning())` → QUERY-5Ngd9 → wedge at ~4-minute intervals.
+- [x] 5.2 Confirm `projections.failed_events2` is empty (no poison events). Root cause is position backlog, not failed events.
+- [x] 5.3 Identify backlog source: `projections.notifications.position` was rolled back to `1782101700`; eventstore latest is `1787110216`; handler needed to scan 5,994 events (4,586 `auth_request.added`) — useless re-scan monopolising the connection pool.
+- [x] 5.4 Fix SMTP: pulumi up v221 activated `smtp-activation`; no new notification failures will accumulate.
+- [x] 5.5 Advance `projections.notifications` position to current eventstore head (`1787110216`) via DB UPDATE; handler released from backlog.
+- [x] 5.6 Confirm wedge resolved: 5-minute monitoring window showed QUERY-5Ngd9 = 0, pod RESTARTS = 0. Wedge has not recurred.


### PR DESCRIPTION
Final reconciliation of `fix-zitadel-watchdog-slow-wedge-detection` (tracking #804) with what actually shipped.

## Summary of changes

- **proposal.md**: rewrites as 3-phase story: (1) time-based hang detection shipped, (2) sidecar liveness probe attempted + K8s design constraint discovered (probe restarts wrong container) + reverted, (3) root cause identified and resolved
- **specs delta**: `MODIFIED → REMOVED` for "Self-healing watchdog auto-restarts a wedged Zitadel API" — the requirement is removed because no watchdog implementation was viable and the root cause is resolved
- **tasks.md**: 19/19 complete; Phase 2 tasks rewritten to reflect sidecar revert; Phase 3 (root cause investigation + fix) added as completed section

## Root cause (for the record)

`projections.notifications` position was rolled back to a past value → handler re-scanned 5,994 events → `MaxOpenConns: 3` exhausted → login `Trigger(WithAwaitRunning())` had no DB connection → QUERY-5Ngd9 → wedge every ~4 min. Fixed by advancing position to current eventstore head. SMTP reactivated prevents new notification failures from accumulating. Wedge has not recurred (5-min clean window confirmed 2026-08-19T04:02).

`openspec validate --strict` → valid. `state: all_done`.

Refs: #804