### PR TITLE
docs(openspec): revise organizer-rpc-server planning artifacts

### DIFF
--- a/openspec/changes/organizer-rpc-server/design.md
+++ b/openspec/changes/organizer-rpc-server/design.md
@@ -2,45 +2,90 @@
 
 See proposal.md - Why. Mirrors `admin-rpc-server` (each audience gets its own
 Connect server + ingress + CORS + cert + DNS + health). Depends on
-`organizer-accounts` (the `Organizer` entity + the `zitadel_org_id`
-tenant→Organizer link) and `organizer-tenancy` (the `organizer-console`
-project id used as the token audience). Full design + authorization matrix:
+`organizer-accounts` (the `Organizer` and `Artist` entities, the
+`zitadel_org_id` link between an Organizer and its Zitadel org, and the
+`organizer_artists` roster) and
+`organizer-tenancy` (the `organizer-console` project id used as the token
+audience). Full design + authorization matrix:
 [`docs/organizer-platform-design.md`](../../../docs/organizer-platform-design.md);
 Zitadel claim shapes in
 [`docs/zitadel-tenancy-model.md`](../../../docs/zitadel-tenancy-model.md).
 
 ## Goals / Non-Goals
 
-**Goals:** a dedicated, isolated organizer API server; `OrganizerService.Get`;
-correct org-scoped authorization with an explicit failure matrix.
+**Goals:** a dedicated, isolated organizer API server; `OrganizerService.Get`
+and `ListArtists` (the read surface for step ①); correct org-scoped
+authorization with an explicit failure matrix.
 
-**Non-Goals:** organizer-side `Update`/`List` (Phase 2); write/business RPCs;
-the admin surface (`organizer-accounts`).
+**Non-Goals:** organizer-side `Update` and write/business or association-
+mutation RPCs (later); roster mutation (`AssociateArtist`/`DisassociateArtist`)
+stays admin-only; the admin surface (`organizer-accounts`).
 
 ## Decisions
 
 **D1 — Dedicated server per audience.** The organizer audience is external
-and org-scoped, distinct from consumer (public) and admin (Google-Workspace)
-audiences, so it gets its own Connect server, ingress `api.organizer.{base}`,
-CORS allowlist, cert, DNS, and health — and is excluded from the other
-servers. Mirrors `admin-rpc-server`.
+and org-scoped, distinct from fan (public) and admin (Google-Workspace)
+audiences, so it gets its own Connect server — the `organizer-console-api`
+workload (named per `workload-naming-convention`, mirroring `fan-api` and
+`admin-console-api`) — at ingress `api.organizer.{base}`, with its own CORS
+allowlist, cert, DNS, and health, and is excluded from the other servers.
+Mirrors `admin-rpc-server`.
 
-**D2 — Authorization from the org-scoped role claim.** Validate JWT →
-require the organizer-console project id in `aud` (console requests the
-`...:project:id:{id}:aud` scope) → read `role → { orgId → domain }`; the
-inner orgId is the tenant. Authorize `{tenant, role}`; resolve the active
-tenant from the session's login-scope org; a multi-org operator is
-authorized only against that org. Analogous to `rpc-auth-scoping` (body id
-vs token), here target Organizer vs token tenant.
+**D2 — Authorization from the org-scoped role claim.** No "tenant" entity
+exists in the domain; the only defined nouns are the `Organizer` (entity), its
+Zitadel org, and the `zitadel_org_id` link between them. Authorization is
+therefore stated in those terms. Validate JWT → require the organizer-console
+project id in `aud` (console requests the `...:project:id:{id}:aud` scope) →
+read `role → { orgId → domain }`, where each `orgId` is a Zitadel org id (the
+top role is `owner`, not `admin`). The caller's Zitadel org is the id that
+appears BOTH in the login-scope scope (`urn:zitadel:iam:org:id:<orgId>`) and as
+an `orgId` under which the operator holds a role; these two derivations MUST
+agree. A multi-org operator is authorized only against their login-scope org.
+Holding any role for that org is sufficient (no specific-role gate this phase).
+The existing backend role extraction flattens the claim to a `[]string` of role
+names and discards the inner `orgId` — the org-scoped interceptor MUST preserve
+`role → orgId` so the caller's Zitadel org can be derived. Applies uniformly to
+`Get` and `ListArtists`. Analogous to `rpc-auth-scoping` (body id vs token),
+here the requested `OrganizerId` (resolved via `zitadel_org_id`) vs the caller's
+Zitadel org.
 
