### PR TITLE
docs(auth): expand graceful-session-reauth to the full mid-session lifecycle

### DIFF
--- a/openspec/changes/graceful-session-reauth/design.md
+++ b/openspec/changes/graceful-session-reauth/design.md
@@ -73,6 +73,42 @@ entries) so consumer/admin/organizer get identical behavior. The consumer's
 `resume-revalidator` (data revalidation) is orthogonal and remains; the new
 resume refresh operates at the auth layer, below it.
 
+**D5 — The single-flight lock lives in `AuthService`, not the interceptor.**
+Today the reactive interceptors hold their own module-level `refreshPromise`
+(`connect-error-router.ts:5`, `admin-auth-retry-interceptor.ts`), and
+`restoreSession()` calls `signinSilent()` independently — so a boot restore and
+an early-RPC 401 can run two concurrent `signinSilent()` calls (the exact
+rotation race). Move the single-flight promise INTO `AuthService` as one
+`ensureFreshToken()`-style method that all callers (boot restore, resume hook,
+both interceptors) go through. One lock, one home. The interceptors stop owning a
+`refreshPromise` and delegate to the service.
+
+**D6 — Reactive refresh contract is explicit and bounded to one retry.** Codify
+what the interceptors already do (`signinSilent()` → set the new bearer token →
+retry the original request) as the contract, and add the missing guard: retry at
+most once per request. If the retried request still returns `Unauthenticated`,
+treat the session as unrecoverable (D7) rather than looping. Guest/no-session
+callers pass the `Unauthenticated` through unchanged (the consumer already does
+this via `if (!auth.user) throw`; keep it, and make the admin path consistent —
+admin always has a session so it is a no-op there).
+
+**D7 — Forced logout reuses the voluntary sign-out cleanup + preserves return-to.**
+The forced-logout path today does `removeUser()` + `window.location.href` (or
+`signIn()`) WITHOUT publishing `SignedOut`, so user-specific stores keep stale
+data — unlike the voluntary `signOut()` which publishes it. Route the forced
+logout through the same cleanup: publish `SignedOut` (stores self-clear), then
+re-authenticate. Preserve the pre-logout location (e.g. capture
+`window.location` and restore after the OIDC callback, or pass it through the
+re-auth redirect) so the user returns where they were. Keep the consumer's
+`window.location.href = '/welcome'` semantics where a full re-auth is required,
+but add the missing `SignedOut` publish + return-to.
+
+**D8 — No raw transport text at any surface.** The interceptor failure branch and
+every route/error mapper (e.g. the admin organizers route `toUserMessage` default
+case that returns `err.rawMessage`) must map `Code.Unauthenticated` to the
+neutral "session expired" state, never the raw string. This is enforced at both
+layers so a code path that bypasses the interceptor still cannot leak the text.
+
 ## Risks / Trade-offs
 
 - **Double-fire on resume + first RPC.** If the user resumes and immediately

--- a/openspec/changes/graceful-session-reauth/specs/authentication/spec.md
+++ b/openspec/changes/graceful-session-reauth/specs/authentication/spec.md
@@ -6,8 +6,23 @@ NOT run a proactive background renewal timer (`automaticSilentRenew` stays
 disabled): (1) at boot, if the stored access token is already expired; (2) on
 **resume to the foreground** (`visibilitychange` to `visible`), if the stored
 access token is expired or within a small skew window of expiry; (3) reactively,
-when an RPC returns `Unauthenticated`. All three paths share a single-flight
-guard so concurrent triggers perform at most one `signinSilent()` call.
+when an RPC returns `Unauthenticated`.
+
+**Reactive refresh contract**: when an authenticated caller's RPC returns
+`Unauthenticated`, the app SHALL perform a silent refresh and then **retry the
+original request once** with the new access token. The retry is bounded to a
+single attempt per request: if the retried request also returns
+`Unauthenticated`, the app SHALL NOT refresh-and-retry again (no unbounded
+loop) — it SHALL treat the session as unrecoverable (see *Graceful session
+re-authentication*).
+
+**Single-flight**: all three refresh points, and every concurrent trigger within
+them, SHALL share **one** in-flight refresh so that at most one `signinSilent()`
+runs at a time. This includes the boot-time restore and the reactive interceptor:
+an early RPC that 401s while boot-time restore is still in flight MUST join the
+in-flight refresh rather than start a second, concurrent `signinSilent()`. This
+single-flight guarantee is the direct antidote to the Zitadel refresh-token
+rotation race the disabled background timer was avoiding.
 
 **Rationale**: With Zitadel refresh token rotation, a *background timer* running
 concurrently with a service-worker page reload causes both the old and new page
