### PR TITLE
docs(openspec): propose promote-pwa-install-with-banner

### DIFF
--- a/openspec/changes/promote-pwa-install-with-banner/.openspec.yaml
+++ b/openspec/changes/promote-pwa-install-with-banner/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-21

--- a/openspec/changes/promote-pwa-install-with-banner/design.md
+++ b/openspec/changes/promote-pwa-install-with-banner/design.md
@@ -1,0 +1,81 @@
+## Context
+
+The app currently has two PWA install affordances:
+- `pwa-install-fab` — a 2.75 rem FAB in the bottom-right corner, shown post-onboarding to all users (guest + authenticated). Dismissed permanently by tapping and completing the native dialog; iOS uses an instruction bottom-sheet with a close-only button.
+- `PostSignupDialog` — a bottom-sheet shown once after new account creation. Contains an inline install row for Chrome/Edge only (iOS is excluded via `canShowInstallOption`).
+
+`PwaInstallService` currently exposes:
+- `@observable canShowFab` — requires `beforeinstallprompt` captured AND onboarding completed (or iOS)
+- `canShowInstallOption` — requires `!installed && browserSupportsPwa` (excludes iOS)
+- `isIos`, `browserSupportsPwa` — stable getters
+
+The `signup-prompt-banner` component provides the proven visual pattern (see spec). It is auth-state-exclusive with the new banner: guests see `signup-prompt-banner`, authenticated users see `pwa-install-banner`.
+
+See proposal.md for motivation.
+
+## Goals / Non-Goals
+
+**Goals**:
+- Single install CTA replacing the FAB for all post-signup scenarios
+- iOS users included in the banner flow via guide sheet
+- Session-level dismiss that does not permanently suppress the banner
+- Reactively switches between native and guide CTA modes
+
+**Non-Goals**:
+- Analytics/tracking of install conversion (deferred)
+- Changes to `PostSignupDialog` install row logic (unchanged)
+- Notification prompt UI changes (unchanged)
+
+## Decisions
+
+### D1: `shouldShowInstallBanner` as `@observable` property (not a getter)
+
+`PwaInstallService.installed` is a private, non-observable field. A plain getter derived from it will not trigger Aurelia's template re-evaluation when `installed` changes (via `appinstalled` or `confirmInstalled()`). Making `shouldShowInstallBanner` an `@observable` property — updated explicitly in `evaluateVisibility()`, `listenForAppInstalled()`, and `confirmInstalled()` — ensures templates react correctly.
+
+Alternative considered: make `installed` observable. Rejected because `installed` is internal state; exposing it as observable widens the API surface unnecessarily and risks misuse by other components.
+
+### D2: `if.bind` over `show.bind` for the banner element
+
+The banner contains two interactive elements (CTA + close button). Using `show.bind` (DOM kept but hidden) would require `aria-hidden` and `tabindex` management on each child — the same complexity the FAB manages for a single button. Since the banner should disappear entirely when hidden (no a11y reason to keep it in the tree), `if.bind` is simpler and correct: removes both buttons from the tab order automatically.
+
+Alternative considered: `show.bind` + explicit `aria-hidden`/`tabindex` per child, matching the FAB pattern. Rejected because the multi-child case adds brittleness without benefit.
+
+### D3: Session-level dismiss via `sessionStorage` (not `localStorage`)
+
+`localStorage` dismiss would permanently suppress the banner for users who tapped close on impulse but still intend to install later. `sessionStorage` clears on tab close / new session, so the banner naturally re-surfaces — persistent pressure without being permanently dismissible.
+
+### D4: Reuse `signup-prompt-banner` visual language (no new design tokens)
+
+The banner uses existing design tokens (`--color-brand-primary`, `--color-brand-secondary`, `--space-*`, `--step-*`) and the same CSS structure (`@layer block { @scope (pwa-install-banner) { ... } }`). This keeps the two banners visually consistent without introducing a shared base component, which would require a new abstraction for two consumers.
+
+### D5: Banner is auth-gated (`shouldShowInstallBanner` checked at app-shell level alongside `isAuthenticated`)
+
+Guests already see `signup-prompt-banner`. Showing `pwa-install-banner` to guests too would stack two banners. The auth gate (`if.bind="showNav && isAuthenticated"` at the app-shell level, or equivalent) ensures mutual exclusivity.
+
+### D6: `confirmInstalled()` as explicit iOS completion signal
+
+iOS's `appinstalled` event is unreliable (fired inconsistently across iOS versions). A "追加しました" button in the guide sheet lets the user signal completion, which `confirmInstalled()` records to `localStorage['pwa.installed']` and sets `shouldShowInstallBanner = false`. On the next standalone launch, `detectInstalled()` will confirm via `navigator.standalone`, providing a second verification layer.
+
+### D7: Banner suppressed (not co-rendered) while PostSignupDialog is open
+
+Both are `position: fixed` at the bottom. Co-rendering them would cause visual overlap. The host (`DashboardRoute` or `app-shell`) suppresses the banner while `showPostSignupDialog` is true — the same mechanism used to suppress the notification prompt. The banner becomes visible after the dialog is dismissed.
+
+## Risks / Trade-offs
+
+- **iOS `appinstalled` never fires** → Mitigated by `confirmInstalled()` in guide sheet. On next standalone launch, `detectInstalled()` auto-detects via `navigator.standalone`.
+- **`beforeinstallprompt` arrives after banner renders** → Handled by `@watch((vm) => vm.pwaInstall.canShowFab)` in the banner VM, same pattern as `PostSignupDialog`. CTA mode upgrades reactively without needing to re-mount the banner.
+- **Session dismiss state lost if tab crashes** → Acceptable; the banner simply reappears. Worst case is a slightly more frequent appearance in crash-heavy sessions.
+
+## Migration Plan
+
+1. Add `shouldShowInstallBanner` and `confirmInstalled()` to `PwaInstallService` (additive — no existing callers affected).
+2. Implement `pwa-install-banner` component.
+3. Swap `<pwa-install-fab>` for `<pwa-install-banner>` in `app-shell.html`.
+4. Delete `pwa-install-fab` component files.
+5. Add i18n keys (`pwaInstallBanner.*`) to both locale files.
+6. Update `PostSignupDialog` spec reference (iOS path → banner).
+7. No rollback needed — the FAB component files are deleted, not gated. If rollback is required, restore from git.
+
+## Open Questions
+
+None — all scope questions resolved during the explore phase.

