### PR TITLE
docs(openspec): propose refactor-dna-orb-activation-model

### DIFF
--- a/openspec/changes/refactor-dna-orb-activation-model/.openspec.yaml
+++ b/openspec/changes/refactor-dna-orb-activation-model/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-22

--- a/openspec/changes/refactor-dna-orb-activation-model/design.md
+++ b/openspec/changes/refactor-dna-orb-activation-model/design.md
@@ -1,0 +1,60 @@
+## Context
+
+See proposal.md — Why. The orb spans an Aurelia component (`dna-orb-canvas.ts`), a plain renderer class (`orb-renderer.ts`), and a pure stage-parameter function (`stage-effects.ts`). Key current wiring, confirmed in code and reviewed for Aurelia 2 correctness:
+
+- `pulse()` (the celebratory flash + strobe + staggered shockwaves) is called **only** from `followedCountChanged` (`dna-orb-canvas.ts`), i.e. a `@bindable` state observer.
+- `setFollowCount()` (persistent stage level: `baseIntensity`, `stageParams`, `orbRadius`, plus the physics orb-zone and comet-trail flag) is also called **only** from `followedCountChanged` — never at init.
+- `followedCount` is bound from `discovery-route.ts` (`get followedCount => followStore.followedCount`); the router `loading()` hook hydrates guest follows **before** the canvas binds.
+- Aurelia 2 does **not** invoke `[prop]Changed` for the value present at initial bind (framework contract) — so a hydrated guest binds at N and the stage is never applied.
+- The canvas defers renderer init: `attached()` awaits `initWhenSized()` (a `ResizeObserver` wait) because the element can attach at 0×0 on SPA re-entry; `orbRenderer.init()` runs inside that await.
+- `onAbsorbComplete(hue)` already runs on the true follow-gesture landing and unifies `injectColor` + gated `spawnShockwave` + `playLanding`. It is reachable only from the two absorption paths (bubble tap, search follow) — never from unfollow, migration, hydration, or rollback.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Make stage level a silent, idempotent function of the current count, applied on entry and on every change.
+- Make the celebration a one-shot fired only from a real follow absorption.
+- Ease stage transitions on the render loop; stop resetting transient state on a level apply.
+
+**Non-Goals:**
+- Changing `getStageParams` values or the `festival-orb-effects` contract.
+- Re-tuning the zero-follow baseline aesthetics beyond removing the spurious activation (any further "how dim" tuning is a separate visual change).
+- Modeling the gesture as a route-level event/callback (kept canvas-internal — see D3).
+
+## Decisions
+
+### D1: Split `setFollowCount` into a silent, idempotent `applyLevel`
+
+Rename `setFollowCount(n)` → `applyLevel(n)`. It recomputes `stageParams = getStageParams(n)`, sets **target** values for continuous quantities (`baseIntensity`, `orbRadius`), and folds in the currently-in-`followedCountChanged` physics calls (`updateOrbZone`, `cometTrailEnabled`). It MUST NOT wipe particle trails (the current trail reset is transient-state destruction and breaks idempotency). `followedCountChanged(n)` becomes exactly `applyLevel(n)` — no `pulse()`.
+
+- **Alternative — keep snap writes:** rejected; snapping plus trail-wipe is what couples transient and persistent state and causes visible hitches on rapid follows.
+
+### D2: Seed the stage level after async size-init, reading the latest count
+
+Insert `this.applyLevel(this.followedCount)` in `attached()` **after** `await this.initWhenSized()` and the `if (this.detached) return` guard, immediately before `physics.addBubbles(...)`. This is the async-safe analogue of Aurelia's documented "manual initial call" idiom (`bound() { this.xChanged(this.x, undefined) }`), relocated because the renderer is not initialized until after the size wait. Reading `this.followedCount` **after** the await captures any change that landed during the wait; idempotency makes a later `followedCountChanged` apply harmless.
+
+- **Alternative — seed in `bound()`/`binding()`:** rejected; runs before `orbRenderer.init()`, writing into an uninitialized renderer.
+- **Alternative — a bindable `set:`/coercion:** rejected; abusing a setter for side effects is an anti-pattern and does not solve initial application.
+
+### D3: Keep the celebration canvas-internal, fired from `onAbsorbComplete`
+
+Add a private `celebrate(hue)` unifying `pulse()` (made private) + `injectColor` + gated `spawnShockwave` + `playLanding` on one frame; call it only from `onAbsorbComplete`. This co-locates the whole same-frame burst at the true "gesture landed" moment and structurally eliminates the misfire: unfollow/migrate/hydrate/rollback provably never reach `onAbsorbComplete` (only the tap and search-follow absorption paths do). It also fixes today's timing skew — `follow()` flips the count immediately (optimistic) while absorption lands later, so a count-observer flash preceded the bubble's arrival.
+
+- **Alternative — a route-level `@bindable` gesture callback from `discovery-route`:** rejected; the route would have to re-derive absorption-completion timing the canvas already owns.
+
+### D4: Ease continuous quantities on the existing rAF loop, not per-call
+
+`applyLevel` sets `targetBaseIntensity`/`targetOrbRadius`; the existing `orbRenderer.update(delta)` eases current→target each frame (same pattern already used for `pulseIntensity`/`swirlIntensity` decay). Do NOT start a timer/rAF per `applyLevel` call — rapid successive follows would stack tweens. Easing on the loop makes rapid follows collapse naturally to the latest target and keeps all animation off Aurelia's binding/task queue.
+
+## Risks / Trade-offs
+
+- **[A follow lands while the canvas is still 0×0 (pre-init)]** → `followedCountChanged` runs `applyLevel` against an uninitialized renderer (harmless no-op); the D2 post-await seed re-applies with the current count against the initialized renderer. Paths converge; no lost update, no double count.
+- **[Color palette not restored on re-entry]** → `OrbRenderer` is re-`new`ed per component, so `colorPalette` starts empty on SPA re-entry; the seed restores stage geometry but not prior hues. Correct by design (color is gesture-driven, concern C); noted so reviewers don't expect hue restoration.
+- **[Getter-backed bindable observation cost]** → `followedCount` is a getter over an `@observable`; propagation is via Aurelia's task queue, so `applyLevel` on the mutation path may run a microtask after `follow()` returns. Fine for a continuous rAF paint, and the reason the seed reads the value directly rather than assuming the observer already ran.
+- **[Behavior change: unfollow now eases the stage down]** → Previously the snap already dropped intensity on any recompute; easing is a visual refinement, not a regression.
+
+## Migration Plan
+
+- Pure frontend deploy; no data migration, no proto/BSR. Standard frontend release path.
+- Rollback: revert the frontend change; the orb returns to the prior observer-driven activation.
+- No feature flag; the refactor is self-contained and preserves the `getStageParams` contract, so `festival-orb-effects` tests remain green.