-**D3 — Every failure is PERMISSION_DENIED / UNAUTHENTICATED, never 500.**
-Missing/empty roles claim (require `accessTokenRoleAssertion=true` on the
-app), `aud` without the project id, or login-scope↔target mismatch →
-`PERMISSION_DENIED`; absent/invalid token → `UNAUTHENTICATED`.
+**D3 — Authorization failures are PERMISSION_DENIED / UNAUTHENTICATED, never
+500; existence is never revealed.** Missing/empty roles claim (require
+`accessTokenRoleAssertion=true` on the app), `aud` without the project id,
+login-scope↔role-claim org disagreement, requested `OrganizerId` resolving to a
+different org, the caller's Organizer being **deactivated** (per
+`organizer-accounts`, which mandates rejecting operations on a deactivated
+Organizer), or **no Organizer linked** to the caller's Zitadel org → all
+`PERMISSION_DENIED`, non-revealing (unlike the admin surface, which returns
+`NOT_FOUND`, because the organizer surface is external and org-scoped, matching
+`rpc-auth-scoping`'s "SHALL NOT reveal whether the resource exists"). Absent or
+invalid token → `UNAUTHENTICATED`. The one non-authz exception: a missing or
+malformed `OrganizerId` fails validation first → `INVALID_ARGUMENT` via
+protovalidate.
 
-**D4 — `Get` request shape.** `GetRequest` carries an explicit `OrganizerId`
-verified equal to the token tenant (consistent with `rpc-auth-scoping`),
-rejecting any other value.
+**D4 — `Get` / `ListArtists` request shape.** Each request carries an explicit
+`OrganizerId` verified to resolve to the caller's own Organizer (its
+`zitadel_org_id` equals the caller's Zitadel org), consistent with
+`rpc-auth-scoping`, rejecting any other value. `GetResponse` wraps the
+`Organizer` entity; `ListArtistsResponse` carries `repeated Artist artists`.
+
+**D5 — Roster is a separate RPC, not embedded in `Get`.** The `Organizer`
+entity intentionally carries no artist field, and the admin `OrganizerService`
+already models the roster with a dedicated `ListArtists` RPC (Get returns the
+entity; ListArtists returns the roster). The organizer-facing surface mirrors
+that split — and the fan `UserService.Get`, which likewise returns only
+its entity — rather than embedding artists in `GetResponse`. This keeps entity
+reads and roster reads independently cacheable and paginatable in a later phase.
+
+**D6 — `ListArtists` stable order by artist id.** Return the roster
+`ORDER BY a.id` ascending. Artist ids are UUID v7 (minted by the backend's
+single `entity.NewID()` site), so id order is a deterministic, unique,
+effectively creation-time ordering — fixing UI reordering and test flakiness
+and giving a total order a later pagination phase can page over without a
+tie-breaker. This mirrors the existing `listPerformersByEventIDs` `ORDER BY
+a.id` convention (same "stable, if not semantically billed" rationale). It
+orders by artist creation, not roster-add time; a roster-add ordinal is a
+future concern, tracked separately.
 
 ## Risks / Trade-offs
 
@@ -48,19 +93,20 @@ rejecting any other value.
   `accessTokenRoleAssertion` on the app and require the project id in `aud`;
   cover the no-role / wrong-aud / scope-mismatch paths with tests (the
   crown-jewel security tests).
-- **Tenant→Organizer resolution** → read the `zitadel_org_id` link from
-  `organizer-accounts` (DB is source of truth); do not depend on a Zitadel
-  round-trip per request.
+- **Organizer resolution** → resolve the caller's Organizer by the
+  `zitadel_org_id` link from `organizer-accounts` (DB is source of truth); do
+  not depend on a Zitadel round-trip per request.
 
 ## Migration Plan
 
 1. specification: `rpc/organizer/v1/organizer_service.proto` → merge →
    Release → BSR gen.
-2. backend: dedicated organizer Connect server + `Get` handler + org-scoped
-   authorization interceptor; tests for the failure matrix.
+2. backend: dedicated organizer Connect server + `Get` and `ListArtists`
+   handlers + org-scoped authorization interceptor; tests for the failure
+   matrix.
 3. cloud-provisioning: `api.organizer.{base}` ingress (HTTPRoute, cert, Cloud
    DNS), CORS, health; mirror `admin-rpc-server`.
-- Rollback: additive server + host; remove with no consumer/admin impact.
+- Rollback: additive server + host; remove with no fan or admin impact.
 
 ## Open Questions
 

--- a/openspec/changes/organizer-rpc-server/proposal.md
+++ b/openspec/changes/organizer-rpc-server/proposal.md
@@ -1,11 +1,12 @@
 ## Why
 
-Organizer operators need an API to read their own Organizer. This sub-change
-(4/4 of roadmap step ①) adds the organizer-facing `OrganizerService.Get` on a
-**dedicated** Connect server at `api.organizer.{base}` with its own CORS,
-cert, DNS, and health, plus **org-scoped role-claim authorization** — every
-prior audience surface on this platform (`admin-rpc-server`) gets its own
-server, and the external organizer audience must too. Grounded in
+Organizer operators need an API to read their own Organizer and the artists it
+represents. This sub-change (4/4 of roadmap step ①) adds the organizer-facing
+`OrganizerService.Get` and `OrganizerService.ListArtists` on a **dedicated**
+Connect server at `api.organizer.{base}` with its own CORS, cert, DNS, and
+health, plus **org-scoped role-claim authorization** — every prior audience
+surface on this platform (`admin-rpc-server`) gets its own server, and the
+external organizer audience must too. Grounded in
 `docs/organizer-platform-design.md` and `docs/zitadel-tenancy-model.md`,
 tracked by liverty-music/specification#759. Depends on `organizer-accounts`
 (the Organizer entity) and `organizer-tenancy` (the `organizer-console`
@@ -13,46 +14,59 @@ project + audience).
 
 ## What Changes
 
-- Add `rpc/organizer/v1/organizer_service.proto`: bare-verb **`Get`**
-  returning the authenticated Organizer's identity + associated artists. The
-  request carries an `OrganizerId` that MUST equal the token-derived tenant.
-- Serve it on a **dedicated organizer Connect server** at
+- Add `rpc/organizer/v1/organizer_service.proto` with two bare-verb read RPCs,
+  mirroring the admin `OrganizerService`'s separation of entity-get from
+  roster-list (the organizer entity intentionally carries no artist field):
+  - **`Get`** returns the authenticated Organizer's identity (id, name).
+  - **`ListArtists`** returns the artists the Organizer represents.
+  Each request carries an `OrganizerId` that MUST resolve to the caller's own
+  Organizer — the one whose `zitadel_org_id` equals the Zitadel org the token
+  is scoped to — and both RPCs pass the same org-scoped authorization.
+- Serve them on a **dedicated organizer Connect server** at
   `api.organizer.{base-domain}` with its own CORS allowlist (only the
   `organizer.{base}` origin), TLS cert, Cloud DNS, and health check. The
-  consumer and admin servers SHALL NOT serve organizer services, and this
-  server SHALL NOT serve consumer/admin services.
+  fan and admin servers SHALL NOT serve organizer services, and this
+  server SHALL NOT serve fan or admin services.
 - Add an **org-scoped authorization interceptor**: validate the JWT, require
-  the organizer-console project id in the token `aud`, read the roles claim
-  (`role → { orgId → domain }`), and authorize `{tenant, role}` — the inner
-  orgId is the tenant. Reject with `PERMISSION_DENIED` on a missing/empty
-  roles claim, an `aud` without the project id, or a mismatch between the
-  session's login-scope org and the requested Organizer; `UNAUTHENTICATED`
-  when the token is absent/invalid.
+  the organizer-console project id in the token `aud`, and read the roles claim
+  (`role → { orgId → domain }`, where each `orgId` is a Zitadel org id and the
+  top role is `owner`). The caller's Zitadel org is fixed by two token-derived
+  ids that MUST agree — the login-scope scope (`urn:zitadel:iam:org:id:<orgId>`)
+  and the `orgId` under which the operator holds a role — and the requested
+  `OrganizerId` MUST resolve (via `zitadel_org_id`) to that same Zitadel org.
+  Reject with `PERMISSION_DENIED` on a missing/empty roles claim, an `aud`
+  without the project id, or any disagreement among those three org ids;
+  `UNAUTHENTICATED` when the token is absent/invalid.
 
-Explicit non-goals: organizer-side `Update`/`List` (Phase 2); any write/
-business RPCs (later changes); the admin surface (in `organizer-accounts`).
+Explicit non-goals: organizer-side `Update` and any write/business or
+association-mutation RPCs (later changes); managing the roster
+(`AssociateArtist`/`DisassociateArtist`) stays admin-only in
+`organizer-accounts`; the admin surface itself (in `organizer-accounts`).
 
 ## Capabilities
 
 ### New Capabilities
 - `organizer-rpc-server`: the dedicated organizer Connect server
   (`api.organizer.{base}` + CORS + cert + DNS + health), the
-  `OrganizerService.Get` RPC, and the org-scoped role-claim authorization
-  with its failure matrix.
+  `OrganizerService.Get` and `OrganizerService.ListArtists` RPCs, and the
+  org-scoped role-claim authorization with its failure matrix.
 
 ### Modified Capabilities
 <!-- None. The organizer server is a new, isolated surface; existing
-     consumer/admin servers are unchanged (they already exclude services
+     fan and admin servers are unchanged (they already exclude services
      they do not own). -->
 
 ## Impact
 
 - **specification**: new `rpc/organizer/v1/organizer_service.proto` (imports
-  the `Organizer` entity from `organizer-accounts`). Ships via the cross-repo
-  release order.
+  the `Organizer` and `Artist` entities from `organizer-accounts`). Ships via
+  the cross-repo release order.
 - **backend**: a dedicated organizer Connect server + `OrganizerService.Get`
-  handler + the org-scoped authorization interceptor (analogous to
-  `rpc-auth-scoping`, tenant variant); reads the tenant→Organizer link
-  (`zitadel_org_id`) from `organizer-accounts`.
-- **cloud-provisioning**: `api.organizer.{base}` ingress host (HTTPRoute,
-  cert, Cloud DNS), CORS config, and health; mirrors `admin-rpc-server`.
+  and `ListArtists` handlers + the org-scoped authorization interceptor
+  (analogous to `rpc-auth-scoping`, org-scoped variant); resolves the caller's
+  Organizer via the `zitadel_org_id` link and reads the roster from
+  `organizer-accounts`.
+- **cloud-provisioning**: the `organizer-console-api` workload (name per
+  `workload-naming-convention`, mirroring `fan-api`/`admin-console-api`) at
+  `api.organizer.{base}` — HTTPRoute (`organizer-console-api-route`), TLS cert,
+  Cloud DNS, CORS config, and health; mirrors `admin-rpc-server`.

--- a/openspec/changes/organizer-rpc-server/specs/organizer-rpc-server/spec.md
+++ b/openspec/changes/organizer-rpc-server/specs/organizer-rpc-server/spec.md
@@ -1,9 +1,10 @@
 ## Purpose
 
 The organizer-facing API surface: a dedicated Connect server at
-`api.organizer.{base}` serving `OrganizerService.Get`, isolated from the
-consumer and admin servers, with org-scoped role-claim authorization so an
-operator can read only their own Organizer.
+`api.organizer.{base}` serving `OrganizerService.Get` and
+`OrganizerService.ListArtists`, isolated from the fan and admin servers,
+with org-scoped role-claim authorization so an operator can read only their own
+Organizer and the artists it represents.
 
 ## ADDED Requirements
 
@@ -12,14 +13,14 @@ operator can read only their own Organizer.
 The system SHALL serve the organizer-facing `OrganizerService` on a
 dedicated Connect server at `api.organizer.{base-domain}` with its own CORS
 allowlist (only the `organizer.{base-domain}` origin), TLS cert, Cloud DNS,
-and health check. The consumer and admin servers SHALL NOT serve organizer
-services, and this server SHALL NOT serve consumer or admin services.
+and health check. The fan and admin servers SHALL NOT serve organizer
+services, and this server SHALL NOT serve fan or admin services.
 
 #### Scenario: Organizer server is reachable and isolated
 
 - **WHEN** the organizer console calls `api.organizer.{base-domain}`
 - **THEN** the request SHALL be served by the dedicated organizer server
-- **AND** the same organizer service SHALL NOT be reachable on the consumer
+- **AND** the same organizer service SHALL NOT be reachable on the fan
   or admin API hosts
 
 #### Scenario: CORS admits only the organizer origin
@@ -31,37 +32,79 @@ services, and this server SHALL NOT serve consumer or admin services.
 
 ### Requirement: OrganizerService.Get returns the caller's own organizer
 
-The system SHALL expose a bare-verb `Get` returning the authenticated
-Organizer's identity (id, name) and associated artists. The request SHALL
-carry an `OrganizerId` that MUST equal the tenant derived from the token; a
-mismatch SHALL be rejected.
+The system SHALL expose a bare-verb `Get` returning the caller's own
+Organizer's identity (id, name). The request SHALL carry an `OrganizerId` that
+MUST resolve to the caller's own Organizer — the Organizer whose
+`zitadel_org_id` equals the Zitadel org the token is scoped to; any other
+`OrganizerId` SHALL be rejected. The roster of represented artists is returned
+by a separate `ListArtists` RPC, not embedded in the `Get` response —
+consistent with the admin `OrganizerService` and the fan `UserService.Get`.
 
 #### Scenario: Operator reads their own organizer
 
-- **WHEN** an operator calls `Get` with their own OrganizerId
-- **THEN** the system SHALL return that Organizer's id, name, and associated
-  artists
+- **WHEN** an operator calls `Get` with the `OrganizerId` of their own
+  Organizer
+- **THEN** the system SHALL return that Organizer's id and name
 
 #### Scenario: Operator cannot read a different organizer
 
-- **WHEN** an operator calls `Get` with an OrganizerId other than their
-  token's tenant
+- **WHEN** an operator calls `Get` with an `OrganizerId` that does not resolve
+  to their own Organizer
+- **THEN** the system SHALL reject it with a permission-denied error
+
+### Requirement: OrganizerService.ListArtists returns the caller's roster
+
+The system SHALL expose a bare-verb `ListArtists` returning the artists the
+caller's own Organizer represents. The request SHALL carry an `OrganizerId`
+that MUST resolve to the caller's own Organizer (as defined for `Get`); any
+other `OrganizerId` SHALL be rejected. The response SHALL be empty when the
+Organizer represents no artists. The artists SHALL be returned in a stable
+order, ascending by artist id — a UUID v7, so effectively artist-creation order
+— giving a deterministic, unique ordering a later pagination phase can page
+over. (This orders by when the artist was created, not when it was added to the
+roster; a roster-add ordinal is a future concern.)
+
+#### Scenario: Operator lists their own roster
+
+- **WHEN** an operator calls `ListArtists` with the `OrganizerId` of their own
+  Organizer
+- **THEN** the system SHALL return the artists that Organizer represents,
+  ascending by artist id
+- **AND** the list SHALL be empty when it represents none
+
+#### Scenario: Roster order is stable across calls
+
+- **WHEN** an operator calls `ListArtists` twice with no change to the roster
+- **THEN** the system SHALL return the artists in the same order both times
+
+#### Scenario: Operator cannot list a different organizer's roster
+
+- **WHEN** an operator calls `ListArtists` with an `OrganizerId` that does not
+  resolve to their own Organizer
 - **THEN** the system SHALL reject it with a permission-denied error
 
 ### Requirement: Org-scoped authorization from the role claim
 
-The system SHALL authorize organizer requests from the token: it SHALL
-validate the JWT, require the organizer-console project id in the token
-`aud`, and read the roles claim (`role → { orgId → domain }`) where the inner
-orgId is the tenant. It SHALL authorize the request against `{tenant, role}`
-and resolve the active tenant from the session's login-scope org. All
-authorization failures SHALL return `PERMISSION_DENIED` (never a server
-error); an absent/invalid token SHALL return `UNAUTHENTICATED`.
+The system SHALL authorize organizer requests from the token. It SHALL
+validate the JWT, require the organizer-console project id in the token `aud`,
+and read the roles claim (`role → { orgId → domain }`, where each `orgId` is a
+Zitadel org id). The caller's Zitadel org SHALL be the org id that appears
+BOTH in the session's login-scope scope (`urn:zitadel:iam:org:id:<orgId>`) AND
+as an `orgId` under which the operator holds a role. A request SHALL be
+authorized only when the requested `OrganizerId` resolves (via `zitadel_org_id`)
+to that same Zitadel org and that Organizer is active; holding any role for the
+org is sufficient (the top role is `owner`; no specific role is required in
+this phase).
+
+All authorization failures SHALL return `PERMISSION_DENIED`, SHALL NOT execute
+handler business logic, and SHALL NOT reveal whether the requested Organizer
+exists or is active. An absent or invalid token SHALL return `UNAUTHENTICATED`.
+A missing or malformed `OrganizerId` SHALL return `INVALID_ARGUMENT` via
+protovalidate.
 
 #### Scenario: Missing or empty roles claim is denied
 
-- **WHEN** a request's token carries no `organizer-console` role for the
-  target tenant
+- **WHEN** a request's token carries no role for the caller's Zitadel org
 - **THEN** the system SHALL reject it with `PERMISSION_DENIED`
 
 #### Scenario: Token audience without the project id is denied
@@ -70,11 +113,29 @@ error); an absent/invalid token SHALL return `UNAUTHENTICATED`.
   project id
 - **THEN** the system SHALL reject it with `PERMISSION_DENIED`
 