--- a/openspec/changes/promote-pwa-install-with-banner/proposal.md
+++ b/openspec/changes/promote-pwa-install-with-banner/proposal.md
@@ -1,0 +1,36 @@
+## Why
+
+The PWA install FAB is insufficiently prominent — a 2.75 rem circular button in the screen corner that is easy to overlook. Because push notifications (the core feature of this service) require PWA installation on iOS 16.4+, low install conversion directly limits reach. A persistent banner using the same visual language as the proven `signup-prompt-banner` raises the install CTA to a prominence level appropriate for a core-feature dependency.
+
+## What Changes
+
+- **New**: `pwa-install-banner` component — full-width persistent fixed banner shown to signed-in, non-installed users. Reuses `signup-prompt-banner` visual treatment (gradient border-top, frosted glass, pulsing CTA). Supports two CTA modes: native one-tap install (Chrome/Edge with deferred prompt) and guided manual steps (iOS Safari / no deferred prompt).
+- **New**: `PwaInstallService.shouldShowInstallBanner` `@observable` property — visibility predicate for the banner. Extends eligibility to iOS Safari (`!installed && (browserSupportsPwa || isIos)`), unlike the existing `canShowInstallOption` which excludes iOS.
+- **New**: `PwaInstallService.confirmInstalled()` — allows iOS users to manually confirm installation from the guide sheet, compensating for unreliable `appinstalled` event on iOS.
+- **New**: Session-level dismiss — the banner can be dismissed per session via a close button; the dismiss state is stored in `sessionStorage` and clears on next session load, so the banner reappears until the app is installed.
+- **REMOVED**: `pwa-install-fab` component (all files: `.ts`, `.html`, `.css`, `.spec.ts`).
+- **Modified**: `PwaInstallService` — adds `shouldShowInstallBanner` and `confirmInstalled()`; existing `canShowFab`, `canShowInstallOption`, `isIos`, and `browserSupportsPwa` are unchanged.
+- **Modified**: `app-shell.html` / `app-shell.ts` — swap `<pwa-install-fab>` for `<pwa-install-banner>`.
+- **Modified**: `prompt-timing` spec — update "PWA install FAB has no dismiss action" rule to reflect session-level dismiss; clarify that session dismiss is not a permanent suppression.
+- **Modified**: `post-signup-dialog` spec — update iOS install path reference from "persistent FAB" to `pwa-install-banner`.
+
+## Capabilities
+
+### New Capabilities
+
+- `pwa-install-banner`: Persistent PWA install promotion banner for signed-in users, with session-level dismiss, iOS support (guided sheet), and reactive CTA mode switching (native vs. guide).
+
+### Modified Capabilities
+
+- `pwa-install-fab`: All requirements REMOVED — capability retired and superseded by `pwa-install-banner`.
+- `prompt-timing`: Update "passive UI / no dismiss" language to reflect banner's session-level dismiss while preserving the banner's classification as passive (not subject to the single-prompt-per-session constraint).
+- `post-signup-dialog`: Update iOS install path reference from FAB instruction sheet to `pwa-install-banner`.
+
+## Impact
+
+- **Frontend only** — no backend, proto, or BSR changes required.
+- **New component**: `src/components/pwa-install-banner/` (`.ts`, `.html`, `.css`)
+- **Deleted component**: `src/components/pwa-install-fab/` (all files)
+- **Service change**: `src/services/pwa-install-service.ts` (additive only)
+- **Shell change**: `src/app-shell.html`, `src/app-shell.ts`
+- **i18n**: New translation keys (`pwaInstallBanner.*`) in `en/translation.json` and `ja/translation.json`