--- a/openspec/changes/refactor-dna-orb-activation-model/proposal.md
+++ b/openspec/changes/refactor-dna-orb-activation-model/proposal.md
@@ -1,0 +1,37 @@
+## Why
+
+On the Discovery screen the DNA orb's activation animation misfires: the orb reads as "activated" before/without a genuine follow, and the celebratory flash triggers on state changes that are not a user follow. This is a structural design flaw, not a one-off bug.
+
+The orb conflates three distinct concerns into a single state observer (`followedCountChanged`): (A) the persistent stage level derived from follow count, (B) the one-shot gesture celebration (pulse/strobe/shockwave), and (C) bubble→orb color injection. Concern B's trigger (`pulse()`) is wired to the count-change observer, and concern A's applier (`setFollowCount()`) is called only from that same observer — never at initialization. Consequences:
+
+- The celebratory flash fires on any follow-count change that is not a fresh gesture: guest-follow hydration on entry, guest→account migration, an unfollow, or an optimistic-update rollback.
+- Aurelia 2 does not invoke a `@bindable` change handler for the value present at initial bind, so a returning user who enters Discovery already following N artists renders at stage 0 until the count next changes — the stage level is never seeded on entry.
+
+The fix separates the two axes: stage level becomes a silent, idempotent function of the current count applied on entry and on every change; the celebration becomes an explicit one-shot fired only when a real follow absorption completes. This is frontend-only and was reviewed and approved for Aurelia 2 lifecycle correctness.
+
+## What Changes
+
+- The orb's **stage level** SHALL be applied idempotently and silently whenever the follow count is known — including on Discovery entry (first paint) and on any subsequent change from any source — with no celebratory side effect.
+- The orb's **celebratory activation** (the one-shot flash) SHALL fire only when a genuine follow gesture's bubble absorption completes, unified on the same frame with the existing color injection, shockwave, and landing tone.
+- Non-gesture follow-count changes (hydration, migration, unfollow, rollback) SHALL update the stage level silently and SHALL NOT trigger the celebratory flash.
+- Stage-level transitions SHALL ease toward the new stage's targets rather than snapping, and a stage-level update SHALL NOT reset in-flight transient effects (e.g. particle trails).
+- At zero follows with no follow performed this session, the orb SHALL present its unobtrusive baseline with no celebratory activation.
+- The pure stage-parameter function (`getStageParams`, capability `festival-orb-effects`) is **unchanged**; its input→output contract at counts 0–5 is preserved.
+
+## Capabilities
+
+### New Capabilities
+
+_None._
+
+### Modified Capabilities
+
+- `artist-discovery-dna-orb-ui`: Adds the requirement that the orb's celebratory activation is gesture-driven while the stage level tracks the follow count silently and idempotently (seeded on entry, eased transitions, no reset of transient effects). No change to the color-injection or burst requirements.
+
+## Impact
+
+- **Frontend only** (`liverty-music/frontend`). No proto, backend, or BSR changes.
+- `src/components/dna-orb/dna-orb-canvas.ts` — `followedCountChanged` becomes a silent stage-level apply; the stage level is seeded after async size-init in `attached()`; the celebration is invoked only from `onAbsorbComplete()`.
+- `src/components/dna-orb/orb-renderer.ts` — `setFollowCount` becomes an idempotent, side-effect-free stage-level apply that eases continuous quantities toward targets (via the existing `update(delta)` loop) and no longer wipes particle trails; `pulse()` becomes internal to a unified `celebrate()` entry point.
+- `src/components/dna-orb/stage-effects.ts` — unchanged (pure, spec-pinned by `festival-orb-effects`).
+- Existing dna-orb unit tests; add coverage for entry-seed, silent non-gesture updates, and gesture-only celebration.

