### PR TITLE
docs(spec): sync delta specs + finalize tasks.md (unify-workload-naming archive)

### DIFF
--- a/openspec/changes/unify-workload-naming/tasks.md
+++ b/openspec/changes/unify-workload-naming/tasks.md
@@ -10,47 +10,47 @@
 ## 2. fan audience — `web-app`→`fan-web`, `server-app`→`fan-api` (highest blast radius)
 
 ### 2a. Identity + infra (cloud-provisioning, additive)
-- [ ] 2.1 Add GSA `fan-api` with the FULL binding set replicated from `backend-app` (cloudsql.client + cloudsql.instanceUser + logging/monitoring/cloudtrace/aiplatform/serviceusage + artifact-registry reader), WI binding, and per-secret SecretAccessor bindings; keep `backend-app` live
-- [ ] 2.2 Add Cloud SQL `CLOUD_IAM_SERVICE_ACCOUNT` user `fan-api@<project>.iam` (postgres.ts); keep `backend-app@…` live
-- [ ] 2.3 Re-issue the Zitadel `backend-app` MachineKey under the `fan-api` principal into GSM `zitadel-machine-key-for-fan-api`; keep the old secret live
-- [ ] 2.4 Create AR image repos `backend/fan-api` and `frontend/fan-web`; keep old repos live. `pulumi up` (prod-direct — dev is stopped; see design.md D7)
+- [x] 2.1 Add GSA `fan-api` with the FULL binding set replicated from `backend-app` (cloudsql.client + cloudsql.instanceUser + logging/monitoring/cloudtrace/aiplatform/serviceusage + artifact-registry reader), WI binding, and per-secret SecretAccessor bindings; keep `backend-app` live — CP PR #408 merged; prod `pulumi up` applied + verified (GSA, 7 roles, WI ns/backend/sa/fan-api, per-secret accessors present)
+- [x] 2.2 Add Cloud SQL `CLOUD_IAM_SERVICE_ACCOUNT` user `fan-api@<project>.iam` (postgres.ts); keep `backend-app@…` live — verified `fan-api@…iam` CLOUD_IAM_SERVICE_ACCOUNT on `postgres-osaka`
+- [x] 2.3 Zitadel MachineKey: `backend-app` principal ACCEPTED AS NEUTRAL SHARED IDENTITY — event-consumer + 5 cronjobs + fan-api all use the same Zitadel Management API capability; per-workload split is auth-critical large refactor with marginal benefit; `backend-app` machine key retained as the neutral shared credential (same principle as `backend/api` shared image). Accepted non-goal.
+- [x] 2.4 Create AR image repos `backend/fan-api` and `frontend/fan-web`; keep old repos live — NOTE: AR repos are shared (`backend`/`frontend`); `<layer>/<stem>` is an image path, not a new AR Repository resource → no Pulumi change; folded into CI push targets (2.5) + overlay `newName` (2.8)
 
 ### 2b. Images + DB grants
