### PR TITLE
docs(spec): update artist-discovery-dna-orb-ui for bubble cap and fade

### DIFF
--- a/openspec/changes/tune-small-screen-responsive-layout/specs/artist-discovery-dna-orb-ui/spec.md
+++ b/openspec/changes/tune-small-screen-responsive-layout/specs/artist-discovery-dna-orb-ui/spec.md
@@ -6,6 +6,7 @@ On narrow canvases (width < 390px), the system SHALL limit the number of simulta
 #### Scenario: Bubble count is capped on narrow screens
 - **WHEN** the Discovery canvas width is less than 390px
 - **THEN** the number of artist bubbles simultaneously rendered in the physics layer SHALL NOT exceed 30
+- **AND** this cap SHALL apply both on initial render and when the bubble set is reconciled after the user follows an artist
 - **AND** bubble size SHALL remain unchanged to preserve label readability
 
 #### Scenario: Bubble count is uncapped on wider screens
@@ -19,3 +20,7 @@ On narrow canvases (width < 390px), the system SHALL limit the number of simulta
 #### Scenario: DNA Orb radius follows follow-count on wider screens
 - **WHEN** the Discovery canvas width is 390px or greater
 - **THEN** the DNA Orb radius SHALL follow the existing follow-count-driven stage escalation (up to 90px)
+
+#### Scenario: Bubble area top edge fades gracefully
+- **WHEN** artist bubbles are rendered near the top boundary of the Discovery canvas
+- **THEN** the bubble area SHALL apply a fade-out at its top edge so that bubbles dissolve toward the genre-chip bar rather than being hard-clipped at the boundary

--- a/openspec/specs/artist-discovery-dna-orb-ui/spec.md
+++ b/openspec/specs/artist-discovery-dna-orb-ui/spec.md
@@ -237,6 +237,7 @@ On narrow canvases (width < 390px), the system SHALL limit the number of simulta
 #### Scenario: Bubble count is capped on narrow screens
 - **WHEN** the Discovery canvas width is less than 390px
 - **THEN** the number of artist bubbles simultaneously rendered in the physics layer SHALL NOT exceed 30
+- **AND** this cap SHALL apply both on initial render and when the bubble set is reconciled after the user follows an artist
 - **AND** bubble size SHALL remain unchanged to preserve label readability
 
 #### Scenario: Bubble count is uncapped on wider screens
@@ -250,6 +251,10 @@ On narrow canvases (width < 390px), the system SHALL limit the number of simulta
 #### Scenario: DNA Orb radius follows follow-count on wider screens
 - **WHEN** the Discovery canvas width is 390px or greater
 - **THEN** the DNA Orb radius SHALL follow the existing follow-count-driven stage escalation (up to 90px)
+
+#### Scenario: Bubble area top edge fades gracefully
+- **WHEN** artist bubbles are rendered near the top boundary of the Discovery canvas
+- **THEN** the bubble area SHALL apply a fade-out at its top edge so that bubbles dissolve toward the genre-chip bar rather than being hard-clipped at the boundary
 
 ---
 


### PR DESCRIPTION
## Summary

Update the `artist-discovery-dna-orb-ui` spec and delta spec to reflect two bug fixes shipped in frontend v1.55.3.

## Changes

**`openspec/specs/artist-discovery-dna-orb-ui/spec.md`** (main spec):
- "Bubble count is capped on narrow screens" scenario: added AND clause clarifying the cap applies both on initial render and after following an artist (reconcile path)
- New scenario: "Bubble area top edge fades gracefully" — the bubble area SHALL apply a top-edge fade so bubbles dissolve toward the genre-chip bar rather than being hard-clipped

**`openspec/changes/tune-small-screen-responsive-layout/specs/artist-discovery-dna-orb-ui/spec.md`** (delta spec):
- Same additions to keep delta in sync with implementation

## Related

- Frontend: liverty-music/frontend v1.55.3 (PR #546)

close: #836