--- a/openspec/changes/refactor-dna-orb-activation-model/specs/artist-discovery-dna-orb-ui/spec.md
+++ b/openspec/changes/refactor-dna-orb-activation-model/specs/artist-discovery-dna-orb-ui/spec.md
@@ -1,0 +1,45 @@
+## ADDED Requirements
+
+### Requirement: Orb Activation Separates Gesture Celebration From Follow-Count State
+
+The system SHALL treat the DNA orb's celebratory activation (the one-shot flash/pulse and its associated strobe/staggered shockwaves) and its persistent stage level as two independent concerns. The celebratory activation SHALL fire ONLY when a genuine follow gesture's bubble absorption completes. The stage level (radius, orbital count, light rays, breathing, ground glow, and other quantities derived from the follow count) SHALL track the current follow count from any source — silently, idempotently, and including on first render — with no celebratory side effect. A stage-level update SHALL NOT reset in-flight transient effects.
+
+The stage-parameter mapping itself (the pure `getStageParams(followCount)` function defined by `festival-orb-effects`) is unchanged by this requirement; this requirement governs WHEN and HOW that mapping is applied and WHEN the celebration fires, not the mapping's values.
+
+#### Scenario: Stage level is seeded on Discovery entry
+
+- **WHEN** the Discovery screen is entered
+- **AND** the user already has N followed artists (e.g. restored/hydrated from a prior session before the canvas binds)
+- **THEN** the orb SHALL render at the stage level for N on its first paint (radius, orbital count, light rays, ground glow, etc. consistent with `getStageParams(N)`)
+- **AND** no celebratory activation flash SHALL fire
+
+#### Scenario: Non-gesture follow-count changes update the stage silently
+
+- **WHEN** the follow count changes for a reason other than a follow gesture completing on this screen — for example guest-follow hydration, guest→account migration on sign-in, an unfollow, or an optimistic-update rollback
+- **THEN** the orb stage level SHALL update to match the new count
+- **AND** no celebratory activation flash SHALL fire
+
+#### Scenario: Celebration fires only on a real follow absorption
+
+- **WHEN** a user follows an artist and the bubble absorption into the orb completes
+- **THEN** the orb SHALL fire the celebratory activation together with the color injection, the shockwave (if enabled by the current stage level), and the landing tone on the same completion
+- **AND** the follow-absorption completion SHALL be the only path that triggers the celebratory activation
+
+#### Scenario: Unfollow does not celebrate
+
+- **WHEN** the follow count decreases because the user unfollows an artist
+- **THEN** the orb stage level SHALL step down to match the new count
+- **AND** no celebratory activation flash SHALL fire
+
+#### Scenario: Stage transitions are eased and preserve transient effects
+
+- **WHEN** the stage level changes
+- **THEN** the orb's continuous visual quantities (e.g. radius, base intensity) SHALL transition smoothly toward the new stage's targets rather than snapping instantaneously
+- **AND** in-flight transient effects such as particle trails SHALL NOT be reset by the stage-level change
+
+#### Scenario: Zero follows is dormant with no spurious activation
+
+- **WHEN** the user has followed no artists (follow count is 0)
+- **AND** the user has not completed a follow on this screen this session
+- **THEN** the orb SHALL present its unobtrusive baseline (consistent with the "small seed radius / unobtrusive at zero follows" behavior)
+- **AND** no celebratory activation flash SHALL fire