@@ -55,6 +70,26 @@ already makes a manual reload recover the session.
 - **AND** the token SHALL be refreshed on the next resume event or the next RPC
   that receives `Unauthenticated`, whichever comes first
 
+#### Scenario: Reactive refresh retries the original request once
+- **WHEN** an authenticated caller's RPC returns `Unauthenticated`
+- **THEN** the app SHALL perform a silent refresh
+- **AND** if the refresh succeeds, the app SHALL retry the original request once
+  with the new access token
+- **AND** the retried request's result SHALL be returned to the caller (a success
+  is transparent; the caller never observes the initial `Unauthenticated`)
+
+#### Scenario: Refresh-and-retry is bounded to once per request
+- **WHEN** the retried request also returns `Unauthenticated`
+- **THEN** the app SHALL NOT trigger another refresh-and-retry for that request
+- **AND** the session SHALL be treated as unrecoverable
+
+#### Scenario: Concurrent triggers share one refresh (single-flight)
+- **WHEN** multiple refresh triggers occur close together (e.g. several RPCs
+  return `Unauthenticated` at once, or a resume event coincides with an
+  in-flight boot-time restore)
+- **THEN** the app SHALL execute at most one `signinSilent()` call
+- **AND** all waiting callers SHALL observe the result of that single refresh
+
 ## ADDED Requirements
 
 ### Requirement: Graceful session re-authentication
@@ -67,6 +102,27 @@ itself is expired or invalid), the app SHALL present a neutral, human-readable
 state (for example "your session expired — signing you back in") and route the
 user to re-authentication, rather than rendering the transport-level error text.
 
+**Forced-logout cleanup parity**: an involuntary logout triggered by an
+unrecoverable `Unauthenticated` SHALL clear session state the same way a
+voluntary sign-out does — it SHALL publish the same signed-out signal so that
+user-specific caches/stores self-clear. The involuntary and voluntary logout
+paths SHALL NOT diverge in what they clean up (a forced logout MUST NOT leave
+stale user data behind).
+
+**Return-to preservation**: on an involuntary re-authentication, the app SHALL
+preserve where the user was so that, after re-authenticating, the user returns to
+the same location rather than a default landing page.
+
+**Unauthenticated caller pass-through**: an `Unauthenticated` response for a
+caller that has no session (guest / pre-authentication flows) SHALL NOT trigger a
+silent refresh or a forced logout; the error SHALL propagate to the caller so the
+flow can handle it locally.
+
+**Cross-context note**: the single-flight guard is per browsing context (per
+tab). Concurrent refreshes across separate tabs or a service-worker-reloaded page
+remain possible; they are tolerated (Zitadel rotation causes the loser to simply
+refresh again) and cross-tab leader election is out of scope for this change.
+
 #### Scenario: Recoverable expiry is invisible
 - **WHEN** an RPC returns `Unauthenticated` because the access token expired
 - **AND** a silent refresh succeeds and the retried RPC succeeds
@@ -78,3 +134,23 @@ user to re-authentication, rather than rendering the transport-level error text.
 - **THEN** the app SHALL NOT render the transport-level error string to the user
 - **AND** the app SHALL present a neutral "session expired" state and route to
   re-authentication
+
+#### Scenario: Forced logout clears user data like a voluntary sign-out
+- **WHEN** an unrecoverable `Unauthenticated` forces a logout
+- **THEN** the app SHALL publish the same signed-out signal a voluntary sign-out
+  publishes
+- **AND** user-specific caches/stores SHALL be cleared
+- **AND** no stale user data SHALL remain after the forced logout
+
+#### Scenario: User returns to where they were after involuntary re-auth
+- **WHEN** the user is forced to re-authenticate mid-session from a specific
+  location
+- **AND** they complete re-authentication
+- **THEN** the app SHALL return them to that location (not a default landing page)
+
+#### Scenario: Guest 401 propagates without refresh or logout
+- **WHEN** an RPC returns `Unauthenticated` for a caller with no established
+  session (guest / onboarding)
+- **THEN** the app SHALL NOT attempt a silent refresh
+- **AND** the app SHALL NOT force a logout/redirect
+- **AND** the error SHALL propagate to the caller

