### PR TITLE
chore(openspec): archive fix-zitadel-httpclient-denylist-blocks-webhook

### DIFF
--- a/openspec/changes/archive/2026-08-23-fix-zitadel-httpclient-denylist-blocks-webhook/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-23-fix-zitadel-httpclient-denylist-blocks-webhook/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-23

--- a/openspec/changes/archive/2026-08-23-fix-zitadel-httpclient-denylist-blocks-webhook/design.md
+++ b/openspec/changes/archive/2026-08-23-fix-zitadel-httpclient-denylist-blocks-webhook/design.md
@@ -1,0 +1,111 @@
+## Context
+
+See proposal.md — Why. The failure is Zitadel v4.15.2+'s protected outbound HTTP
+client denying the in-cluster webhook ClusterIP. Two facts shape the approach:
+
+- **Setting `ZITADEL_HTTPCLIENT_DENYLIST` replaces the entire default list** — it
+  does not merge with Zitadel's built-in defaults. The upstream `defaults.yaml`
+  even carries a "CRITICAL SECURITY NOTE: Do not remove the CIDR subnets." So any
+  override MUST re-enumerate every default entry, changing only the `10.0.0.0/8`
+  line.
+- The webhook is reached via the `fan-api-webhook-svc` ClusterIP
+  (prod `10.30.12.134`, within the Service CIDR `10.30.0.0/20`). Zitadel enforces
+  the deny check pre-dial on the resolved IP, so a hostname exemption is not
+  possible — only a CIDR carve-out works. This is the maintainer-endorsed
+  technique (issue #12326, `NOT_PLANNED`).
+
+The full v4.17.1 default deny list (the set to preserve):
+`localhost, 0.0.0.0/8, 10.0.0.0/8, 100.64.0.0/10, 127.0.0.0/8, 169.254.0.0/16,
+172.16.0.0/12, 192.168.0.0/16, 198.18.0.0/15, ::/128, ::1/128, fc00::/7,
+fe80::/10`.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Restore login by making the in-cluster webhook reachable from Zitadel's
+  outbound client.
+- Preserve every other SSRF protection, especially the cloud metadata range
+  `169.254.0.0/16`.
+
+**Non-Goals:**
+- L2 network-layer egress (Kubernetes NetworkPolicy) — deferred; L1 only.
+- Any change to the backend webhook handlers or their auth model
+  (`zitadel-action-webhook` is unaffected).
+- Pinning the webhook Service ClusterIP (only needed for a `/32` hole, which we
+  are not using).
+
+## Decisions
+
+### Decision 1: Carve out the `/20` Service CIDR, not the `/32` ClusterIP
+
+Replace `10.0.0.0/8` with the 12 CIDRs that cover `10.0.0.0/8` minus
+`10.30.0.0/20` (computed via `ipaddress.address_exclude`):
+
+```
+10.0.0.0/12, 10.16.0.0/13, 10.24.0.0/14, 10.28.0.0/15,
+10.30.16.0/20, 10.30.32.0/19, 10.30.64.0/18, 10.30.128.0/17,
+10.31.0.0/16, 10.32.0.0/11, 10.64.0.0/10, 10.128.0.0/9
+```
+
+**Why `/20` over `/32`**: A `/32` hole (`10.30.12.134/32`) is the tightest but
+breaks silently if the Service is recreated and its ClusterIP is reassigned, and
+would need `spec.clusterIP` pinning. The `/20` Service CIDR opens only
+in-cluster, non-internet-routable ClusterIPs (4096 addresses, all cluster-owned),
+survives ClusterIP reassignment, and covers any future in-cluster Target without
+re-computation. The marginal SSRF exposure over `/32` is limited to other
+in-cluster services, which are not an attacker-reachable pivot.
+
+### Decision 2: Set `HTTPClient.DenyList` under `zitadel.configmapConfig`
+
+The chart already carries Zitadel's structured config under
+`zitadel.configmapConfig` (base holds `ExternalSecure`, `TLS`, `Database`,
+`Notifications`, `Log`; the prod overlay adds `ExternalDomain`, `Database`
+usernames). Add `HTTPClient.DenyList` there as a YAML list.
+**Alternative considered**: the chart's top-level `env:` list as
+`ZITADEL_HTTPCLIENT_DENYLIST` (comma-separated string). Rejected because the
+`env:` list lives in `base/values.yaml` (with the `OTEL_*` vars) and Helm
+*replaces* list values across values files rather than merging them — an overlay
+that re-declares `env:` would drop the base OTEL vars unless it re-lists them.
+`configmapConfig` is a map that deep-merges, so a per-overlay
+`configmapConfig.HTTPClient.DenyList` composes cleanly with the base config and
+is naturally environment-scoped. Either way the list fully replaces Zitadel's
+built-in default, so all default entries must still be enumerated.
+
+### Decision 3: Per-environment Service CIDR via overlays
+
+The `10.30.0.0/20` value is the **prod** Service CIDR. The base value must not
+hardcode a prod-specific CIDR that is wrong for dev. Set the prod-correct list in
+the prod overlay (or a base value overridden per overlay). Dev's Service CIDR
+must be looked up from the dev cluster and its own list computed; dev is
+currently stopped, so dev is config-only and lower priority (see Open Questions).
+
+## Risks / Trade-offs
+
+- **Dropping a default deny entry re-opens SSRF** → The override replaces the
+  whole list. Mitigation: enumerate all 13 default entries verbatim, changing
+  only the `10.0.0.0/8` line; add a task to diff the final list against the
+  deployed version's `defaults.yaml` and explicitly confirm `169.254.0.0/16` is
+  present.
+- **Zitadel upgrade adds new default deny entries we won't inherit** → Because we
+  now pin the full list, a future version's new default protections are silently
+  missed. Mitigation: task/checklist note to re-review this override against
+  `defaults.yaml` on every Zitadel version bump.
+- **`/20` exposes other in-cluster ClusterIPs to Zitadel's outbound client** →
+  Accepted; these are non-internet-routable and not an external pivot. The
+  metadata endpoint and all other private ranges stay denied.
+
+## Migration Plan
+
+1. Add `ZITADEL_HTTPCLIENT_DENYLIST` (full list with the `/20` hole) to the
+   Zitadel deployment config in `cloud-provisioning`, per environment.
+2. Merge → ArgoCD syncs → Zitadel pods roll with the new env.
+3. Verify prod: `POST /oauth/v2/token` no longer 500s and login completes; the
+   `error calling target ... address is denied` log line stops.
+4. **Rollback**: revert the config commit (returns to the failing state); no data
+   migration involved.
+
+## Open Questions
+
+- Dev Service CIDR is not retrievable while the dev cluster is stopped. The dev
+  overlay value can be computed and applied when dev is next brought up; it does
+  not affect the prod fix or the specs.

--- a/openspec/changes/archive/2026-08-23-fix-zitadel-httpclient-denylist-blocks-webhook/proposal.md
+++ b/openspec/changes/archive/2026-08-23-fix-zitadel-httpclient-denylist-blocks-webhook/proposal.md
@@ -1,0 +1,57 @@
+## Why
+
+The Zitadel upgrade to v4.17.1 (from v4.14.0) crossed v4.15.2, which introduced a
+protected outbound HTTP client (`HTTPClient.DenyList`, CVE-2026-55671 SSRF
+hardening) that **denies all RFC1918 ranges by default**. Zitadel's Actions v2
+webhook Targets are dialed through this client, so both in-cluster Target calls
+(`/pre-access-token` and `/account-login-event`, served by
+`fan-api-webhook-svc` at a `10.30.0.0/20` ClusterIP) are now refused with
+`address is denied by '10.0.0.0/8'`. The `pre-access-token` Target runs during
+token issuance, so `POST /oauth/v2/token` returns **500 Internal Server Error**
+and **every user login fails**. This is a live production outage introduced by
+today's upgrade.
+
+## What Changes
+
+- Override Zitadel's `HTTPClient.DenyList` (env `ZITADEL_HTTPCLIENT_DENYLIST`)
+  in the Zitadel deployment config so the in-cluster webhook Service CIDR
+  (`10.30.0.0/20`) is reachable, while every other default deny entry is
+  preserved.
+  - The `10.0.0.0/8` entry is replaced by the 12 CIDRs produced by excluding
+    `10.30.0.0/20` from `10.0.0.0/8`, keeping the rest of the `10/8` space denied.
+  - **Metadata endpoint stays denied**: `169.254.0.0/16` (covers the GCP
+    metadata server `169.254.169.254`) remains in the deny list, as do
+    `127.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, and the default IPv6 ranges.
+- Scope: **L1 (application-layer) only**. No Kubernetes NetworkPolicy / egress
+  work in this change.
+- This is a **permanent** configuration, not a temporary workaround: upstream
+  issue [#12326](https://github.com/zitadel/zitadel/issues/12326) requesting an
+  AllowList / per-target exemption was closed `NOT_PLANNED`, and the maintainers
+  endorse the CIDR-hole technique as the supported solution.
+
+## Capabilities
+
+### New Capabilities
+<!-- none -->
+
+### Modified Capabilities
+- `zitadel-self-hosted-deployment`: Add a requirement that Zitadel's outbound
+  protected HTTP client permits the in-cluster webhook Service CIDR while
+  retaining SSRF protection for all other private ranges and the cloud metadata
+  endpoint.
+
+## Impact
+
+- **Repo**: `cloud-provisioning` — Zitadel Helm values / configmap env
+  (`k8s/namespaces/zitadel/...`), no application code.
+- **Affected flow**: OIDC token issuance (`/oauth/v2/token`) and the
+  `account.login` Actions v2 event → both Zitadel Actions v2 Targets defined in
+  `src/zitadel/components/actions-v2.ts` (`pre-access-token-webhook`,
+  `login-event-webhook`), both dialing `fan-api-webhook-svc`.
+- **Blast radius**: Fixes total login outage in prod. The un-denied
+  `10.30.0.0/20` range contains only in-cluster (non-internet-routable) Service
+  ClusterIPs; the cloud metadata endpoint and all other private ranges remain
+  denied.
+- **Dev**: `10.30.0.0/20` is the prod Service CIDR; the dev overlay must use its
+  own Service CIDR value (dev env is currently stopped, so verification is
+  config-review only).

--- a/openspec/changes/archive/2026-08-23-fix-zitadel-httpclient-denylist-blocks-webhook/specs/zitadel-self-hosted-deployment/spec.md
+++ b/openspec/changes/archive/2026-08-23-fix-zitadel-httpclient-denylist-blocks-webhook/specs/zitadel-self-hosted-deployment/spec.md
@@ -1,0 +1,55 @@
+## ADDED Requirements
+
+### Requirement: Outbound HTTP Client Permits In-Cluster Webhook Targets While Retaining SSRF Protection
+
+Zitadel's protected outbound HTTP client (the deny list that governs Actions v2
+Target calls, `HTTPClient.DenyList` / env `ZITADEL_HTTPCLIENT_DENYLIST`) SHALL be
+configured so that the in-cluster webhook Service CIDR (`fan-api-webhook-svc`,
+prod `10.30.0.0/20`) is reachable, while all other RFC1918 private ranges, the
+loopback range, and the cloud metadata range remain denied. Concretely, the
+default `10.0.0.0/8` entry SHALL be replaced by the exact set of CIDRs that
+covers `10.0.0.0/8` **minus** the webhook Service CIDR, and every other default
+deny entry — `127.0.0.0/8`, `169.254.0.0/16` (which covers the cloud metadata
+endpoint `169.254.169.254`), `172.16.0.0/12`, `192.168.0.0/16`, and the default
+IPv6 ranges — SHALL be retained.
+
+**Rationale**: Zitadel v4.15.2+ denies all RFC1918 ranges by default (SSRF
+hardening, CVE-2026-55671) and routes Actions v2 Target calls through this
+client. The in-cluster webhook is dialed on a private ClusterIP, so without an
+exemption the deny list blocks token issuance and breaks all logins. Upstream
+[#12326](https://github.com/zitadel/zitadel/issues/12326) requesting an AllowList
+was closed `NOT_PLANNED`; the maintainer-endorsed technique is to punch a CIDR
+hole in the deny list for the trusted target. The hole is scoped to the Service
+CIDR (not `10.0.0.0/8` wholesale) so the exposure is limited to
+in-cluster-only ClusterIPs, and the metadata endpoint stays denied.
+
+#### Scenario: In-cluster Actions v2 Target call succeeds
+
+- **WHEN** Zitadel dials an Actions v2 Target at
+  `http://fan-api-webhook-svc.backend.svc.cluster.local:9090` (paths
+  `/pre-access-token` or `/account-login-event`), resolving to a ClusterIP within
+  the webhook Service CIDR
+- **THEN** the outbound HTTP client SHALL NOT deny the dial on the basis of the
+  destination being a private address
+- **AND** the request SHALL reach the backend webhook handler
+
+#### Scenario: Token issuance completes with the pre-access-token Target enabled
+
+- **WHEN** a user completes authentication and `POST /oauth/v2/token` triggers the
+  `pre-access-token` Actions v2 Target
+- **THEN** the Target call SHALL succeed and the token endpoint SHALL return a
+  successful response rather than HTTP 500 `Errors.Internal`
+
+#### Scenario: Cloud metadata endpoint remains denied
+
+- **WHEN** an outbound HTTP request from Zitadel targets the cloud metadata
+  endpoint `169.254.169.254` (or any address in `169.254.0.0/16`)
+- **THEN** the outbound HTTP client SHALL deny the dial
+
+#### Scenario: Non-webhook private ranges remain denied
+
+- **WHEN** an outbound HTTP request from Zitadel targets a private address outside
+  the webhook Service CIDR — including any `172.16.0.0/12`, `192.168.0.0/16`,
+  `127.0.0.0/8`, or the remainder of `10.0.0.0/8` not covered by the webhook
+  Service CIDR
+- **THEN** the outbound HTTP client SHALL deny the dial

