### PR TITLE
docs(spec): reconcile old workload names to <audience>-<tier> (unify-workload-naming 6.2)

### DIFF
--- a/openspec/specs/apex-frontend-serving/spec.md
+++ b/openspec/specs/apex-frontend-serving/spec.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-Defines the contract for serving the apex domain `liverty-music.app` via GKE Gateway with Google-managed TLS. Cloudflare is the authoritative DNS provider, with an A record (DNS-only, `proxied: false`) pointing to the shared `api-gateway-static-ip`. All prod-stack apex resources (A record, DnsAuthorization, Certificate, CertificateMapEntry) carry Pulumi `protect: true`. Routing is handled by a pre-existing HTTPRoute (from the `prod-k8s-manifests` change) that targets the `web-app` Service in the `frontend` namespace.
+Defines the contract for serving the apex domain `liverty-music.app` via GKE Gateway with Google-managed TLS. Cloudflare is the authoritative DNS provider, with an A record (DNS-only, `proxied: false`) pointing to the shared `api-gateway-static-ip`. All prod-stack apex resources (A record, DnsAuthorization, Certificate, CertificateMapEntry) carry Pulumi `protect: true`. Routing is handled by a pre-existing HTTPRoute (from the `prod-k8s-manifests` change) that targets the `fan-web-app` Service in the `frontend` namespace.
 
 ## Requirements
 ### Requirement: Apex hostname SHALL be served end-to-end via the GKE Gateway with a Google-managed TLS certificate
@@ -33,8 +33,8 @@ The production apex hostname `liverty-music.app` SHALL serve the Aurelia fronten
 - **AND** Google's ACME validator SHALL resolve the challenge via Cloudflare's authoritative nameservers
 - **AND** the Cert SHALL reach `state: ACTIVE` within 60 minutes of DnsAuthorization creation
 
-### Requirement: Apex serving SHALL route to the `web-app` frontend Service via HTTPRoute hostname matching
-The Kubernetes HTTPRoute that serves the apex SHALL match on `hostnames: ['liverty-music.app']` and route to the `web-app` Service in the `frontend` namespace. This HTTPRoute SHALL share the same Gateway as the HTTPRoutes for `api.liverty-music.app` (routing to backend) and `auth.liverty-music.app` (routing to Zitadel) — differentiation is by HTTPRoute hostname, not by Gateway listener.
+### Requirement: Apex serving SHALL route to the `fan-web-app` frontend Service via HTTPRoute hostname matching
+The Kubernetes HTTPRoute that serves the apex SHALL match on `hostnames: ['liverty-music.app']` and route to the `fan-web-app` Service in the `frontend` namespace. This HTTPRoute SHALL share the same Gateway as the HTTPRoutes for `api.liverty-music.app` (routing to backend) and `auth.liverty-music.app` (routing to Zitadel) — differentiation is by HTTPRoute hostname, not by Gateway listener.
 
 > **Note**: The HTTPRoute hostname binding is pre-existing — configured by the prior `prod-k8s-manifests` change (archived 2026-05-14) in `cloud-provisioning/k8s/namespaces/frontend/overlays/prod/kustomization.yaml`. The `consolidate-public-dns-on-cloudflare` change consumes the existing binding and verifies it via a pre-flight task; it does not author or modify any HTTPRoute YAML. The requirement is documented here because the apex-frontend-serving capability collects the end-to-end serving contract regardless of which change first satisfied each piece.
 
@@ -42,7 +42,7 @@ The Kubernetes HTTPRoute that serves the apex SHALL match on `hostnames: ['liver
 - **WHEN** rendering `cloud-provisioning/k8s/namespaces/frontend/overlays/prod/`
 - **THEN** an `HTTPRoute` resource SHALL exist with `spec.hostnames` containing `liverty-music.app`
 - **AND** the HTTPRoute SHALL reference the shared prod Gateway via `spec.parentRefs`
-- **AND** the HTTPRoute SHALL route to the `web-app` Service via `spec.rules[].backendRefs`
+- **AND** the HTTPRoute SHALL route to the `fan-web-app` Service via `spec.rules[].backendRefs`
 
 #### Scenario: Apex traffic reaches the frontend SPA
 - **WHEN** an end user requests `https://liverty-music.app/` after the prod cutover completes

--- a/openspec/specs/argocd-image-automation/spec.md
+++ b/openspec/specs/argocd-image-automation/spec.md
@@ -80,8 +80,8 @@ The system SHALL support automated updates for all dev container images.
 - **WHEN** a new backend server image is pushed to GAR
 - **THEN** Image Updater SHALL update the backend ArgoCD Application
 
-#### Scenario: Frontend web-app image auto-update
-- **WHEN** a new frontend web-app image is pushed to GAR
+#### Scenario: Frontend fan-web image auto-update
+- **WHEN** a new frontend fan-web image is pushed to GAR
 - **THEN** Image Updater SHALL update the frontend ArgoCD Application
 
 ### Requirement: Rollback capability

--- a/openspec/specs/deployment-infrastructure/spec.md
+++ b/openspec/specs/deployment-infrastructure/spec.md
@@ -102,7 +102,7 @@ The backend server deployment in the dev environment SHALL run with 1 replica. P
 #### Scenario: Dev backend replica count
 
 - **WHEN** rendering the backend dev overlay manifests
