### PR TITLE
docs(openspec): propose tune-small-screen-responsive-layout

### DIFF
--- a/openspec/changes/tune-small-screen-responsive-layout/.openspec.yaml
+++ b/openspec/changes/tune-small-screen-responsive-layout/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-20

--- a/openspec/changes/tune-small-screen-responsive-layout/design.md
+++ b/openspec/changes/tune-small-screen-responsive-layout/design.md
@@ -1,0 +1,60 @@
+## Context
+
+See `proposal.md — Why` for motivation.
+
+Five files require changes, spanning two different control layers:
+- **CSS layer** (`discovery-route.css`, `page-header.css`, `coach-mark.css`): padding and sizing adjustments.
+- **Canvas/JS layer** (`dna-orb-canvas.ts`, `stage-effects.ts`): bubble count cap and orb radius cap driven by canvas dimensions, which are already tracked via an existing `ResizeObserver` + `resize()` hook.
+
+The `bubble-area` container already declares `container-type: size`, but this is irrelevant to the JS-driven canvas — container queries cannot control TypeScript logic.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Reduce vertical UI chrome on screens ≤ 700px tall (search bar, page header).
+- Cap rendered bubble count and orb radius when canvas width < 390px.
+- Fix coach-mark tooltip overflow on 320px-wide devices.
+- Keep all changes frontend-only with no data or API impact.
+
+**Non-Goals:**
+- Landscape orientation support (separate concern).
+- Tablet or desktop layout changes.
+- Bubble pool fetch logic or artist data changes.
+- Any changes to bubble size or label rendering.
+
+## Decisions
+
+### D1: `@media (height <= 700px)` for CSS vertical compression
+
+**Decision**: Use `@media (height <= 700px)` in `discovery-route.css` and `page-header.css` to tighten `padding-block` on short screens.
+
+**Why not `@container (max-block-size: ...)`**: `bubble-area` has `container-type: size`, but `search-bar` and `page-header` are siblings/ancestors of `bubble-area` — not descendants — so they cannot be queried from inside it. A `@container` approach would require adding a new wrapper container above both, adding complexity for no benefit.
+
+**Why `height` not `width`**: The constraint on iPhone SE is vertical. The screen is 375px wide (enough for the layout) but 667px tall (limiting bubble-area height). Height-based media queries target the actual constraint.
+
+**Threshold choice (700px)**: iPhone SE is 667px; iPhone 14 is 844px. 700px captures all "short" phones without affecting standard-height devices.
+
+### D2: Bubble count and orb radius derived from `canvasWidth` inside `resize()`
+
+**Decision**: Read `canvasWidth` (already computed in `resize()`) and derive a `displayLimit` and `effectiveMaxRadius` based on the 390px threshold. Pass these to the physics initializer and `getStageParams`.
+
+**Why not CSS custom properties or JS `matchMedia`**: The physics engine and orb renderer work in canvas pixel space, not CSS layout space. Using the already-available `rect.width` from `getBoundingClientRect()` in `resize()` is the simplest and most direct path — no extra subscriptions.
+
+**Why 390px threshold**: iPhone SE is 375px CSS pixels; most "standard" phones start at 390px (iPhone 14). This naturally separates small-form-factor devices from the mainstream.
+
+**Why reduce count, not size**: Reducing bubble radius below ~30px degrades label readability. Reducing count while keeping radius intact preserves the visual quality of each bubble.
+
+### D3: Coach-mark uses `min()` instead of a media query
+
+**Decision**: Change `max-inline-size: 320px` to `max-inline-size: min(320px, calc(100dvw - 2 * var(--space-s)))` in `coach-mark.css`.
+
+**Why not a media query**: The tooltip is a floating component that could appear anywhere on any route. A single `min()` value self-adapts to any viewport without needing a separate `@media` block.
+
+## Risks / Trade-offs
+
+- **Bubble count threshold is a hard cutoff at 390px**: A device that is 389px wide will show 30 bubbles; one that is 390px will show 50. This may be noticeable if a user rotates their device. Acceptable because the transition happens at landscape rotation, which is already an edge case for this UI.
+- **`@media (height <= 700px)` is viewport height, not available canvas height**: The page header and search bar shrink based on viewport height, not on how tall the bubble-area actually is. In practice these track closely enough on mobile.
+
+## Migration Plan
+
+Frontend-only change. Deploy as a standard frontend release. No data migrations or feature flags required. Rollback is a normal frontend rollback.

