### PR TITLE
docs(openspec): propose fix-bottom-sheet-swipe-dismiss

### DIFF
--- a/openspec/changes/fix-bottom-sheet-swipe-dismiss/.openspec.yaml
+++ b/openspec/changes/fix-bottom-sheet-swipe-dismiss/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-22

--- a/openspec/changes/fix-bottom-sheet-swipe-dismiss/design.md
+++ b/openspec/changes/fix-bottom-sheet-swipe-dismiss/design.md
@@ -1,0 +1,69 @@
+## Context
+
+See proposal.md - Why. The `<bottom-sheet>` CE is currently a modal `<dialog>` opened with `showModal()` (see `openspec/specs/bottom-sheet-ce/spec.md` and `frontend/src/components/bottom-sheet/`). Dismiss is committed on `scrollsnapchange`/`pointerup`/`scrollend` heuristics that call `dialog.close()`, which then runs a fixed-duration (160ms) `opacity`+`overlay allow-discrete` fade. That fade is a second animation system, decoupled from and competing with the scroll-snap position, and `overlay allow-discrete` keeps the modal (and its pointer-blocking `::backdrop`) in the Top Layer for its whole duration.
+
+Google/web.dev's `navigation-drawer` guide (retrieved via the `modern-web-guidance` skill) is the canonical pattern for a swipe-dismissible, scroll-snap-driven, Top-Layer overlay with a scroll-linked backdrop fade — the same UI this CE implements. It explicitly prefers scroll-snap over JS `transform` drag ("the scroll mechanism gives the user direct control ... and much more closely matches native mobile apps") and uses an `IntersectionObserver` as the single source of truth for state.
+
+Constraints:
+- Target browsers include iOS Safari (primary), Android Chrome, and desktop Chrome/Firefox/Safari (mobile-first PWA).
+- CUBE CSS, Aurelia 2 CE conventions, Biome lint. See frontend AGENTS.md / `aurelia2-component` skill.
+- The public CE contract (`open`, `dismissable` bindables; `sheet-closed` event) must not change — many consumers depend on it.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Eliminate bounce-back and the closing-window operation lock by construction, not by tuning.
+- Adopt the web.dev `navigation-drawer` architecture adapted to a vertical bottom sheet.
+- Preserve the scroll-linked backdrop fade and the existing public CE contract.
+- Keep behavior correct on iOS Safari and Firefox (no reliance on Chromium-only features without a working cross-browser path).
+
+**Non-Goals:**
+- No JavaScript pointer-drag / `transform`-tween dismiss implementation (web.dev explicitly deprecates this vs scroll-snap).
+- No change to consumer components' public API or to their history/`popstate` handling.
+- No adoption of `scroll-initial-target` yet (see Decisions).
+- No visual redesign of the sheet chrome (handle bar, radius, shadow, tokens unchanged).
+
+## Decisions
+
+### D1. `popover="manual"` instead of `<dialog>.showModal()`
+A `popover` is non-modal: its `::backdrop` does not block background pointer events, and it does not force the background `inert`. This is precisely what unlocks the "tap another card during close" behavior. `popover="manual"` (not `auto`) is required so the browser's native light-dismiss does not fire mid-swipe. **Cost:** we lose the free focus-trap, `inert`, and ESC handling that `showModal()` provided; we re-implement them (D4). **Alternative considered:** keep `showModal()` and only defer `close()` until off-screen — rejected because a modal `::backdrop` blocks the background for the entire dismiss scroll regardless of when `close()` fires, so the operation lock cannot be fixed while remaining modal.
+
+### D2. `IntersectionObserver` on the sheet body as the single source of truth
+All dismiss paths (swipe, tap-outside, ESC, Android back, programmatic) reduce to "scroll the container to the closed stop"; the observer fires the actual `hidePopover()` + `sheet-closed` when the sheet body has left the viewport. This removes the `scrollsnapchange`/`scrollend`/`pointerup` heuristics and their magic ratios (`0.25`, `0.1`) entirely. **Alternative considered:** keep `scrollsnapchange` as primary with IO as fallback (the current spec's shape) — rejected because two detection systems is exactly the complexity that produced the drift and the iOS "flash then close" defect; IO alone covers all engines.
+
+### D3. Close = scroll to the closed snap stop; hide only after off-screen
+Dismiss never commits a `close()`/`hidePopover()` mid-gesture. It scrolls (`scroll-behavior: smooth`, honoring reduced-motion) toward the dismiss zone; the scroll itself, plus the scroll-timeline backdrop fade, is the animation. This is what makes the gesture interruptible (reverse = just scroll back = stays open, no bounce-back) and removes the need for the `pointer-events: none` lock. `hidePopover()` runs in the IO callback once the body is off-screen.
+
+### D4. CE-managed focus-trap, `inert`, and Escape
+- **`inert`**: apply to the app shell root (or `document.body` children outside the popover) on open; **remove it the moment a dismiss begins** (not at `hidePopover()`), so the closing window is interactive. For `dismissable="false"`, keep `inert` for the whole lifetime.
+- **Focus**: record `document.activeElement` on open, move focus into the sheet body (`tabindex="-1"`), restore on close. A lightweight focus-trap (wrap Tab within the sheet) is added since `popover` does not trap.
+- **Escape**: a `keydown` listener (Escape) initiates the dismiss scroll; suppressed when `dismissable="false"`.
+- **Semantics**: set `role="dialog"` + `aria-modal="true"` + accessible name on the popover host (a `popover` has no implicit dialog role).
+
+### D5. Keep the `initial-snap` keyframe hack; defer `scroll-initial-target`
+The existing `initial-snap` keyframe (`--_snap-align: none`, `0.01s backwards`) snaps to the sheet body on open and works in all target engines. `scroll-initial-target: nearest` is the declarative web.dev alternative but is **Chromium-only** (Chrome/Edge 133+, unsupported in Safari desktop/iOS and Firefox as of 2026-08 per caniuse) and not Baseline. Adopting it would still require a rAF/`scrollTo` fallback that runs on our primary target (iOS Safari), making it strictly more complex than the keyframe hack. **Decision:** retain the keyframe hack now; add a code comment marking `scroll-initial-target: nearest` as the replacement to apply once it reaches Baseline.
+
+### D6. `svh` and `overscroll-behavior: none`
+`100dvh` → `100svh` on `.scroll-area`/`.dismiss-zone` and `90dvh` → `90svh` on `.sheet-body` so the sheet height does not jump when the iOS Safari address bar resizes mid-swipe. `overscroll-behavior-y: contain` → `overscroll-behavior: none` to fully stop the dismiss swipe from chaining into page scroll at the edges.
+
+## Risks / Trade-offs
+
+- **Re-implementing focus-trap/inert/ESC by hand can regress a11y** → Mirror web.dev's `navigation-drawer` guidance exactly (inert on shell, focus into sheet, Escape keydown); cover with unit tests for focus move/restore and an E2E keyboard-dismiss check; verify VoiceOver/TalkBack reach only sheet content when open.
+- **`popover` API / scroll-driven animations browser support** → Popover is Baseline (since 2025-01, incl. iOS Safari 18.3+). The scroll-timeline backdrop fade is already `@supports`-gated with an opacity-transition fallback; keep that gate. Confirm iOS Safari popover version floor against the app's supported-OS matrix.
+- **Non-modal means the background is technically live while open** → We still set `inert` on open, so behavior matches a modal until dismiss begins; only the *closing* window becomes interactive (the desired fix).
+- **Spec/code drift already exists** (the current `bottom-sheet-ce` spec describes an IO-fallback + heuristic-removal state the shipped code does not fully match) → This change makes IO the single primary path and removes the heuristics, so the delta supersedes the drifted scenarios; the implementation and spec re-converge.
+- **Reduced-motion**: a smooth dismiss scroll must collapse to instant under `prefers-reduced-motion: reduce` → gate `scroll-behavior: smooth` behind `@media (prefers-reduced-motion: no-preference)` (web.dev pattern) and jump-scroll otherwise.
+- **Programmatic close during an in-flight open** → the just-opened guard (retained) plus IO settle detection prevent a self-close before the sheet settles on the body.
+
+## Migration Plan
+
+1. Frontend-only change; no proto/BSR/backend coordination. Ship via the normal frontend release once `make check` and E2E pass.
+2. Implement in `frontend/src/components/bottom-sheet/` (`.ts`, `.html`, `.css`), update `bottom-sheet.spec.ts`.
+3. Regression-guard: the artist-filter chip-check E2E (`contain: layout` stability) and add/extend swipe-dismiss + keyboard-dismiss + "tap card during close" coverage.
+4. Smoke every consumer of `<bottom-sheet>` (event-detail-sheet, post-signup-dialog, date-range-sheet, artist-unfollow-sheet, user-home-selector, page-help) for open/close, dismissable vs non-dismissable, and focus behavior.
+5. Rollback: revert the frontend PR; no data or schema migration involved.
+6. At archive/sync time, update the `bottom-sheet-ce` main-spec `## Purpose` line (currently says `showModal()`) to reflect the `popover` architecture — the delta does not carry Purpose.
+
+## Open Questions
+
+- None that affect the specs, approach, or task breakdown. (The exact minimum iOS Safari version floor is a verification detail resolved during testing, not a design fork.)

--- a/openspec/changes/fix-bottom-sheet-swipe-dismiss/proposal.md
+++ b/openspec/changes/fix-bottom-sheet-swipe-dismiss/proposal.md
@@ -1,0 +1,37 @@
+## Why
+
+The `<bottom-sheet>` swipe-to-dismiss has two user-facing defects that a prior tuning fix (reduced duration, `pointer-events` lock, `pointerup` threshold) could not resolve because they are architectural, not parametric:
+
+1. **Bounce-back**: after a swipe-down dismiss gesture the sheet often reappears when the user scrolls up to interact with the page. `close()` is committed prematurely on snap detection while a *separate* opacity/`overlay` fade keeps the still-scrollable element alive for 160ms; an upward gesture in that window re-snaps it to the sheet body.
+2. **Operation lock**: the user cannot tap another card (e.g. open a different concert's detail) until the sheet has *fully* closed, because the modal `<dialog>` `::backdrop` plus `overlay ... allow-discrete` keeps the dialog in the Top Layer — blocking all background pointer events — for the entire close animation.
+
+Both stem from the same root: the sheet is a **modal `<dialog>` opened with `showModal()`**, whose close is a time-based fade decoupled from the scroll gesture. Google/web.dev's official pattern for this exact UI (the `navigation-drawer` guide) uses a **non-modal `popover` driven entirely by scroll-snap**, where dismiss *is* the scroll and state is read from an `IntersectionObserver`. Aligning to that standard removes both defects by construction and keeps the scroll-linked backdrop fade we already have.
+
+## What Changes
+
+- **BREAKING (internal primitive behavior)**: Re-architect `<bottom-sheet>` from a modal `<dialog>.showModal()` host to the web.dev `navigation-drawer` pattern:
+  - Promote the sheet via **`popover="manual"`** (non-modal Top Layer) instead of `<dialog>.showModal()`.
+  - Make an **`IntersectionObserver` on the sheet body the single source of truth** for open/closed state; all dismiss paths (swipe, tap-outside, ESC, Android back, programmatic) converge in its callback.
+  - **Close = scroll the container to the closed snap stop**; call `hidePopover()` only after the observer confirms the sheet is off-screen. The scroll (native momentum/velocity, fully interruptible) *is* the close animation.
+  - **Remove** the `scrollsnapchange`/`scrollend`/`pointerup` scroll-ratio heuristics (`< 0.25`, `< 0.1`) and the `pointer-events: none` bounce-back lock — they become unnecessary.
+  - Because `popover` is non-modal, **manually re-implement the a11y affordances** `showModal()` gave for free: set the rest of the document `inert` while the sheet is open, move focus into the sheet on open and restore it on close, and handle Escape via a `keydown` listener. `inert` is lifted the moment the close scroll begins, so the closing window is interactive (fixes operation lock).
+- Keep the **scroll-timeline backdrop fade** (`@supports (animation-timeline: scroll())`), unchanged in intent.
+- **`100dvh` → `100svh`** for the scroll area / dismiss zone so the sheet height does not jump when the iOS Safari address bar resizes mid-swipe (web.dev guidance).
+- **`overscroll-behavior-y: contain` → `overscroll-behavior: none`** to fully stop the dismiss swipe from chaining into page scroll.
+- Retain the existing cross-browser `initial-snap` keyframe hack for the open-position snap (works in Safari/Firefox). Do **not** adopt `scroll-initial-target: nearest` yet — it is Chromium-only (unsupported in Safari & Firefox as of 2026-08) and not Baseline; design records that it should replace the keyframe hack only after it reaches Baseline.
+
+## Capabilities
+
+### New Capabilities
+<!-- None. -->
+
+### Modified Capabilities
+- `bottom-sheet-ce`: The dismiss/lifecycle mechanism changes at the requirement level — Top-Layer promotion moves from modal `<dialog>.showModal()` to non-modal `popover="manual"`; dismiss detection and open/closed state move to an `IntersectionObserver` (removing scroll-ratio heuristics and the `pointer-events` lock); close becomes scroll-to-closed-stop with deferred `hidePopover()`; focus-trap / `inert` / ESC become CE-managed; `100dvh`→`100svh`; `overscroll-behavior: none`.
+
+## Impact
+
+- **Frontend only.** No proto / RPC / backend changes.
+- Affected component: `frontend/src/components/bottom-sheet/` (`.ts`, `.html`, `.css`, `.spec.ts`).
+- Consumers keep their public contract unchanged: the `open` bindable, `dismissable` bindable, and `sheet-closed` event are preserved, so `event-detail-sheet`, `post-signup-dialog`, `date-range-sheet`, `artist-unfollow-sheet`, `user-home-selector`, `page-help`, etc. need no API changes. Non-dismissable consumers retain modal-like blocking via CE-managed `inert`.
+- Observable UX improvement on the dashboard: a closing event-detail sheet no longer blocks tapping another concert card.
+- Test surface: `bottom-sheet.spec.ts` and the artist-filter chip-check E2E regression guard.

--- a/openspec/changes/fix-bottom-sheet-swipe-dismiss/specs/bottom-sheet-ce/spec.md
+++ b/openspec/changes/fix-bottom-sheet-swipe-dismiss/specs/bottom-sheet-ce/spec.md
@@ -1,0 +1,193 @@
+## MODIFIED Requirements
+
+### Requirement: Bottom Sheet Custom Element
+The system SHALL provide a `<bottom-sheet>` custom element as the single dialog primitive for all overlay content, promoted to the Top Layer via a **non-modal `popover="manual"`** element (NOT `<dialog>.showModal()`), with CSS scroll-snap dismiss via an internal scroll container. The open/closed lifecycle SHALL be driven by an `IntersectionObserver` on the sheet body as the single source of truth: all dismiss paths (swipe, tap-outside, ESC, Android back, programmatic) converge in its callback. Dismissing SHALL be performed by scrolling the container to the closed snap stop; the popover SHALL be hidden (`hidePopover()`) only after the observer confirms the sheet has left the viewport, so the dismiss scroll itself is the (native, momentum-driven, interruptible) close animation. Because a `popover` is non-modal, the CE SHALL manage focus-trap, background `inert`, and the Escape close request itself.
+
+#### Scenario: Basic open/close via bindable
+- **WHEN** `<bottom-sheet open.bind="isOpen">` has `open` set to `true`
+- **THEN** the CE SHALL call `showPopover()` on the popover element (via `ref`)
+- **AND** the popover SHALL be promoted to the Top Layer
+- **AND** the CE SHALL set the rest of the document `inert` and move focus into the sheet body
+- **AND** the sheet-body SHALL be visible at the bottom of the viewport via the CSS `initial-snap` animation (no JS `scrollTo` required on open)
+- **WHEN** `open` is set to `false`
+- **THEN** the CE SHALL scroll `.scroll-area` to the closed snap stop (the dismiss zone) and SHALL call `hidePopover()` only after the `IntersectionObserver` reports the sheet body has left the viewport
+
+#### Scenario: Open bound to true at component creation time
+- **WHEN** `open` is bound to `true` at initial bind time (before `attached()`)
+- **AND** `openChanged(true)` is called during the `binding` phase
+- **THEN** `showPopover()` SHALL be called but MAY fail silently if the popover ref is not yet resolved
+- **AND** the error SHALL be caught and suppressed (matching the existing `hidePopover()` try-catch pattern)
+- **AND** the `attached()` lifecycle hook SHALL retry via `if (this.open) this.openChanged(true)` after the popover ref is initialized
+- **AND** the sheet SHALL open successfully at `attached()` time
+
+#### Scenario: DOM structure
+- **WHEN** the sheet is rendered
+- **THEN** the CE host (`<bottom-sheet>`) SHALL contain a popover element (`popover="manual"`) as the Top-Layer host
+- **AND** the popover host SHALL have an accessible name (`aria-label` or `aria-labelledby`) and SHALL carry `role="dialog"` and `aria-modal="true"` (a `popover` has no implicit dialog semantics, so these SHALL be set explicitly)
+- **AND** the internal DOM SHALL be `[popover] > .scroll-area > .dismiss-zone + section.sheet-body`
+- **AND** `.scroll-area` SHALL be a `<div>` element serving as the scroll-snap container (`overflow-y: auto`, `scroll-snap-type: y mandatory`, `block-size: 100svh`, `overscroll-behavior: none`)
+- **NOTE** `.scroll-area` MUST use viewport-relative height (`100svh`, not `100%`) because percentage block-size does not resolve against the popover's fixed-position height inside the Top Layer — the scroll container would expand to content size, preventing overflow and disabling scroll-snap. `svh` (not `dvh`/`vh`) is used so the height does not jump when the iOS Safari address bar resizes mid-swipe.
+- **AND** `.sheet-body` SHALL be a `<section>` element (semantic content container) with `contain: layout`
+- **AND** the `::backdrop` pseudo-element SHALL belong to the popover host
+
+#### Scenario: Background inert and focus trap
+- **WHEN** the sheet is open
+- **THEN** the CE SHALL make all content outside the popover `inert` (not focusable, not reachable by Tab or assistive technology)
+- **AND** keyboard focus SHALL be trapped within the sheet until it closes
+- **NOTE** Because `popover` (unlike `<dialog>.showModal()`) does not provide `inert` or a focus trap natively, the CE SHALL apply `inert` to the document (or the app shell root) while open and remove it on close.
+
+#### Scenario: Background interactive during the close animation
+- **WHEN** the user dismisses the sheet and the close scroll begins
+- **THEN** the CE SHALL lift the background `inert` as soon as the dismiss is underway (not only after the popover is fully hidden)
+- **AND** the user SHALL be able to interact with background content (e.g. tap another concert card) during the close animation without waiting for the sheet to fully close
+- **NOTE** This removes the prior "operation lock", where the modal `<dialog>` `::backdrop` plus `overlay ... allow-discrete` blocked all background pointer events for the entire close animation.
+
+#### Scenario: Layout stability with dynamic sheet content
+- **WHEN** content inside `.sheet-body` changes layout (e.g., a checkbox is checked, an element toggles `display`)
+- **THEN** `.sheet-body` SHALL remain at the bottom of the viewport
+- **AND** `.scroll-area` SHALL NOT be displaced from its rendered position
+- **NOTE** This is enforced by `contain: layout` on `.sheet-body`. Without it, Chromium's scroll-snap re-evaluation inside a Top-Layer container incorrectly offsets `.scroll-area` by `-scrollTop` pixels when a child layout change triggers a re-snap. This is a Chromium rendering bug. `contain: layout` prevents child layout changes from propagating to `.scroll-area`. When Chromium fixes this bug, `contain: layout` MAY be removed — the regression guard is the artist-filter chip-check E2E test.
+
+#### Scenario: Initial snap animation
+- **WHEN** the popover opens (`showPopover()`)
+- **THEN** `.scroll-area` SHALL run an `initial-snap` CSS animation (`0.01s`, `animation-fill-mode: backwards`)
+- **AND** during the animation, `--_snap-align` SHALL be `none`, disabling dismiss-zone's scroll-snap-align
+- **AND** `.sheet-body` (`scroll-snap-align: end`) SHALL be the only active snap target
+- **AND** the browser SHALL snap to `.sheet-body` on open
+- **AND** after the animation completes, dismiss-zone snap SHALL restore to its CSS-determined value
+- **AND** no JavaScript `scrollTo()` or `requestAnimationFrame` SHALL be required on open in browsers that support the keyframe hack
+- **NOTE** The cross-browser `initial-snap` keyframe hack is retained deliberately. The declarative `scroll-initial-target: nearest` alternative is Chromium-only (unsupported in Safari and Firefox as of 2026-08) and not Baseline; it SHALL replace the keyframe hack only after it reaches Baseline.
+
+#### Scenario: Scroll-snap dismiss
+- **WHEN** the sheet is open and `dismissable` is `true`
+- **THEN** `.scroll-area` SHALL have `data-dismissable="true"`
+- **AND** the dismiss zone SHALL have `scroll-snap-align: var(--_snap-align, start)` (active after the initial-snap animation)
+- **AND** swiping down (physical gesture: finger moves downward, scrollTop decreases) SHALL scroll toward the dismiss zone at the top
+- **AND** `overscroll-behavior: none` SHALL prevent the dismiss swipe from chaining into page scroll
+
+#### Scenario: Responsive swipe-down dismiss detection
+- **WHEN** the user swipes the sheet down so the sheet body scrolls off the viewport (the dismiss zone becomes the settled snap target)
+- **THEN** the CE SHALL detect the dismiss via an `IntersectionObserver` observing the sheet body's visibility within the popover
+- **AND** on the sheet body leaving the viewport the CE SHALL call `hidePopover()`, set `open` to `false`, and dispatch `sheet-closed`
+- **AND** dismiss detection SHALL NOT depend on any `scrollTop / maxScroll` ratio threshold, nor on committing `close()` on the `scrollsnapchange` event
+- **NOTE** The `IntersectionObserver` fires regardless of how the sheet moved (user swipe, programmatic close scroll, or snap settle), so every dismiss path converges in one callback. This replaces the prior `scrollsnapchange` + scroll-ratio detection.
+
+#### Scenario: Early close on pointerup at dismiss threshold
+- **WHEN** the user lifts their pointer (`pointerup`) at any scroll position
+- **THEN** the CE SHALL NOT close the sheet based on a `scrollTop / maxScroll` ratio threshold
+- **AND** the prior `pointerup` (`scrollTop/max < 0.25`) and `scrollend` (`scrollRatio < 0.1`) early-close heuristics SHALL be removed
+- **AND** the CE SHALL NOT set `pointer-events: none` on `.scroll-area` to prevent bounce-back
+- **NOTE** These heuristics and the pointer-events lock are unnecessary under the scroll-to-closed-stop + `IntersectionObserver` model: the dismiss is the scroll itself and no premature `close()`/`hidePopover()` is committed mid-gesture, so there is nothing to lock against. (Title retained for spec-delta continuity; behavior is the removal of the heuristic.)
+
+#### Scenario: Dismiss detection ignores programmatic and initial-snap scroll
+- **WHEN** the sheet opens and the `initial-snap` sequence (or any programmatic scroll) momentarily rests the scroll position on the dismiss zone before settling on `.sheet-body`
+- **THEN** the CE SHALL NOT dismiss the sheet
+- **AND** dismiss SHALL be honored only once the sheet has settled on `.sheet-body` and the sheet body subsequently leaves the viewport (guarded by the just-opened guard)
+- **NOTE** This prevents the iOS/WebKit "flash then close" defect, where the programmatic re-snap trace (scroll ratio `1 → 0`) was previously misread as a user swipe-to-dismiss by scroll-ratio heuristics.
+
+#### Scenario: Fallback dismiss detection where scrollsnapchange is unsupported
+- **WHEN** the engine does not support `scrollsnapchange` (e.g., Firefox)
+- **THEN** dismiss detection SHALL still function unchanged, because the `IntersectionObserver` (not `scrollsnapchange`) is the single primary detection mechanism across all engines
+- **AND** no `scrollend`/`pointerup` scroll-ratio fallback SHALL be required
+- **NOTE** By making `IntersectionObserver` the primary path rather than a fallback, the CE removes the engine-specific detection branching that previously distinguished Chromium (`scrollsnapchange`) from other engines.
+
+#### Scenario: Just-opened dismiss guard
+- **WHEN** the sheet has just been opened (during the open transition / before it has settled on `.sheet-body`)
+- **THEN** the CE SHALL suppress any dismiss signal, so the sheet cannot close itself before the user interacts
+- **AND** the guard SHALL release once the sheet has settled on `.sheet-body`
+
+#### Scenario: Bounce-back prevention after dismiss-zone snap
+- **WHEN** the user begins a swipe-down dismiss and then reverses direction (scrolls the sheet back up) before it leaves the viewport
+- **THEN** the sheet SHALL settle back to `.sheet-body` and remain open, with no `hidePopover()` call and no `sheet-closed` event
+- **AND** after a genuine dismiss, a subsequent upward page scroll SHALL NOT cause the sheet to reappear
+- **AND** the CE SHALL achieve this WITHOUT setting `pointer-events: none` on `.scroll-area`
+- **NOTE** Because no `close()` is committed mid-gesture and there is no separate opacity/`overlay` fade competing with the scroll, reversing the gesture is honored as ordinary direct manipulation rather than being overridden — eliminating the prior bounce-back defect. (Title retained for spec-delta continuity; the mechanism changes from a pointer-events lock to not committing a premature close.)
+
+#### Scenario: Close animation completes within 160ms
+- **WHEN** the sheet is dismissed by any mechanism (swipe, tap-outside, ESC, Android back, programmatic)
+- **THEN** the visible close SHALL be the scroll of `.scroll-area` to the closed snap stop, coupled with the scroll-driven backdrop fade
+- **AND** `hidePopover()` SHALL be called only after the `IntersectionObserver` confirms the sheet body has left the viewport, so the slide-out is fully visible
+- **AND** the CE SHALL NOT rely on a fixed-duration opacity/`overlay allow-discrete` fade decoupled from the scroll to perform the close
+- **NOTE** Title retained for spec-delta continuity; the close is now the dismiss scroll (native momentum, honoring `prefers-reduced-motion`), not a fixed 160ms fade. The prior 160ms `--_duration` fade is removed.
+
+#### Scenario: Tap-outside dismiss
+- **WHEN** the sheet is open and `dismissable` is `true`
+- **AND** the user taps/clicks the dimmed area above the sheet body (the `.dismiss-zone`)
+- **THEN** the CE SHALL scroll to the closed snap stop, and on the resulting off-screen detection set `open` to `false`, call `hidePopover()`, and dispatch `sheet-closed`
+- **NOTE** Tap-outside is implemented as a `click` handler on the `.dismiss-zone` element. Native popover light-dismiss is intentionally disabled by using `popover="manual"` (auto light-dismiss would also fire mid-swipe). Under full-viewport coverage the sheet-body occludes most of the surface, so the explicit `.dismiss-zone` click handler is the reliable tap-outside path.
+- **WHEN** `dismissable` is `false`
+- **THEN** the `.dismiss-zone` tap SHALL NOT close the sheet
+
+#### Scenario: Gesture-coupled backdrop fade
+- **WHEN** the browser supports scroll-driven animations (`@supports (animation-timeline: scroll())`)
+- **THEN** the `::backdrop` opacity (and its blur) SHALL be driven by the `.scroll-area` scroll position via `animation-timeline: scroll()`, so the backdrop fades as the user swipes the sheet toward the dismiss zone and is fully cleared by the dismiss threshold
+- **WHEN** the browser does NOT support scroll-driven animations (e.g., Firefox)
+- **THEN** the `::backdrop` SHALL fall back to an opacity `transition` on open/close (the prior behavior)
+
+#### Scenario: Non-dismissable mode
+- **WHEN** `dismissable` is `false`
+- **THEN** the popover SHALL be opened with `showPopover()` and the CE SHALL keep the background `inert` for the sheet's whole lifetime (modal-like blocking)
+- **AND** the CE SHALL suppress the Escape close request (the `keydown` Escape handler SHALL NOT close it), and there SHALL be no tap-outside close
+- **AND** `.scroll-area` SHALL have `data-dismissable="false"`
+- **AND** the dismiss zone SHALL remain in the DOM with `aria-hidden="true"` (required for the `initial-snap` animation pattern)
+- **AND** CSS SHALL set `.dismiss-zone` to `scroll-snap-align: none` and `pointer-events: none` via `.scroll-area:not([data-dismissable="true"]) .dismiss-zone`
+- **AND** `.sheet-body` SHALL be the only active snap target, ensuring the sheet body is visible on open
+
+#### Scenario: Dismissable mode with close-request dismiss (ESC / Android back)
+- **WHEN** `dismissable` is `true` (default)
+- **THEN** pressing Escape (desktop) SHALL close the sheet, handled by a CE `keydown` listener (a `popover="manual"` does not emit a native `cancel`/close request), which SHALL initiate the scroll-to-closed-stop dismiss
+- **AND** the Android back gesture/button SHALL close the sheet via the consumer's `popstate` handling (history-driven), which sets `open` to `false` and triggers the programmatic close path
+- **AND** each SHALL result in `open` being set to `false` and a `sheet-closed` event being dispatched
+
+#### Scenario: Close animation completes within 160ms (legacy duration removed)
+- **WHEN** `prefers-reduced-motion: reduce` is NOT active
+- **THEN** the dismiss scroll SHALL use `scroll-behavior: smooth` for the slide-out
+- **WHEN** `prefers-reduced-motion: reduce` is active
+- **THEN** the close SHALL resolve instantly (jump-scroll), with no smooth animation
+- **NOTE** This scenario documents the replacement of the fixed 160ms `--_duration` close fade; the perceived close latency is now bounded by the native smooth-scroll settle, not a CSS transition duration.
+
+#### Scenario: Sheet closed event
+- **WHEN** the sheet is closed by any mechanism (ESC / Android back, tap-outside, scroll-snap swipe, programmatic)
+- **THEN** the CE SHALL dispatch a `sheet-closed` CustomEvent with `bubbles: true`
+- **AND** the parent component SHALL respond by setting `open` to `false`
+
+#### Scenario: Handle bar rendering
+- **WHEN** the sheet is open
+- **THEN** a handle bar (2.5rem wide, 0.25rem tall, rounded) SHALL be rendered at the top of the sheet body
+- **AND** the handle bar SHALL be styled with `oklch(100% 0 0deg / 20%)` background
+
+#### Scenario: Sheet body structure
+- **WHEN** the sheet is rendered
+- **THEN** the sheet body (`<section>`) SHALL have `border-radius: var(--radius-sheet)` on top corners
+- **AND** background SHALL be `var(--color-surface-raised)`
+- **AND** box-shadow SHALL be `var(--shadow-sheet)`
+- **AND** `max-block-size` SHALL be `90svh`
+- **AND** overflow-y SHALL be `auto` for scrollable content
+- **AND** `contain` SHALL be `layout` (layout containment boundary — see layout stability scenario)
+
+#### Scenario: Slotted content
+- **WHEN** content is placed inside `<bottom-sheet>`
+- **THEN** it SHALL be projected via `<au-slot>` into the sheet body below the handle bar
+
+#### Scenario: Focus management
+- **WHEN** the sheet opens
+- **THEN** the CE SHALL move focus into the sheet body and trap it there while open (CE-managed, since `popover` provides no native focus trap)
+- **WHEN** the sheet closes
+- **THEN** focus SHALL return to the element that was focused before the sheet opened
+
+#### Scenario: History integration
+- **WHEN** the sheet opens
+- **THEN** a history entry SHALL NOT be pushed by the CE itself
+- **AND** consuming components MAY manage history state independently via `open` binding
+
+#### Scenario: Reduced motion
+- **WHEN** `prefers-reduced-motion: reduce` is active
+- **THEN** the open/close SHALL resolve to an instant (or near-instant) transition with no smooth dismiss scroll animation
+- **AND** the scroll-driven backdrop fade SHALL likewise resolve to an instant open/close
+
+#### Scenario: Detach cleanup
+- **WHEN** the CE is detached from the DOM while the sheet is open
+- **THEN** all event listeners and observers (`.dismiss-zone` click, the Escape `keydown` listener, and the `IntersectionObserver`) SHALL be removed / disconnected
+- **AND** `hidePopover()` SHALL be called on the popover
+- **AND** any background `inert` applied by the CE SHALL be removed
+- **AND** no memory leaks SHALL occur

--- a/openspec/changes/fix-bottom-sheet-swipe-dismiss/tasks.md
+++ b/openspec/changes/fix-bottom-sheet-swipe-dismiss/tasks.md
@@ -1,0 +1,49 @@
+## 1. Markup & structure (bottom-sheet.html)
+
+- [ ] 1.1 Replace the inner `<dialog>` host with a `popover="manual"` element (via `ref`); set `role="dialog"`, `aria-modal="true"`, and mirror the accessible name (`aria-label`/`aria-labelledby`) onto it
+- [ ] 1.2 Keep the internal DOM `[popover] > .scroll-area > .dismiss-zone + section.sheet-body`; make the sheet body focusable (`tabindex="-1"`) for focus-in on open
+- [ ] 1.3 Remove the `cancel`/`close` `<dialog>` event bindings and the `scrollend`/`scrollsnapchange`/`pointerup` handlers from `.scroll-area`; keep the `.dismiss-zone` `click` binding
+
+## 2. Styles (bottom-sheet.css)
+
+- [ ] 2.1 `.scroll-area`/`.dismiss-zone`: `100dvh` → `100svh`; `overscroll-behavior-y: contain` → `overscroll-behavior: none`
+- [ ] 2.2 `.sheet-body`: `max-block-size: 90dvh` → `90svh` (keep `contain: layout`, radius, shadow, background tokens)
+- [ ] 2.3 Retain the `initial-snap` keyframe hack; add a code comment marking `scroll-initial-target: nearest` as the replacement to apply once it reaches Baseline (Chromium-only / not Baseline as of 2026-08)
+- [ ] 2.4 Gate the dismiss scroll on `@media (prefers-reduced-motion: no-preference) { .scroll-area { scroll-behavior: smooth } }`; remove the fixed-duration `opacity`/`overlay allow-discrete` close fade that competed with the scroll
+- [ ] 2.5 Keep the `@supports (animation-timeline: scroll())` scroll-timeline backdrop fade and its opacity-transition fallback, re-scoped to the popover `::backdrop`
+
+## 3. ViewModel — lifecycle & open (bottom-sheet.ts)
+
+- [ ] 3.1 `openChanged(true)`: call `showPopover()` (try/catch for pre-attach ref), record `document.activeElement`, apply background `inert`, move focus into the sheet body; retry in `attached()` when `this.open`
+- [ ] 3.2 Add the just-opened dismiss guard: suppress dismiss signals until the sheet has settled on `.sheet-body`; release the guard on settle
+- [ ] 3.3 `openChanged(false)` (programmatic close): initiate the scroll-to-closed-stop dismiss (shared close path), not an immediate `hidePopover()`
+
+## 4. ViewModel — dismiss via IntersectionObserver
+
+- [ ] 4.1 Create an `IntersectionObserver` on `.sheet-body` (root = popover) as the single source of truth; on the body leaving the viewport (and past the just-opened guard): remove background `inert`, call `hidePopover()`, set `open = false`, dispatch `sheet-closed` (`bubbles: true`)
+- [ ] 4.2 Implement the shared `dismiss()` = scroll `.scroll-area` to the closed snap stop (dismiss zone); lift background `inert` as soon as the dismiss scroll begins so the closing window is interactive
+- [ ] 4.3 Wire dismiss triggers to `dismiss()`: `.dismiss-zone` click (only when `dismissable`), Escape `keydown` (only when `dismissable`), programmatic `open=false`
+- [ ] 4.4 Remove the `onSnapChange`/`onScrollEnd`/`onPointerUp` heuristics and the `pointer-events: none` bounce-back lock entirely
+
+## 5. ViewModel — non-dismissable & a11y
+
+- [ ] 5.1 `dismissable=false`: keep background `inert` for the whole lifetime; suppress the Escape handler and the `.dismiss-zone` click; set `data-dismissable="false"` (CSS already disables dismiss-zone snap)
+- [ ] 5.2 Add a lightweight focus trap (wrap Tab within the sheet) since `popover` does not trap; restore focus to the previously-focused element on close
+- [ ] 5.3 `detaching()`: disconnect the `IntersectionObserver`, remove the Escape `keydown` and `.dismiss-zone` click listeners, remove any CE-applied `inert`, and call `hidePopover()`
+
+## 6. Tests
+
+- [ ] 6.1 Update `bottom-sheet.spec.ts`: open/close via bindable (showPopover/hidePopover), `sheet-closed` on each path, non-dismissable suppresses ESC/tap-outside, focus move+restore, detach cleanup (observer disconnected, inert removed)
+- [ ] 6.2 Add/extend E2E: swipe-down dismiss closes; reverse-mid-gesture keeps it open with no bounce-back; tap another concert card during the close animation opens the new sheet (operation-lock regression); keyboard Escape dismiss
+- [ ] 6.3 Confirm the artist-filter chip-check E2E (`contain: layout` stability) still passes
+
+## 7. Verify & consumer smoke
+
+- [ ] 7.1 Run `make check` (Biome lint + stylelint + typecheck + vitest) and `npx playwright test` for the affected suites
+- [ ] 7.2 Smoke all `<bottom-sheet>` consumers (event-detail-sheet, post-signup-dialog, date-range-sheet, artist-unfollow-sheet, user-home-selector, page-help): open/close, dismissable vs non-dismissable, focus behavior
+- [ ] 7.3 Verify on iOS Safari (no height jump on address-bar resize during swipe) and Firefox (backdrop-fade fallback + IO dismiss)
+
+## 8. Ship & spec sync
+
+- [ ] 8.1 Open the frontend PR (Refs the tracking issue), pass CI, merge, and ship to prod via the frontend release
+- [ ] 8.2 At archive/sync time, update the `bottom-sheet-ce` main-spec `## Purpose` line to describe the `popover` architecture (the delta does not carry Purpose)


### PR DESCRIPTION
## Summary

Proposes the OpenSpec change `fix-bottom-sheet-swipe-dismiss` to resolve two architectural defects in the `<bottom-sheet>` custom element's swipe-to-dismiss. This PR adds planning artifacts only (proposal / design / specs / tasks) — no implementation.

## Why

The bottom sheet has two user-facing defects a prior tuning fix could not resolve, because they are architectural, not parametric:

1. **Bounce-back**: after a swipe-down dismiss, the sheet reappears when the user scrolls up — `close()` is committed prematurely while a separate opacity/`overlay` fade keeps the still-scrollable element alive for ~160ms, and an upward gesture re-snaps it.
2. **Operation lock**: the user cannot tap another card until the sheet *fully* closes, because the modal `<dialog>` `::backdrop` + `overlay ... allow-discrete` keeps the pointer-blocking backdrop in the Top Layer for the whole close animation.

Both stem from the sheet being a modal `<dialog>.showModal()` whose close is a time-based fade decoupled from the scroll gesture.

## What Changes (proposed)

Realign to Google/web.dev's official `navigation-drawer` pattern (verified via `modern-web-guidance`):

- Non-modal **`popover="manual"`** instead of `<dialog>.showModal()`.
- **`IntersectionObserver`** on the sheet body as the single source of truth for open/closed state — removes the `scrollsnapchange`/`scrollend`/`pointerup` ratio heuristics and the `pointer-events` bounce-back lock.
- **Close = scroll to the closed snap stop**; `hidePopover()` only after off-screen. The scroll is the animation (interruptible by construction).
- CE-managed focus-trap / `inert` / Escape (since `popover` is non-modal); `inert` lifted the moment close begins → background interactive during close.
- Keep the scroll-timeline backdrop fade. `dvh` → `svh` (iOS Safari address bar), `overscroll-behavior: none`.
- Retain the cross-browser `initial-snap` keyframe hack; `scroll-initial-target: nearest` deferred until it reaches Baseline (Chromium-only / unsupported in Safari & Firefox as of 2026-08).

## Modified Capability

- `bottom-sheet-ce` — dismiss/lifecycle mechanism moves from modal `<dialog>` to non-modal `popover` + `IntersectionObserver`. Public CE contract (`open`, `dismissable`, `sheet-closed`) unchanged, so consumers need no API changes.

## Testing

- `openspec validate fix-bottom-sheet-swipe-dismiss --strict` → valid.
- Planning-only change; implementation and tests land in the follow-up frontend PR.

close: #837