-- **THEN** the server-app Deployment SHALL have replicas set to 1
+- **THEN** the fan-api Deployment SHALL have replicas set to 1
 
 ### Requirement: All dev workload kinds use Spot VM scheduling
 

--- a/openspec/specs/frontend-hosting/spec.md
+++ b/openspec/specs/frontend-hosting/spec.md
@@ -169,27 +169,27 @@ The Caddy web server in the frontend container SHALL serve `/config.json` from t
 
 ### Requirement: Frontend Deployment SHALL mount a per-environment runtime-config ConfigMap
 
-The Kubernetes Deployment for the `web-app` container SHALL mount a ConfigMap volume at `/srv/config.json` using a `subPath` mount, sourced from a ConfigMap named `web-app-runtime-config` in the same namespace. Each environment overlay under `cloud-provisioning/k8s/namespaces/frontend/overlays/<env>/` SHALL define this ConfigMap with the values appropriate for that environment. The Deployment SHALL carry a Reloader annotation so that ConfigMap changes trigger a rolling restart.
+The Kubernetes Deployment for the `fan-web-app` container SHALL mount a ConfigMap volume at `/srv/config.json` using a `subPath` mount, sourced from a ConfigMap named `fan-web-runtime-config` in the same namespace. Each environment overlay under `cloud-provisioning/k8s/namespaces/frontend/overlays/<env>/` SHALL define this ConfigMap with the values appropriate for that environment. The Deployment SHALL carry a Reloader annotation so that ConfigMap changes trigger a rolling restart.
 
 #### Scenario: Base Deployment declares the volume and volumeMount
 
 - **WHEN** inspecting `cloud-provisioning/k8s/namespaces/frontend/base/web/deployment.yaml` (or an equivalent base patch)
 - **THEN** the `caddy` container SHALL declare a `volumeMounts` entry with `name: runtime-config`, `mountPath: /srv/config.json`, and `subPath: config.json`
-- **AND** the pod template SHALL declare a `volumes` entry with `name: runtime-config` sourced from a ConfigMap with `name: web-app-runtime-config`
+- **AND** the pod template SHALL declare a `volumes` entry with `name: runtime-config` sourced from a ConfigMap with `name: fan-web-runtime-config`
 
 #### Scenario: Per-environment overlay defines the ConfigMap
 
 - **WHEN** inspecting `cloud-provisioning/k8s/namespaces/frontend/overlays/<env>/` for each env in `{dev, prod}` (and `staging` if/when introduced)
-- **THEN** a ConfigMap named `web-app-runtime-config` SHALL exist (defined inline in `configmap.yaml` or via `configMapGenerator`)
+- **THEN** a ConfigMap named `fan-web-runtime-config` SHALL exist (defined inline in `configmap.yaml` or via `configMapGenerator`)
 - **AND** the ConfigMap SHALL have a `config.json` key whose value parses as JSON
 - **AND** the parsed JSON SHALL conform to the AppConfig schema declared in the `frontend-runtime-config` capability
 - **AND** the `environment` field SHALL match the overlay's environment identifier (`dev` → `dev`, `prod` → `prod`)
 
 #### Scenario: Reloader annotation triggers rollout on ConfigMap change
 
-- **WHEN** inspecting the rendered `web-app` Deployment in any environment overlay
+- **WHEN** inspecting the rendered `fan-web-app` Deployment in any environment overlay
 - **THEN** the Deployment metadata SHALL include the annotation `reloader.stakater.com/auto: "true"`
-- **AND** the cluster's deployed Reloader operator SHALL be responsible for issuing the rolling restart when `web-app-runtime-config` changes. Precise rollout latency is determined by the operator's configured reconciliation interval (typically tens of seconds) and is an operational expectation rather than a CI-testable assertion. See `Risks / Trade-offs` in the proposing change for the live-update caveat behind this mechanism.
+- **AND** the cluster's deployed Reloader operator SHALL be responsible for issuing the rolling restart when `fan-web-runtime-config` changes. Precise rollout latency is determined by the operator's configured reconciliation interval (typically tens of seconds) and is an operational expectation rather than a CI-testable assertion. See `Risks / Trade-offs` in the proposing change for the live-update caveat behind this mechanism.
 
 #### Scenario: Pod is healthy with the mounted config
 

--- a/openspec/specs/gke-gateway-infrastructure/spec.md
+++ b/openspec/specs/gke-gateway-infrastructure/spec.md
@@ -22,7 +22,7 @@ The system SHALL provide HTTPRoute resources that route traffic from the Gateway
 
 #### Scenario: API requests routed correctly
 - **WHEN** a request matches hostname `api.liverty-music.app` and path `/`
-- **THEN** the request is forwarded to `backend/server:8080` Service
+- **THEN** the request is forwarded to `backend/fan-api:8080` Service
 
 #### Scenario: Path prefix matching
 - **WHEN** a request to `api.liverty-music.app/liverty_music.rpc.*/` arrives

--- a/openspec/specs/identity-management/spec.md
+++ b/openspec/specs/identity-management/spec.md
@@ -123,7 +123,7 @@ end-user authentication.
 - **AND** the application Type SHALL be "SPA"
 - **AND** the Auth Method Type SHALL be "NONE"
 - **AND** the application's `client_id` SHALL be committed to the