--- a/openspec/changes/promote-pwa-install-with-banner/specs/post-signup-dialog/spec.md
+++ b/openspec/changes/promote-pwa-install-with-banner/specs/post-signup-dialog/spec.md
@@ -1,0 +1,70 @@
+## MODIFIED Requirements
+
+### Requirement: Post-Signup Dialog on First Authentication
+
+The system SHALL display a dialog after the first successful signup that consolidates a celebration message with optional power-up actions (notification permission, PWA install), without front-loading guidance for features the user has not yet encountered.
+
+#### Scenario: Dialog shown after first signup
+
+- **WHEN** the auth-callback route completes `provisionUser()` for a new user
+- **AND** `localStorage['liverty:postSignup:shown']` is not set
+- **THEN** the system SHALL set `localStorage['liverty:postSignup:shown']` to `'1'`
+- **AND** the system SHALL navigate to `/dashboard`
+- **AND** the Dashboard SHALL display the `PostSignupDialog` on load
+
+#### Scenario: Dialog not shown on subsequent logins
+
+- **WHEN** the auth-callback route completes for a returning user
+- **AND** `localStorage['liverty:postSignup:shown']` is already set
+- **THEN** the system SHALL NOT show the `PostSignupDialog`
+
+#### Scenario: Dialog content leads with celebration
+
+- **WHEN** the PostSignupDialog is displayed
+- **THEN** the first content row SHALL be a celebration message acknowledging completion of onboarding
+- **AND** it SHALL offer a notification opt-in action if `notificationManager.permission === 'default'`
+- **AND** it SHALL show a notification denied message if `notificationManager.permission === 'denied'`
+- **AND** it SHALL offer a PWA install action if `PwaInstallService.canShowInstallOption` is `true`
+- **AND** it SHALL provide a dismiss/close action in the footer
+
+#### Scenario: Footer button label when all actions are complete
+
+- **WHEN** the PostSignupDialog is displayed
+- **AND** `PwaInstallService.canShowInstallOption` is `false` (PWA already installed or browser not capable)
+- **AND** `notificationManager.permission` is `'granted'`
+- **THEN** the footer button SHALL display the label "Close"
+
+#### Scenario: Footer button label when actions remain
+
+- **WHEN** the PostSignupDialog is displayed
+- **AND** either `PwaInstallService.canShowInstallOption` is `true` OR `notificationManager.permission` is not `'granted'`
+- **THEN** the footer button SHALL display the label "Later"
+
+#### Scenario: Notification opt-in from dialog
+
+- **WHEN** the user taps the notification opt-in button in the PostSignupDialog
+- **THEN** the system SHALL call `PushService.create()` (backed by `PushNotificationService.Create` RPC)
+- **AND** the system SHALL NOT write any `localStorage` flag for push notification enabled state
+- **AND** on success, the notification row SHALL show a confirmed state
+- **AND** on failure or denial, the notification row SHALL show an error state
+- **AND** the settings page SHALL subsequently derive the toggle state from the backend via `PushNotificationService.Get` without relying on any `localStorage` flag
+
+#### Scenario: PWA install from dialog — native prompt
+
+- **WHEN** the user taps the install button in the PostSignupDialog
+- **AND** `PwaInstallService.canShowFab` is `true` (native prompt captured)
+- **THEN** the system SHALL trigger the deferred `beforeinstallprompt` event
+
+#### Scenario: PWA install row hidden on iOS Safari
+
+- **WHEN** the PostSignupDialog is displayed
+- **AND** `PwaInstallService.browserSupportsPwa` is `false` (browser lacks `BeforeInstallPromptEvent`, i.e. iOS Safari)
+- **THEN** the PWA install row SHALL NOT be shown in the dialog
+- **AND** the persistent `pwa-install-banner` provides the iOS install path instead
+
+#### Scenario: Dialog dismissed
+
+- **WHEN** the user taps the dismiss button
+- **THEN** the PostSignupDialog SHALL close
+- **AND** the notification prompt SHALL NOT be shown again in the same session (coordinated via `IPromptCoordinator`)
+- **AND** the `pwa-install-banner` SHALL become visible (it is not suppressed by PostSignupDialog dismissal)

