### PR TITLE
docs(openspec): add harden-gemini-discovery-extraction change

### DIFF
--- a/openspec/changes/harden-gemini-discovery-extraction/.openspec.yaml
+++ b/openspec/changes/harden-gemini-discovery-extraction/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-24

--- a/openspec/changes/harden-gemini-discovery-extraction/design.md
+++ b/openspec/changes/harden-gemini-discovery-extraction/design.md
@@ -1,0 +1,39 @@
+## Context
+
+The concert extractor is the two-step grounded pipeline in `internal/infrastructure/gcp/gemini` (see the `gemini-grounded-extract-and-coerce` capability); the sales-phase extractor is an analogous two-step pipeline. Both are exercised by the matrix A/B harness (`searcher_integration_test.go`, `GEMINI_AB_EVAL=1`) against a frozen ground-truth fixture, scored on `(local_date, normalized_venue)`. This change was driven by (a) an A/B evaluation of a candidate model upgrade and (b) analysis of production discovery data. See proposal.md — Why.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Decide, on evidence, whether to adopt `gemini-3.7-flash` for the extract step.
+- Remove the two production extraction defects that the data exposed (venue translation / weak `source_url`; play-guide-as-`一般` and missing lottery dates).
+- Keep the A/B harness honest so future model/prompt decisions are measurable.
+
+**Non-Goals:**
+- Changing production `pkg/config` model / thinking / temperature defaults (the measured `low` / `0.4` optimum is recorded for a follow-up, not applied here).
+- Building a sales-phase eval harness or fixture.
+- Fixing series fragmentation or deprecating merch discovery (separate changes).
+
+## Decisions
+
+### Retain gemini-3.6-flash; do not adopt gemini-3.7-flash
+A/B on a refreshed 4-artist fixture, offline re-scored to neutralize venue-string artifacts, showed **both models at 100% date-coverage recall** (equal discovery quality). `gemini-3.6-flash` and `gemini-3.7-flash` share identical token pricing (introductory $0.75 / $3.75 per 1M through 2026, both doubling in 2027), yet 3.7 consumed ~4.8× the Step 1 grounding tokens (`ToolUsePromptTokenCount`), i.e. ~1.75× the per-search cost, for no quality gain. 3.7 is ~2× faster, but concert discovery is a background job where cost dominates latency. Alternatives considered: adopt 3.7 for speed/newness (rejected — cost, no quality gain); switch the extract step to `thinking=low, temperature=0.4` now (deferred — it is the measured optimum for 3.6 but a production-behavior change best shipped on its own).
+
+### Extract every field in the source's original language
+The measured quality gap for 3.7 was an artifact of it translating Japanese venue names to English on multilingual tour sites; 3.6 exhibited a milder form (old-vs-new renamed-venue strings). The Step 1 instruction now forbids translation/romanization and mandates the Japanese form even on multilingual pages. This directly protects downstream event de-dup, `admin_area` inference, and display. Alternative: post-process/normalize venue strings Go-side (rejected — lossy, and it hides a real instruction-following defect rather than fixing it at the source).
+
+### Prefer the tour-specific page for source_url
+Production `source_url` was often the site top or a news-list page. The instruction now prefers the tour special/feature page (or specific announcement) over the top/news-list page. This is measurable via the harness `field_accuracy.source_url`. It also makes a separate merch link largely redundant (the tour page carries goods info) — motivating the deferred merch-discovery deprecation.
+
+### Sales-phase: play-guide priority and lottery completeness
+Production classified 45% of `一般` phases that actually carried a named play-guide provider; and left `lottery_result` empty on 78% of `抽選` phases. The instruction now classifies any named-play-guide sale as `プレイガイド` (reserving `一般` for non-guide direct sales) and directs the model to extract the application deadline and result date for `抽選` phases when published (never guessed).
+
+### Harness correctness (supporting)
+`gemini-3.7-flash`/`gemini-3.6-flash` pricing rows were added; a Step 1/Step 2 cost-attribution bug (Step 1 cost computed against the wrong model → $0) was fixed; venue normalization gained aliases for a renamed venue and a `某所`/TBD collapse so eval matching reflects real equivalence. The genai SDK was bumped v1.57→v1.69 (no breaking changes).
+
+## Risks / Trade-offs
+
+- **Sales-phase prompt changes are unmeasured.** No sales-phase eval harness exists, and their production effect is confounded by the separately-tracked series-fragmentation defect (a tour's events are minted as one series per event, duplicating every series-level attribute). They ship as reasoned, low-risk prompt improvements; verification will come with the series-grouping fix.
+- **The `source_url` and native-language changes are prompt-only** and depend on the model's instruction-following; the harness measures the outcome for concert extraction but not for the sales-phase pipeline.
+- **The `thinking=low, temperature=0.4` optimum is documented but not applied**, so production keeps its current (higher-cost) extract behavior until a follow-up change lands.
+- Introductory model pricing doubles on 2027-01-01; cost figures here are point-in-time (2026).

--- a/openspec/changes/harden-gemini-discovery-extraction/proposal.md
+++ b/openspec/changes/harden-gemini-discovery-extraction/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+Analysis of production discovery data surfaced two extraction-quality defects. (1) The concert grounded-extract step translated / romanized Japanese venue names (e.g. `幕張メッセ 9・11ホール` → `Makuhari Messe Halls 9 & 11`) — especially on multilingual tour sites — which breaks event de-duplication, `admin_area` inference, and display; and it frequently stored the official-site top page or a generic news page as `source_url` instead of the tour's dedicated page. (2) The sales-phase step mis-classified play-guide sales as `一般 (GENERAL)` (45% of GENERAL rows carry a named play-guide provider such as イープラス / ローチケ / ぴあ) and left the lottery result-announcement date empty on 78% of `抽選` phases and the application deadline empty on 55% of phases. Separately, a candidate model upgrade to `gemini-3.7-flash` needed an evidence-based accept/reject decision.
+
+## What Changes
+
+- **Concert grounded-extract (Step 1)**: every verbatim field, and venue in particular, MUST be extracted in its original language — no translation, romanization, or localization even when a page offers an English/multilingual view; and `source_url` MUST prefer the tour-specific special/feature page (or the specific announcement article) over the official-site top page or a generic news-list page.
+- **Sales-phase extract (Step 1)**: a sale conducted through a named play guide is classified `プレイガイド` (with the guide in `provider_name`) even when it is a general (non-membership) on-sale — `一般` is reserved for a general sale not tied to a named guide; and for `抽選` (lottery) phases the application deadline and the result-announcement date SHALL be extracted from the ticket page when published (never guessed).
+- **Model evaluation — decision, non-BREAKING**: `gemini-3.7-flash` was A/B-evaluated against `gemini-3.6-flash` on a refreshed 4-artist ground-truth fixture. Both reach equal discovery quality (100% date-coverage recall), but 3.7 costs ~1.75× (≈4.8× grounding tokens) at identical unit pricing, so **`gemini-3.6-flash` is retained**; the measured optimum for the extract step is `thinking=low, temperature=0.4`.
+- **Tooling / fixtures**: bump `google.golang.org/genai` v1.57.0 → v1.69.0; the A/B harness gains `gemini-3.7-flash` support, a Step 1/Step 2 cost-attribution fix, model pricing rows, and venue-normalization aliases (renamed venue + `某所`/TBD collapse); the ground-truth fixture is refreshed to 101 events across 4 artists with `evaluation_from = 2026-08-23`.
+
+## Capabilities
+
+### New Capabilities
+
+- (none)
+
+### Modified Capabilities
+
+- `gemini-grounded-extract-and-coerce`: Step 1 verbatim extraction now mandates original-language (no translation / romanization) values, and `source_url` selection prefers the tour-specific page over the site top / news-list page.
+- `sales-phase-discovery`: Step 1 classification prioritizes `プレイガイド` when a named guide is present (over `一般`), and `抽選` phases extract the application-deadline and result-announcement dates when published.
+
+## Impact
+
+- **Code**: `internal/infrastructure/gcp/gemini/searcher.go` (Step 1 prompt), `internal/infrastructure/gcp/gemini/sales_phase_searcher.go` (Step 1 prompt), `internal/infrastructure/gcp/gemini/{searcher_integration_test.go, abeval_scoring.go, abeval_test.go}` and `testdata/*` (A/B harness + fixture), `go.mod` / `go.sum` (genai v1.69.0).
+- **No API / proto / DB-schema changes and no migration.** Production `pkg/config` defaults are unchanged — `gemini-3.6-flash` remains the extract model; the `thinking=low, temperature=0.4` optimum is documented for a follow-up config tuning, not applied here.
+- **Measurability**: the `source_url` prompt change is measurable via the existing A/B harness `field_accuracy.source_url`; the sales-phase prompt changes are not yet covered by an eval harness (their production effect is also confounded by the separately-tracked series-fragmentation defect).
+- **Deferred to separate changes** (out of scope here): deprecating `merch-discovery` and dropping `series.merch_url` (redundant with `source_url`); and fixing series fragmentation in the persistence layer (a tour's events are minted as one series per event instead of one series per tour) plus the associated data migration.

--- a/openspec/changes/harden-gemini-discovery-extraction/specs/gemini-grounded-extract-and-coerce/spec.md
+++ b/openspec/changes/harden-gemini-discovery-extraction/specs/gemini-grounded-extract-and-coerce/spec.md
@@ -1,0 +1,29 @@
+# gemini-grounded-extract-and-coerce Specification (delta)
+
+## ADDED Requirements
+
+### Requirement: Step 1 extracts every field in the source page's original language
+
+Step 1 SHALL copy every extracted field — venue in particular — verbatim in the language it is written on the source page, and SHALL NOT translate, romanize, anglicize, or otherwise localize any value, even when the page offers an English or otherwise multilingual view. A Japanese venue name SHALL be emitted in Japanese.
+
+#### Scenario: Multilingual tour page — Japanese venue retained
+- **WHEN** Step 1 extracts an event whose venue is printed as `幕張メッセ 9・11ホール` on a page that also offers an English view rendering it "Makuhari Messe Halls 9 & 11"
+- **THEN** the emitted `<venue>` SHALL be `幕張メッセ 9・11ホール`
+- **AND** it SHALL NOT be romanized or translated to English
+
+#### Scenario: Renamed venue kept verbatim, not semantically translated
+- **WHEN** the source prints a venue such as `クロコくんホール（旧 日本ガイシホール）`
+- **THEN** the emitted `<venue>` SHALL reproduce that Japanese string verbatim
+- **AND** it SHALL NOT be rendered as an English gloss such as "Crocodile Hall"
+
+### Requirement: Step 1 selects the tour-specific page as source_url
+
+For each extracted tour or show, Step 1 SHALL set `source_url` to the artist's page dedicated to THAT specific tour/show — a tour special/feature page or the specific announcement article — in preference to the official-site top page or a generic news-list page, choosing the most detailed tour-specific candidate.
+
+#### Scenario: Tour feature page preferred over the site top
+- **WHEN** a tour has a dedicated feature page (e.g. a `/feature/<tour>` page) and the artist also has an official-site top page
+- **THEN** `source_url` SHALL be the tour feature page, not the site top page
+
+#### Scenario: No tour-specific page available
+- **WHEN** no tour-specific page exists and only a general news-list or top page is available
+- **THEN** Step 1 MAY use the most detailed available official page as `source_url`

--- a/openspec/changes/harden-gemini-discovery-extraction/specs/sales-phase-discovery/spec.md
+++ b/openspec/changes/harden-gemini-discovery-extraction/specs/sales-phase-discovery/spec.md
@@ -1,0 +1,29 @@
+# sales-phase-discovery Specification (delta)
+
+## ADDED Requirements
+
+### Requirement: Play-guide sales are classified as プレイガイド even when general
+
+When a sales phase is conducted through a named third-party play guide (for example e+ / イープラス, ローチケ, チケットぴあ, CN Playguide), the grounded extraction step SHALL classify its channel as `プレイガイド` and record the guide in `provider_name`, even when the sale is a general (non-membership) on-sale. The `一般` channel SHALL be reserved for a general on-sale that is not tied to a named play guide.
+
+#### Scenario: General on-sale sold via a named play guide
+- **WHEN** a general on-sale for a series is sold through イープラス
+- **THEN** the phase channel SHALL be `プレイガイド`
+- **AND** `provider_name` SHALL be the guide name (e.g. `イープラス`)
+- **AND** the channel SHALL NOT be `一般`
+
+#### Scenario: General on-sale with no named guide
+- **WHEN** a general on-sale is a direct sale on the official site with no third-party play guide named
+- **THEN** the phase channel SHALL be `一般`
+
+### Requirement: Lottery phases extract the application deadline and result date when published
+
+For a `抽選` (lottery) phase, the grounded extraction step SHALL extract the application deadline (`apply_end`) and the result-announcement date (`lottery_result`) from the ticket page when they are published alongside the application window, and SHALL leave them empty only when they are genuinely absent — never guessed.
+
+#### Scenario: Lottery with a published deadline and result date
+- **WHEN** a `抽選` phase's page publishes an application window with a deadline and a result-announcement date
+- **THEN** the extracted phase SHALL include both `apply_end` and `lottery_result`
+
+#### Scenario: Lottery with no published result date
+- **WHEN** a `抽選` phase's page does not publish a result-announcement date
+- **THEN** `lottery_result` SHALL be left empty rather than guessed

--- a/openspec/changes/harden-gemini-discovery-extraction/tasks.md
+++ b/openspec/changes/harden-gemini-discovery-extraction/tasks.md
@@ -1,0 +1,35 @@
+# Tasks
+
+## 1. SDK & A/B harness tooling
+
+- [x] 1.1 Bump `google.golang.org/genai` v1.57.0 → v1.69.0; `go mod tidy`; build/vet clean
+- [x] 1.2 Add `gemini-3.6-flash` / `gemini-3.7-flash` pricing rows to the A/B pricing table
+- [x] 1.3 Fix the Step 1 / Step 2 cost-attribution bug (cost computed against the wrong model → $0)
+- [x] 1.4 Add venue-normalization aliases to the matcher (renamed venue; `某所` / TBD collapse)
+- [x] 1.5 Add `gemini-3.7-flash` to the harness model list and set the evaluation axes
+
+## 2. Ground-truth fixture
+
+- [x] 2.1 Refresh `ab_ground_truth.json` to 101 events across 4 artists, `evaluation_from = 2026-08-23` (official-site verified; UVERworld special-page open/start times; SUPER BEAVER 高知 venue fix; +Zepp Taipei; +TBA-venue dates)
+- [x] 2.2 Update the `LoadGroundTruth` fixture-well-formed assertion and the harness README (run commands / matrix axes / search pricing)
+
+## 3. Concert Step 1 prompt — gemini-grounded-extract-and-coerce
+
+- [x] 3.1 Mandate original-language extraction (no translation / romanization) for venue and all verbatim fields, including on multilingual pages
+- [x] 3.2 Prefer the tour-specific special/feature page for `source_url` over the site top page or a generic news-list page
+
+## 4. Sales-phase Step 1 prompt — sales-phase-discovery
+
+- [x] 4.1 Classify a named-play-guide sale as `プレイガイド` (record the guide in `provider_name`); reserve `一般` for non-guide direct sales
+- [x] 4.2 Extract `apply_end` and `lottery_result` for `抽選` phases when published (never guess)
+
+## 5. Model evaluation & decision
+
+- [x] 5.1 Run the 3.6-vs-3.7 A/B matrix (thinking × temperature, then `low` / `temp 0.4` across 4 artists)
+- [x] 5.2 Offline re-score neutralizing venue-string artifacts; record decision — retain `gemini-3.6-flash`; measured optimum `thinking=low, temperature=0.4`
+
+## 6. Verification & rollout
+
+- [x] 6.1 Re-run the A/B harness with the hardened concert prompt and confirm `field_accuracy.source_url` improves
+- [x] 6.2 `make check` (lint + unit tests) green
+- [ ] 6.3 Open the PR for the backend branch and merge after CI passes


### PR DESCRIPTION
## Summary

OpenSpec planning artifacts for the backend change that hardens Gemini discovery extraction and records the model decision. Implements the code in liverty-music/backend#404.

- **proposal.md** — native-language venue extraction, tour-specific `source_url`, sales-phase play-guide classification + lottery-date completeness; SDK bump; A/B harness/fixture; decision to retain `gemini-3.6-flash` over `gemini-3.7-flash`.
- **specs/gemini-grounded-extract-and-coerce/spec.md** — ADDED: original-language extraction; tour-specific `source_url` selection.
- **specs/sales-phase-discovery/spec.md** — ADDED: named-play-guide -> `プレイガイド`; extract `apply_end` / `lottery_result` for `抽選` phases.
- **design.md** — 3.7-vs-3.6 A/B methodology and rationale (equal quality, ~1.75x cost); per-prompt decisions; risks.
- **tasks.md** — implementation checklist (1-5 + verification done; 6.3 = this PR pair).

`openspec validate --strict` passes.

**Deferred to separate changes:** deprecate merch-discovery + drop `series.merch_url`; fix series fragmentation + data migration.