-  per-environment `web-app-runtime-config` ConfigMap under
+  per-environment `fan-web-runtime-config` ConfigMap under
   `cloud-provisioning/k8s/namespaces/frontend/overlays/<env>/configmap.yaml`
   (`zitadelClientId` field) alongside the owning org's id
   (`zitadelOrgId` field), so each env's pod serves its own identifiers

--- a/openspec/specs/infra/spec.md
+++ b/openspec/specs/infra/spec.md
@@ -11,7 +11,7 @@ Defines infrastructure invariants for KEDA-managed Deployments and how ArgoCD re
 Deployments targeted by a KEDA ScaledObject SHALL omit `spec.replicas` from their Kustomize base manifest, delegating replica count management entirely to KEDA.
 
 #### Scenario: Consumer Deployment with no replicas field
-- **WHEN** the `consumer-app` Deployment manifest is rendered by Kustomize
+- **WHEN** the `event-consumer` Deployment manifest is rendered by Kustomize
 - **THEN** the output SHALL NOT contain `spec.replicas`
 
 ### Requirement: ArgoCD SHALL ignore replicas drift for KEDA-managed Deployments
@@ -19,5 +19,5 @@ Deployments targeted by a KEDA ScaledObject SHALL omit `spec.replicas` from thei
 The ArgoCD Application for the `backend` namespace SHALL include `ignoreDifferences` for `spec.replicas` on Deployments managed by KEDA ScaledObjects.
 
 #### Scenario: KEDA scales consumer to zero
-- **WHEN** KEDA scales `consumer-app` to 0 replicas due to no active triggers
+- **WHEN** KEDA scales `event-consumer` to 0 replicas due to no active triggers
 - **THEN** ArgoCD SHALL NOT report the Deployment as OutOfSync