-#### Scenario: Login-scope org and requested organizer must match
+#### Scenario: Login-scope org and role-claim org must agree
 
-- **WHEN** the session's login-scope org does not map to the requested
-  Organizer
+- **WHEN** the login-scope org id and the `orgId` under which the operator
+  holds a role are not the same Zitadel org
 - **THEN** the system SHALL reject it with `PERMISSION_DENIED`
+
+#### Scenario: Deactivated organizer is denied
+
+- **WHEN** the Organizer resolved for the caller's Zitadel org is deactivated
+- **THEN** the system SHALL reject the request with `PERMISSION_DENIED`
+- **AND** the response SHALL NOT reveal that the Organizer is deactivated
+
+#### Scenario: Caller's Zitadel org has no linked Organizer
+
+- **WHEN** no active Organizer has a `zitadel_org_id` matching the caller's
+  Zitadel org (e.g. the link is not yet established)
+- **THEN** the system SHALL reject the request with `PERMISSION_DENIED`
+- **AND** the response SHALL NOT reveal whether an Organizer exists
+
+#### Scenario: Missing or malformed OrganizerId is rejected
+
+- **WHEN** a request omits `OrganizerId` or supplies a malformed value
+- **THEN** the system SHALL reject it with `INVALID_ARGUMENT` via protovalidate
 
 #### Scenario: Unauthenticated request is rejected
 

