### PR TITLE
docs(openspec): archive batch-frontend-prod-pin-dispatch

### DIFF
--- a/openspec/changes/archive/2026-08-24-batch-frontend-prod-pin-dispatch/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-24-batch-frontend-prod-pin-dispatch/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-23

--- a/openspec/changes/archive/2026-08-24-batch-frontend-prod-pin-dispatch/design.md
+++ b/openspec/changes/archive/2026-08-24-batch-frontend-prod-pin-dispatch/design.md
@@ -1,0 +1,51 @@
+## Context
+
+The prod pin-bump automation (`automate-prod-pin-bump`, #553) was designed around **one dispatch per release component**: `component: "backend"` covers four backend images, `component: "frontend"` covers the (then single) `fan-web` bundle. `bump-prod-pin.yml` maps a component to its image set and pins them in one commit; a `concurrency: { group: bump-prod-pin, cancel-in-progress: false }` serializes bumps, and a fetch-rebase-retry push loop absorbs the backend-vs-frontend interleave (disjoint overlay files).
+
+When the admin and organizer console bundles were added, `push-image.yaml` was extended to emit **three** dispatches with three *new* component values (`frontend`, `frontend-admin`, `frontend-organizer`) — rather than expanding the existing `frontend` component's image set the way `backend` already handles four images. All three frontend pins live in one file (`k8s/namespaces/frontend/overlays/prod/kustomization.yaml`), so the three dispatches are three near-simultaneous writers to the same file, all in the one `bump-prod-pin` concurrency group.
+
+Authoritative GitHub Actions behavior: a concurrency group's default is `queue: single` — "at most one job or workflow run can be pending; when a new run queues, any existing pending run in the same group is canceled and replaced." `cancel-in-progress: false` protects the *running* run only, not a superseded *pending* one. With three dispatches → one running + one pending, the third evicts the second. One frontend bundle is silently never pinned. Reproduced on v1.58.0 and v1.58.1.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Eliminate the silent per-release bundle drop at its structural root (the fan-out), not just mask it.
+- Restore the spec's "one dispatch per release component" pattern: `frontend` covers all its bundles like `backend` covers its four images.
+- Make a frontend release's bundles pin **atomically** — one commit, all-or-nothing.
+- Keep the design the simplest form that is correct; add no machinery that guards races the root fix removes.
+
+**Non-Goals:**
+- Adopting ArgoCD Image Updater for prod (deliberately rejected: prod pins to immutable semver tags with release-driven provenance and no-downgrade — `enable-prod-ar-immutable-tags` #274). It stays prod-disabled.
+- Changing the git-push-from-dispatch model (chosen over clone-and-push for auth blast-radius reasons — D1 of #553), the provenance gate, the no-downgrade guard, or the admin-gated `workflow_dispatch` recovery path.
+- Any proto/BSR/runtime-code change.
+
+## Decisions
+
+### D1: Collapse the frontend fan-out into one `component: "frontend"` dispatch
+
+`push-image.yaml`'s `dispatch-prod-pin` job already `needs: [build-and-push, build-and-push-admin, build-and-push-organizer]` — it blocks on all three builds before emitting anything, so splitting into three dispatches buys **no** timing benefit. Emit one `component: "frontend"` dispatch and let `bump-prod-pin.yml` expand it to all three frontend bundle images (exactly as `component: "backend"` expands to four). This removes the third queued run, so the pending-eviction race cannot occur; it also cuts CI 3→1 (one federate / checkout / provenance loop / kustomize build / push) and makes the pin atomic (one commit).
+
+**Alternatives considered:**
+- **`queue: max`** (allow up to 100 pending, FIFO — GitHub, 2026-05-07). A one-line fix that stops the eviction but keeps three runs, three commits, a transient mixed-version window, and three writers to one file. Masks the fan-out instead of removing it. Rejected as the primary fix (see D3).
+- **Per-component concurrency groups.** Lets the three run in parallel — more same-file push contention, more rebase-retry churn, still non-atomic. Strictly worse than one run.
+
+### D2: All-or-nothing, mirroring the backend partial-retag rule
+
+The single frontend dispatch is emitted only when **all three** bundle retags succeed; if any fails, no dispatch (no bundle is pinned). This mirrors the existing backend rule ("a partially-failed retag SHALL NOT dispatch") and is simpler than carrying a dynamic "which bundles succeeded" list. All three bundles come from the same release commit, so a build failure means the release is incomplete and should not be partially pinned — fail loudly, recover via the admin path.
+
+**Alternative:** dynamic partial-success (pin the bundles that built). Rejected: adds payload/edit complexity to salvage a rare case that all-or-nothing handles more safely (an incomplete release should not go partially live).
+
+### D3: Add no concurrency insurance (no `queue: max`, no reconcile job)
+
+Once the fan-out is gone, the only concurrent writers to the `bump-prod-pin` group are a backend release and a frontend release — two writers, touching **disjoint** overlay files. That is precisely the one-running-plus-one-pending case the existing `concurrency` + rebase-retry already handle correctly (eviction needs a *third* queued run). So `queue: max`, per-component groups, and a post-release reconcile job would all guard a three-writer race that no longer exists — added surface for no live benefit. The simplest correct design leaves the concurrency block unchanged. (If a *third* independently-releasing writer to this group is ever introduced, revisit `queue: max` then — cheap, one line.)
+
+### D4: Consume-side mapping + transitional back-compat
+
+`bump-prod-pin.yml` maps `component: "frontend"` to the three frontend image entries + the `app.kubernetes.io/version` label (fan-web as the primary label source, unchanged) + the single frontend overlay path, editing and committing them in one pass. The old `frontend-admin` / `frontend-organizer` component branches MAY be retained for one release cycle so an in-flight old-style dispatch is not orphaned, then removed once no release emits them.
+
+## Risks / Trade-offs
+
+- **A slow/failed single bundle now blocks the whole frontend pin (all-or-nothing).** Accepted: the three bundles ship from one release; a partial release should not go live. The admin `workflow_dispatch` recovery path remains for exceptional manual pinning.
+- **Transitional window.** Until the frontend workflow change ships, an old three-dispatch release still races. Mitigation: land the emit-side (frontend) and consume-side (cloud-provisioning) changes together, and keep the old component branches for one cycle (D4) so a straddling dispatch still applies.
+- **Spec was itself drifted** (it still described `frontend` as the single `fan-web` entry, never updated for admin/organizer). This change reconciles the spec to the multi-bundle reality in the *aligned* one-dispatch form, so spec and implementation converge rather than both carrying the fan-out.
+- **Loss of independent per-bundle pinning cadence.** Trivial in practice: all three are always cut from the same frontend release at the same tag, so there is no real independent cadence to lose.

--- a/openspec/changes/archive/2026-08-24-batch-frontend-prod-pin-dispatch/proposal.md
+++ b/openspec/changes/archive/2026-08-24-batch-frontend-prod-pin-dispatch/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+A frontend release silently fails to pin one of its web bundles to prod on every cut. `push-image.yaml` emits **three** `repository_dispatch` events (`frontend`, `frontend-admin`, `frontend-organizer`) within one second, all landing in `bump-prod-pin.yml`'s single `concurrency` group. A concurrency group holds at most one running + one pending run (`queue: single`, the default); when the third dispatch queues it evicts the middle pending one, so one bundle is never pinned and stays on the previous release. This reproduced on both v1.58.0 and v1.58.1, each requiring a manual admin-gated recovery bump.
+
+The three-way fan-out is drift, not design. The `prod-image-pipeline` spec already defines the pattern as **one dispatch per release component**: `component: "frontend"` (like `component: "backend"`, which covers four images in a single dispatch). When the admin and organizer console bundles were added, the implementation introduced two *new* component values and split into three dispatches — instead of expanding the existing `frontend` component's image set the way `backend` already does. That split is what created both the concurrency race and 3× the CI cost for what is logically one atomic operation: pin the frontend release's bundles.
+
+## What Changes
+
+- The frontend release path SHALL emit a **single** `component: "frontend"` `repository_dispatch` covering all frontend prod bundles (`fan-web`, `admin-console-web`, `organizer-console-web`), mirroring how `backend` covers its four images in one dispatch. **Remove** the `frontend-admin` and `frontend-organizer` component values and their separate dispatch steps.
+- `bump-prod-pin.yml` SHALL map `component: "frontend"` to the full set of frontend prod images/labels and pin them in a **single commit** (one `kustomize build`, one push), the same multi-image handling it already applies to `component: "backend"`.
+- Frontend pin-bumps become **atomic** (all bundles move together in one commit) and **all-or-nothing**: a partially-failed frontend retag SHALL NOT dispatch — mirroring the existing backend partial-retag rule — so prod never sees a half-pinned release or a transient mixed state.
+- The `queue: single` concurrency behavior is **left unchanged**: once the fan-out is gone, the only concurrent writers are a backend release and a frontend release, which touch disjoint overlay files — exactly the one-running-plus-one-pending case the existing `concurrency` + fetch-rebase-retry already handle safely. No `queue: max`, no per-component groups, no reconcile job are added; they would guard a three-writer race that no longer exists.
+
+## Capabilities
+
+### Modified Capabilities
+- `prod-image-pipeline`: the "Prod kustomize pin-bumps SHALL be automated via repository_dispatch" requirement changes so the frontend release emits one `component: "frontend"` dispatch covering all frontend bundles (removing the `frontend-admin`/`frontend-organizer` fan-out), and the bump pins them atomically in one commit with all-or-nothing partial-failure semantics.
+
+## Impact
+
+- **frontend** `.github/workflows/push-image.yaml`: `dispatch-prod-pin` job — collapse three dispatch steps into one `component: "frontend"` dispatch; keep the `needs: [build-and-push, build-and-push-admin, build-and-push-organizer]` gate but make it all-or-nothing (dispatch only if all three retags succeeded).
+- **cloud-provisioning** `.github/workflows/bump-prod-pin.yml`: extend the `frontend` component's image/label/path mapping to cover `fan-web` + `admin-console-web` + `organizer-console-web` in a single edit pass; drop the `frontend-admin` / `frontend-organizer` component branches; correct the stale "a queued bump waits rather than being dropped" comment.
+- No change to: the immutable-semver prod pinning model, the provenance gate (`crane manifest`), the no-downgrade guard, the admin-gated `workflow_dispatch` recovery path, ArgoCD auto-sync, or the dev-path `argocd-image-updater` (which stays prod-disabled). No proto/BSR/runtime-code change.
+- Backwards compatibility: transitional — the bump workflow MAY retain the old `frontend-admin`/`frontend-organizer` component branches for one release cycle so an in-flight dispatch is not orphaned, then remove them.

--- a/openspec/changes/archive/2026-08-24-batch-frontend-prod-pin-dispatch/specs/prod-image-pipeline/spec.md
+++ b/openspec/changes/archive/2026-08-24-batch-frontend-prod-pin-dispatch/specs/prod-image-pipeline/spec.md
@@ -1,0 +1,100 @@
+## MODIFIED Requirements
+
+### Requirement: Prod kustomize pin-bumps SHALL be automated via repository_dispatch
+
+After a release path successfully promotes images to prod AR, the originating workflow SHALL trigger an automated update of the prod kustomize pin in `cloud-provisioning` rather than relying on a manually-authored pull request. The backend `deploy.yml` and frontend `push-image.yaml` release paths SHALL emit a GitHub `repository_dispatch` event to `liverty-music/cloud-provisioning` with `event_type: bump-prod-pin` and a `client_payload` of `{ component, tag, sha }`, where `component` is `backend` or `frontend`, `tag` is the release tag (`vX.Y.Z`), and `sha` is `${GITHUB_SHA}`. The dispatch trigger SHALL be the only cross-repo action the release workflows perform. The dispatch credential is the org-owned `liverty-music-ci-bot` GitHub App, which requires `Contents: write` on `cloud-provisioning` (the documented minimum for `repository_dispatch`).
+
+A release SHALL emit exactly **one** `bump-prod-pin` dispatch per originating repository, naming a single `component`. `backend` covers all four backend images in that one dispatch; `frontend` covers all frontend prod bundles — `fan-web`, `admin-console-web`, and `organizer-console-web` — in that one dispatch. A release path SHALL NOT fan out into multiple per-bundle dispatches (no `frontend-admin` / `frontend-organizer` component values): all bundles of one release are pinned as a single atomic unit. This keeps the dispatch count independent of how many bundles a repository ships, so the cross-repo pin update is one operation whose bundles either all land together or not at all.
+
+> **Boundary note (revised during implementation — see design D9).** The original design (D1) intended the release workflows to be unable to push to `cloud-provisioning:main`, with the `main` bypass scoped to `github-actions[bot]` only. That proved infeasible: a repository ruleset rejects the global `github-actions` integration as a bypass actor (`422 — must be part of the ruleset source or owner organization`, GitHub-owned), and an organization ruleset (which would accept it) requires a GitHub Team plan (`403` on Free). The `main` bypass actor is therefore the org-owned `ci-bot` App — the same credential the release workflows hold — so a compromised prod release workflow CAN push `cloud-provisioning:main`. This relaxed boundary is accepted and mitigated by: the ci-bot secrets being scoped to the `prod` environment (release events only), the provenance gate (a bump cannot pin a non-existent prod image), and the GitHub Release remaining the human gate. The strict boundary MAY be restored later by introducing a dedicated push-only App (keyed/installed only on `cloud-provisioning`) as the bypass actor.
+
+The dispatch step SHALL run only after the prod-AR retag for that component has succeeded. For the backend's 4-image `fail-fast: false` matrix, the dispatch SHALL be a job gated on the retag job completing successfully (`needs` + `if: <retag>.result == 'success'`), so a partially-failed retag never bumps the pin to a release tag whose prod images are incomplete. For the frontend's three independent bundle build jobs (`fan-web`, `admin-console-web`, `organizer-console-web`), the single dispatch SHALL likewise be all-or-nothing: it SHALL be emitted only when **all three** bundle retags succeed, so the frontend release is never pinned with an incomplete set of prod images.
+
+#### Scenario: Backend release dispatches a pin-bump after retag
+
+- **WHEN** a GitHub Release `vX.Y.Z` is published in `liverty-music/backend` and all 4 retag matrix entries succeed
+- **THEN** `deploy.yml` SHALL emit a `repository_dispatch` to `liverty-music/cloud-provisioning` with `event_type: bump-prod-pin` and `client_payload: { component: "backend", tag: "vX.Y.Z", sha: "<github.sha>" }`
+
+#### Scenario: Frontend release dispatches a pin-bump after retag
+
+- **WHEN** a GitHub Release `vX.Y.Z` is published in `liverty-music/frontend` and the `fan-web`, `admin-console-web`, and `organizer-console-web` retags all succeed
+- **THEN** `push-image.yaml` SHALL emit exactly **one** `repository_dispatch` to `liverty-music/cloud-provisioning` with `event_type: bump-prod-pin` and `client_payload: { component: "frontend", tag: "vX.Y.Z", sha: "<github.sha>" }`
+- **AND** it SHALL NOT emit any `frontend-admin` or `frontend-organizer` component dispatch
+
+#### Scenario: A partially-failed backend retag SHALL NOT dispatch
+
+- **WHEN** a GitHub Release is published in `liverty-music/backend` and at least one of the 4 retag matrix entries fails
+- **THEN** the dispatch step SHALL NOT run
+- **AND** no `bump-prod-pin` event SHALL be emitted to `cloud-provisioning`
+
+#### Scenario: A partially-failed frontend retag SHALL NOT dispatch
+
+- **WHEN** a GitHub Release is published in `liverty-music/frontend` and at least one of the `fan-web` / `admin-console-web` / `organizer-console-web` retags fails
+- **THEN** the dispatch step SHALL NOT run
+- **AND** no `bump-prod-pin` event SHALL be emitted to `cloud-provisioning` (no bundle is pinned rather than pinning a partial set)
+
+#### Scenario: Dispatch credential is the org-owned ci-bot App, prod-env scoped
+
+- **WHEN** inspecting the secrets/permissions used by the dispatch step in `deploy.yml` and `push-image.yaml`
+- **THEN** the credential SHALL be the `liverty-music-ci-bot` GitHub App (App id + private key), with `Contents: write` (the documented minimum for the dispatches API)
+- **AND** those secrets SHALL be scoped to the backend/frontend `prod` GitHub Environments (release events), NOT org-wide
+- **AND** because that same App is the `cloud-provisioning:main` ruleset bypass actor (design D9), a release workflow CAN push `main`; this relaxed boundary SHALL be mitigated by the prod-environment scoping, the provenance gate, and the Release-as-human-gate (it SHALL NOT rely on the token being unable to push `main`)
+
+### Requirement: A cloud-provisioning workflow SHALL apply the prod pin-bump on dispatch
+
+`cloud-provisioning` SHALL contain a workflow (`bump-prod-pin.yml`) triggered by `repository_dispatch` of type `bump-prod-pin`. On receipt, for the `component` named in the payload it SHALL rewrite, in `k8s/namespaces/<component>/overlays/prod/kustomization.yaml`, every `images[].newTag` (all 4 entries for `backend`; the three frontend bundle entries — `fan-web`, `admin-console-web`, `organizer-console-web` — for `frontend`) and the `labels[].pairs."app.kubernetes.io/version"` value, in lock-step, to the release version. The `newTag` SHALL be the `vX.Y.Z` form; the version label SHALL be the bare semver (no leading `v`). The inline source-commit trailer comment after each `newTag` SHALL be updated to the payload `sha`. All of a component's image entries SHALL be rewritten and committed as a **single commit** (one edit pass, one `kustomize build`, one push), so a component's bundles never land in prod as separate commits or a transient mixed-version state.
+
+Before editing, the workflow SHALL validate the payload: `component` SHALL be one of `backend | frontend` and `tag` SHALL match `^v[0-9]+\.[0-9]+\.[0-9]+$`. Shape validation alone is insufficient — the workflow SHALL ALSO verify **image provenance** before any edit: for every image of the component (the 4 backend images, or the three frontend bundle images) it SHALL confirm the prod-AR image at the target tag exists via `crane manifest asia-northeast2-docker.pkg.dev/liverty-music-prod/<component>/<img>:<tag>`. A missing manifest for any image SHALL abort the run before any file is edited (fail-closed). Because a prod-AR image at `:<tag>` exists only if the release retag wrote it, this provenance gate confirms the tag names a genuine release whose retag completed, and prevents a well-formed-but-bogus or stale tag from corrupting `main` (including the silent-downgrade-to-bogus-tag case).
+
+The workflow SHALL then validate the edited overlay with `kustomize build k8s/namespaces/<component>/overlays/prod` BEFORE committing; a non-zero build SHALL abort the run without pushing. On success it SHALL commit and push directly to `cloud-provisioning:main` using a `liverty-music-ci-bot` GitHub App installation token (the App is the `main` ruleset bypass actor — see design D9; the built-in `GITHUB_TOKEN` / `github-actions[bot]` cannot be a repo-ruleset bypass actor). ArgoCD's existing auto-sync rolls the change out — the workflow SHALL NOT open a pull request.
+
+#### Scenario: Dispatch updates newTag and version label in lock-step
+
+- **WHEN** `bump-prod-pin.yml` receives `{ component: "backend", tag: "v1.4.0", sha: "abc123..." }`
+- **THEN** all 4 `images[].newTag` in `k8s/namespaces/backend/overlays/prod/kustomization.yaml` SHALL be set to `v1.4.0`
+- **AND** the `app.kubernetes.io/version` label SHALL be set to `1.4.0`
+- **AND** each `newTag`'s inline `# commit <sha>` trailer SHALL be updated to `abc123...`
+
+#### Scenario: A frontend dispatch pins all bundles atomically in one commit
+
+- **WHEN** `bump-prod-pin.yml` receives `{ component: "frontend", tag: "v1.58.1", sha: "6139459..." }`
+- **THEN** the `fan-web`, `admin-console-web`, and `organizer-console-web` `images[].newTag` in `k8s/namespaces/frontend/overlays/prod/kustomization.yaml` SHALL ALL be set to `v1.58.1`
+- **AND** the `app.kubernetes.io/version` label SHALL be set to `1.58.1`
+- **AND** all three rewrites SHALL be committed and pushed as a single commit (no per-bundle commits and no transient state where only some bundles are on `v1.58.1`)
+
+#### Scenario: Provenance gate rejects a frontend tag whose bundles are not all in prod AR
+
+- **WHEN** `bump-prod-pin.yml` receives a `frontend` dispatch for a `tag` for which at least one of the three frontend bundle images does not exist in prod AR
+- **THEN** the workflow SHALL abort at the provenance check before editing any file
+- **AND** it SHALL NOT commit or push a partial or bogus pin
+
+#### Scenario: Missing prod-AR image aborts before any edit
+
+- **WHEN** `bump-prod-pin.yml` receives a well-formed payload whose `tag` has no corresponding prod-AR image (`crane manifest asia-northeast2-docker.pkg.dev/liverty-music-prod/<component>/<img>:<tag>` returns not-found for any image of the component)
+- **THEN** the workflow SHALL fail at the provenance step
+- **AND** SHALL NOT edit `kustomization.yaml`, commit, or push
+- **AND** the failure SHALL occur regardless of which trigger (`repository_dispatch` or the `workflow_dispatch` fallback) delivered the payload
+
+#### Scenario: kustomize build failure aborts before push
+
+- **WHEN** the post-edit `kustomize build k8s/namespaces/<component>/overlays/prod` exits non-zero
+- **THEN** the workflow SHALL fail
+- **AND** SHALL NOT commit or push any change to `main`
+
+#### Scenario: Successful bump pushes directly to main, no PR
+
+- **WHEN** the edit validates and differs from the current pin
+- **THEN** the workflow SHALL commit and push to `cloud-provisioning:main` as the `liverty-music-ci-bot` App
+- **AND** SHALL NOT open a pull request
+- **AND** ArgoCD SHALL subsequently auto-sync the prod overlay to the new tag
+
+#### Scenario: Bump is idempotent
+
+- **WHEN** `bump-prod-pin.yml` receives a payload whose `tag` already matches every target `newTag` for that component
+- **THEN** the workflow SHALL exit successfully without creating a commit or pushing
+
+#### Scenario: Concurrent backend and frontend bumps both land
+
+- **WHEN** a `backend` bump and a `frontend` bump are dispatched within seconds of each other
+- **THEN** the workflow SHALL serialize the runs (`concurrency` group) and/or rebase-retry the push so that both the backend overlay and the frontend overlay end up bumped on `main`
+- **AND** neither bump SHALL be lost to a push rejection

--- a/openspec/changes/archive/2026-08-24-batch-frontend-prod-pin-dispatch/tasks.md
+++ b/openspec/changes/archive/2026-08-24-batch-frontend-prod-pin-dispatch/tasks.md
@@ -1,0 +1,28 @@
+## 1. Consume side — `cloud-provisioning/.github/workflows/bump-prod-pin.yml`
+
+- [x] 1.1 Extend the `frontend` component mapping to cover all three prod bundle images (`fan-web`, `admin-console-web`, `organizer-console-web`): the provenance `crane manifest` loop, the `yq` `newTag` + inline `# commit <sha>` trailer rewrite, and the overlay path SHALL all iterate the three frontend images (mirroring how `backend` iterates its four) (D1, D4)
+- [x] 1.2 Keep the `app.kubernetes.io/version` label bump sourced from the primary bundle (`fan-web`) only — unchanged behavior (D4)
+- [x] 1.3 Ensure all three frontend `newTag` rewrites happen in one edit pass and land in a single commit + single `kustomize build` + single push (atomic) (D1, spec: single-commit)
+- [x] 1.4 Retain the `frontend-admin` / `frontend-organizer` component branches as a transitional single-image alias for one release cycle so an in-flight old-style dispatch is not orphaned; mark them for removal (D4)
+- [x] 1.5 Correct the stale `concurrency` comment ("a queued bump waits for the running one rather than being dropped") — document `queue: single` semantics and that, post-fan-out-removal, the only concurrent writers are backend vs frontend (disjoint files), so no `queue: max` is needed (D3)
+- [x] 1.6 Leave the `concurrency` block, provenance gate, no-downgrade guard, and admin-gated `workflow_dispatch` recovery path unchanged (Non-Goals)
+
+## 2. Emit side — `frontend/.github/workflows/push-image.yaml`
+
+- [x] 2.1 Collapse the three `dispatch-prod-pin` steps (`frontend`, `frontend-admin`, `frontend-organizer`) into a **single** `component: "frontend"` `repository_dispatch` (D1)
+- [x] 2.2 Gate the single dispatch on **all three** bundle retags succeeding — dropped `always()` so the default `needs: [build-and-push, build-and-push-admin, build-and-push-organizer]` success gate skips the job (hence the dispatch) if any bundle retag fails — all-or-nothing (D2, spec: partial-failed frontend)
+- [x] 2.3 Confirm no other consumer of the removed `frontend-admin` / `frontend-organizer` dispatch component values exists (only `bump-prod-pin.yml`'s retained transitional aliases + descriptive comments + the operator runbook remain; no workflow still *emits* those component values)
+
+## 3. Verification
+
+- [x] 3.1 Dry-run / trace the frontend release path to confirm exactly one `bump-prod-pin` dispatch is emitted with `component: "frontend"` — static: the job now has a single dispatch step emitting only `component:"frontend"` (grep-confirmed)
+- [x] 3.2 On the next real frontend release: confirm `bump-prod-pin` runs exactly once for frontend (no `cancelled` sibling run), and the prod overlay's `fan-web` + `admin-console-web` + `organizer-console-web` `newTag` all move to the release tag in a **single commit** — VALIDATED on **v1.59.0**: one `component=frontend` dispatch run (`completed/success`, no cancelled sibling; a coinciding `component=backend` v1.59.0 dispatch also succeeded — the 2-disjoint-writer case), and cloud-provisioning commit `baafd5f81e` "pin frontend prod overlay to v1.59.0" moved all three `newTag`s in ONE commit (contrast v1.58.3's separate per-component commits + a cancelled run)
+- [x] 3.3 Confirm ArgoCD auto-syncs all three frontend deployments to the release tag without a manual recovery bump (the defect this change removes, reproduced on v1.58.0 / v1.58.1) — VALIDATED on v1.59.0: `fan-web-app` / `admin-console-web-app` / `organizer-console-web-app` all at `v1.59.0`, READY 1 / AVAIL 1, no manual recovery needed
+- [x] 3.4 Negative check: verify a single-bundle build failure results in **no** dispatch (all-or-nothing) — static: `needs: [all three]` with no `always()` skips the whole `dispatch-prod-pin` job if any bundle retag fails
+
+## 4. Ship
+
+- [x] 4.1 Open the cloud-provisioning PR (Conventional Commits, mandatory body + `Refs: #<issue>`); CI green — PR #448 (bump-prod-pin.yml + runbook), merged (4adaf66); Refs specification#852
+- [x] 4.2 Open the frontend workflow PR (Conventional Commits, mandatory body + `Refs: #<issue>`); CI green — PR #568 (push-image.yaml), merged (ebc72be); Refs specification#852
+- [x] 4.3 Land both together (consume side first) so no release straddles a half-applied change — merged #448 (consume) then #568 (emit); transitional aliases (1.4) cover a straddling dispatch
+- [x] 4.4 After a subsequent frontend release validates 3.2–3.3, remove the transitional `frontend-admin` / `frontend-organizer` aliases (follow-up) — v1.59.0 validated 3.2/3.3, so removed in cloud-provisioning PR #450: `bump-prod-pin.yml` `component` choice + payload validation now accept only `backend | frontend`, the two transitional case branches dropped, runbook + prod-overlay comments updated

--- a/openspec/specs/prod-image-pipeline/spec.md
+++ b/openspec/specs/prod-image-pipeline/spec.md
@@ -243,14 +243,15 @@ A force-push or branch-creation push SHALL take the BUILD path, never the inheri
 - **AND** an intermediate *pending* run MAY be cancelled by GitHub's one-pending-per-group rule, leaving that commit without a `<image>:<sha>` image
 - **AND** this SHALL NOT publish an incorrect digest — a subsequent inherit whose parent is the cancelled commit fails loudly per "Missing parent image"; recovery is to re-run the cancelled push's workflow or push a build-relevant seed
 
-
 ### Requirement: Prod kustomize pin-bumps SHALL be automated via repository_dispatch
 
 After a release path successfully promotes images to prod AR, the originating workflow SHALL trigger an automated update of the prod kustomize pin in `cloud-provisioning` rather than relying on a manually-authored pull request. The backend `deploy.yml` and frontend `push-image.yaml` release paths SHALL emit a GitHub `repository_dispatch` event to `liverty-music/cloud-provisioning` with `event_type: bump-prod-pin` and a `client_payload` of `{ component, tag, sha }`, where `component` is `backend` or `frontend`, `tag` is the release tag (`vX.Y.Z`), and `sha` is `${GITHUB_SHA}`. The dispatch trigger SHALL be the only cross-repo action the release workflows perform. The dispatch credential is the org-owned `liverty-music-ci-bot` GitHub App, which requires `Contents: write` on `cloud-provisioning` (the documented minimum for `repository_dispatch`).
 
+A release SHALL emit exactly **one** `bump-prod-pin` dispatch per originating repository, naming a single `component`. `backend` covers all four backend images in that one dispatch; `frontend` covers all frontend prod bundles — `fan-web`, `admin-console-web`, and `organizer-console-web` — in that one dispatch. A release path SHALL NOT fan out into multiple per-bundle dispatches (no `frontend-admin` / `frontend-organizer` component values): all bundles of one release are pinned as a single atomic unit. This keeps the dispatch count independent of how many bundles a repository ships, so the cross-repo pin update is one operation whose bundles either all land together or not at all.
+
 > **Boundary note (revised during implementation — see design D9).** The original design (D1) intended the release workflows to be unable to push to `cloud-provisioning:main`, with the `main` bypass scoped to `github-actions[bot]` only. That proved infeasible: a repository ruleset rejects the global `github-actions` integration as a bypass actor (`422 — must be part of the ruleset source or owner organization`, GitHub-owned), and an organization ruleset (which would accept it) requires a GitHub Team plan (`403` on Free). The `main` bypass actor is therefore the org-owned `ci-bot` App — the same credential the release workflows hold — so a compromised prod release workflow CAN push `cloud-provisioning:main`. This relaxed boundary is accepted and mitigated by: the ci-bot secrets being scoped to the `prod` environment (release events only), the provenance gate (a bump cannot pin a non-existent prod image), and the GitHub Release remaining the human gate. The strict boundary MAY be restored later by introducing a dedicated push-only App (keyed/installed only on `cloud-provisioning`) as the bypass actor.
 
-The dispatch step SHALL run only after the prod-AR retag for that component has succeeded. For the backend's 4-image `fail-fast: false` matrix, the dispatch SHALL be a job gated on the retag job completing successfully (`needs` + `if: <retag>.result == 'success'`), so a partially-failed retag never bumps the pin to a release tag whose prod images are incomplete.
+The dispatch step SHALL run only after the prod-AR retag for that component has succeeded. For the backend's 4-image `fail-fast: false` matrix, the dispatch SHALL be a job gated on the retag job completing successfully (`needs` + `if: <retag>.result == 'success'`), so a partially-failed retag never bumps the pin to a release tag whose prod images are incomplete. For the frontend's three independent bundle build jobs (`fan-web`, `admin-console-web`, `organizer-console-web`), the single dispatch SHALL likewise be all-or-nothing: it SHALL be emitted only when **all three** bundle retags succeed, so the frontend release is never pinned with an incomplete set of prod images.
 
 #### Scenario: Backend release dispatches a pin-bump after retag
 
@@ -259,14 +260,21 @@ The dispatch step SHALL run only after the prod-AR retag for that component has 
 
 #### Scenario: Frontend release dispatches a pin-bump after retag
 
-- **WHEN** a GitHub Release `vX.Y.Z` is published in `liverty-music/frontend` and the retag succeeds
-- **THEN** `push-image.yaml` SHALL emit a `repository_dispatch` to `liverty-music/cloud-provisioning` with `event_type: bump-prod-pin` and `client_payload: { component: "frontend", tag: "vX.Y.Z", sha: "<github.sha>" }`
+- **WHEN** a GitHub Release `vX.Y.Z` is published in `liverty-music/frontend` and the `fan-web`, `admin-console-web`, and `organizer-console-web` retags all succeed
+- **THEN** `push-image.yaml` SHALL emit exactly **one** `repository_dispatch` to `liverty-music/cloud-provisioning` with `event_type: bump-prod-pin` and `client_payload: { component: "frontend", tag: "vX.Y.Z", sha: "<github.sha>" }`
+- **AND** it SHALL NOT emit any `frontend-admin` or `frontend-organizer` component dispatch
 
 #### Scenario: A partially-failed backend retag SHALL NOT dispatch
 
 - **WHEN** a GitHub Release is published in `liverty-music/backend` and at least one of the 4 retag matrix entries fails
 - **THEN** the dispatch step SHALL NOT run
 - **AND** no `bump-prod-pin` event SHALL be emitted to `cloud-provisioning`
+
+#### Scenario: A partially-failed frontend retag SHALL NOT dispatch
+
+- **WHEN** a GitHub Release is published in `liverty-music/frontend` and at least one of the `fan-web` / `admin-console-web` / `organizer-console-web` retags fails
+- **THEN** the dispatch step SHALL NOT run
+- **AND** no `bump-prod-pin` event SHALL be emitted to `cloud-provisioning` (no bundle is pinned rather than pinning a partial set)
 
 #### Scenario: Dispatch credential is the org-owned ci-bot App, prod-env scoped
 
@@ -277,9 +285,9 @@ The dispatch step SHALL run only after the prod-AR retag for that component has 
 
 ### Requirement: A cloud-provisioning workflow SHALL apply the prod pin-bump on dispatch
 
-`cloud-provisioning` SHALL contain a workflow (`bump-prod-pin.yml`) triggered by `repository_dispatch` of type `bump-prod-pin`. On receipt, for the `component` named in the payload it SHALL rewrite, in `k8s/namespaces/<component>/overlays/prod/kustomization.yaml`, every `images[].newTag` (all 4 entries for `backend`, the single `fan-web` entry for `frontend`) and the `labels[].pairs."app.kubernetes.io/version"` value, in lock-step, to the release version. The `newTag` SHALL be the `vX.Y.Z` form; the version label SHALL be the bare semver (no leading `v`). The inline source-commit trailer comment after each `newTag` SHALL be updated to the payload `sha`.
+`cloud-provisioning` SHALL contain a workflow (`bump-prod-pin.yml`) triggered by `repository_dispatch` of type `bump-prod-pin`. On receipt, for the `component` named in the payload it SHALL rewrite, in `k8s/namespaces/<component>/overlays/prod/kustomization.yaml`, every `images[].newTag` (all 4 entries for `backend`; the three frontend bundle entries — `fan-web`, `admin-console-web`, `organizer-console-web` — for `frontend`) and the `labels[].pairs."app.kubernetes.io/version"` value, in lock-step, to the release version. The `newTag` SHALL be the `vX.Y.Z` form; the version label SHALL be the bare semver (no leading `v`). The inline source-commit trailer comment after each `newTag` SHALL be updated to the payload `sha`. All of a component's image entries SHALL be rewritten and committed as a **single commit** (one edit pass, one `kustomize build`, one push), so a component's bundles never land in prod as separate commits or a transient mixed-version state.
 
-Before editing, the workflow SHALL validate the payload: `component` SHALL be one of `backend | frontend` and `tag` SHALL match `^v[0-9]+\.[0-9]+\.[0-9]+$`. Shape validation alone is insufficient — the workflow SHALL ALSO verify **image provenance** before any edit: for every image of the component (the 4 backend images, or the single `fan-web` image) it SHALL confirm the prod-AR image at the target tag exists via `crane manifest asia-northeast2-docker.pkg.dev/liverty-music-prod/<component>/<img>:<tag>`. A missing manifest for any image SHALL abort the run before any file is edited (fail-closed). Because a prod-AR image at `:<tag>` exists only if the release retag wrote it, this provenance gate confirms the tag names a genuine release whose retag completed, and prevents a well-formed-but-bogus or stale tag from corrupting `main` (including the silent-downgrade-to-bogus-tag case).
+Before editing, the workflow SHALL validate the payload: `component` SHALL be one of `backend | frontend` and `tag` SHALL match `^v[0-9]+\.[0-9]+\.[0-9]+$`. Shape validation alone is insufficient — the workflow SHALL ALSO verify **image provenance** before any edit: for every image of the component (the 4 backend images, or the three frontend bundle images) it SHALL confirm the prod-AR image at the target tag exists via `crane manifest asia-northeast2-docker.pkg.dev/liverty-music-prod/<component>/<img>:<tag>`. A missing manifest for any image SHALL abort the run before any file is edited (fail-closed). Because a prod-AR image at `:<tag>` exists only if the release retag wrote it, this provenance gate confirms the tag names a genuine release whose retag completed, and prevents a well-formed-but-bogus or stale tag from corrupting `main` (including the silent-downgrade-to-bogus-tag case).
 
 The workflow SHALL then validate the edited overlay with `kustomize build k8s/namespaces/<component>/overlays/prod` BEFORE committing; a non-zero build SHALL abort the run without pushing. On success it SHALL commit and push directly to `cloud-provisioning:main` using a `liverty-music-ci-bot` GitHub App installation token (the App is the `main` ruleset bypass actor — see design D9; the built-in `GITHUB_TOKEN` / `github-actions[bot]` cannot be a repo-ruleset bypass actor). ArgoCD's existing auto-sync rolls the change out — the workflow SHALL NOT open a pull request.
 
@@ -289,6 +297,19 @@ The workflow SHALL then validate the edited overlay with `kustomize build k8s/na
 - **THEN** all 4 `images[].newTag` in `k8s/namespaces/backend/overlays/prod/kustomization.yaml` SHALL be set to `v1.4.0`
 - **AND** the `app.kubernetes.io/version` label SHALL be set to `1.4.0`
 - **AND** each `newTag`'s inline `# commit <sha>` trailer SHALL be updated to `abc123...`
+
+#### Scenario: A frontend dispatch pins all bundles atomically in one commit
+
+- **WHEN** `bump-prod-pin.yml` receives `{ component: "frontend", tag: "v1.58.1", sha: "6139459..." }`
+- **THEN** the `fan-web`, `admin-console-web`, and `organizer-console-web` `images[].newTag` in `k8s/namespaces/frontend/overlays/prod/kustomization.yaml` SHALL ALL be set to `v1.58.1`
+- **AND** the `app.kubernetes.io/version` label SHALL be set to `1.58.1`
+- **AND** all three rewrites SHALL be committed and pushed as a single commit (no per-bundle commits and no transient state where only some bundles are on `v1.58.1`)
+
+#### Scenario: Provenance gate rejects a frontend tag whose bundles are not all in prod AR
+
+- **WHEN** `bump-prod-pin.yml` receives a `frontend` dispatch for a `tag` for which at least one of the three frontend bundle images does not exist in prod AR
+- **THEN** the workflow SHALL abort at the provenance check before editing any file
+- **AND** it SHALL NOT commit or push a partial or bogus pin
 
 #### Scenario: Missing prod-AR image aborts before any edit
 
@@ -351,3 +372,4 @@ To permit `bump-prod-pin.yml` to push directly to `cloud-provisioning:main`, the
 - **WHEN** the workflow is triggered by a `repository_dispatch` of type `bump-prod-pin` from the release path
 - **THEN** the bump job's `environment:` SHALL resolve to empty (not `prod-pin`), so no required-reviewer rule applies
 - **AND** the bump SHALL proceed unattended (no manual approval), subject to the payload-validation and provenance gates
+


### PR DESCRIPTION
## What

Archives the OpenSpec change `batch-frontend-prod-pin-dispatch`: syncs its `prod-image-pipeline` delta into the canonical spec (2 modified requirements) and moves the change to `openspec/changes/archive/2026-08-24-batch-frontend-prod-pin-dispatch/`.

## Canonical spec change

One frontend release now emits **exactly one** `component: frontend` `repository_dispatch` covering all three web bundles (`fan-web`, `admin-console-web`, `organizer-console-web`), and `bump-prod-pin.yml` pins them in a **single atomic commit**. The per-console `frontend-admin` / `frontend-organizer` component values no longer exist. This fixes the concurrency-group eviction race that silently dropped a bundle's pin on v1.58.0 / v1.58.1.

## Shipped & verified in production

- cloud-provisioning #448 — pin all frontend bundles in one atomic dispatch (consume side)
- frontend #568 — emit one prod-pin dispatch for all frontend bundles (emit side)
- cloud-provisioning #450 — remove the transitional aliases (task 4.4)
- Validated on **v1.59.0** and **v1.59.1**: one `component=frontend` dispatch, all three overlays moved to the tag in a single commit, ArgoCD auto-synced all three deployments with no manual recovery bump.

## Verified before archive

- `openspec validate --strict` clean (change + synced canonical spec)
- All 17 tasks checked
- Implementation matches the deltas; all shipping PRs merged

Refs: liverty-music/specification#852
