### PR TITLE
docs(auth): propose graceful-session-reauth (resume-time silent refresh)

### DIFF
--- a/openspec/changes/graceful-session-reauth/.openspec.yaml
+++ b/openspec/changes/graceful-session-reauth/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-21

--- a/openspec/changes/graceful-session-reauth/design.md
+++ b/openspec/changes/graceful-session-reauth/design.md
@@ -1,0 +1,103 @@
+## Context
+
+The frontend (`shared/services/auth-service.ts`) is a browser-based OAuth
+client (oidc-client-ts v3.4.1) against a self-hosted Zitadel. Instance token
+lifetimes: access 30m, refresh idle 30d / absolute 90d. `automaticSilentRenew`
+and `monitorSession` are both disabled (documented in the `authentication` and
+`user-auth` specs) because Zitadel rotates refresh tokens and the self-hosted
+`check_session_iframe` is served with `frame-ancestors 'none'`.
+
+Investigation (2026-08-21, server logs + browser console) established:
+
+- Zitadel refreshes succeed (all `/oauth/v2/token` return 200; a `refreshToken`
+  grant for the admin org user succeeded live). Refresh is NOT broken at the IdP.
+- The on-`Unauthenticated` reactive refresh+retry works: creating `org-test-11`
+  after ~42m idle produced `Create → 401 → Auth state updated (refresh) → org
+  created` in one pass.
+- The user-visible problem is the **cold-start 401**: with no resume-time
+  refresh, the token goes cold during idle, so the first foreground RPC 401s.
+  The browser logs that 401, and the admin route renders the raw error text
+  (`"exp" not satisfied`). Reactive recovery is also occasionally flaky.
+- fan-web does not show this because it re-fetches constantly and has a
+  `visibilitychange` resume-revalidator that warms the token before the user
+  acts; admin/organizer have neither.
+
+## Goals / Non-Goals
+
+**Goals:** eliminate the cold-start 401 for idle→resume→action; never show a raw
+auth error; do it uniformly in the shared auth service so all three entries
+benefit; keep the refresh-token-rotation race closed.
+
+**Non-Goals:** enabling `automaticSilentRenew` or any background timer; a BFF /
+server-side token model; changing Zitadel token lifetimes; reworking the
+consumer's resume-revalidator (it stays and is complementary).
+
+## Decisions
+
+**D1 — Refresh on resume (`visibilitychange`), not on a timer.** The gap is
+"token went cold while the tab was idle/backgrounded". A background timer cannot
+close it: oidc-client-ts `automaticSilentRenew` abandons renewal once the token
+is already expired (issue #2012), and browsers throttle/suspend background-tab
+timers so the timer would not fire during idle anyway. The boot-time
+`restoreSession()` already refreshes-if-expired-before-any-call and is exactly
+why a manual reload fixes the error. So the fix generalizes that boot behavior to
+every foreground resume: on `visibilitychange` to `visible`, if the access token
+is expired (or within a small skew, e.g. ~60s), run one `signinSilent()` before
+the next RPC. This is the ecosystem-recommended "refresh on resume / before-use"
+pattern (cf. angular-auth-oidc-client silent renew, oidc-spa
+`renewTimeBeforeTokenExpiresInSeconds`), adapted to our iframe-less, timer-less
+constraints.
+
+**D2 — Single-flight guard, shared across all three refresh paths.** The reason
+`automaticSilentRenew` was disabled is the refresh-token rotation race (two
+concurrent `signinSilent()` calls spend the same rotating refresh token; the
+second gets `RefreshTokenInvalid`). The resume refresh MUST NOT reintroduce it.
+Reuse a single module/service-level in-flight promise so boot, resume, and
+on-`Unauthenticated` refreshes coalesce into at most one concurrent
+`signinSilent()`. Because resume fires only on an explicit event (at most once
+per resume) and coalesces with any in-flight refresh, it does not race a
+service-worker reload the way a free-running timer did.
+
+**D3 — Recoverable auth errors are invisible; unrecoverable ones show a neutral
+state.** Today a token-expiry `Unauthenticated` that the interceptor cannot
+recover throws, and route error handlers render `err.rawMessage` — the raw
+`"exp" not satisfied`. Change the contract: successful refresh+retry is silent
+(already the intent); on unrecoverable expiry the app shows a neutral "session
+expired — signing you back in" state and routes to re-auth, never the transport
+string. This applies both to the interceptors' failure branch and to any route
+`toUserMessage`-style mapper, so an `Unauthenticated` code never maps to raw text.
+
+**D4 — Shared service, per-entry activation.** Implement in
+`shared/services/auth-service.ts` (the single OIDC surface used by all three
+entries) so consumer/admin/organizer get identical behavior. The consumer's
+`resume-revalidator` (data revalidation) is orthogonal and remains; the new
+resume refresh operates at the auth layer, below it.
+
+## Risks / Trade-offs
+
+- **Double-fire on resume + first RPC.** If the user resumes and immediately
+  triggers an RPC, the resume refresh and a reactive refresh could both start.
+  The single-flight guard (D2) makes them coalesce — no double refresh-token
+  spend.
+- **Skew window tuning.** Too large a pre-expiry skew wastes refreshes; too
+  small risks a cold RPC right after resume. ~60s is a safe default (well under
+  the 30m access lifetime).
+- **Multi-tab.** Two visible tabs resuming simultaneously could each refresh.
+  The per-tab single-flight guard prevents intra-tab races; cross-tab remains as
+  today (the existing on-`Unauthenticated` path already tolerates it, and Zitadel
+  rotation means the loser simply re-refreshes). Cross-tab leader election is a
+  possible future hardening but is out of scope.
+
+## Migration Plan
+
+1. Add the resume-time refresh + shared single-flight guard to
+   `shared/services/auth-service.ts`; wire a `visibilitychange` listener at
+   bootstrap for each entry (or in the shared service).
+2. Route `Unauthenticated` through a graceful mapper so no raw transport text is
+   rendered; unrecoverable → neutral "session expired" + re-auth.
+3. Unit-test: resume-with-expired → one refresh; resume-with-valid → no refresh;
+   concurrent triggers → single `signinSilent()`; unrecoverable → neutral state,
+   no raw string.
+4. Verify in prod on the admin console: idle > 30m → resume → create an Organizer
+   with no 401 in the console and no error text.
+- Rollback: additive listener + mapper; remove to revert to on-`Unauthenticated`-only.

--- a/openspec/changes/graceful-session-reauth/proposal.md
+++ b/openspec/changes/graceful-session-reauth/proposal.md
@@ -1,0 +1,71 @@
+## Why
+
+After a session sits idle past the 30-minute access-token lifetime, the first
+RPC an operator triggers fails with a raw `Unauthenticated` error — surfaced to
+the admin console user as the literal backend string
+`invalid token: failed to validate token: "exp" not satisfied` (observed live,
+2026-08-21, creating an Organizer). The app *does* recover on the next attempt
+(the on-`Unauthenticated` refresh works — verified: `org-test-11` was created
+after a single 401→refresh→retry), but the user still sees a scary console
+error and, intermittently, a rendered error in the UI.
+
+Root cause (confirmed by server logs + browser console, not assumed): the
+frontend refreshes the token at exactly two points — boot, and reactively on an
+RPC `Unauthenticated`. There is **no refresh when the app resumes from idle**.
+So the token is allowed to go cold; the first foreground action after idle
+always 401s. The fan-web SPA hides this because it constantly re-fetches and has
+a `visibilitychange` resume-revalidator that warms the token before the user
+acts; the admin and organizer consoles have neither, so an idle-then-mutate is
+the one place the cold-token 401 is visible.
+
+The naive fix — enabling `automaticSilentRenew` — does NOT work here: the
+existing spec already documents (citing oidc-client-ts #2012) that the background
+timer abandons renewal once the token is already expired, and browsers throttle
+background-tab timers so it never fires during idle. The correct, ecosystem-aligned
+fix is a **resume-time silent refresh** (refresh on `visibilitychange` when the
+token is expired/near-expiry, before any RPC), plus never surfacing a raw auth
+error to the user.
+
+## What Changes
+
+- Add a **third silent-refresh trigger** to the shared auth service: on
+  `visibilitychange` to `visible` (app resumes to the foreground), if the stored
+  access token is expired or within a small skew window of expiry, perform a
+  single silent refresh (`signinSilent()`) **before** the user's next RPC —
+  mirroring the boot-time `restoreSession()` behavior that already works (and is
+  why a manual reload fixes the error today).
+- Keep `automaticSilentRenew` **disabled** (the service-worker-reload refresh-token
+  rotation race that motivated disabling it is unchanged); the resume refresh
+  reuses the existing single-flight dedup so it cannot double-spend a rotating
+  refresh token.
+- Make `Unauthenticated` recovery **silent**: a token-expiry error that is (or
+  can be) recovered SHALL NOT render a raw backend error string to the user. On
+  unrecoverable expiry (refresh token itself dead), the app SHALL present a
+  neutral "session expired — signing you back in" state and route to
+  re-authentication, never the raw `"exp" not satisfied` text.
+- Apply uniformly via the shared `auth-service.ts` so all three entries
+  (consumer/fan-web, admin, organizer) get the same behavior; the consumer's
+  existing resume-revalidator continues to work and is complementary.
+
+Explicit non-goals: enabling `automaticSilentRenew`; a background renewal timer;
+migrating to a BFF / server-side token model; changing Zitadel token lifetimes.
+
+## Capabilities
+
+### New Capabilities
+<!-- None. This refines existing authentication behavior. -->
+
+### Modified Capabilities
+- `authentication`: the **Silent token refresh strategy** requirement changes
+  from "refresh at exactly two points (boot, on-`Unauthenticated`)" to add a
+  third point — **resume-time refresh on `visibilitychange`** — and a new
+  requirement that auth-expiry recovery is graceful (no raw backend error text
+  surfaced to the user).
+
+## Impact
+
+- **frontend** (`shared/services/auth-service.ts` + a small resume hook): a
+  `visibilitychange`-triggered silent refresh guarded by an expiry check and the
+  existing refresh dedup; graceful mapping of `Unauthenticated` so no raw error
+  string reaches the UI. Affects the consumer, admin, and organizer entries
+  (shared surface). No proto, no BSR, no backend changes.

--- a/openspec/changes/graceful-session-reauth/specs/authentication/spec.md
+++ b/openspec/changes/graceful-session-reauth/specs/authentication/spec.md
@@ -1,0 +1,80 @@
+## MODIFIED Requirements
+
+### Requirement: Silent token refresh strategy
+The frontend SHALL refresh access tokens silently at three points, and SHALL
+NOT run a proactive background renewal timer (`automaticSilentRenew` stays
+disabled): (1) at boot, if the stored access token is already expired; (2) on
+**resume to the foreground** (`visibilitychange` to `visible`), if the stored
+access token is expired or within a small skew window of expiry; (3) reactively,
+when an RPC returns `Unauthenticated`. All three paths share a single-flight
+guard so concurrent triggers perform at most one `signinSilent()` call.
+
+**Rationale**: With Zitadel refresh token rotation, a *background timer* running
+concurrently with a service-worker page reload causes both the old and new page
+to use the same refresh token, resulting in `RefreshTokenInvalid (400)` and
+forced logout — so the timer stays off. The resume-time refresh is NOT a timer:
+it fires only on an explicit foreground-resume event, at most once per resume,
+through the shared single-flight guard, so it does not reintroduce the rotation
+race. It closes the gap the timer cannot cover — `oidc-client-ts`
+`automaticSilentRenew` abandons renewal once the access token is already expired
+(issue #2012) and browsers throttle background-tab timers, so neither would
+refresh a token that went cold while the tab was idle. Resume-time refresh warms
+the token *before* the user's next action, mirroring the boot-time restore that
+already makes a manual reload recover the session.
+
+#### Scenario: Boot with valid access token
+- **WHEN** the app boots and the stored access token is not expired
+- **THEN** the app SHALL proceed without calling `signinSilent()`
+
+#### Scenario: Boot with expired access token
+- **WHEN** the app boots and the stored access token is expired
+- **THEN** the app SHALL call `signinSilent()` once via `restoreSession()`
+- **AND** if `signinSilent()` succeeds, the user session SHALL be restored transparently
+- **AND** if `signinSilent()` fails, the user SHALL start the session unauthenticated
+
+#### Scenario: Resume from idle with an expired access token
+- **WHEN** the app returns to the foreground (`visibilitychange` to `visible`)
+  after an idle period
+- **AND** the stored user is authenticated but the access token is expired or
+  within the skew window of expiry
+- **THEN** the app SHALL perform a single silent refresh before the user's next
+  RPC
+- **AND** if it succeeds, subsequent RPCs SHALL use the fresh token with no
+  visible interruption
+- **AND** the refresh SHALL be de-duplicated with any in-flight refresh (at most
+  one `signinSilent()` for concurrent triggers)
+
+#### Scenario: Resume with a still-valid access token
+- **WHEN** the app returns to the foreground and the stored access token is not
+  expired and not within the skew window
+- **THEN** the app SHALL NOT trigger a resume-time refresh
+
+#### Scenario: No background timer
+- **WHEN** the access token is about to expire during an active, foreground session
+- **THEN** the app SHALL NOT proactively refresh the token on a timer
+- **AND** the token SHALL be refreshed on the next resume event or the next RPC
+  that receives `Unauthenticated`, whichever comes first
+
+## ADDED Requirements
+
+### Requirement: Graceful session re-authentication
+The frontend SHALL NOT surface a raw backend authentication error (for example
+the literal string `invalid token: failed to validate token: "exp" not
+satisfied`) to the user. When an RPC fails with `Unauthenticated`, the app SHALL
+attempt silent recovery (refresh + retry) transparently; a successful recovery
+SHALL be invisible to the user. When recovery is not possible (the refresh token
+itself is expired or invalid), the app SHALL present a neutral, human-readable
+state (for example "your session expired — signing you back in") and route the
+user to re-authentication, rather than rendering the transport-level error text.
+
+#### Scenario: Recoverable expiry is invisible
+- **WHEN** an RPC returns `Unauthenticated` because the access token expired
+- **AND** a silent refresh succeeds and the retried RPC succeeds
+- **THEN** the user SHALL NOT see any error text for that RPC
+
+#### Scenario: Unrecoverable expiry shows a neutral state, not the raw error
+- **WHEN** an RPC returns `Unauthenticated` and silent refresh fails (refresh
+  token expired/invalid)
+- **THEN** the app SHALL NOT render the transport-level error string to the user
+- **AND** the app SHALL present a neutral "session expired" state and route to
+  re-authentication

--- a/openspec/changes/graceful-session-reauth/tasks.md
+++ b/openspec/changes/graceful-session-reauth/tasks.md
@@ -1,0 +1,26 @@
+## 1. Resume-time silent refresh (shared auth service)
+
+- [ ] 1.1 In `shared/services/auth-service.ts`, expose a shared single-flight refresh (one in-flight `signinSilent()` promise) reused by boot, resume, and the on-`Unauthenticated` interceptors (dedup across all three)
+- [ ] 1.2 Add a resume hook: on `document` `visibilitychange` → `visible`, if the stored user is authenticated AND the access token is expired or within a skew window (~60s), trigger the shared refresh before the next RPC
+- [ ] 1.3 Skip the resume refresh when the access token is still valid (outside the skew window) and when there is no stored user (guest)
+- [ ] 1.4 Register the resume hook for all three entries (consumer, admin, organizer) via the shared surface; ensure it is removed/no-ops cleanly (no duplicate listeners)
+
+## 2. Graceful `Unauthenticated` UX (no raw error)
+
+- [ ] 2.1 Ensure a recovered `Unauthenticated` (refresh+retry success) surfaces no error to the user (verify both consumer `connect-error-router` and `admin-auth-retry-interceptor` paths)
+- [ ] 2.2 On unrecoverable expiry (refresh fails), present a neutral "session expired — signing you back in" state and route to re-auth; do NOT render the transport-level string
+- [ ] 2.3 Update route/error mappers (e.g. the admin organizers route `toUserMessage`) so `Code.Unauthenticated` never maps to `err.rawMessage`
+
+## 3. Tests
+
+- [ ] 3.1 Resume with expired access token → exactly one `signinSilent()`; subsequent RPC uses the fresh token
+- [ ] 3.2 Resume with valid access token → no `signinSilent()`
+- [ ] 3.3 Concurrent triggers (resume + reactive) → single-flight: only one `signinSilent()`
+- [ ] 3.4 Unrecoverable expiry → neutral state, no raw `"exp" not satisfied` string rendered
+- [ ] 3.5 `make check` passes (frontend)
+
+## 4. Ship to prod + verify
+
+- [ ] 4.1 Frontend PR merged → release → shipped (consumer/admin/organizer images)
+- [ ] 4.2 Cloud-provisioning prod pin bumped (if a release bump is required) → ArgoCD synced
+- [ ] 4.3 Verify in prod on the admin console: idle > 30 min → resume → create an Organizer with NO 401 in the console and NO error text; confirm the same on fan-web (still fine) and organizer console


### PR DESCRIPTION
## 🔗 Related Issue

Refs: #759

<!-- No dedicated issue for this specific change; it emerged from organizer/admin
     console verification (roadmap step ①, #759). -->

## 📝 Summary of Changes

OpenSpec **planning** change only (no proto, no code) — proposes
`graceful-session-reauth`.

**Problem.** After a session sits idle past the 30-minute access-token lifetime,
the first RPC an operator triggers fails with a raw `Unauthenticated`, surfaced
to the admin console user as the literal backend string
`invalid token: failed to validate token: "exp" not satisfied` (observed live
2026-08-21 while creating an Organizer).

**Root cause (evidence-based, not assumed).** Server logs show Zitadel refreshes
succeed (all `/oauth/v2/token` → 200) and the browser console shows the reactive
refresh+retry recovers in one pass (`org-test-11` was created after a single
`401 → refresh → retry`). The gap: the frontend refreshes the token at only two
points — boot and reactively on `Unauthenticated` — with **no refresh when the
app resumes from idle**. So the token goes cold and the first foreground action
after idle 401s. fan-web is immune because its `visibilitychange`
resume-revalidator warms the token before the user acts; admin/organizer have
neither. Enabling `automaticSilentRenew` does **not** fix it (oidc-client-ts
#2012: the timer abandons renewal once the token is already expired, and browsers
throttle background-tab timers).

**Technical approach.** MODIFY the `authentication` capability's *Silent token
refresh strategy* to add a **third trigger — resume-time silent refresh on
`visibilitychange`** (timer stays off; a shared single-flight guard keeps the
refresh-token rotation race closed). ADD a *Graceful session re-authentication*
requirement: a recovered expiry is invisible, and an unrecoverable expiry shows
a neutral "session expired — signing you back in" state, never the raw transport
string. Frontend-only, in the shared `auth-service.ts`; benefits
consumer/admin/organizer.

Artifacts: `proposal.md`, `specs/authentication/spec.md` (MODIFIED + ADDED),
`design.md` (D1–D4), `tasks.md`. `openspec validate --strict` passes.

## ✅ Self-Checklist

- [x] I have linked the related issue.
- [x] I have updated the relevant documentation (the spec delta is the documentation).
- [x] No proto changes — `buf lint` / `buf format` N/A (planning-only, `openspec/changes/` markdown).
- [x] No proto definitions changed.
- [x] No breaking changes (planning artifacts only).