--- a/openspec/changes/organizer-rpc-server/tasks.md
+++ b/openspec/changes/organizer-rpc-server/tasks.md
@@ -1,19 +1,19 @@
 ## 1. Specification (proto)
 
-- [ ] 1.1 `rpc/organizer/v1/organizer_service.proto`: bare-verb `Get` (request carries `OrganizerId`) returning the Organizer identity + associated artists; import the `Organizer` entity from `organizer-accounts`; document the error matrix
+- [ ] 1.1 `rpc/organizer/v1/organizer_service.proto`: bare-verb `Get` (request carries `OrganizerId`; `GetResponse` wraps the `Organizer` entity — identity only) and bare-verb `ListArtists` (request carries `OrganizerId`; `ListArtistsResponse` carries `repeated Artist artists`), mirroring the admin `OrganizerService` split; import the `Organizer` and `Artist` entities from `organizer-accounts`; document the per-RPC error matrix as INVALID_ARGUMENT (missing/malformed `OrganizerId`) / PERMISSION_DENIED (any authz failure, non-revealing — deliberately no `NOT_FOUND`, unlike the admin surface) / UNAUTHENTICATED (absent/invalid token)
 - [ ] 1.2 `buf lint`/`format`/`breaking` pass; open specification PR, merge, cut Release, confirm BSR gen succeeds
 
 ## 2. Backend — server & authorization
 
