### PR TITLE
docs(spec): sync artist-discovery-dna-orb-ui delta to main spec

### DIFF
--- a/openspec/changes/tune-small-screen-responsive-layout/tasks.md
+++ b/openspec/changes/tune-small-screen-responsive-layout/tasks.md
@@ -1,41 +1,41 @@
 ## 1. CSS: Discovery search bar vertical compression
 
-- [ ] 1.1 In `src/routes/discovery/discovery-route.css`, add `@media (height <= 700px)` block that sets `.search-bar` `padding-block` to `var(--space-3xs)` and `margin-block-start` to `var(--space-3xs)`
-- [ ] 1.2 Confirm search bar renders ~8px shorter overall (4px per side) at 375×667 viewport in browser DevTools
+- [x] 1.1 In `src/routes/discovery/discovery-route.css`, add `@media (height <= 700px)` block that sets `.search-bar` `padding-block` to `var(--space-3xs)` and `margin-block-start` to `var(--space-3xs)`
+- [x] 1.2 Confirm search bar renders ~8px shorter overall (4px per side) at 375×667 viewport in browser DevTools
 
 ## 2. CSS: Page header vertical compression
 
-- [ ] 2.1 In `src/components/page-header/page-header.css`, add `@media (height <= 700px)` block that sets `.page-header` `padding-block` to `var(--space-2xs)`
-- [ ] 2.2 Confirm header row is visibly more compact on 375×667 viewport without breaking the title or slot actions layout
+- [x] 2.1 In `src/components/page-header/page-header.css`, add `@media (height <= 700px)` block that sets `.page-header` `padding-block` to `var(--space-2xs)`
+- [x] 2.2 Confirm header row is visibly more compact on 375×667 viewport without breaking the title or slot actions layout
 
 ## 3. CSS: Coach mark tooltip overflow fix
 
-- [ ] 3.1 In `src/components/coach-mark/coach-mark.css`, change `.coach-tip` `max-inline-size` from `320px` to `min(320px, calc(100dvw - 2 * var(--space-s)))`
-- [ ] 3.2 Verify tooltip does not overflow on a 320px-wide viewport in DevTools
+- [x] 3.1 In `src/components/coach-mark/coach-mark.css`, change `.coach-tip` `max-inline-size` from `320px` to `min(320px, calc(100dvi - 2 * var(--space-s)))`
+- [x] 3.2 Verify tooltip does not overflow on a 320px-wide viewport in DevTools
 
 ## 4. TypeScript: Bubble count cap on narrow canvases
 
-- [ ] 4.1 In `src/components/dna-orb/dna-orb-canvas.ts`, derive a `displayLimit` constant inside (or just after) `resize()` using the existing `rect.width`: `Math.min(artists.length, rect.width < 390 ? 30 : 50)`
-- [ ] 4.2 Apply `displayLimit` when passing artists to the physics initializer so that only that many bubbles are spawned
-- [ ] 4.3 Confirm that at 375px canvas width, no more than 30 bubbles are rendered; at 390px+, up to 50 are rendered
+- [x] 4.1 In `src/components/dna-orb/dna-orb-canvas.ts`, derive a `displayLimit` constant inside (or just after) `resize()` using the existing `rect.width`: `Math.min(artists.length, rect.width < 390 ? 30 : 50)`
+- [x] 4.2 Apply `displayLimit` when passing artists to the physics initializer so that only that many bubbles are spawned
+- [x] 4.3 Confirm that at 375px canvas width, no more than 30 bubbles are rendered; at 390px+, up to 50 are rendered
 
 ## 5. TypeScript: DNA Orb radius cap on narrow canvases
 
-- [ ] 5.1 In `src/components/dna-orb/stage-effects.ts`, introduce a `effectiveMaxRadius` variable that is `Math.min(MAX_RADIUS, canvasWidth < 390 ? 70 : MAX_RADIUS)` and apply it in `getStageParams` when computing `orbRadius`
-- [ ] 5.2 Thread `canvasWidth` into `getStageParams` (or pass `effectiveMaxRadius` from the call site in `dna-orb-canvas.ts`)
-- [ ] 5.3 Confirm at 375px canvas width that the orb diameter does not exceed 140px
+- [x] 5.1 In `src/components/dna-orb/stage-effects.ts`, introduce a `effectiveMaxRadius` variable that is `Math.min(MAX_RADIUS, canvasWidth < 390 ? 70 : MAX_RADIUS)` and apply it in `getStageParams` when computing `orbRadius`
+- [x] 5.2 Thread `canvasWidth` into `getStageParams` (or pass `effectiveMaxRadius` from the call site in `dna-orb-canvas.ts`)
+- [x] 5.3 Confirm at 375px canvas width that the orb diameter does not exceed 140px
 
 ## 6. Verification
 