--- a/openspec/changes/promote-pwa-install-with-banner/specs/prompt-timing/spec.md
+++ b/openspec/changes/promote-pwa-install-with-banner/specs/prompt-timing/spec.md
@@ -1,0 +1,91 @@
+## MODIFIED Requirements
+
+### Requirement: PWA Install Prompt Blocked During Onboarding
+
+The system SHALL NOT display the `pwa-install-banner` while the user is in active onboarding steps (DISCOVERY, DASHBOARD, MY_ARTISTS).
+
+#### Scenario: User is mid-tutorial on the dashboard
+
+- **WHEN** the user is at onboarding step DASHBOARD
+- **AND** the browser fires the `beforeinstallprompt` event
+- **THEN** the system SHALL capture the event
+- **AND** the system SHALL NOT display the `pwa-install-banner`
+- **AND** `PwaInstallService.canShowFab` SHALL remain `false`
+
+#### Scenario: User has not started onboarding (LP step)
+
+- **WHEN** the user is at onboarding step LP
+- **AND** the browser fires the `beforeinstallprompt` event
+- **THEN** the system SHALL NOT display the `pwa-install-banner`
+
+---
+
+### Requirement: Notification Prompt Priority Over Disruptive PWA Prompts
+
+The notification prompt SHALL have higher priority than any disruptive PWA install prompt. The `pwa-install-banner` is passive UI and is not subject to this constraint — it SHALL remain visible regardless of whether the notification prompt is shown.
+
+#### Scenario: Both prompts eligible (first or later post-completion session)
+
+- **WHEN** the user has completed onboarding
+- **AND** notification permission is not yet granted
+- **AND** the notification prompt has not been dismissed
+- **AND** the `pwa-install-banner` is also eligible
+- **THEN** the system SHALL display the notification prompt
+- **AND** the `pwa-install-banner` SHALL remain visible (it is passive UI and does not compete with the notification prompt)
+
+#### Scenario: Notification prompt already dismissed
+
+- **WHEN** the user has previously dismissed the notification prompt
+- **AND** the `pwa-install-banner` is eligible
+- **THEN** the system SHALL display the `pwa-install-banner`
+
+---
+
+### Requirement: PWA Install Banner Eligible After Onboarding Completion
+
+The `pwa-install-banner` SHALL be eligible immediately after onboarding completion for authenticated users who have not installed the app.
+
+#### Scenario: First session after completion — authenticated user
+
+- **WHEN** the user has completed onboarding
+- **AND** the user IS authenticated
+- **AND** the app has not been installed
+- **THEN** the system SHALL display the `pwa-install-banner`
+
+#### Scenario: Guest user after onboarding — banner not shown
+
+- **WHEN** the user has completed onboarding
+- **AND** the user is NOT authenticated
+- **THEN** the system SHALL NOT display the `pwa-install-banner`
+
+#### Scenario: Completion within the same session
+
+- **WHEN** the user transitions to `OnboardingStep.COMPLETED` within the current session
+- **AND** the user is authenticated
+- **THEN** the banner SHALL become visible immediately in that same session
+
+---
+
+### Requirement: Dismissed Prompts Do Not Reappear
+
+When the user dismisses the notification prompt, the system SHALL persist the dismissal and SHALL NOT show that prompt again. The `pwa-install-banner` supports session-level dismiss: tapping the close button suppresses the banner for the current session only, and it reappears in subsequent sessions until the app is installed.
+
+#### Scenario: User dismisses notification prompt
+
+- **WHEN** the user taps the dismiss control on the notification prompt
+- **THEN** the system SHALL write the dismissal to `localStorage`
+- **AND** the notification prompt SHALL NOT appear on subsequent sessions
+
+#### Scenario: User dismisses pwa-install-banner (session-level)
+
+- **WHEN** the user taps the close button on the `pwa-install-banner`
+- **THEN** the banner SHALL be hidden for the remainder of the current session
+- **AND** the dismiss state SHALL be stored in `sessionStorage` only (NOT `localStorage`)
+- **AND** the banner SHALL reappear on the next session if the app has not been installed
+
+#### Scenario: Session dismiss is not permanent suppression
+
+- **WHEN** the user has dismissed the `pwa-install-banner` in a previous session
+- **AND** a new session begins
+- **AND** the app has not been installed
+- **THEN** the banner SHALL be shown again (session storage is cleared on new session)

