### PR TITLE
docs(openspec): propose fix-ios-help-sheet-dismiss-and-edit-mode-unfollow

### DIFF
--- a/openspec/changes/fix-ios-help-sheet-dismiss-and-edit-mode-unfollow/.openspec.yaml
+++ b/openspec/changes/fix-ios-help-sheet-dismiss-and-edit-mode-unfollow/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-20

--- a/openspec/changes/fix-ios-help-sheet-dismiss-and-edit-mode-unfollow/design.md
+++ b/openspec/changes/fix-ios-help-sheet-dismiss-and-edit-mode-unfollow/design.md
@@ -1,0 +1,76 @@
+# Design
+
+## Context
+
+See proposal.md — Why. Two iOS-only touch defects, both from WebKit/Blink engine differences:
+
+- **Help sheet**: `<bottom-sheet>` (shared by page-help, event-detail, post-signup, user-home-selector, …) uses CSS scroll-snap for swipe-to-dismiss. A WebKit Playwright repro captured the mechanism precisely: on open, the CSS `initial-snap` trick lands the scroll on `.sheet-body` (ratio `1`), then WebKit re-snaps to the dismiss zone (ratio `0`) as the animation ends. The fallback heuristics `onScrollEnd` (`scrollRatio < 0.1`) and `onPointerUp` (`scrollTop/max < 0.25`) — added under the now-stale assumption "Safari lacks `scrollsnapchange`" — fire on that *programmatic* re-snap and call `requestClose()`. Measured ratio trace: `[1, 0]`; `dialog.open` timeline: `true×7 → false×8`. Chromium never reproduces (it keeps `scrollsnapchange` + a stable initial snap).
+- **Long-press unfollow**: the list row's hidden 500 ms long-press is cancelled by the iOS system gesture (`pointercancel`), and the visible trash column is hidden on `pointer: coarse`, so touch users have no working unfollow.
+
+Constraints: Aurelia 2 SPA, CUBE CSS, Biome, no inline styles (lint), frontend-only (no proto/RPC), ship via frontend release.
+
+## Goals / Non-Goals
+
+**Goals**
+- Sheet reliably stays open on iOS until a genuine user dismiss.
+- Unfollow works on every pointer type via a discoverable, accessible, single-pointer affordance.
+- Net reduction in bespoke gesture/heuristic code; align with web-standard primitives.
+- A regression guard that actually runs on the WebKit engine.
+
+**Non-Goals**
+- No re-introduction of any swipe or long-press unfollow.
+- No change to the follow-store unfollow flow, Undo mechanism, or backend.
+- No rework of the bottom-sheet's open/`initial-snap`/inert/focus-trap architecture (kept as-is).
+- Grid (Festival) view and its long-press context menu are out of scope (already removed from the frontend; residual spec drift is a separate cleanup).
+
+## Decisions
+
+### D1: Edit-mode toggle over swipe or long-press for list unfollow
+Chosen: an iOS-style "Edit" toggle in the header reveals a per-row remove (−) control; single tap → immediate unfollow + Undo.
+
+Rationale & alternatives:
+- **Long-press (current)** — hidden, non-discoverable, conflicts with the iOS system gesture; broken on iOS. Rejected.
+- **Swipe-to-reveal** — attempted twice historically and abandoned both times: v1 JS-transform swipe (main-thread jank, extra DOM layers, #174 proposal), then v2 CSS scroll-snap horizontal swipe (nested vertical-list × horizontal-row scroll and, critically, the in-row interactive hype radios conflicting with the horizontal gesture — reverted within ~1 week). The row still contains interactive hype radios, so any in-row gesture re-hits that wall. Rejected as high-risk "attempt #3".
+- **Always-visible per-row button** — clutters a dense list (name + 4 hype columns). Rejected on UX grounds.
+- **Edit mode** — no gesture, no scroll/tap conflict, single-pointer (WCAG 2.5.1 Level A), the iOS HIG standard pairing, and default list stays uncluttered. Chosen.
+
+Placement & scope:
+- The Edit toggle lives in the shared `page-header` `<au-slot>`, on the trailing side of the title, next to the existing `<page-help>` (`?`) control (iOS "Edit top-trailing" convention). It renders only in the populated state — hidden while loading and in the empty (zero-artist) state.
+- **Unified across pointer types** (decision): the desktop-only always-visible trash column is removed too; both `pointer: fine` and `pointer: coarse` use Edit mode. Rationale: a single affordance and code path, consistent with the spec's "no persistent per-row control." Trade-off: desktop unfollow becomes two clicks (Edit → −) instead of one; accepted for consistency and reduced surface.
+- Lifecycle: edit mode auto-exits when the list empties and is not persisted across navigation (fresh, non-editing on re-entry). Hype controls remain interactive while editing.
+
+### D2: `scrollsnapchange` as the primary dismiss signal; delete scroll-ratio heuristics
+Chosen: detect user swipe-dismiss via `scrollsnapchange` (fires only on user scroll gestures per the CSS Scroll Snap module), and DELETE `onScrollEnd`/`onPointerUp` scroll-ratio heuristics.
+
+Rationale & alternatives:
+- **Add a user-engagement flag to the existing heuristics ("Fix②-only, bolted on")** — works, but *adds* state to fragile code and keeps the misfiring signals. Inferior.
+- **Use `scrollsnapchange`** — the platform already guarantees the user-vs-programmatic distinction we need, so the programmatic `[1→0]` re-snap cannot fire it. This is a net code *deletion*, matches the canonical reference implementation (viliket/pure-web-bottom-sheet) and Chrome for Developers guidance, and satisfies the "don't over-complicate" constraint. Chosen.
+- Support: `scrollsnapchange` is in Chrome 129+ and Safari 18.2+ (the app targets latest browsers; iOS 26 qualifies). The stale "Safari lacks `scrollsnapchange`" comment is corrected.
+
+### D3: `IntersectionObserver` fallback + just-opened guard (not `scrollend`-ratio)
+For engines without `scrollsnapchange` (Firefox), detect dismiss via an `IntersectionObserver` on the dismiss zone / sheet-body, armed only after the sheet settles on `.sheet-body`. Keep a small "just-opened" guard suppressing any dismiss until settled. The reference implementation does the same (`checkVisibility()` / transition-state guard). This mirrors D2's robustness on non-supporting engines without resurrecting scroll-ratio guessing.
+
+### D4: Keep the CSS `initial-snap` trick
+It is the canonical way to land a scroll-snap sheet on its body without JS `scrollTo`, and the reference implementation uses it too. The bug was never the initial snap itself but the heuristics misreading the subsequent programmatic re-snap. Left unchanged.
+
+### D5: WebKit regression test as the acceptance gate
+A real-WebKit Playwright project (`webkit-repro`, iPhone 14) plus a `chromium-control` on the same viewport. The spec asserts the help sheet opens and stays open. RED before the fix, GREEN after. Rationale: Chromium device emulation cannot reproduce engine-difference bugs; only a real WebKit engine can. These projects are opt-in (not in the default CI selection / require the WebKit browser) so they don't destabilize existing Chromium-only CI.
+
+## Risks / Trade-offs
+
+- **[Risk] With heuristics removed, WebKit could rest the scroll on the dismiss zone (ratio 0) → sheet "open but blank".** → The `initial-snap` trick lands on `.sheet-body` first; the just-opened guard + settle detection re-assert the body position. The `webkit-repro` test asserts the sheet content is actually visible (not merely `open`), so this failure mode is caught before merge; if observed, add a one-line deterministic `scrollTop = maxScroll` on settle (still no heuristic guessing).
+- **[Risk] `scrollsnapchange` unsupported on older/other engines.** → `IntersectionObserver` fallback (D3); no reliance on `scrollend`-ratio.
+- **[Risk] Edit-mode discoverability lower than an always-visible control.** → The visible "Edit" label is self-describing; help copy updated to document it; matches a pattern iOS users already know.
+- **[Risk] Removing `ArtistUnfollowSheet` / `long-press` could touch shared wiring (main.ts registration, i18n keys, page-help section).** → Enumerated in Impact; unit tests updated; `make check` gate.
+- **[Risk] Bundling two concerns (sheet fix + unfollow redesign) in one change.** → They share the same iOS-touch root theme and the same files region; kept in one change for a single release, with independent tasks so either can be reverted in isolation.
+
+## Migration Plan
+
+1. Land frontend changes behind normal review; `make check` + unit/E2E green; `webkit-repro` GREEN, `chromium-control` GREEN.
+2. Merge to `main`; cut a frontend release (GH Release → prod AR retag → automated pin-bump → ArgoCD sync), per project convention.
+3. Verify on a real iOS device: help sheet opens and stays open; Edit mode unfollow + Undo works.
+4. Rollback: revert the PR / roll back the release pin. No data migration (frontend-only; unfollow flow unchanged).
+
+## Open Questions
+
+- Whether the settle guard alone keeps the sheet content visible on WebKit, or a one-line deterministic `scrollTop` re-assert is also needed (D5 / first Risk). Safely deferrable: it does not change the specs, the chosen approach, or the task breakdown — the `webkit-repro` test resolves it during implementation.

--- a/openspec/changes/fix-ios-help-sheet-dismiss-and-edit-mode-unfollow/proposal.md
+++ b/openspec/changes/fix-ios-help-sheet-dismiss-and-edit-mode-unfollow/proposal.md
@@ -1,0 +1,36 @@
+## Why
+
+On iOS Safari the app has two touch-interaction defects that make core actions unusable, both stemming from browser-engine differences that Android/Chromium hides:
+
+1. **Help sheet auto-closes ("flash then close").** The shared `<bottom-sheet>` opens and immediately dismisses itself on WebKit. A WebKit Playwright reproduction confirmed the cause: the fallback dismiss heuristics (`onScrollEnd` when `scrollRatio < 0.1`, `onPointerUp` when `scrollTop/max < 0.25`) fire on the *programmatic* initial re-snap (measured scroll-ratio trace `[1, 0]`) and misread it as a user swipe-to-dismiss. Because `page-help` auto-opens on first visit, iOS users effectively cannot see help.
+2. **Long-press unfollow does not work.** The list-view unfollow is a hidden 500 ms long-press that the iOS system gesture (text selection / callout / magnifier) cancels via `pointercancel` before the timer fires. On touch devices the visible trash column is hidden (`@media (pointer: coarse)`), so long-press is the *only* unfollow path — leaving iOS users unable to unfollow at all.
+
+Both are fixed by aligning with current web-standard best practice: use the purpose-built `scrollsnapchange` event (which by spec fires only on user gestures) for sheet dismiss, and replace the hidden long-press gesture with a discoverable, accessible iOS-style Edit mode.
+
+## What Changes
+
+- **BREAKING (interaction): Retire long-press unfollow.** Remove the long-press gesture, the `ArtistUnfollowSheet` confirmation sheet, the `pointer: coarse` trash-column hiding hack, and the long-press help copy. The `long-press-unfollow` capability is retired in full.
+- **Add Edit mode unfollow (My Artists list).** A header "Edit" toggle puts the list into edit mode, revealing a per-row remove (−) control. Tapping it unfollows immediately using the existing optimistic-removal + Undo-toast flow. No gesture, no confirmation sheet. This is the single-pointer, discoverable affordance (WCAG 2.5.1; iOS HIG Edit-mode pattern) and avoids the in-row hype-radio tap conflict that sank two prior swipe attempts.
+- **Fix bottom-sheet swipe-dismiss detection.** Make `scrollsnapchange` the primary dismiss signal (user-gesture-only by spec; Chrome 129+, Safari 18.2+), remove the fragile `scrollend`/`pointerup` scroll-ratio heuristics that misfire on programmatic re-snap, add an `IntersectionObserver` fallback for engines without `scrollsnapchange` (Firefox), and keep a small "just opened" dismiss guard. This is a net code reduction and improves iOS behaviour for **all** sheets (page-help, event-detail, post-signup, user-home-selector, …).
+- **Update My Artists help content** to describe Edit mode instead of the long-press gesture.
+- **Add a WebKit regression guard.** A real-WebKit Playwright project (`webkit-repro`) with a Chromium control asserts the help sheet stays open — RED before the fix, GREEN after.
+
+## Capabilities
+
+### New Capabilities
+
+- `edit-mode-unfollow`: An Edit-mode toggle on the My Artists list that reveals per-row remove controls and unfollows with immediate optimistic removal plus Undo, as the single-pointer accessible unfollow affordance for all pointer types.
+
+### Modified Capabilities
+
+- `bottom-sheet-ce`: Swipe-to-dismiss detection changes from scroll-ratio heuristics (`scrollend`/`pointerup`) to the `scrollsnapchange` event with an `IntersectionObserver` fallback and a just-opened dismiss guard, so a programmatic initial re-snap can no longer auto-close the sheet.
+- `my-artists`: The page-help gesture-documentation requirement changes from documenting long-press-to-unfollow to documenting Edit mode.
+- `long-press-unfollow`: Retired — all requirements REMOVED (the capability no longer exists; its behavior is superseded by `edit-mode-unfollow`).
+
+## Impact
+
+- **Removed code**: `frontend/src/custom-attributes/long-press.ts`; `frontend/src/components/artist-unfollow-sheet/*`; long-press binding + `openUnfollowSheet` wiring in `my-artists-route.{ts,html}`; the `@media (pointer: coarse) { .artist-unfollow-col { display:none } }` rule; `page-help` long-press section + `longPressTip` i18n keys (ja/en); `long-press` registration in `main.ts`.
+- **Changed code**: `frontend/src/components/bottom-sheet/bottom-sheet.ts` (dismiss detection); `bottom-sheet.css` if needed; `my-artists-route.{ts,html,css}` (Edit-mode toggle + per-row remove control + `editing` state); `page-help` My Artists help copy + i18n.
+- **Tests**: new `e2e/functional/page-help-sheet-webkit.spec.ts` + `webkit-repro` / `chromium-control` projects in `playwright.config.mjs` (regression guard); update/remove long-press unit tests; add Edit-mode tests.
+- **No backend / proto / RPC changes.** Frontend-only; unfollow reuses the existing follow-store flow.
+- **Ship**: frontend release to production per project convention.

--- a/openspec/changes/fix-ios-help-sheet-dismiss-and-edit-mode-unfollow/specs/bottom-sheet-ce/spec.md
+++ b/openspec/changes/fix-ios-help-sheet-dismiss-and-edit-mode-unfollow/specs/bottom-sheet-ce/spec.md
@@ -1,0 +1,170 @@
+## MODIFIED Requirements
+
+### Requirement: Bottom Sheet Custom Element
+The system SHALL provide a `<bottom-sheet>` custom element as the single dialog primitive for all overlay content, using a native `<dialog>` element opened via `showModal()` (promoted to the Top Layer with native focus-trap, `inert` background, and close-request handling) with CSS scroll-snap dismiss via an internal scroll container. User-initiated swipe-to-dismiss SHALL be detected via the `scrollsnapchange` event, which by specification fires only for a user scroll gesture and not for programmatic or initial-layout snap changes. The CE host (`<bottom-sheet>`) SHALL wrap an inner `<dialog>` element; the scroll container, dismiss zone, and sheet body SHALL live inside that `<dialog>`.
+
+#### Scenario: Basic open/close via bindable
+- **WHEN** `<bottom-sheet open.bind="isOpen">` has `open` set to `true`
+- **THEN** the CE SHALL call `showModal()` on the inner `<dialog>` element (via `ref`)
+- **AND** the `<dialog>` SHALL be promoted to the Top Layer with the rest of the document made `inert`
+- **AND** the sheet-body SHALL be visible at the bottom of the viewport via CSS `initial-snap` animation (no JS `scrollTo` required)
+- **WHEN** `open` is set to `false`
+- **THEN** the CE SHALL call `close()` on the inner `<dialog>` and the sheet SHALL animate out within 160ms
+
+#### Scenario: Open bound to true at component creation time
+- **WHEN** `open` is bound to `true` at initial bind time (before `attached()`)
+- **AND** `openChanged(true)` is called during the `binding` phase
+- **THEN** `showModal()` SHALL be called but MAY fail silently if the inner `<dialog>` ref is not yet resolved
+- **AND** the error SHALL be caught and suppressed (matching the existing `close()` try-catch pattern)
+- **AND** the `attached()` lifecycle hook SHALL retry via `if (this.open) this.openChanged(true)` after the `<dialog>` ref is initialized
+- **AND** the sheet SHALL open successfully at `attached()` time
+
+#### Scenario: DOM structure
+- **WHEN** the sheet is rendered
+- **THEN** the CE host (`<bottom-sheet>`) SHALL contain an inner `<dialog>` element as the Top-Layer / modal host
+- **AND** the `<dialog>` SHALL have an accessible name (`aria-label` or `aria-labelledby`) and SHALL NOT require a manually-set `role` (the native `<dialog>` role suffices)
+- **AND** the internal DOM SHALL be `dialog > .scroll-area > .dismiss-zone + section.sheet-body`
+- **AND** `.scroll-area` SHALL be a `<div>` element serving as the scroll-snap container (`overflow-y: auto`, `scroll-snap-type: y mandatory`, `block-size: 100dvh`)
+- **NOTE** `.scroll-area` MUST use `100dvh` (not `100%`) because percentage block-size does not resolve against the `<dialog>`'s fixed-position height inside the Top Layer — the scroll container would expand to content size, preventing overflow and disabling scroll-snap
+- **AND** `.sheet-body` SHALL be a `<section>` element (semantic content container) with `contain: layout`
+- **AND** the `::backdrop` pseudo-element SHALL belong to the inner `<dialog>`
+
+#### Scenario: Background inert and focus trap
+- **WHEN** the sheet is open (`showModal()`)
+- **THEN** all content outside the `<dialog>` SHALL be `inert` (not focusable, not reachable by Tab or assistive technology)
+- **AND** keyboard focus SHALL be trapped within the `<dialog>` until it closes
+
+#### Scenario: Layout stability with dynamic sheet content
+- **WHEN** content inside `.sheet-body` changes layout (e.g., a checkbox is checked, an element toggles `display`)
+- **THEN** `.sheet-body` SHALL remain at the bottom of the viewport
+- **AND** `.scroll-area` SHALL NOT be displaced from its rendered position
+- **NOTE** This is enforced by `contain: layout` on `.sheet-body`. Without it, Chromium's scroll-snap re-evaluation inside a Top-Layer container incorrectly offsets `.scroll-area` by `-scrollTop` pixels when a child layout change triggers a re-snap. This is a Chromium rendering bug. `contain: layout` prevents child layout changes from propagating to `.scroll-area`. When Chromium fixes this bug, `contain: layout` MAY be removed — the regression guard is the artist-filter chip-check E2E test.
+
+#### Scenario: Initial snap animation
+- **WHEN** the `<dialog>` opens (`showModal()`)
+- **THEN** `.scroll-area` SHALL run an `initial-snap` CSS animation (`0.01s`, `animation-fill-mode: backwards`)
+- **AND** during the animation, `--_snap-align` SHALL be `none`, disabling dismiss-zone's scroll-snap-align
+- **AND** `.sheet-body` (`scroll-snap-align: end`) SHALL be the only active snap target
+- **AND** the browser SHALL snap to `.sheet-body` on open
+- **AND** after the animation completes, dismiss-zone snap SHALL restore to its CSS-determined value
+- **AND** no JavaScript `scrollTo()` or `requestAnimationFrame` SHALL be required
+
+#### Scenario: Scroll-snap dismiss
+- **WHEN** the sheet is open and `dismissable` is `true`
+- **THEN** `.scroll-area` SHALL have `data-dismissable="true"`
+- **AND** the dismiss zone SHALL have `scroll-snap-align: var(--_snap-align, start)` (active after initial-snap animation)
+- **AND** swiping down (physical gesture: finger moves downward, scrollTop decreases) SHALL scroll toward the dismiss zone at the top
+
+#### Scenario: Responsive swipe-down dismiss detection
+- **WHEN** the user swipes down (finger moves downward), and the user's scroll gesture rests on the dismiss zone as the new snap target
+- **THEN** the CE SHALL detect the dismiss via the `scrollsnapchange` event (whose `snapTargetBlock` is the dismiss zone)
+- **AND** the CE SHALL set `open` to `false`, call `close()`, and dispatch `sheet-closed`
+- **AND** the close SHALL NOT be gated on any `scrollend` settle, so dismiss does not wait on UA-controlled settle latency
+- **NOTE** `scrollsnapchange` fires only for a user scroll gesture (per the CSS Scroll Snap module), so a programmatic or initial-layout re-snap to the dismiss zone SHALL NOT trigger dismiss. This replaces the prior scroll-ratio threshold detection.
+
+#### Scenario: Early close on pointerup at dismiss threshold
+- **WHEN** the user lifts their pointer (`pointerup`) while the scroll position is near the dismiss zone but no user-gesture snap change to the dismiss zone has occurred
+- **THEN** the CE SHALL NOT close the sheet based on a `scrollTop / maxScroll` ratio threshold
+- **AND** the prior `pointerup` (`scrollTop/max < 0.25`) and `scrollend` (`scrollRatio < 0.1`) early-close heuristics SHALL be removed, because they fire on the programmatic initial re-snap and caused the iOS/WebKit "flash then close" defect
+- **NOTE** Dismiss is now driven by `scrollsnapchange` (user-gesture-only) with an `IntersectionObserver` fallback; there is no scroll-ratio early-close path. (Title retained for spec-delta continuity; behavior is the removal of the heuristic.)
+
+#### Scenario: Dismiss detection ignores programmatic and initial-snap scroll
+- **WHEN** the sheet opens and the `initial-snap` sequence (or any programmatic scroll) momentarily rests the scroll position on the dismiss zone before settling on `.sheet-body`
+- **THEN** the CE SHALL NOT dismiss the sheet
+- **AND** dismiss SHALL be honored only for a user-initiated scroll gesture (as signalled by `scrollsnapchange` or, on non-supporting engines, by the fallback described below combined with a just-opened guard)
+- **NOTE** This prevents the iOS/WebKit "flash then close" defect, where the programmatic re-snap trace (scroll ratio `1 → 0`) was previously misread as a user swipe-to-dismiss by scroll-ratio heuristics.
+
+#### Scenario: Fallback dismiss detection where scrollsnapchange is unsupported
+- **WHEN** the engine does not support `scrollsnapchange` (e.g., Firefox)
+- **THEN** the CE SHALL detect a user swipe-to-dismiss via an `IntersectionObserver` that observes the dismiss zone / sheet-body crossing the viewport, rather than via `scrollend`/`pointerup` scroll-ratio heuristics
+- **AND** the fallback SHALL be armed only after the sheet has opened and settled on `.sheet-body`, so the initial snap does not trigger dismiss
+
+#### Scenario: Just-opened dismiss guard
+- **WHEN** the sheet has just been opened (during the open transition / before it has settled on `.sheet-body`)
+- **THEN** the CE SHALL suppress any dismiss signal, so the sheet cannot close itself before the user interacts
+- **AND** the guard SHALL release once the sheet has settled on `.sheet-body`
+
+#### Scenario: Bounce-back prevention after dismiss-zone snap
+- **WHEN** a user scroll gesture changes the scroll-snap target to the dismiss zone (detected via `scrollsnapchange`)
+- **THEN** the CE SHALL immediately set `pointer-events: none` on `.scroll-area`
+- **AND** any subsequent upward swipe input SHALL be ignored by the scroll container
+- **AND** the sheet SHALL NOT re-snap to `.sheet-body` after the dismiss-zone snap is detected
+- **AND** `pointer-events` SHALL be restored to its default value in `onClose()`
+
+#### Scenario: Close animation completes within 160ms
+- **WHEN** the sheet is dismissed by any mechanism (swipe, tap-outside, ESC)
+- **THEN** the close transition (opacity + overlay + display) SHALL complete within 160ms
+- **NOTE** This replaces the prior 240ms duration; the shorter duration reduces perceived latency after the swipe gesture
+
+#### Scenario: Tap-outside dismiss
+- **WHEN** the sheet is open and `dismissable` is `true`
+- **AND** the user taps/clicks the dimmed area above the sheet body (the `.dismiss-zone`)
+- **THEN** the CE SHALL set `open` to `false`, call `close()`, and dispatch `sheet-closed`
+- **NOTE** Tap-outside is implemented as a `click` handler on the `.dismiss-zone` element, NOT via `::backdrop` and NOT via `closedby`: under full-viewport coverage the dialog box occludes the backdrop, so every tap targets a `<dialog>` descendant and neither the `::backdrop` (the `event.target === dialog` light-dismiss pattern) nor `closedby` native light-dismiss ever fires. (The `[popover]::backdrop { pointer-events: none }` UA rule applies to popovers, not `<dialog>::backdrop`, so it is not the reason here.)
+- **WHEN** `dismissable` is `false`
+- **THEN** the `.dismiss-zone` tap SHALL NOT close the sheet
+
+#### Scenario: Gesture-coupled backdrop fade
+- **WHEN** the browser supports scroll-driven animations (`@supports (animation-timeline: scroll())`)
+- **THEN** the `::backdrop` opacity (and its blur) SHALL be driven by the `.scroll-area` scroll position via `animation-timeline: scroll()`, so the backdrop fades as the user swipes the sheet toward the dismiss zone and is fully cleared by the dismiss threshold
+- **WHEN** the browser does NOT support scroll-driven animations (e.g., Firefox)
+- **THEN** the `::backdrop` SHALL fall back to an opacity `transition` on open/close (the prior behavior)
+
+#### Scenario: Non-dismissable mode
+- **WHEN** `dismissable` is `false`
+- **THEN** the inner `<dialog>` SHALL be opened with `showModal()` and SHALL suppress close requests (the `cancel` event SHALL be `preventDefault()`-ed so ESC / Android back do NOT close it)
+- **AND** `.scroll-area` SHALL have `data-dismissable="false"`
+- **AND** the dismiss zone SHALL remain in the DOM with `aria-hidden="true"` (required for the `initial-snap` animation pattern)
+- **AND** CSS SHALL set `.dismiss-zone` to `scroll-snap-align: none` and `pointer-events: none` via `.scroll-area:not([data-dismissable="true"]) .dismiss-zone`
+- **AND** `.sheet-body` SHALL be the only active snap target, ensuring the sheet body is visible on open
+
+#### Scenario: Dismissable mode with close-request dismiss (ESC / Android back)
+- **WHEN** `dismissable` is `true` (default)
+- **THEN** pressing Escape (desktop) or the Android back gesture/button SHALL close the sheet via the `<dialog>`'s native close request
+- **AND** the CE SHALL handle the `cancel` (and/or `close`) event on the inner `<dialog>` to set `open` to `false` and dispatch `sheet-closed`
+
+#### Scenario: Sheet closed event
+- **WHEN** the sheet is closed by any mechanism (ESC / Android back, tap-outside, scroll-snap swipe, programmatic)
+- **THEN** the CE SHALL dispatch a `sheet-closed` CustomEvent with `bubbles: true`
+- **AND** the parent component SHALL respond by setting `open` to `false`
+
+#### Scenario: Handle bar rendering
+- **WHEN** the sheet is open
+- **THEN** a handle bar (2.5rem wide, 0.25rem tall, rounded) SHALL be rendered at the top of the sheet body
+- **AND** the handle bar SHALL be styled with `oklch(100% 0 0deg / 20%)` background
+
+#### Scenario: Sheet body structure
+- **WHEN** the sheet is rendered
+- **THEN** the sheet body (`<section>`) SHALL have `border-radius: var(--radius-sheet)` on top corners
+- **AND** background SHALL be `var(--color-surface-raised)`
+- **AND** box-shadow SHALL be `var(--shadow-sheet)`
+- **AND** `max-block-size` SHALL be `90dvh`
+- **AND** overflow-y SHALL be `auto` for scrollable content
+- **AND** `contain` SHALL be `layout` (layout containment boundary — see layout stability scenario)
+
+#### Scenario: Slotted content
+- **WHEN** content is placed inside `<bottom-sheet>`
+- **THEN** it SHALL be projected via `<au-slot>` into the sheet body below the handle bar
+
+#### Scenario: Focus management
+- **WHEN** the sheet opens
+- **THEN** `showModal()` SHALL move focus into the `<dialog>` and trap it there
+- **WHEN** the sheet closes
+- **THEN** focus SHALL return to the element that was focused before the sheet opened
+
+#### Scenario: History integration
+- **WHEN** the sheet opens
+- **THEN** a history entry SHALL NOT be pushed by the CE itself
+- **AND** consuming components MAY manage history state independently via `open` binding
+
+#### Scenario: Reduced motion
+- **WHEN** `prefers-reduced-motion: reduce` is active
+- **THEN** all transition durations SHALL be reduced to `var(--_duration-reduced)`
+- **AND** the scroll-driven backdrop fade SHALL likewise resolve to an instant open/close
+
+#### Scenario: Detach cleanup
+- **WHEN** the CE is detached from the DOM while the sheet is open
+- **THEN** all event listeners (`cancel`/`close`, `.dismiss-zone` click, `scrollsnapchange`, and any `IntersectionObserver`) SHALL be removed / disconnected
+- **AND** `close()` SHALL be called on the inner `<dialog>`
+- **AND** `pointer-events` on `.scroll-area` SHALL be restored to its default value
+- **AND** no memory leaks SHALL occur

--- a/openspec/changes/fix-ios-help-sheet-dismiss-and-edit-mode-unfollow/specs/edit-mode-unfollow/spec.md
+++ b/openspec/changes/fix-ios-help-sheet-dismiss-and-edit-mode-unfollow/specs/edit-mode-unfollow/spec.md
@@ -1,0 +1,100 @@
+## Purpose
+
+Provide a discoverable, accessible way to unfollow artists from the My Artists list on every pointer type: a header Edit-mode toggle that reveals a per-row remove control, replacing the retired hidden long-press gesture.
+
+## ADDED Requirements
+
+### Requirement: Edit-mode toggle reveals per-row remove controls
+
+The My Artists list SHALL provide an "Edit" toggle control in the page header. Toggling it ON SHALL put the list into edit mode, in which each artist row SHALL display a remove (−) control as a single-tap, single-pointer affordance available on all pointer types (touch and mouse). Toggling it OFF SHALL leave edit mode and hide the remove controls. Edit mode SHALL NOT depend on any path-based or timed gesture (no swipe, no long-press), satisfying single-pointer operability (WCAG 2.5.1).
+
+#### Scenario: Entering edit mode reveals remove controls
+
+- **WHEN** the user activates the Edit toggle on the My Artists page
+- **THEN** every artist row SHALL display a remove (−) control
+- **AND** the Edit toggle SHALL indicate the active (editing) state
+
+#### Scenario: Leaving edit mode hides remove controls
+
+- **WHEN** the user deactivates the Edit toggle while in edit mode
+- **THEN** the remove controls SHALL no longer be displayed
+- **AND** the list SHALL return to its default (non-editing) presentation
+
+#### Scenario: Remove control is available on all pointer types
+
+- **WHEN** the My Artists page is viewed on a touch device (`pointer: coarse`) OR a mouse device (`pointer: fine`)
+- **AND** edit mode is active
+- **THEN** the per-row remove (−) control SHALL be visible and operable with a single tap or click
+- **AND** no interaction SHALL require a long-press or swipe gesture
+
+#### Scenario: Default (non-editing) list shows no persistent per-row unfollow control
+
+- **WHEN** the My Artists page loads and edit mode is NOT active
+- **THEN** no persistent per-row unfollow control SHALL be shown on any pointer type (touch or mouse), keeping the default list uncluttered
+- **AND** unfollow SHALL be reachable only after entering edit mode
+
+#### Scenario: Edit toggle presented in the page header
+
+- **WHEN** the My Artists page renders with at least one followed artist
+- **THEN** the Edit toggle SHALL be presented in the page header, on the trailing side of the page title, alongside the existing help (`?`) control
+
+#### Scenario: Edit toggle hidden when there is nothing to edit
+
+- **WHEN** the My Artists page is loading, OR has zero followed artists (empty state)
+- **THEN** the Edit toggle SHALL NOT be shown (there is nothing to edit)
+- **AND** the page title and help control SHALL still render
+
+#### Scenario: Edit mode exits when the last artist is removed
+
+- **WHEN** the user is in edit mode and removes the last remaining artist
+- **THEN** the list SHALL transition to the empty state
+- **AND** edit mode SHALL be exited (the Edit toggle returns to its non-editing label / is hidden per the previous scenario)
+
+#### Scenario: Edit mode is not persisted across navigation
+
+- **WHEN** the user leaves the My Artists page while in edit mode and later returns
+- **THEN** the page SHALL open in the default (non-editing) state
+
+#### Scenario: Hype controls remain usable in edit mode
+
+- **WHEN** edit mode is active
+- **THEN** the per-row hype controls SHALL remain interactive (the user can still change hype while remove controls are visible)
+
+### Requirement: Edit-mode controls are accessible
+
+The Edit toggle and the per-row remove controls SHALL be operable and understandable by assistive technology and keyboard users. The Edit toggle SHALL expose its pressed/active state, and each remove control SHALL have an accessible name identifying the artist it removes.
+
+#### Scenario: Edit toggle exposes pressed state
+
+- **WHEN** the Edit toggle is rendered
+- **THEN** it SHALL be a real button operable by keyboard (Enter/Space)
+- **AND** it SHALL expose its active state to assistive technology (e.g., `aria-pressed`)
+
+#### Scenario: Remove control has an accessible name
+
+- **WHEN** a per-row remove (−) control is shown in edit mode
+- **THEN** it SHALL have an accessible name that identifies the artist to be unfollowed (e.g., "Unfollow {artist name}")
+- **AND** it SHALL be operable by keyboard
+
+### Requirement: Remove control unfollows immediately with Undo
+
+Tapping the per-row remove (−) control in edit mode SHALL unfollow that artist immediately using the existing optimistic-removal flow, without a separate confirmation sheet, and SHALL surface an Undo affordance so the action is recoverable. Unfollow SHALL route through the existing follow-store flow (guest localStorage write or authenticated RPC) unchanged.
+
+#### Scenario: Remove unfollows immediately
+
+- **WHEN** the user taps the remove (−) control for an artist row in edit mode
+- **THEN** the artist SHALL be removed from the list optimistically
+- **AND** the unfollow SHALL be committed via the existing follow-store flow
+
+#### Scenario: Undo restores the artist
+
+- **WHEN** an unfollow has just been triggered via the remove control
+- **AND** the user activates the Undo affordance before it expires
+- **THEN** the artist SHALL be restored to the list
+- **AND** the pending unfollow SHALL NOT be committed (or SHALL be reversed) consistent with the existing undo behavior
+
+#### Scenario: Unfollow blocked during onboarding
+
+- **WHEN** the user is still in onboarding (`OnboardingService.isOnboarding` is `true`)
+- **AND** the user taps a remove control
+- **THEN** the unfollow SHALL NOT execute, preserving the existing onboarding guard

--- a/openspec/changes/fix-ios-help-sheet-dismiss-and-edit-mode-unfollow/specs/long-press-unfollow/spec.md
+++ b/openspec/changes/fix-ios-help-sheet-dismiss-and-edit-mode-unfollow/specs/long-press-unfollow/spec.md
@@ -1,0 +1,7 @@
+## REMOVED Requirements
+
+### Requirement: Long-press gesture triggers unfollow confirmation on touch devices
+
+**Reason**: The hidden 500 ms long-press gesture does not work on iOS Safari — the OS text-selection / callout / magnifier gesture fires `pointercancel` before the timer completes, and because the visible trash column is hidden on `pointer: coarse` devices, long-press is the only unfollow path there, leaving touch users unable to unfollow. Long-press is also a hidden, non-discoverable gesture whose semantics match neither the iOS (system-reserved) nor Android (multi-select) convention. It is superseded by the `edit-mode-unfollow` capability, which is discoverable, single-pointer (WCAG 2.5.1), and works identically across pointer types.
+
+**Migration**: Unfollow from the My Artists list is now performed via the Edit-mode toggle in the page header, which reveals a per-row remove (−) control; tapping it unfollows immediately with an Undo affordance (see the `edit-mode-unfollow` capability). The `ArtistUnfollowSheet` confirmation sheet, the `long-press` custom attribute, and the `pointer: coarse` trash-column hiding are removed. No user data migration is required.

--- a/openspec/changes/fix-ios-help-sheet-dismiss-and-edit-mode-unfollow/specs/my-artists/spec.md
+++ b/openspec/changes/fix-ios-help-sheet-dismiss-and-edit-mode-unfollow/specs/my-artists/spec.md
@@ -1,0 +1,20 @@
+## MODIFIED Requirements
+
+### Requirement: My Artists page help content documents all available gestures
+
+The My Artists page help content SHALL explain how to unfollow an artist via the Edit-mode
+toggle. The help text SHALL communicate that activating "Edit" in the page header reveals a
+per-row remove control that unfollows immediately (with Undo). The help content SHALL NOT
+reference a long-press-to-unfollow gesture (that interaction is retired). Desktop-specific
+interactions need not be documented in help as they are visually self-evident.
+
+#### Scenario: Help text visible to touch device users
+
+- **WHEN** the user opens the My Artists page help (on any device, including touch)
+- **THEN** help content includes an explanation that entering Edit mode reveals a per-row remove control to unfollow an artist
+- **AND** the help content SHALL NOT mention a long-press unfollow gesture
+
+#### Scenario: Help text available in all supported locales
+
+- **WHEN** the app is displayed in any supported locale (Japanese, English)
+- **THEN** the Edit-mode unfollow help text is translated and rendered correctly

--- a/openspec/changes/fix-ios-help-sheet-dismiss-and-edit-mode-unfollow/tasks.md
+++ b/openspec/changes/fix-ios-help-sheet-dismiss-and-edit-mode-unfollow/tasks.md
@@ -1,0 +1,56 @@
+## 1. Regression guard (WebKit) — land first, must be RED
+
+- [ ] 1.1 Add `e2e/functional/page-help-sheet-webkit.spec.ts`: open the My Artists page-help sheet, sample `dialog.open` over ~1.5s, assert it stays open AND its content is visible (not merely `open`)
+- [ ] 1.2 Add `webkit-repro` (real WebKit, iPhone 14) and `chromium-control` projects to `playwright.config.mjs`; exclude the spec from the Chromium `functional` project
+- [ ] 1.3 Confirm the guard is RED on `webkit-repro` and GREEN on `chromium-control` before the fix (`npx playwright test --project=webkit-repro --project=chromium-control`)
+
+## 2. Bottom-sheet dismiss fix (`bottom-sheet-ce`)
+
+- [ ] 2.1 Make `scrollsnapchange` (`onSnapChange`) the primary swipe-dismiss signal in `bottom-sheet.ts`
+- [ ] 2.2 Delete the `onScrollEnd` (`scrollRatio < 0.1`) and `onPointerUp` (`scrollTop/max < 0.25`) scroll-ratio dismiss heuristics and their template bindings
+- [ ] 2.3 Add an `IntersectionObserver` fallback for engines without `scrollsnapchange` (Firefox), armed only after the sheet settles on `.sheet-body`
+- [ ] 2.4 Add a "just-opened" dismiss guard that suppresses all dismiss signals until the sheet settles on `.sheet-body`
+- [ ] 2.5 Correct the stale "Safari lacks `scrollsnapchange`" comment; keep the CSS `initial-snap` trick unchanged
+- [ ] 2.6 Ensure detach cleanup disconnects the `IntersectionObserver` and removes the `scrollsnapchange` listener
+- [ ] 2.7 Run the guard again: `webkit-repro` MUST now be GREEN; verify sheet content is visible (add a one-line deterministic `scrollTop = maxScroll` on settle only if the test shows it parking blank)
+
+## 3. Edit-mode unfollow (`edit-mode-unfollow`)
+
+- [ ] 3.1 Add an "Edit" toggle control in the `page-header` slot (trailing, beside `<page-help>`) with an `editing` state on the route; toggle label reflects state (Edit ↔ Done)
+- [ ] 3.2 Reveal a per-row remove (−) control in edit mode; hide it otherwise; no persistent per-row control in the default list on any pointer type
+- [ ] 3.3 Show the Edit toggle only in the populated state; hide it while loading and in the empty (zero-artist) state
+- [ ] 3.4 Edit-mode lifecycle: auto-exit when the last artist is removed; do not persist edit state across navigation (fresh non-editing on re-entry); keep hype controls interactive while editing
+- [ ] 3.5 Wire the remove control to the existing `unfollowArtist()` flow (immediate optimistic removal + Undo), preserving the onboarding guard
+- [ ] 3.6 Accessibility: Edit toggle is a keyboard-operable button exposing `aria-pressed`; each remove control has an accessible name identifying the artist (e.g., "Unfollow {name}")
+- [ ] 3.7 Ensure the remove control is a single-tap target on both `pointer: coarse` and `pointer: fine` (min 44px touch target); style per CUBE CSS, no inline styles
+- [ ] 3.8 Add unit/E2E coverage: entering/leaving edit mode, toggle hidden when empty/loading, remove-unfollow, Undo restore, auto-exit on last removal, edit state not persisted across nav, onboarding block
+
+## 4. Remove long-press unfollow (`long-press-unfollow` retired)
+
+- [ ] 4.1 Delete `frontend/src/custom-attributes/long-press.ts` and its registration in `main.ts`
+- [ ] 4.2 Delete the `ArtistUnfollowSheet` component (`artist-unfollow-sheet.{ts,html,css}`) and its usage in `my-artists-route.html`
+- [ ] 4.3 Remove the long-press binding, `openUnfollowSheet`/`unfollowSheetOpen` wiring, and `selectedArtistForUnfollow` from `my-artists-route.{ts,html}`
+- [ ] 4.4 Remove the always-visible trash column entirely for all pointer types (the `.artist-unfollow-col` cell, the `@media (pointer: coarse) { display:none }` rule, and the visually-hidden `myArtists.table.unfollowCol` header if no longer applicable), unified onto Edit mode
+- [ ] 4.5 Delete the long-press unit tests and any `long-press` E2E references
+
+## 5. Help content (`my-artists` / page-help)
+
+- [ ] 5.1 Replace the page-help "long press to unfollow" section with Edit-mode guidance; remove the `isPointerCoarse` gate on that section if no longer needed
+- [ ] 5.2 Replace `longPressTip` i18n keys with Edit-mode copy in both `ja` and `en`; remove orphaned keys
+
+## 6. Verification
+
+- [ ] 6.1 `make check` (Biome lint + format + stylelint + typecheck + brand-vocabulary + unit tests) passes
+- [ ] 6.2 Full Playwright suite passes, including `webkit-repro` GREEN and `chromium-control` GREEN
+- [ ] 6.3 Manual real-iOS-device check: help sheet opens and stays open; Edit-mode unfollow + Undo works
+
+## 7. Ship to production
+
+- [ ] 7.1 Open the frontend PR; wait for all CI checks to complete green; address review; merge to `main`
+- [ ] 7.2 Cut a frontend GH Release (SemVer tag) → prod AR retag → automated pin-bump → ArgoCD sync
+- [ ] 7.3 Confirm the release deployed to prod (workflow runs green; new pin live)
+
+## 8. Post-ship & archive readiness
+
+- [ ] 8.1 Verify the two defects are resolved on prod (real iOS device)
+- [ ] 8.2 Sync delta specs to main specs, then archive the change (`edit-mode-unfollow` created, `long-press-unfollow` removed, `bottom-sheet-ce` + `my-artists` updated)


### PR DESCRIPTION
## 🔗 Related Issue

Closes #820

## 📝 Summary of Changes

OpenSpec planning change `fix-ios-help-sheet-dismiss-and-edit-mode-unfollow` (proposal / specs / design / tasks). Planning only — no proto or implementation changes.

**Motivation** — two iOS-only touch defects, both hidden by Android/Chromium and confirmed on real WebKit:

1. **Help sheet auto-closes ("flash then close").** The shared `<bottom-sheet>` opens then immediately dismisses on iOS. A real-WebKit Playwright repro pinned the cause: the fallback dismiss heuristics (`onScrollEnd` `scrollRatio < 0.1`, `onPointerUp` `scrollTop/max < 0.25`) fire on the *programmatic* initial re-snap (measured ratio trace `[1, 0]`) and misread it as a user swipe. Because `page-help` auto-opens on first visit, iOS users could not see help.
2. **Long-press unfollow broken.** The list unfollow is a hidden 500 ms long-press the iOS system gesture cancels; the visible trash control is hidden on `pointer: coarse`, so touch users had no working unfollow.

**Technical approach captured by the specs:**

- **`bottom-sheet-ce` (MODIFIED)** — move dismiss detection onto the `scrollsnapchange` event (user-gesture-only by spec; Chrome 129+, Safari 18.2+), delete the fragile scroll-ratio heuristics, add an `IntersectionObserver` fallback (Firefox) and a just-opened dismiss guard. Net code reduction; fixes all sheets.
- **`edit-mode-unfollow` (NEW)** — an iOS-style Edit-mode toggle in the page header (trailing, beside `?`) reveals per-row remove controls; immediate unfollow + Undo. Single-pointer (WCAG 2.5.1), discoverable, unified across all pointer types (the always-visible desktop trash column is retired too).
- **`long-press-unfollow` (REMOVED)** — retired in full; superseded by `edit-mode-unfollow`.
- **`my-artists` (MODIFIED)** — page-help now documents Edit mode instead of the long-press gesture.

A real-WebKit Playwright regression guard (RED before fix, GREEN after) is specified in tasks. Frontend-only; ships via a frontend release. Implementation lands in a separate frontend PR after this planning change merges.

## ✅ Self-Checklist

- [x] I have linked the related issue.
- [x] I have updated the relevant documentation (OpenSpec change artifacts).
- [ ] I have run `buf lint` and `buf format` locally and all checks have passed. — N/A: no `.proto` changes (OpenSpec markdown only).
- [ ] My proto definitions follow the project's style guidelines and validation rules. — N/A: no proto changes.
- [x] Breaking changes have been justified and documented if applicable. — No proto breaking changes; the interaction change (long-press retired) is documented in the delta specs.