-- [ ] 6.1 Open Discovery page in Chrome DevTools at iPhone SE (375×667) — verify bubbles are fewer and not visually crowded, search bar is slimmer, orb is proportionate
-- [ ] 6.2 Open Discovery page at 390×844 (iPhone 14 baseline) — verify no visual regression (full 50 bubbles, full orb radius)
-- [ ] 6.3 Open coach mark at 320px width — verify tooltip stays within the viewport
-- [ ] 6.4 Run `make check` in frontend and confirm zero type errors and lint failures
+- [x] 6.1 Open Discovery page in Chrome DevTools at iPhone SE (375×667) — verify bubbles are fewer and not visually crowded, search bar is slimmer, orb is proportionate
+- [x] 6.2 Open Discovery page at 390×844 (iPhone 14 baseline) — verify no visual regression (full 50 bubbles, full orb radius)
+- [x] 6.3 Open coach mark at 320px width — verify tooltip stays within the viewport
+- [x] 6.4 Run `make check` in frontend and confirm zero type errors and lint failures
 
 ## 7. Specification sync and release
 
-- [ ] 7.1 Open PR in frontend with all changes and pass CI
-- [ ] 7.2 Sync delta spec to main spec (`openspec sync-specs` or manual merge of `artist-discovery-dna-orb-ui`)
+- [x] 7.1 Open PR in frontend with all changes and pass CI
+- [x] 7.2 Sync delta spec to main spec (`openspec sync-specs` or manual merge of `artist-discovery-dna-orb-ui`)
 - [ ] 7.3 Open specification PR for the delta-to-main sync
 - [ ] 7.4 Merge frontend PR and create a patch release
 - [ ] 7.5 Merge specification PR

--- a/openspec/specs/artist-discovery-dna-orb-ui/spec.md
+++ b/openspec/specs/artist-discovery-dna-orb-ui/spec.md
@@ -231,6 +231,28 @@ The `ArtistDiscoveryService.listFollowedFromBackend` method SHALL use the instan
 
 ---
 
+### Requirement: Small-screen bubble and orb density adaptation
+On narrow canvases (width < 390px), the system SHALL limit the number of simultaneously rendered artist bubbles and constrain the DNA Orb radius to prevent visual crowding and maintain readability of bubble labels.
+
+#### Scenario: Bubble count is capped on narrow screens
+- **WHEN** the Discovery canvas width is less than 390px
+- **THEN** the number of artist bubbles simultaneously rendered in the physics layer SHALL NOT exceed 30
+- **AND** bubble size SHALL remain unchanged to preserve label readability
+
+#### Scenario: Bubble count is uncapped on wider screens
+- **WHEN** the Discovery canvas width is 390px or greater
+- **THEN** the number of artist bubbles simultaneously rendered SHALL follow the existing pool capacity (up to 50)
+
+#### Scenario: DNA Orb radius is constrained on narrow screens
+- **WHEN** the Discovery canvas width is less than 390px
+- **THEN** the DNA Orb rendered radius SHALL NOT exceed 70px
+
+#### Scenario: DNA Orb radius follows follow-count on wider screens
+- **WHEN** the Discovery canvas width is 390px or greater
+- **THEN** the DNA Orb radius SHALL follow the existing follow-count-driven stage escalation (up to 90px)
+
+---
+
 ## Technical Context
 
 This specification defines the Artist Discovery UI for Liverty Music MVP, featuring:


### PR DESCRIPTION
## Summary

Syncs the `artist-discovery-dna-orb-ui` delta spec from the `tune-small-screen-responsive-layout` change into the main spec. Adds a new requirement capturing the screen-size-aware rendering constraints introduced by the frontend change (liverty-music/frontend#543).

## Changes

**`openspec/specs/artist-discovery-dna-orb-ui/spec.md`** — Added requirement:

> **Small-screen bubble and orb density adaptation**: On narrow canvases (width < 390px), the system SHALL limit the number of simultaneously rendered artist bubbles and constrain the DNA Orb radius to prevent visual crowding and maintain readability of bubble labels.

With four scenarios:
- Bubble count capped at 30 on canvas width < 390px
- Bubble count follows pool capacity (up to 50) on canvas width ≥ 390px
- DNA Orb radius capped at 70px on canvas width < 390px
- DNA Orb radius follows follow-count-driven stage escalation on canvas width ≥ 390px

**`openspec/changes/tune-small-screen-responsive-layout/tasks.md`** — Updated task completion markers (all implementation and verification tasks now marked done).

## Testing

`openspec validate --specs` passes — 197 specs, 0 failures.

close: #836
