### PR TITLE
docs(openspec): align organizer invite onboarding with the Zitadel standard flow

### DIFF
--- a/openspec/changes/align-organizer-invite-onboarding-with-zitadel-standard/.openspec.yaml
+++ b/openspec/changes/align-organizer-invite-onboarding-with-zitadel-standard/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-23

--- a/openspec/changes/align-organizer-invite-onboarding-with-zitadel-standard/design.md
+++ b/openspec/changes/align-organizer-invite-onboarding-with-zitadel-standard/design.md
@@ -1,0 +1,135 @@
+## Context
+
+See proposal.md — Why. This change realigns organizer operator onboarding with
+Zitadel's **standard** invitation flow and closes a session-reuse / org-pinning
+gap. It supersedes the archived organizer-console decisions **D1** (org-pinned
+entry via a URL `org_id`) and **D5** (console-pointed invite), and revises **D7**
++ tracking issue liverty-music/specification#843.
+
+Current shipped state (all in prod): backend v1.39.0 (provisioner creates the
+operator via v2 `AddHumanUser` with verified email + no password; login policy
+`allowUsernamePassword=true`; invite via `CreateInviteCode(SendInviteCode)` with
+a **console** `url_template`); frontend v1.57.5; Zitadel **v4.17.1**. Note the
+canonical main specs `organizer-accounts` / `organizer-tenancy` were never
+updated for the v1.38.0/v1.39.0 backend fixes, so they still describe the old
+"passkey-registration init link" and `allowUsernamePassword=false` — this change
+corrects that drift as part of the delta.
+
+Source references (Zitadel `apps/login`): the standard invite UX
+([zitadel/zitadel#8310](https://github.com/zitadel/zitadel/issues/8310),
+[zitadel/typescript#166](https://github.com/zitadel/typescript/issues/166));
+`lib/server/verify.ts` `buildVerificationUrlTemplate`; `lib/server/loginname.ts`;
+`lib/server/passkeys.ts` and `lib/client.ts` (@ v4.17.1). Evidence for the
+findings below is from a live re-verification on 2026-08-23 (org-test-30 clean
+run + Zitadel logs).
+
+## Goals / Non-Goals
+
+**Goals:** one standard "Accept invite" email (click, not type); the invite
+credential stays on the IdP surface; the operator lands back on the console after
+accepting; the console enforces the authenticated org so a stale/other session
+cannot onboard the wrong tenant; correct the stale login-policy spec and the
+duplicate-email record.
+
+**Non-Goals:** business screens; email-domain discovery; per-tenant IdP wiring;
+a self-serve OTP recovery lane (admin re-invite remains the recovery path);
+re-verifying every Zitadel version — this targets v4.17.1 (prod).
+
+## Decisions
+
+**D-A — Invite points at Zitadel's own `/verify`, not the console (Pattern C).**
+The provisioner creates the invite with `SendInviteCode` and a `url_template` of
+`https://auth.{base}/ui/v2/login/verify?code={{.Code}}&userId={{.UserID}}&organization={{.OrgID}}&invite=true`.
+This is the standard form — **proven supported**: the login app's own
+`buildVerificationUrlTemplate` (verify-server.ts) builds exactly this shape and
+passes it to `createInviteCode`, so those placeholders are first-class. Result:
+ONE "Accept invite" email, the operator clicks (never types), the code rides in
+the link on the IdP surface (never in a console URL). Drops the console-first
+"transport invite" indirection that caused the empty "enter code" screen and the
+second email. *Alternative rejected:* keep the console-pointed invite — it is the
+source of the UX mismatch and the second email.
+
+**D-B — Return to the console via the tenant login policy `default_redirect_uri`.**
+An invite accepted outside any in-flight OIDC request has no `requestId` to
+resume, so after passkey setup the login app uses the org's default redirect.
+**Proven wiring (v4.17.1):** `lib/server/passkeys.ts` fetches
+`getLoginSettings(...).defaultRedirectUri` (L265) and passes it to
+`completeFlowOrGetUrl(...)`; in the no-`requestId` branch
+(`else if (session?.factors?.user?.loginName)`, L303-308) it calls
+`completeFlowOrGetUrl({ loginName, organization }, loginSettings?.defaultRedirectUri)`.
+`lib/client.ts` `resolveRedirectUri` priority is: `DEFAULT_REDIRECT_URI` env →
+**org-settings `defaultRedirectUri`** → `/signedin` fallback. So setting the
+tenant login policy `default_redirect_uri = https://organizer.{base}/`
+(via `UpdateCustomLoginPolicy`, which the provisioner already calls) returns the
+operator to the console. The console then completes OIDC against the fresh
+session → `/welcome`. *Alternative rejected:* set the OIDC app default redirect
+or a `DEFAULT_REDIRECT_URI` env — those are instance/app-wide, not per-tenant.
+
+**D-C — Login policy: `allowUsernamePassword=true` (correct the stale spec).**
+Already shipped in v1.39.0 and required: the field gates ALL local auth
+(username + passkey OR password), so `false` removes the username form and dead-
+ends onboarding. Passkey-primary = `PASSWORDLESS_TYPE_ALLOWED` + no password on
+the operator. This delta brings `organizer-tenancy` in line with prod.
+
+**D-D — Console enforces the authenticated org (session-reuse fix).** After the
+callback, the console SHALL check the token's org (the `owner` grant's org in the
+`urn:zitadel:iam:org:project:roles` claim / resource owner) against the intended
+tenant. On mismatch it forces re-authentication (`prompt=login`) or signs the
+stale session out, rather than admitting the wrong operator. This closes the
+reproduced bug where an existing org-test-21 session satisfied org-test-30's
+entry.
+
+**The "intended tenant" signal (resolved — Option 2).** The tenant login policy
+`default_redirect_uri` carries this tenant's org id
+(`https://organizer.{base}/?org_id=<tenantOrgId>`, set by the provisioner). On
+the post-invite landing the console compares the token's org to that `org_id`;
+on a match it proceeds to `/welcome` (no extra passkey tap), and only on a
+mismatch does it force `prompt=login` (+ `org:id` pin) to re-authenticate as the
+correct tenant. *Alternative rejected:* always `prompt=login` on the landing —
+safe but costs the just-onboarded operator an extra passkey tap in the normal
+case; and trusting any single-org `owner` token does NOT fix the bug (a reused
+org-21 token is itself a valid single-org owner token).
+
+**D-E — Correct the duplicate-email record.** Logs proved the duplicate "Zitadel
+Login" emails came from **two OIDC authorize flows** (each sending one invite via
+the login app's per-mount-guarded `initialSendVerification`), NOT from "/verify
+re-firing on every render." Under Pattern C the operator no longer transits
+loginname→/verify from the console, so this class of duplicate is largely
+designed out; the finding is recorded against #843 and supersedes D7's wording.
+
+## Risks / Trade-offs
+
+- **[Not end-to-end validated] Single email under Pattern C.** Strongly
+  source-supported (arriving at `/verify?code=…` carries the code, so loginname's
+  server-side `trySendVerification` is not on the path), but not live-tested →
+  validate during implementation; log the login-app `CreateInviteCode` count.
+- **[Not validated] `DefaultRedirectUri` safe-redirect acceptance.** `client.ts`
+  `resolveRedirectUri` runs `isSafeRedirectUri` on the settings value → confirm
+  the console origin passes; fall back to `DEFAULT_REDIRECT_URI` env if needed.
+- **[Fresh-session org context] After the default redirect the console has no
+  `org_id` in the URL.** With D1 removed, the console must derive the org from
+  the session/token (the operator authenticated as themselves). Confirm the
+  guard/config path works without a URL `org_id` → see Open Questions.
+- **[Zitadel notification bug, independent] `could not set notification event on
+  aggregate: Errors.User.NotFound`** reproduces for tenant-org operators. It did
+  not cause the duplicate and is out of scope here; track separately.
+
+## Migration Plan
+
+1. backend (`organizer-accounts`): change the `CreateInviteCode` `url_template`
+   to the Zitadel `/verify` form; set login policy `default_redirect_uri` to the
+   console (extend the existing `ensureLoginPolicy` / `UpdateCustomLoginPolicy`).
+2. frontend (`organizer-console`): implement the token-org enforcement (D-D);
+   handle the default-redirect landing without a URL `org_id`; narrow/retire the
+   now-optional `login_hint` handling.
+3. Verify E2E on a fresh operator in a clean session: one email, click-not-type,
+   `/welcome`, and that a pre-existing other-org session is rejected.
+4. Reconcile the archived organizer-console D7 / issue #843 wording.
+- **Rollback:** the changes are per-tenant policy + provisioner template + a
+  console guard; revert restores the current (working but irregular) flow.
+
+## Open Questions
+
+- None. The "intended tenant" signal for D-D was resolved to Option 2 (the
+  tenant `org_id` carried in `default_redirect_uri` + post-callback comparison) —
+  see decision D-D.

--- a/openspec/changes/align-organizer-invite-onboarding-with-zitadel-standard/proposal.md
+++ b/openspec/changes/align-organizer-invite-onboarding-with-zitadel-standard/proposal.md
@@ -1,0 +1,92 @@
+## Why
+
+The shipped organizer operator onboarding deviates from Zitadel's standard
+invite flow, producing a confusing UX and a tenant-isolation bug. A live
+re-verification (2026-08-23, backend v1.39.0 / frontend v1.57.5 / Zitadel
+v4.17.1) established, with logs and source, three problems:
+
+1. **UX mismatch.** The backend sends its own "Liverty Organizer" transport
+   invite pointing at the **console**, which starts OIDC and lands the operator
+   on Zitadel's `/verify` **without the code**, so they see an empty "enter the
+   code" screen. Hosted Login v2 then sends a **second** "Invitation to Zitadel
+   Login" email whose link is a "click Accept invite" button (code embedded in
+   the link, not shown as text). The screen says "type a code"; the email says
+   "click a button" — they contradict each other. Zitadel's standard invite is
+   ONE "Accept invite" email whose link opens `/verify?code=…&invite=true`
+   directly (code in the link, click-not-type) — see zitadel/zitadel#8310 and
+   zitadel/typescript#166.
+
+2. **Tenant-isolation / org-pinning bug (security-relevant).** Opening a fresh
+   operator's invite while an unrelated Zitadel session already exists in the
+   browser **reuses that session** — the `urn:zitadel:iam:org:id:<id>` scope is
+   a hint Zitadel ignores when a session exists, and prod does not force
+   re-authentication (`prompt=login` is dev-only). The operator is then
+   authenticated as the **wrong org** and the genuine invite is silently
+   swallowed. Not a cross-user data breach (backend authz is per-token), but a
+   real org-pinning enforcement gap that must be closed before business screens.
+
+3. **Corrections to prior records.** The earlier "duplicate invite emails" were
+   proven (Zitadel logs) to come from **two OIDC authorize flows**, each
+   legitimately sending one invite — NOT from "/verify re-firing on every
+   render." The tracking issue liverty-music/specification#843 and the archived
+   organizer-console design D7 must be corrected.
+
+## What Changes
+
+- **Adopt Zitadel's standard invite flow (Pattern C).** The provisioner creates
+  the invite with a `url_template` pointing at Zitadel's own login `/verify`
+  (`/verify?code={{.Code}}&userId={{.UserID}}&organization={{.OrgID}}&invite=true`)
+  instead of the console — ONE "Accept invite" email, click-not-type, and the
+  code stays on the IdP surface (`auth.{base}`), never in a console URL.
+- **Return the operator to the console after acceptance via the tenant login
+  policy's `default_redirect_uri`.** Set it to `https://organizer.{base}/`. After
+  passkey setup with no OIDC request in flight, Login v2 redirects there
+  (source-verified wiring; see design). The console then completes OIDC (fresh
+  session) → `/welcome`.
+- **BREAKING (onboarding model): drop console-first org-pinned entry.** The
+  console no longer relies on an `org_id` URL param to pin the org on first
+  sign-in (D1) nor on a console-pointed invite (D5). The invite code (bound to
+  the operator) carries org context; the console derives the org from the token.
+- **Fix the session-reuse / org-pinning bug.** The console enforces that the
+  authenticated token's org matches the intended tenant; a mismatched or reused
+  session forces re-authentication (or sign-out) rather than silently admitting
+  the wrong operator.
+- **Correct prior records.** Reconcile the duplicate-email cause (two authorize
+  flows) in the affected spec text and note it against issue #843.
+
+## Capabilities
+
+### New Capabilities
+<!-- None. This change modifies existing, already-archived capabilities. -->
+
+### Modified Capabilities
+- `organizer-accounts`: the "Initial operator bootstraps credentials on first
+  sign-in" requirement — the invite is created with a Zitadel-standard
+  `/verify` `url_template` (one email, click-not-type), replacing the
+  console-pointed transport invite.
+- `organizer-tenancy`: the "Organizer tenant orgs use a passkey-primary login
+  policy…" requirement — the tenant login policy additionally sets
+  `default_redirect_uri` to the organizer console so invite/passkey completion
+  returns to the console.
+- `organizer-console`: the "Authenticate operators via org-pinned entry…" and
+  "login_hint pre-fill…" requirements — first-time entry is via the login-policy
+  default redirect after invite acceptance (not a console-pointed link or a
+  fixed `org_id` URL param); the console enforces the session's org matches the
+  intended tenant (closing the session-reuse gap).
+
+## Impact
+
+- **backend** (`organizer-accounts` provisioner,
+  `internal/infrastructure/zitadel/organizer_provisioner.go`): change the
+  `CreateInviteCode` `url_template`; set the login policy `default_redirect_uri`.
+  No new email/SMTP infrastructure.
+- **frontend** (`organizer-console`): entry/guard/callback handling for the
+  default-redirect landing and the org-match enforcement; the `login_hint` role
+  narrows.
+- **cloud-provisioning / organizer-tenancy**: none expected beyond the login
+  policy field, which the backend provisioner sets at runtime.
+- No proto changes. Supersedes archived organizer-console decisions D1 and D5;
+  revises D7 and tracking issue liverty-music/specification#843.
+- Prod stack: Zitadel v4.17.1 (server-side invite send via `trySendVerification`,
+  `codeSent` verify flag), backend v1.39.0, frontend v1.57.5. Tracked under
+  liverty-music/specification#759 (roadmap step ①).

--- a/openspec/changes/align-organizer-invite-onboarding-with-zitadel-standard/specs/organizer-accounts/spec.md
+++ b/openspec/changes/align-organizer-invite-onboarding-with-zitadel-standard/specs/organizer-accounts/spec.md
@@ -1,0 +1,56 @@
+## MODIFIED Requirements
+
+### Requirement: Initial operator bootstraps credentials on first sign-in
+
+The system SHALL create the initial operator as a human user in the Organizer's
+tenant org with a **verified email and no password**, and onboard them using
+Zitadel's **standard invitation flow**: the system creates an invite code for
+the operator and has Zitadel send **one** branded invitation email whose
+"accept" link opens the identity provider's own credential-setup page with the
+code already carried in the link. The operator SHALL complete first sign-in by
+**clicking that link** (never by transcribing a code) and registering a passkey.
+On completion the operator SHALL be returned to the organizer console
+authenticated (the tenant login policy's post-setup redirect targets the
+console — see `organizer-tenancy`), landing on the owner-gated placeholder.
+
+The invitation email SHALL be the **only** message the operator must act on for
+first sign-in (no separate "transport" email, and no second code email under the
+normal single-entry flow). The credential (invite/verification code) SHALL
+remain on the identity-provider surface and SHALL NOT be exposed in a
+console/application URL.
+
+Recovery SHALL be an **admin-initiated re-invite** (the system re-issues the
+operator's invitation), consistent with the tenant org's passkey-primary policy
+and its recovery path in `organizer-tenancy`. Org resolution is bound to the
+operator's account by the invitation itself — the operator cannot be routed to a
+different org by supplying a different email (no cross-org access).
+
+#### Scenario: Operator completes first sign-in via init link and passkey
+
+- **WHEN** an initial operator opens their invitation ("accept invite") link and
+  starts first sign-in
+- **THEN** they SHALL register a passkey without transcribing any code, and be
+  returned to the organizer console authenticated to their own Organizer tenant
+  org
+
+#### Scenario: Operator is routed to their org by org-pinned entry
+
+- **WHEN** an operator signs in (first-time via the invitation, or thereafter
+  with their passkey)
+- **THEN** the org SHALL be resolved from the operator's own account/token — the
+  invitation binds the operator to exactly one tenant org — never by raw email
+  domain
+- **AND** supplying a different email SHALL NOT route them into a different org
+  (no cross-org access)
+
+#### Scenario: The invitation credential is never placed in a console URL
+
+- **WHEN** the invitation email and its link are generated
+- **THEN** the invite/verification code SHALL appear only on the identity
+  provider surface and SHALL NOT appear in any console/application URL
+
+#### Scenario: Recovery is an admin re-invite
+
+- **WHEN** an operator cannot sign in (e.g. lost all authenticators)
+- **THEN** recovery SHALL be an admin-initiated re-invite that re-issues the
+  operator's invitation, not a weaker password/self-registration lane

--- a/openspec/changes/align-organizer-invite-onboarding-with-zitadel-standard/specs/organizer-console/spec.md
+++ b/openspec/changes/align-organizer-invite-onboarding-with-zitadel-standard/specs/organizer-console/spec.md
@@ -1,0 +1,74 @@
+## MODIFIED Requirements
+
+### Requirement: Authenticate operators via org-pinned entry, one client for all tenants
+
+The organizer console SHALL authenticate operators through Zitadel OIDC (PKCE,
+no client secret) using the shared `organizer-console` client. The operator's
+tenant org is **bound to their account** — NOT to a URL parameter and NOT to
+email domain:
+
+- **First sign-in** happens through the identity provider's standard invitation
+  flow (the invite links to the IdP, not the console). After the operator sets
+  up a passkey, the tenant login policy's default redirect returns them to the
+  console (see `organizer-tenancy` / `organizer-accounts`); the console then
+  completes OIDC using the operator's freshly established session.
+- **Returning sign-in** is initiated from the console and authenticated with the
+  operator's existing passkey.
+
+The console SHALL **enforce that the authenticated token's org is the intended
+tenant org**. A session belonging to a different org (e.g. an unrelated Zitadel
+SSO session already present in the browser) SHALL NOT be silently accepted for a
+different operator/tenant: the console SHALL detect the mismatch and force
+re-authentication (or sign the stale session out) rather than admitting the
+wrong operator. There is no fixed org id at build time and no org picker.
+
+#### Scenario: Operator signs in and is routed to their org by org-pinned entry
+
+- **WHEN** an operator completes sign-in
+- **THEN** the console SHALL return them to their own Organizer tenant org,
+  resolved from their authenticated account/token (the org is bound to the
+  operator) — never by raw email domain
+- **AND** a session or entry that does not resolve to the operator's own org
+  SHALL fail auth (no cross-org access)
+
+#### Scenario: One OIDC client serves all tenants
+
+- **WHEN** operators of different Organizer tenant orgs sign in
+- **THEN** the same `organizer-console` OIDC client SHALL serve them all (no
+  per-tenant client, no build-time org id)
+
+#### Scenario: Invited operator lands on the console after accepting the invite
+
+- **WHEN** an invited operator completes credential setup via the identity
+  provider's invitation flow
+- **THEN** they SHALL be returned to the organizer console and, after the console
+  completes OIDC, land authenticated on their own Organizer tenant org
+
+#### Scenario: A reused or mismatched session does not silently onboard the wrong operator
+
+- **WHEN** the console is entered while a Zitadel session for a different org
+  already exists in the browser
+- **THEN** the console SHALL NOT admit that session as the intended operator; it
+  SHALL force re-authentication (or sign the stale session out) so the operator
+  is authenticated as the correct tenant — never routed into another org
+
+## REMOVED Requirements
+
+### Requirement: login_hint pre-fill for first-time sign-in
+
+**Reason**: First-time sign-in no longer routes through the console. Under the
+Zitadel-standard invitation flow (this change), the invitation links directly to
+the identity provider's credential-setup page (with the code carried in the
+link), and the operator is returned to the console only *after* accepting the
+invite (via the tenant login policy default redirect). The console-first
+onboarding that `login_hint` supported — a console URL of the form
+`organizer.{base}/?org_id=<id>&login_hint=<email>` that pre-fills and
+auto-submits the email step — no longer exists, and onboarding correctness no
+longer depends on `login_hint`. (This also removed a confusing "type the code"
+screen that did not match the "click the link" invitation email.)
+
+**Migration**: The frontend's `login_hint` handling is no longer load-bearing
+for onboarding and MAY be retained only as an optional pre-fill convenience or
+removed; no operator flow depends on it. First-time entry is covered by the
+identity provider's invitation flow plus the tenant login policy default
+redirect (see `organizer-accounts` and `organizer-tenancy`).

--- a/openspec/changes/align-organizer-invite-onboarding-with-zitadel-standard/specs/organizer-tenancy/spec.md
+++ b/openspec/changes/align-organizer-invite-onboarding-with-zitadel-standard/specs/organizer-tenancy/spec.md
@@ -1,0 +1,120 @@
+## MODIFIED Requirements
+
+### Requirement: Organizer tenant orgs use a passkey-primary login policy with a designed recovery path
+
+Every runtime-provisioned Organizer tenant org SHALL be given an **explicit**
+login policy — it SHALL NOT inherit the instance default (admin
+Google-IdP-only) policy. The policy SHALL make **passkeys the primary
+credential** and SHALL have this shape:
+
+- `passwordlessType = PASSWORDLESS_TYPE_ALLOWED` — passkeys enabled and primary;
+  operators enroll a passkey on first login.
+- `allowUsernamePassword = true` — **local authentication is enabled.** Despite
+  its name, this field gates ALL local authentication (username plus **passkey**
+  OR password), not only passwords: with it disabled, the hosted login UI
+  renders no username-entry form and, with no external IdP configured, the
+  invited operator is left with an empty login card and cannot proceed.
+  Passkey-primary / "no passwords" is therefore expressed by
+  `passwordlessType=ALLOWED` **plus never setting a password on the operator**
+  (the operator's only usable local method is the passkey), NOT by disabling
+  local authentication.
+- `allowRegister = false` — no open self-registration; operator accounts are
+  backend-provisioned for vetted Organizers only.
+- `allowExternalIDP = true` — permit OIDC federation so an Organizer that
+  already has a workspace IdP can federate.
+- `ignoreUnknownUsernames = true` — the login flow SHALL NOT disclose whether a
+  given account or org exists (anti-enumeration).
+- `defaultRedirectUri = <organizer console origin>` — after the operator
+  completes credential setup via the invitation flow (which runs outside any
+  in-flight OIDC request), the identity provider SHALL redirect them to the
+  organizer console, from which the console completes sign-in. Without this, an
+  operator who accepts the invite would dead-end on an identity-provider page
+  with no path back to the console.
+- `allowDomainDiscovery` — **NOT required (MVP defaults it off).**
+
+A **recovery path MUST exist** — passkey-only with **no** recovery is
+prohibited. Recovery SHALL be an **admin-initiated re-invite** (the system
+re-issues the operator's invitation after out-of-band verification), optionally
+with an email magic-link/OTP self-serve fallback; any non-passkey fallback lane
+SHALL be step-up protected so it is not a weaker bypass. The policy SHALL NOT
+rely on a hard `allowLocalAuthentication=false` lockdown; `no password on the
+operator` expresses the "no passwords" intent while the invite/recovery lane
+stays available.
+
+Synced passkeys (iCloud Keychain / Google Password Manager) survive
+single-device loss, so a second **hardware** authenticator is NOT mandated for
+this operator persona.
+
+**Org resolution is bound to the operator's account, not to a URL parameter.**
+The single OIDC app serves all tenants; the operator's org is fixed by the
+**invitation** (the invite code is bound to the operator, who belongs to exactly
+one tenant org) and, thereafter, by the operator's authenticated session/token.
+An operator SHALL NOT be routed to a different org by supplying a different
+email, and a session belonging to a different org SHALL NOT satisfy an
+onboarding entry for this tenant (the console enforces the token's org — see
+`organizer-console`). This covers consumer-domain operators without any
+per-tenant domain verification.
+
+Applying this policy per org, the exact field values, per-tenant IdP wiring, and
+the invitation channel/TTL are runtime concerns of `organizer-accounts`. This
+requirement defines the required shape.
+
+#### Scenario: A provisioned tenant org has the passkey-primary policy
+
+- **WHEN** an Organizer tenant org is provisioned
+- **THEN** it SHALL have an explicitly set login policy, not the inherited admin
+  default
+- **AND** the policy SHALL be passkey-primary with **local authentication
+  enabled** (`passwordlessType=PASSWORDLESS_TYPE_ALLOWED`,
+  `allowUsernamePassword=true`, `allowRegister=false`) and the operator SHALL be
+  created with no password so the passkey is their only usable local method
+- **AND** `allowExternalIDP` and `ignoreUnknownUsernames` SHALL be enabled
+
+#### Scenario: The policy renders a usable login and returns the operator to the console
+
+- **WHEN** an invited operator reaches the tenant org's hosted login
+- **THEN** local authentication SHALL be available (no empty login card)
+- **AND** after the operator completes passkey setup via the invitation flow,
+  the identity provider SHALL redirect them to the organizer console
+  (`defaultRedirectUri`)
+
+#### Scenario: Operator completes first login by enrolling a passkey
+
+- **WHEN** the backend creates a no-password operator and the operator opens the
+  invitation and enrolls a passkey
+- **THEN** the operator SHALL complete first login by enrolling a passkey via the
+  invitation flow
+- **AND** passkeys SHALL be the credential used on subsequent logins
+
+#### Scenario: A recovery path exists for a lost passkey
+
+- **WHEN** an operator loses access to their passkey(s)
+- **THEN** an admin SHALL be able to re-invite them (re-issue the invitation)
+  after out-of-band verification
+- **AND** a policy with no recovery path (passkey-only, no re-invite / no
+  fallback) SHALL be rejected
+- **AND** any non-passkey fallback lane SHALL be step-up protected
+
+#### Scenario: Org is resolved by org-pinned entry for every operator
+
+- **WHEN** any operator (consumer / free-mail such as `gmail.com`, or a custom
+  domain) signs in
+- **THEN** the org SHALL be resolved from the operator's own account/token, never
+  by the email domain: the invitation binds the operator to exactly one tenant
+  org on first login, and the authenticated session/token thereafter
+- **AND** an operator SHALL NOT be routed into a different org by supplying a
+  different address, and a session belonging to a different org SHALL NOT satisfy
+  onboarding for this tenant (no cross-org access; `ignoreUnknownUsernames` keeps
+  org existence undisclosed)
+- **AND** no per-tenant domain verification SHALL be required for this path
+
+#### Scenario: Email-domain discovery is a future optional enhancement
+
+- **WHEN** a later change enables type-email-only routing for an Organizer that
+  has a **verified** custom domain (typically alongside enterprise SSO)
+- **THEN** that enhancement MAY set `allowDomainDiscovery=true` for that org,
+  gated on domain ownership verification (DNS-TXT) and excluding consumer /
+  free-mail domains
+- **AND** it SHALL remain additive — the account-bound org resolution above stays
+  the baseline and is never removed
+- **AND** this change neither requires nor implements domain discovery

--- a/openspec/changes/align-organizer-invite-onboarding-with-zitadel-standard/tasks.md
+++ b/openspec/changes/align-organizer-invite-onboarding-with-zitadel-standard/tasks.md
@@ -1,0 +1,28 @@
+## 1. Backend — standard invite + login policy (organizer-accounts)
+
+- [x] 1.1 Change the provisioner `CreateInviteCode` `url_template` to the Zitadel
+  standard `/verify` form — `https://auth.{base}/ui/v2/login/verify?code={{.Code}}&userId={{.UserID}}&organization={{.OrgID}}&invite=true` — deriving `auth.{base}` from the issuer; remove the console-pointed `url_template` and the `login_hint`/`org_id` baking (design D-A)
+- [x] 1.2 Set the tenant login policy `default_redirect_uri = https://organizer.{base}/?org_id=<tenantOrgId>` in `ensureLoginPolicy` on BOTH the `AddCustomLoginPolicy` (create) and `UpdateCustomLoginPolicy` (converge existing) paths; the `org_id` lets the console enforce the authenticated org (design D-B + D-D Option 2)
+- [x] 1.3 Keep `allowUsernamePassword=true` (shipped v1.39.0); ensure the Update path converges existing tenant orgs to include the new `default_redirect_uri` (design D-C)
+- [x] 1.4 Unit tests: `url_template` points at `auth.{base}/…/verify`, contains `{{.Code}}`/`{{.UserID}}`, and carries no console origin; login-policy request includes the console `default_redirect_uri`
+- [x] 1.5 `make check` passes
+
+## 2. Frontend — enforce the authenticated org, land via default redirect (organizer-console)
+
+- [x] 2.1 After the OIDC callback, enforce the token's org equals the URL `org_id` (carried by `default_redirect_uri`, design D-D Option 2); on match proceed to `/welcome`, on mismatch sign the stale session out and re-sign-in with `prompt=login` (+ `org:id` pin) so the operator authenticates as the correct tenant
+- [x] 2.2 Handle the `default_redirect_uri` landing: read `org_id` from the URL, pin the `org:id` scope on the OIDC request, and complete sign-in to `/welcome`
+- [x] 2.3 Retire the now-optional `login_hint` first-time onboarding handling (no operator flow depends on it); keep only if useful as a plain pre-fill
+- [x] 2.4 Unit tests for the org-enforcement branch (match → welcome; mismatch → re-auth/sign-out) and the default-redirect landing
+- [x] 2.5 `make check` passes
+
+## 3. Ship + verify end-to-end (clean session, fresh operator)
+
+- [ ] 3.1 Release backend and frontend to prod
+- [ ] 3.2 E2E on a fresh operator in a clean (incognito) session: exactly ONE "Accept invite" email → click → passkey → `/welcome`; confirm from Zitadel logs that the login-app `CreateInviteCode` fired once (no second email) — validates the design's not-yet-verified single-email claim
+- [ ] 3.3 Security check: enter the console with a pre-existing DIFFERENT-org Zitadel session in the browser → confirm the operator is NOT silently onboarded as the other org (forced re-auth / rejection)
+- [ ] 3.4 Confirm the console origin passes Login v2 `isSafeRedirectUri` for `default_redirect_uri` (else fall back to the `DEFAULT_REDIRECT_URI` env override)
+
+## 4. Reconcile prior records
+
+- [ ] 4.1 Correct the archived organizer-console design D7 and tracking issue liverty-music/specification#843: the duplicate invite emails were caused by TWO OIDC authorize flows (each sending one invite), NOT by "/verify re-firing on every render"
+- [ ] 4.2 File/track the independent Zitadel notification defect (`could not set notification event on aggregate: Errors.User.NotFound` for tenant-org operators) separately — out of scope for this change


### PR DESCRIPTION
## Summary

Proposes **align-organizer-invite-onboarding-with-zitadel-standard** — replace the console-first organizer operator invite with Zitadel's **standard** invitation flow, and fold in the org-pinning / session-reuse **security fix**. Both `organizer-console` and `organizer-accounts` are archived, so this is a NEW change with MODIFIED deltas.

## Why (evidence-based, live re-verification 2026-08-23)

- **UX mismatch:** the backend's console-pointed invite routes the operator to Zitadel `/verify` **without the code** (empty "enter code" screen) and triggers a **second** invite email. The standard flow (zitadel/zitadel#8310, zitadel/typescript#166) is ONE "Accept invite" email → `/verify?code=…` (click, not type).
- **Tenant-isolation bug:** a pre-existing SSO session for another org is silently reused (org-test-30's invite authenticated as org-test-21). Must be enforced.
- **Record correction:** the "duplicate emails" were proven (Zitadel logs) to be **two authorize flows**, not "/verify re-firing on every render" (revises D7 / #843).

## Design (Pattern C — mechanism source-proven)

- **organizer-accounts:** invite `url_template` → Zitadel `/verify?code={{.Code}}&userId={{.UserID}}&organization={{.OrgID}}&invite=true`. One email, click-not-type, code stays on the IdP surface.
- **organizer-tenancy:** login policy `default_redirect_uri = organizer.{base}/?org_id=<tenantOrgId>` returns the operator to the console after passkey setup (source-verified: `apps/login/lib/server/passkeys.ts` → `resolveRedirectUri`). Also corrects the stale `allow_username_password=false` → **true**.
- **organizer-console:** the callback **enforces the token's org == the intended tenant** (`org_id`); a reused/mismatched session forces `prompt=login` re-auth (D-D Option 2). The console-first `login_hint` requirement is REMOVED.

## Implementation status

Downstream code is implemented + `make check` green on both repos (PRs linked separately). No proto changes → no BSR dependency. Full prod E2E (fresh operator + the security check) is the gate before archiving.

Refs: #759