### PR TITLE
feat(entity)!: retire Series.merch_url (reserve field 5)

### DIFF
--- a/openspec/changes/remove-merch-search/tasks.md
+++ b/openspec/changes/remove-merch-search/tasks.md
@@ -1,15 +1,15 @@
 ## 1. cloud-provisioning — stop the workload first
 
-- [ ] 1.1 Delete the CronJob dirs `k8s/namespaces/backend/{base,overlays/dev,overlays/prod}/cronjob/merch-discovery/`
-- [ ] 1.2 Remove `- cronjob/merch-discovery` from `base/kustomization.yaml` and the merch entries from `overlays/dev/kustomization.yaml` (schedule patch + `merch-discovery-job-config` generator) and `overlays/prod/kustomization.yaml` (config generator + images pin lines)
-- [ ] 1.3 Remove the `Merch Discovery` workload entry from `src/gcp/components/monitoring.ts` (drops the `alert-error-log-merch-discovery` AlertPolicy)
-- [ ] 1.4 Remove `merch-discovery` from the `IMAGES` list in `.github/workflows/bump-prod-pin.yml`
+- [x] 1.1 Delete the CronJob dirs `k8s/namespaces/backend/{base,overlays/dev,overlays/prod}/cronjob/merch-discovery/`
+- [x] 1.2 Remove `- cronjob/merch-discovery` from `base/kustomization.yaml` and the merch entries from `overlays/dev/kustomization.yaml` (schedule patch + `merch-discovery-job-config` generator) and `overlays/prod/kustomization.yaml` (config generator + images pin lines)
+- [x] 1.3 Remove the `Merch Discovery` workload entry from `src/gcp/components/monitoring.ts` (drops the `alert-error-log-merch-discovery` AlertPolicy)
+- [x] 1.4 Remove `merch-discovery` from the `IMAGES` list in `.github/workflows/bump-prod-pin.yml`
 - [ ] 1.5 Deploy: dev ArgoCD/Pulumi sync + prod `pulumi up` (AlertPolicy deletion) and ArgoCD sync; confirm no merch-discovery CronJob remains and nothing repopulates `merch_url`
 
 ## 2. specification — proto + BSR release
 
-- [ ] 2.1 In `proto/liverty_music/entity/v1/series.proto` delete `Url merch_url = 5;` and add `reserved 5; reserved "merch_url";`; remove its doc comment
-- [ ] 2.2 Run `buf lint` + `buf breaking`; if `FIELD_NO_DELETE` still flags despite the reserve, add the `buf skip breaking` PR label
+- [x] 2.1 In `proto/liverty_music/entity/v1/series.proto` delete `Url merch_url = 5;` and add `reserved 5; reserved "merch_url";`; remove its doc comment
+- [x] 2.2 Run `buf lint` + `buf breaking`; if `FIELD_NO_DELETE` still flags despite the reserve, add the `buf skip breaking` PR label
 - [ ] 2.3 Merge the specification PR, cut a GitHub Release (tag `vX.Y.Z`), and watch `buf-release.yml` until BSR gen succeeds (spec-sync + tombstone deletion happen at archive — see section 6)
 
 ## 3. backend release A — remove code and read/write path (column stays)

--- a/proto/liverty_music/entity/v1/series.proto
+++ b/proto/liverty_music/entity/v1/series.proto
@@ -77,13 +77,9 @@ message Series {
   // field never hit the Url.value min_len / uri rules.
   Url source_url = 4 [(google.api.field_behavior) = OPTIONAL];
 
-  // The official merchandise information page shared across the series
-  // (an official site page or official social media post). Optional and
-  // populated asynchronously by the merch-url discovery job, so most
-  // series carry a nil wrapper until their earliest event nears. Stores
-  // only the link: no sale timing, channel, price, or item data — those
-  // remain on the linked page. Same optionality semantics as source_url:
-  // a nil wrapper skips inner-Url validation, while a present wrapper
-  // SHALL satisfy the Url.value min_len / uri rules.
-  Url merch_url = 5 [(google.api.field_behavior) = OPTIONAL];
+  // Field 5 (`merch_url`) was retired with the merch-url discovery feature.
+  // The number and name are reserved so they are never reused and downstream
+  // regeneration stays wire-safe.
+  reserved 5;
+  reserved "merch_url";
 }


### PR DESCRIPTION
## Summary

Ship-order **step 2** of the cross-repo `remove-merch-search` OpenSpec change: remove the merch-url discovery feature's schema surface.

- Delete `Url merch_url = 5` from the `Series` message and its doc comment
- Add `reserved 5; reserved "merch_url";` so the number and name are never reused and downstream regeneration stays wire-safe

## Breaking change

`Series.merch_url` (field 5) is removed. `buf breaking` (FILE strategy) still flags `FIELD_NO_DELETE` on the deletion despite the reserve — this is the documented, intentional case, so this PR carries the **`buf skip breaking`** label.

## Verification

- `buf lint` ✅ / `buf format -w` applied
- `buf breaking` flags only the expected `FIELD_NO_DELETE` on `merch_url`

## Release (post-merge)

Merge → cut a GitHub Release (`vX.Y.Z`) → `buf-release.yml` pushes to BSR → backend/frontend consume the new types. Spec-sync + tombstone-scenario deletion happen at archive (tasks §6).

Depends-on ordering: land after cloud-provisioning PR (stops the CronJob) so nothing repopulates `merch_url`.

Part of OpenSpec change \`remove-merch-search\` (tasks §2).