--- a/openspec/changes/promote-pwa-install-with-banner/specs/pwa-install-banner/spec.md
+++ b/openspec/changes/promote-pwa-install-with-banner/specs/pwa-install-banner/spec.md
@@ -1,0 +1,237 @@
+## Purpose
+
+Defines a persistent full-width banner that promotes PWA installation to signed-in users, replacing the floating action button. The banner covers both native one-tap install (Chrome/Edge) and manual guided install (iOS Safari), and persists across sessions with a per-session dismiss until the app is installed.
+
+## ADDED Requirements
+
+### Requirement: Banner Visible to Authenticated Non-Installed Users After Onboarding
+
+The system SHALL display the `pwa-install-banner` to authenticated users who have not installed the PWA, once onboarding is completed. The banner SHALL NOT be shown to unauthenticated (guest) users.
+
+#### Scenario: Authenticated user has not installed the PWA
+
+- **WHEN** the user is authenticated
+- **AND** onboarding is completed (`OnboardingStep.COMPLETED`)
+- **AND** the app has not been installed (`PwaInstallService.shouldShowInstallBanner` is `true`)
+- **AND** the session-dismiss flag is NOT set in `sessionStorage`
+- **THEN** the system SHALL display the `pwa-install-banner`
+
+#### Scenario: Guest user is not shown the banner
+
+- **WHEN** the user is NOT authenticated
+- **THEN** the system SHALL NOT display the `pwa-install-banner`
+
+#### Scenario: App already installed — banner not shown
+
+- **WHEN** the app has been installed (detected via `localStorage['pwa.installed']`, `navigator.standalone === true`, or `display-mode: standalone`)
+- **THEN** `PwaInstallService.shouldShowInstallBanner` SHALL be `false`
+- **AND** the system SHALL NOT display the `pwa-install-banner`
+
+#### Scenario: Banner not shown during onboarding
+
+- **WHEN** the user is in active onboarding steps (DISCOVERY, DASHBOARD, MY_ARTISTS)
+- **THEN** the system SHALL NOT display the `pwa-install-banner`
+
+---
+
+### Requirement: Banner CTA Install Flow by Platform
+
+The banner SHALL trigger the appropriate install action based on platform and available deferred prompt.
+
+#### Scenario: Native one-tap install (Chrome/Edge with deferred prompt)
+
+- **WHEN** the user taps the CTA button
+- **AND** `PwaInstallService.canShowFab` is `true` (deferred prompt captured, not iOS)
+- **THEN** the system SHALL call `deferredPrompt.prompt()`
+- **AND** the native browser install dialog SHALL appear
+
+#### Scenario: Guide sheet (iOS Safari or no deferred prompt)
+
+- **WHEN** the user taps the CTA button
+- **AND** `PwaInstallService.canShowFab` is `false` (iOS Safari or deferred prompt not yet captured)
+- **THEN** the system SHALL open a bottom sheet containing step-by-step install instructions
+
+#### Scenario: iOS guide sheet content
+
+- **WHEN** the guide sheet is shown
+- **AND** the platform is iOS (`PwaInstallService.isIos` is `true`)
+- **THEN** the sheet SHALL display:
+  1. Safari の共有ボタン（□↑）をタップ
+  2. 「ホーム画面に追加」を選択
+  3. 「追加」をタップ
+
+#### Scenario: Chrome guide sheet content
+
+- **WHEN** the guide sheet is shown
+- **AND** the platform is NOT iOS
+- **THEN** the sheet SHALL display:
+  1. ブラウザのメニュー（⋮）をタップ
+  2. 「ホーム画面に追加」を選択
+  3. 「追加」をタップ
+
+#### Scenario: Manual confirm from guide sheet
+
+- **WHEN** the user taps the "追加しました" button in the guide sheet
+- **THEN** the system SHALL call `PwaInstallService.confirmInstalled()`
+- **AND** the guide sheet SHALL close
+- **AND** the banner SHALL be permanently removed
+
+#### Scenario: CTA mode upgrades reactively when deferred prompt arrives
+
+- **WHEN** the banner is visible in guide mode
+- **AND** the browser fires `beforeinstallprompt` (deferred prompt arrives)
+- **THEN** `PwaInstallService.canShowFab` becomes `true`
+- **AND** the banner CTA SHALL reactively switch to native one-tap mode without a page reload
+
+---
+
+### Requirement: Banner Disappears Permanently After Installation
+
+The system SHALL remove the banner permanently once the app is installed.
+
+#### Scenario: App installed via native dialog
+
+- **WHEN** the browser fires the `appinstalled` event
+- **THEN** `PwaInstallService.shouldShowInstallBanner` SHALL become `false`
+- **AND** the banner SHALL be removed from the DOM
+- **AND** the banner SHALL NOT reappear in subsequent sessions
+
+#### Scenario: App installed confirmed manually (iOS)
+
+- **WHEN** `PwaInstallService.confirmInstalled()` is called
+- **THEN** `PwaInstallService.shouldShowInstallBanner` SHALL become `false`
+- **AND** the banner SHALL be removed from the DOM
+- **AND** the banner SHALL NOT reappear in subsequent sessions
+
+---
+
+### Requirement: Session-Level Dismiss
+
+The banner SHALL support a per-session dismiss that suppresses the banner until the next session.
+
+#### Scenario: User taps the close button
+
+- **WHEN** the banner is visible
+- **AND** the user taps the close button (`×`)
+- **THEN** the banner SHALL be hidden for the remainder of the session
+- **AND** the dismiss state SHALL be persisted in `sessionStorage`
+
+#### Scenario: Banner reappears on next session
+
+- **WHEN** the user dismissed the banner in a previous session
+- **AND** the user starts a new session (page load / new tab)
+- **AND** the app has NOT been installed
+- **THEN** the session-dismiss state SHALL be cleared
+- **AND** the banner SHALL be displayed again
+
+#### Scenario: Session dismiss is NOT a permanent suppression
+
+- **WHEN** the user has dismissed the banner via the close button
+- **THEN** the banner dismissal SHALL NOT be persisted in `localStorage`
+- **AND** the system SHALL NOT treat this as a permanent "user declined to install" signal
+
+---
+
+### Requirement: Banner Suppressed While PostSignupDialog Is Open
+
+The banner SHALL NOT be visible while the `PostSignupDialog` is open to avoid visual conflict at the bottom of the screen.
+
+#### Scenario: PostSignupDialog open — banner hidden
+
+- **WHEN** the `PostSignupDialog` is open
+- **THEN** the system SHALL suppress the `pwa-install-banner`
+- **AND** the banner SHALL NOT be rendered in the DOM
+
+#### Scenario: PostSignupDialog closed — banner visible
+
+- **WHEN** the `PostSignupDialog` is closed (user taps Later/Close)
+- **AND** `PwaInstallService.shouldShowInstallBanner` is `true`
+- **AND** session-dismiss flag is NOT set
+- **THEN** the banner SHALL be rendered
+
+---
+
+### Requirement: Banner Visual Presentation
+
+The `pwa-install-banner` SHALL use the same visual design language as `signup-prompt-banner`.
+
+#### Scenario: Banner is fixed at the bottom above the nav bar
+
+- **WHEN** the banner is visible
+- **THEN** the banner SHALL be positioned fixed at `inset-block-end: calc(3.5rem + env(safe-area-inset-bottom, 0px))`
+- **AND** the banner SHALL span the full inline width of the screen (`inset-inline: 0`)
+
+#### Scenario: Banner frosted glass and gradient border
+
+- **WHEN** the banner is rendered
+- **THEN** the background SHALL use a frosted glass surface (dark base at ~85% opacity with `backdrop-filter: blur`)
+- **AND** the top border SHALL be a 2px gradient from `--color-brand-primary` to `--color-brand-secondary`
+
+#### Scenario: CTA button glow pulse animation
+
+- **WHEN** the banner is rendered
+- **AND** `prefers-reduced-motion` is not set to `reduce`
+- **THEN** the CTA button SHALL display a continuous glow pulse animation using `--color-brand-primary` cycling every 2.5 seconds
+
+#### Scenario: Reduced motion — no animation
+
+- **WHEN** `prefers-reduced-motion: reduce` is set
+- **THEN** the CTA button glow animation SHALL be suppressed
+- **AND** the banner SHALL appear without a slide-up animation
+
+#### Scenario: Banner slides in on appearance
+
+- **WHEN** the banner becomes visible
+- **AND** `prefers-reduced-motion` is not set to `reduce`
+- **THEN** the banner SHALL animate in with a slide-up from below over 400ms
+
+---
+
+### Requirement: Banner Accessibility
+
+The banner SHALL be accessible to keyboard and assistive technology users.
+
+#### Scenario: Banner element has an accessible label
+
+- **WHEN** the banner is rendered
+- **THEN** the root `<aside>` element SHALL have an `aria-label` identifying it as the install prompt
+
+#### Scenario: Close button has an accessible name
+
+- **WHEN** the close button is rendered
+- **THEN** it SHALL have an `aria-label` (e.g., "閉じる") so assistive technology announces its purpose
+
+#### Scenario: Banner is removed from DOM when hidden
+
+- **WHEN** the banner is not visible (session-dismissed, installed, or PostSignupDialog open)
+- **THEN** the banner element SHALL be removed from the DOM (`if.bind`, not `show.bind`)
+- **AND** neither the CTA button nor the close button SHALL be reachable via keyboard navigation
+
+---
+
+### Requirement: PwaInstallService Banner Visibility API
+
+`PwaInstallService` SHALL expose a reactive property and a method to support the banner's lifecycle.
+
+#### Scenario: shouldShowInstallBanner is true for Chrome/Edge non-installed users
+
+- **WHEN** `PwaInstallService.browserSupportsPwa` is `true`
+- **AND** the app has not been installed
+- **THEN** `PwaInstallService.shouldShowInstallBanner` SHALL be `true`
+
+#### Scenario: shouldShowInstallBanner is true for iOS non-installed users
+
+- **WHEN** `PwaInstallService.isIos` is `true`
+- **AND** the app has not been installed
+- **THEN** `PwaInstallService.shouldShowInstallBanner` SHALL be `true`
+
+#### Scenario: shouldShowInstallBanner becomes false on appinstalled
+
+- **WHEN** the browser fires the `appinstalled` event
+- **THEN** `PwaInstallService.shouldShowInstallBanner` SHALL reactively update to `false`
+
+#### Scenario: confirmInstalled marks the app as installed
+
+- **WHEN** `PwaInstallService.confirmInstalled()` is called
+- **THEN** the service SHALL persist `localStorage['pwa.installed'] = 'true'`
+- **AND** `PwaInstallService.shouldShowInstallBanner` SHALL become `false`