-- [ ] 2.1 Dedicated organizer Connect server (own port) serving `rpc.organizer.v1.OrganizerService`; excluded from the consumer and admin servers
-- [ ] 2.2 Org-scoped authorization interceptor: validate JWT, require the organizer-console project id in `aud`, read `role → { orgId }`, authorize `{tenant, role}`, resolve active tenant from login-scope org
-- [ ] 2.3 `Get` handler: verify request `OrganizerId` == token tenant; resolve tenant→Organizer via the `zitadel_org_id` link; return identity + associated artists
-- [ ] 2.4 Tests (crown-jewel security): cross-organizer `Get` → PERMISSION_DENIED; missing role / missing `aud` / login-scope mismatch → PERMISSION_DENIED; no token → UNAUTHENTICATED; happy path returns own organizer
+- [ ] 2.1 Dedicated organizer Connect server (own port) serving `rpc.organizer.v1.OrganizerService`; excluded from the fan and admin servers
+- [ ] 2.2 Org-scoped authorization interceptor: validate JWT, require the organizer-console project id in `aud`, read `role → { orgId }` (preserve the inner `orgId` — the existing extraction flattens to `[]string` and discards it), derive the caller's Zitadel org as the id appearing in BOTH the login-scope scope `urn:zitadel:iam:org:id:<orgId>` and an `orgId` under which the operator holds a role (the two MUST agree; any role suffices, top role `owner`); applies to `Get` and `ListArtists`
+- [ ] 2.3 `Get` handler: resolve the caller's Organizer by the `zitadel_org_id` matching the caller's Zitadel org (add a `GetByZitadelOrgID` lookup); verify the request `OrganizerId` equals that Organizer's id and it is active; return identity (id, name). `ListArtists` handler: same resolution + active check; return the roster via the repository (empty when none), `ORDER BY a.id` ascending (stable, UUID v7 ≈ creation order; mirrors the existing `listPerformersByEventIDs` convention)
+- [ ] 2.4 Tests (crown-jewel security): cross-organizer `Get`/`ListArtists` (`OrganizerId` resolving to another org) → PERMISSION_DENIED; missing role / missing `aud` / login-scope↔role-claim disagreement → PERMISSION_DENIED; deactivated Organizer and no-linked-Organizer → PERMISSION_DENIED (non-revealing); missing/malformed `OrganizerId` → INVALID_ARGUMENT; no token → UNAUTHENTICATED; happy paths return own organizer and own roster (incl. empty roster)
 - [ ] 2.5 `make check` passes with upgraded BSR package
 
 ## 3. Cloud-provisioning (ingress)
 
