### PR TITLE
docs(agents): add Review criteria for CI code review

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,4 +124,9 @@ Before modifying `.proto` files, read:
 1. `docs/product-design.md` — domain concepts and product vision
 2. This file — project rules and core design constraints
 
+## Review criteria (flag violations)
+
+- Domain concepts are wrapper messages with protovalidate (`UserId`, `VenueName`…), never bare `string`/`int` (cf. `entity/v1/*.proto`).
+- `entity/v1/` holds pure data types (no service logic); `rpc/*/v1/` imports entities and follows Google AIP.
+
 </agent-rules>


### PR DESCRIPTION
## What

Adds a `Review criteria` section to AGENTS.md (CLAUDE.md symlink) so the CI Claude reviewer enforces cross-file consistency rules a diff-only pass cannot see.

## Rules added

- Domain concepts are wrapper messages with protovalidate (`UserId`, `VenueName`…), never bare `string`/`int` (cf. `entity/v1/*.proto`).
- `entity/v1/` holds pure data types (no service logic); `rpc/*/v1/` imports entities and follows Google AIP.

Pairs with the reviewer charter in liverty-music/.github#8.