--- a/openspec/changes/promote-pwa-install-with-banner/specs/pwa-install-fab/spec.md
+++ b/openspec/changes/promote-pwa-install-with-banner/specs/pwa-install-fab/spec.md
@@ -1,0 +1,36 @@
+## REMOVED Requirements
+
+### Requirement: FAB Visible After Onboarding Completion
+
+**Reason**: Replaced by `pwa-install-banner`, which provides greater visual prominence and includes iOS in a unified banner component.
+**Migration**: Users are shown `pwa-install-banner` instead. See `pwa-install-banner` capability spec.
+
+### Requirement: FAB Install Behavior by Platform
+
+**Reason**: Install flow by platform is now handled by `pwa-install-banner` (native CTA mode and guide sheet mode).
+**Migration**: See `pwa-install-banner` — Requirement: Banner CTA Install Flow by Platform.
+
+### Requirement: FAB Disappears After Installation
+
+**Reason**: Permanent removal after installation is now handled by `pwa-install-banner`.
+**Migration**: See `pwa-install-banner` — Requirement: Banner Disappears Permanently After Installation.
+
+### Requirement: FAB Entry Animation
+
+**Reason**: Animation is replaced by the `pwa-install-banner` slide-up and pulsing CTA button.
+**Migration**: See `pwa-install-banner` — Requirement: Banner Visual Presentation.
+
+### Requirement: FAB Icon Size
+
+**Reason**: FAB component is deleted; no equivalent in the banner component.
+**Migration**: Not applicable.
+
+### Requirement: FAB Accessibility State
+
+**Reason**: Accessibility is now handled by `pwa-install-banner`.
+**Migration**: See `pwa-install-banner` — Requirement: Banner Accessibility.
+
+### Requirement: FAB Position When signup-prompt-banner Is Visible
+
+**Reason**: The FAB coexistence layout with `signup-prompt-banner` is no longer needed. `pwa-install-banner` is shown only to authenticated users; `signup-prompt-banner` is shown only to guests — the two banners are mutually exclusive by user state.
+**Migration**: Not applicable.

