### PR TITLE
docs(openspec): propose enrich-welcome-landing-page

### DIFF
--- a/openspec/changes/enrich-welcome-landing-page/.openspec.yaml
+++ b/openspec/changes/enrich-welcome-landing-page/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-21

--- a/openspec/changes/enrich-welcome-landing-page/design.md
+++ b/openspec/changes/enrich-welcome-landing-page/design.md
@@ -1,0 +1,69 @@
+## Context
+
+See proposal.md — Why. Current state (verified against `frontend/src/routes/welcome/`):
+
+- The Welcome page is a two-screen `scroll-snap-type: y proximity` layout: Screen 1 (hero, `100svh`) and Screen 2 (`100svh`) holding the read-only `concert-highway` preview plus the CTA footer.
+- The hero already implements the "message-first" two-layer CTA: with preview data, Screen 1 shows only the scroll-affordance (`welcome.hero.seePreview` = `サンプルを覗く`) and the language switcher; the commit CTAs (`Get Started` / `Log In`) live only in Screen 2's footer. Without preview data (`dateGroups.length === 0`) the commit CTAs fall back inline to the hero.
+- Preview data comes from `ConcertStore.listByArtists(previewArtistIds, 'JP', 'JP-13', …)` where `previewArtistIds`/`previewArtistNames` are curated in runtime `config.json`. Preview renders only when at least `PREVIEW_MIN_ARTISTS_WITH_CONCERTS` (5) curated artists resolve concerts; otherwise it silently degrades to the no-preview fallback. Preview concerts use synthetic `hype: 'watch'` on purpose to get the softer "unmatched" faded-poster treatment.
+- The only motion today is `animation: fade-in 600ms ease-out both` on the hero, already disabled under `prefers-reduced-motion`.
+- `event-detail-sheet` renders concert detail inside a `bottom-sheet` and already surfaces official-info (`sourceUrl`), merch (`merchUrl`, gated by `hasMerchUrl`), venue + Google Maps, and calendar. Its ticket-journey block is gated by `isAuthenticated`, so it is naturally hidden for the anonymous visitor.
+- Styling follows CUBE CSS (`@layer` / `@scope`) with design tokens (`--step-*`, `--space-*`) and a "festival-spotlight glow" brand vocabulary (brand-accent `text-shadow`) already used by the hero and event cards.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Show all three real value pillars through the product's own UI, in a continuous scroll narrative with entrance-only reveal motion.
+- Keep the hero byte-for-byte behaviorally identical (copy, glow, language switcher, scroll-affordance label, two-layer CTA, fallback).
+- Reuse existing components (`concert-highway`, the `event-detail-sheet` content) rather than adding illustrations or device chrome.
+- Keep motion cheap and calm: entrance-only reveals + one-shot (Lv2) arrival motions, never continuous loops.
+
+**Non-Goals:**
+- No changes to the preview data source, the curated-artist mechanism, or the `PREVIEW_MIN_ARTISTS_WITH_CONCERTS` threshold.
+- No phone-frame device chrome, no stats/trust numbers, no social proof.
+- No new capabilities advertised beyond the three existing pillars.
+- No backend/proto/RPC/BSR work — frontend only.
+
+## Decisions
+
+### D1. Continuous scroll narrative, hero keeps its snap
+
+Replace the rigid two-`100svh`-snap model with: hero stays `100svh` and keeps `scroll-snap-align: start`; the value sections below flow in a continuous column with a consistent vertical rhythm (feather-like breathing room via `--space-*`). Rationale: three pillars cannot be told in two hard-snapped screens; a narrative needs room. Alternative considered — keep snapping every section — rejected: hard snap fights storytelling and makes reveal timing feel abrupt.
+
+### D2. Scroll-reveal via a shared `IntersectionObserver` utility
+
+A single reveal mechanism observes each value section and toggles a "revealed" state on first entry; CSS drives the entrance-only fade + short upward slide. It honors `prefers-reduced-motion` by rendering the final state immediately (no observer-driven animation, or the CSS transition is nulled). Rationale: one source of truth for reveal, no per-section bespoke JS, cheap for INP. Alternative — CSS `animation-timeline: view()` (scroll-driven CSS) — attractive but browser support/consistency is still uneven for a launch LP; keep it as a possible later simplification. **Content must be in the DOM and reachable even if the observer never fires** (spec: "Content is present without motion").
+
+### D3. Reuse the event-detail-sheet content as a read-only embed (§3)
+
+Extract the sheet's inner content (`sheet-content`: hero image, artist header, detail rows, official/merch/calendar footer) so it can render outside `bottom-sheet` in a static, read-only card on the LP. The ticket-journey `isAuthenticated` gate keeps auth-only controls hidden for the anonymous visitor with no extra logic. Rationale: the real detail UI *is* the feature demo; extracting the content view also makes it reusable beyond the LP. Alternative — render the whole `bottom-sheet` "open and pinned" — rejected: couples the LP to sheet/backdrop/dismiss behavior and fights the page's scroll.
+
+### D4. Motion levels — Lv2 one-shot arrival for §3 and §4
+
+- §3 (ticket/goods): the detail card **rises once** into place on section entry.
+- §4 (notification): a **new mock notification card** **drops in** with a single brief bell nudge on entry.
+
+Both are one-shot on first reveal, layered on top of the D2 reveal, and disabled under reduced motion. Rationale: arrival motion reads as refined and "alive" without the INP/perf cost and visual noise of continuous (Lv3) loops. Alternative — Lv3 looping demos (feather-style tap→open loop, rotating notifications) — deferred; can be revisited after seeing Lv2 in the localhost check.
+
+### D5. Notification section content is a mock card, not a live push (§4)
+
+Real OS push cannot render inside a page, so §4 uses a purpose-built mock card styled to read as a Liverty new-concert alert (bell, brand, sample artist line). Rationale: honestly represents the value without faking system UI. Copy is added to `translation.json` (JA/EN); no new capability is implied.
+
+### D6. Commit-CTA placement preserved via a final CTA section
+
+The commit CTAs remain after the value content in a final CTA section (the role Screen 2's footer plays today), preserving the two-layer intent from `Passkey Authentication CTA` (CTAs never on the hero when preview exists). The no-preview fallback (inline hero CTAs) is untouched.
+
+### D7. Hero is untouched
+
+No edits to hero markup/copy/CSS beyond what D1 requires structurally (the scroll target is now the first value section rather than a single Screen 2). `welcome.hero.*` keys, including `seePreview` (`サンプルを覗く`), are unchanged.
+
+## Risks / Trade-offs
+
+- **Preview data can be empty** (fewer than 5 curated artists resolve concerts) → the whole value-section stack is preview-dependent. Mitigation: preserve the existing no-preview fallback (inline hero CTAs, no scroll-affordance); §3/§4 render only within the value-section stack, so they disappear together with §2 in the fallback — the page never shows a half-built narrative. The localhost check must exercise both the data-present and data-absent paths.
+- **Reveal motion hiding content if JS/observer fails** → Mitigation: author CSS so the un-revealed state is still readable (e.g., start near-final, or apply the "hidden" pre-state only when a `js-enabled`/observer-ready flag is set), and always render content in the DOM. Verified by the "Content is present without motion" scenario.
+- **INP/scroll jank on mobile** from observers + motion → Mitigation: one shared observer, `transform`/`opacity`-only animations, one-shot (not looping) arrivals, unobserve after first reveal.
+- **Extracting `sheet-content` could regress the real sheet** → Mitigation: extract into a shared content view consumed by both the sheet and the LP; keep the sheet's existing tests green.
+- **Longer page = more to keep responsive** → Mitigation: reuse existing tokens/spacing; verify mobile width in the localhost check (no phone frame means UI renders at native/full-bleed size).
+
+## Open Questions
+
+- Whether to later upgrade §3/§4 to Lv3 looping demos, or adopt scroll-driven CSS (`animation-timeline: view()`) once support is comfortable. Deferring these does not change the specs, the approach, or the task breakdown.

--- a/openspec/changes/enrich-welcome-landing-page/proposal.md
+++ b/openspec/changes/enrich-welcome-landing-page/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+The Welcome page (`/`) is the product's only landing page (LP), but today it demonstrates just one of the three core value pillars — the auto-collected concert timetable — and leaves the other two (ticket/goods info, new-concert push notifications) invisible. Its two-screen hard-snap layout and single hero fade-in read as a "static page" rather than a refined product, so a first-time visitor rarely feels what Liverty Music actually does before deciding to leave. This change turns the Welcome page into a value-communicating LP that shows all three real capabilities through the product's own UI, with scroll-driven storytelling — following LP best practice and the motion/whitespace craft of references like feather.art.
+
+## What Changes
+
+- Convert the Welcome page from a two-screen hard-snap layout into a **continuous scrolling narrative** (hero stays full-viewport; subsequent sections flow) with **scroll-reveal** on section entry (`IntersectionObserver`, fade + slide-up), fully disabled under `prefers-reduced-motion`.
+- **Keep the hero screen unchanged**: brand glow, `title` / `subtitlePain` / `subtitleAction` copy, the emphasized-verb glow, the language switcher, and the existing scroll-affordance CTA (`サンプルを覗く` / `Peek at a sample`) all remain as-is.
+- Add a **timetable section** that reuses the existing read-only `concert-highway` preview (the concert auto-collection pillar) as a complete, composed frame — no cropped "half-peek".
+- Add a **ticket/goods section** that embeds the existing event detail view (from `event-detail-sheet`) in a read-only, non-sheet form, showing official-info (`sourceUrl`), merch (`merchUrl`), venue, and calendar affordances. The authenticated-only ticket-journey block naturally stays hidden for the anonymous visitor. It plays a **Lv2 arrival motion** (the detail card rises once on entry).
+- Add a **new-concert notification section** with a **new notification mock card** (real OS push cannot be shown inside a page), playing a **Lv2 arrival motion** (drop-in + a single bell nudge).
+- Preserve the existing **two-layer CTA structure**: the hero exposes only the soft scroll affordance; the commit CTAs (`Get Started` / `Log In`) remain after the value is communicated, at the final CTA section. The no-preview-data fallback (inline CTAs on the hero) is preserved.
+- Restrict shown capabilities to the **three that actually exist** (concert-info auto-collection, ticket/goods info, new-concert push). Do **not** introduce phone-frame device chrome, trust numbers/stats, or social proof (the service is pre-launch with no such material).
+
+## Capabilities
+
+### New Capabilities
+<!-- None. This change enriches an existing capability's presentation and behavior. -->
+
+### Modified Capabilities
+- `landing-page`: Add requirements for scroll-reveal storytelling behavior, the timetable value section, the ticket/goods value section (read-only embed of the event detail view), and the new-concert notification mock section with its arrival motion. The existing hero, two-layer CTA, scroll-affordance, guest-friendly copy, language switcher, and authenticated-redirect requirements are unchanged except where the added sections extend the scroll target and reveal behavior.
+
+## Impact
+
+- **Frontend only.** No proto/backend/RPC changes; no BSR gen. Uses the existing `ConcertStore.listByArtists` preview path and curated `previewArtistIds` from runtime `config.json`.
+- Affected code: `src/routes/welcome/` (`welcome-route.html` / `.css` / `.ts` / `.stories.ts`), locale files `src/locales/{ja,en}/translation.json` (new section copy; hero keys untouched).
+- Reused components: `concert-highway` (read-only), `event-detail-sheet` (its `sheet-content` extracted/embedded as a read-only view), `svg-icon`.
+- New component: a notification mock card for the notification section.
+- Motion utility: a shared scroll-reveal mechanism (`IntersectionObserver`) honoring `prefers-reduced-motion`; INP/perf kept in check by preferring Lv2 one-shot arrival motions over continuous loops.
+- Residual risk to resolve in design: the preview depends on live concert data for curated artists and can be empty — the page must degrade gracefully (existing fallback) and the added sections must not break when preview data is unavailable.

--- a/openspec/changes/enrich-welcome-landing-page/specs/landing-page/spec.md
+++ b/openspec/changes/enrich-welcome-landing-page/specs/landing-page/spec.md
@@ -1,0 +1,125 @@
+## ADDED Requirements
+
+### Requirement: Scroll-Reveal Storytelling
+
+When the dashboard preview is available and the landing page renders its value sections below the hero, the system SHALL present those sections as a continuous scrolling narrative and reveal each section's content on scroll entry. Reveal motion SHALL be entrance-only (fade with a short upward slide) and SHALL be fully disabled when the user prefers reduced motion. Content SHALL be fully readable and reachable regardless of whether reveal motion runs.
+
+#### Scenario: Sections reveal on scroll entry
+
+- **WHEN** an unauthenticated user scrolls the landing page and a value section enters the viewport
+- **THEN** the system SHALL animate that section's content into view with an entrance-only fade and short upward slide
+- **AND** each section SHALL reveal the first time it enters the viewport
+
+#### Scenario: Reduced motion disables reveal animation
+
+- **WHEN** the user has `prefers-reduced-motion: reduce` set in their environment
+- **THEN** the system SHALL render all sections in their final visible state without reveal animation
+- **AND** all section content SHALL remain fully readable and reachable
+
+#### Scenario: Content is present without motion
+
+- **WHEN** reveal motion does not run for any reason (reduced motion, or motion unsupported)
+- **THEN** every value section's content SHALL still be rendered and reachable in the document
+
+### Requirement: Timetable Value Section
+
+The landing page SHALL present the concert auto-collection value pillar as a timetable section that displays the read-only dashboard preview as a complete, composed frame. The section SHALL NOT present the preview as a cropped or half-obscured peek. This section is rendered only when preview data is available.
+
+#### Scenario: Timetable section shown with preview data
+
+- **WHEN** an unauthenticated user reaches the timetable section and preview data is available
+- **THEN** the system SHALL display the read-only concert timetable preview
+- **AND** the preview SHALL be presented as a complete composed frame, not a cropped peek
+- **AND** the section SHALL communicate that this timetable is auto-collected from the user's followed artists
+
+#### Scenario: Timetable section absent without preview data
+
+- **WHEN** preview data is unavailable
+- **THEN** the system SHALL NOT render the timetable section
+- **AND** the landing page SHALL fall back to the hero inline CTA behavior defined by `Passkey Authentication CTA`
+
+### Requirement: Ticket and Goods Value Section
+
+The landing page SHALL present the ticket and goods information value pillar as a section that shows the product's own concert detail view in a read-only form. The section SHALL surface the official-information link, the merchandise link, venue information, and the calendar affordance. Controls that require authentication (such as the ticket-journey tracker) SHALL NOT be shown to the anonymous visitor. On entry, the detail view SHALL play a single arrival motion; the motion SHALL be disabled under reduced-motion.
+
+#### Scenario: Ticket and goods detail shown read-only
+
+- **WHEN** an unauthenticated user reaches the ticket and goods section
+- **THEN** the system SHALL display the concert detail view in a read-only form
+- **AND** the view SHALL surface official-information, merchandise, venue, and calendar affordances
+- **AND** the system SHALL NOT display authentication-gated controls such as the ticket-journey tracker
+
+#### Scenario: Arrival motion on entry
+
+- **WHEN** the ticket and goods section enters the viewport and reduced motion is not preferred
+- **THEN** the system SHALL play a single arrival motion in which the detail view rises into place once
+- **WHEN** reduced motion is preferred
+- **THEN** the system SHALL render the detail view in its final state without arrival motion
+
+### Requirement: New-Concert Notification Value Section
+
+The landing page SHALL present the new-concert push notification value pillar as a section containing a mock notification card that represents an in-product new-concert alert, since a real operating-system push cannot be rendered inside the page. On entry, the mock card SHALL play a single arrival motion (a drop-in with a brief attention cue); the motion SHALL be disabled under reduced-motion.
+
+#### Scenario: Notification mock card communicates the push value
+
+- **WHEN** an unauthenticated user reaches the notification section
+- **THEN** the system SHALL display a mock notification card representing a new-concert alert
+- **AND** the card SHALL communicate that new concerts are delivered via push notification
+
+#### Scenario: Notification arrival motion on entry
+
+- **WHEN** the notification section enters the viewport and reduced motion is not preferred
+- **THEN** the system SHALL play a single arrival motion in which the card drops in with a brief attention cue
+- **WHEN** reduced motion is preferred
+- **THEN** the system SHALL render the card in its final state without arrival motion
+
+### Requirement: Landing Page Value Pillars Scope
+
+The landing page SHALL communicate only the product capabilities that currently exist: concert-information auto-collection, ticket and goods information, and new-concert push notifications. The landing page SHALL NOT advertise capabilities that are not currently offered, and SHALL NOT present device-frame chrome, usage statistics, or social-proof material as value signals.
+
+#### Scenario: Only existing capabilities are advertised
+
+- **WHEN** the landing page renders its value sections
+- **THEN** the system SHALL present only concert-information auto-collection, ticket and goods information, and new-concert push notifications
+- **AND** the system SHALL NOT present any capability that is not currently offered
+- **AND** the system SHALL NOT present usage statistics or social-proof material as value signals
+
+## MODIFIED Requirements
+
+### Requirement: Hero Screen Scroll Affordance
+
+The landing page Screen 1 SHALL provide a single, clearly labeled affordance that invites the user to reveal the value sections below, whenever those sections are rendered. This affordance SHALL be the only primary interactive control on Screen 1 (apart from the language switcher) when the value sections are present, preserving the "message-first" intent of the hero screen. When the value sections are not rendered (no preview data), the scroll-affordance SHALL NOT be displayed, because there is no target to scroll to — the inline CTA fallback takes its place (see `Passkey Authentication CTA`). The affordance label and behavior are unchanged from the prior single-preview-screen design.
+
+#### Scenario: Scroll affordance button is rendered when preview is available
+
+- **WHEN** an unauthenticated user visits `/` and views Screen 1, and preview data is available
+- **THEN** the system SHALL display a labeled scroll-affordance button within Screen 1
+- **AND** the button SHALL be rendered as a `<button>` element
+- **AND** the button SHALL have a minimum tap target of 44×44px
+- **AND** the button SHALL be focusable via keyboard navigation
+- **AND** the visible focus indicator SHALL be preserved under keyboard focus
+
+#### Scenario: Tapping the scroll affordance reveals the preview
+
+- **WHEN** the user taps or activates the scroll-affordance button
+- **THEN** the system SHALL scroll the viewport to the first value section below the hero
+- **AND** the scrolling SHALL use smooth-scroll animation by default
+
+#### Scenario: Reduced motion preference disables smooth scroll
+
+- **WHEN** the user has `prefers-reduced-motion: reduce` set in their environment
+- **AND** the user activates the scroll-affordance button
+- **THEN** the system SHALL jump directly to the first value section without a smooth-scroll animation
+
+#### Scenario: Scroll affordance hidden when preview data is unavailable
+
+- **WHEN** an unauthenticated user visits `/` and preview data is unavailable
+- **THEN** the system SHALL NOT render the scroll-affordance button
+- **AND** the hero Screen 1 SHALL instead render inline `[Get Started]` and `[Log In]` CTAs (see `Passkey Authentication CTA`)
+
+#### Scenario: Button label is localized
+
+- **WHEN** the landing page is rendered in Japanese
+- **THEN** the button label SHALL display the Japanese scroll-affordance label
+- **WHEN** the landing page is rendered in English
+- **THEN** the button label SHALL display the English scroll-affordance label

--- a/openspec/changes/enrich-welcome-landing-page/tasks.md
+++ b/openspec/changes/enrich-welcome-landing-page/tasks.md
@@ -1,0 +1,51 @@
+## 1. Scroll narrative + reveal foundation
+
+- [ ] 1.1 Convert `welcome-route` layout from two-`100svh`-snap to hero (`100svh`, keeps snap) + continuous value-section column with a consistent vertical rhythm (`--space-*`), preserving the hero markup/copy/CSS unchanged (D1, D7)
+- [ ] 1.2 Add a shared `IntersectionObserver`-based scroll-reveal utility that toggles a "revealed" state on first entry and unobserves after (D2)
+- [ ] 1.3 Author entrance-only reveal CSS (fade + short upward slide, `transform`/`opacity` only); ensure the un-revealed state keeps content readable/reachable if the observer never fires (spec: "Content is present without motion")
+- [ ] 1.4 Disable all reveal + arrival motion under `prefers-reduced-motion: reduce`, rendering final state immediately (reuse existing reduced-motion pattern)
+
+## 2. §2 Timetable value section
+
+- [ ] 2.1 Render the read-only `concert-highway` preview as a complete composed frame (no cropped half-peek), reusing the existing `dateGroups` preview path unchanged
+- [ ] 2.2 Add section copy communicating "auto-collected from your followed artists" to `translation.json` (JA/EN); do not touch `welcome.hero.*`
+- [ ] 2.3 Ensure the section renders only when preview data is available and disappears with the rest of the stack in the no-preview fallback
+
+## 3. §3 Ticket/goods value section
+
+- [ ] 3.1 Extract the `event-detail-sheet` inner content (`sheet-content`) into a shared read-only content view usable outside `bottom-sheet` (D3); keep the existing sheet + its tests green
+- [ ] 3.2 Embed the read-only detail view in §3 surfacing official-info (`sourceUrl`), merch (`merchUrl`), venue + map, and calendar; confirm the `isAuthenticated`-gated ticket-journey stays hidden for the anonymous visitor
+- [ ] 3.3 Implement Lv2 arrival motion: the detail view rises once into place on section entry (one-shot, layered on reveal, reduced-motion disabled)
+- [ ] 3.4 Add §3 section copy (JA/EN)
+
+## 4. §4 New-concert notification value section
+
+- [ ] 4.1 Create a notification mock card component styled as a Liverty new-concert alert (bell, brand, sample artist line) (D5)
+- [ ] 4.2 Implement Lv2 arrival motion: the card drops in with a single brief bell nudge on entry (one-shot, reduced-motion disabled)
+- [ ] 4.3 Add §4 section copy (JA/EN)
+
+## 5. §5 Final CTA + value-pillar scope
+
+- [ ] 5.1 Place the commit CTAs (`Get Started` / `Log In`) in a final CTA section after the value content, preserving the two-layer intent (no commit CTAs on the hero when preview exists) and the guest-friendly copy proximity (D6)
+- [ ] 5.2 Verify the no-preview fallback (inline hero CTAs, no scroll-affordance) is unchanged
+- [ ] 5.3 Confirm no capability beyond the three real pillars is advertised, and no phone-frame chrome / stats / social proof is introduced
+
+## 6. Tests
+
+- [ ] 6.1 Update/extend `welcome-route.stories.ts` for the new sections (data-present and data-absent states)
+- [ ] 6.2 Add/adjust unit tests for reveal behavior, reduced-motion no-op, and the no-preview fallback path
+- [ ] 6.3 Run `make check` (lint + typecheck + unit tests) and fix issues
+
+## 7. Post-implementation localhost verification (manual, required)
+
+- [ ] 7.1 `npm start` and open the Welcome page (`/`) on localhost as an unauthenticated visitor
+- [ ] 7.2 Scroll §1→§5 and visually confirm section scroll-reveal fires cleanly on entry
+- [ ] 7.3 Visually confirm §3 (detail view rises once) and §4 (card drop-in + bell nudge) Lv2 arrival motions
+- [ ] 7.4 Confirm the preview shows real curated data; then exercise the no-preview state (e.g., empty/insufficient `previewArtistIds`) and confirm graceful degradation to the hero inline-CTA fallback
+- [ ] 7.5 Enable `prefers-reduced-motion` and confirm all reveal/arrival motion stops while content stays fully readable
+- [ ] 7.6 Check mobile width (real device or DevTools) for layout integrity and readability (no phone-frame; UI renders full-bleed/native size)
+
+## 8. Ship
+
+- [ ] 8.1 Open the frontend PR (Conventional Commits, mandatory body + `Refs: #<issue>`), pass CI
+- [ ] 8.2 Merge and cut the frontend release to prod; confirm the prod pin-bump reaches ArgoCD and the change is live


### PR DESCRIPTION
## Summary

Proposes `enrich-welcome-landing-page` — an OpenSpec change to turn the Welcome page (`/`) from a thin, mostly-static landing page into a value-communicating LP that shows all three real product pillars through the product's own UI, with scroll-driven storytelling.

Planning artifacts only. No code changes; the actual implementation is a separate follow-up (frontend-only).

## Why

Today the Welcome page demonstrates just one of the three core value pillars — the auto-collected concert timetable — and leaves ticket/goods info and new-concert push notifications invisible. Its two-screen hard-snap layout and single hero fade-in read as a static page, so a first-time visitor rarely grasps what Liverty Music does before leaving.

## What this change proposes

- **Continuous scroll narrative** replacing the two-screen hard snap, with `IntersectionObserver` scroll-reveal (entrance-only, `prefers-reduced-motion` honored).
- **Hero kept unchanged** — copy, brand/verb glow, language switcher, and the `サンプルを覗く` scroll-affordance all stay as-is.
- **§2 Timetable** — reuse the read-only `concert-highway` preview as a complete composed frame (no cropped peek).
- **§3 Ticket/goods** — read-only embed of the `event-detail-sheet` content (official-info, merch, venue, calendar; auth-gated ticket-journey naturally hidden) with a Lv2 one-shot arrival motion.
- **§4 New-concert notification** — a new mock notification card with a Lv2 arrival motion (drop-in + bell nudge), since real OS push can't render in-page.
- **§5 Final CTA** — preserves the existing two-layer CTA (commit CTAs after the value content, never on the hero) and the no-preview fallback.
- Advertises **only the three existing pillars**; no phone-frame chrome, stats, or social proof (pre-launch service).

## Artifacts

- `proposal.md` — why / what / capabilities (modifies `landing-page`) / impact
- `specs/landing-page/spec.md` — ADDED reveal/timetable/ticket-goods/notification/scope requirements; MODIFIED scroll-affordance
- `design.md` — 7 design decisions (D1–D7), risks, deferred open questions
- `tasks.md` — implementation breakdown incl. a required post-implementation **localhost visual verification** step and prod shipping

Validated with `openspec validate --strict` ✅.

## Testing

- `openspec validate enrich-welcome-landing-page --strict` passes.
- No code paths changed in this PR (planning docs only).

close: #832
