### PR TITLE
docs(openspec): propose fix-signin-celebration-misfire

### DIFF
--- a/openspec/changes/fix-signin-celebration-misfire/.openspec.yaml
+++ b/openspec/changes/fix-signin-celebration-misfire/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-22

--- a/openspec/changes/fix-signin-celebration-misfire/design.md
+++ b/openspec/changes/fix-signin-celebration-misfire/design.md
@@ -1,0 +1,51 @@
+## Context
+
+See proposal.md — Why. The frontend auth-callback currently gates the post-signup celebration/dialog on `UserStore.ensureLoaded()`'s `created` flag, which is derived purely from "was a `user_id` cached in localStorage before the call?". Two facts constrain the fix:
+
+1. The backend `Create` RPC is idempotent and returns a wire-identical `CreateResponse` for new and returning identities (no "created" field). The frontend cannot learn account novelty from the response.
+2. The OIDC library in use (`oidc-client-ts`) supports an application-defined `state` object on `signinRedirect({ state })` that is persisted (session storage keyed by the OIDC `state` id) and returned intact on the callback via the resolved `User.state`.
+
+`signIn()` and `signUp()` are already distinct methods (`shared/services/auth-service.ts`) invoked from distinct UI affordances. Only the sign-up-flow intent is missing from the callback, having been removed earlier.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Move the celebration/dialog gate off the `created` cache-miss proxy and onto a reliable, frontend-only signal of the flow the user initiated (sign-up vs sign-in).
+- Guarantee a returning **sign-in** never triggers the first-run celebration/dialog, regardless of local cache state.
+- Keep the change contained to the auth flow; do not alter provisioning, guest-follow migration, or user hydration.
+
+**Non-Goals:**
+- Perfect account-novelty detection. "Flow intent" is not identical to "backend minted a fresh row": a returning user who deliberately taps "Sign up" is out of scope for suppression here (rare and low-harm). A truly perfect signal would require a backend `created` field (a separate, cross-repo change) and is explicitly deferred.
+- Changing the `UserStore.ensureLoaded()` return shape or removing its `created` flag (it may still be used to further narrow the gate; see Decisions).
+- Any change to `onboarding-celebration` behavior — it remains gated on the same `liverty:postSignup:shown` flag and is fixed transitively.
+
+## Decisions
+
+### D1: Carry the flow intent through OIDC `state`, not `prompt`
+
+`signUp()` already sends `prompt: 'create'` to Zitadel, but `prompt` is a request-only hint and is **not** echoed to the callback. Use the app `state` round-trip instead: `signUp()` calls `signinRedirect({ prompt: 'create', state: { flow: 'signup' } })`. `handleCallback()` resolves the OIDC `User` (whose `.state` is the original object) and exposes the flow marker to `AuthCallbackRoute`.
+
+- **Alternative — re-derive from `prompt` on the callback:** not possible; `prompt` is not returned.
+- **Alternative — a separate `localStorage`/`sessionStorage` breadcrumb written by `signUp()`:** works, but duplicates state the OIDC library already round-trips reliably and risks desync across tabs/redirect edge cases. The OIDC `state` channel is purpose-built for exactly this.
+
+### D2: Gate the pending flag on `flow === 'signup'`
+
+In `AuthCallbackRoute`, set `localStorage['liverty:postSignup:shown'] = pending` only when the resolved flow marker is `'signup'`. The `signIn()` path (default, or `prompt: 'login'` in DEV) carries no such marker → the flag is never set on sign-in.
+
+- **Optional narrowing (recommended): `flow === 'signup' && created`.** Keeping the existing `created` cache-miss as an additional AND-condition also suppresses the residual "returning user taps Sign up on a device that already cached their id" case, at zero extra cost. It never re-introduces the sign-in bug because the sign-in flow already fails the first condition. Final choice recorded in tasks; default to the AND form.
+
+### D3: Backward/robustness for a missing marker
+
+A callback with **no** flow marker (older in-flight redirect started before deploy, or a direct `/auth/callback` hit) SHALL be treated as **not** sign-up (fail closed → no celebration). This is the safe default: at worst a brand-new user who somehow lost the marker misses the confetti; no returning user is ever wrongly celebrated.
+
+## Risks / Trade-offs
+
+- **[Returning user deliberately taps "Sign up" → sees first-run payoff]** → Mitigated by the D2 optional AND-`created` narrowing for the common same-device case; the cross-device residue is rare and harmless. Full correctness deferred to a future backend `created` signal.
+- **[A brand-new user's marker is lost (blocked storage, cross-tab redirect anomaly) → misses the celebration]** → Accepted; fail-closed per D3. Missing a one-time confetti is strictly less harmful than the current false-positive on every returning sign-in.
+- **[OIDC `state` serialization limits]** → `state` must be JSON-serializable; a small `{ flow: 'signup' }` object is well within `oidc-client-ts` support and its session-storage persistence.
+
+## Migration Plan
+
+- Pure frontend deploy; no data migration, no proto/BSR. Standard frontend release path.
+- Rollback: revert the frontend change; behavior returns to the prior `created`-only gate.
+- No feature flag needed; the change is self-contained and fail-closed.

--- a/openspec/changes/fix-signin-celebration-misfire/proposal.md
+++ b/openspec/changes/fix-signin-celebration-misfire/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+The post-signup celebration overlay ("ようこそ！" confetti) and the `PostSignupDialog` bottom sheet fire on **sign-IN** (a returning user logging in), not only on **sign-UP**. This violates `post-signup-dialog` ("Dialog not shown on subsequent logins") and the `onboarding-celebration` intent of a "newly signed-up user" payoff. It presents a jarring first-run experience to established users every time they log in on a fresh browser, a new device, or after clearing storage.
+
+The root cause is that the auth-callback decides "is this a new account?" from the wrong signal: `UserStore.ensureLoaded()` returns `created: true` whenever there is **no cached `user_id` in localStorage**, then falls through to the idempotent backend `Create`. A *returning* user with an empty cache (new browser/device, cleared storage, or guest-browse-then-sign-in — the guest path never caches a `user_id`) therefore looks identical to a brand-new account. The backend `Create` is idempotent and wire-identical for new vs. returning identities (`CreateResponse` carries no "created" field), so the local cache-miss is a fundamentally unreliable proxy for account novelty.
+
+The reliable signal — which button the user actually pressed — was deliberately removed from the OIDC `state` round-trip on the false premise that a backend new-account signal exists. Re-introducing that flow signal fixes the reported sign-in case completely, entirely within the frontend, with no cross-repo/BSR dependency.
+
+## What Changes
+
+- The frontend `signUp()` flow SHALL stamp the OIDC authorization request with an application `state` marker identifying the **sign-up flow** (via `oidc-client-ts` `signinRedirect({ state })`), which round-trips back to `/auth/callback`.
+- The auth-callback SHALL set the post-signup "pending" flag (`liverty:postSignup:shown`) **only when the completed flow is the sign-up flow** — i.e. the user arrived via `signUp()` — instead of keying it solely on the `created` cache-miss heuristic.
+- As a result, a returning user completing the **sign-in** flow SHALL NOT trigger the celebration overlay or the PostSignupDialog, regardless of local cache state (fresh browser, cleared storage, guest-then-sign-in).
+- The celebration overlay (`onboarding-celebration` Tier Z-full) is transitively corrected because it is gated on the same "pending" flag; no behavioral requirement of `onboarding-celebration` changes.
+
+## Capabilities
+
+### New Capabilities
+
+_None._
+
+### Modified Capabilities
+
+- `post-signup-dialog`: The "Post-Signup Dialog on First Authentication" requirement changes the condition under which the post-signup "pending" flag is set — from "provisioned a new user (cache-miss)" to "completed the sign-up flow (OIDC flow signal)". Adds a scenario asserting the flag is NOT set for a returning sign-in with an empty local cache.
+
+## Impact
+
+- **Frontend only** (`liverty-music/frontend`). No proto, backend, or BSR changes.
+- `shared/services/auth-service.ts` — `signUp()` adds a `state: { flow: 'signup' }` marker to `signinRedirect`; `handleCallback()` must surface the returned `user.state`.
+- `src/routes/auth-callback/auth-callback-route.ts` — gate the `liverty:postSignup:shown = 'pending'` write on the sign-up flow marker.
+- No change to `UserStore.ensureLoaded()` provisioning semantics (the guest-follow migration and user hydration paths are untouched); only the celebration-gating decision moves off the `created` proxy.
+- Existing unit tests for the auth-callback and (optionally) an e2e sign-in-does-not-celebrate check.

--- a/openspec/changes/fix-signin-celebration-misfire/specs/post-signup-dialog/spec.md
+++ b/openspec/changes/fix-signin-celebration-misfire/specs/post-signup-dialog/spec.md
@@ -1,0 +1,80 @@
+## MODIFIED Requirements
+
+### Requirement: Post-Signup Dialog on First Authentication
+
+The system SHALL display a dialog after the first successful **sign-up** that consolidates a celebration message with optional power-up actions (notification permission, PWA install), without front-loading guidance for features the user has not yet encountered.
+
+Whether an authenticated callback is treated as a first sign-up SHALL be determined by the **flow the user initiated** — the sign-up flow versus the sign-in flow — carried as a signal that round-trips through the OIDC authorization request and back to the auth-callback. It SHALL NOT be inferred solely from the absence of a locally cached user identifier, because a returning user can arrive with an empty local cache (new browser or device, cleared storage, or a prior anonymous/guest session that never cached an identifier) and MUST NOT be treated as a new sign-up.
+
+#### Scenario: Dialog shown after first signup
+
+- **WHEN** the auth-callback route completes an authenticated callback whose originating flow is the **sign-up** flow
+- **AND** `localStorage['liverty:postSignup:shown']` is not set
+- **THEN** the system SHALL set `localStorage['liverty:postSignup:shown']` to the pending marker
+- **AND** the system SHALL navigate to `/dashboard`
+- **AND** the Dashboard SHALL display the `PostSignupDialog` on load
+
+#### Scenario: Dialog not shown on subsequent logins
+
+- **WHEN** the auth-callback route completes for a returning user
+- **AND** `localStorage['liverty:postSignup:shown']` is already set
+- **THEN** the system SHALL NOT show the `PostSignupDialog`
+
+#### Scenario: Sign-in with an empty local cache does not trigger the dialog
+
+- **WHEN** the auth-callback route completes an authenticated callback whose originating flow is the **sign-in** flow
+- **AND** no user identifier is cached locally (e.g. a new browser/device, cleared storage, or a prior guest session)
+- **THEN** the system SHALL NOT set `localStorage['liverty:postSignup:shown']` to the pending marker
+- **AND** the system SHALL NOT display the celebration overlay or the `PostSignupDialog`
+- **AND** the user SHALL be navigated to `/dashboard` without a first-run payoff
+
+#### Scenario: Dialog content leads with celebration
+
+- **WHEN** the PostSignupDialog is displayed
+- **THEN** the first content row SHALL be a celebration message acknowledging completion of onboarding
+- **AND** it SHALL offer a notification opt-in action if `notificationManager.permission === 'default'`
+- **AND** it SHALL show a notification denied message if `notificationManager.permission === 'denied'`
+- **AND** it SHALL offer a PWA install action if `PwaInstallService.canShowInstallOption` is `true`
+- **AND** it SHALL provide a dismiss/close action in the footer
+
+#### Scenario: Footer button label when all actions are complete
+
+- **WHEN** the PostSignupDialog is displayed
+- **AND** `PwaInstallService.canShowInstallOption` is `false` (PWA already installed or browser not capable)
+- **AND** `notificationManager.permission` is `'granted'`
+- **THEN** the footer button SHALL display the label "Close"
+
+#### Scenario: Footer button label when actions remain
+
+- **WHEN** the PostSignupDialog is displayed
+- **AND** either `PwaInstallService.canShowInstallOption` is `true` OR `notificationManager.permission` is not `'granted'`
+- **THEN** the footer button SHALL display the label "Later"
+
+#### Scenario: Notification opt-in from dialog
+
+- **WHEN** the user taps the notification opt-in button in the PostSignupDialog
+- **THEN** the system SHALL call `PushService.create()` (backed by `PushNotificationService.Create` RPC)
+- **AND** the system SHALL NOT write any `localStorage` flag for push notification enabled state
+- **AND** on success, the notification row SHALL show a confirmed state
+- **AND** on failure or denial, the notification row SHALL show an error state
+- **AND** the settings page SHALL subsequently derive the toggle state from the backend via `PushNotificationService.Get` without relying on any `localStorage` flag
+
+#### Scenario: PWA install from dialog — native prompt
+
+- **WHEN** the user taps the install button in the PostSignupDialog
+- **AND** `PwaInstallService.canShowFab` is `true` (native prompt captured)
+- **THEN** the system SHALL trigger the deferred `beforeinstallprompt` event
+
+#### Scenario: PWA install row hidden on iOS Safari
+
+- **WHEN** the PostSignupDialog is displayed
+- **AND** `PwaInstallService.browserSupportsPwa` is `false` (browser lacks `BeforeInstallPromptEvent`, i.e. iOS Safari)
+- **THEN** the PWA install row SHALL NOT be shown in the dialog
+- **AND** the persistent `pwa-install-banner` provides the iOS install path instead
+
+#### Scenario: Dialog dismissed
+
+- **WHEN** the user taps the dismiss button
+- **THEN** the PostSignupDialog SHALL close
+- **AND** the notification prompt SHALL NOT be shown again in the same session (coordinated via `IPromptCoordinator`)
+- **AND** the `pwa-install-banner` SHALL become visible (it is not suppressed by PostSignupDialog dismissal)

--- a/openspec/changes/fix-signin-celebration-misfire/tasks.md
+++ b/openspec/changes/fix-signin-celebration-misfire/tasks.md
@@ -1,0 +1,23 @@
+## 1. Carry the sign-up flow signal through OIDC
+
+- [ ] 1.1 In `shared/services/auth-service.ts`, update `signUp()` to pass `state: { flow: 'signup' }` to `signinRedirect` (alongside the existing `prompt: 'create'`). Leave `signIn()` without a flow marker.
+- [ ] 1.2 Ensure `handleCallback()` returns / exposes the resolved OIDC `User.state` (or a typed accessor for the flow marker) so `AuthCallbackRoute` can read it. Add a small type for the state shape.
+
+## 2. Gate the celebration on the flow signal
+
+- [ ] 2.1 In `src/routes/auth-callback/auth-callback-route.ts`, read the flow marker from the callback result and set `localStorage['liverty:postSignup:shown'] = 'pending'` only when the flow is `'signup'` (per design D2, default to `flow === 'signup' && created`). Remove the sole reliance on `created`.
+- [ ] 2.2 Treat a missing/absent flow marker as NOT sign-up (fail closed → no celebration), per design D3.
+- [ ] 2.3 Update the stale code comment that claims a backend new-account signal exists to reflect the flow-signal approach.
+
+## 3. Tests
+
+- [ ] 3.1 Unit-test the auth-callback gating: sign-up flow → flag set; sign-in flow with empty cache → flag NOT set; missing marker → flag NOT set.
+- [ ] 3.2 Unit-test `signUp()`/`signIn()` pass (respectively carry / omit) the `state.flow` marker to `signinRedirect`.
+- [ ] 3.3 (Optional) E2E/regression: complete a sign-in with cleared local cache and assert the dashboard shows no celebration overlay / PostSignupDialog.
+
+## 4. Verify & ship
+
+- [ ] 4.1 `make check` (lint + typecheck + unit) passes in `frontend`.
+- [ ] 4.2 Manually verify in a fresh browser profile: sign-in → no celebration; sign-up → celebration + PostSignupDialog once.
+- [ ] 4.3 Open the frontend PR, merge after CI + review.
+- [ ] 4.4 Ship to production via the frontend release path (GitHub Release → prod AR retag → automated pin-bump) and confirm the fix in the dev/prod environment.


### PR DESCRIPTION
## Summary

OpenSpec proposal for `fix-signin-celebration-misfire`. Planning artifacts only (proposal / design / spec delta / tasks) — no implementation in this PR.

The onboarding celebration overlay ("ようこそ！" confetti) and the `PostSignupDialog` bottom sheet fire on **sign-IN** (a returning user logging in), not only on **sign-UP**, violating `post-signup-dialog` ("Dialog not shown on subsequent logins").

## Root cause

The auth-callback keys the post-signup `pending` flag on `UserStore.ensureLoaded()`'s `created` flag, which is derived purely from "was a `user_id` cached in localStorage?". A returning user with an empty cache (new browser/device, cleared storage, or guest-browse-then-sign-in — the guest path never caches an id) hits the idempotent backend `Create` and is misread as new. The backend `Create` is wire-identical for new vs returning (`CreateResponse` has no `created` field), so cache-miss is an unreliable proxy.

## Proposed change

Frontend-only. Re-introduce the sign-up flow signal via the `oidc-client-ts` `state` round-trip (`signUp()` stamps `state: { flow: 'signup' }`), and gate the post-signup `pending` flag on `flow === 'signup'` (recommended `&& created` to also suppress the rare returning-user-taps-signup case). Fail-closed when the marker is absent. No proto/backend/BSR changes.

## Artifacts

- `proposal.md` — why & what
- `specs/post-signup-dialog/spec.md` — MODIFIED "Post-Signup Dialog on First Authentication" (flow-signal gate + empty-cache sign-in scenario)
- `design.md` — D1 state round-trip vs prompt, D2 gate, D3 fail-closed
- `tasks.md` — implementation → tests → prod ship

## Testing

N/A (planning artifacts). `openspec validate --strict` passes.

close: #839