--- a/openspec/changes/promote-pwa-install-with-banner/tasks.md
+++ b/openspec/changes/promote-pwa-install-with-banner/tasks.md
@@ -1,0 +1,77 @@
+## 1. PwaInstallService — Extend API
+
+- [ ] 1.1 Add `@observable public shouldShowInstallBanner = false` property to `PwaInstallService`
+- [ ] 1.2 Add `private updateBannerVisibility()` helper that sets `shouldShowInstallBanner = !this.installed && (this.browserSupportsPwa || this.isIos)`
+- [ ] 1.3 Call `updateBannerVisibility()` in `evaluateVisibility()` (after the existing `canShowFab` update)
+- [ ] 1.4 Call `shouldShowInstallBanner = false` in `listenForAppInstalled()` handler (alongside existing `canShowFab = false`)
+- [ ] 1.5 Add `public confirmInstalled()` method: set `this.installed = true`, write `localStorage['pwa.installed'] = 'true'`, set `this.canShowFab = false`, set `this.shouldShowInstallBanner = false`
+- [ ] 1.6 Update `PwaInstallService` unit tests (`pwa-install-service.spec.ts`) to cover `shouldShowInstallBanner` reactive updates and `confirmInstalled()`
+
+## 2. pwa-install-banner Component — Scaffold
+
+- [ ] 2.1 Create `src/components/pwa-install-banner/pwa-install-banner.ts` (Aurelia 2 convention-based component)
+- [ ] 2.2 Create `src/components/pwa-install-banner/pwa-install-banner.html` (template)
+- [ ] 2.3 Create `src/components/pwa-install-banner/pwa-install-banner.css` (`@layer block { @scope (pwa-install-banner) { ... } }`)
+
+## 3. pwa-install-banner Component — ViewModel
+
+- [ ] 3.1 Inject `IPwaInstallService` via `resolve()`; read `shouldShowInstallBanner`, `canShowFab`, `isIos`
+- [ ] 3.2 Add `@observable dismissed = false`; read initial value from `sessionStorage` in `binding()` lifecycle hook
+- [ ] 3.3 Add `@watch((vm) => vm.pwaInstall.canShowFab)` watcher to reactively sync `installMode` (`'native' | 'guide'`) — same pattern as `PostSignupDialog.canShowFabChanged()`
+- [ ] 3.4 Add `dismiss()` method: set `this.dismissed = true` and write to `sessionStorage`
+- [ ] 3.5 Add `onInstall()` method: call `pwaInstall.install()` when in native mode (use `busy-on-click`)
+- [ ] 3.6 Add `isGuideSheetOpen = false` property; guide sheet opens when CTA is tapped in guide mode
+- [ ] 3.7 Add `onConfirmInstalled()` method: call `pwaInstall.confirmInstalled()`, close guide sheet
+- [ ] 3.8 Expose `get isVisible(): boolean` = `pwaInstall.shouldShowInstallBanner && !dismissed` (used by host for `if.bind`)
+
+## 4. pwa-install-banner Component — Template
+
+- [ ] 4.1 Root `<aside>` with `if.bind="isVisible"` and `aria-label` bound to i18n key
+- [ ] 4.2 Label paragraph bound to `pwaInstallBanner.label` i18n key
+- [ ] 4.3 CTA `<button>` with `busy-on-click.bind="() => onCta()"` and label `pwaInstallBanner.cta`; `onCta()` calls `onInstall()` in native mode or opens guide sheet in guide mode
+- [ ] 4.4 Close `<button>` with `click.trigger="dismiss()"`, `aria-label` bound to `pwaInstallBanner.close` i18n key
+- [ ] 4.5 `<bottom-sheet>` for guide sheet: `open.bind="isGuideSheetOpen"`, `sheet-closed.trigger="isGuideSheetOpen = false"`; contains platform-appropriate step list and a "追加しました" confirm button
+
+## 5. pwa-install-banner Component — CSS
+
+- [ ] 5.1 Fixed position: `inset-block-end: calc(3.5rem + env(safe-area-inset-bottom, 0px))`, `inset-inline: 0`
+- [ ] 5.2 Frosted glass background: `oklch(18% 0.04 275deg / 85%)` + `backdrop-filter: blur(12px)`
+- [ ] 5.3 Gradient top border: `border-block-start: 2px solid; border-image: linear-gradient(to right, var(--color-brand-primary), var(--color-brand-secondary)) 1`
+- [ ] 5.4 Slide-up entrance animation (400ms ease-out, `translateY(100%) → translateY(0)`) under `@media (prefers-reduced-motion: no-preference)`
+- [ ] 5.5 CTA button pulsing glow (`cta-glow` keyframes, 2.5s ease-in-out infinite) under `@media (prefers-reduced-motion: no-preference)`
+- [ ] 5.6 Close button: subtle icon or text, positioned in top-right corner with adequate touch target (min 44px)
+
+## 6. i18n Keys
+
+- [ ] 6.1 Add `pwaInstallBanner.*` keys to `src/locales/en/translation.json`: `label`, `cta`, `close`, `guideTitle`, `guideStep1`, `guideStep2`, `guideStep3`, `guideConfirm`
+- [ ] 6.2 Add `pwaInstallBanner.*` keys to `src/locales/ja/translation.json` with Japanese text
+- [ ] 6.3 iOS-specific guide step keys (Share button → ホーム画面に追加 flow) for `ja` locale
+- [ ] 6.4 Chrome-specific guide step keys (⋮ menu → ホーム画面に追加 flow) for `ja` locale; ensure EN parity
+
+## 7. App Shell — Swap Component
+
+- [ ] 7.1 Remove `<import from="./components/pwa-install-fab/pwa-install-fab">` from `app-shell.html`
+- [ ] 7.2 Add `<import from="./components/pwa-install-banner/pwa-install-banner">` to `app-shell.html`
+- [ ] 7.3 Replace `<pwa-install-fab if.bind="showNav">` with `<pwa-install-banner if.bind="showNav && isAuthenticated">` (auth gate per D5 in design)
+- [ ] 7.4 Suppress banner while PostSignupDialog is open: pass or derive a suppression condition so the banner is hidden when `showPostSignupDialog` is `true` (e.g., `if.bind="showNav && isAuthenticated && !showPostSignupDialog"`)
+
+## 8. Delete pwa-install-fab Component
+
+- [ ] 8.1 Delete `src/components/pwa-install-fab/pwa-install-fab.ts`
+- [ ] 8.2 Delete `src/components/pwa-install-fab/pwa-install-fab.html`
+- [ ] 8.3 Delete `src/components/pwa-install-fab/pwa-install-fab.css`
+- [ ] 8.4 Delete `src/components/pwa-install-fab/pwa-install-fab.spec.ts`
+- [ ] 8.5 Search codebase for any remaining `pwa-install-fab` references and remove them
+
+## 9. Tests
+
+- [ ] 9.1 Write unit tests for `pwa-install-banner` VM: session dismiss initialisation in `binding()`, `dismiss()` writes to `sessionStorage`, `isVisible` computed correctly, `@watch` on `canShowFab` switches `installMode`
+- [ ] 9.2 Test `confirmInstalled()` path: guide sheet confirm → `pwaInstall.confirmInstalled()` called → `isGuideSheetOpen` closes
+- [ ] 9.3 Verify `make check` passes (TypeScript, CSS lint, unit tests)
+
+## 10. Ship to Prod
+
+- [ ] 10.1 Open frontend PR, confirm CI green
+- [ ] 10.2 Merge PR and create GitHub Release (`vX.Y.Z`) to trigger prod deploy
+- [ ] 10.3 Verify in prod: banner appears on a signed-in, non-installed Chrome session; native install dialog triggers; banner disappears after install
+- [ ] 10.4 Verify in prod: iOS Safari session shows banner with guide sheet; "追加しました" closes banner