-- [ ] 3.1 `api.organizer.{base}` ingress host: HTTPRoute + TLS cert (certmap) + Cloud DNS (dev + prod); health check
+- [ ] 3.1 `organizer-console-api` workload (name per `workload-naming-convention`, mirroring `admin-console-api`) at `api.organizer.{base}`: HTTPRoute `organizer-console-api-route` + Service `organizer-console-api-svc` + TLS cert (certmap) + Cloud DNS (dev + prod) + HealthCheckPolicy `organizer-console-api-policy`
 - [ ] 3.2 CORS allowlist limited to the `organizer.{base}` origin
 - [ ] 3.3 `make lint` (kustomize render) passes; `pulumi preview` shows only intended additions
 
@@ -21,4 +21,4 @@
 
 - [ ] 4.1 Backend PR merged → release → prod pin bump; confirm the organizer server pod is running
 - [ ] 4.2 Cloud-provisioning PR merged → ArgoCD synced (host, cert, DNS, CORS)
-- [ ] 4.3 Verify in prod: an operator's console reads their own organizer via `api.organizer.liverty-music.app`; a cross-organizer request is denied; the organizer service is not reachable on the consumer/admin API hosts
+- [ ] 4.3 Verify in prod: an operator's console reads their own organizer and its artist roster via `api.organizer.liverty-music.app`; a cross-organizer `Get`/`ListArtists` request is denied; the organizer service is not reachable on the fan/admin API hosts