--- a/openspec/changes/tune-small-screen-responsive-layout/proposal.md
+++ b/openspec/changes/tune-small-screen-responsive-layout/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+Small-screen mobile devices (iPhone SE and similar, 375px wide / 667px tall) render the Discovery page with overly dense artist bubbles and proportionally oversized UI chrome — the search bar, page header, and DNA Orb occupy a disproportionate share of the vertical space, leaving the bubble canvas cramped. The root cause is that bubble count, orb radius, and key UI padding values are all screen-size-agnostic constants.
+
+## What Changes
+
+- **Discovery search bar**: Reduce `padding-block` on short screens (`height ≤ 700px`) from `var(--space-2xs)` (8px) to `var(--space-3xs)` (4px), recovering ~8px of vertical space.
+- **Page header**: Reduce `padding-block` on short screens, recovering ~8px of vertical space in the header row.
+- **DNA Orb radius**: Cap `MAX_RADIUS` at ~70px (down from 90px) when canvas width is < 390px, keeping the orb diameter under 38% of screen width.
+- **Bubble count**: Cap the number of artist bubbles rendered in physics at ~30 when canvas width is < 390px (instead of the unconditional maximum of 50), reducing canvas area saturation while preserving visual richness.
+- **Coach Mark tooltip**: Change `max-inline-size` from the fixed `320px` to `min(320px, calc(100vw - 2 * var(--space-s)))` so the tooltip cannot overflow on 320px-wide devices.
+
+## Capabilities
+
+### New Capabilities
+
+_None._
+
+### Modified Capabilities
+
+- `artist-discovery-dna-orb-ui`: Add a screen-size-aware constraint on the number of bubbles rendered and the DNA Orb radius. The existing requirement specifies "approximately 30 artist bubbles"; this change makes that bound formally responsive to canvas width.
+
+## Impact
+
+- **Frontend only**: `discovery-route.css`, `page-header.css`, `coach-mark.css`, `dna-orb-canvas.ts`, `stage-effects.ts`.
+- No backend, protocol buffer, or infrastructure changes.
+- No changes to pool fetch logic, follow state, or artist data; only the visual rendering layer is affected.

--- a/openspec/changes/tune-small-screen-responsive-layout/proposal.md
+++ b/openspec/changes/tune-small-screen-responsive-layout/proposal.md
@@ -6,9 +6,9 @@ Small-screen mobile devices (iPhone SE and similar, 375px wide / 667px tall) ren
 
 - **Discovery search bar**: Reduce `padding-block` on short screens (`height ≤ 700px`) from `var(--space-2xs)` (8px) to `var(--space-3xs)` (4px), recovering ~8px of vertical space.
 - **Page header**: Reduce `padding-block` on short screens, recovering ~8px of vertical space in the header row.
-- **DNA Orb radius**: Cap `MAX_RADIUS` at ~70px (down from 90px) when canvas width is < 390px, keeping the orb diameter under 38% of screen width.
+- **DNA Orb radius**: Cap `MAX_RADIUS` at ~70px (down from 90px) when canvas width is < 390px, reducing orb dominance on small screens.
 - **Bubble count**: Cap the number of artist bubbles rendered in physics at ~30 when canvas width is < 390px (instead of the unconditional maximum of 50), reducing canvas area saturation while preserving visual richness.
-- **Coach Mark tooltip**: Change `max-inline-size` from the fixed `320px` to `min(320px, calc(100vw - 2 * var(--space-s)))` so the tooltip cannot overflow on 320px-wide devices.
+- **Coach Mark tooltip**: Change `max-inline-size` from the fixed `320px` to `min(320px, calc(100dvw - 2 * var(--space-s)))` so the tooltip cannot overflow on 320px-wide devices.
 
 ## Capabilities
 

