### PR TITLE
docs(openspec): propose upgrade-backend-go-1-27

### DIFF
--- a/openspec/changes/upgrade-backend-go-1-27/.openspec.yaml
+++ b/openspec/changes/upgrade-backend-go-1-27/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-23

--- a/openspec/changes/upgrade-backend-go-1-27/design.md
+++ b/openspec/changes/upgrade-backend-go-1-27/design.md
@@ -1,0 +1,60 @@
+## Context
+
+See proposal.md — Why. Current state that shapes the approach:
+
+- `backend/go.mod` is on `go 1.26` with the toolchain pinned to `1.26.6` for stdlib CVE fixes.
+- All UUIDs come from `github.com/google/uuid v1.6.0`: 14 call sites across ~11 files, all `NewV7()` for IDs plus one `Parse()` in `internal/infrastructure/analytics/posthog/posthog_client.go`. A central helper `internal/entity` (`newID()` → `uuid.Must(uuid.NewV7()).String()`) exists but most repositories/usecases call `uuid.NewV7()` directly, so the abstraction is leaky.
+- **No pprof/debug HTTP endpoint is currently mounted anywhere** in the backend.
+- Monitoring is metric-based: Google Managed Prometheus (`PodMonitoring`) + Cloud Monitoring `AlertPolicy` provisioned via Pulumi in `cloud-provisioning`. Application metrics already flow through an OTel SDK/metric pipeline (`backend-otel-instrumentation`). Existing consumer health is alerted on `nats_consumer_num_pending` backlog and liveness.
+- Go 1.27 promotes the `goroutineleak` profile to GA (no `GOEXPERIMENT` needed) and makes the stdlib `uuid` package available; `go test` now runs the `stdversion` vet check by default.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Land the toolchain + `go` directive bump to 1.27 cleanly, including the one-time `go fix` modernizer diff.
+- Detect silent goroutine wedges through an alertable metric, reusing the existing OTel-metric → GMP → AlertPolicy path rather than inventing a new monitoring channel.
+- Remove the `github.com/google/uuid` direct dependency with zero change to ID format or behavior.
+
+**Non-Goals:**
+- Migrating application code to the explicit `encoding/json/v2` API or tightening Gemini parse strictness (separate follow-on change; this change only inherits the implicit v2-backed speedup by upgrading).
+- Adopting other 1.27 features (generic methods, `simd`, ML-DSA/post-quantum TLS — the backend imports no `crypto/tls`).
+- Changing consumer backlog-stall or liveness alerting; leak detection is additive.
+
+## Decisions
+
+### D1: Two-step upgrade — toolchain first, then `go` directive, in one change
+Bump the toolchain to 1.27.x and raise the `go 1.27` directive together, but treat them as ordered steps. Rationale: the stdlib `uuid` migration cannot compile until the directive is `1.27` (the package does not exist earlier and the new default `stdversion` vet check would flag it). Landing both in the same change keeps `go.mod` and the uuid migration consistent. Alternative (directive-only, keep old toolchain) rejected: the directive raises the language/stdlib floor, so the toolchain must match.
+
+### D2: Route all UUID generation through the `entity` ID helper; parse stays local
+Consolidate the 14 call sites to a single generation helper in `internal/entity` and update the lone `Parse` in `posthog_client.go` in place. Rationale: stdlib `uuid.NewV7()` returns `UUID` with **no error** (it panics internally on entropy failure) versus google/uuid's `(UUID, error)`. This deletes the `id, err := ...` / `if err != nil` boilerplate and the `uuid.Must` wrapper at every site, and the panic-on-entropy-failure semantics exactly match the existing helper's documented contract. Collapsing to one import site also makes the dependency swap a one-line edit and prevents the leaky abstraction from regrowing. Alternative (mechanical in-place swap at every site) rejected: same edit count, but leaves 11 direct imports and misses the consolidation win.
+
+### D3: Alert on a leaked-goroutine **metric**, expose pprof for on-demand debugging
+Two complementary surfaces:
+- **Alerting path (primary):** a periodic in-process sampler looks up the `goroutineleak` profile, counts leaked goroutines, and publishes it as an OTel gauge (e.g. `backend_goroutine_leak_count`) with a workload label. A Cloud Monitoring `AlertPolicy` (Pulumi, alongside existing consumer alerts) fires when the value stays `> 0` beyond an evaluation window and auto-closes on recovery.
+- **Debug path (secondary):** mount `net/http/pprof` (including the `goroutineleak` profile) on an **internal-only** listener (separate port, not the public Connect-RPC/ingress surface) so operators can pull a full profile with stacks on demand.
+
+Rationale: their alerting is metric-driven (GMP/PromQL), so a metric is the idiomatic escalation path and satisfies the spec's "alert without a user report"; the raw pprof endpoint satisfies the spec's "stack to identify the blocking site" for investigation. Alternative (log-based alert) rejected: memory notes GMP notificationRateLimit issues with log-based policies and the team already standardizes on metric AlertPolicies. Alternative (public pprof) rejected on security grounds (spec forbids public unauthenticated exposure).
+
+### D4: Sampling cadence is conservative and configurable
+The `goroutineleak` profile analysis is not free (it inspects the runtime's goroutine set). Sample on a slow interval (order of minutes, env-configurable) rather than per-request or per-scrape. Rationale: leak detection is a slow-moving condition; a wedge that matters persists for minutes, so a coarse interval catches it while keeping overhead negligible. The evaluation window in the AlertPolicy — not the sampler — provides the transient-vs-sustained distinction the spec requires.
+
+### D5: `make fix` runs `go fix ./...`; `make modernize` gate unchanged in shape
+`make modernize` already fails closed on non-empty `go fix -diff ./...` — keep it. Fix the `make fix` gap so it runs `go fix ./...` (twice, for fixed point per Go guidance) in addition to `gofmt -w`, so the message "Run 'go fix ./...'" the gate prints is actually actionable via `make fix`. The 1.27 modernizer set changes (adds `atomictypes`/`embedlit`/`slicesbackward`/`unsafefuncs`, removes `fmtappendf`, renames `waitgroup`→`waitgroupgo`) are picked up automatically from the bundled toolchain; the one-time diff they produce is applied in this change.
+
+## Risks / Trade-offs
+
+- **`goroutineleak` profile blind spots** (leaks via global variables or via still-runnable goroutines are not reported) → Documented in the spec as a known limitation; leak alerting is additive to, not a replacement for, backlog-stall/liveness alerting, so those failure classes remain covered by existing signals.
+- **NATS-internal wedges may not surface as Go-side blocked goroutines** (a durable misbind means "NATS isn't delivering," which may not block a Go goroutine on a primitive) → Same mitigation: backlog-stall alert stays as the complementary signal; leak alert catches the Go-side-blocked subset.
+- **Sampling overhead / pause** from profile analysis → D4 coarse, configurable interval keeps cost negligible; can be disabled via config if it ever regresses.
+- **`go fix` modernizer churn on the toolchain bump** (new modernizers rewrite existing code) → Apply and review the diff as ordinary code in this change from a clean tree, run twice to reach fixed point; CI gate then keeps it green going forward.
+- **1.27 behavioral change: `time`-package channels are now always unbuffered/synchronous** (`asynctimerchan` GODEBUG removed) → Audit `time.After`/`Ticker` usage in `select` loops (consumers) during implementation; low likelihood given no reliance on buffered timer channels, but verify.
+- **Removed GODEBUG settings fail the build if referenced** → `backend/go.mod` sets no GODEBUG values and the backend imports no `crypto/tls`; confirm no `//go:debug` directives before raising the directive.
+
+## Migration Plan
+
+1. Bump toolchain to 1.27.x in `backend/go.mod`; run `go build`/`go test` to confirm the runtime upgrade (malloc + json/v2-backed speedups land here with no code change).
+2. Raise the `go 1.27` directive; run `go fix ./...` (×2) from a clean tree and commit the modernizer diff; fix `make fix`.
+3. Migrate UUID call sites through the `entity` helper; drop `github.com/google/uuid`; `go mod tidy`.
+4. Add the goroutine-leak sampler + OTel gauge and the internal pprof listener.
+5. Provision the `AlertPolicy` in `cloud-provisioning`.
+- **Rollback:** each step is independently revertible. The directive/toolchain bump and uuid swap revert as ordinary `go.mod`/code changes; the sampler and AlertPolicy can be removed without affecting request paths. No data migration is involved.

--- a/openspec/changes/upgrade-backend-go-1-27/proposal.md
+++ b/openspec/changes/upgrade-backend-go-1-27/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+Go 1.27 (August 2026) ships changes that map directly onto this backend's operational pain and dependency surface: a GA `goroutineleak` runtime profile that detects goroutines permanently blocked on channels/mutexes — the exact failure class behind our repeated JetStream consumer wedge outages that fired no alert — plus a size-specialized allocator and a `json/v2`-backed `encoding/json` that speed up our allocation- and JSON-heavy RPC/event paths for free. The release also adds a standard-library `uuid` package that covers everything we use, letting us drop the `github.com/google/uuid` direct dependency. Upgrading now, while the toolchain pin is already carrying stdlib CVE fixes, keeps us on a supported, hardened runtime.
+
+## What Changes
+
+- Upgrade the backend Go toolchain from 1.26 to 1.27, then raise the `go` directive in `backend/go.mod` to `1.27` (unlocks the stdlib `uuid` package and enables the `stdversion` vet check `go test` now runs by default).
+- **Enable goroutine leak detection**: expose the GA `runtime/pprof` `goroutineleak` profile (via `/debug/pprof/goroutineleak`) and wire it into monitoring/alerting so silent consumer wedges surface as an alert rather than a user-reported outage.
+- Migrate all UUID generation/parsing from `github.com/google/uuid` to the standard-library `uuid` package (V7 for IDs, `Parse` for validation), consolidating call sites through the existing `entity` ID helper, and **remove the `github.com/google/uuid` direct dependency**.
+- Adopt the size-specialized allocator and the `json/v2`-backed `encoding/json` implicitly by upgrading (no code change); optionally tighten Gemini LLM-output parsing against `json/v2` strict semantics (reject duplicate keys / invalid UTF-8) — scoped as a follow-on, behind compatibility verification.
+- Refine the existing `make modernize` / `make fix` targets for the Go 1.27 modernizer set (new `atomictypes`/`embedlit`/`slicesbackward`/`unsafefuncs`, removed `fmtappendf`, renamed `waitgroup`→`waitgroupgo`); close the `make fix` gap so it actually runs `go fix ./...`, and apply the one-time modernizer diff surfaced by the toolchain bump.
+
+## Capabilities
+
+### New Capabilities
+- `goroutine-leak-detection`: The backend continuously exposes a goroutine leak profile and raises an alert when goroutines are detected permanently blocked on concurrency primitives, catching silent consumer/RPC wedges that backlog-stall and liveness signals can miss.
+
+### Modified Capabilities
+<!-- None. The Go 1.27 toolchain bump, stdlib uuid migration, json/v2 adoption, and
+     modernize target tuning change implementation and tooling only — no externally
+     observable spec-level behavior changes. UUIDs remain V7 with identical string
+     format; JSON wire behavior is unchanged unless the optional strict-parsing
+     follow-on is pursued, which would be scoped as its own change. -->
+
+## Impact
+
+- **Code**: `backend/go.mod` (toolchain + `go` directive, drop `github.com/google/uuid`); 14 UUID call sites across ~11 files (`internal/usecase/*`, `internal/infrastructure/database/rdb/*`, `internal/infrastructure/messaging/cloudevents.go`, `internal/infrastructure/analytics/posthog/posthog_client.go`) routed through `internal/entity` ID helper; a new pprof/monitoring wiring point for the goroutine leak profile.
+- **Dependencies**: `github.com/google/uuid v1.6.0` removed from direct requires (transitive `lithammer/shortuuid` unaffected). No new third-party dependency added.
+- **Tooling/CI**: `make modernize` (already gates on `go fix -diff`) and `make fix` updated for the 1.27 modernizer set; `go test` gains the default `stdversion` vet check. Toolchain bump must land the one-time `go fix ./...` diff in the same change.
+- **Ops/Infra**: new alert policy / monitoring hook for the goroutine leak profile (aligns with existing `app-error-log-alerting`, `jetstream-consumer-reliability` observability). No API, proto, or frontend impact.
+- **Sequencing**: stdlib `uuid` adoption depends on the `go` directive reaching `1.27` first (the `stdversion` vet check enforces it).

--- a/openspec/changes/upgrade-backend-go-1-27/specs/goroutine-leak-detection/spec.md
+++ b/openspec/changes/upgrade-backend-go-1-27/specs/goroutine-leak-detection/spec.md
@@ -1,0 +1,57 @@
+## Purpose
+
+Give operators an automatic signal when backend goroutines become permanently blocked on concurrency primitives, so silent consumer or RPC wedges are detected and alerted instead of surfacing later as a user-reported outage.
+
+## ADDED Requirements
+
+### Requirement: Goroutine leak profile is exposed
+
+The backend SHALL expose a goroutine leak profile that reports goroutines detected as permanently blocked on a concurrency primitive (channel operation, `sync.Mutex`, or `sync.Cond`) with no possibility of becoming runnable. The profile SHALL be retrievable at runtime from a running backend instance without a restart or redeploy, and each entry SHALL include the blocked goroutine's stack so the blocking site can be identified.
+
+#### Scenario: Profile retrievable from a healthy instance
+
+- **WHEN** an operator requests the goroutine leak profile from a running backend instance that has no leaked goroutines
+- **THEN** the request succeeds and returns an empty (zero-entry) profile
+
+#### Scenario: Leaked goroutine appears in the profile with its stack
+
+- **WHEN** a goroutine is permanently blocked on a channel receive, mutex, or condition variable that can never unblock, and an operator requests the goroutine leak profile
+- **THEN** the profile includes an entry for that goroutine annotated with its blocking stack trace
+
+#### Scenario: Profiling endpoint is not publicly reachable
+
+- **WHEN** the goroutine leak profiling endpoint is deployed
+- **THEN** it is reachable only through operator/internal access paths and is not exposed on a public, unauthenticated route
+
+### Requirement: Detected goroutine leaks raise an alert
+
+The backend's monitoring SHALL raise an alert to the operations notification channel when the goroutine leak profile reports one or more leaked goroutines that persist beyond a transient window, so that a silent wedge is escalated without depending on a user report. The alert SHALL identify the affected workload.
+
+#### Scenario: Sustained leak escalates to operators
+
+- **WHEN** the goroutine leak profile reports one or more leaked goroutines on a workload continuously beyond the configured evaluation window
+- **THEN** an alert is delivered to the operations notification channel identifying the affected workload
+
+#### Scenario: Transient blocking does not alert
+
+- **WHEN** a goroutine appears blocked only momentarily and clears within the evaluation window
+- **THEN** no alert is raised
+
+#### Scenario: Incident auto-resolves when leaks clear
+
+- **WHEN** a previously alerting workload reports zero leaked goroutines for the configured recovery window
+- **THEN** the corresponding incident is automatically closed
+
+### Requirement: Leak detection complements existing consumer health signals
+
+The goroutine leak alert SHALL be an additional, independent signal that does not replace existing consumer backlog-stall or liveness alerting, so that a wedge missed by backlog metrics is still caught, and its scope and known blind spots (leaks reachable only through global variables or through goroutines that remain runnable) SHALL be documented for operators.
+
+#### Scenario: Wedge invisible to backlog metrics is still detected
+
+- **WHEN** a consumer goroutine is wedged on a concurrency primitive while its backlog metric does not breach the backlog-stall threshold
+- **THEN** the goroutine leak alert still fires for that workload independently of the backlog-stall alert
+
+#### Scenario: Known blind spots are documented
+
+- **WHEN** an operator consults the capability's documentation
+- **THEN** it states that the profile may miss leaks reachable only via global variables or via still-runnable goroutines, and directs the operator to complementary signals for those cases

--- a/openspec/changes/upgrade-backend-go-1-27/tasks.md
+++ b/openspec/changes/upgrade-backend-go-1-27/tasks.md
@@ -1,0 +1,35 @@
+## 1. Toolchain upgrade (runtime speedups, no code change)
+
+- [ ] 1.1 Confirm no `//go:debug` directives or removed GODEBUG settings in `backend/go.mod` / sources (e.g. `asynctimerchan`); backend imports no `crypto/tls`, so TLS GODEBUG removals are N/A
+- [ ] 1.2 Bump the toolchain to Go 1.27.x in `backend/go.mod`
+- [ ] 1.3 Run `go build ./...` and `go test ./...`; verify green (inherits size-specialized malloc + `json/v2`-backed `encoding/json` speedups for free)
+- [ ] 1.4 Audit `time.After` / `time.Ticker` usage in consumer `select` loops for reliance on the old buffered timer-channel behavior (now always unbuffered)
+
+## 2. Raise `go` directive and apply modernizers
+
+- [ ] 2.1 Raise the `go 1.27` directive in `backend/go.mod`
+- [ ] 2.2 From a clean tree, run `go fix ./...` twice (fixed point) and commit the modernizer diff for the 1.27 set (`atomictypes`/`embedlit`/`slicesbackward`/`unsafefuncs`; `waitgroup`→`waitgroupgo`; `fmtappendf` removed)
+- [ ] 2.3 Update `make fix` to run `go fix ./...` (×2) in addition to `gofmt -w .`
+- [ ] 2.4 Run `make modernize` and `go test ./...` (now including the default `stdversion` vet check) and confirm both pass
+
+## 3. Migrate to stdlib `uuid`, drop google/uuid
+
+- [ ] 3.1 Update `internal/entity` ID helper to use stdlib `uuid.NewV7().String()` (drop the `uuid.Must` / error handling)
+- [ ] 3.2 Route the 14 `uuid.NewV7()` generation call sites (in `internal/usecase/*`, `internal/infrastructure/database/rdb/*`, `internal/infrastructure/messaging/cloudevents.go`) through the `entity` helper; delete their local `id, err := ...` boilerplate
+- [ ] 3.3 Switch the `Parse` call in `internal/infrastructure/analytics/posthog/posthog_client.go` to stdlib `uuid.Parse`
+- [ ] 3.4 Remove `github.com/google/uuid` from imports and run `go mod tidy`; confirm it is gone from direct requires
+- [ ] 3.5 Run tests and verify generated IDs remain UUIDv7 with identical string format (existing ID/entity tests pass)
+
+## 4. Goroutine leak detection — metric + pprof (spec: goroutine-leak-detection)
+
+- [ ] 4.1 Add an internal-only HTTP listener that mounts `net/http/pprof` including the `goroutineleak` profile, on a separate non-public port (not the Connect-RPC/ingress surface)
+- [ ] 4.2 Add a periodic sampler that looks up the `goroutineleak` profile, counts leaked goroutines, and publishes an OTel gauge (e.g. `backend_goroutine_leak_count`) with a workload label; interval is env-configurable and coarse (minutes)
+- [ ] 4.3 Verify the profile is empty on a healthy instance and that a deliberately wedged goroutine (test/staging) appears with its stack and increments the gauge
+- [ ] 4.4 Confirm the pprof listener is not reachable on any public/unauthenticated route
+
+## 5. Alerting and documentation
+
+- [ ] 5.1 Provision a Cloud Monitoring `AlertPolicy` (Pulumi, `cloud-provisioning`, alongside existing consumer alerts) that fires when `backend_goroutine_leak_count > 0` beyond the evaluation window and auto-closes on recovery, notifying the ops channel and identifying the workload
+- [ ] 5.2 Validate the metric ingests in GMP and the alert previews without apply-time errors (disableMetricValidation if not-yet-ingested)
+- [ ] 5.3 Document the capability's known blind spots (leaks via globals / still-runnable goroutines) and its complementary relationship to backlog-stall & liveness alerting
+- [ ] 5.4 Run the full `make check` (lint + schema-lint + modernize + test) and confirm green


### PR DESCRIPTION
## 🔗 Related Issue

N/A — planning proposal (no tracking issue). Implementation will follow via the OpenSpec apply workflow.

## 📝 Summary of Changes

Adds a new OpenSpec change, `upgrade-backend-go-1-27`, that plans the backend Go **1.26 → 1.27** upgrade. This PR contains planning artifacts only (proposal / spec delta / design / tasks) — no backend code changes.

**Motivation.** Go 1.27 lands features that map directly onto this backend's operational history and dependency surface: a GA `goroutineleak` runtime profile that detects goroutines permanently blocked on channels/mutexes — the exact failure class behind our repeated silent JetStream consumer wedges — plus a size-specialized allocator and a `json/v2`-backed `encoding/json` that speed up our allocation- and JSON-heavy paths for free, and a standard-library `uuid` package that lets us drop a third-party dependency.

**What the change plans:**
- **Toolchain + `go` directive → 1.27**, applying the one-time `go fix` modernizer diff.
- **New capability `goroutine-leak-detection`** — expose the GA `goroutineleak` profile and alert on sustained leaks via a metric (OTel gauge → GMP → Cloud Monitoring `AlertPolicy`), with an internal-only pprof endpoint for on-demand stacks. This is additive to existing backlog-stall / liveness signals, with known blind spots documented.
- **Migrate UUIDs to stdlib `uuid`** (V7 + `Parse`), consolidating 14 call sites through the `entity` ID helper and **removing the `github.com/google/uuid` direct dependency** — no change to ID format.
- **Inherit the allocator + `json/v2` speedups** implicitly (no code change); explicit `json/v2` strict parsing is deferred to a separate change.
- **Tune `make modernize` / `make fix`** for the 1.27 modernizer set and close the `make fix` gap so it runs `go fix ./...`.

**Scope note.** Only `goroutine-leak-detection` is a spec delta (new observable behavior); the toolchain bump, uuid migration, and modernize tuning are tooling/refactor with no spec-level behavior change. `openspec validate --strict` passes.

## ✅ Self-Checklist

- [ ] I have linked the related issue. — N/A, planning proposal
- [x] I have updated the relevant documentation if needed. — OpenSpec change artifacts added
- [ ] I have run `buf lint` and `buf format` locally and all checks have passed. — N/A, no proto changes
- [x] My proto definitions follow the project's style guidelines and validation rules. — N/A; `openspec validate --strict` passes
- [ ] Breaking changes have been justified and documented if applicable. — N/A, no breaking changes