--- a/openspec/changes/refactor-dna-orb-activation-model/tasks.md
+++ b/openspec/changes/refactor-dna-orb-activation-model/tasks.md
@@ -1,0 +1,27 @@
+## 1. Renderer: silent, idempotent stage level (orb-renderer.ts)
+
+- [ ] 1.1 Rename `setFollowCount(count)` → `applyLevel(count)`; recompute `stageParams = getStageParams(count)` and set **target** values for `baseIntensity` and `orbRadius` (do not snap).
+- [ ] 1.2 Remove the particle-trail wipe from the level apply (it is transient state, unrelated to stage level; required for idempotency).
+- [ ] 1.3 In `update(delta)`, ease current `baseIntensity`/`orbRadius` toward their targets (mirror the existing `pulseIntensity`/`swirlIntensity` decay pattern). No per-call timers/rAF.
+- [ ] 1.4 Make `pulse()` private; add a private `celebrate(hue)` that unifies `pulse()` + `injectColor(hue)` + gated `spawnShockwave(hue)` + landing tone on one frame. (Keep `injectColor`/`spawnShockwave` callable as today; `celebrate` composes them.)
+
+## 2. Canvas: split state-apply from gesture-celebration (dna-orb-canvas.ts)
+
+- [ ] 2.1 `followedCountChanged(newVal)` → body becomes `applyLevel(newVal)` only; fold the current `updateOrbZone`/`cometTrailEnabled` calls into `applyLevel` so both the seed and the mutation path get them. Remove the `pulse()` call.
+- [ ] 2.2 Seed the stage in `attached()`: after `await this.initWhenSized()` and the `if (this.detached) return` guard, before `physics.addBubbles(...)`, call `this.applyLevel(this.followedCount)` (reads the freshest count post-await).
+- [ ] 2.3 In `onAbsorbComplete(hue)`, call the unified `celebrate(hue)` (the sole celebration trigger). Ensure the stage gate for the shockwave reads the same `stageParams` the seed/apply set.
+
+## 3. Tests
+
+- [ ] 3.1 Entry-seed: mounting the canvas with `followedCount = N` (N>0) renders at stage N on first paint (assert `orbRadius`/stage params reflect N), with no pulse.
+- [ ] 3.2 Silent non-gesture update: driving `followedCountChanged` (hydrate/migrate/unfollow/rollback simulation) updates the stage level but does NOT invoke the celebration.
+- [ ] 3.3 Gesture celebration: completing an absorption (`onAbsorbComplete`) invokes `celebrate` exactly once and unifies pulse + color inject + shockwave (when enabled) + tone.
+- [ ] 3.4 Idempotency: repeated `applyLevel(n)` does not reset in-flight particle trails.
+- [ ] 3.5 Confirm `festival-orb-effects` `getStageParams` tests remain unchanged and green (no edits to `stage-effects.ts`).
+
+## 4. Verify & ship
+
+- [ ] 4.1 `make check` (lint + typecheck + unit) passes in `frontend`.
+- [ ] 4.2 Manually verify on Discovery: fresh 0-follow entry → dormant orb, no flash; first follow → single unified celebration on absorption; re-enter with existing follows → correct stage on first paint, no flash; unfollow → eases down silently.
+- [ ] 4.3 Open the frontend PR, merge after CI + review.
+- [ ] 4.4 Ship to production via the frontend release path and confirm the orb behavior in the dev/prod environment.