--- a/openspec/specs/k8s-resource-right-sizing/spec.md
+++ b/openspec/specs/k8s-resource-right-sizing/spec.md
@@ -23,12 +23,12 @@ All dev environment workloads SHALL set CPU request to 10m (Standard GKE minimum
 
 #### Scenario: Backend server resource requests
 - **WHEN** rendering the backend dev overlay manifests
-- **THEN** server-app CPU request SHALL be 10m with memory request of 60MiB
-- **AND** consumer-app CPU request SHALL be 10m with memory request of 20MiB
+- **THEN** fan-api CPU request SHALL be 10m with memory request of 60MiB
+- **AND** event-consumer CPU request SHALL be 10m with memory request of 20MiB
 
-#### Scenario: Frontend web-app resource requests
+#### Scenario: Frontend fan-web-app resource requests
 - **WHEN** rendering the frontend dev overlay manifests
-- **THEN** web-app CPU request SHALL be 10m with memory request of 52MiB
+- **THEN** fan-web-app CPU request SHALL be 10m with memory request of 52MiB
 
 #### Scenario: Reloader resource requests
 - **WHEN** rendering the reloader dev overlay manifests
@@ -53,7 +53,7 @@ All dev environment workloads SHALL set CPU request to 10m (Standard GKE minimum
 ### Requirement: KEDA ScaledObjects in dev SHALL cap at maxReplicaCount 1
 Consumer workload ScaledObjects in the dev environment SHALL set `maxReplicaCount: 1` to prevent horizontal scale-out in a low-traffic environment.
 
-#### Scenario: consumer-app ScaledObject maxReplicaCount
+#### Scenario: event-consumer ScaledObject maxReplicaCount
 - **WHEN** rendering the backend dev overlay manifests
-- **THEN** the consumer-app ScaledObject `maxReplicaCount` SHALL be 1
+- **THEN** the event-consumer ScaledObject `maxReplicaCount` SHALL be 1
 - **AND** `minReplicaCount` SHALL remain 0 (zero-scale on idle is preserved)

--- a/openspec/specs/prod-environment-bootstrap/spec.md
+++ b/openspec/specs/prod-environment-bootstrap/spec.md
@@ -246,7 +246,7 @@ This invariant prevents the silent-failure mode where Web Push subscriptions sig
 
 #### Scenario: Frontend bundle public key matches GSM private key
 
-- **WHEN** an operator extracts `VITE_VAPID_PUBLIC_KEY` from the prod-built `web-app` static assets
+- **WHEN** an operator extracts `VITE_VAPID_PUBLIC_KEY` from the prod-built `fan-web` static assets
 - **AND** derives the public key from GSM `vapid-private-key`
 - **THEN** the two values SHALL be byte-equal
 

--- a/openspec/specs/prod-image-pipeline/spec.md
+++ b/openspec/specs/prod-image-pipeline/spec.md
@@ -10,12 +10,12 @@ Every container image referenced by a workload in the `liverty-music-prod` GKE c
 
 #### Scenario: Backend prod images come from prod AR
 
-- **WHEN** inspecting any backend Deployment in the prod cluster (`server-app`, `consumer-app`, `concert-discovery-app`, `artist-image-sync-app`)
+- **WHEN** inspecting any backend Deployment in the prod cluster (`fan-api`, `event-consumer`, `concert-discovery-app`, `artist-image-sync-app`)
 - **THEN** the container `image` field SHALL match the prefix `asia-northeast2-docker.pkg.dev/liverty-music-prod/backend/`
 
 #### Scenario: Frontend prod image comes from prod AR
 
-- **WHEN** inspecting the frontend `web-app` Deployment in the prod cluster
+- **WHEN** inspecting the frontend `fan-web-app` Deployment in the prod cluster
 - **THEN** the container `image` field SHALL match the prefix `asia-northeast2-docker.pkg.dev/liverty-music-prod/frontend/`
 
 #### Scenario: No cross-project image references in prod kustomize overlays
@@ -135,31 +135,31 @@ The backend `deploy.yml` workflow SHALL publish to `liverty-music-prod/backend/{
 
 ### Requirement: Frontend prod image SHALL be promoted to prod AR on GitHub Release tags
 
-The frontend `push-image.yaml` workflow SHALL publish to `liverty-music-prod/frontend/web-app` Artifact Registry only when triggered by a published GitHub Release. On the release path, the workflow SHALL **promote the dev AR image via cross-repository copy** rather than rebuild — it resolves the dev AR digest for `github.sha`, then invokes `crane copy` (from `google/go-containerregistry`, installed via `imjasonh/setup-crane`) twice to copy that exact digest to `liverty-music-prod/frontend/web-app:<release-tag>` and `:<sha>`. No `docker build` SHALL run on the release path. The dev path (push-to-`main`) SHALL guarantee a resolvable `liverty-music-dev/frontend/web-app:<sha>` for every `main` commit — by build or by parent-digest inheritance (see "Every main commit SHALL have a resolvable dev AR image") — so a release cut on `main` HEAD always resolves. This ensures prod runs byte-identical bytes to dev: the digest tested in dev is the digest deployed to prod.
+The frontend `push-image.yaml` workflow SHALL publish to `liverty-music-prod/frontend/fan-web` Artifact Registry only when triggered by a published GitHub Release. On the release path, the workflow SHALL **promote the dev AR image via cross-repository copy** rather than rebuild — it resolves the dev AR digest for `github.sha`, then invokes `crane copy` (from `google/go-containerregistry`, installed via `imjasonh/setup-crane`) twice to copy that exact digest to `liverty-music-prod/frontend/fan-web:<release-tag>` and `:<sha>`. No `docker build` SHALL run on the release path. The dev path (push-to-`main`) SHALL guarantee a resolvable `liverty-music-dev/frontend/fan-web:<sha>` for every `main` commit — by build or by parent-digest inheritance (see "Every main commit SHALL have a resolvable dev AR image") — so a release cut on `main` HEAD always resolves. This ensures prod runs byte-identical bytes to dev: the digest tested in dev is the digest deployed to prod.
 
 #### Scenario: Push to main triggers dev-only frontend build or inherit
 
 - **WHEN** a commit is pushed to `liverty-music/frontend:main`
-- **THEN** the workflow SHALL publish (by build or by parent-digest inheritance) only to `liverty-music-dev/frontend/web-app`
-- **AND** SHALL NOT push to `liverty-music-prod/frontend/web-app`
+- **THEN** the workflow SHALL publish (by build or by parent-digest inheritance) only to `liverty-music-dev/frontend/fan-web`
+- **AND** SHALL NOT push to `liverty-music-prod/frontend/fan-web`
 
 #### Scenario: GitHub Release publish promotes the dev AR digest
 
 - **WHEN** a GitHub Release is published in `liverty-music/frontend` with tag `vX.Y.Z`
 - **THEN** the workflow SHALL NOT invoke `docker build` or `docker/build-push-action` on the release path
-- **AND** the workflow SHALL resolve the dev AR digest for `asia-northeast2-docker.pkg.dev/liverty-music-dev/frontend/web-app:${GITHUB_SHA}` via `gcloud artifacts docker images describe`
-- **AND** the workflow SHALL run `crane copy asia-northeast2-docker.pkg.dev/liverty-music-dev/frontend/web-app@<digest> asia-northeast2-docker.pkg.dev/liverty-music-prod/frontend/web-app:vX.Y.Z`
-- **AND** the workflow SHALL run `crane copy asia-northeast2-docker.pkg.dev/liverty-music-dev/frontend/web-app@<digest> asia-northeast2-docker.pkg.dev/liverty-music-prod/frontend/web-app:${GITHUB_SHA}`
+- **AND** the workflow SHALL resolve the dev AR digest for `asia-northeast2-docker.pkg.dev/liverty-music-dev/frontend/fan-web:${GITHUB_SHA}` via `gcloud artifacts docker images describe`
+- **AND** the workflow SHALL run `crane copy asia-northeast2-docker.pkg.dev/liverty-music-dev/frontend/fan-web@<digest> asia-northeast2-docker.pkg.dev/liverty-music-prod/frontend/fan-web:vX.Y.Z`
+- **AND** the workflow SHALL run `crane copy asia-northeast2-docker.pkg.dev/liverty-music-dev/frontend/fan-web@<digest> asia-northeast2-docker.pkg.dev/liverty-music-prod/frontend/fan-web:${GITHUB_SHA}`
 - **AND** the workflow SHALL invoke `gcloud auth configure-docker asia-northeast2-docker.pkg.dev` before the copy steps so `crane`'s authentication (which reads `~/.docker/config.json` credential helpers, not `GOOGLE_APPLICATION_CREDENTIALS` directly) resolves to the prod CI service account's WIF token
 
 #### Scenario: Prod and dev images share the same digest after promotion
 
-- **WHEN** comparing `gcloud artifacts docker images describe asia-northeast2-docker.pkg.dev/liverty-music-dev/frontend/web-app:<sha>` against `gcloud artifacts docker images describe asia-northeast2-docker.pkg.dev/liverty-music-prod/frontend/web-app:vX.Y.Z` after a release event for that SHA
+- **WHEN** comparing `gcloud artifacts docker images describe asia-northeast2-docker.pkg.dev/liverty-music-dev/frontend/fan-web:<sha>` against `gcloud artifacts docker images describe asia-northeast2-docker.pkg.dev/liverty-music-prod/frontend/fan-web:vX.Y.Z` after a release event for that SHA
 - **THEN** the `image_summary.digest` field SHALL be identical between the two outputs
 
 #### Scenario: Release CI SHALL refuse if dev AR :<sha> is missing
 
-- **WHEN** a GitHub Release is published with a `github.sha` for which no `asia-northeast2-docker.pkg.dev/liverty-music-dev/frontend/web-app:<sha>` tag exists — which, given the "every main commit has a resolvable dev AR image" invariant, can only mean the build/inherit job for that commit is still in-flight (release cut seconds after the push) or that job failed
+- **WHEN** a GitHub Release is published with a `github.sha` for which no `asia-northeast2-docker.pkg.dev/liverty-music-dev/frontend/fan-web:<sha>` tag exists — which, given the "every main commit has a resolvable dev AR image" invariant, can only mean the build/inherit job for that commit is still in-flight (release cut seconds after the push) or that job failed
 - **THEN** the release workflow SHALL fail at the digest-resolve step with an explicit error referencing the recovery runbook section
 - **AND** the workflow SHALL NOT publish any tag to prod AR
 - **AND** the digest-resolve step SHALL retry up to 5 additional times after the initial attempt (6 total attempts) with 60-second waits between attempts, for a maximum total wait of approximately 5 minutes — to absorb the race window where a release is cut seconds after a push and the dev build/inherit is still in-flight
@@ -185,13 +185,13 @@ Each prod overlay under `cloud-provisioning/k8s/namespaces/<ns>/overlays/prod/` 
 #### Scenario: Frontend prod overlay rewrites image URIs
 
 - **WHEN** running `kustomize build k8s/namespaces/frontend/overlays/prod`
-- **THEN** the rendered `web-app` Deployment's `image:` SHALL begin with `asia-northeast2-docker.pkg.dev/liverty-music-prod/frontend/`
+- **THEN** the rendered `fan-web-app` Deployment's `image:` SHALL begin with `asia-northeast2-docker.pkg.dev/liverty-music-prod/frontend/`
 
 > **Historical note**: the "Image tags are explicit, never `:latest`" scenario that previously lived under this requirement was removed during the archive of `promote-prod-image-via-retag` — it was superseded by `prod-image-tag-immutability`'s strictly stricter "Prod kustomize overlays SHALL pin image URIs to semantic version tags" requirement (which forbids `:<sha>`-only tags and `:latest`).
 
 ### Requirement: Every main commit SHALL have a resolvable dev AR image
 
-For both the backend (`deploy.yml`, 4-image matrix) and frontend (`push-image.yaml`, `web-app`) pipelines, every commit observed by the push-to-`main` workflow as `${GITHUB_SHA}` SHALL have a resolvable dev-AR `<image>:${GITHUB_SHA}` tag after that workflow run completes. The workflow SHALL trigger on **every** push to `main` (the `paths:` trigger gate SHALL NOT be used to skip the workflow). The workflow SHALL decide, by diffing the pushed range `${{ github.event.before }}..${GITHUB_SHA}` against the build-relevant glob set, whether to **build** (any matched file) or **inherit** (no matched file):
+For both the backend (`deploy.yml`, 4-image matrix) and frontend (`push-image.yaml`, `fan-web`) pipelines, every commit observed by the push-to-`main` workflow as `${GITHUB_SHA}` SHALL have a resolvable dev-AR `<image>:${GITHUB_SHA}` tag after that workflow run completes. The workflow SHALL trigger on **every** push to `main` (the `paths:` trigger gate SHALL NOT be used to skip the workflow). The workflow SHALL decide, by diffing the pushed range `${{ github.event.before }}..${GITHUB_SHA}` against the build-relevant glob set, whether to **build** (any matched file) or **inherit** (no matched file):
 
 - On the **build** path the workflow builds and pushes `<image>:latest,:main,:<sha>` to dev AR (unchanged from prior behavior).
 - On the **inherit** path the workflow SHALL `crane copy` the parent push tip's dev-AR digest (`<image>:${{ github.event.before }}`, by digest) onto `<image>:${GITHUB_SHA}` (and re-point `:main` and `:latest` at that digest), with no `docker build`. This is byte-exact: a commit that changed no build-relevant file produces bytes identical to its parent.
@@ -207,7 +207,7 @@ A force-push or branch-creation push SHALL take the BUILD path, never the inheri
 #### Scenario: Build-relevant push produces a built image
 
 - **WHEN** a push to `main` changes at least one file matching the build glob set (backend: `**.go`, `go.mod`, `go.sum`, `Dockerfile`, `.github/workflows/deploy.yml`; frontend: `src/**`, `public/**`, `scripts/**`, `package.json`, `package-lock.json`, `vite.config.ts`, `Dockerfile`, `Caddyfile`, `.github/workflows/push-image.yaml`) anywhere in `${{ github.event.before }}..${GITHUB_SHA}`
-- **THEN** the workflow SHALL build and push `<image>:${GITHUB_SHA}` (and `:latest`, `:main`) to the dev AR for every image in the pipeline (the 4 backend matrix images, or frontend `web-app`)
+- **THEN** the workflow SHALL build and push `<image>:${GITHUB_SHA}` (and `:latest`, `:main`) to the dev AR for every image in the pipeline (the 4 backend matrix images, or frontend `fan-web`)
 
 #### Scenario: Build-irrelevant push inherits the parent digest
 
@@ -277,9 +277,9 @@ The dispatch step SHALL run only after the prod-AR retag for that component has 
 
 ### Requirement: A cloud-provisioning workflow SHALL apply the prod pin-bump on dispatch
 
-`cloud-provisioning` SHALL contain a workflow (`bump-prod-pin.yml`) triggered by `repository_dispatch` of type `bump-prod-pin`. On receipt, for the `component` named in the payload it SHALL rewrite, in `k8s/namespaces/<component>/overlays/prod/kustomization.yaml`, every `images[].newTag` (all 4 entries for `backend`, the single `web-app` entry for `frontend`) and the `labels[].pairs."app.kubernetes.io/version"` value, in lock-step, to the release version. The `newTag` SHALL be the `vX.Y.Z` form; the version label SHALL be the bare semver (no leading `v`). The inline source-commit trailer comment after each `newTag` SHALL be updated to the payload `sha`.
+`cloud-provisioning` SHALL contain a workflow (`bump-prod-pin.yml`) triggered by `repository_dispatch` of type `bump-prod-pin`. On receipt, for the `component` named in the payload it SHALL rewrite, in `k8s/namespaces/<component>/overlays/prod/kustomization.yaml`, every `images[].newTag` (all 4 entries for `backend`, the single `fan-web` entry for `frontend`) and the `labels[].pairs."app.kubernetes.io/version"` value, in lock-step, to the release version. The `newTag` SHALL be the `vX.Y.Z` form; the version label SHALL be the bare semver (no leading `v`). The inline source-commit trailer comment after each `newTag` SHALL be updated to the payload `sha`.
 
-Before editing, the workflow SHALL validate the payload: `component` SHALL be one of `backend | frontend` and `tag` SHALL match `^v[0-9]+\.[0-9]+\.[0-9]+$`. Shape validation alone is insufficient — the workflow SHALL ALSO verify **image provenance** before any edit: for every image of the component (the 4 backend images, or the single `web-app` image) it SHALL confirm the prod-AR image at the target tag exists via `crane manifest asia-northeast2-docker.pkg.dev/liverty-music-prod/<component>/<img>:<tag>`. A missing manifest for any image SHALL abort the run before any file is edited (fail-closed). Because a prod-AR image at `:<tag>` exists only if the release retag wrote it, this provenance gate confirms the tag names a genuine release whose retag completed, and prevents a well-formed-but-bogus or stale tag from corrupting `main` (including the silent-downgrade-to-bogus-tag case).
+Before editing, the workflow SHALL validate the payload: `component` SHALL be one of `backend | frontend` and `tag` SHALL match `^v[0-9]+\.[0-9]+\.[0-9]+$`. Shape validation alone is insufficient — the workflow SHALL ALSO verify **image provenance** before any edit: for every image of the component (the 4 backend images, or the single `fan-web` image) it SHALL confirm the prod-AR image at the target tag exists via `crane manifest asia-northeast2-docker.pkg.dev/liverty-music-prod/<component>/<img>:<tag>`. A missing manifest for any image SHALL abort the run before any file is edited (fail-closed). Because a prod-AR image at `:<tag>` exists only if the release retag wrote it, this provenance gate confirms the tag names a genuine release whose retag completed, and prevents a well-formed-but-bogus or stale tag from corrupting `main` (including the silent-downgrade-to-bogus-tag case).
 
 The workflow SHALL then validate the edited overlay with `kustomize build k8s/namespaces/<component>/overlays/prod` BEFORE committing; a non-zero build SHALL abort the run without pushing. On success it SHALL commit and push directly to `cloud-provisioning:main` using a `liverty-music-ci-bot` GitHub App installation token (the App is the `main` ruleset bypass actor — see design D9; the built-in `GITHUB_TOKEN` / `github-actions[bot]` cannot be a repo-ruleset bypass actor). ArgoCD's existing auto-sync rolls the change out — the workflow SHALL NOT open a pull request.
 

--- a/openspec/specs/prod-image-tag-immutability/spec.md
+++ b/openspec/specs/prod-image-tag-immutability/spec.md
@@ -36,7 +36,7 @@ Today only `liverty-music-dev` and `liverty-music-prod` projects exist; the prod
 #### Scenario: Attempting to re-point a post-enablement prod tag SHALL fail with 409 Conflict
 
 - **GIVEN** a tag `:vX.Y.Z` that was first written to the prod AR repository AFTER `dockerConfig.immutableTags = true` was applied (i.e., the first release cut after this change merged, OR any subsequent release tag)
-- **WHEN** an operator runs `gcloud artifacts docker tags add asia-northeast2-docker.pkg.dev/liverty-music-prod/backend/server@sha256:<other-digest> asia-northeast2-docker.pkg.dev/liverty-music-prod/backend/server:vX.Y.Z` (attempts to re-point that tag to a different digest)
+- **WHEN** an operator runs `gcloud artifacts docker tags add asia-northeast2-docker.pkg.dev/liverty-music-prod/backend/api@sha256:<other-digest> asia-northeast2-docker.pkg.dev/liverty-music-prod/backend/api:vX.Y.Z` (attempts to re-point that tag to a different digest)
 - **THEN** the command SHALL fail with an error referencing HTTP 409 / "tag already exists" / "immutable tags" semantics
 - **AND** the tag SHALL continue to resolve to its originally-written digest
 
@@ -58,7 +58,7 @@ Every kustomize `images:` transformation entry inside `cloud-provisioning/k8s/na
 #### Scenario: Frontend prod overlay uses semver tags only
 
 - **WHEN** reading `cloud-provisioning/k8s/namespaces/frontend/overlays/prod/kustomization.yaml`
-- **THEN** the `web-app` `images:` entry SHALL have `newTag:` matching the regex `^v\d+\.\d+\.\d+(-[A-Za-z0-9.-]+)?$`
+- **THEN** the `fan-web` `images:` entry SHALL have `newTag:` matching the regex `^v\d+\.\d+\.\d+(-[A-Za-z0-9.-]+)?$`
 - **AND** the `newTag:` value SHALL NOT match a 40-character hex string
 - **AND** the `newTag:` value SHALL NOT equal `latest`
 
@@ -72,7 +72,7 @@ Every kustomize `images:` transformation entry inside `cloud-provisioning/k8s/na
 
 - **WHEN** running `kubectl kustomize cloud-provisioning/k8s/namespaces/backend/overlays/prod` and extracting `.spec.template.spec.containers[*].image` from all rendered Deployments + CronJobs
 - **THEN** every rendered image URI SHALL end with `:vX.Y.Z` matching the semver regex
-- **AND** the same SHALL hold for `cloud-provisioning/k8s/namespaces/frontend/overlays/prod` (the rendered `web-app` Deployment image)
+- **AND** the same SHALL hold for `cloud-provisioning/k8s/namespaces/frontend/overlays/prod` (the rendered `fan-web-app` Deployment image)
 
 ### Requirement: Prod workload Deployments and CronJobs SHALL carry the app.kubernetes.io/version Recommended Label, propagated to the Pod template
 
@@ -110,9 +110,9 @@ The kustomize `labels:` block with `includeTemplates: true` (Kustomize v4.5+) co
 
 #### Scenario: Frontend prod Deployment carries the version label at both Deployment and Pod-template levels
 
-- **WHEN** running `kubectl --context=prod -n frontend get deploy web-app -o jsonpath='{.metadata.labels.app\.kubernetes\.io/version}'`
+- **WHEN** running `kubectl --context=prod -n frontend get deploy fan-web-app -o jsonpath='{.metadata.labels.app\.kubernetes\.io/version}'`
 - **THEN** the output SHALL be a non-empty semver string matching the regex
-- **AND** running `kubectl --context=prod -n frontend get deploy web-app -o jsonpath='{.spec.template.metadata.labels.app\.kubernetes\.io/version}'`
+- **AND** running `kubectl --context=prod -n frontend get deploy fan-web-app -o jsonpath='{.spec.template.metadata.labels.app\.kubernetes\.io/version}'`
 - **THEN** the output SHALL be a non-empty semver string matching the regex
 
 #### Scenario: Dev manifests SHALL NOT carry the version label

--- a/openspec/specs/zitadel-action-webhook/spec.md
+++ b/openspec/specs/zitadel-action-webhook/spec.md
@@ -66,25 +66,25 @@ The upstream community Go reference implementation ([xianyu-one/zitadel-mapping]
 
 ### Requirement: Webhook Reachable Only Within Cluster
 
-The webhook endpoints SHALL be served on a dedicated backend port (`:9090`) behind a dedicated in-cluster `Service` (`server-webhook-svc`), distinct from the public Connect-RPC port (`:8080` / `server-svc`). The existing GKE Gateway / `HTTPRoute` SHALL continue to reference only `server-svc`. The webhook **handler** SHALL therefore be unreachable from the public hostname because no handler is registered on the `:8080` listener for webhook paths; the public `:8080` listener's `authn.Middleware` provides defense-in-depth by rejecting any unauthenticated request before the request mux dispatches.
+The webhook endpoints SHALL be served on a dedicated backend port (`:9090`) behind a dedicated in-cluster `Service` (`fan-api-webhook-svc`), distinct from the public Connect-RPC port (`:8080` / `fan-api-svc`). The existing GKE Gateway / `HTTPRoute` SHALL continue to reference only `fan-api-svc`. The webhook **handler** SHALL therefore be unreachable from the public hostname because no handler is registered on the `:8080` listener for webhook paths; the public `:8080` listener's `authn.Middleware` provides defense-in-depth by rejecting any unauthenticated request before the request mux dispatches.
 
 **Rationale**: With `iss` and `aud` checks removed (per `Webhook Authentication via Zitadel-Issued JWT Signature`), the listener separation rises in importance — it's now the second of three security layers, not a redundant defense. Webhook traffic is internal service-to-service communication; exposing it to the public internet broadens the attack surface for no functional benefit.
 
 #### Scenario: In-cluster call from Zitadel succeeds
 
-- **WHEN** the Zitadel pod POSTs to `http://server-webhook-svc.backend.svc.cluster.local:9090/pre-access-token`
+- **WHEN** the Zitadel pod POSTs to `http://fan-api-webhook-svc.backend.svc.cluster.local:9090/pre-access-token`
 - **THEN** the call SHALL reach the backend webhook handler on port `9090`
 
 #### Scenario: External call from the internet is blocked
 
 - **WHEN** a request arrives at the backend's public Gateway hostname for path `/pre-access-token`
 - **THEN** the request SHALL NOT reach any webhook handler
-- **AND** the request SHALL receive a 401 from `authn.Middleware` (the existing `server-route` `/*` catch-all forwards the request to `server-svc:80`, where `authn.Middleware` rejects unauthenticated requests before the mux dispatches; the public `:8080` listener has no handler registered for webhook paths)
+- **AND** the request SHALL receive a 401 from `authn.Middleware` (the existing `fan-api-route` `/*` catch-all forwards the request to `fan-api-svc:80`, where `authn.Middleware` rejects unauthenticated requests before the mux dispatches; the public `:8080` listener has no handler registered for webhook paths)
 
-> **Note**: A future follow-up MAY tighten the `server-route` HTTPRoute to enumerate only public paths, at which point the rejection upgrades to a Gateway-level 404 without changing the security outcome (external requests cannot reach the webhook handler in either case).
+> **Note**: A future follow-up MAY tighten the `fan-api-route` HTTPRoute to enumerate only public paths, at which point the rejection upgrades to a Gateway-level 404 without changing the security outcome (external requests cannot reach the webhook handler in either case).
 
 #### Scenario: Public Connect-RPC listener does not serve webhooks
 
-- **WHEN** an in-cluster client POSTs to `http://server-svc.backend.svc.cluster.local/pre-access-token` on port `80`
+- **WHEN** an in-cluster client POSTs to `http://fan-api-svc.backend.svc.cluster.local/pre-access-token` on port `80`
 - **THEN** the public Connect-RPC listener on port `8080` SHALL NOT expose webhook routes
 - **AND** the request SHALL receive a 404

--- a/openspec/specs/zitadel-observability/spec.md
+++ b/openspec/specs/zitadel-observability/spec.md
@@ -41,7 +41,7 @@ The latency signal SHALL be sourced from Zitadel v4's native OpenTelemetry SDK (
 
 The system SHALL provision a Cloud Monitoring `AlertPolicy` that fires when the rate of backend JWT validation ERROR-level log entries exceeds 10 events per minute, evaluated over a 5-minute window. The alert SHALL route to the same notification channel as the latency alert.
 
-The signal SHALL be a Cloud Logging log-based metric `backend_jwt_validation_zitadel_errors` scoped to the `backend/server` workload's `severity=ERROR` entries whose `jsonPayload.msg` OR `jsonPayload.error` field matches the case-insensitive regex `jwt|jwks|token|authn|invalid token|failed to validate`. No new application code is required; the alert reads existing structured `slog` ERROR entries that the backend's `JWTValidator` already emits.
+The signal SHALL be a Cloud Logging log-based metric `backend_jwt_validation_zitadel_errors` scoped to the `backend/api` workload's `severity=ERROR` entries whose `jsonPayload.msg` OR `jsonPayload.error` field matches the case-insensitive regex `jwt|jwks|token|authn|invalid token|failed to validate`. No new application code is required; the alert reads existing structured `slog` ERROR entries that the backend's `JWTValidator` already emits.
 
 The filter is intentionally broad-then-tight: scoped tightly by namespace + workload + severity (the only place that validates Zitadel-issued JWTs), then keyword-filtered. False positives are tolerable in dev — the 10/min threshold is well above steady-state JWT validation noise.
 


### PR DESCRIPTION
## Summary
Task 6.2 spec sweep — update **incidental** old-name references across the canonical main specs to the shipped `<audience>-<tier>` convention. Identifier-only swaps; surrounding wording preserved. 13 spec files, no structural changes.

## Renames applied
- Deployments: `server-app`→`fan-api`, `consumer-app`→`event-consumer`, `web-app`→`fan-web-app`
- Services: `server-svc`→`fan-api-svc`, `server-webhook-svc`→`fan-api-webhook-svc`
- Routes: `server-route`→`fan-api-route`, `server-admin-route`→`admin-console-api-route`
- ConfigMaps: `web-app-runtime-config`→`fan-web-runtime-config`
- Image paths: `backend/server` + `backend/fan-api`→`backend/api`; `frontend/web-app`→`frontend/fan-web`

## Deliberately NOT changed (accepted non-goals / out of scope)
- `backend-app` — the neutral shared GSA / DB user / Zitadel MachineUser identity (kept by design; same principle as the neutral `backend/api` image).
- DNS / TLS-cert Pulumi resource names (`*-a-record`, `*-cert`, `*-cert-map-entry`, `*-dns-auth`) — renaming forces prod certificate replacement (accepted non-goal).
- The `server` Docker build target (still exists); historical/past-tense references.

Refs: #799