--- a/openspec/changes/archive/2026-08-23-fix-zitadel-httpclient-denylist-blocks-webhook/tasks.md
+++ b/openspec/changes/archive/2026-08-23-fix-zitadel-httpclient-denylist-blocks-webhook/tasks.md
@@ -1,0 +1,23 @@
+## 1. Compute and verify the deny list
+
+- [x] 1.1 Recompute `10.0.0.0/8` minus the prod webhook Service CIDR `10.30.0.0/20` with `ipaddress.address_exclude` and confirm the 12 CIDRs match design.md Decision 1
+- [x] 1.2 Assemble the full prod deny list = all 13 v4.17.1 defaults with `10.0.0.0/8` replaced by the 12 CIDRs; diff it against the deployed version's `cmd/defaults.yaml` `HTTPClient.DenyList` and confirm every other entry (esp. `169.254.0.0/16`, `127.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, `0.0.0.0/8`, `100.64.0.0/10`, `198.18.0.0/15`, and all IPv6 entries) is preserved
+- [x] 1.3 Confirm the prod webhook ClusterIP (`fan-api-webhook-svc`, `10.30.12.134`) falls inside `10.30.0.0/20` and is NOT in any denied CIDR
+
+## 2. Apply the config in cloud-provisioning
+
+- [x] 2.1 Add `HTTPClient.DenyList` (full list from 1.2) under `zitadel.configmapConfig` in the prod overlay values, so prod gets the `10.30.0.0/20`-hole list (deep-merges with base `configmapConfig`; env-scoped)
+- [x] 2.2 Render the manifests (kustomize/helm) and confirm the config appears in the rendered Zitadel config with the exact expected value (24 entries, `169.254.0.0/16` preserved, `10.0.0.0/8` hole-punched) and no dropped entries
+- [x] 2.3 Run the cloud-provisioning checks/lint and open the PR per the standard workflow (issue #445, PR #446)
+
+## 3. Deploy and verify (prod)
+
+- [x] 3.1 Merge → confirm ArgoCD syncs and the Zitadel pods roll with the new env (ArgoCD Synced/Healthy at `da99a2a`; pods rolled `564cf5454c`→`66b5cfdc54` with new `checksum/configmap`)
+- [x] 3.2 Verify `POST /oauth/v2/token` returns success (not HTTP 500 `Errors.Internal`) and a real login completes end-to-end (user confirmed successful login post-roll; zero token 500s in logs)
+- [x] 3.3 Confirm the `error calling target ... address is denied by '10.0.0.0/8'` log line has stopped for both `/pre-access-token` and `/account-login-event` (0 deny + 0 target errors since roll; only benign session WARNs)
+- [x] 3.4 Spot-check that a denied range is still blocked (metadata `169.254.169.254` remains denied) — via config review, since it is not externally exercisable (rendered + running config keep `169.254.0.0/16`)
+
+## 4. Follow-ups
+
+- [x] 4.1 Add a note/checklist item to re-review this deny-list override against `defaults.yaml` on every future Zitadel version bump (merged inline comment in `overlays/prod/values.yaml`; runbook version-bump procedure note shipped in PR #447)
+- [x] 4.2 Record the dev-overlay Service CIDR value to apply when the dev env is next brought up (recorded as design.md Open Question; dev cluster stopped so the CIDR value cannot be fetched now)

--- a/openspec/specs/zitadel-self-hosted-deployment/spec.md
+++ b/openspec/specs/zitadel-self-hosted-deployment/spec.md
@@ -635,3 +635,57 @@ edit procedure applies to dev when it is next started.
 - **AND** the documented recovery for a projection-trigger wedge SHALL remain
   `kubectl rollout restart deploy/zitadel-api`
 
+### Requirement: Outbound HTTP Client Permits In-Cluster Webhook Targets While Retaining SSRF Protection
+
+Zitadel's protected outbound HTTP client (the deny list that governs Actions v2
+Target calls, `HTTPClient.DenyList` / env `ZITADEL_HTTPCLIENT_DENYLIST`) SHALL be
+configured so that the in-cluster webhook Service CIDR (`fan-api-webhook-svc`,
+prod `10.30.0.0/20`) is reachable, while all other RFC1918 private ranges, the
+loopback range, and the cloud metadata range remain denied. Concretely, the
+default `10.0.0.0/8` entry SHALL be replaced by the exact set of CIDRs that
+covers `10.0.0.0/8` **minus** the webhook Service CIDR, and every other default
+deny entry — `127.0.0.0/8`, `169.254.0.0/16` (which covers the cloud metadata
+endpoint `169.254.169.254`), `172.16.0.0/12`, `192.168.0.0/16`, and the default
+IPv6 ranges — SHALL be retained.
+
+**Rationale**: Zitadel v4.15.2+ denies all RFC1918 ranges by default (SSRF
+hardening, CVE-2026-55671) and routes Actions v2 Target calls through this
+client. The in-cluster webhook is dialed on a private ClusterIP, so without an
+exemption the deny list blocks token issuance and breaks all logins. Upstream
+[#12326](https://github.com/zitadel/zitadel/issues/12326) requesting an AllowList
+was closed `NOT_PLANNED`; the maintainer-endorsed technique is to punch a CIDR
+hole in the deny list for the trusted target. The hole is scoped to the Service
+CIDR (not `10.0.0.0/8` wholesale) so the exposure is limited to
+in-cluster-only ClusterIPs, and the metadata endpoint stays denied.
+
+#### Scenario: In-cluster Actions v2 Target call succeeds
+
+- **WHEN** Zitadel dials an Actions v2 Target at
+  `http://fan-api-webhook-svc.backend.svc.cluster.local:9090` (paths
+  `/pre-access-token` or `/account-login-event`), resolving to a ClusterIP within
+  the webhook Service CIDR
+- **THEN** the outbound HTTP client SHALL NOT deny the dial on the basis of the
+  destination being a private address
+- **AND** the request SHALL reach the backend webhook handler
+
+#### Scenario: Token issuance completes with the pre-access-token Target enabled
+
+- **WHEN** a user completes authentication and `POST /oauth/v2/token` triggers the
+  `pre-access-token` Actions v2 Target
+- **THEN** the Target call SHALL succeed and the token endpoint SHALL return a
+  successful response rather than HTTP 500 `Errors.Internal`
+
+#### Scenario: Cloud metadata endpoint remains denied
+
+- **WHEN** an outbound HTTP request from Zitadel targets the cloud metadata
+  endpoint `169.254.169.254` (or any address in `169.254.0.0/16`)
+- **THEN** the outbound HTTP client SHALL deny the dial
+
+#### Scenario: Non-webhook private ranges remain denied
+
+- **WHEN** an outbound HTTP request from Zitadel targets a private address outside
+  the webhook Service CIDR — including any `172.16.0.0/12`, `192.168.0.0/16`,
+  `127.0.0.0/8`, or the remainder of `10.0.0.0/8` not covered by the webhook
+  Service CIDR
+- **THEN** the outbound HTTP client SHALL deny the dial
+


### PR DESCRIPTION
## Summary

Archive the shipped-and-verified `fix-zitadel-httpclient-denylist-blocks-webhook` change.

- Syncs the `zitadel-self-hosted-deployment` delta into the main spec: new requirement **Outbound HTTP Client Permits In-Cluster Webhook Targets While Retaining SSRF Protection** (4 scenarios — in-cluster Target reachable, token issuance succeeds, cloud metadata still denied, other private ranges still denied).
- Moves the change to `openspec/changes/archive/2026-08-23-fix-zitadel-httpclient-denylist-blocks-webhook/`.

## Shipping evidence

Fix shipped and verified end-to-end in prod:
- cloud-provisioning [#446](https://github.com/liverty-music/cloud-provisioning/pull/446) — DenyList override (merged)
- cloud-provisioning [#447](https://github.com/liverty-music/cloud-provisioning/pull/447) — version-bump runbook note (merged)
- ArgoCD synced, Zitadel pods rolled, user-confirmed login recovery; `POST /oauth/v2/token` no longer 500s, deny/target errors cleared.

`openspec validate --strict` clean; `openspec validate --specs` 200/200.

Refs: liverty-music/cloud-provisioning#445