### PR DESCRIPTION
## Summary

Replace the PWA install FAB with a persistent `pwa-install-banner` that uses the same visual language as `signup-prompt-banner`. The banner covers both Chrome/Edge (native one-tap install) and iOS Safari (guided manual steps), and persists across sessions with per-session dismiss until the app is installed.

This is a planning-only PR — all artifacts for the `promote-pwa-install-with-banner` OpenSpec change.

## Changes

- **New capability spec**: `pwa-install-banner` — visibility predicate, two CTA modes (native/guide), session-level dismiss, PostSignupDialog suppression, accessibility, iOS `confirmInstalled()` flow
- **Modified spec**: `pwa-install-fab` — all requirements REMOVED (superseded by `pwa-install-banner`)
- **Modified spec**: `prompt-timing` — session dismiss clarification, banner's passive-UI classification, auth gate
- **Modified spec**: `post-signup-dialog` — iOS install path reference updated from FAB to `pwa-install-banner`
- **design.md**: 7 key decisions (D1–D7) with rationale — `@observable` vs getter, `if.bind` vs `show.bind`, `sessionStorage` vs `localStorage`, auth gate, `confirmInstalled()` for iOS
- **tasks.md**: 36 tasks across 10 phases (service extension → component → CSS → i18n → shell swap → FAB deletion → tests → prod verification)

## Testing

- [ ] `openspec validate --change promote-pwa-install-with-banner` passes in CI

## Links

Closes: liverty-music/frontend#544