--- a/openspec/changes/tune-small-screen-responsive-layout/specs/artist-discovery-dna-orb-ui/spec.md
+++ b/openspec/changes/tune-small-screen-responsive-layout/specs/artist-discovery-dna-orb-ui/spec.md
@@ -14,7 +14,7 @@ On narrow canvases (width < 390px), the system SHALL limit the number of simulta
 
 #### Scenario: DNA Orb radius is constrained on narrow screens
 - **WHEN** the Discovery canvas width is less than 390px
-- **THEN** the DNA Orb rendered radius SHALL NOT exceed 70px (diameter 140px, ≤ 37% of canvas width)
+- **THEN** the DNA Orb rendered radius SHALL NOT exceed 70px
 
 #### Scenario: DNA Orb radius follows follow-count on wider screens
 - **WHEN** the Discovery canvas width is 390px or greater

--- a/openspec/changes/tune-small-screen-responsive-layout/specs/artist-discovery-dna-orb-ui/spec.md
+++ b/openspec/changes/tune-small-screen-responsive-layout/specs/artist-discovery-dna-orb-ui/spec.md
@@ -1,0 +1,21 @@
+## ADDED Requirements
+
+### Requirement: Small-screen bubble and orb density adaptation
+On narrow canvases (width < 390px), the system SHALL limit the number of simultaneously rendered artist bubbles and constrain the DNA Orb radius to prevent visual crowding and maintain readability of bubble labels.
+
+#### Scenario: Bubble count is capped on narrow screens
+- **WHEN** the Discovery canvas width is less than 390px
+- **THEN** the number of artist bubbles simultaneously rendered in the physics layer SHALL NOT exceed 30
+- **AND** bubble size SHALL remain unchanged to preserve label readability
+
+#### Scenario: Bubble count is uncapped on wider screens
+- **WHEN** the Discovery canvas width is 390px or greater
+- **THEN** the number of artist bubbles simultaneously rendered SHALL follow the existing pool capacity (up to 50)
+
+#### Scenario: DNA Orb radius is constrained on narrow screens
+- **WHEN** the Discovery canvas width is less than 390px
+- **THEN** the DNA Orb rendered radius SHALL NOT exceed 70px (diameter 140px, ≤ 37% of canvas width)
+
+#### Scenario: DNA Orb radius follows follow-count on wider screens
+- **WHEN** the Discovery canvas width is 390px or greater
+- **THEN** the DNA Orb radius SHALL follow the existing follow-count-driven stage escalation (up to 90px)

--- a/openspec/changes/tune-small-screen-responsive-layout/tasks.md
+++ b/openspec/changes/tune-small-screen-responsive-layout/tasks.md
@@ -1,7 +1,7 @@
 ## 1. CSS: Discovery search bar vertical compression
 
 - [ ] 1.1 In `src/routes/discovery/discovery-route.css`, add `@media (height <= 700px)` block that sets `.search-bar` `padding-block` to `var(--space-3xs)` and `margin-block-start` to `var(--space-3xs)`
-- [ ] 1.2 Confirm search bar renders ~8px shorter per side at 375×667 viewport in browser DevTools
+- [ ] 1.2 Confirm search bar renders ~8px shorter overall (4px per side) at 375×667 viewport in browser DevTools
 
 ## 2. CSS: Page header vertical compression
 