--- a/openspec/changes/graceful-session-reauth/tasks.md
+++ b/openspec/changes/graceful-session-reauth/tasks.md
@@ -1,26 +1,41 @@
-## 1. Resume-time silent refresh (shared auth service)
+## 1. Unified single-flight refresh (shared auth service)
 
-- [ ] 1.1 In `shared/services/auth-service.ts`, expose a shared single-flight refresh (one in-flight `signinSilent()` promise) reused by boot, resume, and the on-`Unauthenticated` interceptors (dedup across all three)
-- [ ] 1.2 Add a resume hook: on `document` `visibilitychange` → `visible`, if the stored user is authenticated AND the access token is expired or within a skew window (~60s), trigger the shared refresh before the next RPC
-- [ ] 1.3 Skip the resume refresh when the access token is still valid (outside the skew window) and when there is no stored user (guest)
-- [ ] 1.4 Register the resume hook for all three entries (consumer, admin, organizer) via the shared surface; ensure it is removed/no-ops cleanly (no duplicate listeners)
+- [ ] 1.1 In `shared/services/auth-service.ts`, add one single-flight refresh method (e.g. `ensureFreshToken()` / a shared in-flight promise) that runs at most one `signinSilent()` at a time and returns the resulting user (or null)
+- [ ] 1.2 Route `restoreSession()` (boot) through the same single-flight promise so a boot restore and an early-RPC 401 cannot run two concurrent `signinSilent()` calls
+- [ ] 1.3 Remove the interceptors' own module-level `refreshPromise`; the consumer `connect-error-router` and the `admin-auth-retry-interceptor` both delegate to the service's single-flight refresh
 
-## 2. Graceful `Unauthenticated` UX (no raw error)
+## 2. Resume-time refresh (visibilitychange)
 
-- [ ] 2.1 Ensure a recovered `Unauthenticated` (refresh+retry success) surfaces no error to the user (verify both consumer `connect-error-router` and `admin-auth-retry-interceptor` paths)
-- [ ] 2.2 On unrecoverable expiry (refresh fails), present a neutral "session expired — signing you back in" state and route to re-auth; do NOT render the transport-level string
-- [ ] 2.3 Update route/error mappers (e.g. the admin organizers route `toUserMessage`) so `Code.Unauthenticated` never maps to `err.rawMessage`
+- [ ] 2.1 Add a resume hook: on `document` `visibilitychange` → `visible`, if the stored user is authenticated AND the access token is expired or within a skew window (~60s), call the single-flight refresh before the next RPC
+- [ ] 2.2 Skip when the token is still valid (outside skew) and when there is no stored user (guest)
+- [ ] 2.3 Register for all three entries via the shared surface; idempotent listener (no duplicates); leave the consumer `resume-revalidator` (data) untouched
 
-## 3. Tests
+## 3. Reactive refresh contract + bounds
 
-- [ ] 3.1 Resume with expired access token → exactly one `signinSilent()`; subsequent RPC uses the fresh token
-- [ ] 3.2 Resume with valid access token → no `signinSilent()`
-- [ ] 3.3 Concurrent triggers (resume + reactive) → single-flight: only one `signinSilent()`
-- [ ] 3.4 Unrecoverable expiry → neutral state, no raw `"exp" not satisfied` string rendered
-- [ ] 3.5 `make check` passes (frontend)
+- [ ] 3.1 On `Unauthenticated` for an authenticated caller: single-flight refresh → retry the original request once with the new token; return the retried result to the caller
+- [ ] 3.2 Bound the retry to once per request (retried request still `Unauthenticated` → do NOT loop; treat as unrecoverable)
+- [ ] 3.3 Guest/no-session caller: `Unauthenticated` propagates unchanged (no refresh, no forced logout) — keep the consumer's `if (!auth.user) throw`; keep admin consistent
 
-## 4. Ship to prod + verify
+## 4. Graceful failure (no raw text) + forced-logout parity
 