### PR DESCRIPTION
## Summary

Revises the planning artifacts of the in-progress OpenSpec change `organizer-rpc-server` (proposal / design / spec / tasks). No implementation code — the change is still at planning stage (tasks 0/13). Refines the spec after reconciling it against the already-shipped dependencies (`organizer-accounts`, `organizer-tenancy`, `admin-rpc-server`, `workload-naming-convention`).

Related: liverty-music/specification#759 (not closed — the change is not yet implemented/archived).

## Changes

- **Add `OrganizerService.ListArtists` alongside `Get`.** The organizer entity carries no artist field, so the roster is a separate RPC — mirroring the admin `OrganizerService` (`Get` returns the entity; `ListArtists` returns the roster) and the fan `UserService.Get`. Artists are **not** embedded in `GetResponse`.
- **Naming consistency (`consumer` → `fan`).** The end-user audience is `fan` (`fan-api` / `fan-web`) per `workload-naming-convention`; "consumer" collides with `event-consumer` and is removed. The new organizer API workload is named `organizer-console-api` (mirroring `admin-console-api`), with `organizer-console-api-route` / `-svc` / `-policy`.
- **Ubiquitous-language fix — remove the undefined term "tenant".** No `tenant` entity is defined in the domain; the defined nouns are `Organizer` (entity), its **Zitadel org**, and the `zitadel_org_id` link. All authorization is restated in those terms.
- **Authorization failure matrix clarified.** Cross-check the login-scope org (`urn:zitadel:iam:org:id:<orgId>`) against the roles-claim `orgId`; both must resolve, via `zitadel_org_id`, to the requested `OrganizerId`. Deactivated Organizer and no-linked-Organizer → `PERMISSION_DENIED` (non-revealing, matching `rpc-auth-scoping`; deliberately **not** the admin surface's `NOT_FOUND`). Missing/malformed `OrganizerId` → `INVALID_ARGUMENT` (protovalidate). Any role for the org suffices (no specific-role gate this phase).
- **`ListArtists` stable ordering.** Return the roster ascending by artist id (UUID v7 ≈ creation order) — deterministic, unique, pagination-ready — mirroring the existing `listPerformersByEventIDs` `ORDER BY a.id` convention.

## Testing

- `openspec validate organizer-rpc-server --strict` → valid.
- Doc-only change; no code, no proto, no build impact.