--- a/openspec/changes/tune-small-screen-responsive-layout/tasks.md
+++ b/openspec/changes/tune-small-screen-responsive-layout/tasks.md
@@ -1,0 +1,41 @@
+## 1. CSS: Discovery search bar vertical compression
+
+- [ ] 1.1 In `src/routes/discovery/discovery-route.css`, add `@media (height <= 700px)` block that sets `.search-bar` `padding-block` to `var(--space-3xs)` and `margin-block-start` to `var(--space-3xs)`
+- [ ] 1.2 Confirm search bar renders ~8px shorter per side at 375×667 viewport in browser DevTools
+
+## 2. CSS: Page header vertical compression
+
+- [ ] 2.1 In `src/components/page-header/page-header.css`, add `@media (height <= 700px)` block that sets `.page-header` `padding-block` to `var(--space-2xs)`
+- [ ] 2.2 Confirm header row is visibly more compact on 375×667 viewport without breaking the title or slot actions layout
+
+## 3. CSS: Coach mark tooltip overflow fix
+
+- [ ] 3.1 In `src/components/coach-mark/coach-mark.css`, change `.coach-tip` `max-inline-size` from `320px` to `min(320px, calc(100dvw - 2 * var(--space-s)))`
+- [ ] 3.2 Verify tooltip does not overflow on a 320px-wide viewport in DevTools
+
+## 4. TypeScript: Bubble count cap on narrow canvases
+
+- [ ] 4.1 In `src/components/dna-orb/dna-orb-canvas.ts`, derive a `displayLimit` constant inside (or just after) `resize()` using the existing `rect.width`: `Math.min(artists.length, rect.width < 390 ? 30 : 50)`
+- [ ] 4.2 Apply `displayLimit` when passing artists to the physics initializer so that only that many bubbles are spawned
+- [ ] 4.3 Confirm that at 375px canvas width, no more than 30 bubbles are rendered; at 390px+, up to 50 are rendered
+
+## 5. TypeScript: DNA Orb radius cap on narrow canvases
+
+- [ ] 5.1 In `src/components/dna-orb/stage-effects.ts`, introduce a `effectiveMaxRadius` variable that is `Math.min(MAX_RADIUS, canvasWidth < 390 ? 70 : MAX_RADIUS)` and apply it in `getStageParams` when computing `orbRadius`
+- [ ] 5.2 Thread `canvasWidth` into `getStageParams` (or pass `effectiveMaxRadius` from the call site in `dna-orb-canvas.ts`)
+- [ ] 5.3 Confirm at 375px canvas width that the orb diameter does not exceed 140px
+
+## 6. Verification
+
+- [ ] 6.1 Open Discovery page in Chrome DevTools at iPhone SE (375×667) — verify bubbles are fewer and not visually crowded, search bar is slimmer, orb is proportionate
+- [ ] 6.2 Open Discovery page at 390×844 (iPhone 14 baseline) — verify no visual regression (full 50 bubbles, full orb radius)
+- [ ] 6.3 Open coach mark at 320px width — verify tooltip stays within the viewport
+- [ ] 6.4 Run `make check` in frontend and confirm zero type errors and lint failures
+
+## 7. Specification sync and release
+
+- [ ] 7.1 Open PR in frontend with all changes and pass CI
+- [ ] 7.2 Sync delta spec to main spec (`openspec sync-specs` or manual merge of `artist-discovery-dna-orb-ui`)
+- [ ] 7.3 Open specification PR for the delta-to-main sync
+- [ ] 7.4 Merge frontend PR and create a patch release
+- [ ] 7.5 Merge specification PR


### PR DESCRIPTION
## Summary

- Proposes the `tune-small-screen-responsive-layout` OpenSpec change: planning artifacts (proposal, delta spec, design, tasks) for making the Discovery page and shared UI components responsive on narrow short-screen devices.
- Adds a delta spec to `artist-discovery-dna-orb-ui` that formally defines screen-size-aware bubble count (≤30 on canvas width < 390px) and DNA Orb radius (≤70px on canvas width < 390px) constraints.

## What's in this PR

| Artifact | Content |
|---|---|
| `proposal.md` | Problem statement and scope (frontend-only, 5 files) |
| `specs/artist-discovery-dna-orb-ui/spec.md` | ADDED requirement: small-screen bubble and orb density adaptation |
| `design.md` | Technical decisions: `@media (height)` vs `@container`, canvas-width threshold in `resize()`, `min()` for coach mark |
| `tasks.md` | 7-phase, 17-task implementation checklist |

## Closes

close: #822