-- [ ] 4.1 Frontend PR merged → release → shipped (consumer/admin/organizer images)
-- [ ] 4.2 Cloud-provisioning prod pin bumped (if a release bump is required) → ArgoCD synced
-- [ ] 4.3 Verify in prod on the admin console: idle > 30 min → resume → create an Organizer with NO 401 in the console and NO error text; confirm the same on fan-web (still fine) and organizer console
+- [ ] 4.1 On unrecoverable expiry: publish the `SignedOut` event (same cleanup as voluntary `signOut()`) so user-specific stores self-clear — fix the forced-logout path that skips it today
+- [ ] 4.2 Preserve return-to: capture the pre-logout location and return the user there after re-authentication (not a default landing)
+- [ ] 4.3 Present a neutral "session expired — signing you back in" state; never render the transport-level string
+- [ ] 4.4 Map `Code.Unauthenticated` to the neutral state at every route/error mapper (e.g. admin organizers route `toUserMessage` default → not `err.rawMessage`)
+
+## 5. Tests
+
+- [ ] 5.1 Resume with expired token → exactly one `signinSilent()`; next RPC uses the fresh token
+- [ ] 5.2 Resume with valid token → no `signinSilent()`
+- [ ] 5.3 Concurrent triggers (boot restore + 401, N concurrent 401s, resume + 401) → single `signinSilent()` (single-flight)
+- [ ] 5.4 Reactive refresh retries the original request once; retried-still-401 → no loop, unrecoverable
+- [ ] 5.5 Forced logout publishes `SignedOut`; return-to preserved
+- [ ] 5.6 Guest 401 → propagates, no refresh/logout
+- [ ] 5.7 Unrecoverable expiry → neutral state, no raw `"exp" not satisfied` string rendered
+- [ ] 5.8 `make check` passes (frontend)
+
+## 6. Ship to prod + verify
+
+- [ ] 6.1 Frontend PR merged → release → shipped (consumer/admin/organizer images)
+- [ ] 6.2 Cloud-provisioning prod pin bumped (if required) → ArgoCD synced
+- [ ] 6.3 Verify in prod on the admin console: idle > 30 min → resume → create an Organizer with NO 401 in the console and NO error text; confirm fan-web and organizer console unaffected


### PR DESCRIPTION
## 🔗 Related Issue

Refs: #759

## 📝 Summary of Changes

Follow-up to #835 — expands the `graceful-session-reauth` OpenSpec change (still
planning-only, no proto/code) to cover the **full mid-session re-auth
lifecycle**. A spec-vs-implementation diff (`auth-service.ts`,
`connect-error-router.ts`, `admin-auth-retry-interceptor.ts`) found the original
proposal under-scoped — it defined the resume trigger and the no-raw-error UX,
but the actual mid-session behavior was undefined. Folded in:

- **Reactive refresh contract** — on `Unauthenticated`, refresh then retry the
  original request **once** (bounded; no loop).
- **Unified single-flight** — one lock in `AuthService`, shared by boot restore,
  resume, and both interceptors. Today the interceptors hold their own
  module-level `refreshPromise` and `restoreSession()` refreshes independently,
  so a boot restore + an early-RPC 401 can run two concurrent `signinSilent()`
  calls — the exact refresh-token rotation race. This closes it.
- **Forced-logout parity** — an involuntary logout must publish `SignedOut`
  (voluntary `signOut()` does; the forced path doesn't → stale user caches) and
  **preserve return-to** so the user comes back to where they were.
- **Guest 401 pass-through** — no-session callers propagate the error (no
  refresh/logout).
- **No raw transport text at any surface** — interceptor branch + route mappers.
- **Cross-tab** single-flight documented as a best-effort residual (out of scope).

Adds design decisions D5–D8, expands the `authentication` spec delta (MODIFIED
refresh strategy + ADDED graceful re-auth, new scenarios), and rewrites `tasks.md`
into 6 groups. Frontend-only implementation to follow. `openspec validate
--strict` passes.

## ✅ Self-Checklist

- [x] I have linked the related issue.
- [x] The spec delta is the documentation.
- [x] No proto changes — `buf lint`/`buf format` N/A (planning markdown only).
- [x] No proto definitions changed.
- [x] No breaking changes (planning artifacts only).