### PR DESCRIPTION
## Summary

OpenSpec proposal for `refactor-dna-orb-activation-model`. Planning artifacts only (proposal / design / spec delta / tasks) — no implementation in this PR.

On the Discovery screen the DNA orb reads as "activated" before/without a genuine follow, and the celebratory flash triggers on state changes that are not a user follow. This is a structural design flaw.

## Root cause (design flaw)

The orb conflates three concerns into one state observer (`followedCountChanged`): (A) persistent stage level from follow count, (B) one-shot gesture celebration (pulse/strobe/shockwave), (C) bubble→orb color injection. `pulse()` (B) is wired to the count-change observer, and `setFollowCount()` (A) is only called from that observer — never at init. Consequences:

- The flash misfires on any non-gesture count change: guest-follow hydration on entry, guest→account migration, an unfollow, or an optimistic-update rollback.
- Aurelia 2 does not invoke a `@bindable` change handler for the value present at initial bind, so a returning user entering Discovery already following N artists renders at stage 0 until the count next changes.

## Proposed change

Frontend-only, reviewed for Aurelia 2 lifecycle correctness. Split the two axes:

- **Declarative level** — `applyLevel(n)`: silent, idempotent, seeded on entry after the async size-init, eases continuous quantities toward targets on the rAF loop, no trail reset.
- **Imperative `celebrate(hue)`** — fired only from `onAbsorbComplete` (the real follow-gesture landing, which unfollow/migrate/hydrate/rollback provably never reach), unifying pulse + color inject + shockwave + tone on one frame.

`getStageParams` (`festival-orb-effects`) stays pure and unchanged. No proto/backend/BSR changes.

## Artifacts

- `proposal.md` — why & what
- `specs/artist-discovery-dna-orb-ui/spec.md` — ADDED "Orb Activation Separates Gesture Celebration From Follow-Count State" (6 scenarios)
- `design.md` — D1 applyLevel, D2 async-safe entry seed, D3 celebrate placement, D4 rAF easing
- `tasks.md` — renderer → canvas → tests → prod ship

## Testing

N/A (planning artifacts). `openspec validate --strict` passes.

close: #840