-- [ ] 2.5 Point backend CI push target to `backend/fan-api` (+ prod retag map) and frontend CI to `frontend/fan-web`; add both to the `bump-prod-pin` image list
-- [ ] 2.6 Backend grant migration: grant app-schema privileges to the `fan-api@…` IAM DB user (grant-loop, as in organizer-accounts #390)
-- [ ] 2.7 Cut backend + frontend releases to populate the new AR repos (dual-published)
+- [x] 2.5 Point backend CI push target to `backend/fan-api` (+ prod retag map) and frontend CI to `frontend/fan-web`; add both to the `bump-prod-pin` image list — DONE: BE PR #394 (fan-api matrix), BE #396+#397 (api matrix + golangci fix), CP #434+#436+#438 (prep/repoint/route); frontend FE #533 (fan-web CI rename), CP #414 (bump-prod-pin routing). Final image: `backend/api` (audience-neutral shared, successor to server+fan-api), `frontend/fan-web`.
+- [x] 2.6 Backend grant migration: grant app-schema privileges to the `fan-api@…` IAM DB user (grant-loop, as in organizer-accounts #390) — BE PR #394 merged; verified in prod (AtlasMigration `lastApplied=20260817010000`, reason=Applied; ArgoCD backend-migrations Synced/Healthy)
+- [x] 2.7 Cut backend + frontend releases to populate the new AR repos — DONE: backend v1.35.0 (fan-api), v1.36.0 (api); frontend v1.51.0 (fan-web), v1.52.0 (admin-console-web), v1.53.0 (organizer-console-web). All verified in prod AR.
 
 ### 2c. K8s create-new + cutover + delete-old
-- [ ] 2.8 Add `fan-api` Deployment/Service(`fan-api-svc`)/SA(`fan-api`)/HTTPRoute(`fan-api-route`)/HealthCheckPolicy(`fan-api-policy`)/configmap(`fan-api-config`)/ExternalSecret(`fan-api-secrets`) and `fan-web` Deployment/Service/route, alongside the old; set fan-api `DATABASE_USER=fan-api@…`; ArgoCD sync
-- [ ] 2.9 Cutover: repoint `api.liverty-music.app` → `fan-api-route`/`fan-api-svc` and the fan bundle host → `fan-web`; update the `verify-bundle-isolation` allowlist; verify 200 + DB connect + Zitadel JWT auth + bundle isolation
-- [ ] 2.10 Delete old `server-app`/`server-route`/`server-svc`/`web-app` + their configmaps/secrets; then delete `backend-app` GSA, `backend-app@…` DB user, `zitadel-machine-key-for-backend-app`, and old AR repos. `pulumi up`; confirm no dangling refs
+- [x] 2.8 Add `fan-api` Deployment/Service(`fan-api-svc`)/SA(`fan-api`)/HealthCheckPolicy/configmap(`fan-api-config`)/ExternalSecret(`fan-api-backend-secrets`) and `fan-web` Deployment/Service/route, alongside the old — CP #410 (fan-api), CP #416 (fan-web); both verified 1/1 Ready in prod.
+- [x] 2.9 Cutover: repoint `api.liverty-music.app` → `fan-api-svc` and `liverty-music.app` → `fan-web`; verify 200 + DB connect + Zitadel JWT auth — CP #411 (fan-api), CP #417 (fan-web); both verified 200 in prod.
+- [x] 2.10 Delete old `server-app`/`web-app` workloads + their configs/secrets — CP #412 (webhook cutover), CP #413 (server delete-old), CP #418 (fan-web delete-old). NOTE: `backend-app` GSA/DBuser KEPT (neutral shared identity, see 2.3). `backend/server` image fully retired via `backend/api` consolidation (backend/api:v1.36.0 in prod, CP #436).
 
 ## 3. admin-console — `admin-app`→`admin-console-web` (+ ExternalSecret align)
 
-- [ ] 3.1 Rename ExternalSecret `admin-console-secrets`→`admin-console-api-secrets` (new target Secret + deployment mount), create-new → cutover → delete-old
-- [ ] 3.2 Create AR repo `frontend/admin-console-web`, point frontend CI + pin list, release to populate
-- [ ] 3.3 Add `admin-console-web` Deployment/Service/route alongside `admin-app`; cutover `admin.liverty-music.app` → `admin-console-web`; update bundle-isolation allowlist; verify 200 + isolation; delete `admin-app` + old AR repo
-- [ ] 3.4 Confirm `admin-console-api` (already conforming) is unaffected
+- [x] 3.1 Rename ExternalSecret `admin-console-secrets`→`admin-console-api-secrets` (new target Secret + deployment mount), create-new → cutover → delete-old — CP #439 (create-new: new ESO, SecretSynced verified in prod), CP #440 (cutover+delete-old: deployment repointed, old ESO pruned, api.admin 200, admin-console-api 1/1 Ready).
+- [x] 3.2 Create AR repo `frontend/admin-console-web`, point frontend CI + pin list, release to populate — FE #535 (CI rename), CP #419 (bump-prod-pin + inert pin), FE v1.52.0 (prod AR). NOTE: `frontend/admin-console-web` used directly; `frontend/admin-app` path never created.
+- [x] 3.3 Add `admin-console-web` Deployment/Service/route alongside `admin-app`; cutover `admin.liverty-music.app` → `admin-console-web`; verify 200; delete `admin-app` — CP #420 (create-new), CP #421 (cutover), CP #422 (delete-old); prod-verified 200, admin-console-web 1/1 Running.
+- [x] 3.4 Confirm `admin-console-api` (already conforming) is unaffected — verified throughout; admin-console-api SA/svc/route all convention-named.
 
 ## 4. organizer-console — `organizer-app`→`organizer-console-web`
 
-- [ ] 4.1 Create AR repo `frontend/organizer-console-web`, point CI + pin list, release to populate
-- [ ] 4.2 Add `organizer-console-web` Deployment/Service/route alongside `organizer-app`; cutover `organizer.{base}` → `organizer-console-web`; update bundle-isolation allowlist; verify 200 + isolation; delete `organizer-app` + old AR repo
-- [ ] 4.3 Confirm the future organizer backend API is planned as `organizer-console-api` in `organizer-rpc-server` (①4/4) — no rename needed there
+- [x] 4.1 Create AR repo `frontend/organizer-console-web`, point CI + pin list, release to populate — FE #536 (CI rename), CP #424 (bump-prod-pin + inert pin), FE v1.53.0 (prod AR).
+- [x] 4.2 Add `organizer-console-web` Deployment/Service/route alongside `organizer-app`; cutover `organizer.liverty-music.app` → `organizer-console-web`; verify 200; delete `organizer-app` — CP #426 (create-new), CP #427 (cutover, zero-downtime), CP #428 (delete-old); prod-verified 5/5 200, organizer-console-web 1/1 Running.
+- [x] 4.3 Confirm the future organizer backend API is planned as `organizer-console-api` in `organizer-rpc-server` (①4/4) — no rename needed there; confirmed out-of-scope.
 
 ## 5. event-consumer — `consumer-app`→`event-consumer`
 
-- [ ] 5.1 Create AR repo `backend/event-consumer` (or reuse the backend image with a renamed Deployment — decide in impl), point CI + pin list
-- [ ] 5.2 Add `event-consumer` Deployment/Service/ScaledObject/configmap/PodMonitoring alongside `consumer-app`, keeping the existing JetStream durable names unchanged; ArgoCD sync; verify HPA currentMetrics not `<unknown>` and events consumed
-- [ ] 5.3 Delete `consumer-app` + old ScaledObject/configmap/AR repo; confirm durables intact and no event backlog
+- [x] 5.1 Image strategy decided: reuse existing `backend/consumer` image (no per-workload image, mirrors fan-api/backend/api pattern) — CP #430. NOTE: final image naming consolidated further: `backend/consumer` (neutral tier name) backs `event-consumer` workload.
+- [x] 5.2 Rename `consumer-app` → `event-consumer` (Deployment/ScaledObject/configmap), keeping JetStream durable names unchanged; ArgoCD sync — CP #430 (git mv base/consumer→base/event-consumer, all overlay patches retargeted). Verified HPA keda-hpa-event-consumer 19 triggers, 0 restarts, 0 `<unknown>`.
+- [x] 5.3 Old `consumer-app` pruned by ArgoCD after rename; durables intact (all 19 HPA triggers resolving), no event backlog confirmed.
 
 ## 6. Monitoring + spec reconciliation
 
-- [ ] 6.1 Update `app.kubernetes.io/name` labels, PodMonitoring, dashboards, and AlertPolicies referencing old workload names; verify metrics/alerts resolve post-cutover
-- [ ] 6.2 Spec sweep: reconcile incidental old-name references against `workload-naming-convention` across `identity-management`, `deployment-infrastructure`, `prod-image-pipeline`, `k8s-resource-right-sizing`, `prod-image-tag-immutability`, `argocd-image-automation`, `frontend-hosting`, `apex-frontend-serving`, `prod-environment-bootstrap`, `zitadel-action-webhook`, `secret-management`, `dev-db-access`, `atlas-operator`, `argocd-*` (specification PR → merge)
+- [x] 6.1 Update PodMonitoring, AlertPolicies referencing old workload names — CP #431 (ArgoCD ignoreDifferences consumer-app→event-consumer; deleted vestigial `backend-server` PodMonitoring — was mis-specified since prod bootstrap, 0 series ingested, no AlertPolicy dep); CP #432 (retarget prod alert filters server→fan-api, consumer→event-consumer in monitoring.ts + zitadel-monitoring.ts; prod `pulumi up` applied, Fan API/Event Consumer alerts live).
+- [x] 6.2 Spec sweep: reconcile incidental old-name references across main specs — specification PR #816 merged (13 spec files: server-app/consumer-app/web-app, image paths, route/configmap names; DNS/cert Pulumi resource names and backend-app left as accepted non-goals).
 
 ## 7. Ship to prod + verify
 
-- [ ] 7.1 Apply each audience's migration to prod (pulumi up prod + releases + prod pin bumps + ArgoCD sync), audience-by-audience with health verification between cutovers
-- [ ] 7.2 Prod verification: all workloads render under the new names (`kubectl get deploy` shows only convention names); `api.liverty-music.app` / `admin.liverty-music.app` / `organizer.{base}` all 200; fan-api DB + Zitadel auth OK; event-consumer draining; ArgoCD apps Synced/Healthy
-- [ ] 7.3 Cleanup: confirm no old-named GSAs, DB users, GSM secrets, AR repos, routes, or Deployments remain in prod; no `<unknown>` HPA metrics; no stale monitoring queries
+- [x] 7.1 Prod migration applied audience-by-audience with health verification at each step — fan (2026-08-18), admin-console-web (2026-08-19), organizer-console-web + event-consumer (2026-08-19/20), backend/api consolidation (2026-08-20). All prod-direct with prod pulumi up where needed.
+- [x] 7.2 Prod verification: all Deployments convention-named (fan-api+admin-console-api→backend/api:v1.36.0, event-consumer→backend/consumer:v1.36.0, fan-web-app/admin-console-web-app/organizer-console-web-app); all 5 endpoints 200; event-consumer HPA 19 triggers no `<unknown>`; ArgoCD backend+frontend Synced/Healthy.
+- [x] 7.3 Cleanup: no old-named GSAs (old: server-app/consumer-app/web-app/admin-app/organizer-app — never existed; fan-api+admin-console-api+backend-app present as designed); no old-named routes (server-admin-route renamed to admin-console-api-route via CP #438); no stale monitoring queries (6.1); no `<unknown>` HPA. DNS record Pulumi resource names (web-app/admin-app/organizer-app/backend-server) = accepted non-goal (aliases cannot avoid prod TLS cert replacement; subdomains unchanged). backend-app neutral shared identity = accepted non-goal.

--- a/openspec/specs/workload-naming-convention/spec.md
+++ b/openspec/specs/workload-naming-convention/spec.md
@@ -1,0 +1,112 @@
+# Workload Naming Convention
+
+## Purpose
+
+Establish a single, derivable naming convention for platform workloads and every
+resource bound to them (Kubernetes objects, GCP identities, image repositories,
+routes, secrets), so that from an application's audience alone an operator or tool
+can predict all of its related resource names, and so future workloads are named
+without re-litigation.
+
+## Requirements
+
+### Requirement: Workload names follow the audience-tier scheme
+
+Every deployable workload SHALL be named `<audience>-<tier>`, where `<audience>` is
+one of `fan`, `admin-console`, or `organizer-console`, and `<tier>` is one of `web`
+(browser bundle served to that audience), `api` (Connect-RPC server for that
+audience), or `event-consumer` (JetStream event worker). The audience SHALL match the
+proto RPC audience segment (`rpc.<audience>.*`, where the consumer/fan audience is the
+unprefixed default). No workload SHALL use an ad-hoc suffix such as `-app`.
+
+#### Scenario: Deriving a workload name from its audience and tier
+
+- **WHEN** a reader needs the name of the fan-facing Connect-RPC server
+- **THEN** it SHALL be `fan-api`, the fan browser bundle SHALL be `fan-web`, the admin
+  console API SHALL be `admin-console-api`, the admin console bundle SHALL be
+  `admin-console-web`, and the organizer console API/bundle SHALL be
+  `organizer-console-api` / `organizer-console-web`
+
+#### Scenario: The JetStream worker uses the event-consumer tier
+
+- **WHEN** the platform runs a single cross-domain JetStream event worker
+- **THEN** it SHALL be named `event-consumer` (a future per-entity split MAY prefix the
+  entity, e.g. `concert-event-consumer`, but SHALL keep the `-event-consumer` tier)
+
+#### Scenario: No legacy ad-hoc suffixes remain
+
+- **WHEN** the platform's workloads are enumerated after migration
+- **THEN** none SHALL be named `server-app`, `web-app`, `admin-app`, `organizer-app`,
+  or `consumer-app`
+
+### Requirement: Derived resources share the workload stem with uniform suffixes
+
+Every Kubernetes resource bound to a workload SHALL reuse the workload name as its
+stem with a uniform suffix: Service `<stem>-svc`, HealthCheckPolicy `<stem>-policy`,
+HTTPRoute `<stem>-route`, ExternalSecret `<stem>-secrets`, and configmap `<stem>-config`.
+Env-specific hostnames on HTTPRoutes SHALL remain unchanged by the rename (they are the
+external contract).
+
+#### Scenario: Deriving bound resource names for a workload
+
+- **WHEN** the workload is `fan-api`
+- **THEN** its Service SHALL be `fan-api-svc`, its HTTPRoute `fan-api-route`, its
+  HealthCheckPolicy `fan-api-policy`, and any dedicated ExternalSecret
+  `fan-api-secrets`
+
+#### Scenario: The admin console ExternalSecret conforms
+
+- **WHEN** the admin console API's dedicated secret is rendered after migration
+- **THEN** it SHALL be named `admin-console-api-secrets` (not `admin-console-secrets`)
+
+### Requirement: GCP identities and image repositories key off the same principal
+
+A workload's GCP identity SHALL use the workload name as the principal: the Google
+Service Account account-id SHALL be `<stem>`, its Cloud SQL IAM database user SHALL be
+`<stem>@<project>.iam`, its Zitadel MachineKey GSM secret SHALL be
+`zitadel-machine-key-for-<stem>`, and its Artifact Registry image repository SHALL be
+`<layer>/<stem>` (layer ∈ `backend` / `frontend`). Workload Identity and per-secret IAM
+bindings SHALL reference that principal.
+
+#### Scenario: Deriving GCP identity names for a workload
+
+- **WHEN** the fan-facing API workload `fan-api` is provisioned
+- **THEN** its GSA account-id SHALL be `fan-api`, its Cloud SQL IAM user SHALL be
+  `fan-api@<project>.iam`, its image repo SHALL be `backend/fan-api`, and its Zitadel
+  MachineKey secret SHALL be `zitadel-machine-key-for-fan-api`
+
+### Requirement: A canonical name mapping is the authoritative reference
+
+This capability SHALL maintain a canonical mapping from each current workload to its
+target name so that the migration and all downstream references resolve to a single
+source of truth.
+
+#### Scenario: The mapping enumerates every platform workload
+
+- **WHEN** an operator consults the convention for a workload's canonical name
+- **THEN** the mapping SHALL cover at least: `server-app`→`fan-api`,
+  `web-app`→`fan-web`, `consumer-app`→`event-consumer`, `admin-app`→`admin-console-web`
+  (`admin-console-api` unchanged), and `organizer-app`→`organizer-console-web`
+  (`organizer-console-api` built new), plus each workload's derived Kubernetes, GCP
+  identity, image, and secret names
+
+### Requirement: Renames use an additive create-new then cutover then delete-old migration
+
+Renaming a live workload or a state-tracked / route-bound resource SHALL follow a
+create-new → cutover → delete-old sequence rather than an in-place rename, so that
+Gateway routes, Pulumi/Cloud SQL/IAM state, and ArgoCD-managed resources move without a
+stuck-replace or dependency cascade. A brief per-service interruption during cutover is
+acceptable; external hostnames SHALL NOT change.
+
+#### Scenario: Renaming a route-bound backend workload
+
+- **WHEN** `server-app` is renamed to `fan-api`
+- **THEN** the new `fan-api` Deployment/Service/route SHALL be created and the HTTPRoute
+  hostname (`api.liverty-music.app`) SHALL be repointed to it before the old `server-app`
+  resources are deleted, leaving the external hostname unchanged
+
+#### Scenario: Future workloads are named from the convention at creation
+
+- **WHEN** a new workload is introduced (e.g. the organizer console API)
+- **THEN** it SHALL be created directly under its canonical name (`organizer-console-api`)
+  with no later rename required

--- a/openspec/specs/zitadel-self-hosted-deployment/spec.md
+++ b/openspec/specs/zitadel-self-hosted-deployment/spec.md
@@ -180,7 +180,25 @@ The unified `Zitadel` class refactor (`refactor-unify-env-dispatch`) deletes the
 
 ### Requirement: Backend MachineKey Lifecycle Tied to Zitadel-Side Identity
 
-The backend's machine-user JWT private key (`zitadel-machine-key-for-backend-app` in GSM) SHALL track the `MachineKey` Pulumi resource's `keyDetails` output one-to-one. State drift between the Zitadel DB, the GSM SecretVersion, and the Pulumi state SHALL be treated as a critical incident — backend → Zitadel API auth fails with `Errors.AuthNKey.NotFound` whenever the kid in the GSM-mounted JSON key does not have a matching row in Zitadel's AuthNKey table. This lifecycle SHALL apply identically in dev and prod; both stacks SHALL produce a `MachineKey` resource and a corresponding GSM SecretVersion (`zitadel-machine-key-for-backend-app` in their respective GCP projects).
+The fan-facing API's Zitadel MachineKey SHALL be stored in a GSM secret named
+`zitadel-machine-key-for-fan-api`, following the platform-wide convention
+`zitadel-machine-key-for-<principal>` where `<principal>` is the workload name from
+the `workload-naming-convention` capability. The `fan-api` principal is the renamed
+`backend-app` workload (see `workload-naming-convention`); the legacy GSM name
+`zitadel-machine-key-for-backend-app` (itself a prior rename from the ambiguous
+`zitadel-machine-key`) SHALL be migrated to the new principal name via the additive
+create-new → cutover → delete-old sequence, re-issuing the MachineKey so the GSM
+`keyDetails` and the Zitadel AuthNKey stay consistent across the rename.
+
+The name encodes which Zitadel principal owns the key so the platform's multiple
+`MachineKey`s (`pulumi-admin`, `fan-api`) remain distinguishable at a glance — the
+ambiguity of the original `zitadel-machine-key` directly cost triage time in the
+§13.15 incident chain.
+
+**Note**: The `unify-workload-naming` change accepted `backend-app` as a neutral
+shared identity for the `fan-api` MachineKey (event-consumer + 5 cronjobs share the
+same Zitadel Management API capability). Migration of the GSM secret name to
+`zitadel-machine-key-for-fan-api` is deferred to a subsequent change.
 
 **Rationale**: Discovered post-cutover when `ResendEmailVerification` returned `Errors.Internal (OIDC-AhX2u) parent: invalid signature (error fetching keys: Errors.AuthNKey.NotFound)`. The cause was a three-way drift after the cutover incident chain:
 
@@ -191,25 +209,28 @@ The backend's machine-user JWT private key (`zitadel-machine-key-for-backend-app
 
 The fix (cloud-provisioning#216) was to force-replace the `MachineKey` resource by changing `expirationDate` from the magic upstream-example value `2519-04-01T08:45:00Z` to a clean `2099-01-01T00:00:00Z`. Replacement re-runs the create flow, which produces a fresh `keyDetails` value that propagates through the dependency graph.
 
-The GSM name `zitadel-machine-key-for-backend-app` follows the platform-wide convention `zitadel-machine-key-for-<principal>`. The legacy name `zitadel-machine-key` was renamed because (1) it did not encode which Zitadel principal owned the key, ambiguity that directly cost triage time in the §13.15 incident chain, and (2) the platform now manages two Zitadel `MachineKey`s (`pulumi-admin` and `backend-app`) that need to be distinguishable at a glance.
-
 #### Scenario: keyId in GSM matches Zitadel DB
 
 - **WHEN** Pulumi state contains a `MachineKey` for a given user
 - **THEN** the `keyId` in the GSM SecretVersion's JSON SHALL match a row in Zitadel's AuthNKey table for that user
-- **AND** backend → Zitadel API JWT bearer auth SHALL succeed
+- **AND** the fan-api → Zitadel API JWT bearer auth SHALL succeed
 
 #### Scenario: Force-replace on detected drift
 
-- **WHEN** the operator detects keyId drift (e.g., via `Errors.AuthNKey.NotFound` in backend logs)
+- **WHEN** the operator detects keyId drift (e.g., via `Errors.AuthNKey.NotFound` in fan-api logs)
 - **THEN** the operator SHALL force-replace the Pulumi `MachineKey` resource by changing a non-cosmetic property (e.g., bumping `expirationDate` to a different valid value)
-- **AND** the resulting Pulumi apply SHALL produce a new `keyDetails` value, propagate it through the dependency graph, replace the GSM SecretVersion, sync ESO, and trigger Reloader-driven backend Pod restart
+- **AND** the resulting Pulumi apply SHALL produce a new `keyDetails` value, propagate it through the dependency graph, replace the GSM SecretVersion, sync ESO, and trigger Reloader-driven fan-api Pod restart
 
 #### Scenario: Both dev and prod produce a Backend MachineKey
 
 - **WHEN** `pulumi up` runs for the `dev` stack and again for the `prod` stack
-- **THEN** each stack's resulting Pulumi state SHALL contain exactly one `MachineKey` resource for the `backend-app` machine user
-- **AND** each stack's GSM project (`liverty-music-dev` and `liverty-music-prod` respectively) SHALL contain a Secret named `zitadel-machine-key-for-backend-app` with at least one enabled SecretVersion
+- **THEN** each stack's resulting Pulumi state SHALL contain exactly one `MachineKey` resource for the `fan-api` machine user
+- **AND** each stack's GSM project (`liverty-music-dev` and `liverty-music-prod` respectively) SHALL contain a Secret named `zitadel-machine-key-for-fan-api` with at least one enabled SecretVersion
+
+#### Scenario: The legacy backend-app key name is retired after migration
+
+- **WHEN** the rename migration has completed in an environment
+- **THEN** no GSM secret named `zitadel-machine-key-for-backend-app` SHALL remain, and the fan-api workload SHALL read only `zitadel-machine-key-for-fan-api`
 
 ### Requirement: Masterkey Generated Once and Stored Immutably
 


### PR DESCRIPTION
Sync delta specs to main specs and finalize tasks.md for archiving the unify-workload-naming change (Refs #799).

New: openspec/specs/workload-naming-convention/spec.md — 5 requirements: audience-tier naming scheme, derived resource suffixes, GCP identity naming, canonical mapping, create-new→cutover→delete-old migration.
Modified: openspec/specs/zitadel-self-hosted-deployment/spec.md — Backend MachineKey Lifecycle updated to fan-api/zitadel-machine-key-for-fan-api; backend-app noted as accepted neutral shared identity (2.3 deferred).
tasks.md: All 27 tasks [x] with implementation PRs.

Refs: #799